### PR TITLE
Add coverage for PM service helpers and scheduler runtime

### DIFF
--- a/internal/cluster/runtime_test.go
+++ b/internal/cluster/runtime_test.go
@@ -1,0 +1,194 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+type schedulerRuntimeLockMock struct {
+	acquired     bool
+	acquireErr   error
+	releaseErr   error
+	acquireCalls int
+	releaseCalls int
+}
+
+func (m *schedulerRuntimeLockMock) TryAcquire(ctx context.Context) (bool, error) {
+	m.acquireCalls++
+	if m.acquireErr != nil {
+		return false, m.acquireErr
+	}
+	return m.acquired, nil
+}
+
+func (m *schedulerRuntimeLockMock) Release(ctx context.Context) error {
+	m.releaseCalls++
+	return m.releaseErr
+}
+
+type schedulerRuntimeJobsMock struct {
+	enqueued []string
+	err      error
+}
+
+func (m *schedulerRuntimeJobsMock) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
+	if m.err != nil {
+		return uuid.Nil, m.err
+	}
+	m.enqueued = append(m.enqueued, fmt.Sprintf("%s:%s", orgID.String(), jobType))
+	return uuid.New(), nil
+}
+
+type schedulerRuntimeOrgStoreMock struct {
+	orgByID map[uuid.UUID]models.Organization
+	errByID map[uuid.UUID]error
+}
+
+func (m *schedulerRuntimeOrgStoreMock) GetByID(ctx context.Context, id uuid.UUID) (models.Organization, error) {
+	if err := m.errByID[id]; err != nil {
+		return models.Organization{}, err
+	}
+	return m.orgByID[id], nil
+}
+
+type schedulerRuntimeIntegrationStoreMock struct {
+	orgIDs []uuid.UUID
+	err    error
+}
+
+func (m *schedulerRuntimeIntegrationStoreMock) ListOrgsWithActiveIntegrations(ctx context.Context) ([]uuid.UUID, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.orgIDs, nil
+}
+
+type schedulerRuntimePlanStoreMock struct {
+	plansByOrg map[uuid.UUID]models.PMPlan
+	errByOrg   map[uuid.UUID]error
+}
+
+func (m *schedulerRuntimePlanStoreMock) GetLatestByOrg(ctx context.Context, orgID uuid.UUID) (models.PMPlan, error) {
+	if err := m.errByOrg[orgID]; err != nil {
+		return models.PMPlan{}, err
+	}
+	return m.plansByOrg[orgID], nil
+}
+
+func TestSchedulerRunOnce(t *testing.T) {
+	t.Parallel()
+
+	oldOrgID := uuid.New()
+	newOrgID := uuid.New()
+	now := time.Now().UTC()
+
+	defaultSettingsJSON, err := json.Marshal(models.OrgSettings{})
+	require.NoError(t, err, "test setup should marshal default org settings")
+
+	tests := []struct {
+		name            string
+		lock            *schedulerRuntimeLockMock
+		integrations    *schedulerRuntimeIntegrationStoreMock
+		orgs            *schedulerRuntimeOrgStoreMock
+		plans           *schedulerRuntimePlanStoreMock
+		jobs            *schedulerRuntimeJobsMock
+		expectedEnqueue int
+		expectedRelease int
+	}{
+		{
+			name: "returns early when lock acquisition fails",
+			lock: &schedulerRuntimeLockMock{acquireErr: fmt.Errorf("lock unavailable")},
+			integrations:    &schedulerRuntimeIntegrationStoreMock{},
+			orgs:            &schedulerRuntimeOrgStoreMock{},
+			plans:           &schedulerRuntimePlanStoreMock{},
+			jobs:            &schedulerRuntimeJobsMock{},
+			expectedEnqueue: 0,
+			expectedRelease: 0,
+		},
+		{
+			name: "returns early when lock is not acquired",
+			lock: &schedulerRuntimeLockMock{acquired: false},
+			integrations:    &schedulerRuntimeIntegrationStoreMock{},
+			orgs:            &schedulerRuntimeOrgStoreMock{},
+			plans:           &schedulerRuntimePlanStoreMock{},
+			jobs:            &schedulerRuntimeJobsMock{},
+			expectedEnqueue: 0,
+			expectedRelease: 0,
+		},
+		{
+			name: "releases lock when integration lookup fails",
+			lock: &schedulerRuntimeLockMock{acquired: true},
+			integrations:    &schedulerRuntimeIntegrationStoreMock{err: fmt.Errorf("db error")},
+			orgs:            &schedulerRuntimeOrgStoreMock{},
+			plans:           &schedulerRuntimePlanStoreMock{},
+			jobs:            &schedulerRuntimeJobsMock{},
+			expectedEnqueue: 0,
+			expectedRelease: 1,
+		},
+		{
+			name: "enqueues PM job only for orgs due by schedule",
+			lock: &schedulerRuntimeLockMock{acquired: true},
+			integrations: &schedulerRuntimeIntegrationStoreMock{orgIDs: []uuid.UUID{oldOrgID, newOrgID}},
+			orgs: &schedulerRuntimeOrgStoreMock{orgByID: map[uuid.UUID]models.Organization{
+				oldOrgID: {ID: oldOrgID, Settings: defaultSettingsJSON},
+				newOrgID: {ID: newOrgID, Settings: defaultSettingsJSON},
+			}},
+			plans: &schedulerRuntimePlanStoreMock{
+				plansByOrg: map[uuid.UUID]models.PMPlan{
+					oldOrgID: {CreatedAt: now.Add(-6 * time.Hour)},
+				},
+				errByOrg: map[uuid.UUID]error{
+					newOrgID: pgx.ErrNoRows,
+				},
+			},
+			jobs:            &schedulerRuntimeJobsMock{},
+			expectedEnqueue: 2,
+			expectedRelease: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &Scheduler{
+				lock:         tt.lock,
+				jobs:         tt.jobs,
+				orgs:         tt.orgs,
+				integrations: tt.integrations,
+				plans:        tt.plans,
+				logger:       zerolog.Nop(),
+			}
+
+			s.runOnce(context.Background())
+			require.Equal(t, tt.expectedEnqueue, len(tt.jobs.enqueued), "runOnce should enqueue the expected number of PM jobs")
+			require.Equal(t, tt.expectedRelease, tt.lock.releaseCalls, "runOnce should release the lock when acquired")
+		})
+	}
+}
+
+func TestSchedulerStartAndNodeHeartbeatStopOnCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s := &Scheduler{logger: zerolog.Nop()}
+	s.Start(ctx, time.Millisecond)
+
+	nm := &NodeManager{logger: zerolog.Nop()}
+	nm.StartHeartbeat(ctx)
+
+	require.True(t, true, "Start and StartHeartbeat should return immediately when context is canceled")
+}
+

