### PR TITLE
Add Linear integration connect flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ Use docs/design/overall.md as the overall design of the system, think of it as a
 
 **API response format**: Lists return `{data: [...], meta: {next_cursor}}` with cursor-based pagination. Errors return `{error: {code, message, details}}`. All routes under `/api/v1/`.
 
+**Enum response fields use typed strings**: For model fields that represent enums (especially API response fields like provider/status/state/type), define a dedicated typed string in `internal/models` with named constants and a `Validate() error` method. Prefer `IntegrationProvider`/`IntegrationStatus`-style types over raw `string` fields. When writing new enum-like fields, add table-driven validation tests.
+
 **Job queue**: Postgres-backed async work queue using the `jobs` table. Workers claim jobs with `SELECT ... FOR UPDATE SKIP LOCKED` — no external queue needed. Jobs have `status`, `attempts`, `max_attempts`, and exponential backoff on failure.
 
 ## Frontend Architecture (Next.js / React)

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -17,6 +17,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
     - Support tickets
     - Sentry errors
     - Linear issues
+    - Integration setup is initiated from Settings integration cards (for example, "Connect Linear" creates an active Linear integration record for the org so webhook ingestion can be enabled without manual DB setup).
 - Step 2: Prioritize and identify top issues based on business impact
     - The system determines how many customers were affected, regression severity, and optionally (if you integrate Salesforce or some other CRM) the revenue risk.
     - The admins can specify product context (philosophy + direction + focus/avoid areas) to steer prioritization.

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -10,6 +10,8 @@ const {
   codexDisconnectMock,
   codexInitiateMock,
   loginMock,
+  integrationsListMock,
+  connectLinearMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
@@ -39,6 +41,8 @@ const {
     },
   }),
   loginMock: vi.fn(),
+  integrationsListMock: vi.fn().mockResolvedValue({ data: [] }),
+  connectLinearMock: vi.fn().mockResolvedValue({ data: { id: 'lin-1', provider: 'linear', status: 'active' } }),
 }));
 
 vi.mock('@/lib/api', () => ({
@@ -55,6 +59,10 @@ vi.mock('@/lib/api', () => ({
     },
     auth: {
       login: loginMock,
+    },
+    integrations: {
+      list: integrationsListMock,
+      connectLinear: connectLinearMock,
     },
   },
 }));
@@ -76,6 +84,8 @@ describe('SettingsPage', () => {
       },
     });
     loginMock.mockClear();
+    integrationsListMock.mockClear();
+    connectLinearMock.mockClear();
   });
 
   it('renders the General section with organization name', async () => {
@@ -93,6 +103,19 @@ describe('SettingsPage', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Integrations')).toBeInTheDocument();
+    });
+  });
+
+  it('connects linear when clicking Connect Linear', async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<SettingsPage />);
+
+    const button = await screen.findByRole('button', { name: 'Connect Linear' });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(connectLinearMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -259,6 +259,14 @@ export default function SettingsPage() {
   });
   const codexAuthStatus = codexAuthStatusResp?.data;
 
+  const { data: integrationsResp } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: () => api.integrations.list(),
+  });
+  const linearIntegration = integrationsResp?.data?.find(
+    (integration) => integration.provider === "linear" && integration.status === "active"
+  );
+
   const orgSettings = (settings?.data?.settings ?? {}) as OrgSettings;
 
   const [defaultAgentType, setDefaultAgentType] = useState(DEFAULT_SETTINGS.default_agent_type);
@@ -335,6 +343,13 @@ export default function SettingsPage() {
     mutationFn: () => api.codexAuth.disconnect(),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+    },
+  });
+
+  const connectLinearMutation = useMutation({
+    mutationFn: () => api.integrations.connectLinear(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
     },
   });
 
@@ -446,7 +461,17 @@ export default function SettingsPage() {
               id: linear.key,
               title: linear.name,
               description: linear.description,
-              action: <Badge variant="secondary">Coming soon</Badge>,
+              action: (
+                <Button
+                  size="sm"
+                  aria-label={linearIntegration ? "Linear Connected" : "Connect Linear"}
+                  loading={connectLinearMutation.isPending}
+                  disabled={Boolean(linearIntegration) || connectLinearMutation.isPending}
+                  onClick={() => connectLinearMutation.mutate()}
+                >
+                  {linearIntegration ? "Connected" : "Connect"}
+                </Button>
+              ),
             },
           ]}
         />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -164,6 +164,7 @@ export const api = {
   },
   integrations: {
     list: () => get<import('./types').ListResponse<import('./types').Integration>>('/api/v1/integrations'),
+    connectLinear: () => post<import('./types').SingleResponse<import('./types').Integration>>('/api/v1/integrations/linear/connect'),
   },
   codexAuth: {
     initiate: () => post<import('./types').SingleResponse<import('./types').CodexDeviceAuth>>('/api/v1/settings/codex-auth/initiate'),

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -28,3 +28,30 @@ func (h *IntegrationHandler) ListIntegrations(w http.ResponseWriter, r *http.Req
 	}
 	writeJSON(w, http.StatusOK, models.ListResponse[models.Integration]{Data: integrations})
 }
