### PR TITLE
Handle non-integer Codex device auth interval

### DIFF
--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -147,14 +148,19 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID) (*Dev
 		UserCode        string `json:"user_code"`
 		VerificationURI string `json:"verification_uri"`
 		ExpiresIn       int    `json:"expires_in"`
-		Interval        int    `json:"interval"`
+		Interval        any    `json:"interval"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
 		return nil, fmt.Errorf("parse device auth response: %w", err)
 	}
 
-	if result.Interval <= 0 {
-		result.Interval = 5
+	interval, err := parsePollInterval(result.Interval)
+	if err != nil {
+		return nil, fmt.Errorf("parse device auth response interval: %w", err)
+	}
+
+	if interval <= 0 {
+		interval = 5
 	}
 	if result.VerificationURI == "" {
 		result.VerificationURI = DefaultVerificationURI
@@ -171,7 +177,7 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID) (*Dev
 		UserCode:        result.UserCode,
 		VerificationURI: result.VerificationURI,
 		ExpiresAt:       expiresAt,
-		Interval:        result.Interval,
+		Interval:        interval,
 	}
 	s.pending.Store(orgID.String(), pending)
 
@@ -182,7 +188,7 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID) (*Dev
 			UserCode:        result.UserCode,
 			VerificationURI: result.VerificationURI,
 			ExpiresAt:       expiresAt,
-			PollInterval:    result.Interval,
+			PollInterval:    interval,
 		}
 		if err := s.credentials.Upsert(ctx, orgID, pendingCfg); err != nil {
 			s.logger.Warn().Err(err).Msg("failed to persist pending device auth to DB")
@@ -346,6 +352,25 @@ func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID) (*AuthStatu
 		Status:      "completed",
 		AccountType: cfg.AccountType,
 	}, nil
+}
+
+func parsePollInterval(raw any) (int, error) {
+	if raw == nil {
+		return 0, nil
+	}
+
+	switch v := raw.(type) {
+	case float64:
+		return int(v), nil
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			return 0, fmt.Errorf("invalid interval value %q", v)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("unsupported interval type %T", raw)
+	}
 }
 
 // RefreshToken refreshes an expired access token using the refresh token.

--- a/internal/services/codexauth/service_initiate_test.go
+++ b/internal/services/codexauth/service_initiate_test.go
@@ -1,0 +1,78 @@
+package codexauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitiateDeviceAuth_IntervalParsing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		intervalValue     any
+		expectedPollIntvl int
+		expectErr         bool
+	}{
+		{
+			name:              "accepts numeric interval string",
+			intervalValue:     "5",
+			expectedPollIntvl: 5,
+		},
+		{
+			name:              "accepts numeric interval",
+			intervalValue:     7,
+			expectedPollIntvl: 7,
+		},
+		{
+			name:          "rejects non-numeric interval string",
+			intervalValue: "five",
+			expectErr:     true,
+		},
+	}
+
+	for i := range tests {
+		tc := tests[i]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"device_auth_id":   "dev_123",
+					"user_code":        "ABCD-1234",
+					"verification_uri": "https://auth.openai.com/codex/device",
+					"expires_in":       900,
+					"interval":         tc.intervalValue,
+				}), "test server should return valid JSON")
+			}))
+			defer server.Close()
+
+			svc := NewService(newMockCredentialStore(), zerolog.Nop())
+			svc.SetHTTPClient(server.Client())
+			svc.SetIssuer(server.URL)
+
+			orgID := uuid.New()
+			_, err := svc.InitiateDeviceAuth(context.Background(), orgID)
+			if tc.expectErr {
+				require.Error(t, err, "initiate should fail for invalid interval values")
+				return
+			}
+
+			require.NoError(t, err, "initiate should succeed for supported interval formats")
+			val, ok := svc.pending.Load(orgID.String())
+			require.True(t, ok, "pending auth should be stored after successful initiation")
+
+			pending, ok := val.(*PendingAuth)
+			require.True(t, ok, "pending auth should have expected type")
+			require.Equal(t, tc.expectedPollIntvl, pending.Interval, "pending auth should store parsed poll interval")
+		})
+	}
+}


### PR DESCRIPTION
Summary
- parse the device auth `interval` field as either a number or string and fall back to the default when required
- normalize the parsed interval before storing it in pending auth so polling stays consistent
- add tests covering numeric, string, and invalid interval payloads

Testing
- Not run (not requested)