### PR TITLE
Ensure handler errors are logged with context

### DIFF
--- a/internal/api/AGENTS.md
+++ b/internal/api/AGENTS.md
@@ -1,0 +1,13 @@
+## API Error Response Pattern
+
+- Use `writeError` from `internal/api/handlers/helpers.go` for handler errors.
+- Return the standard `models.ErrorResponse` shape: `{ "error": { "code", "message", "details" } }`.
+- Always provide a stable machine-readable error `code` and a user-safe `message`.
+- Do not return raw internal errors to clients.
+- When adding new handlers, keep errors JSON and consistent so middleware logging can extract `error.code` and `error.message` for 5xx responses.
+
+## Status Code Guidance
+
+- Use 4xx for caller/input/auth/permission problems.
+- Use 5xx for internal/server dependency failures.
+- For 5xx responses, include a specific error code (for example `AUTH_INITIATE_FAILED`) and a user-safe message.

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -1,20 +1,42 @@
 package middleware
 
 import (
+	"encoding/json"
 	"net/http"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/rs/zerolog"
 )
 
 type responseWriter struct {
 	http.ResponseWriter
-	status int
+	status        int
+	errorResponse *models.ErrorResponse
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
 	rw.status = code
 	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	rw.captureErrorDetails(b)
+	return rw.ResponseWriter.Write(b)
+}
+
+func (rw *responseWriter) captureErrorDetails(responseBody []byte) {
+	if rw.status < http.StatusInternalServerError {
+		return
+	}
+
+	var response models.ErrorResponse
+	if err := json.Unmarshal(responseBody, &response); err != nil {
+		return
+	}
+
+	rw.errorResponse = &response
 }
 
 func Logging(logger zerolog.Logger) func(http.Handler) http.Handler {
@@ -23,12 +45,31 @@ func Logging(logger zerolog.Logger) func(http.Handler) http.Handler {
 			start := time.Now()
 			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r)
-			logger.Info().
+
+			logEvent := logger.Info()
+			if rw.status >= http.StatusInternalServerError {
+				logEvent = logger.Error()
+			}
+
+			logEvent.
 				Str("method", r.Method).
 				Str("path", r.URL.Path).
+				Str("request_id", chiMiddleware.GetReqID(r.Context())).
 				Int("status", rw.status).
-				Dur("duration", time.Since(start)).
-				Msg("request")
+				Dur("duration", time.Since(start))
+
+			if rw.status >= http.StatusInternalServerError {
+				if rw.errorResponse != nil && rw.errorResponse.Error.Code != "" {
+					logEvent = logEvent.Str("error_code", rw.errorResponse.Error.Code)
+				}
+				if rw.errorResponse != nil && rw.errorResponse.Error.Message != "" {
+					logEvent = logEvent.Str("error_message", rw.errorResponse.Error.Message)
+				}
+				logEvent.Msg("request failed")
+				return
+			}
+
+			logEvent.Msg("request")
 		})
 	}
 }

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -59,6 +61,72 @@ func TestLogging(t *testing.T) {
 			require.Equal(t, tt.expectedCode, w.Code, "should return expected HTTP status code")
 			if tt.expectedBody != "" {
 				require.Equal(t, tt.expectedBody, w.Body.String(), "should return expected response body")
+			}
+		})
+	}
+}
+
+func TestLogging_ErrorResponsesAreLoggedAtErrorLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                 string
+		handler              http.HandlerFunc
+		expectedLevel        string
+		expectedErrorCode    string
+		expectedErrorMessage string
+	}{
+		{
+			name: "500 response logs error details",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":{"code":"AUTH_INITIATE_FAILED","message":"failed to initiate device auth"}}`))
+			},
+			expectedLevel:        "error",
+			expectedErrorCode:    "AUTH_INITIATE_FAILED",
+			expectedErrorMessage: "failed to initiate device auth",
+		},
+		{
+			name: "200 response stays info level",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			},
+			expectedLevel: "info",
+		},
+		{
+			name: "500 non-json response still logs as error",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte("internal server error"))
+			},
+			expectedLevel: "error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logBuffer bytes.Buffer
+			logger := zerolog.New(&logBuffer)
+			handler := Logging(logger)(tt.handler)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/settings/codex-auth/initiate", nil)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			var logEvent map[string]any
+			require.NoError(t, json.Unmarshal(logBuffer.Bytes(), &logEvent), "logging middleware should emit valid JSON log event")
+			require.Equal(t, tt.expectedLevel, logEvent["level"], "logging middleware should use expected log level")
+
+			if tt.expectedErrorCode != "" {
+				require.Equal(t, tt.expectedErrorCode, logEvent["error_code"], "logging middleware should include API error code for 5xx responses")
+			}
+			if tt.expectedErrorMessage != "" {
+				require.Equal(t, tt.expectedErrorMessage, logEvent["error_message"], "logging middleware should include API error message for 5xx responses")
 			}
 		})
 	}


### PR DESCRIPTION
Summary
- teach logging middleware to capture 5xx responses, downgrade them to error level, and emit any structured API error code/message we returned
- propagate request ID into all logs and keep normal requests logged at info level
- document the internal API error response pattern in `internal/api/AGENTS.md`

Testing
- Not run (not requested)