### PR TITLE
Redesign overview page with multi-agent selection and improved onboarding

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -63,7 +63,50 @@ describe('OverviewPage', () => {
     agentDefaultsMock.mockClear();
   });
 
-  it('starts GitHub onboarding directly from the dashboard', async () => {
+  it('renders the page header', () => {
+    renderWithProviders(<Overview />);
+
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Set up your coding agent and connect your tools to start fixing issues automatically.')).toBeInTheDocument();
+  });
+
+  it('renders the page description text', () => {
+    renderWithProviders(<Overview />);
+
+    expect(screen.getByText(/Once integrations are connected/)).toBeInTheDocument();
+  });
+
+  it('shows all three coding agent options with Codex as recommended', async () => {
+    renderWithProviders(<Overview />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Codex')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    expect(screen.getByText('Gemini CLI')).toBeInTheDocument();
+    expect(screen.getByText('Recommended')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: 'Configure' })).toHaveLength(2);
+  });
+
+  it('shows coding agent section before source control and integrations', () => {
+    renderWithProviders(<Overview />);
+
+    const codingAgentHeader = screen.getByText('Coding agent');
+    const sourceControlHeader = screen.getByText('Source control');
+    const integrationsHeader = screen.getByText('Additional integrations');
+
+    // Verify ordering via DOM position
+    expect(
+      codingAgentHeader.compareDocumentPosition(sourceControlHeader) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      sourceControlHeader.compareDocumentPosition(integrationsHeader) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('starts GitHub onboarding from the source control section', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<Overview />);
@@ -73,7 +116,7 @@ describe('OverviewPage', () => {
     expect(loginMock).toHaveBeenCalledTimes(1);
   });
 
-  it('starts Sentry onboarding directly from the dashboard', async () => {
+  it('starts Sentry onboarding from the additional integrations section', async () => {
     const user = userEvent.setup();
 
     renderWithProviders(<Overview />);
@@ -81,65 +124,25 @@ describe('OverviewPage', () => {
     await user.click(screen.getByRole('button', { name: 'Connect Sentry' }));
 
     expect(sentryLoginMock).toHaveBeenCalledTimes(1);
-    expect(screen.queryByRole('heading', { name: 'Integrations' })).not.toBeInTheDocument();
   });
 
-  it('shows Linear integration on the dashboard', () => {
+  it('shows Linear integration as coming soon', () => {
     renderWithProviders(<Overview />);
 
     expect(screen.getByText('Connect Linear')).toBeInTheDocument();
     expect(screen.getByText('Coming soon')).toBeInTheDocument();
   });
 
-  it('shows the AgentSetupCard with connect prompt when not authenticated', async () => {
-    renderWithProviders(<Overview />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Connect your coding agent')).toBeInTheDocument();
-    });
-
-    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
-  });
-
-  it('opens agent settings modal from setup card and saves updates', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<Overview />);
-
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('button', { name: 'Settings' }));
-
-    await waitFor(() => {
-      expect(screen.getByText('Edit agent settings')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('For gpt-5.3-codex model access.')).toBeInTheDocument();
-    expect(screen.getByText('Recommended')).toBeInTheDocument();
-
-    await user.clear(screen.getByLabelText('Model'));
-    await user.type(screen.getByLabelText('Model'), 'codex-mini');
-    await user.click(screen.getByRole('button', { name: 'Save changes' }));
-
-    await waitFor(() => {
-      expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
-    });
-
-    expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows the AgentSetupCard as connected when auth status is completed', async () => {
+  it('shows Codex as connected when ChatGPT auth status is completed', async () => {
     codexStatusMock.mockResolvedValue({ data: { status: 'completed' } });
 
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Codex is connected via ChatGPT.')).toBeInTheDocument();
+      expect(screen.getByText('Connected')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign in with ChatGPT' })).not.toBeInTheDocument();
   });
 
   it('opens device code modal when Sign in with ChatGPT is clicked', async () => {
@@ -147,27 +150,42 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('Connect your ChatGPT account')).toBeInTheDocument();
     });
   });
 
-  it('renders the page description text', () => {
+  it('opens agent settings modal from Configure button on Claude Code card', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<Overview />);
 
-    expect(screen.getByText(/Once integrations are connected/)).toBeInTheDocument();
-  });
+    await waitFor(() => {
+      expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    });
 
-  it('renders the page header', () => {
-    renderWithProviders(<Overview />);
+    const configureButtons = screen.getAllByRole('button', { name: 'Configure' });
+    await user.click(configureButtons[0]);
 
-    expect(screen.getByText('Overview')).toBeInTheDocument();
-    expect(screen.getByText('Get started by connecting your tools.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Configure coding agent')).toBeInTheDocument();
+    });
+
+    // Claude Code should be pre-selected, showing its env var fields
+    await waitFor(() => {
+      expect(screen.getByLabelText('Model')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Model'), 'claude-sonnet-4-5');
+    await user.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('shows device code and verification URI in modal after initiation', async () => {
@@ -175,10 +193,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
@@ -195,10 +213,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('Connect your ChatGPT account')).toBeInTheDocument();
@@ -217,10 +235,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
@@ -236,7 +254,7 @@ describe('OverviewPage', () => {
   });
 
   it('shows completed state when polling returns completed', async () => {
-    // First call returns pending (for initial status check in AgentSetupCard)
+    // First call returns pending (for initial status check in AgentSelectionSection)
     // Second call onwards returns completed (for polling inside modal)
     codexStatusMock
       .mockResolvedValueOnce({ data: { status: 'pending' } })
@@ -246,10 +264,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
@@ -269,10 +287,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
@@ -294,10 +312,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();
@@ -313,10 +331,10 @@ describe('OverviewPage', () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Sign in with ChatGPT')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Sign in with ChatGPT'));
+    await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
       expect(screen.getByText('ABCD-1234')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -156,11 +156,26 @@ describe('OverviewPage', () => {
     await user.click(screen.getByRole('button', { name: 'Sign in with ChatGPT' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Edit agent settings')).toBeInTheDocument();
+      expect(screen.getByText('Connect your ChatGPT account')).toBeInTheDocument();
+    });
+  });
+
+  it('opens agent settings modal from Codex Settings button and saves updates', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Overview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Configure coding agent')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Best for gpt-5.3-codex model access.')).toBeInTheDocument();
-    expect(screen.getByText('Recommended')).toBeInTheDocument();
+    expect(screen.getAllByText('Recommended').length).toBeGreaterThanOrEqual(1);
 
     await user.click(screen.getByRole('radio', { name: 'Use API key' }));
 

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -9,7 +9,7 @@ import { PageHeader } from "@/components/page-header";
 import { IntegrationsCard } from "@/components/integrations-card";
 import { AgentSettingsEditor } from "@/components/agent-settings-editor";
 import { INTEGRATIONS } from "@/lib/integrations";
-import type { CodexAuthStatus, CodexDeviceAuth } from "@/lib/types";
+import type { CodexAuthStatus, CodexDeviceAuth, OrgSettings } from "@/lib/types";
 
 function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void; onConnected: () => void }) {
   const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
@@ -112,13 +112,14 @@ function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void
   );
 }
 
-function AgentSettingsModal({ onClose }: { onClose: () => void }) {
+function AgentSettingsModal({ onClose, initialAgentType }: { onClose: () => void; initialAgentType?: OrgSettings["default_agent_type"] }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
       <div className="w-full max-w-2xl rounded-lg border bg-background p-6 shadow-lg">
         <AgentSettingsEditor
-          title="Edit agent settings"
-          description="Update your default coding agent and auth credentials without leaving setup."
+          title="Configure coding agent"
+          description="Set your default agent and configure credentials."
+          initialAgentType={initialAgentType}
           onClose={onClose}
         />
       </div>
@@ -126,57 +127,152 @@ function AgentSettingsModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function AgentSetupCard() {
-  const [authStatus, setAuthStatus] = useState<CodexAuthStatus | null>(null);
-  const [showModal, setShowModal] = useState(false);
+function AgentSelectionSection() {
+  const [codexAuthStatus, setCodexAuthStatus] = useState<CodexAuthStatus | null>(null);
+  const [agentConfig, setAgentConfig] = useState<Record<string, Record<string, string>>>({});
+  const [agentDefaults, setAgentDefaults] = useState<Record<string, Record<string, string>>>({});
+  const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
+  const [settingsAgentType, setSettingsAgentType] = useState<OrgSettings["default_agent_type"]>("codex");
 
-  const fetchStatus = useCallback(() => {
-    api.codexAuth.status().then((res) => setAuthStatus(res.data)).catch(() => {});
+  const fetchData = useCallback(() => {
+    api.codexAuth.status().then((res) => setCodexAuthStatus(res.data)).catch(() => {});
+    api.settings.get().then((res) => {
+      const settings = res.data?.settings as OrgSettings | undefined;
+      setAgentConfig(settings?.agent_config ?? {});
+    }).catch(() => {});
+    api.settings.getAgentDefaults().then((res) => {
+      setAgentDefaults(res.data ?? {});
+    }).catch(() => {});
   }, []);
 
-  useEffect(() => { fetchStatus(); }, [fetchStatus]);
+  useEffect(() => { fetchData(); }, [fetchData]);
 
-  if (authStatus?.status === "completed") {
-    return (
-      <Card className="py-0">
-        <CardContent className="flex items-center justify-between gap-4 py-4">
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium text-foreground">Coding Agent</p>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              Codex is connected via ChatGPT.
-            </p>
-          </div>
-          <Badge variant="secondary">Connected</Badge>
-        </CardContent>
-      </Card>
-    );
-  }
+  const isCodexConnected = codexAuthStatus?.status === "completed"
+    || Boolean(agentConfig.codex?.OPENAI_API_KEY)
+    || Boolean(agentDefaults.codex?.OPENAI_API_KEY);
+
+  const isClaudeConnected = Boolean(agentConfig.claude_code?.ANTHROPIC_API_KEY)
+    || Boolean(agentDefaults.claude_code?.ANTHROPIC_API_KEY);
+
+  const isGeminiConnected = Boolean(agentConfig.gemini_cli?.GEMINI_API_KEY)
+    || Boolean(agentDefaults.gemini_cli?.GEMINI_API_KEY);
 
   return (
     <>
-      <Card className="py-0">
-        <CardContent className="flex items-center justify-between gap-4 py-4">
-          <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium text-foreground">Connect your coding agent</p>
-            <p className="mt-0.5 text-sm text-muted-foreground">
-              Sign in with ChatGPT to let Codex fix issues automatically, or configure an API key in Settings.
-            </p>
-          </div>
-          <div className="flex shrink-0 gap-2">
-            <Button size="sm" onClick={() => setShowModal(true)}>Sign in with ChatGPT</Button>
-            <Button size="sm" variant="outline" onClick={() => setShowSettingsModal(true)}>Settings</Button>
-          </div>
-        </CardContent>
-      </Card>
-      {showModal && (
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-sm font-medium text-foreground">Coding agent</h2>
+          <p className="text-xs text-muted-foreground">
+            Choose the agent that fixes your issues. You can change this later in settings.
+          </p>
+        </div>
+
+        {/* Featured: Codex (Recommended) */}
+        <Card className={`py-0 ${!isCodexConnected ? "border-primary" : ""}`} data-testid="agent-card-codex">
+          <CardContent className="flex items-center justify-between gap-4 py-4">
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-medium text-foreground">Codex</p>
+                <Badge variant="secondary" className="text-xs">Recommended</Badge>
+              </div>
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                Sign in with ChatGPT for instant access to gpt-5.3-codex. No API key needed.
+              </p>
+            </div>
+            <div className="flex shrink-0 gap-2">
+              {isCodexConnected ? (
+                <Badge variant="secondary">Connected</Badge>
+              ) : (
+                <>
+                  <Button size="sm" onClick={() => setShowDeviceCodeModal(true)}>
+                    Sign in with ChatGPT
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setSettingsAgentType("codex");
+                      setShowSettingsModal(true);
+                    }}
+                  >
+                    Settings
+                  </Button>
+                </>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Secondary agents: Claude Code + Gemini CLI */}
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Card className="py-0" data-testid="agent-card-claude">
+            <CardContent className="flex items-center justify-between gap-4 py-4">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground">Claude Code</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  Use your Anthropic API key for Claude-powered fixes.
+                </p>
+              </div>
+              <div className="shrink-0">
+                {isClaudeConnected ? (
+                  <Badge variant="secondary">Connected</Badge>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setSettingsAgentType("claude_code");
+                      setShowSettingsModal(true);
+                    }}
+                  >
+                    Configure
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card className="py-0" data-testid="agent-card-gemini">
+            <CardContent className="flex items-center justify-between gap-4 py-4">
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground">Gemini CLI</p>
+                <p className="mt-0.5 text-sm text-muted-foreground">
+                  Use your Google Gemini API key for Gemini-powered fixes.
+                </p>
+              </div>
+              <div className="shrink-0">
+                {isGeminiConnected ? (
+                  <Badge variant="secondary">Connected</Badge>
+                ) : (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      setSettingsAgentType("gemini_cli");
+                      setShowSettingsModal(true);
+                    }}
+                  >
+                    Configure
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+
+      {showDeviceCodeModal && (
         <OverviewDeviceCodeModal
-          onClose={() => setShowModal(false)}
-          onConnected={() => { setShowModal(false); fetchStatus(); }}
+          onClose={() => setShowDeviceCodeModal(false)}
+          onConnected={() => { setShowDeviceCodeModal(false); fetchData(); }}
         />
       )}
       {showSettingsModal && (
-        <AgentSettingsModal onClose={() => setShowSettingsModal(false)} />
+        <AgentSettingsModal
+          initialAgentType={settingsAgentType}
+          onClose={() => { setShowSettingsModal(false); fetchData(); }}
+        />
       )}
     </>
   );
@@ -186,13 +282,23 @@ export default function Overview() {
   const [github, sentry, linear] = INTEGRATIONS;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
       <PageHeader
         title="Overview"
-        description="Get started by connecting your tools."
+        description="Set up your coding agent and connect your tools to start fixing issues automatically."
       />
 
+      {/* Step 1: Coding Agent — the core of the product */}
+      <AgentSelectionSection />
+
+      {/* Step 2: Source Control — needed so the agent can access repos and open PRs */}
       <div className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-sm font-medium text-foreground">Source control</h2>
+          <p className="text-xs text-muted-foreground">
+            Connect GitHub so the agent can access your repositories and open PRs.
+          </p>
+        </div>
         <IntegrationsCard
           items={[
             {
@@ -205,12 +311,31 @@ export default function Overview() {
                 </Button>
               ),
             },
+          ]}
+        />
+      </div>
+
+      {/* Step 3: Additional Integrations — optional, lower priority */}
+      <div className="space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-sm font-medium text-muted-foreground">Additional integrations</h2>
+          <p className="text-xs text-muted-foreground">
+            Optional — connect issue and error sources to feed the agent automatically.
+          </p>
+        </div>
+        <IntegrationsCard
+          items={[
             {
               id: sentry.key,
               title: `Connect ${sentry.name}`,
               description: sentry.description,
               action: (
-                <Button size="sm" onClick={() => api.auth.loginSentry()} aria-label="Connect Sentry">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => api.auth.loginSentry()}
+                  aria-label="Connect Sentry"
+                >
                   Connect
                 </Button>
               ),
@@ -224,8 +349,6 @@ export default function Overview() {
           ]}
         />
       </div>
-
-      <AgentSetupCard />
 
       <p className="text-sm text-muted-foreground">
         Once integrations are connected, 143 picks up issues, generates fixes, and opens PRs automatically.

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -205,13 +205,15 @@ export function AgentSettingsEditor({
   title,
   description,
   onClose,
+  initialAgentType,
 }: {
   title: string;
   description: string;
   onClose?: () => void;
+  initialAgentType?: OrgSettings["default_agent_type"];
 }) {
   const queryClient = useQueryClient();
-  const [defaultAgentTypeOverride, setDefaultAgentTypeOverride] = useState<OrgSettings["default_agent_type"] | null>(null);
+  const [defaultAgentTypeOverride, setDefaultAgentTypeOverride] = useState<OrgSettings["default_agent_type"] | null>(initialAgentType ?? null);
   const [agentConfigOverride, setAgentConfigOverride] = useState<Record<string, Record<string, string>> | null>(null);
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);


### PR DESCRIPTION
## Summary
Restructured the overview/onboarding page to prioritize coding agent selection as the first step, followed by source control and optional integrations. Introduced support for multiple coding agents (Codex, Claude Code, Gemini CLI) with individual connection status tracking.

## Key Changes

- **Renamed and expanded agent setup component**: `AgentSetupCard` → `AgentSelectionSection` with support for three distinct coding agents (Codex, Claude Code, Gemini CLI)
- **Multi-agent connection tracking**: Added state management for agent configuration and defaults, with individual connection status indicators for each agent
- **Improved UX flow**: Reorganized page sections into three clear steps:
  1. Coding agent selection (primary focus)
  2. Source control (GitHub) integration
  3. Additional integrations (Sentry, Linear) as optional
- **Enhanced agent settings modal**: Added `initialAgentType` prop to `AgentSettingsModal` and `AgentSettingsEditor` to pre-select the agent being configured
- **Visual hierarchy improvements**: 
  - Added section headers with descriptions for each setup step
  - Marked Codex as "Recommended" with featured card styling
  - Secondary agents (Claude, Gemini) displayed in a 2-column grid
  - Changed Sentry button to outline variant for visual consistency
- **Updated page messaging**: Changed header description to emphasize agent setup as the core first step
- **Comprehensive test updates**: Added new tests for multi-agent display, section ordering, and agent-specific configuration flows; updated existing tests to reflect new component structure and messaging

## Implementation Details

- Agent connection status determined by checking: ChatGPT auth completion, stored API keys in agent config, or agent defaults
- Settings modal now receives the selected agent type to pre-populate the correct configuration form
- Data fetching consolidated into single `fetchData` callback that retrieves Codex auth status, organization settings, and agent defaults
- Modal refresh behavior updated to refetch all data after settings changes

https://claude.ai/code/session_01LoyGD491yyMZ1oS1CRkmph