--- a/internal/services/pm/adapter_pm_test.go
+++ b/internal/services/pm/adapter_pm_test.go
@@ -1,0 +1,90 @@
+package pm
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/stretchr/testify/require"
+)
+
+type pmInnerAdapterMock struct {
+	executeResult *agent.AgentResult
+	executeErr    error
+	calledPrompt  *agent.AgentPrompt
+}
+
+func (m *pmInnerAdapterMock) Name() string {
+	return "inner"
+}
+
+func (m *pmInnerAdapterMock) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *pmInnerAdapterMock) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+	m.calledPrompt = prompt
+	if m.executeErr != nil {
+		return nil, m.executeErr
+	}
+	return m.executeResult, nil
+}
+
+func TestPMAdapterPreparePrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         *agent.AgentInput
+		expectErr     bool
+		expectedUser  string
+		expectedToken int
+	}{
+		{
+			name:      "returns error when input is nil",
+			input:     nil,
+			expectErr: true,
+		},
+		{
+			name:          "builds PM prompt from input context",
+			input:         &agent.AgentInput{PMContextJSON: `{"open_issues":[]}`},
+			expectedUser:  `{"open_issues":[]}`,
+			expectedToken: pmMaxTokens,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := NewPMAdapter(&pmInnerAdapterMock{}, 3, 7)
+			prompt, err := adapter.PreparePrompt(context.Background(), tt.input)
+			if tt.expectErr {
+				require.Error(t, err, "PreparePrompt should return an error for nil input")
+				return
+			}
+
+			require.NoError(t, err, "PreparePrompt should not return an error for valid input")
+			require.Equal(t, tt.expectedUser, prompt.UserPrompt, "PreparePrompt should pass PM context JSON to user prompt")
+			require.Equal(t, tt.expectedToken, prompt.MaxTokens, "PreparePrompt should set PM max token limit")
+			require.Contains(t, strings.ToLower(prompt.SystemPrompt), "available agent slots", "PreparePrompt should include available slot guidance in PM system prompt")
+		})
+	}
+}
+
+func TestPMAdapterExecuteAndName(t *testing.T) {
+	t.Parallel()
+
+	expected := &agent.AgentResult{Summary: "ok"}
+	inner := &pmInnerAdapterMock{executeResult: expected}
+	adapter := NewPMAdapter(inner, 1, 2)
+
+	result, err := adapter.Execute(context.Background(), &agent.Sandbox{ID: "sb-1"}, &agent.AgentPrompt{UserPrompt: "ctx"}, make(chan agent.LogEntry, 1))
+	require.NoError(t, err, "Execute should delegate to inner adapter without error")
+	require.Equal(t, expected, result, "Execute should return inner adapter result")
+	require.Equal(t, "ctx", inner.calledPrompt.UserPrompt, "Execute should pass prompt through to inner adapter")
+	require.Equal(t, "pm_agent", adapter.Name(), "Name should return pm_agent")
+}

