### PR TITLE
Add P-80 Shooting Star easter egg to console on app load

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,7 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ErrorBoundary } from "@/components/error-boundary";
 
 export default function RootLayout({
@@ -12,6 +12,47 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   const [queryClient] = useState(() => new QueryClient());
+
+  useEffect(() => {
+    // ── P-80 Shooting Star easter egg ──────────────────────────────────────────
+    // Top-down silhouette: nose (top), straight wings, torpedo wingtip tanks,
+    // bubble canopy, and H-tail — just like the canvas on the landing page.
+    const art = [
+      '                         *',
+      '                        /|\\',
+      '                       / | \\',
+      '        ______________/  |  \\______________',
+      '       /               ( ^ )               \\',
+      '      /                                     \\',
+      '=====/                                       \\=====',
+      '      \\                                     /',
+      '       \\______________       ______________/',
+      '                      \\     /',
+      '                       \\   /',
+      '                        | |',
+      '                       _| |_',
+      '                      / | | \\',
+      '                     /  | |  \\',
+    ].join('\n');
+
+    console.log(
+      '%c' + art,
+      'color:#d2dae6;font-family:monospace;font-size:11px;line-height:1.5'
+    );
+    console.log(
+      '%c  XP-80 Shooting Star  %c  Built in 143 days  ',
+      'color:#d2dae6;background:#08080f;padding:3px 8px;font-family:monospace;font-weight:bold;letter-spacing:1px',
+      'color:#ffd700;background:#08080f;padding:3px 8px;font-family:monospace;letter-spacing:1px'
+    );
+    console.log(
+      '%c  "Be quick, be quiet, be on time."  ',
+      'color:#ffd700;font-family:monospace;font-style:italic;font-size:13px;padding:4px 0;letter-spacing:0.5px'
+    );
+    console.log(
+      '%c  — Kelly Johnson, Skunk Works',
+      'color:#555555;font-family:monospace;font-size:11px;padding-bottom:4px'
+    );
+  }, []);
 
   return (
     <html lang="en">

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -40,17 +40,12 @@ export default function RootLayout({
       'color:#d2dae6;font-family:monospace;font-size:11px;line-height:1.5'
     );
     console.log(
-      '%c  XP-80 Shooting Star  %c  Built in 143 days  ',
-      'color:#d2dae6;background:#08080f;padding:3px 8px;font-family:monospace;font-weight:bold;letter-spacing:1px',
-      'color:#ffd700;background:#08080f;padding:3px 8px;font-family:monospace;letter-spacing:1px'
+      '%c  143 days  ',
+      'color:#ffd700;background:#08080f;padding:3px 8px;font-family:monospace;letter-spacing:2px'
     );
     console.log(
-      '%c  "Be quick, be quiet, be on time."  ',
-      'color:#ffd700;font-family:monospace;font-style:italic;font-size:13px;padding:4px 0;letter-spacing:0.5px'
-    );
-    console.log(
-      '%c  — Kelly Johnson, Skunk Works',
-      'color:#555555;font-family:monospace;font-size:11px;padding-bottom:4px'
+      '%cBe quick, be quiet, be on time.',
+      'color:#555555;font-family:monospace;font-style:italic;font-size:11px;letter-spacing:0.5px'
     );
   }, []);
 


### PR DESCRIPTION
## Summary
Added a console easter egg that displays ASCII art of a P-80 Shooting Star aircraft along with a cryptic message when the app loads.

## Changes
- Imported `useEffect` hook in addition to existing `useState`
- Added `useEffect` hook in `RootLayout` component that runs once on mount
- Displays styled ASCII art of a P-80 Shooting Star (top-down silhouette) in the browser console
- Includes two additional console messages:
  - A gold-colored "143 days" counter with dark background
  - A gray italicized message: "Be quick, be quiet, be on time."
- All console output uses custom styling with monospace font and specific colors

## Implementation Details
- The easter egg uses `console.log()` with CSS styling via the `%c` directive
- The aircraft ASCII art matches the design referenced on the landing page
- The effect has an empty dependency array, ensuring it runs only once when the component mounts
- No functional changes to the app's behavior or rendering

https://claude.ai/code/session_01XdqhpkbVix1hUQJ8DJYyh7