### PR TITLE
Add team navigation entry to user menu

### DIFF
--- a/docs/design/03-frontend.md
+++ b/docs/design/03-frontend.md
@@ -57,6 +57,8 @@ Settings        — "How is the system configured?"
 
 **Why 6, not 8:** Pull Requests were removed as a standalone page. PRs are a stage in a run's lifecycle (not a separate concept), so they appear as a tab on the run detail page.
 
+**User menu navigation:** Team management and organization-level settings are available from the bottom-left user dropdown. Team is a separate destination from organization settings to keep membership workflows distinct from configuration workflows.
+
 Deploy-impact experiments are shown inline on the run detail page's PR & Validation tab (where they contextually belong). Agent config experiments live under Settings > Experiments (they're a configuration concern, not a standalone workflow).
 
 ### Keyboard Navigation
@@ -83,8 +85,10 @@ frontend/
 │   │   │   └── page.tsx              # failure analytics dashboard
 │   │   ├── costs/
 │   │   │   └── page.tsx              # cost summary, budget, forecast, ROI
+│   │   ├── team/
+│   │   │   └── page.tsx              # team members, roles, invitations
 │   │   ├── settings/
-│   │   │   ├── page.tsx              # general settings + integrations
+│   │   │   ├── page.tsx              # organization settings + integrations
 │   │   │   ├── agents/
 │   │   │   │   └── page.tsx          # agent config, execution strategy
 │   │   │   ├── experiments/

--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -7,20 +7,20 @@ vi.mock('next/navigation', () => ({
 }));
 
 describe('SettingsLayout', () => {
-  it('renders Settings header and navigation tabs', () => {
+  it('renders organization settings header without team tab', () => {
     renderWithProviders(
       <SettingsLayout>
         <div>child content</div>
       </SettingsLayout>
     );
 
-    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByText('Organization Settings')).toBeInTheDocument();
     expect(screen.getByText('General')).toBeInTheDocument();
-    expect(screen.getByText('Team')).toBeInTheDocument();
+    expect(screen.queryByText('Team')).not.toBeInTheDocument();
     expect(screen.getByText('child content')).toBeInTheDocument();
   });
 
-  it('renders tab links with correct hrefs', () => {
+  it('renders only the general tab link', () => {
     renderWithProviders(
       <SettingsLayout>
         <div />
@@ -28,9 +28,8 @@ describe('SettingsLayout', () => {
     );
 
     const generalLink = screen.getByRole('link', { name: 'General' });
-    const teamLink = screen.getByRole('link', { name: 'Team' });
 
     expect(generalLink).toHaveAttribute('href', '/settings');
-    expect(teamLink).toHaveAttribute('href', '/settings/team');
+    expect(screen.queryByRole('link', { name: 'Team' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -7,7 +7,6 @@ import { PageHeader } from "@/components/page-header";
 
 const settingsTabs = [
   { label: "General", href: "/settings" },
-  { label: "Team", href: "/settings/team" },
 ];
 
 export default function SettingsLayout({
@@ -20,8 +19,8 @@ export default function SettingsLayout({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Settings"
-        description="Manage your organization, team, and integrations."
+        title="Organization Settings"
+        description="Manage your organization and integrations."
       />
       <nav className="flex gap-1 border-b border-border">
         {settingsTabs.map((tab) => {

--- a/frontend/src/app/(dashboard)/team/page.tsx
+++ b/frontend/src/app/(dashboard)/team/page.tsx
@@ -1,5 +1,14 @@
-import { redirect } from "next/navigation";
+import TeamSettingsPage from "../settings/team/page";
+import { PageHeader } from "@/components/page-header";
 
-export default function TeamPageRedirect() {
-  redirect("/settings/team");
+export default function TeamPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Team"
+        description="Manage members, roles, and invitations for your organization."
+      />
+      <TeamSettingsPage />
+    </div>
+  );
 }

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { AuthenticatedLayout } from "./authenticated-layout";
+
+const { pushMock, replaceMock, logoutMock } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  replaceMock: vi.fn(),
+  logoutMock: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/overview",
+  useRouter: () => ({
+    push: pushMock,
+    replace: replaceMock,
+  }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: {
+      id: "user-1",
+      name: "Alex Doe",
+      email: "alex@example.com",
+      role: "admin",
+    },
+    isLoading: false,
+    isAuthenticated: true,
+    logout: logoutMock,
+  }),
+}));
+
+describe("AuthenticatedLayout", () => {
+  it("shows Team and organization settings entries in the user menu", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
+
+    expect(screen.getByRole("menuitem", { name: "Team" })).toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Organization Settings" })).toBeInTheDocument();
+  });
+
+  it("routes to Team and organization settings from the user menu", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
+    await user.click(screen.getByRole("menuitem", { name: "Team" }));
+
+    expect(pushMock).toHaveBeenCalledWith("/team");
+
+    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
+    await user.click(screen.getByRole("menuitem", { name: "Organization Settings" }));
+
+    expect(pushMock).toHaveBeenCalledWith("/settings");
+  });
+});

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -40,10 +40,10 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
+    await user.click(screen.getByRole("button", { name: /Alex Doe/ }));
 
-    expect(screen.getByRole("menuitem", { name: "Team" })).toBeInTheDocument();
-    expect(screen.getByRole("menuitem", { name: "Organization Settings" })).toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: "Team" })).toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: "Organization Settings" })).toBeInTheDocument();
   });
 
   it("routes to Team and organization settings from the user menu", async () => {
@@ -55,13 +55,13 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
-    await user.click(screen.getByRole("menuitem", { name: "Team" }));
+    await user.click(screen.getByRole("button", { name: /Alex Doe/ }));
+    await user.click(await screen.findByRole("menuitem", { name: "Team" }));
 
     expect(pushMock).toHaveBeenCalledWith("/team");
 
-    await user.click(screen.getByRole("button", { name: "Alex Doe" }));
-    await user.click(screen.getByRole("menuitem", { name: "Organization Settings" }));
+    await user.click(screen.getByRole("button", { name: /Alex Doe/ }));
+    await user.click(await screen.findByRole("menuitem", { name: "Organization Settings" }));
 
     expect(pushMock).toHaveBeenCalledWith("/settings");
   });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -7,6 +7,7 @@ import {
   BarChart3,
   DollarSign,
   Settings,
+  Users,
   LogOut,
   ChevronsUpDown,
   ClipboardList,
@@ -126,7 +127,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
                 <button
                   className={cn(
                     "flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors",
-                    pathname.startsWith("/settings")
+                    pathname.startsWith("/settings") || pathname.startsWith("/team")
                       ? "bg-sidebar-accent text-sidebar-accent-foreground"
                       : "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                   )}
@@ -147,9 +148,13 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" side="top" className="w-48">
+                <DropdownMenuItem onClick={() => router.push("/team")}>
+                  <Users className="h-4 w-4" />
+                  Team
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/settings")}>
                   <Settings className="h-4 w-4" />
-                  Settings
+                  Organization Settings
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={logout}>


### PR DESCRIPTION
Summary
- align layout copy with organization vs. team settings so the tabs describe what lives under each section
- wire the authenticated layout user menu to surface Team and Organization Settings entries pointing to the new paths
- add coverage for the authenticated layout menu behavior and document the navigation change in the frontend design doc

Testing
- Not run (not requested)