### PR TITLE
Add Render Blueprint for deployment configuration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,84 @@
+# render.yaml — Render Blueprint for 143.dev
+#
+# Deploy:
+#   1. Push this file to your GitHub repo
+#   2. Go to https://dashboard.render.com/blueprints
+#   3. Click "New Blueprint Instance" and connect your repo
+#   4. Fill in the environment variables (GitHub OAuth, API keys, etc.)
+#   5. Click "Apply"
+#
+# After first deploy, update BASE_URL, FRONTEND_URL, and CORS_ALLOWED_ORIGINS
+# in the Render dashboard to match your actual service URLs (or custom domains).
+
+databases:
+  - name: onefortythree-db
+    plan: starter
+    databaseName: onefortythree
+    user: onefortythree
+    region: oregon
+    postgresMajorVersion: "17"
+
+services:
+  # ── Go API ─────────────────────────────────────────────────────────
+  - type: web
+    name: onefortythree-api
+    runtime: docker
+    plan: starter
+    region: oregon
+    dockerfilePath: ./Dockerfile
+    dockerContext: .
+    healthCheckPath: /healthz
+    preDeployCommand: /bin/migrate up
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: onefortythree-db
+          property: connectionString
+      - key: PORT
+        value: "8080"
+      - key: LOG_LEVEL
+        value: info
+      - key: MODE
+        value: all
+      - key: BASE_URL
+        sync: false # Set to your API URL after first deploy
+      - key: FRONTEND_URL
+        sync: false # Set to your frontend URL after first deploy
+      - key: CORS_ALLOWED_ORIGINS
+        sync: false # Set to your frontend URL after first deploy
+      - key: SESSION_SECRET
+        generateValue: true
+      - key: ENCRYPTION_MASTER_KEY
+        generateValue: true
+      # ── GitHub OAuth ──
+      - key: GITHUB_OAUTH_CLIENT_ID
+        sync: false
+      - key: GITHUB_OAUTH_CLIENT_SECRET
+        sync: false
+      # ── GitHub App ──
+      - key: GITHUB_APP_ID
+        sync: false
+      - key: GITHUB_APP_PRIVATE_KEY
+        sync: false
+      - key: GITHUB_WEBHOOK_SECRET
+        sync: false
+      # ── LLM ──
+      - key: LLM_MODEL
+        value: claude-sonnet-4-5
+      - key: ANTHROPIC_API_KEY
+        sync: false
+
+  # ── Next.js Frontend ───────────────────────────────────────────────
+  - type: web
+    name: onefortythree-web
+    runtime: node
+    plan: starter
+    region: oregon
+    rootDir: frontend
+    buildCommand: npm install && npm run build
+    startCommand: npm run start
+    envVars:
+      - key: API_PROXY_TARGET
+        sync: false # Set to your API's URL (e.g. https://onefortythree-api.onrender.com)
+      - key: NODE_ENV
+        value: production


### PR DESCRIPTION
## Summary
This PR adds infrastructure-as-code configuration for deploying the 143.dev application to Render, along with Node.js version specification for the frontend.

## Key Changes
- **Added `render.yaml`**: Complete Render Blueprint defining the deployment infrastructure including:
  - PostgreSQL 17 database (starter plan) in Oregon region
  - Go API service with Docker runtime, health checks, and database migrations
  - Next.js frontend service with Node.js runtime
  - Environment variables for GitHub OAuth, GitHub App integration, LLM configuration, and security keys
  - Instructions for initial setup and post-deployment configuration
  
- **Updated `frontend/package.json`**: Added Node.js engine requirement (`>=22`) to ensure compatibility with the deployment environment

## Notable Details
- The Blueprint includes auto-generated secrets for `SESSION_SECRET` and `ENCRYPTION_MASTER_KEY`
- Several environment variables are marked with `sync: false` to be manually configured after initial deployment (API URLs, OAuth credentials, GitHub App keys, Anthropic API key)
- Pre-deploy migration command is configured to run database migrations automatically
- Both services are configured for the Oregon region with starter-tier plans

https://claude.ai/code/session_01VqrnNTmizVVH6Dsnep4NoS