### PR TITLE
Consolidate dashboard agent selection into single card

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -8,6 +8,13 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 
 # Overall flow
 
+## Onboarding dashboard UX
+
+- The Overview page uses a progressive, low-friction setup sequence: (1) choose coding agent, (2) connect GitHub, (3) add optional integrations.
+- Coding agent selection uses a **single card with an agent dropdown** (default `Codex`) instead of multiple parallel agent cards. This reduces first-run decision fatigue and keeps focus on the primary onboarding path.
+- The selected agent card always presents one clear next action: sign in (Codex) or configure credentials (Claude/Gemini), with a persistent settings entrypoint.
+- Codex remains visually recommended to guide most users toward the quickest "time to first fix" path while preserving flexibility for teams with existing Anthropic/Google setups.
+
 - Step 0: Connect repositories and build codebase context
     - Users sign in with GitHub OAuth and install the 143.dev GitHub App on their organization/repos. The GitHub App (same auth model used by Codex web, Claude Code web, and other modern AI coding platforms) provides fine-grained, short-lived installation tokens for repo access — no personal access tokens needed.
     - For each connected repo, the system automatically builds a **Repository Context Package** — a structured body of knowledge including architecture docs (CLAUDE.md, AGENTS.md), coding conventions extracted from the codebase and past PR reviews, a feature-to-file map (which files own which features), test infrastructure knowledge (how to run tests, what patterns are used), and a dependency map (service boundaries, safe-to-change-in-isolation analysis).

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -76,18 +76,38 @@ describe('OverviewPage', () => {
     expect(screen.getByText(/Once integrations are connected/)).toBeInTheDocument();
   });
 
