### PR TITLE
Add native dev mode and improve Docker Compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit
+.PHONY: dev dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -12,6 +12,32 @@ dev:
 		exit 1; \
 	fi; \
 	docker compose up --build
+
+# Run the full stack natively without Docker — lowest resource footprint.
+# Requires Go, Node.js, and PostgreSQL installed locally (run: make setup first).
+# Run each command in a separate terminal:
+#   Terminal 1: make server-dev
+#   Terminal 2: make frontend-dev
+dev-local:
+	@echo "Run each of the following in a separate terminal:"
+	@echo ""
+	@echo "  Terminal 1 (backend):  make server-dev"
+	@echo "  Terminal 2 (frontend): make frontend-dev"
+	@echo ""
+	@echo "Both processes write to stdout in their own terminal."
+	@echo "Prerequisites: Go, Node.js, PostgreSQL (run 'make setup' first)."
+
+# Run only the Next.js frontend, proxying API calls to a remote backend.
+# Useful on low-resource machines or when you only need to work on the UI.
+# Usage: REMOTE_API_URL=https://staging.example.com make dev-frontend-only
+dev-frontend-only:
+	@if [ -z "$(REMOTE_API_URL)" ]; then \
+		echo "Error: REMOTE_API_URL is required."; \
+		echo ""; \
+		echo "Usage: REMOTE_API_URL=https://your-backend.example.com make dev-frontend-only"; \
+		exit 1; \
+	fi
+	cd frontend && API_PROXY_TARGET=$(REMOTE_API_URL) npm run dev
 
 setup:
 	./setup.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - .:/app
       - go_mod_cache:/go/pkg/mod
       - go_build_cache:/root/.cache/go-build
+      - go_bin_cache:/go/bin  # cache compiled binaries (e.g. air) across restarts
     deploy:
       resources:
         limits:
@@ -53,17 +54,32 @@ services:
   frontend:
     image: node:22-alpine
     working_dir: /app
-    command: sh -c "npm install && npm run dev"
+    # npm ci is faster than npm install and uses package-lock.json exactly.
+    # The node_modules volume persists packages across restarts so subsequent
+    # starts only verify the lockfile rather than re-downloading everything.
+    command: sh -c "npm ci && npm run dev"
     depends_on:
       - server
     environment:
       API_PROXY_TARGET: http://server:8080
+      NODE_ENV: development
+      # Cap the Node.js V8 heap so the process doesn't expand to fill all
+      # available container memory before triggering GC.
+      NODE_OPTIONS: "--max-old-space-size=512"
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     volumes:
       - ./frontend:/app
+      - frontend_node_modules:/app/node_modules  # persist node_modules across restarts
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "2.0"
 
 volumes:
   pgdata:
   go_mod_cache:
   go_build_cache:
+  go_bin_cache:            # persists compiled Go tool binaries (air, etc.)
+  frontend_node_modules:   # persists node_modules between container restarts


### PR DESCRIPTION
## Summary
This PR adds a new native development mode for running the full stack without Docker, improves the existing Docker Compose setup with better caching and resource management, and introduces a frontend-only development mode for working on the UI with a remote backend.

## Key Changes

- **New `dev-local` target**: Allows running the backend and frontend natively on the host machine without Docker. Requires Go, Node.js, and PostgreSQL to be installed locally. Instructions guide users to run backend and frontend in separate terminals.

- **New `dev-frontend-only` target**: Enables frontend-only development by proxying API calls to a remote backend via the `REMOTE_API_URL` environment variable. Useful for low-resource machines or when focusing solely on UI work.

- **Docker Compose improvements**:
  - Added `go_bin_cache` volume to persist compiled Go tool binaries (e.g., `air`) across container restarts
  - Changed frontend from `npm install` to `npm ci` for faster, more reliable dependency installation using `package-lock.json`
  - Added `frontend_node_modules` volume to persist `node_modules` across container restarts, avoiding re-downloads
  - Added memory and CPU limits to the frontend service (1G memory, 2.0 CPUs)
  - Added `NODE_ENV=development` and `NODE_OPTIONS` heap size limit (512MB) to the frontend service for better resource management

## Implementation Details

- The `dev-local` target is informational and guides users to run `make server-dev` and `make frontend-dev` in separate terminals
- The `dev-frontend-only` target validates that `REMOTE_API_URL` is provided before proceeding, with helpful error messaging
- Docker Compose volume caching improvements reduce startup times and resource usage for iterative development
- Frontend memory constraints prevent unbounded heap growth in containerized environments

https://claude.ai/code/session_019oS2qqtQ7HZZQGtYCB8psM