+
+func (h *IntegrationHandler) ConnectLinear(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	activeIntegrations, err := h.integrationStore.ListByOrgAndProvider(r.Context(), orgID, string(models.IntegrationProviderLinear))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration")
+		return
+	}
+
+	if len(activeIntegrations) > 0 {
+		writeJSON(w, http.StatusOK, models.SingleResponse[models.Integration]{Data: activeIntegrations[0]})
+		return
+	}
+
+	integration := &models.Integration{
+		OrgID:    orgID,
+		Provider: models.IntegrationProviderLinear,
+		Status:   models.IntegrationStatusActive,
+	}
+	if err := h.integrationStore.Create(r.Context(), integration); err != nil {
+		writeError(w, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, models.SingleResponse[models.Integration]{Data: *integration})
+}

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -1,13 +1,16 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
@@ -75,4 +78,79 @@ func TestIntegrationHandler_ListIntegrations_DBError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, w.Code, "should return 500 on DB error")
 	require.Contains(t, w.Body.String(), "LIST_FAILED")
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIntegrationHandler_ConnectLinear_CreatesIntegrationWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store)
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "ConnectLinear should return created status for a new integration")
+
+	var resp models.SingleResponse[models.Integration]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "ConnectLinear response should be valid JSON")
+	require.Equal(t, integrationID, resp.Data.ID, "ConnectLinear should return the created integration ID")
+	require.Equal(t, orgID, resp.Data.OrgID, "ConnectLinear should return the org from request context")
+	require.Equal(t, models.IntegrationProviderLinear, resp.Data.Provider, "ConnectLinear should create a linear integration")
+	require.Equal(t, models.IntegrationStatusActive, resp.Data.Status, "ConnectLinear should create an active integration")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestIntegrationHandler_ConnectLinear_ReturnsExistingIntegration(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store)
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+				AddRow(integrationID, orgID, "linear", json.RawMessage(`{}`), "active", nil, now),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "ConnectLinear should return OK when integration already exists")
+
+	var resp models.SingleResponse[models.Integration]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "ConnectLinear response should be valid JSON")
+	require.Equal(t, integrationID, resp.Data.ID, "ConnectLinear should return the existing integration ID")
+	require.Equal(t, models.IntegrationProviderLinear, resp.Data.Provider, "ConnectLinear should return a linear integration")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -144,9 +144,9 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 		})
 		integration := &models.Integration{
 			OrgID:    org.ID,
-			Provider: "github",
+			Provider: models.IntegrationProviderGitHub,
 			Config:   configJSON,
-			Status:   "active",
+			Status:   models.IntegrationStatusActive,
 		}
 		if err := h.integrationStore.Create(ctx, integration); err != nil {
 			writeError(w, http.StatusInternalServerError, "INTEGRATION_CREATE_FAILED", "failed to create integration")

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -173,6 +173,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Use(middleware.RequireRole("admin", "member"))
 
 			r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
+			r.Post("/api/v1/integrations/linear/connect", integrationHandler.ConnectLinear)
 			r.Post("/api/v1/issues/{id}/fix", runHandler.TriggerFix)
 			r.Post("/api/v1/runs/{id}/questions/{qid}/answer", runHandler.AnswerQuestion)
 		})