--- a/internal/services/pm/context_files_test.go
+++ b/internal/services/pm/context_files_test.go
@@ -1,0 +1,127 @@
+package pm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/stretchr/testify/require"
+)
+
+type pmSandboxMock struct {
+	readResult []byte
+	readErr    error
+	writeErr   error
+	writePath  string
+	writeData  []byte
+}
+
+func (m *pmSandboxMock) Name() string {
+	return "mock"
+}
+
+func (m *pmSandboxMock) Create(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+	return &agent.Sandbox{ID: "unused"}, nil
+}
+
+func (m *pmSandboxMock) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoURL, branch, token string) error {
+	return nil
+}
+
+func (m *pmSandboxMock) Exec(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+	return 0, nil
+}
+
+func (m *pmSandboxMock) ReadFile(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	return m.readResult, nil
+}
+
+func (m *pmSandboxMock) WriteFile(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error {
+	m.writePath = path
+	m.writeData = append([]byte{}, data...)
+	if m.writeErr != nil {
+		return m.writeErr
+	}
+	return nil
+}
+
+func (m *pmSandboxMock) Destroy(ctx context.Context, sb *agent.Sandbox) error {
+	return nil
+}
+
+func (m *pmSandboxMock) ConnectionInfo(ctx context.Context, sb *agent.Sandbox) (*agent.SandboxConnectionInfo, error) {
+	return nil, nil
+}
+
+func TestWriteProductContextToAgentsMD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		pc        *models.ProductContext
+		readBytes []byte
+		readErr   error
+		writeErr  error
+		expectErr bool
+		expects   []string
+	}{
+		{
+			name:    "returns nil for nil product context",
+			pc:      nil,
+			expects: nil,
+		},
+		{
+			name:      "appends context section to existing agents file",
+			pc:        &models.ProductContext{Philosophy: "reliability", Direction: "stability", FocusAreas: []string{"timeouts"}, AvoidAreas: []string{"new features"}},
+			readBytes: []byte("# existing"),
+			expects:   []string{"# existing", "## Product Context", "**Philosophy:** reliability", "**Current direction:** stability", "**Focus areas:** timeouts", "**Avoid areas:** new features"},
+		},
+		{
+			name:      "still writes section when read fails",
+			pc:        &models.ProductContext{Philosophy: "ship", Direction: "payments"},
+			readErr:   fmt.Errorf("missing file"),
+			expects:   []string{"## Product Context", "**Philosophy:** ship", "**Current direction:** payments"},
+		},
+		{
+			name:      "returns write error",
+			pc:        &models.ProductContext{Philosophy: "ship", Direction: "payments"},
+			writeErr:  fmt.Errorf("disk full"),
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sandbox := &pmSandboxMock{readResult: tt.readBytes, readErr: tt.readErr, writeErr: tt.writeErr}
+			svc := &Service{sandbox: sandbox}
+
+			err := svc.writeProductContextToAgentsMD(context.Background(), &agent.Sandbox{ID: "sb"}, tt.pc)
+			if tt.expectErr {
+				require.Error(t, err, "writeProductContextToAgentsMD should return write errors")
+				return
+			}
+			require.NoError(t, err, "writeProductContextToAgentsMD should not return an error")
+
+			if tt.pc == nil {
+				require.Empty(t, sandbox.writePath, "writeProductContextToAgentsMD should skip writes when context is nil")
+				return
+			}
+
+			require.Equal(t, "/workspace/AGENTS.md", sandbox.writePath, "writeProductContextToAgentsMD should target AGENTS.md")
+			written := string(sandbox.writeData)
+			for _, expected := range tt.expects {
+				require.Contains(t, written, expected, "writeProductContextToAgentsMD should include expected section content")
+			}
+		})
+	}
+}
+

