### PR TITLE
Unify ChatGPT connection modal layout

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -356,6 +356,36 @@ describe('OverviewPage', () => {
     expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it('uses the same modal action layout in agent settings auth flow', async () => {
+    codexInitiateMock.mockRejectedValueOnce(new Error('Network error'));
+    const user = userEvent.setup();
+    renderWithProviders(<Overview />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Settings' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Configure coding agent')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getAllByRole('button', { name: 'Sign in with ChatGPT' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
+    });
+
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+
+    expect(cancelButton).toBeInTheDocument();
+    expect(tryAgainButton).toBeInTheDocument();
+    expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
+    expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
   it('shows completed state when polling returns completed', async () => {
     // First call returns pending (for initial status check in AgentSelectionSection)
     // Second call onwards returns completed (for polling inside modal)

--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -347,10 +347,15 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
     });
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
     const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+    const cancelButton = screen
+      .getAllByRole('button', { name: 'Cancel' })
+      .find((button) => button.parentElement === tryAgainButton.parentElement);
 
-    expect(cancelButton).toBeInTheDocument();
+    expect(cancelButton).toBeDefined();
+    if (!cancelButton) {
+      return;
+    }
     expect(tryAgainButton).toBeInTheDocument();
     expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
     expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -377,10 +382,15 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Failed to start authentication. Please try again.')).toBeInTheDocument();
     });
 
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
     const tryAgainButton = screen.getByRole('button', { name: 'Try Again' });
+    const cancelButton = screen
+      .getAllByRole('button', { name: 'Cancel' })
+      .find((button) => button.parentElement === tryAgainButton.parentElement);
 
-    expect(cancelButton).toBeInTheDocument();
+    expect(cancelButton).toBeDefined();
+    if (!cancelButton) {
+      return;
+    }
     expect(tryAgainButton).toBeInTheDocument();
     expect(cancelButton.parentElement).toBe(tryAgainButton.parentElement);
     expect(cancelButton.compareDocumentPosition(tryAgainButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback, useRef } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -19,108 +19,8 @@ import {
   SourceControlIntegrationCard,
 } from "@/components/integration-connection-cards";
 import { AgentSettingsEditor } from "@/components/agent-settings-editor";
-import type { CodexAuthStatus, CodexDeviceAuth, OrgSettings } from "@/lib/types";
-
-function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void; onConnected: () => void }) {
-  const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
-  const [status, setStatus] = useState<string>("initiating");
-  const [error, setError] = useState<string>("");
-  const [timeLeft, setTimeLeft] = useState(0);
-  const pollRef = useRef<NodeJS.Timeout | null>(null);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const onConnectedRef = useRef(onConnected);
-
-  useEffect(() => { onConnectedRef.current = onConnected; }, [onConnected]);
-
-  const startAuth = useCallback(async () => {
-    try {
-      setStatus("initiating");
-      setError("");
-      const resp = await api.codexAuth.initiate();
-      setDeviceAuth(resp.data);
-      setTimeLeft(resp.data.expires_in);
-      setStatus("pending");
-    } catch {
-      setError("Failed to start authentication. Please try again.");
-      setStatus("error");
-    }
-  }, []);
-
-  useEffect(() => { const id = setTimeout(() => { void startAuth(); }, 0); return () => clearTimeout(id); }, [startAuth]);
-
-  useEffect(() => {
-    if (status !== "pending") return;
-    pollRef.current = setInterval(async () => {
-      try {
-        const resp = await api.codexAuth.status();
-        if (resp.data.status === "completed") {
-          setStatus("completed");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-          setTimeout(() => { onConnectedRef.current(); }, 1500);
-        } else if (resp.data.status === "expired") {
-          setStatus("expired");
-          setError("Code expired. Please try again.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        } else if (resp.data.status === "error") {
-          setStatus("error");
-          setError(resp.data.message || "Authentication failed.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        }
-      } catch { /* ignore transient errors */ }
-    }, 3000);
-    timerRef.current = setInterval(() => { setTimeLeft((t) => Math.max(0, t - 1)); }, 1000);
-    return () => { if (pollRef.current) clearInterval(pollRef.current); if (timerRef.current) clearInterval(timerRef.current); };
-  }, [status]);
-
-  const minutes = Math.floor(timeLeft / 60);
-  const seconds = timeLeft % 60;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
-        <h3 className="text-lg font-medium">Connect your ChatGPT account</h3>
-        {status === "initiating" && <p className="mt-4 text-sm text-muted-foreground">Starting authentication...</p>}
-        {status === "pending" && deviceAuth && (
-          <div className="mt-4 space-y-4">
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">1. Open this link:</p>
-              <a href={deviceAuth.verification_uri} target="_blank" rel="noopener noreferrer" className="text-sm font-medium text-primary underline">{deviceAuth.verification_uri}</a>
-            </div>
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">2. Enter this code:</p>
-              <div className="flex items-center gap-2">
-                <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">{deviceAuth.user_code}</code>
-                <Button size="sm" variant="outline" onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}>Copy</Button>
-              </div>
-            </div>
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">Waiting for authentication...</p>
-              <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
-                <div className="h-full rounded-full bg-primary transition-all duration-1000" style={{ width: `${Math.max(0, (timeLeft / deviceAuth.expires_in) * 100)}%` }} />
-              </div>
-              <p className="text-xs text-muted-foreground">Expires in {minutes}:{seconds.toString().padStart(2, "0")}</p>
-            </div>
-          </div>
-        )}
-        {status === "completed" && <div className="mt-4"><p className="text-sm font-medium text-green-600">Connected successfully!</p></div>}
-        {(status === "error" || status === "expired") && (
-          <div className="mt-4">
-            <p className="text-sm text-destructive">{error}</p>
-          </div>
-        )}
-        <div className="mt-6 flex items-center justify-end gap-2">
-          <Button variant="outline" size="sm" onClick={onClose}>{status === "completed" ? "Done" : "Cancel"}</Button>
-          {(status === "error" || status === "expired") && (
-            <Button size="sm" onClick={startAuth}>Try Again</Button>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
+import type { CodexAuthStatus, OrgSettings } from "@/lib/types";
 
 function AgentSettingsModal({ onClose, initialAgentType }: { onClose: () => void; initialAgentType?: OrgSettings["default_agent_type"] }) {
   return (
@@ -268,7 +168,7 @@ function AgentSelectionSection() {
       </div>
 
       {showDeviceCodeModal && (
-        <OverviewDeviceCodeModal
+        <CodexDeviceCodeModal
           onClose={() => setShowDeviceCodeModal(false)}
           onConnected={() => { setShowDeviceCodeModal(false); fetchData(); }}
         />

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, KeyRound, Sparkles } from "lucide-react";
 import { api } from "@/lib/api";
@@ -16,7 +16,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { CodexDeviceAuth, OrgSettings, Organization, SingleResponse } from "@/lib/types";
+import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
+import type { OrgSettings, Organization, SingleResponse } from "@/lib/types";
 
 interface AgentEnvVar {
   name: string;
@@ -70,160 +71,6 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
     ],
   },
 ];
-
-function DeviceCodeModal({ onClose }: { onClose: () => void }) {
-  const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
-  const [status, setStatus] = useState<string>("initiating");
-  const [error, setError] = useState<string>("");
-  const [timeLeft, setTimeLeft] = useState(0);
-  const pollRef = useRef<NodeJS.Timeout | null>(null);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const onCloseRef = useRef(onClose);
-  const queryClient = useQueryClient();
-
-  useEffect(() => {
-    onCloseRef.current = onClose;
-  }, [onClose]);
-
-  const startAuth = async () => {
-    try {
-      setStatus("initiating");
-      setError("");
-      const resp = await api.codexAuth.initiate();
-      setDeviceAuth(resp.data);
-      setTimeLeft(resp.data.expires_in);
-      setStatus("pending");
-    } catch {
-      setError("Failed to start authentication. Please try again.");
-      setStatus("error");
-    }
-  };
-
-  useEffect(() => {
-    const id = setTimeout(() => {
-      void startAuth();
-    }, 0);
-    return () => clearTimeout(id);
-  }, []);
-
-  useEffect(() => {
-    if (status !== "pending") return;
-
-    pollRef.current = setInterval(async () => {
-      try {
-        const resp = await api.codexAuth.status();
-        if (resp.data.status === "completed") {
-          setStatus("completed");
-          queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-          setTimeout(() => onCloseRef.current(), 1500);
-        } else if (resp.data.status === "expired") {
-          setStatus("expired");
-          setError("Code expired. Please try again.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        } else if (resp.data.status === "error") {
-          setStatus("error");
-          setError(resp.data.message || "Authentication failed.");
-          if (pollRef.current) clearInterval(pollRef.current);
-          if (timerRef.current) clearInterval(timerRef.current);
-        }
-      } catch {
-      }
-    }, 3000);
-
-    timerRef.current = setInterval(() => {
-      setTimeLeft((time) => Math.max(0, time - 1));
-    }, 1000);
-
-    return () => {
-      if (pollRef.current) clearInterval(pollRef.current);
-      if (timerRef.current) clearInterval(timerRef.current);
-    };
-  }, [status, queryClient]);
-
-  const minutes = Math.floor(timeLeft / 60);
-  const seconds = timeLeft % 60;
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
-        <h3 className="text-lg font-medium">Connect your ChatGPT account</h3>
-
-        {status === "initiating" && (
-          <p className="mt-4 text-sm text-muted-foreground">Starting authentication...</p>
-        )}
-
-        {status === "pending" && deviceAuth && (
-          <div className="mt-4 space-y-4">
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">1. Open this link:</p>
-              <a
-                href={deviceAuth.verification_uri}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-sm font-medium text-primary underline"
-              >
-                {deviceAuth.verification_uri}
-              </a>
-            </div>
-
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">2. Enter this code:</p>
-              <div className="flex items-center gap-2">
-                <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">
-                  {deviceAuth.user_code}
-                </code>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}
-                >
-                  Copy
-                </Button>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <p className="text-sm text-muted-foreground">Waiting for authentication...</p>
-              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
-                <div
-                  className="h-full rounded-full bg-primary transition-all duration-1000"
-                  style={{ width: `${deviceAuth ? Math.max(0, (timeLeft / deviceAuth.expires_in) * 100) : 0}%` }}
-                />
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Expires in {minutes}:{seconds.toString().padStart(2, "0")}
-              </p>
-            </div>
-          </div>
-        )}
-
-        {status === "completed" && (
-          <div className="mt-4">
-            <p className="text-sm font-medium text-green-600">Connected successfully!</p>
-          </div>
-        )}
-
-        {(status === "error" || status === "expired") && (
-          <div className="mt-4 space-y-3">
-            <p className="text-sm text-destructive">{error}</p>
-            <Button size="sm" onClick={() => void startAuth()}>
-              Try Again
-            </Button>
-          </div>
-        )}
-
-        <div className="mt-6 flex justify-end">
-          <Button variant="outline" size="sm" onClick={onClose}>
-            {status === "completed" ? "Done" : "Cancel"}
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export function AgentSettingsEditor({
   title,
@@ -558,7 +405,13 @@ export function AgentSettingsEditor({
         </div>
       </div>
       {showDeviceCodeModal && (
-        <DeviceCodeModal onClose={() => setShowDeviceCodeModal(false)} />
+        <CodexDeviceCodeModal
+          onClose={() => setShowDeviceCodeModal(false)}
+          onConnected={() => {
+            queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+            setShowDeviceCodeModal(false);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/codex-device-code-modal.tsx
+++ b/frontend/src/components/codex-device-code-modal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import type { CodexDeviceAuth } from "@/lib/types";
+
+export function CodexDeviceCodeModal({
+  onClose,
+  onConnected,
+}: {
+  onClose: () => void;
+  onConnected?: () => void;
+}) {
+  const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
+  const [status, setStatus] = useState<string>("initiating");
+  const [error, setError] = useState("");
+  const [timeLeft, setTimeLeft] = useState(0);
+  const pollRef = useRef<NodeJS.Timeout | null>(null);
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const onConnectedRef = useRef(onConnected);
+
+  useEffect(() => {
+    onConnectedRef.current = onConnected;
+  }, [onConnected]);
+
+  const startAuth = useCallback(async () => {
+    try {
+      setStatus("initiating");
+      setError("");
+      const resp = await api.codexAuth.initiate();
+      setDeviceAuth(resp.data);
+      setTimeLeft(resp.data.expires_in);
+      setStatus("pending");
+    } catch {
+      setError("Failed to start authentication. Please try again.");
+      setStatus("error");
+    }
+  }, []);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      void startAuth();
+    }, 0);
+    return () => clearTimeout(id);
+  }, [startAuth]);
+
+  useEffect(() => {
+    if (status !== "pending") return;
+
+    pollRef.current = setInterval(async () => {
+      try {
+        const resp = await api.codexAuth.status();
+        if (resp.data.status === "completed") {
+          setStatus("completed");
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+          setTimeout(() => {
+            onConnectedRef.current?.();
+          }, 1500);
+        } else if (resp.data.status === "expired") {
+          setStatus("expired");
+          setError("Code expired. Please try again.");
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+        } else if (resp.data.status === "error") {
+          setStatus("error");
+          setError(resp.data.message || "Authentication failed.");
+          if (pollRef.current) clearInterval(pollRef.current);
+          if (timerRef.current) clearInterval(timerRef.current);
+        }
+      } catch {
+      }
+    }, 3000);
+
+    timerRef.current = setInterval(() => {
+      setTimeLeft((time) => Math.max(0, time - 1));
+    }, 1000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [status]);
+
+  const minutes = Math.floor(timeLeft / 60);
+  const seconds = timeLeft % 60;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="w-full max-w-md rounded-lg border bg-background p-6 shadow-lg">
+        <h3 className="text-lg font-medium">Connect your ChatGPT account</h3>
+        {status === "initiating" && <p className="mt-4 text-sm text-muted-foreground">Starting authentication...</p>}
+        {status === "pending" && deviceAuth && (
+          <div className="mt-4 space-y-4">
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">1. Open this link:</p>
+              <a href={deviceAuth.verification_uri} target="_blank" rel="noopener noreferrer" className="text-sm font-medium text-primary underline">{deviceAuth.verification_uri}</a>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">2. Enter this code:</p>
+              <div className="flex items-center gap-2">
+                <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">{deviceAuth.user_code}</code>
+                <Button size="sm" variant="outline" onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}>Copy</Button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">Waiting for authentication...</p>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full bg-primary transition-all duration-1000" style={{ width: `${Math.max(0, (timeLeft / deviceAuth.expires_in) * 100)}%` }} />
+              </div>
+              <p className="text-xs text-muted-foreground">Expires in {minutes}:{seconds.toString().padStart(2, "0")}</p>
+            </div>
+          </div>
+        )}
+        {status === "completed" && <div className="mt-4"><p className="text-sm font-medium text-green-600">Connected successfully!</p></div>}
+        {(status === "error" || status === "expired") && (
+          <div className="mt-4">
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
+        <div className="mt-6 flex items-center justify-end gap-2">
+          <Button variant="outline" size="sm" onClick={onClose}>{status === "completed" ? "Done" : "Cancel"}</Button>
+          {(status === "error" || status === "expired") && (
+            <Button size="sm" onClick={startAuth}>Try Again</Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Summary
- extract a reusable `CodexDeviceCodeModal` component with the dashboard layout and copyable code UI
- wire the new modal into the overview page and agent settings so both flows share the same action ordering and behavior
- add a regression test ensuring the modal action layout in agent settings matches the dashboard modal

Testing
- Not run (not requested)