### PR TITLE
Improve team settings list layout and admin controls

### DIFF
--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -9,6 +9,7 @@ const {
   removeMemberMock,
   createInvitationMock,
   revokeInvitationMock,
+  currentUserMock,
 } = vi.hoisted(() => ({
   listMembersMock: vi.fn().mockResolvedValue({
     data: [
@@ -51,6 +52,12 @@ const {
   removeMemberMock: vi.fn().mockResolvedValue(undefined),
   createInvitationMock: vi.fn().mockResolvedValue({ data: {} }),
   revokeInvitationMock: vi.fn().mockResolvedValue(undefined),
+  currentUserMock: {
+    id: 'user-1',
+    email: 'admin@example.com',
+    name: 'Admin User',
+    role: 'admin',
+  },
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -71,7 +78,7 @@ vi.mock('@/lib/api', () => ({
 
 vi.mock('@/hooks/use-auth', () => ({
   useAuth: () => ({
-    user: { id: 'user-1', email: 'admin@example.com', name: 'Admin User', role: 'admin' },
+    user: currentUserMock,
     isLoading: false,
   }),
 }));
@@ -84,6 +91,10 @@ describe('TeamSettingsPage', () => {
     removeMemberMock.mockClear();
     createInvitationMock.mockClear();
     revokeInvitationMock.mockClear();
+    currentUserMock.id = 'user-1';
+    currentUserMock.email = 'admin@example.com';
+    currentUserMock.name = 'Admin User';
+    currentUserMock.role = 'admin';
   });
 
   it('renders the Members section with team members', async () => {
@@ -96,6 +107,19 @@ describe('TeamSettingsPage', () => {
     expect(screen.getByText('Member User')).toBeInTheDocument();
     expect(screen.getByText('admin@example.com')).toBeInTheDocument();
     expect(screen.getByText('member@example.com')).toBeInTheDocument();
+  });
+
+  it('renders the members in list format with column headers', async () => {
+    renderWithProviders(<TeamSettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin User')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Role')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
   });
 
   it('shows (you) label for the current user', async () => {
@@ -115,6 +139,14 @@ describe('TeamSettingsPage', () => {
 
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send Invite' })).toBeInTheDocument();
+  });
+
+  it('uses consistent compact sizing for invite email input', async () => {
+    renderWithProviders(<TeamSettingsPage />);
+
+    const emailInput = await screen.findByLabelText('Email');
+    expect(emailInput).toHaveClass('h-9');
+    expect(emailInput).toHaveClass('text-sm');
   });
 
   it('renders pending invitations', async () => {
@@ -230,6 +262,39 @@ describe('TeamSettingsPage', () => {
     expect(screen.getAllByText('Admin').length).toBeGreaterThanOrEqual(1);
     // Other user should show "Member" role
     expect(screen.getAllByText('Member').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('updates another member role when admin changes the role selection', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamSettingsPage />);
+
+    const roleSelectTrigger = await screen.findByRole('combobox', {
+      name: 'Role for Member User',
+    });
+
+    await user.click(roleSelectTrigger);
+    await user.click(screen.getByRole('option', { name: 'Viewer' }));
+
+    await waitFor(() => {
+      expect(changeRoleMock).toHaveBeenCalledWith('user-2', 'viewer');
+    });
+  });
+
+  it('disables management actions for non-admin users', async () => {
+    currentUserMock.id = 'user-2';
+    currentUserMock.email = 'member@example.com';
+    currentUserMock.name = 'Member User';
+    currentUserMock.role = 'member';
+
+    renderWithProviders(<TeamSettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Member User')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Send Invite' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument();
   });
 
   it('shows loading state when members are loading', () => {

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -31,6 +31,7 @@ import type { User, InvitationResponse, ListResponse } from "@/lib/types";
 export default function TeamSettingsPage() {
   const queryClient = useQueryClient();
   const { user: currentUser } = useAuth();
+  const canManageTeam = currentUser?.role === "admin";
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteRole, setInviteRole] = useState("member");
   const [inviteError, setInviteError] = useState("");
@@ -126,6 +127,12 @@ export default function TeamSettingsPage() {
         </div>
       )}
 
+      {!canManageTeam && (
+        <div className="rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+          Only admins can manage member roles, invitations, and removals.
+        </div>
+      )}
+
       {/* Members List */}
       <section className="space-y-3">
         <h2 className="text-[13px] font-medium text-foreground">Members</h2>
@@ -141,12 +148,18 @@ export default function TeamSettingsPage() {
               </div>
             ) : (
               <div className="divide-y divide-border">
+                <div className="hidden items-center gap-4 bg-muted/30 px-4 py-2 text-xs font-medium uppercase tracking-wide text-muted-foreground md:grid md:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_140px_100px]">
+                  <div>Name</div>
+                  <div>Email</div>
+                  <div>Role</div>
+                  <div>Actions</div>
+                </div>
                 {members.map((member) => {
                   const isSelf = currentUser?.id === member.id;
                   return (
                     <div
                       key={member.id}
-                      className="flex items-center justify-between px-4 py-3"
+                      className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1.3fr)_minmax(0,1.3fr)_140px_100px] md:items-center"
                     >
                       <div className="flex items-center gap-3 min-w-0">
                         {member.avatar_url ? (
@@ -171,13 +184,13 @@ export default function TeamSettingsPage() {
                               </span>
                             )}
                           </div>
-                          <div className="text-xs text-muted-foreground truncate">
-                            {member.email}
-                          </div>
                         </div>
                       </div>
-                      <div className="flex items-center gap-2 ml-4">
-                        {isSelf ? (
+                      <div className="min-w-0 text-sm text-muted-foreground truncate">
+                        {member.email}
+                      </div>
+                      <div className="flex items-center">
+                        {isSelf || !canManageTeam ? (
                           <Badge variant={roleBadgeVariant(member.role)}>
                             {capitalize(member.role)}
                           </Badge>
@@ -191,7 +204,11 @@ export default function TeamSettingsPage() {
                               })
                             }
                           >
-                            <SelectTrigger size="sm" className="w-24">
+                            <SelectTrigger
+                              size="default"
+                              className="h-9 w-full max-w-28"
+                              aria-label={`Role for ${member.name}`}
+                            >
                               <SelectValue>
                                 {capitalize(member.role)}
                               </SelectValue>
@@ -203,7 +220,9 @@ export default function TeamSettingsPage() {
                             </SelectContent>
                           </Select>
                         )}
-                        {!isSelf && (
+                      </div>
+                      <div className="flex items-center justify-start md:justify-end">
+                        {canManageTeam && !isSelf ? (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -213,6 +232,8 @@ export default function TeamSettingsPage() {
                           >
                             Remove
                           </Button>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">—</span>
                         )}
                       </div>
                     </div>
@@ -225,52 +246,55 @@ export default function TeamSettingsPage() {
       </section>
 
       {/* Invite Form */}
-      <section className="space-y-3">
-        <h2 className="text-[13px] font-medium text-foreground">
-          Invite a Member
-        </h2>
-        <Card>
-          <CardContent>
-            <form onSubmit={handleInvite} className="flex items-end gap-3">
-              <div className="flex-1 space-y-1.5">
-                <Label htmlFor="invite-email">Email</Label>
-                <Input
-                  id="invite-email"
-                  type="email"
-                  placeholder="colleague@company.com"
-                  value={inviteEmail}
-                  onChange={(e) => setInviteEmail(e.target.value)}
-                  required
-                />
-              </div>
-              <div className="w-28 space-y-1.5">
-                <Label>Role</Label>
-                <Select value={inviteRole} onValueChange={setInviteRole}>
-                  <SelectTrigger className="h-9 w-full">
-                    <SelectValue>
-                      {capitalize(inviteRole)}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="admin">Admin</SelectItem>
-                    <SelectItem value="member">Member</SelectItem>
-                    <SelectItem value="viewer">Viewer</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <Button type="submit" className="h-9" disabled={inviteMutation.isPending}>
-                {inviteMutation.isPending ? "Sending..." : "Send Invite"}
-              </Button>
-            </form>
-            {inviteError && (
-              <p className="mt-2 text-sm text-destructive">{inviteError}</p>
-            )}
-          </CardContent>
-        </Card>
-      </section>
+      {canManageTeam && (
+        <section className="space-y-3">
+          <h2 className="text-[13px] font-medium text-foreground">
+            Invite a Member
+          </h2>
+          <Card>
+            <CardContent>
+              <form onSubmit={handleInvite} className="flex items-end gap-3">
+                <div className="flex-1 space-y-1.5">
+                  <Label htmlFor="invite-email">Email</Label>
+                  <Input
+                    id="invite-email"
+                    type="email"
+                    placeholder="colleague@company.com"
+                    value={inviteEmail}
+                    onChange={(e) => setInviteEmail(e.target.value)}
+                    className="h-9 text-sm"
+                    required
+                  />
+                </div>
+                <div className="w-28 space-y-1.5">
+                  <Label>Role</Label>
+                  <Select value={inviteRole} onValueChange={setInviteRole}>
+                    <SelectTrigger className="h-9 w-full text-sm">
+                      <SelectValue>
+                        {capitalize(inviteRole)}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="admin">Admin</SelectItem>
+                      <SelectItem value="member">Member</SelectItem>
+                      <SelectItem value="viewer">Viewer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button type="submit" className="h-9" disabled={inviteMutation.isPending}>
+                  {inviteMutation.isPending ? "Sending..." : "Send Invite"}
+                </Button>
+              </form>
+              {inviteError && (
+                <p className="mt-2 text-sm text-destructive">{inviteError}</p>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+      )}
 
       {/* Pending Invitations */}
-      {invitations.length > 0 && (
+      {canManageTeam && invitations.length > 0 && (
         <section className="space-y-3">
           <h2 className="text-[13px] font-medium text-foreground">
             Pending Invitations


### PR DESCRIPTION
Summary
- replace member cards with a responsive list view (headers + grid layout) and ensure consistent input sizing in the invite card
- gate invite/invitation/removal controls to admins, show a helper banner for other roles, and add role-change handling so only admins can change/remove others
- expand tests for list layout, privilege enforcement, and consistent styling while keeping membership APIs mocked per current user role

Testing
- Not run (not requested)