### PR TITLE
Implement Linear integration UI wiring

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -17,7 +17,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
     - Support tickets
     - Sentry errors
     - Linear issues
-    - Integration setup is initiated from Settings integration cards (for example, "Connect Linear" creates an active Linear integration record for the org so webhook ingestion can be enabled without manual DB setup).
+    - Integration setup is initiated from dashboard integration cards (Overview + Integrations pages). "Connect Linear" calls `/api/v1/integrations/linear/connect`, which creates or reuses an active org-scoped Linear integration record so webhook ingestion can be enabled without manual DB setup.
 - Step 2: Prioritize and identify top issues based on business impact
     - The system determines how many customers were affected, regression severity, and optionally (if you integrate Salesforce or some other CRM) the revenue risk.
     - The admins can specify product context (philosophy + direction + focus/avoid areas) to steer prioritization.

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -5,6 +5,8 @@ import Overview from './page';
 const {
   loginMock,
   sentryLoginMock,
+  integrationsListMock,
+  connectLinearMock,
   codexStatusMock,
   codexInitiateMock,
   settingsGetMock,
@@ -13,6 +15,16 @@ const {
 } = vi.hoisted(() => ({
   loginMock: vi.fn(),
   sentryLoginMock: vi.fn(),
+  integrationsListMock: vi.fn().mockResolvedValue({ data: [] }),
+  connectLinearMock: vi.fn().mockResolvedValue({
+    data: {
+      id: 'linear-1',
+      org_id: 'org-1',
+      provider: 'linear',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+  }),
   codexStatusMock: vi.fn().mockResolvedValue({ data: { status: 'pending' } }),
   codexInitiateMock: vi.fn().mockResolvedValue({
     data: {
@@ -40,6 +52,10 @@ vi.mock('@/lib/api', () => ({
       login: loginMock,
       loginSentry: sentryLoginMock,
     },
+    integrations: {
+      list: integrationsListMock,
+      connectLinear: connectLinearMock,
+    },
     codexAuth: {
       status: codexStatusMock,
       initiate: codexInitiateMock,
@@ -56,6 +72,18 @@ describe('OverviewPage', () => {
   beforeEach(() => {
     loginMock.mockReset();
     sentryLoginMock.mockReset();
+    integrationsListMock.mockReset();
+    integrationsListMock.mockResolvedValue({ data: [] });
+    connectLinearMock.mockReset();
+    connectLinearMock.mockResolvedValue({
+      data: {
+        id: 'linear-1',
+        org_id: 'org-1',
+        provider: 'linear',
+        status: 'active',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    });
     codexStatusMock.mockClear();
     codexStatusMock.mockResolvedValue({ data: { status: 'pending' } });
     settingsGetMock.mockClear();
@@ -126,11 +154,34 @@ describe('OverviewPage', () => {
     expect(sentryLoginMock).toHaveBeenCalledTimes(1);
   });
 
-  it('shows Linear integration as coming soon', () => {
+  it('connects Linear from the additional integrations section', async () => {
+    const user = userEvent.setup();
+
     renderWithProviders(<Overview />);
 
-    expect(screen.getByText('Connect Linear')).toBeInTheDocument();
-    expect(screen.getByText('Coming soon')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Connect Linear' }));
+
+    await waitFor(() => {
+      expect(connectLinearMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows Linear as connected when active integration exists', async () => {
+    integrationsListMock.mockResolvedValue({
+      data: [
+        {
+          id: 'linear-1',
+          org_id: 'org-1',
+          provider: 'linear',
+          status: 'active',
+          created_at: '2026-01-01T00:00:00Z',
+        },
+      ],
+    });
+
+    renderWithProviders(<Overview />);
+
+    expect(await screen.findByRole('button', { name: 'Linear Connected' })).toBeDisabled();
   });
 
   it('shows Codex as connected when ChatGPT auth status is completed', async () => {

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -280,6 +281,22 @@ function AgentSelectionSection() {
 
 export default function Overview() {
   const [github, sentry, linear] = INTEGRATIONS;
+  const queryClient = useQueryClient();
+
+  const { data: integrationsResp } = useQuery({
+    queryKey: ["integrations"],
+    queryFn: () => api.integrations.list(),
+  });
+  const linearIntegration = integrationsResp?.data?.find(
+    (integration) => integration.provider === "linear" && integration.status === "active"
+  );
+
+  const connectLinearMutation = useMutation({
+    mutationFn: () => api.integrations.connectLinear(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["integrations"] });
+    },
+  });
 
   return (
     <div className="space-y-8">
@@ -344,7 +361,18 @@ export default function Overview() {
               id: linear.key,
               title: `Connect ${linear.name}`,
               description: linear.description,
-              action: <Badge variant="secondary">Coming soon</Badge>,
+              action: (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  aria-label={linearIntegration ? "Linear Connected" : "Connect Linear"}
+                  loading={connectLinearMutation.isPending}
+                  disabled={Boolean(linearIntegration) || connectLinearMutation.isPending}
+                  onClick={() => connectLinearMutation.mutate()}
+                >
+                  {linearIntegration ? "Connected" : "Connect"}
+                </Button>
+              ),
             },
           ]}
         />

--- a/frontend/src/components/integrations-card.test.tsx
+++ b/frontend/src/components/integrations-card.test.tsx
@@ -23,9 +23,9 @@ describe("IntegrationsCard", () => {
             ),
           },
           {
-            id: "linear",
-            title: "Linear",
-            description: "Sync issues from Linear and auto-assign fixes.",
+            id: "sentry",
+            title: "Sentry",
+            description: "Pull production errors and auto-generate fixes.",
             action: <Badge variant="secondary">Coming soon</Badge>,
           },
         ]}
@@ -33,7 +33,7 @@ describe("IntegrationsCard", () => {
     );
 
     expect(screen.getByText("GitHub")).toBeInTheDocument();
-    expect(screen.getByText("Linear")).toBeInTheDocument();
+    expect(screen.getByText("Sentry")).toBeInTheDocument();
     expect(screen.getAllByTestId("integration-card")).toHaveLength(2);
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
     expect(onConnect).toHaveBeenCalledTimes(1);

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -154,3 +154,61 @@ func TestIntegrationHandler_ConnectLinear_ReturnsExistingIntegration(t *testing.
 	require.Equal(t, models.IntegrationProviderLinear, resp.Data.Provider, "ConnectLinear should return a linear integration")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenLookupFails(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store)
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("db unavailable"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "ConnectLinear should return 500 when lookup fails")
+	require.Contains(t, w.Body.String(), "CONNECT_LINEAR_FAILED", "ConnectLinear should return a stable error code")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenCreateFails(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store)
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("insert failed"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "ConnectLinear should return 500 when create fails")
+	require.Contains(t, w.Body.String(), "CONNECT_LINEAR_FAILED", "ConnectLinear should return a stable error code")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}


### PR DESCRIPTION
Summary
- expand the overview page to query existing integrations, show an action button, and call the backend connect endpoint
- wire the dashboard integration card tests to use the new behavior and verify connected state
- document that the dashboard integrations card drives Linear setup and harden handler tests for failure paths

Testing
- Not run (not requested)