--- a/internal/db/integration_store_test.go
+++ b/internal/db/integration_store_test.go
@@ -120,8 +120,8 @@ func TestIntegrationStore_GetByOrgAndProvider(t *testing.T) {
 			require.NoError(t, err, "GetByOrgAndProvider should not return an error")
 			require.Equal(t, integrationID, integration.ID, "should return the correct integration ID")
 			require.Equal(t, orgID, integration.OrgID, "should return the correct org ID")
-			require.Equal(t, "github", integration.Provider, "should return the correct provider")
-			require.Equal(t, "active", integration.Status, "should return the correct status")
+			require.Equal(t, models.IntegrationProviderGitHub, integration.Provider, "should return the correct provider")
+			require.Equal(t, models.IntegrationStatusActive, integration.Status, "should return the correct status")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
@@ -178,7 +178,7 @@ func TestIntegrationStore_GetByID(t *testing.T) {
 			}
 			require.NoError(t, err, "GetByID should not return an error")
 			require.Equal(t, integrationID, integration.ID, "should return the correct integration ID")
-			require.Equal(t, "sentry", integration.Provider, "should return the correct provider")
+			require.Equal(t, models.IntegrationProviderSentry, integration.Provider, "should return the correct provider")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/models/integration_enums.go
+++ b/internal/models/integration_enums.go
@@ -1,0 +1,40 @@
+package models
+
+import "fmt"
+
+// IntegrationProvider identifies an external integration provider.
+type IntegrationProvider string
+
+const (
+	IntegrationProviderGitHub IntegrationProvider = "github"
+	IntegrationProviderSentry IntegrationProvider = "sentry"
+	IntegrationProviderLinear IntegrationProvider = "linear"
+)
+
+func (p IntegrationProvider) Validate() error {
+	switch p {
+	case IntegrationProviderGitHub, IntegrationProviderSentry, IntegrationProviderLinear:
+		return nil
+	default:
+		return fmt.Errorf("invalid IntegrationProvider: %q", p)
+	}
+}
+
+// IntegrationStatus captures lifecycle state for an integration.
+type IntegrationStatus string
+
+const (
+	IntegrationStatusActive   IntegrationStatus = "active"
+	IntegrationStatusInactive IntegrationStatus = "inactive"
+	IntegrationStatusError    IntegrationStatus = "error"
+)
+
+func (s IntegrationStatus) Validate() error {
+	switch s {
+	case IntegrationStatusActive, IntegrationStatusInactive, IntegrationStatusError:
+		return nil
+	default:
+		return fmt.Errorf("invalid IntegrationStatus: %q", s)
+	}
+}
+

--- a/internal/models/integration_enums_test.go
+++ b/internal/models/integration_enums_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegrationProviderValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   IntegrationProvider
+		wantErr bool
+	}{
+		{name: "valid github", value: IntegrationProviderGitHub},
+		{name: "valid sentry", value: IntegrationProviderSentry},
+		{name: "valid linear", value: IntegrationProviderLinear},
+		{name: "invalid empty", value: IntegrationProvider(""), wantErr: true},
+		{name: "invalid unknown", value: IntegrationProvider("jira"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.value.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "Validate should return error for invalid integration provider")
+				return
+			}
+			require.NoError(t, err, "Validate should succeed for valid integration provider")
+		})
+	}
+}
+
+func TestIntegrationStatusValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   IntegrationStatus
+		wantErr bool
+	}{
+		{name: "valid active", value: IntegrationStatusActive},
+		{name: "valid inactive", value: IntegrationStatusInactive},
+		{name: "valid error", value: IntegrationStatusError},
+		{name: "invalid empty", value: IntegrationStatus(""), wantErr: true},
+		{name: "invalid unknown", value: IntegrationStatus("paused"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.value.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "Validate should return error for invalid integration status")
+				return
+			}
+			require.NoError(t, err, "Validate should succeed for valid integration status")
+		})
+	}
+}
+

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -41,9 +41,9 @@ type Session struct {
 type Integration struct {
 	ID           uuid.UUID       `db:"id" json:"id"`
 	OrgID        uuid.UUID       `db:"org_id" json:"org_id"`
-	Provider     string          `db:"provider" json:"provider"`
+	Provider     IntegrationProvider `db:"provider" json:"provider"`
 	Config       json.RawMessage `db:"config" json:"-"` // never expose config in JSON (contains secrets)
-	Status       string          `db:"status" json:"status"`
+	Status       IntegrationStatus `db:"status" json:"status"`
 	LastSyncedAt *time.Time      `db:"last_synced_at" json:"last_synced_at,omitempty"`
 	CreatedAt    time.Time       `db:"created_at" json:"created_at"`
 }


### PR DESCRIPTION
Summary
- introduce typed enums for integration provider/status, add validation tests, and update instructions/design docs to mention the pattern
- add backend handler, router entry, and tests for linear connection plus refactor webhook creation to use the new types
- hook up the Settings page with a shadcn button to list integrations and trigger the connect endpoint

Testing
- Not run (not requested)