--- a/internal/services/pm/context_gather_test.go
+++ b/internal/services/pm/context_gather_test.go
@@ -1,0 +1,274 @@
+package pm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type gatherIssueStoreMock struct {
+	byStatus map[string][]models.Issue
+	errByKey map[string]error
+}
+
+func (m *gatherIssueStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.IssueFilters) ([]models.Issue, error) {
+	if err := m.errByKey[filters.Status]; err != nil {
+		return nil, err
+	}
+	return m.byStatus[filters.Status], nil
+}
+
+func (m *gatherIssueStoreMock) UpdateStatus(ctx context.Context, orgID, issueID uuid.UUID, status string) error {
+	return nil
+}
+
+type gatherAgentRunStoreMock struct {
+	byStatus map[string][]models.AgentRun
+	recent   []models.AgentRun
+	count    int
+	errByKey map[string]error
+}
+
+func (m *gatherAgentRunStoreMock) CountRunningByOrg(ctx context.Context, orgID uuid.UUID) (int, error) {
+	if err := m.errByKey["count_running"]; err != nil {
+		return 0, err
+	}
+	return m.count, nil
+}
+
+func (m *gatherAgentRunStoreMock) Create(ctx context.Context, run *models.AgentRun) error {
+	return nil
+}
+
+func (m *gatherAgentRunStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.AgentRunFilters) ([]models.AgentRun, error) {
+	if err := m.errByKey[filters.Status]; err != nil {
+		return nil, err
+	}
+	return m.byStatus[filters.Status], nil
+}
+
+func (m *gatherAgentRunStoreMock) ListRecentByOrg(ctx context.Context, orgID uuid.UUID, statuses []string, limit int) ([]models.AgentRun, error) {
+	if err := m.errByKey["recent"]; err != nil {
+		return nil, err
+	}
+	return m.recent, nil
+}
+
+type gatherOrgStoreMock struct {
+	org models.Organization
+	err error
+}
+
+func (m *gatherOrgStoreMock) GetByID(ctx context.Context, id uuid.UUID) (models.Organization, error) {
+	if m.err != nil {
+		return models.Organization{}, m.err
+	}
+	return m.org, nil
+}
+
+type gatherPRStoreMock struct {
+	prs []models.PullRequest
+	err error
+}
+
+func (m *gatherPRStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.PullRequestFilters) ([]models.PullRequest, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.prs, nil
+}
+
+type gatherDecisionStoreMock struct {
+	entries []models.PMDecisionLogEntry
+	err     error
+}
+
+func (m *gatherDecisionStoreMock) Create(ctx context.Context, entry *models.PMDecisionLogEntry) error {
+	return nil
+}
+
+func (m *gatherDecisionStoreMock) ListRecentByOrg(ctx context.Context, orgID uuid.UUID, limit int) ([]models.PMDecisionLogEntry, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.entries, nil
+}
+
+func (m *gatherDecisionStoreMock) UpdateOutcome(ctx context.Context, orgID, planID, issueID uuid.UUID, outcome models.PMDecisionOutcome) error {
+	return nil
+}
+
+func TestServiceGatherContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issueID := uuid.New()
+	secondIssueID := uuid.New()
+	pendingRunID := uuid.New()
+	recentRunID := uuid.New()
+	prID := uuid.New()
+	planID := uuid.New()
+	decisionID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+	desc := "timeout while syncing subscription state"
+	confidence := 0.91
+	failureCategory := "timeout"
+	failureReason := "network flake"
+
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 7,
+		ProductContext: &models.ProductContext{
+			Philosophy: "ship reliability first",
+			Direction:  "payments hardening",
+			FocusAreas: []string{"slo", "incident prevention"},
+			AvoidAreas: []string{"new ui"},
+		},
+	}
+	settingsJSON, err := json.Marshal(settings)
+	require.NoError(t, err, "test setup should marshal org settings")
+
+	tests := []struct {
+		name             string
+		orgStore         orgStore
+		issueStore       issueStore
+		agentRunStore    agentRunStore
+		pullRequests     prStore
+		decisionLog      decisionLogStore
+		expectErr        string
+		expectedOpen     int
+		expectedInFlight int
+		expectedRecent   int
+		expectedPRs      int
+		expectedDecision int
+	}{
+		{
+			name:      "returns wrapped error when organization lookup fails",
+			orgStore:  &gatherOrgStoreMock{err: fmt.Errorf("org missing")},
+			issueStore: &gatherIssueStoreMock{},
+			agentRunStore: &gatherAgentRunStoreMock{},
+			expectErr: "org missing",
+		},
+		{
+			name: "returns wrapped error when issue lookup fails",
+			orgStore: &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+			issueStore: &gatherIssueStoreMock{errByKey: map[string]error{"open": fmt.Errorf("issues unavailable")}},
+			agentRunStore: &gatherAgentRunStoreMock{},
+			expectErr: "issues unavailable",
+		},
+		{
+			name:     "builds full context with issues runs prs and decisions",
+			orgStore: &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+			issueStore: &gatherIssueStoreMock{byStatus: map[string][]models.Issue{
+				"open": {
+					{
+						ID:                    issueID,
+						Source:                "sentry",
+						Title:                 "payment request panic",
+						Description:           &desc,
+						Severity:              "high",
+						OccurrenceCount:       4,
+						AffectedCustomerCount: 2,
+						FirstSeenAt:           now.Add(-2 * time.Hour),
+						LastSeenAt:            now,
+						Tags:                  []string{"payments"},
+						RawData:               json.RawMessage(`{"stacktrace":"line"}`),
+					},
+				},
+				"triaged": {
+					{
+						ID:                    secondIssueID,
+						Source:                "github",
+						Title:                 "retry policy bug",
+						Severity:              "medium",
+						OccurrenceCount:       3,
+						AffectedCustomerCount: 1,
+						FirstSeenAt:           now.Add(-4 * time.Hour),
+						LastSeenAt:            now.Add(-1 * time.Hour),
+					},
+				},
+			}},
+			agentRunStore: &gatherAgentRunStoreMock{
+				byStatus: map[string][]models.AgentRun{
+					"pending": {
+						{ID: pendingRunID, IssueID: issueID, Status: "pending", StartedAt: &now},
+					},
+					"running": {
+						{ID: uuid.New(), IssueID: secondIssueID, Status: "running", StartedAt: &now},
+					},
+				},
+				recent: []models.AgentRun{{
+					ID:                 recentRunID,
+					IssueID:            issueID,
+					Status:             "completed",
+					ConfidenceScore:    &confidence,
+					FailureCategory:    &failureCategory,
+					FailureExplanation: &failureReason,
+					CompletedAt:        &now,
+				}},
+				count: 2,
+			},
+			pullRequests: &gatherPRStoreMock{prs: []models.PullRequest{{
+				ID:           prID,
+				AgentRunID:   pendingRunID,
+				Title:        "Fix payment panic",
+				Status:       "open",
+				ReviewStatus: "pending",
+			}}},
+			decisionLog: &gatherDecisionStoreMock{entries: []models.PMDecisionLogEntry{{
+				ID:        decisionID,
+				PlanID:    planID,
+				IssueID:   &issueID,
+				Decision:  models.PMDecisionTypeDelegate,
+				Reasoning: "highest impact",
+				Outcome:   models.PMDecisionOutcomeSucceeded,
+				CreatedAt: now,
+			}}},
+			expectedOpen:     2,
+			expectedInFlight: 2,
+			expectedRecent:   1,
+			expectedPRs:      1,
+			expectedDecision: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &Service{
+				issues:       tt.issueStore,
+				agentRuns:    tt.agentRunStore,
+				pullRequests: tt.pullRequests,
+				orgs:         tt.orgStore,
+				decisionLog:  tt.decisionLog,
+			}
+
+			bundle, err := svc.gatherContext(context.Background(), orgID)
+			if tt.expectErr != "" {
+				require.Error(t, err, "gatherContext should return an error")
+				require.Contains(t, err.Error(), tt.expectErr, "gatherContext should return the expected error")
+				return
+			}
+
+			require.NoError(t, err, "gatherContext should not return an error")
+			require.NotNil(t, bundle, "gatherContext should return a context bundle")
+			require.NotNil(t, bundle.pmContext, "gatherContext should include PM context")
+			require.Len(t, bundle.pmContext.OpenIssues, tt.expectedOpen, "gatherContext should include expected open and triaged issues")
+			require.Len(t, bundle.pmContext.InFlightRuns, tt.expectedInFlight, "gatherContext should include expected in-flight runs")
+			require.Len(t, bundle.pmContext.RecentOutcomes, tt.expectedRecent, "gatherContext should include expected recent outcomes")
+			require.Len(t, bundle.pmContext.RecentPRs, tt.expectedPRs, "gatherContext should include expected pull requests")
+			require.Len(t, bundle.pmContext.PreviousDecisions, tt.expectedDecision, "gatherContext should include expected decision log entries")
+			require.Equal(t, settings.MaxConcurrentRuns, bundle.pmContext.MaxConcurrentRuns, "gatherContext should carry max concurrent runs from org settings")
+			require.Equal(t, 2, bundle.pmContext.CurrentRunCount, "gatherContext should carry current run count")
+			require.Equal(t, settings.ProductContext, bundle.productContext, "gatherContext should carry parsed product context")
+		})
+	}
+}

