### PR TITLE
Update invite flow to show invited email and org context

### DIFF
--- a/docs/design/26-team-management.md
+++ b/docs/design/26-team-management.md
@@ -269,7 +269,7 @@ This is the endpoint hit when a user clicks the invite link in their email. The 
 
 **Flow:** When the user clicks the email link (`{FRONTEND_URL}/invite/accept?token=...`), the frontend calls this endpoint. Based on the response:
 - If `action: "joined"`, the user is already authenticated and now part of the org — redirect to dashboard.
-- If `action: "register"`, the frontend redirects to the registration page with the invitation token pre-filled. After registration completes, the auth handler checks for a pending invitation token, accepts it, and places the user in the correct org with the invited role.
+- If `action: "register"`, the frontend redirects to the registration page with the invitation token pre-filled and carries the invited email + org for display context. The registration form pre-fills the invited email and keeps it read-only so users set name/password without changing invite identity. After registration completes, the auth handler checks for a pending invitation token, accepts it, and places the user in the correct org with the invited role.
 
 ### Change member role
 

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -9,6 +9,7 @@ const registerMock = vi.hoisted(() => vi.fn());
 
 const useAuthMock = vi.hoisted(() => vi.fn());
 const useAuthProvidersMock = vi.hoisted(() => vi.fn());
