### PR TITLE
Add org credential driving agent env setup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,7 +93,7 @@ func main() {
 		// Build Phase 3+ services if runtime dependencies are available.
 		var services *worker.Services
 		if canBuildServices(cfg, logger) {
-			services = buildServices(cfg, pool, logger, codexAuthSvc, issueStore, agentRunStore,
+			services = buildServices(cfg, pool, logger, codexAuthSvc, credentialStore, issueStore, agentRunStore,
 				jobStore, orgStore, repoStore, validationStore, pullRequestStore,
 				deployStore, priorityScoreStore, complexityEstimateStore, pmPlanStore, pmDecisionLogStore)
 		}
@@ -157,6 +157,7 @@ func buildServices(
 	pool *pgxpool.Pool,
 	logger zerolog.Logger,
 	codexAuthSvc *codexauth.Service,
+	credentialStore *db.OrgCredentialStore,
 	issueStore *db.IssueStore,
 	agentRunStore *db.AgentRunStore,
 	jobStore *db.JobStore,
@@ -214,8 +215,8 @@ func buildServices(
 		Jobs:              jobStore,
 		GitHub:            ghSvc,
 		CodexAuth:         codexAuthSvc,
+		Credentials:       credentialStore,
 		Logger:            logger,
-		AgentEnv:          cfg.AgentEnv(),
 	})
 
 	// Validation service.

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -25,6 +25,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 - Step 3: Execute a coding agent
     - Admins set a **confidence threshold** that controls which issues the system will auto-attempt. Issues below the threshold require manual triggering.
     - The agent runs in a sandboxed container and produces a code diff.
+    - Agent runtime credentials are loaded from org-scoped encrypted credentials (`org_credentials`) rather than process `.env` defaults, so each org can manage Codex/Claude/Gemini auth independently.
     - The agent outputs a **confidence score** with its fix. Low-confidence runs are paused for human review before proceeding to validation.
     - If the agent asks a clarifying question during execution, the run pauses and the question surfaces in the Fix Queue. The user can answer in the UI, provide guidance, or **resume the session locally** via CLI (e.g., `143 resume <run-id>` or `claude --resume <session-id>`) to take over the sandbox interactively.
     - When a run fails, the system generates a **human-readable failure explanation** with actionable next steps — see [17-failure-communication.md](17-failure-communication.md). Failures are classified by sub-type and feed back into the system to improve future runs.

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -13,19 +13,20 @@ import (
 type ProviderName string
 
 const (
-	ProviderAnthropic      ProviderName = "anthropic"
-	ProviderOpenAI         ProviderName = "openai"
-	ProviderOpenAIChatGPT  ProviderName = "openai_chatgpt"
-	ProviderOpenRouter     ProviderName = "openrouter"
-	ProviderGitHubApp      ProviderName = "github_app"
-	ProviderGitHubOAuth    ProviderName = "github_oauth"
-	ProviderSentry         ProviderName = "sentry"
-	ProviderLinear         ProviderName = "linear"
+	ProviderAnthropic     ProviderName = "anthropic"
+	ProviderOpenAI        ProviderName = "openai"
+	ProviderGemini        ProviderName = "gemini"
+	ProviderOpenAIChatGPT ProviderName = "openai_chatgpt"
+	ProviderOpenRouter    ProviderName = "openrouter"
+	ProviderGitHubApp     ProviderName = "github_app"
+	ProviderGitHubOAuth   ProviderName = "github_oauth"
+	ProviderSentry        ProviderName = "sentry"
+	ProviderLinear        ProviderName = "linear"
 )
 
 // AllProviders is the canonical list of credential providers.
 var AllProviders = []ProviderName{
-	ProviderAnthropic, ProviderOpenAI, ProviderOpenAIChatGPT, ProviderOpenRouter,
+	ProviderAnthropic, ProviderOpenAI, ProviderGemini, ProviderOpenAIChatGPT, ProviderOpenRouter,
 	ProviderGitHubApp, ProviderGitHubOAuth,
 	ProviderSentry, ProviderLinear,
 }
@@ -73,6 +74,11 @@ type OpenAIConfig struct {
 	APIKey  string `json:"api_key"` // #nosec G117 -- JSON config field
 	BaseURL string `json:"base_url,omitempty"`
 	APIType string `json:"api_type"`
+}
+
+type GeminiConfig struct {
+	APIKey string `json:"api_key"` // #nosec G117 -- JSON config field
+	Model  string `json:"model,omitempty"`
 }
 
 type OpenRouterConfig struct {
@@ -127,14 +133,15 @@ func (c OpenAIChatGPTConfig) NeedsRefresh(window time.Duration) bool {
 
 // --- Provider() implementations ---
 
-func (c AnthropicConfig) Provider() ProviderName   { return ProviderAnthropic }
-func (c OpenAIConfig) Provider() ProviderName      { return ProviderOpenAI }
-func (c OpenRouterConfig) Provider() ProviderName   { return ProviderOpenRouter }
-func (c GitHubAppConfig) Provider() ProviderName    { return ProviderGitHubApp }
-func (c GitHubOAuthConfig) Provider() ProviderName  { return ProviderGitHubOAuth }
-func (c SentryConfig) Provider() ProviderName       { return ProviderSentry }
-func (c LinearConfig) Provider() ProviderName         { return ProviderLinear }
-func (c OpenAIChatGPTConfig) Provider() ProviderName  { return ProviderOpenAIChatGPT }
+func (c AnthropicConfig) Provider() ProviderName     { return ProviderAnthropic }
+func (c OpenAIConfig) Provider() ProviderName        { return ProviderOpenAI }
+func (c GeminiConfig) Provider() ProviderName        { return ProviderGemini }
+func (c OpenRouterConfig) Provider() ProviderName    { return ProviderOpenRouter }
+func (c GitHubAppConfig) Provider() ProviderName     { return ProviderGitHubApp }
+func (c GitHubOAuthConfig) Provider() ProviderName   { return ProviderGitHubOAuth }
+func (c SentryConfig) Provider() ProviderName        { return ProviderSentry }
+func (c LinearConfig) Provider() ProviderName        { return ProviderLinear }
+func (c OpenAIChatGPTConfig) Provider() ProviderName { return ProviderOpenAIChatGPT }
 
 // --- Validate() implementations ---
 
@@ -146,6 +153,13 @@ func (c AnthropicConfig) Validate() error {
 }
 
 func (c OpenAIConfig) Validate() error {
+	if c.APIKey == "" {
+		return errors.New("api_key is required")
+	}
+	return nil
+}
+
+func (c GeminiConfig) Validate() error {
 	if c.APIKey == "" {
 		return errors.New("api_key is required")
 	}
@@ -222,6 +236,14 @@ func (c OpenAIConfig) MaskedSummary() CredentialSummary {
 	}
 }
 
+func (c GeminiConfig) MaskedSummary() CredentialSummary {
+	return CredentialSummary{
+		Provider:   ProviderGemini,
+		Configured: true,
+		MaskedKey:  MaskKey(c.APIKey),
+	}
+}
+
 func (c OpenRouterConfig) MaskedSummary() CredentialSummary {
 	return CredentialSummary{
 		Provider:   ProviderOpenRouter,
@@ -289,6 +311,12 @@ func ParseProviderConfig(provider ProviderName, data []byte) (ProviderConfig, er
 		}
 		if cfg.APIType == "" {
 			cfg.APIType = "chat"
+		}
+		return cfg, nil
+	case ProviderGemini:
+		var cfg GeminiConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("invalid gemini config: %w", err)
 		}
 		return cfg, nil
 	case ProviderOpenRouter:

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -17,6 +17,7 @@ func TestProviderName_Valid(t *testing.T) {
 	}{
 		{"anthropic is valid", ProviderAnthropic, true},
 		{"openai is valid", ProviderOpenAI, true},
+		{"gemini is valid", ProviderGemini, true},
 		{"openrouter is valid", ProviderOpenRouter, true},
 		{"github_app is valid", ProviderGitHubApp, true},
 		{"github_oauth is valid", ProviderGitHubOAuth, true},
@@ -129,6 +130,19 @@ func TestParseProviderConfig_OpenAI(t *testing.T) {
 	}
 }
 
+func TestParseProviderConfig_Gemini(t *testing.T) {
+	t.Parallel()
+
+	input := `{"api_key":"gm-test-key","model":"gemini-2.5-pro"}`
+	cfg, err := ParseProviderConfig(ProviderGemini, []byte(input))
+	require.NoError(t, err, "ParseProviderConfig should not return an error")
+
+	gc, ok := cfg.(GeminiConfig)
+	require.True(t, ok, "config should be GeminiConfig")
+	require.Equal(t, "gm-test-key", gc.APIKey, "should parse api_key")
+	require.Equal(t, "gemini-2.5-pro", gc.Model, "should parse model")
+}
+
 func TestParseProviderConfig_OpenRouter(t *testing.T) {
 	t.Parallel()
 
@@ -212,6 +226,7 @@ func TestProviderConfig_Provider(t *testing.T) {
 	}{
 		{"AnthropicConfig", AnthropicConfig{}, ProviderAnthropic},
 		{"OpenAIConfig", OpenAIConfig{}, ProviderOpenAI},
+		{"GeminiConfig", GeminiConfig{}, ProviderGemini},
 		{"OpenRouterConfig", OpenRouterConfig{}, ProviderOpenRouter},
 		{"GitHubAppConfig", GitHubAppConfig{}, ProviderGitHubApp},
 		{"GitHubOAuthConfig", GitHubOAuthConfig{}, ProviderGitHubOAuth},
@@ -242,6 +257,8 @@ func TestProviderConfig_Validate(t *testing.T) {
 		{"openai empty key", OpenAIConfig{APIKey: ""}, true},
 		{"openrouter valid", OpenRouterConfig{APIKey: "sk-or-test"}, false},
 		{"openrouter empty key", OpenRouterConfig{APIKey: ""}, true},
+		{"gemini valid", GeminiConfig{APIKey: "gm-test-key", Model: "gemini-2.5-pro"}, false},
+		{"gemini empty key", GeminiConfig{APIKey: ""}, true},
 		{"github_app valid", GitHubAppConfig{AppID: 123, PrivateKey: "key"}, false},
 		{"github_app missing app_id", GitHubAppConfig{AppID: 0, PrivateKey: "key"}, true},
 		{"github_app missing private_key", GitHubAppConfig{AppID: 123, PrivateKey: ""}, true},
@@ -323,6 +340,17 @@ func TestMaskedSummary_OpenRouter(t *testing.T) {
 
 	require.Equal(t, ProviderOpenRouter, summary.Provider, "summary should have correct provider")
 	require.Equal(t, "143", summary.AppName, "summary should include app_name")
+}
+
+func TestMaskedSummary_Gemini(t *testing.T) {
+	t.Parallel()
+
+	cfg := GeminiConfig{APIKey: "gm-test-key-12345"}
+	summary := cfg.MaskedSummary()
+
+	require.Equal(t, ProviderGemini, summary.Provider, "summary should have correct provider")
+	require.True(t, summary.Configured, "summary should be configured")
+	require.Equal(t, "gm-tes...2345", summary.MaskedKey, "summary should mask api key")
 }
 
 func TestMaskedSummary_GitHubApp(t *testing.T) {
@@ -454,6 +482,7 @@ func TestIsLLMProvider(t *testing.T) {
 		{"anthropic is LLM", ProviderAnthropic, true},
 		{"openai is LLM", ProviderOpenAI, true},
 		{"openrouter is LLM", ProviderOpenRouter, true},
+		{"gemini is not LLM", ProviderGemini, false},
 		{"github_app is not LLM", ProviderGitHubApp, false},
 		{"github_oauth is not LLM", ProviderGitHubOAuth, false},
 		{"sentry is not LLM", ProviderSentry, false},

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -32,6 +32,11 @@ type CodexAuthProvider interface {
 	GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.OpenAIChatGPTConfig, error)
 }
 
+// CredentialProvider abstracts retrieving org-scoped provider credentials.
+type CredentialProvider interface {
+	Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
+}
+
 // AgentRunStore defines the agent run DB operations needed by the orchestrator.
 type AgentRunStore interface {
 	UpdateStatus(ctx context.Context, orgID, runID uuid.UUID, status string) error
@@ -89,9 +94,9 @@ type Orchestrator struct {
 	jobs              JobStore
 	github            GitHubTokenProvider
 	codexAuth         CodexAuthProvider // can be nil
+	credentials       CredentialProvider
 	logger            zerolog.Logger
 	maxConcurrent     int
-	agentEnv          map[string]map[string]string
 }
 
 // OrchestratorConfig holds the dependencies for creating an Orchestrator.
@@ -108,13 +113,9 @@ type OrchestratorConfig struct {
 	Jobs              JobStore
 	GitHub            GitHubTokenProvider
 	CodexAuth         CodexAuthProvider // optional — enables ChatGPT OAuth for Codex agent
+	Credentials       CredentialProvider
 	Logger            zerolog.Logger
 	MaxConcurrent     int
-
-	// AgentEnv maps agent type names to the environment variables that should
-	// be injected into their sandbox containers. These are server-level defaults
-	// that can be overridden by org-level agent_config in org settings.
-	AgentEnv map[string]map[string]string
 }
 
 // NewOrchestrator creates an Orchestrator with the given dependencies.
@@ -122,11 +123,6 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 	maxConcurrent := cfg.MaxConcurrent
 	if maxConcurrent <= 0 {
 		maxConcurrent = defaultMaxConcurrent
-	}
-
-	agentEnv := cfg.AgentEnv
-	if agentEnv == nil {
-		agentEnv = make(map[string]map[string]string)
 	}
 
 	return &Orchestrator{
@@ -142,9 +138,9 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		jobs:              cfg.Jobs,
 		github:            cfg.GitHub,
 		codexAuth:         cfg.CodexAuth,
+		credentials:       cfg.Credentials,
 		logger:            cfg.Logger,
 		maxConcurrent:     maxConcurrent,
-		agentEnv:          agentEnv,
 	}
 }
 
@@ -461,28 +457,49 @@ func (o *Orchestrator) enqueueJob(ctx context.Context, orgID uuid.UUID, queue, j
 	}
 }
 
-// resolveAgentEnv merges server-level and org-level env vars for the given agent type.
-// Org-level values override server-level defaults.
+// resolveAgentEnv builds the sandbox env vars for the given agent type from
+// org-scoped credentials in org_credentials.
 func (o *Orchestrator) resolveAgentEnv(ctx context.Context, orgID uuid.UUID, agentType string) map[string]string {
-	merged := make(map[string]string)
-
-	// Start with server-level defaults.
-	if base, ok := o.agentEnv[agentType]; ok {
-		for k, v := range base {
-			merged[k] = v
-		}
+	if o.credentials == nil {
+		return nil
 	}
 
-	// Overlay org-level overrides from settings.
-	if o.orgs != nil {
-		org, err := o.orgs.GetByID(ctx, orgID)
-		if err == nil {
-			orgSettings := models.ParseOrgSettings(org.Settings)
-			if orgOverrides, ok := orgSettings.AgentConfig[agentType]; ok {
-				for k, v := range orgOverrides {
-					if v != "" {
-						merged[k] = v
-					}
+	merged := make(map[string]string)
+
+	switch agentType {
+	case "claude_code":
+		cred, err := o.credentials.Get(ctx, orgID, models.ProviderAnthropic)
+		if err == nil && cred != nil {
+			if cfg, ok := cred.Config.(models.AnthropicConfig); ok {
+				if cfg.APIKey != "" {
+					merged["ANTHROPIC_API_KEY"] = cfg.APIKey
+				}
+				if cfg.BaseURL != "" {
+					merged["ANTHROPIC_BASE_URL"] = cfg.BaseURL
+				}
+			}
+		}
+	case "codex":
+		cred, err := o.credentials.Get(ctx, orgID, models.ProviderOpenAI)
+		if err == nil && cred != nil {
+			if cfg, ok := cred.Config.(models.OpenAIConfig); ok {
+				if cfg.APIKey != "" {
+					merged["OPENAI_API_KEY"] = cfg.APIKey
+				}
+				if cfg.BaseURL != "" {
+					merged["OPENAI_BASE_URL"] = cfg.BaseURL
+				}
+			}
+		}
+	case "gemini_cli":
+		cred, err := o.credentials.Get(ctx, orgID, models.ProviderGemini)
+		if err == nil && cred != nil {
+			if cfg, ok := cred.Config.(models.GeminiConfig); ok {
+				if cfg.APIKey != "" {
+					merged["GEMINI_API_KEY"] = cfg.APIKey
+				}
+				if cfg.Model != "" {
+					merged["GEMINI_MODEL"] = cfg.Model
 				}
 			}
 		}
@@ -491,6 +508,7 @@ func (o *Orchestrator) resolveAgentEnv(ctx context.Context, orgID uuid.UUID, age
 	if len(merged) == 0 {
 		return nil
 	}
+
 	return merged
 }
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -97,6 +97,21 @@ func (m *mockCodexAuthProvider) GetValidToken(ctx context.Context, orgID uuid.UU
 	return m.cfg, nil
 }
 
+type mockCredentialProvider struct {
+	byProvider map[models.ProviderName]*models.DecryptedCredential
+	err        error
+}
+
+func (m *mockCredentialProvider) Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.byProvider == nil {
+		return nil, nil
+	}
+	return m.byProvider[provider], nil
+}
+
 // mockAgentRunStore implements agent.AgentRunStore.
 type mockAgentRunStore struct {
 	mu              sync.Mutex
@@ -333,6 +348,7 @@ type testDeps struct {
 	jobs      *mockJobStore
 	github    *mockGitHubTokenProvider
 	codexAuth agent.CodexAuthProvider
+	creds     *mockCredentialProvider
 }
 
 func defaultDeps() testDeps {
@@ -349,6 +365,7 @@ func defaultDeps() testDeps {
 		jobs:      &mockJobStore{},
 		github:    &mockGitHubTokenProvider{token: "ghp_test123"},
 		codexAuth: nil,
+		creds:     &mockCredentialProvider{},
 	}
 }
 
@@ -365,6 +382,7 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 		Jobs:              d.jobs,
 		GitHub:            d.github,
 		CodexAuth:         d.codexAuth,
+		Credentials:       d.creds,
 		Logger:            zerolog.Nop(),
 		MaxConcurrent:     3,
 	})
@@ -775,7 +793,7 @@ func TestRunAgent_ExactConfidenceThreshold(t *testing.T) {
 	require.Contains(t, d.jobs.getEnqueued(), "validate")
 }
 
-func TestRunAgent_AgentEnvInjected(t *testing.T) {
+func TestRunAgent_AgentCredentialsInjected(t *testing.T) {
 	t.Parallel()
 
 	orgID := testOrg()
@@ -791,6 +809,17 @@ func TestRunAgent_AgentEnvInjected(t *testing.T) {
 		return &agent.Sandbox{ID: "env-sandbox", Provider: "mock", WorkDir: "/workspace"}, nil
 	}
 
+	d.creds = &mockCredentialProvider{
+		byProvider: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderAnthropic: {
+				Provider: models.ProviderAnthropic,
+				Config: models.AnthropicConfig{
+					APIKey: "sk-ant-test-key",
+				},
+			},
+		},
+	}
+
 	orch := agent.NewOrchestrator(agent.OrchestratorConfig{
 		Provider:          d.provider,
 		Adapters:          map[string]agent.AgentAdapter{d.adapter.Name(): d.adapter},
@@ -802,19 +831,15 @@ func TestRunAgent_AgentEnvInjected(t *testing.T) {
 		Repositories:      d.repos,
 		Jobs:              d.jobs,
 		GitHub:            d.github,
+		Credentials:       d.creds,
 		Logger:            zerolog.Nop(),
 		MaxConcurrent:     3,
-		AgentEnv: map[string]map[string]string{
-			"claude_code": {
-				"ANTHROPIC_API_KEY": "sk-ant-test-key",
-			},
-		},
 	})
 
 	err := orch.RunAgent(context.Background(), run)
 	require.NoError(t, err)
 
-	// Verify the sandbox was created with the correct env vars.
+	// Verify the sandbox was created with the credential-derived env vars.
 	require.NotNil(t, capturedCfg.Env, "sandbox config should have env vars")
 	require.Equal(t, "sk-ant-test-key", capturedCfg.Env["ANTHROPIC_API_KEY"])
 }
@@ -834,7 +859,7 @@ func TestRunAgent_NoAgentEnvForUnknownType(t *testing.T) {
 		return &agent.Sandbox{ID: "no-env-sandbox", Provider: "mock", WorkDir: "/workspace"}, nil
 	}
 
-	// AgentEnv only has "codex" configured, not "claude_code".
+	// No credential configured for "claude_code".
 	orch := agent.NewOrchestrator(agent.OrchestratorConfig{
 		Provider:          d.provider,
 		Adapters:          map[string]agent.AgentAdapter{d.adapter.Name(): d.adapter},
@@ -846,22 +871,50 @@ func TestRunAgent_NoAgentEnvForUnknownType(t *testing.T) {
 		Repositories:      d.repos,
 		Jobs:              d.jobs,
 		GitHub:            d.github,
+		Credentials:       d.creds,
 		Logger:            zerolog.Nop(),
 		MaxConcurrent:     3,
-		AgentEnv: map[string]map[string]string{
-			"codex": {
-				"OPENAI_API_KEY": "sk-openai-test",
-			},
-		},
 	})
 
 	err := orch.RunAgent(context.Background(), run)
 	require.NoError(t, err)
 
-	// Sandbox should have no agent-specific env vars since "claude_code" isn't in AgentEnv,
+	// Sandbox should have no agent-specific env vars since "claude_code" has no credential,
 	// but HOME is always injected as a fallback.
 	require.Equal(t, map[string]string{"HOME": "/workspace"}, capturedCfg.Env,
 		"sandbox config should only have HOME for unconfigured agent type")
+}
+
+func TestRunAgent_CodexUsesOpenAICredentialFallback(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.AgentType = "codex"
+
+	d := defaultDeps()
+	d.adapter.name = "codex"
+	d.codexAuth = nil
+	d.creds = &mockCredentialProvider{
+		byProvider: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderOpenAI: {
+				Provider: models.ProviderOpenAI,
+				Config:   models.OpenAIConfig{APIKey: "sk-openai-fallback", BaseURL: "https://api.openai.com/v1", APIType: "chat"},
+			},
+		},
+	}
+
+	var capturedCfg agent.SandboxConfig
+	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+		capturedCfg = cfg
+		return &agent.Sandbox{ID: "codex-fallback", Provider: "mock", WorkDir: "/workspace"}, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.NoError(t, err, "run should succeed when openai credential exists")
+	require.Equal(t, "sk-openai-fallback", capturedCfg.Env["OPENAI_API_KEY"], "codex should receive OPENAI_API_KEY from org credentials")
 }
 
 func TestRunAgent_CodexAuthWritesToSandboxWorkdir(t *testing.T) {


### PR DESCRIPTION
Summary
- inject org credential store into services and orchestrator so agent sandboxes derive their env vars from `org_credentials`
- add Gemini provider support in the credential model plus CLI/docs notes on org-scoped auth
- update orchestrator tests to cover credential-driven env injection and OpenAI fallback behavior

Testing
- Not run (not requested)