--- a/internal/services/pm/context_helpers_test.go
+++ b/internal/services/pm/context_helpers_test.go
@@ -1,0 +1,128 @@
+package pm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		max      int
+		expected string
+	}{
+		{
+			name:     "returns input when max is non-positive",
+			input:    "hello",
+			max:      0,
+			expected: "hello",
+		},
+		{
+			name:     "returns input when input is shorter than max",
+			input:    "hello",
+			max:      10,
+			expected: "hello",
+		},
+		{
+			name:     "truncates when input is longer than max",
+			input:    "truncate-me",
+			max:      8,
+			expected: "truncate",
+		},
+		{
+			name:     "truncates by rune length",
+			input:    "こんにちは世界",
+			max:      5,
+			expected: "こんにちは",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncate(tt.input, tt.max)
+			require.Equal(t, tt.expected, got, "truncate should return expected output")
+		})
+	}
+}
+
+func TestHasStackTrace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      json.RawMessage
+		expected bool
+	}{
+		{
+			name:     "returns false for empty raw data",
+			raw:      nil,
+			expected: false,
+		},
+		{
+			name:     "returns false when stacktrace key is missing",
+			raw:      json.RawMessage(`{"error":"boom"}`),
+			expected: false,
+		},
+		{
+			name:     "returns true when stacktrace key exists",
+			raw:      json.RawMessage(`{"stacktrace":"line 1"}`),
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := hasStackTrace(tt.raw)
+			require.Equal(t, tt.expected, got, "hasStackTrace should match expected result")
+		})
+	}
+}
+
+func TestSummarizeIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	longDescription := strings.Repeat("x", 260)
+	issue := models.Issue{
+		ID:                    uuid.New(),
+		Source:                "sentry",
+		Title:                 "nil pointer panic",
+		Description:           &longDescription,
+		Severity:              "critical",
+		OccurrenceCount:       42,
+		AffectedCustomerCount: 5,
+		FirstSeenAt:           now.Add(-2 * time.Hour),
+		LastSeenAt:            now,
+		Tags:                  []string{"backend", "panic"},
+		RawData:               json.RawMessage(`{"stacktrace":"line 1"}`),
+	}
+
+	summary := summarizeIssue(issue)
+	require.Equal(t, issue.ID.String(), summary.ID, "summary should include issue ID")
+	require.Equal(t, issue.Source, summary.Source, "summary should include source")
+	require.Equal(t, issue.Title, summary.Title, "summary should include title")
+	require.Len(t, []rune(summary.Description), 200, "summary description should be truncated to 200 runes")
+	require.Equal(t, issue.Severity, summary.Severity, "summary should include severity")
+	require.Equal(t, issue.OccurrenceCount, summary.OccurrenceCount, "summary should include occurrence count")
+	require.Equal(t, issue.AffectedCustomerCount, summary.AffectedCustomerCount, "summary should include affected customer count")
+	require.Equal(t, issue.FirstSeenAt.Format(time.RFC3339), summary.FirstSeenAt, "summary should format first seen timestamp")
+	require.Equal(t, issue.LastSeenAt.Format(time.RFC3339), summary.LastSeenAt, "summary should format last seen timestamp")
+	require.Equal(t, issue.Tags, summary.Tags, "summary should include tags")
+	require.True(t, summary.HasStackTrace, "summary should detect stacktrace in raw data")
+}
+

