### PR TITLE
Improve team settings invite flow

### DIFF
--- a/docs/design/26-team-management.md
+++ b/docs/design/26-team-management.md
@@ -544,7 +544,7 @@ The frontend lives at `frontend/src/` and uses Next.js (App Router), React, TanS
 │  Team Members                              [Invite Member]  │
 │  ┌─────────────────────────────────────────────────────────┐│
 │  │  (avatar) Alice Chen                                    ││
-│  │  alice@example.com        Admin ▾         —             ││
+│  │  alice@example.com        Admin ▾   Current user         ││
 │  ├─────────────────────────────────────────────────────────┤│
 │  │  (avatar) Bob Smith                                     ││
 │  │  bob@example.com          Member ▾        [Remove]      ││

--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -130,19 +130,24 @@ describe('TeamSettingsPage', () => {
     });
   });
 
-  it('renders the Invite a Member form', async () => {
+  it('renders an Invite button and opens the invite modal', async () => {
     renderWithProviders(<TeamSettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Invite a Member')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Invite' })).toBeInTheDocument();
     });
 
+    await userEvent.click(screen.getByRole('button', { name: 'Invite' }));
+
+    expect(screen.getByText('Invite a member')).toBeInTheDocument();
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Send Invite' })).toBeInTheDocument();
   });
 
