### PR TITLE
Update overview page test for API key selection flow

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -116,8 +116,10 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Edit agent settings')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('For gpt-5.3-codex model access.')).toBeInTheDocument();
+    expect(screen.getByText('Best for gpt-5.3-codex model access.')).toBeInTheDocument();
     expect(screen.getByText('Recommended')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Use API key' }));
 
     await user.clear(screen.getByLabelText('Model'));
     await user.type(screen.getByLabelText('Model'), 'codex-mini');


### PR DESCRIPTION
## Summary
Updated the overview page test to reflect changes in the model configuration UI and improve test coverage for the API key selection flow.

## Key Changes
- Updated expected text from "For gpt-5.3-codex model access." to "Best for gpt-5.3-codex model access." to match the current UI copy
- Added explicit user interaction to select the "Use API key" radio button before modifying the model field, ensuring the test follows the actual user workflow more accurately

## Implementation Details
The test now properly exercises the API key selection step in the agent settings configuration flow, making the test more representative of the actual user experience when changing model settings.

https://claude.ai/code/session_012Et1RSAtHiRn17V8V18iaD