+const searchParamsMock = vi.hoisted(() => new URLSearchParams());
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -31,7 +32,7 @@ const pushMock = vi.hoisted(() => vi.fn());
 const replaceMock = vi.hoisted(() => vi.fn());
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: replaceMock }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => searchParamsMock,
 }));
 
 describe('LoginPage', () => {
@@ -42,6 +43,9 @@ describe('LoginPage', () => {
     registerMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
+    searchParamsMock.forEach((_, key) => {
+      searchParamsMock.delete(key);
+    });
 
     useAuthMock.mockReturnValue({
       user: null,
@@ -170,5 +174,29 @@ describe('LoginPage', () => {
     await waitFor(() => {
       expect(signInButton).toBeEnabled();
     });
+  });
+
+  it('prefills invited email and keeps it read-only on sign up', async () => {
+    registerMock.mockResolvedValue({ data: { id: '1' } });
+    searchParamsMock.set('invitation', 'invite-123');
+    searchParamsMock.set('email', 'invitee@example.com');
+    searchParamsMock.set('org', 'Acme');
+    searchParamsMock.set('tab', 'signup');
+
+    const user = userEvent.setup();
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.getByText(/invitee@example.com/i)).toBeInTheDocument();
+    expect(screen.getByText(/Acme/i)).toBeInTheDocument();
+
+    const signupEmail = screen.getByLabelText('Email');
+    expect(signupEmail).toHaveValue('invitee@example.com');
+    expect(signupEmail).toHaveAttribute('readonly');
+
+    await user.type(screen.getByLabelText('Name'), 'Invited User');
+    await user.type(screen.getByLabelText('Password'), 'invitepass123');
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+
+    expect(registerMock).toHaveBeenCalledWith('invitee@example.com', 'invitepass123', 'Invited User', 'invite-123');
   });
 });

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -26,17 +26,19 @@ function LoginPageContent() {
   const { providers } = useAuthProviders();
 
   const invitation = searchParams.get("invitation") ?? undefined;
+  const invitedEmail = searchParams.get("email") ?? "";
+  const invitedOrg = searchParams.get("org") ?? "";
   const [tab, setTab] = useState(searchParams.get("tab") === "signup" ? "signup" : "signin");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Sign in form
-  const [signInEmail, setSignInEmail] = useState("");
+  const [signInEmail, setSignInEmail] = useState(invitedEmail);
   const [signInPassword, setSignInPassword] = useState("");
 
   // Sign up form
   const [signUpName, setSignUpName] = useState("");
-  const [signUpEmail, setSignUpEmail] = useState("");
+  const [signUpEmail, setSignUpEmail] = useState(invitedEmail);
   const [signUpPassword, setSignUpPassword] = useState("");
 
   useEffect(() => {
@@ -44,6 +46,13 @@ function LoginPageContent() {
       router.replace("/overview");
     }
   }, [authLoading, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (invitedEmail) {
+      setSignInEmail(invitedEmail);
+      setSignUpEmail(invitedEmail);
+    }
+  }, [invitedEmail]);
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -108,6 +117,17 @@ function LoginPageContent() {
           <CardTitle className="text-lg font-semibold">143.dev</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          {invitation && invitedEmail && (
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
+              You were invited{invitedOrg ? (
+                <>
+                  {" "}to join <span className="font-medium text-foreground">{invitedOrg}</span>
+                </>
+              ) : null}{" "}
+              as <span className="font-medium text-foreground">{invitedEmail}</span>.
+            </div>
+          )}
+
           {/* Social login buttons */}
           <div className="space-y-2">
             {providers?.github !== false && (
@@ -167,6 +187,7 @@ function LoginPageContent() {
                     placeholder="you@example.com"
                     value={signInEmail}
                     onChange={(e) => setSignInEmail(e.target.value)}
+                    readOnly={Boolean(invitation && invitedEmail)}
                     required
                   />
                 </div>
@@ -207,6 +228,7 @@ function LoginPageContent() {
                     placeholder="you@example.com"
                     value={signUpEmail}
                     onChange={(e) => setSignUpEmail(e.target.value)}
+                    readOnly={Boolean(invitation && invitedEmail)}
                     required
                   />
                 </div>

--- a/frontend/src/app/invite/accept/page.test.tsx
+++ b/frontend/src/app/invite/accept/page.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/test-utils';
+import AcceptInvitationPage from './page';
+
+const pushMock = vi.hoisted(() => vi.fn());
+const replaceMock = vi.hoisted(() => vi.fn());
+const searchParamsMock = vi.hoisted(() => new URLSearchParams());
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+  useSearchParams: () => searchParamsMock,
+}));
+
+describe('AcceptInvitationPage', () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    replaceMock.mockReset();
+    searchParamsMock.forEach((_, key) => {
+      searchParamsMock.delete(key);
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('passes invited email and org to sign-up flow', async () => {
+    searchParamsMock.set('token', 'invite-token-123');
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          action: 'register',
+          email: 'invitee@example.com',
+          org_name: 'Acme',
+        },
+      }),
+    } as Response);
+
+    const user = userEvent.setup();
+    renderWithProviders(<AcceptInvitationPage />);
+
+    await screen.findByRole('button', { name: 'Create Account' });
+    expect(screen.getByText(/invitee@example.com/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Create Account' }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/login?tab=signup&invitation=invite-token-123&email=invitee%40example.com&org=Acme');
+    });
+  });
+});

--- a/frontend/src/app/invite/accept/page.tsx
+++ b/frontend/src/app/invite/accept/page.tsx
@@ -28,6 +28,7 @@ function AcceptInvitationContent() {
     isMissingToken ? "No invitation token provided." : ""
   );
   const [orgName, setOrgName] = useState("");
+  const [invitedEmail, setInvitedEmail] = useState("");
 
   useEffect(() => {
     if (!token) {
@@ -56,6 +57,9 @@ function AcceptInvitationContent() {
         const data = body?.data;
         if (data?.org_name) {
           setOrgName(data.org_name);
+        }
+        if (data?.email) {
+          setInvitedEmail(data.email);
         }
         if (data?.action === "login" || data?.action === "register") {
           setStatus(data.action);
@@ -107,13 +111,25 @@ function AcceptInvitationContent() {
                 <span className="font-medium text-foreground">
                   {orgName}
                 </span>
-                . Create an account to get started.
+                {invitedEmail ? (
+                  <>
+                    {" "}as <span className="font-medium text-foreground">{invitedEmail}</span>. Create an account to get started.
+                  </>
+                ) : (
+                  ". Create an account to get started."
+                )}
               </p>
               <Button
                 className="w-full"
                 onClick={() =>
                   router.push(
-                    `/login?tab=signup&invitation=${encodeURIComponent(token!)}`
+                    `/login?tab=signup&invitation=${encodeURIComponent(token!)}${
+                      invitedEmail
+                        ? `&email=${encodeURIComponent(invitedEmail)}`
+                        : ""
+                    }${
+                      orgName ? `&org=${encodeURIComponent(orgName)}` : ""
+                    }`
                   )
                 }
               >
@@ -124,7 +140,13 @@ function AcceptInvitationContent() {
                 className="w-full"
                 onClick={() =>
                   router.push(
-                    `/login?invitation=${encodeURIComponent(token!)}`
+                    `/login?invitation=${encodeURIComponent(token!)}${
+                      invitedEmail
+                        ? `&email=${encodeURIComponent(invitedEmail)}`
+                        : ""
+                    }${
+                      orgName ? `&org=${encodeURIComponent(orgName)}` : ""
+                    }`
                   )
                 }
               >
@@ -140,13 +162,25 @@ function AcceptInvitationContent() {
                 <span className="font-medium text-foreground">
                   {orgName}
                 </span>
-                . Sign in to accept the invitation.
+                {invitedEmail ? (
+                  <>
+                    {" "}as <span className="font-medium text-foreground">{invitedEmail}</span>. Sign in to accept the invitation.
+                  </>
+                ) : (
+                  ". Sign in to accept the invitation."
+                )}
               </p>
               <Button
                 className="w-full"
                 onClick={() =>
                   router.push(
-                    `/login?invitation=${encodeURIComponent(token!)}`
+                    `/login?invitation=${encodeURIComponent(token!)}${
+                      invitedEmail
+                        ? `&email=${encodeURIComponent(invitedEmail)}`
+                        : ""
+                    }${
+                      orgName ? `&org=${encodeURIComponent(orgName)}` : ""
+                    }`
                   )
                 }
               >


### PR DESCRIPTION
Summary:
- document that invite acceptance now carries invited email/org context so registration can prefill and lock the email field
- enhance invite accept frontend to fetch the invited email/org, show messaging, and propagate them to the login/signup routes
- make login page respect the invite context by pre-filling and locking the email field and asserting the behavior in tests

Testing:
- Not run (not requested)