### PR TITLE
Align modal actions and document pattern

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,23 @@
+# Frontend AGENTS Guide
+
+This file applies to the entire `frontend/` tree.
+
+## UI Patterns
+
+### Modal action layout
+
+- Keep modal actions on a single horizontal row in the footer.
+- In left-to-right layouts, place `Cancel` on the left and the primary action on the right.
+- For retry-style flows, use `Cancel` (secondary/outline) on the left and `Try Again` (primary) on the right.
+- Do not split related modal actions across different vertical sections/heights.
+
+### Dialog consistency
+
+- Follow the same action ordering across custom modals and shadcn `AlertDialog` flows.
+- Prefer using a shared footer pattern (`flex items-center justify-end gap-2`) for custom modals.
+- Keep button sizing/variants consistent with nearby app dialogs unless product requirements explicitly differ.
+
+### Design rationale
+
+- This aligns with common modern AI app UX patterns: dismissive actions first (left), confirm/proceed actions second (right) in LTR interfaces.
+- Consistent placement reduces misclicks and improves scanability across the app.

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -171,7 +171,13 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
     });
 
-    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+
+    expect(cancelButton).toBeInTheDocument();
+    expect(tryAgainButton).toBeInTheDocument();
+    expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
+    expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it('renders the expires timer text in the modal', async () => {

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -96,13 +96,15 @@ function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void
         )}
         {status === "completed" && <div className="mt-4"><p className="text-sm font-medium text-green-600">Connected successfully!</p></div>}
         {(status === "error" || status === "expired") && (
-          <div className="mt-4 space-y-3">
+          <div className="mt-4">
             <p className="text-sm text-destructive">{error}</p>
-            <Button size="sm" onClick={startAuth}>Try Again</Button>
           </div>
         )}
-        <div className="mt-6 flex justify-end">
+        <div className="mt-6 flex items-center justify-end gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>{status === "completed" ? "Done" : "Cancel"}</Button>
+          {(status === "error" || status === "expired") && (
+            <Button size="sm" onClick={startAuth}>Try Again</Button>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -263,6 +263,12 @@ describe('SettingsPage', () => {
     await user.click(btn);
 
     expect(await screen.findByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Try Again' })).toBeInTheDocument();
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+
+    expect(cancelButton).toBeInTheDocument();
+    expect(tryAgainButton).toBeInTheDocument();
+    expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
+    expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -217,18 +217,20 @@ function DeviceCodeModal({ onClose }: { onClose: () => void }) {
         )}
 
         {(status === "error" || status === "expired") && (
-          <div className="mt-4 space-y-3">
+          <div className="mt-4">
             <p className="text-sm text-destructive">{error}</p>
-            <Button size="sm" onClick={startAuth}>
-              Try Again
-            </Button>
           </div>
         )}
 
-        <div className="mt-6 flex justify-end">
+        <div className="mt-6 flex items-center justify-end gap-2">
           <Button variant="outline" size="sm" onClick={onClose}>
             {status === "completed" ? "Done" : "Cancel"}
           </Button>
+          {(status === "error" || status === "expired") && (
+            <Button size="sm" onClick={startAuth}>
+              Try Again
+            </Button>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Summary
- move the auth modal buttons into a single horizontal footer row with Cancel on the left and Try Again on the right for both dashboard overview and settings modals
- add frontend/AGENTS.md documenting the modal action layout pattern (Cancel left, primary right, consistent footer)
- tighten tests to assert modal buttons share a container and order correctly when an error happens

Testing
- Not run (not requested)