### PR TITLE
Update Render Postgres to flexible plan (basic-256mb)

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,8 @@
 
 databases:
   - name: onefortythree-db
-    plan: starter
+    plan: basic-256mb
+    diskSizeGB: 1
     databaseName: onefortythree
     user: onefortythree
     region: oregon


### PR DESCRIPTION
Legacy plan names like 'starter' are no longer supported for new databases on Render. Switch to the new flexible plan format with independent compute and storage sizing.

https://claude.ai/code/session_01VqrnNTmizVVH6Dsnep4NoS