-  it('uses consistent compact sizing for invite email input', async () => {
+  it('uses consistent compact sizing for invite email input in modal', async () => {
     renderWithProviders(<TeamSettingsPage />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Invite' }));
 
     const emailInput = await screen.findByLabelText('Email');
     expect(emailInput).toHaveClass('h-9');
@@ -164,6 +169,8 @@ describe('TeamSettingsPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<TeamSettingsPage />);
 
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
+
     await waitFor(() => {
       expect(screen.getByLabelText('Email')).toBeInTheDocument();
     });
@@ -174,6 +181,17 @@ describe('TeamSettingsPage', () => {
     await waitFor(() => {
       expect(createInvitationMock).toHaveBeenCalledWith('newuser@test.com', 'member');
     });
+  });
+
+  it('shows informative self action text instead of a dash placeholder', async () => {
+    renderWithProviders(<TeamSettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Admin User')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(screen.getByText('Current user')).toBeInTheDocument();
   });
 
   it('shows Remove button for non-self members', async () => {
@@ -292,7 +310,7 @@ describe('TeamSettingsPage', () => {
       expect(screen.getByText('Member User')).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole('button', { name: 'Send Invite' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Invite' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Remove' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -36,6 +36,7 @@ export default function TeamSettingsPage() {
   const [inviteRole, setInviteRole] = useState("member");
   const [inviteError, setInviteError] = useState("");
   const [actionError, setActionError] = useState("");
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const [removingMember, setRemovingMember] = useState<User | null>(null);
 
   const { data: membersData, isLoading: membersLoading } = useQuery<ListResponse<User>>({
@@ -79,6 +80,7 @@ export default function TeamSettingsPage() {
       setInviteEmail("");
       setInviteRole("member");
       setInviteError("");
+      setIsInviteDialogOpen(false);
     },
     onError: (error: Error & { code?: string }) => {
       if (error.message) {
@@ -135,7 +137,20 @@ export default function TeamSettingsPage() {
 
       {/* Members List */}
       <section className="space-y-3">
-        <h2 className="text-[13px] font-medium text-foreground">Members</h2>
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="text-[13px] font-medium text-foreground">Members</h2>
+          {canManageTeam && (
+            <Button
+              size="sm"
+              onClick={() => {
+                setInviteError("");
+                setIsInviteDialogOpen(true);
+              }}
+            >
+              Invite
+            </Button>
+          )}
+        </div>
         <Card>
           <CardContent className="p-0">
             {membersLoading ? (
@@ -232,8 +247,14 @@ export default function TeamSettingsPage() {
                           >
                             Remove
                           </Button>
+                        ) : isSelf ? (
+                          <span className="text-xs text-muted-foreground">
+                            Current user
+                          </span>
                         ) : (
-                          <span className="text-xs text-muted-foreground">—</span>
+                          <span className="text-xs text-muted-foreground">
+                            No access
+                          </span>
                         )}
                       </div>
                     </div>
@@ -244,54 +265,6 @@ export default function TeamSettingsPage() {
           </CardContent>
         </Card>
       </section>
-
-      {/* Invite Form */}
-      {canManageTeam && (
-        <section className="space-y-3">
-          <h2 className="text-[13px] font-medium text-foreground">
-            Invite a Member
-          </h2>
-          <Card>
-            <CardContent>
-              <form onSubmit={handleInvite} className="flex items-end gap-3">
-                <div className="flex-1 space-y-1.5">
-                  <Label htmlFor="invite-email">Email</Label>
-                  <Input
-                    id="invite-email"
-                    type="email"
-                    placeholder="colleague@company.com"
-                    value={inviteEmail}
-                    onChange={(e) => setInviteEmail(e.target.value)}
-                    className="h-9 text-sm"
-                    required
-                  />
-                </div>
-                <div className="w-28 space-y-1.5">
-                  <Label>Role</Label>
-                  <Select value={inviteRole} onValueChange={setInviteRole}>
-                    <SelectTrigger className="h-9 w-full text-sm">
-                      <SelectValue>
-                        {capitalize(inviteRole)}
-                      </SelectValue>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="admin">Admin</SelectItem>
-                      <SelectItem value="member">Member</SelectItem>
-                      <SelectItem value="viewer">Viewer</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button type="submit" className="h-9" disabled={inviteMutation.isPending}>
-                  {inviteMutation.isPending ? "Sending..." : "Send Invite"}
-                </Button>
-              </form>
-              {inviteError && (
-                <p className="mt-2 text-sm text-destructive">{inviteError}</p>
-              )}
-            </CardContent>
-          </Card>
-        </section>
-      )}
 
       {/* Pending Invitations */}
       {canManageTeam && invitations.length > 0 && (
@@ -333,6 +306,68 @@ export default function TeamSettingsPage() {
             </CardContent>
           </Card>
         </section>
+      )}
+
+      {/* Invite Member Dialog */}
+      {canManageTeam && (
+        <AlertDialog
+          open={isInviteDialogOpen}
+          onOpenChange={(open) => {
+            setIsInviteDialogOpen(open);
+            if (!open) {
+              setInviteError("");
+            }
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Invite a member</AlertDialogTitle>
+              <AlertDialogDescription>
+                Send an invitation by email and choose the member&apos;s initial role.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <form onSubmit={handleInvite} className="space-y-4">
+              <div className="space-y-1.5">
+                <Label htmlFor="invite-email">Email</Label>
+                <Input
+                  id="invite-email"
+                  type="email"
+                  placeholder="colleague@company.com"
+                  value={inviteEmail}
+                  onChange={(e) => setInviteEmail(e.target.value)}
+                  className="h-9 text-sm"
+                  required
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="invite-role">Role</Label>
+                <Select value={inviteRole} onValueChange={setInviteRole}>
+                  <SelectTrigger id="invite-role" className="h-9 w-full text-sm">
+                    <SelectValue>{capitalize(inviteRole)}</SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="admin">Admin</SelectItem>
+                    <SelectItem value="member">Member</SelectItem>
+                    <SelectItem value="viewer">Viewer</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              {inviteError && (
+                <p className="text-sm text-destructive">{inviteError}</p>
+              )}
+              <AlertDialogFooter>
+                <AlertDialogCancel type="button">Cancel</AlertDialogCancel>
+                <Button
+                  type="submit"
+                  className="h-9"
+                  disabled={inviteMutation.isPending}
+                >
+                  {inviteMutation.isPending ? "Sending..." : "Send Invite"}
+                </Button>
+              </AlertDialogFooter>
+            </form>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
 
       {/* Remove Member Confirmation Dialog */}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -10,6 +10,22 @@ globalThis.ResizeObserver ??= class ResizeObserver {
   disconnect() {}
 } as unknown as typeof globalThis.ResizeObserver;
 
+if (!Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+}
+
+if (!Element.prototype.setPointerCapture) {
+  Element.prototype.setPointerCapture = () => {};
+}
+
+if (!Element.prototype.releasePointerCapture) {
+  Element.prototype.releasePointerCapture = () => {};
+}
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
Summary
- replace the dash placeholder in the members list with descriptive status text and show a contextual action when viewing yourself (frontend/src/app/(dashboard)/settings/team/page.tsx)
- move the invite form into a modal triggered by a new `Invite` button in the members header for a cleaner layout (frontend/src/app/(dashboard)/settings/team/page.tsx)
- update the page tests and setup helpers to cover the modal invite flow and additional DOM helpers (frontend/src/app/(dashboard)/settings/team/page.test.tsx, frontend/src/test/setup.ts)

Testing
- Not run (not requested)