### PR TITLE
Add dedicated agent settings modal and sync with settings experience

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -484,6 +484,13 @@ The main 143.dev container includes:
     - Sentry: Issue webhooks as well as retrieval of issues via the API. Also linkage of issues to Github PRs in the PR body.
     - Linear: Webhooks and retrieval of issues via the API. Also linkage of issues to Github PRs in the PR title.
 
+# Dashboard onboarding UX
+
+- The Overview dashboard keeps users in setup context when configuring coding agents.
+- In the "Connect your coding agent" card, the **Settings** action opens an in-place modal for common agent edits (default agent selection and provider credentials).
+- The modal includes a secondary path to advanced agent settings at `/settings/agents` for deeper configuration.
+- The UX goal is fast in-flow completion first, with a clear handoff to advanced controls when needed.
+
 # **Why 143?**
 
 The name comes from the XP-80 Shooting Star project. In 1943, a small team at Lockheed Skunk Works designed and built the first US jet fighter in exactly **143 days**. They did it by killing the bureaucracy and giving a small, autonomous team the freedom to execute.

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -2,7 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderWithProviders, screen, waitFor, userEvent } from '@/test/test-utils';
 import Overview from './page';
 
-const { loginMock, sentryLoginMock, codexStatusMock, codexInitiateMock } = vi.hoisted(() => ({
+const {
+  loginMock,
+  sentryLoginMock,
+  codexStatusMock,
+  codexInitiateMock,
+  settingsGetMock,
+  settingsUpdateMock,
+  agentDefaultsMock,
+} = vi.hoisted(() => ({
   loginMock: vi.fn(),
   sentryLoginMock: vi.fn(),
   codexStatusMock: vi.fn().mockResolvedValue({ data: { status: 'pending' } }),
@@ -13,6 +21,17 @@ const { loginMock, sentryLoginMock, codexStatusMock, codexInitiateMock } = vi.ho
       expires_in: 900,
     },
   }),
+  settingsGetMock: vi.fn().mockResolvedValue({
+    data: {
+      name: 'Test Org',
+      settings: {
+        default_agent_type: 'codex',
+        agent_config: {},
+      },
+    },
+  }),
+  settingsUpdateMock: vi.fn().mockResolvedValue({ data: {} }),
+  agentDefaultsMock: vi.fn().mockResolvedValue({ data: {} }),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -25,6 +44,11 @@ vi.mock('@/lib/api', () => ({
       status: codexStatusMock,
       initiate: codexInitiateMock,
     },
+    settings: {
+      get: settingsGetMock,
+      update: settingsUpdateMock,
+      getAgentDefaults: agentDefaultsMock,
+    },
   },
 }));
 
@@ -34,6 +58,9 @@ describe('OverviewPage', () => {
     sentryLoginMock.mockReset();
     codexStatusMock.mockClear();
     codexStatusMock.mockResolvedValue({ data: { status: 'pending' } });
+    settingsGetMock.mockClear();
+    settingsUpdateMock.mockClear();
+    agentDefaultsMock.mockClear();
   });
 
   it('starts GitHub onboarding directly from the dashboard', async () => {
@@ -71,8 +98,36 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Connect your coding agent')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute('href', '/settings');
+    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('opens agent settings modal from setup card and saves updates', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Overview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit agent settings')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('For gpt-5.3-codex model access.')).toBeInTheDocument();
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText('Model'));
+    await user.type(screen.getByLabelText('Model'), 'codex-mini');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getByRole('link', { name: 'Open advanced agent settings' })).toHaveAttribute('href', '/settings/agents');
   });
 
   it('shows the AgentSetupCard as connected when auth status is completed', async () => {

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageHeader } from "@/components/page-header";
 import { IntegrationsCard } from "@/components/integrations-card";
+import { AgentSettingsEditor } from "@/components/agent-settings-editor";
 import { INTEGRATIONS } from "@/lib/integrations";
 import type { CodexAuthStatus, CodexDeviceAuth } from "@/lib/types";
 
@@ -111,9 +112,25 @@ function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void
   );
 }
 