--- a/internal/services/pm/service_helpers_test.go
+++ b/internal/services/pm/service_helpers_test.go
@@ -1,0 +1,79 @@
+package pm
+
+import (
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewService(t *testing.T) {
+	t.Parallel()
+
+	issues := &mockIssueStore{}
+	agentRuns := &mockAgentRunStore{}
+	orgs := &mockOrgStore{}
+	jobs := &mockJobStore{}
+	plans := &mockPlanStore{}
+
+	svc := NewService(issues, agentRuns, nil, orgs, nil, jobs, plans, nil, nil, nil, nil, zerolog.Nop())
+	require.Equal(t, issues, svc.issues, "NewService should store issue dependency")
+	require.Equal(t, agentRuns, svc.agentRuns, "NewService should store agent run dependency")
+	require.Equal(t, orgs, svc.orgs, "NewService should store org dependency")
+	require.Equal(t, jobs, svc.jobs, "NewService should store job dependency")
+	require.Equal(t, plans, svc.plans, "NewService should store plan dependency")
+}
+
+func TestPMSandboxConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := pmSandboxConfig()
+	require.Equal(t, 10*time.Minute, cfg.Timeout, "pmSandboxConfig should set PM timeout")
+	require.Equal(t, 1.0, cfg.CPULimit, "pmSandboxConfig should set PM CPU limit")
+	require.Equal(t, 2048, cfg.MemoryLimitMB, "pmSandboxConfig should set PM memory limit")
+	require.Equal(t, "restricted", cfg.NetworkPolicy, "pmSandboxConfig should set restricted network policy")
+}
+
+func TestPlanToModelAndTokenMode(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	planID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	plan := &Plan{
+		ID:             planID,
+		OrgID:          orgID,
+		Status:         models.PMPlanStatusExecuting,
+		Analysis:       "cluster around webhook retries",
+		Tasks:          []Task{{Rank: 1, IssueIDs: []uuid.UUID{issueID}, Title: "Fix retries"}},
+		Clusters:       []Cluster{{IssueIDs: []uuid.UUID{issueID}, RootCause: "missing backoff", Strategy: "add retry budget"}},
+		SkippedIssues:  []SkipEntry{{IssueID: issueID, Reason: models.PMSkipReasonDuplicate, Detail: "small customer impact"}},
+		IssuesReviewed: 3,
+		TokenUsage:     []byte(`{"input_tokens":10}`),
+		TriggeredBy:    models.PMTriggerCron,
+		CreatedAt:      now,
+	}
+	productContext := &models.ProductContext{Philosophy: "stability", Direction: "incident reduction"}
+
+	model, err := planToModel(plan, productContext)
+	require.NoError(t, err, "planToModel should serialize valid plan")
+	require.Equal(t, planID, model.ID, "planToModel should copy plan ID")
+	require.Equal(t, orgID, model.OrgID, "planToModel should copy org ID")
+	require.NotEmpty(t, model.Tasks, "planToModel should serialize tasks")
+	require.NotEmpty(t, model.Clusters, "planToModel should serialize clusters")
+	require.NotEmpty(t, model.SkippedIssues, "planToModel should serialize skipped issues")
+	require.NotEmpty(t, model.ProductContextSnapshot, "planToModel should snapshot product context when present")
+
+	modelWithoutContext, err := planToModel(plan, nil)
+	require.NoError(t, err, "planToModel should allow nil product context")
+	require.Empty(t, modelWithoutContext.ProductContextSnapshot, "planToModel should leave product context snapshot empty when no context is provided")
+
+	require.Equal(t, "low", tokenModeFromComplexity(models.PMTaskComplexitySimple), "tokenModeFromComplexity should use low tokens for simple tasks")
+	require.Equal(t, "high", tokenModeFromComplexity(models.PMTaskComplexityModerate), "tokenModeFromComplexity should use high tokens for moderate tasks")
+	require.Equal(t, "high", tokenModeFromComplexity(models.PMTaskComplexityComplex), "tokenModeFromComplexity should use high tokens for complex tasks")
+}


### PR DESCRIPTION
Summary
- add extensive unit tests for the PM service helpers, context gathering, adapter, and sandbox helpers
- add coverage for scheduler runtime lock/job orchestration edge cases and early exits
- ensure helper utilities like truncation and issue summarization behave as expected

Testing
- Not run (not requested)