-  it('shows all three coding agent options with Codex as recommended', async () => {
+  it('shows a single coding agent card with dropdown defaulting to Codex', async () => {
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Codex')).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: 'Coding agent provider' })).toBeInTheDocument();
     });
 
-    expect(screen.getByText('Claude Code')).toBeInTheDocument();
-    expect(screen.getByText('Gemini CLI')).toBeInTheDocument();
+    expect(screen.getByText('Codex')).toBeInTheDocument();
     expect(screen.getByText('Recommended')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
-    expect(screen.getAllByRole('button', { name: 'Configure' })).toHaveLength(2);
+    expect(screen.queryByTestId('agent-card-claude')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('agent-card-gemini')).not.toBeInTheDocument();
+  });
+
+  it('updates the single card content when a different coding agent is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Overview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox', { name: 'Coding agent provider' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('combobox', { name: 'Coding agent provider' }));
+    await user.click(await screen.findByRole('option', { name: 'Claude Code' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Claude Code')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Use your Anthropic API key for Claude-powered fixes.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Configure' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign in with ChatGPT' })).not.toBeInTheDocument();
   });
 
   it('shows coding agent section before source control and integrations', () => {
@@ -188,16 +208,17 @@ describe('OverviewPage', () => {
     });
   });
 
-  it('opens agent settings modal from Configure button on Claude Code card', async () => {
+  it('opens agent settings modal from Configure after selecting Claude Code', async () => {
     const user = userEvent.setup();
     renderWithProviders(<Overview />);
 
     await waitFor(() => {
-      expect(screen.getByText('Claude Code')).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: 'Coding agent provider' })).toBeInTheDocument();
     });
 
-    const configureButtons = screen.getAllByRole('button', { name: 'Configure' });
-    await user.click(configureButtons[0]);
+    await user.click(screen.getByRole('combobox', { name: 'Coding agent provider' }));
+    await user.click(await screen.findByRole('option', { name: 'Claude Code' }));
+    await user.click(screen.getByRole('button', { name: 'Configure' }));
 
     await waitFor(() => {
       expect(screen.getByText('Configure coding agent')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -5,6 +5,13 @@ import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { PageHeader } from "@/components/page-header";
 import { IntegrationsCard } from "@/components/integrations-card";
 import { AgentSettingsEditor } from "@/components/agent-settings-editor";
@@ -128,18 +135,52 @@ function AgentSettingsModal({ onClose, initialAgentType }: { onClose: () => void
 }
 
 function AgentSelectionSection() {
+  type AgentType = NonNullable<OrgSettings["default_agent_type"]>;
+
+  const AGENT_OPTIONS: Array<{
+    value: AgentType;
+    label: string;
+    description: string;
+    configureLabel: string;
+    ctaLabel: string;
+  }> = [
+    {
+      value: "codex",
+      label: "Codex",
+      description: "Sign in with ChatGPT for instant access to gpt-5.3-codex. No API key needed.",
+      configureLabel: "Settings",
+      ctaLabel: "Sign in with ChatGPT",
+    },
+    {
+      value: "claude_code",
+      label: "Claude Code",
+      description: "Use your Anthropic API key for Claude-powered fixes.",
+      configureLabel: "Configure",
+      ctaLabel: "Configure",
+    },
+    {
+      value: "gemini_cli",
+      label: "Gemini CLI",
+      description: "Use your Google Gemini API key for Gemini-powered fixes.",
+      configureLabel: "Configure",
+      ctaLabel: "Configure",
+    },
+  ];
+
   const [codexAuthStatus, setCodexAuthStatus] = useState<CodexAuthStatus | null>(null);
   const [agentConfig, setAgentConfig] = useState<Record<string, Record<string, string>>>({});
   const [agentDefaults, setAgentDefaults] = useState<Record<string, Record<string, string>>>({});
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
   const [showSettingsModal, setShowSettingsModal] = useState(false);
   const [settingsAgentType, setSettingsAgentType] = useState<OrgSettings["default_agent_type"]>("codex");
+  const [selectedAgentType, setSelectedAgentType] = useState<AgentType>("codex");
 
   const fetchData = useCallback(() => {
     api.codexAuth.status().then((res) => setCodexAuthStatus(res.data)).catch(() => {});
     api.settings.get().then((res) => {
       const settings = res.data?.settings as OrgSettings | undefined;
       setAgentConfig(settings?.agent_config ?? {});
+      setSelectedAgentType(settings?.default_agent_type ?? "codex");
     }).catch(() => {});
     api.settings.getAgentDefaults().then((res) => {
       setAgentDefaults(res.data ?? {});
@@ -158,108 +199,69 @@ function AgentSelectionSection() {
   const isGeminiConnected = Boolean(agentConfig.gemini_cli?.GEMINI_API_KEY)
     || Boolean(agentDefaults.gemini_cli?.GEMINI_API_KEY);
 
+  const isSelectedAgentConnected = selectedAgentType === "codex"
+    ? isCodexConnected
+    : selectedAgentType === "claude_code"
+      ? isClaudeConnected
+      : isGeminiConnected;
+
+  const selectedAgent = AGENT_OPTIONS.find((agent) => agent.value === selectedAgentType) ?? AGENT_OPTIONS[0];
+
   return (
     <>
       <div className="space-y-3">
         <div className="space-y-1">
           <h2 className="text-sm font-medium text-foreground">Coding agent</h2>
           <p className="text-xs text-muted-foreground">
-            Choose the agent that fixes your issues. You can change this later in settings.
+            Start with Codex (recommended), or pick the agent you already use. You can change this later in settings.
           </p>
         </div>
 
-        {/* Featured: Codex (Recommended) */}
-        <Card className={`py-0 ${!isCodexConnected ? "border-primary" : ""}`} data-testid="agent-card-codex">
+        <Card className={`py-0 ${selectedAgentType === "codex" && !isCodexConnected ? "border-primary" : ""}`} data-testid="agent-card-codex">
           <CardContent className="flex items-center justify-between gap-4 py-4">
             <div className="min-w-0 flex-1">
-              <div className="flex items-center gap-2">
-                <p className="text-sm font-medium text-foreground">Codex</p>
-                <Badge variant="secondary" className="text-xs">Recommended</Badge>
+              <div className="flex items-center gap-2 mb-2">
+                <Select
+                  value={selectedAgentType}
+                  onValueChange={(value) => setSelectedAgentType(value as AgentType)}
+                >
+                  <SelectTrigger aria-label="Coding agent provider" className="w-[220px]">
+                    <SelectValue placeholder="Select coding agent" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {AGENT_OPTIONS.map((agent) => (
+                      <SelectItem key={agent.value} value={agent.value}>
+                        {agent.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                {selectedAgentType === "codex" && <Badge variant="secondary" className="text-xs">Recommended</Badge>}
               </div>
               <p className="mt-0.5 text-sm text-muted-foreground">
-                Sign in with ChatGPT for instant access to gpt-5.3-codex. No API key needed.
+                {selectedAgent.description}
               </p>
             </div>
             <div className="flex shrink-0 gap-2">
-              {isCodexConnected ? (
-                <Badge variant="secondary">Connected</Badge>
-              ) : (
-                <>
-                  <Button size="sm" onClick={() => setShowDeviceCodeModal(true)}>
-                    Sign in with ChatGPT
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setSettingsAgentType("codex");
-                      setShowSettingsModal(true);
-                    }}
-                  >
-                    Settings
-                  </Button>
-                </>
+              {isSelectedAgentConnected && <Badge variant="secondary">Connected</Badge>}
+              {selectedAgentType === "codex" && !isSelectedAgentConnected && (
+                <Button size="sm" onClick={() => setShowDeviceCodeModal(true)}>
+                  {selectedAgent.ctaLabel}
+                </Button>
               )}
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setSettingsAgentType(selectedAgentType);
+                  setShowSettingsModal(true);
+                }}
+              >
+                {selectedAgent.configureLabel}
+              </Button>
             </div>
           </CardContent>
         </Card>
-
-        {/* Secondary agents: Claude Code + Gemini CLI */}
-        <div className="grid gap-3 sm:grid-cols-2">
-          <Card className="py-0" data-testid="agent-card-claude">
-            <CardContent className="flex items-center justify-between gap-4 py-4">
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-foreground">Claude Code</p>
-                <p className="mt-0.5 text-sm text-muted-foreground">
-                  Use your Anthropic API key for Claude-powered fixes.
-                </p>
-              </div>
-              <div className="shrink-0">
-                {isClaudeConnected ? (
-                  <Badge variant="secondary">Connected</Badge>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setSettingsAgentType("claude_code");
-                      setShowSettingsModal(true);
-                    }}
-                  >
-                    Configure
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="py-0" data-testid="agent-card-gemini">
-            <CardContent className="flex items-center justify-between gap-4 py-4">
-              <div className="min-w-0 flex-1">
-                <p className="text-sm font-medium text-foreground">Gemini CLI</p>
-                <p className="mt-0.5 text-sm text-muted-foreground">
-                  Use your Google Gemini API key for Gemini-powered fixes.
-                </p>
-              </div>
-              <div className="shrink-0">
-                {isGeminiConnected ? (
-                  <Badge variant="secondary">Connected</Badge>
-                ) : (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => {
-                      setSettingsAgentType("gemini_cli");
-                      setShowSettingsModal(true);
-                    }}
-                  >
-                    Configure
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
       </div>
 
       {showDeviceCodeModal && (


### PR DESCRIPTION
Summary
- single agent card now owns the onboarding flow, with a dropdown for switching providers while keeping Codex recommended
- selection drives the CTA, badge, settings modal, and test-coverage reflects new UX flows
- documented the new onboarding intent in `docs/design/overall.md`

Testing
- Not run (not requested)