+function AgentSettingsModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-2xl rounded-lg border bg-background p-6 shadow-lg">
+        <AgentSettingsEditor
+          title="Edit agent settings"
+          description="Update your default coding agent and auth credentials without leaving setup."
+          showAdvancedLink
+          onClose={onClose}
+        />
+      </div>
+    </div>
+  );
+}
+
 function AgentSetupCard() {
   const [authStatus, setAuthStatus] = useState<CodexAuthStatus | null>(null);
   const [showModal, setShowModal] = useState(false);
+  const [showSettingsModal, setShowSettingsModal] = useState(false);
 
   const fetchStatus = useCallback(() => {
     api.codexAuth.status().then((res) => setAuthStatus(res.data)).catch(() => {});
@@ -149,9 +166,7 @@ function AgentSetupCard() {
           </div>
           <div className="flex shrink-0 gap-2">
             <Button size="sm" onClick={() => setShowModal(true)}>Sign in with ChatGPT</Button>
-            <a href="/settings">
-              <Button size="sm" variant="outline">Settings</Button>
-            </a>
+            <Button size="sm" variant="outline" onClick={() => setShowSettingsModal(true)}>Settings</Button>
           </div>
         </CardContent>
       </Card>
@@ -160,6 +175,9 @@ function AgentSetupCard() {
           onClose={() => setShowModal(false)}
           onConnected={() => { setShowModal(false); fetchStatus(); }}
         />
+      )}
+      {showSettingsModal && (
+        <AgentSettingsModal onClose={() => setShowSettingsModal(false)} />
       )}
     </>
   );

--- a/frontend/src/app/(dashboard)/settings/agents/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/page.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '@/test/test-utils';
+import AgentSettingsPage from './page';
+
+const {
+  settingsGetMock,
+  settingsUpdateMock,
+  agentDefaultsMock,
+} = vi.hoisted(() => ({
+  settingsGetMock: vi.fn().mockResolvedValue({
+    data: {
+      name: 'Test Org',
+      settings: {
+        default_agent_type: 'codex',
+        agent_config: {},
+      },
+    },
+  }),
+  settingsUpdateMock: vi.fn().mockResolvedValue({ data: {} }),
+  agentDefaultsMock: vi.fn().mockResolvedValue({ data: {} }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    settings: {
+      get: settingsGetMock,
+      update: settingsUpdateMock,
+      getAgentDefaults: agentDefaultsMock,
+    },
+  },
+}));
+
+describe('AgentSettingsPage', () => {
+  beforeEach(() => {
+    settingsGetMock.mockClear();
+    settingsUpdateMock.mockClear();
+    agentDefaultsMock.mockClear();
+  });
+
+  it('renders agent settings and saves changes', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AgentSettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Advanced agent settings')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+
+    await user.clear(screen.getByLabelText('Model'));
+    await user.type(screen.getByLabelText('Model'), 'codex-mini');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/agents/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agents/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+import { AgentSettingsEditor } from "@/components/agent-settings-editor";
+
+export default function AgentSettingsPage() {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-[13px] font-medium text-foreground">Agent Setup</h2>
+      <Card>
+        <CardContent>
+          <AgentSettingsEditor
+            title="Advanced agent settings"
+            description="Configure your default agent and provider credentials for your organization."
+          />
+        </CardContent>
+      </Card>
+    </section>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -138,38 +138,15 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('renders the Agent Setup section with agent type options', async () => {
+  it('does not render Agent Setup on general settings page', async () => {
     renderWithProviders(<SettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Agent Setup')).toBeInTheDocument();
+      expect(screen.getByText('General')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Codex')).toBeInTheDocument();
-    expect(screen.getByText('Claude Code')).toBeInTheDocument();
-    expect(screen.getByText('Gemini CLI')).toBeInTheDocument();
-  });
-
-  it('shows ChatGPT sign-in when Codex is selected and not connected', async () => {
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Recommended')).toBeInTheDocument();
-  });
-
-  it('shows Connected status when ChatGPT OAuth is completed', async () => {
-    codexStatusMock.mockResolvedValue({ data: { status: 'completed' } });
-
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Connected')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Disconnect')).toBeInTheDocument();
+    expect(screen.getByText('Agent Setup')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open Agent Settings' })).toHaveAttribute('href', '/settings/agents');
   });
 
   it('renders the Agent Execution section with autonomy options', async () => {
@@ -219,7 +196,7 @@ describe('SettingsPage', () => {
     });
 
     expect(screen.getByText('Prioritization')).toBeInTheDocument();
-    expect(screen.getByText('Other Agent Configuration')).toBeInTheDocument();
+    expect(screen.getByText('PM Agent')).toBeInTheDocument();
   });
 
   it('calls settings update on save', async () => {
@@ -237,56 +214,6 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('renders API Key section for selected agent', async () => {
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getAllByText('API Key').length).toBeGreaterThanOrEqual(1);
-    });
-  });
-
-  it('opens device code modal when Sign in with ChatGPT button is clicked', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<SettingsPage />);
-
-    const btn = await screen.findByRole('button', { name: 'Sign in with ChatGPT' });
-    await user.click(btn);
-
-    expect(await screen.findByText('Connect your ChatGPT account')).toBeInTheDocument();
-
-    // Wait for device code to appear after async initiation
-    expect(await screen.findByText('TEST-1234')).toBeInTheDocument();
-    expect(screen.getByText('https://auth.openai.com/codex/device')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
-  });
-
-  it('shows Disconnect button when connected and calls disconnect on click', async () => {
-    codexStatusMock.mockResolvedValue({ data: { status: 'completed' } });
-    const user = userEvent.setup();
-
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Connected')).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText('Disconnect'));
-
-    await waitFor(() => {
-      expect(codexDisconnectMock).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it('renders model and base URL fields for selected agent', async () => {
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Model')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Base URL')).toBeInTheDocument();
-  });
-
   it('renders Max Concurrent Runs input', async () => {
     renderWithProviders(<SettingsPage />);
 
@@ -295,23 +222,19 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('shows error state in device code modal when initiation fails', async () => {
-    codexInitiateMock.mockRejectedValueOnce(new Error('fail'));
+  it('renders PM model input in advanced settings', async () => {
     const user = userEvent.setup();
-
     renderWithProviders(<SettingsPage />);
 
-    const btn = await screen.findByRole('button', { name: 'Sign in with ChatGPT' });
-    await user.click(btn);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Advanced Settings' })).toBeInTheDocument();
+    });
 
-    expect(await screen.findByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
-    const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+    await user.click(screen.getByRole('button', { name: 'Advanced Settings' }));
 
-    expect(cancelButton).toBeInTheDocument();
-    expect(tryAgainButton).toBeInTheDocument();
-    expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
-    expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByLabelText('PM Model')).toBeInTheDocument();
+    });
   });
 
   it('syncs server settings into form state on load', async () => {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState } from "react";
+import Link from "next/link";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -14,43 +15,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Slider } from "@/components/ui/slider";
 import { IntegrationsCard } from "@/components/integrations-card";
 import { INTEGRATIONS } from "@/lib/integrations";
-import type { Organization, OrgSettings, SingleResponse, CodexDeviceAuth } from "@/lib/types";
-
-interface AgentEnvVar {
-  name: string;
-  label: string;
-  sensitive?: boolean;
-  placeholder?: string;
-}
-
-const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
-  {
-    key: "codex",
-    label: "Codex",
-    envVars: [
-      { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
-      { name: "OPENAI_MODEL", label: "Model", placeholder: "e.g. codex-mini, o3" },
-      { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
-    ],
-  },
-  {
-    key: "claude_code",
-    label: "Claude Code",
-    envVars: [
-      { name: "ANTHROPIC_API_KEY", label: "API Key", sensitive: true },
-      { name: "ANTHROPIC_MODEL", label: "Model", placeholder: "e.g. claude-sonnet-4-5, opus" },
-      { name: "ANTHROPIC_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
-    ],
-  },
-  {
-    key: "gemini_cli",
-    label: "Gemini CLI",
-    envVars: [
-      { name: "GEMINI_API_KEY", label: "API Key", sensitive: true },
-      { name: "GEMINI_MODEL", label: "Model", placeholder: "e.g. gemini-2.5-pro, gemini-2.5-flash" },
-    ],
-  },
-];
+import type { Organization, OrgSettings, SingleResponse } from "@/lib/types";
 
 const DEFAULT_SETTINGS: Required<OrgSettings> = {
   autonomy_level: "manual",
@@ -80,163 +45,6 @@ const DEFAULT_SETTINGS: Required<OrgSettings> = {
   default_agent_type: "codex",
 };
 
-function DeviceCodeModal({ onClose }: { onClose: () => void }) {
-  const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
-  const [status, setStatus] = useState<string>("initiating");
-  const [error, setError] = useState<string>("");
-  const [timeLeft, setTimeLeft] = useState(0);
-  const pollRef = useRef<NodeJS.Timeout | null>(null);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const onCloseRef = useRef(onClose);
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    onCloseRef.current = onClose;
-  }, [onClose]);
-
-  const startAuth = useCallback(async () => {
-    try {
-      setStatus("initiating");
-      setError("");
-      const resp = await api.codexAuth.initiate();
-      setDeviceAuth(resp.data);
-      setTimeLeft(resp.data.expires_in);
-      setStatus("pending");
-    } catch {
-      setError("Failed to start authentication. Please try again.");
-      setStatus("error");
-    }
-  }, []);
-
-  useEffect(() => {
-    const id = setTimeout(() => {
-      void startAuth();
-    }, 0);
-    return () => clearTimeout(id);
-  }, [startAuth]);
-
-  useEffect(() => {
-    if (status !== "pending") return;
-
-    pollRef.current = setInterval(async () => {
-      try {
-        const resp = await api.codexAuth.status();
-        if (resp.data.status === "completed") {
-          setStatus("completed");
-          queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-          setTimeout(() => onCloseRef.current(), 1500);
-        } else if (resp.data.status === "expired") {
-          setStatus("expired");
-          setError("Code expired. Please try again.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        } else if (resp.data.status === "error") {
-          setStatus("error");
-          setError(resp.data.message || "Authentication failed.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        }
-      } catch {
-        // Ignore transient poll errors.
-      }
-    }, 3000);
-
-    timerRef.current = setInterval(() => {
-      setTimeLeft((t) => Math.max(0, t - 1));
-    }, 1000);
-
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [status, queryClient]);
-
-  const minutes = Math.floor(timeLeft / 60);
-  const seconds = timeLeft % 60;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
-        <h3 className="text-lg font-medium">Connect your ChatGPT account</h3>
-
-        {status === "initiating" && (
-          <p className="mt-4 text-sm text-muted-foreground">Starting authentication...</p>
-        )}
-
-        {status === "pending" && deviceAuth && (
-          <div className="mt-4 space-y-4">
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">1. Open this link:</p>
-              <a
-                href={deviceAuth.verification_uri}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-medium text-primary underline"
-              >
-                {deviceAuth.verification_uri}
-              </a>
-            </div>
-
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">2. Enter this code:</p>
-              <div className="flex items-center gap-2">
-                <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">
-                  {deviceAuth.user_code}
-                </code>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}
-                >
-                  Copy
-                </Button>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">Waiting for authentication...</p>
-              <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-1000"
-                  style={{ width: `${deviceAuth ? Math.max(0, (timeLeft / deviceAuth.expires_in) * 100) : 0}%` }}
-                />
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Expires in {minutes}:{seconds.toString().padStart(2, "0")}
-              </p>
-            </div>
-          </div>
-        )}
-
-        {status === "completed" && (
-          <div className="mt-4">
-            <p className="text-sm font-medium text-green-600">Connected successfully!</p>
-          </div>
-        )}
-
-        {(status === "error" || status === "expired") && (
-          <div className="mt-4">
-            <p className="text-sm text-destructive">{error}</p>
-          </div>
-        )}
-
-        <div className="mt-6 flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={onClose}>
-            {status === "completed" ? "Done" : "Cancel"}
-          </Button>
-          {(status === "error" || status === "expired") && (
-            <Button size="sm" onClick={startAuth}>
-              Try Again
-            </Button>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function SettingsPage() {
   const [github, sentry, linear] = INTEGRATIONS;
   const queryClient = useQueryClient();
@@ -246,19 +54,6 @@ export default function SettingsPage() {
     queryFn: () => api.settings.get(),
   });
 
-  const { data: agentDefaultsResponse } = useQuery({
-    queryKey: ["agent-defaults"],
-    queryFn: () => api.settings.getAgentDefaults(),
-  });
-  const serverAgentDefaults = agentDefaultsResponse?.data ?? {};
-
-  const { data: codexAuthStatusResp } = useQuery({
-    queryKey: ["codex-auth-status"],
-    queryFn: () => api.codexAuth.status(),
-    refetchInterval: false,
-  });
-  const codexAuthStatus = codexAuthStatusResp?.data;
-
   const { data: integrationsResp } = useQuery({
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
@@ -266,10 +61,8 @@ export default function SettingsPage() {
   const linearIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "linear" && integration.status === "active"
   );
-
   const orgSettings = (settings?.data?.settings ?? {}) as OrgSettings;
 
-  const [defaultAgentType, setDefaultAgentType] = useState(DEFAULT_SETTINGS.default_agent_type);
   const [autonomyLevel, setAutonomyLevel] = useState(DEFAULT_SETTINGS.autonomy_level);
   const [aggressiveness, setAggressiveness] = useState(String(DEFAULT_SETTINGS.execution_aggressiveness));
   const [maxConcurrent, setMaxConcurrent] = useState(String(DEFAULT_SETTINGS.max_concurrent_runs));
@@ -288,10 +81,8 @@ export default function SettingsPage() {
   const [recency, setRecency] = useState(String(DEFAULT_SETTINGS.priority_weights.recency));
   const [revenueRisk, setRevenueRisk] = useState(String(DEFAULT_SETTINGS.priority_weights.revenue_risk));
   const [minThreshold, setMinThreshold] = useState(String(DEFAULT_SETTINGS.min_priority_threshold));
-  const [agentConfig, setAgentConfig] = useState<Record<string, Record<string, string>>>({});
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
-  const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
 
   // Sync server data into form state.
   const [prevSettingsRef, setPrevSettingsRef] = useState<unknown>(undefined);
@@ -299,7 +90,6 @@ export default function SettingsPage() {
   if (settingsData && settingsData !== prevSettingsRef) {
     setPrevSettingsRef(settingsData);
     const s = orgSettings;
-    setDefaultAgentType(s.default_agent_type ?? DEFAULT_SETTINGS.default_agent_type);
     setAutonomyLevel(s.autonomy_level ?? DEFAULT_SETTINGS.autonomy_level);
     setAggressiveness(String(s.execution_aggressiveness ?? DEFAULT_SETTINGS.execution_aggressiveness));
     setMaxConcurrent(String(s.max_concurrent_runs ?? DEFAULT_SETTINGS.max_concurrent_runs));
@@ -321,9 +111,6 @@ export default function SettingsPage() {
     setRecency(String(s.priority_weights?.recency ?? DEFAULT_SETTINGS.priority_weights.recency));
     setRevenueRisk(String(s.priority_weights?.revenue_risk ?? DEFAULT_SETTINGS.priority_weights.revenue_risk));
     setMinThreshold(String(s.min_priority_threshold ?? DEFAULT_SETTINGS.min_priority_threshold));
-    const loadedConfig = s.agent_config ?? {};
-    setAgentConfig(loadedConfig);
-    if (Object.keys(loadedConfig).length > 0) setShowAdvanced(true);
   }
 
   const mutation = useMutation({
@@ -339,20 +126,12 @@ export default function SettingsPage() {
     },
   });
 
-  const disconnectMutation = useMutation({
-    mutationFn: () => api.codexAuth.disconnect(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
-    },
-  });
-
   const connectLinearMutation = useMutation({
     mutationFn: () => api.integrations.connectLinear(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["integrations"] });
     },
   });
-
   const weightsSum =
     parseFloat(customerImpact || "0") +
     parseFloat(severity || "0") +
@@ -371,18 +150,6 @@ export default function SettingsPage() {
   };
 
   function handleSave() {
-    const cleanedAgentConfig: Record<string, Record<string, string>> = {};
-    for (const [agentKey, vars] of Object.entries(agentConfig)) {
-      const filtered: Record<string, string> = {};
-      const serverVars = serverAgentDefaults[agentKey] ?? {};
-      for (const [k, v] of Object.entries(vars)) {
-        if (v && v !== serverVars[k]) filtered[k] = v;
-      }
-      if (Object.keys(filtered).length > 0) {
-        cleanedAgentConfig[agentKey] = filtered;
-      }
-    }
-
     const payload: Record<string, unknown> = {
       settings: {
         autonomy_level: autonomyLevel,
@@ -408,15 +175,10 @@ export default function SettingsPage() {
           focus_areas: focusAreas,
           avoid_areas: avoidAreas,
         },
-        default_agent_type: defaultAgentType,
-        ...(Object.keys(cleanedAgentConfig).length > 0 && { agent_config: cleanedAgentConfig }),
       },
     };
     mutation.mutate(payload);
   }
-
-  // Find the selected agent's config for rendering.
-  const selectedAgent = AGENT_TYPES.find((a) => a.key === defaultAgentType) ?? AGENT_TYPES[0];
 
   return (
     <div className="space-y-8">
@@ -477,128 +239,16 @@ export default function SettingsPage() {
         />
       </section>
 
-      {/* Agent Setup — promoted from Advanced Settings */}
       <section className="space-y-3">
         <h2 className="text-[13px] font-medium text-foreground">Agent Setup</h2>
         <Card>
-          <CardContent>
-            <div className="space-y-6">
-              <div className="space-y-3">
-                <Label>Default Agent</Label>
-                <RadioGroup
-                  value={defaultAgentType}
-                  onValueChange={(v) => setDefaultAgentType(v as OrgSettings["default_agent_type"] & string)}
-                  className="grid grid-cols-3 gap-3"
-                >
-                  {AGENT_TYPES.map((agent) => (
-                    <label
-                      key={agent.key}
-                      className={`relative flex cursor-pointer flex-col rounded-lg border p-3 transition-colors ${
-                        defaultAgentType === agent.key
-                          ? "border-primary bg-primary/5"
-                          : "border-input hover:bg-muted/50"
-                      }`}
-                    >
-                      <div className="flex items-center gap-2">
-                        <RadioGroupItem value={agent.key} />
-                        <span className="text-sm font-medium">{agent.label}</span>
-                      </div>
-                    </label>
-                  ))}
-                </RadioGroup>
-              </div>
-
-              {/* ChatGPT OAuth — shown when Codex is selected */}
-              {defaultAgentType === "codex" && (
-                <div className="space-y-4">
-                  <div className="rounded-lg border p-4 space-y-3">
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h4 className="text-sm font-medium">Sign in with ChatGPT</h4>
-                        <p className="text-xs text-muted-foreground">
-                          Use your ChatGPT subscription. Required for gpt-5.3-codex.
-                        </p>
-                      </div>
-                      <Badge variant="secondary">Recommended</Badge>
-                    </div>
-
-                    {codexAuthStatus?.status === "completed" ? (
-                      <div className="flex items-center justify-between">
-                        <div className="flex items-center gap-2">
-                          <span className="h-2 w-2 rounded-full bg-green-500" />
-                          <span className="text-sm text-green-600">Connected</span>
-                        </div>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => disconnectMutation.mutate()}
-                          disabled={disconnectMutation.isPending}
-                        >
-                          Disconnect
-                        </Button>
-                      </div>
-                    ) : (
-                      <Button
-                        size="sm"
-                        onClick={() => setShowDeviceCodeModal(true)}
-                      >
-                        Sign in with ChatGPT
-                      </Button>
-                    )}
-                  </div>
-
-                  <div className="rounded-lg border p-4 space-y-3">
-                    <div>
-                      <h4 className="text-sm font-medium">API Key</h4>
-                      <p className="text-xs text-muted-foreground">
-                        Pay-as-you-go. Does not support gpt-5.3-codex.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* Agent-specific env var config for selected agent */}
-              <div className="space-y-3">
-                {(() => {
-                  const serverVars = serverAgentDefaults[selectedAgent.key] ?? {};
-                  return selectedAgent.envVars.map((envVar) => {
-                    const serverDefault = serverVars[envVar.name] ?? "";
-                    const orgOverride = agentConfig[selectedAgent.key]?.[envVar.name] ?? "";
-                    const displayValue = orgOverride || serverDefault;
-                    const isServerDefault = !orgOverride && !!serverDefault;
-                    return (
-                      <div key={envVar.name} className="space-y-1">
-                        <div className="flex items-center justify-between">
-                          <Label htmlFor={`${selectedAgent.key}-${envVar.name}`} className="text-xs text-muted-foreground">
-                            {envVar.label}
-                          </Label>
-                          {isServerDefault && (
-                            <span className="text-[10px] text-muted-foreground">server default</span>
-                          )}
-                        </div>
-                        <Input
-                          id={`${selectedAgent.key}-${envVar.name}`}
-                          type={envVar.sensitive ? "password" : "text"}
-                          placeholder={envVar.placeholder ?? "Not set"}
-                          value={displayValue}
-                          className={isServerDefault ? "text-muted-foreground" : ""}
-                          onChange={(e) => {
-                            setAgentConfig((prev) => ({
-                              ...prev,
-                              [selectedAgent.key]: {
-                                ...prev[selectedAgent.key],
-                                [envVar.name]: e.target.value,
-                              },
-                            }));
-                          }}
-                        />
-                      </div>
-                    );
-                  });
-                })()}
-              </div>
-            </div>
+          <CardContent className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Agent setup is now managed in its own focused settings page.
+            </p>
+            <Button asChild size="sm" variant="outline">
+              <Link href="/settings/agents">Open Agent Settings</Link>
+            </Button>
           </CardContent>
         </Card>
       </section>
@@ -970,67 +620,6 @@ export default function SettingsPage() {
               </Card>
             </div>
 
-            {/* Other agent configs (non-default) */}
-            <div className="space-y-3">
-              <h3 className="text-[13px] font-medium text-foreground">Other Agent Configuration</h3>
-              <p className="text-xs text-muted-foreground">
-                Configure credentials for agents other than your default.
-              </p>
-              {AGENT_TYPES.filter((a) => a.key !== defaultAgentType).map((agent) => {
-                const serverVars = serverAgentDefaults[agent.key] ?? {};
-                const hasServerConfig = Object.keys(serverVars).length > 0;
-                return (
-                  <Card key={agent.key}>
-                    <CardContent>
-                      <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                          <h3 className="text-sm font-medium">{agent.label}</h3>
-                          {hasServerConfig ? (
-                            <span className="text-xs text-green-600">Server configured</span>
-                          ) : (
-                            <span className="text-xs text-muted-foreground">Not configured</span>
-                          )}
-                        </div>
-                        {agent.envVars.map((envVar) => {
-                          const serverDefault = serverVars[envVar.name] ?? "";
-                          const orgOverride = agentConfig[agent.key]?.[envVar.name] ?? "";
-                          const displayValue = orgOverride || serverDefault;
-                          const isServerDefault = !orgOverride && !!serverDefault;
-                          return (
-                            <div key={envVar.name} className="space-y-1">
-                              <div className="flex items-center justify-between">
-                                <Label htmlFor={`${agent.key}-${envVar.name}`} className="text-xs text-muted-foreground">
-                                  {envVar.label}
-                                </Label>
-                                {isServerDefault && (
-                                  <span className="text-[10px] text-muted-foreground">server default</span>
-                                )}
-                              </div>
-                              <Input
-                                id={`${agent.key}-${envVar.name}`}
-                                type={envVar.sensitive ? "password" : "text"}
-                                placeholder={envVar.placeholder ?? "Not set"}
-                                value={displayValue}
-                                className={isServerDefault ? "text-muted-foreground" : ""}
-                                onChange={(e) => {
-                                  setAgentConfig((prev) => ({
-                                    ...prev,
-                                    [agent.key]: {
-                                      ...prev[agent.key],
-                                      [envVar.name]: e.target.value,
-                                    },
-                                  }));
-                                }}
-                              />
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </CardContent>
-                  </Card>
-                );
-              })}
-            </div>
           </div>
         )}
       </section>
@@ -1046,10 +635,6 @@ export default function SettingsPage() {
           <span className="text-sm text-destructive">Failed to save settings.</span>
         )}
       </div>
-
-      {showDeviceCodeModal && (
-        <DeviceCodeModal onClose={() => setShowDeviceCodeModal(false)} />
-      )}
     </div>
   );
 }

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import type { CodexDeviceAuth, OrgSettings, Organization, SingleResponse } from "@/lib/types";
+
+interface AgentEnvVar {
+  name: string;
+  label: string;
+  sensitive?: boolean;
+  placeholder?: string;
+}
+
+const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
+  {
+    key: "codex",
+    label: "Codex",
+    envVars: [
+      { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
+      { name: "OPENAI_MODEL", label: "Model", placeholder: "e.g. codex-mini, o3" },
+      { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
+    ],
+  },
+  {
+    key: "claude_code",
+    label: "Claude Code",
+    envVars: [
+      { name: "ANTHROPIC_API_KEY", label: "API Key", sensitive: true },
+      { name: "ANTHROPIC_MODEL", label: "Model", placeholder: "e.g. claude-sonnet-4-5, opus" },
+      { name: "ANTHROPIC_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
+    ],
+  },
+  {
+    key: "gemini_cli",
+    label: "Gemini CLI",
+    envVars: [
+      { name: "GEMINI_API_KEY", label: "API Key", sensitive: true },
+      { name: "GEMINI_MODEL", label: "Model", placeholder: "e.g. gemini-2.5-pro, gemini-2.5-flash" },
+    ],
+  },
+];
+
+function DeviceCodeModal({ onClose }: { onClose: () => void }) {
+  const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
+  const [status, setStatus] = useState<string>("initiating");
+  const [error, setError] = useState<string>("");
+  const [timeLeft, setTimeLeft] = useState(0);
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const onCloseRef = useRef(onClose);
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  const startAuth = async () => {
+    try {
+      setStatus("initiating");
+      setError("");
+      const resp = await api.codexAuth.initiate();
+      setDeviceAuth(resp.data);
+      setTimeLeft(resp.data.expires_in);
+      setStatus("pending");
+    } catch {
+      setError("Failed to start authentication. Please try again.");
+      setStatus("error");
+    }
+  };
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      void startAuth();
+    }, 0);
+    return () => clearTimeout(id);
+  }, []);
+
+  useEffect(() => {
+    if (status !== "pending") return;
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const resp = await api.codexAuth.status();
+        if (resp.data.status === "completed") {
+          setStatus("completed");
+          queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+          setTimeout(() => onCloseRef.current(), 1500);
+        } else if (resp.data.status === "expired") {
+          setStatus("expired");
+          setError("Code expired. Please try again.");
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+        } else if (resp.data.status === "error") {
+          setStatus("error");
+          setError(resp.data.message || "Authentication failed.");
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+        }
+      } catch {
+      }
+    }, 3000);
+
+    timerRef.current = setInterval(() => {
+      setTimeLeft((time) => Math.max(0, time - 1));
+    }, 1000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [status, queryClient]);
+
+  const minutes = Math.floor(timeLeft / 60);
+  const seconds = timeLeft % 60;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h3 className="text-lg font-medium">Connect your ChatGPT account</h3>
+
+        {status === "initiating" && (
+          <p className="mt-4 text-sm text-muted-foreground">Starting authentication...</p>
+        )}
+
+        {status === "pending" && deviceAuth && (
+          <div className="mt-4 space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">1. Open this link:</p>
+              <a
+                href={deviceAuth.verification_uri}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm font-medium text-primary underline"
+              >
+                {deviceAuth.verification_uri}
+              </a>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">2. Enter this code:</p>
+              <div className="flex items-center gap-2">
+                <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">
+                  {deviceAuth.user_code}
+                </code>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}
+                >
+                  Copy
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">Waiting for authentication...</p>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full bg-primary transition-all duration-1000"
+                  style={{ width: `${deviceAuth ? Math.max(0, (timeLeft / deviceAuth.expires_in) * 100) : 0}%` }}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Expires in {minutes}:{seconds.toString().padStart(2, "0")}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {status === "completed" && (
+          <div className="mt-4">
+            <p className="text-sm font-medium text-green-600">Connected successfully!</p>
+          </div>
+        )}
+
+        {(status === "error" || status === "expired") && (
+          <div className="mt-4 space-y-3">
+            <p className="text-sm text-destructive">{error}</p>
+            <Button size="sm" onClick={() => void startAuth()}>
+              Try Again
+            </Button>
+          </div>
+        )}
+
+        <div className="mt-6 flex justify-end">
+          <Button variant="outline" size="sm" onClick={onClose}>
+            {status === "completed" ? "Done" : "Cancel"}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentSettingsEditor({
+  title,
+  description,
+  showAdvancedLink,
+  onClose,
+}: {
+  title: string;
+  description: string;
+  showAdvancedLink?: boolean;
+  onClose?: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [defaultAgentTypeOverride, setDefaultAgentTypeOverride] = useState<OrgSettings["default_agent_type"] | null>(null);
+  const [agentConfigOverride, setAgentConfigOverride] = useState<Record<string, Record<string, string>> | null>(null);
+  const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
+  const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
+
+  const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
+    queryKey: ["settings"],
+    queryFn: () => api.settings.get(),
+  });
+
+  const { data: agentDefaultsResponse } = useQuery({
+    queryKey: ["agent-defaults"],
+    queryFn: () => api.settings.getAgentDefaults(),
+  });
+
+  const { data: codexAuthStatusResp } = useQuery({
+    queryKey: ["codex-auth-status"],
+    queryFn: () => api.codexAuth.status(),
+    refetchInterval: false,
+  });
+  const codexAuthStatus = codexAuthStatusResp?.data;
+
+  const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
+  const defaultAgentType = defaultAgentTypeOverride ?? settings?.default_agent_type ?? "codex";
+  const agentConfig = agentConfigOverride ?? settings?.agent_config ?? {};
+
+  const mutation = useMutation({
+    mutationFn: (payload: Record<string, unknown>) => api.settings.update(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["settings"] });
+      setSaveStatus("success");
+      setTimeout(() => setSaveStatus("idle"), 2000);
+    },
+    onError: () => {
+      setSaveStatus("error");
+      setTimeout(() => setSaveStatus("idle"), 3000);
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => api.codexAuth.disconnect(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+    },
+  });
+
+  const selectedAgent = useMemo(
+    () => AGENT_TYPES.find((agent) => agent.key === defaultAgentType) ?? AGENT_TYPES[0],
+    [defaultAgentType]
+  );
+
+  function handleSave() {
+    const serverAgentDefaults = agentDefaultsResponse?.data ?? {};
+    const cleanedAgentConfig: Record<string, Record<string, string>> = {};
+
+    for (const [agentKey, vars] of Object.entries(agentConfig)) {
+      const filtered: Record<string, string> = {};
+      const serverVars = serverAgentDefaults[agentKey] ?? {};
+      for (const [key, value] of Object.entries(vars)) {
+        if (value && value !== serverVars[key]) {
+          filtered[key] = value;
+        }
+      }
+      if (Object.keys(filtered).length > 0) {
+        cleanedAgentConfig[agentKey] = filtered;
+      }
+    }
+
+    mutation.mutate({
+      settings: {
+        default_agent_type: defaultAgentType,
+        ...(Object.keys(cleanedAgentConfig).length > 0 && { agent_config: cleanedAgentConfig }),
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        <h3 className="text-base font-medium text-foreground">{title}</h3>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="space-y-3">
+        <Label>Default Agent</Label>
+        <RadioGroup
+          value={defaultAgentType}
+          onValueChange={(value) => setDefaultAgentTypeOverride(value as OrgSettings["default_agent_type"])}
+          className="grid grid-cols-3 gap-3"
+        >
+          {AGENT_TYPES.map((agent) => (
+            <label
+              key={agent.key}
+              className={`relative flex cursor-pointer flex-col rounded-lg border p-3 transition-colors ${
+                defaultAgentType === agent.key
+                  ? "border-primary bg-primary/5"
+                  : "border-input hover:bg-muted/50"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value={agent.key} />
+                <span className="text-sm font-medium">{agent.label}</span>
+              </div>
+            </label>
+          ))}
+        </RadioGroup>
+      </div>
+
+      {defaultAgentType === "codex" && (
+        <div className="space-y-4">
+          <div className="space-y-3 rounded-lg border p-4">
+            <div className="flex items-center justify-between">
+              <div>
+                <h4 className="text-sm font-medium">Sign in with ChatGPT</h4>
+                <p className="text-xs text-muted-foreground">
+                  For gpt-5.3-codex model access.
+                </p>
+              </div>
+              <Badge variant="secondary">Recommended</Badge>
+            </div>
+
+            <div className="flex items-center gap-2">
+              {codexAuthStatus?.status === "completed" ? (
+                <>
+                  <Badge variant="outline" className="text-green-600 border-green-600">
+                    Connected
+                  </Badge>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => disconnectMutation.mutate()}
+                    disabled={disconnectMutation.isPending}
+                  >
+                    {disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  size="sm"
+                  onClick={() => setShowDeviceCodeModal(true)}
+                >
+                  Sign in with ChatGPT
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-3 rounded-lg border p-4">
+            <div>
+              <h4 className="text-sm font-medium">API Key</h4>
+              <p className="text-xs text-muted-foreground">
+                Pay-as-you-go. Does not support gpt-5.3-codex.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {(() => {
+          const serverVars = (agentDefaultsResponse?.data ?? {})[selectedAgent.key] ?? {};
+          return selectedAgent.envVars.map((envVar) => {
+            const serverDefault = serverVars[envVar.name] ?? "";
+            const orgOverride = agentConfig[selectedAgent.key]?.[envVar.name] ?? "";
+            const displayValue = orgOverride || serverDefault;
+            const isServerDefault = !orgOverride && !!serverDefault;
+
+            return (
+              <div key={envVar.name} className="space-y-1">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor={`${selectedAgent.key}-${envVar.name}`} className="text-xs text-muted-foreground">
+                    {envVar.label}
+                  </Label>
+                  {isServerDefault && (
+                    <span className="text-[10px] text-muted-foreground">server default</span>
+                  )}
+                </div>
+                <Input
+                  id={`${selectedAgent.key}-${envVar.name}`}
+                  type={envVar.sensitive ? "password" : "text"}
+                  placeholder={envVar.placeholder ?? "Not set"}
+                  value={displayValue}
+                  className={isServerDefault ? "text-muted-foreground" : ""}
+                  onChange={(e) => {
+                    setAgentConfigOverride({
+                      ...(agentConfigOverride ?? agentConfig),
+                      [selectedAgent.key]: {
+                        ...(agentConfigOverride ?? agentConfig)[selectedAgent.key],
+                        [envVar.name]: e.target.value,
+                      },
+                    });
+                  }}
+                />
+              </div>
+            );
+          });
+        })()}
+      </div>
+
+      <div className="flex items-center justify-between gap-2 pt-2">
+        <div className="min-h-5 text-xs">
+          {saveStatus === "success" && <span className="text-green-600">Saved.</span>}
+          {saveStatus === "error" && <span className="text-destructive">Save failed.</span>}
+        </div>
+        <div className="flex items-center gap-2">
+          {showAdvancedLink && (
+            <Link href="/settings/agents" className="text-xs text-primary underline">
+              Open advanced agent settings
+            </Link>
+          )}
+          {onClose && (
+            <Button variant="outline" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+          )}
+          <Button size="sm" onClick={handleSave} disabled={mutation.isPending}>
+            {mutation.isPending ? "Saving..." : "Save changes"}
+          </Button>
+        </div>
+      </div>
+      {showDeviceCodeModal && (
+        <DeviceCodeModal onClose={() => setShowDeviceCodeModal(false)} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Summary
- introduce a shared agent settings editor component used both on the dashboard and settings routes
- replace the old standalone agents settings page with the new modal-driven experience while keeping functionality aligned
- document the new UX decision in `docs/design/overall.md`

Testing
- Not run (not requested)