### PR TITLE
Align integration settings cards with dashboard components

### DIFF
--- a/frontend/src/app/(dashboard)/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/integrations/page.tsx
@@ -2,14 +2,10 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { IntegrationsCard } from "@/components/integrations-card";
+import { AllIntegrationCards } from "@/components/integration-connection-cards";
 import { PageHeader } from "@/components/page-header";
-import { INTEGRATIONS } from "@/lib/integrations";
 
 export default function IntegrationsPage() {
-  const [github, sentry, linear] = INTEGRATIONS;
   const queryClient = useQueryClient();
 
   const { data: integrationsResp } = useQuery({
@@ -33,41 +29,12 @@ export default function IntegrationsPage() {
         title="Integrations"
         description="Connect external services to your organization."
       />
-      <IntegrationsCard
-        items={[
-          {
-            id: github.key,
-            title: github.name,
-            description: github.description,
-            action: (
-              <Button size="sm" onClick={() => api.auth.login()} aria-label="Connect GitHub">
-                Connect
-              </Button>
-            ),
-          },
-          {
-            id: sentry.key,
-            title: sentry.name,
-            description: sentry.description,
-            action: <Badge variant="secondary">Coming soon</Badge>,
-          },
-          {
-            id: linear.key,
-            title: linear.name,
-            description: linear.description,
-            action: (
-              <Button
-                size="sm"
-                aria-label={linearIntegration ? "Linear Connected" : "Connect Linear"}
-                loading={connectLinearMutation.isPending}
-                disabled={Boolean(linearIntegration) || connectLinearMutation.isPending}
-                onClick={() => connectLinearMutation.mutate()}
-              >
-                {linearIntegration ? "Connected" : "Connect"}
-              </Button>
-            ),
-          },
-        ]}
+      <AllIntegrationCards
+        linearConnected={Boolean(linearIntegration)}
+        linearLoading={connectLinearMutation.isPending}
+        onConnectGitHub={() => api.auth.login()}
+        onConnectSentry={() => api.auth.loginSentry()}
+        onConnectLinear={() => connectLinearMutation.mutate()}
       />
     </div>
   );

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -14,9 +14,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { PageHeader } from "@/components/page-header";
-import { IntegrationsCard } from "@/components/integrations-card";
+import {
+  AdditionalIntegrationCards,
+  SourceControlIntegrationCard,
+} from "@/components/integration-connection-cards";
 import { AgentSettingsEditor } from "@/components/agent-settings-editor";
-import { INTEGRATIONS } from "@/lib/integrations";
 import type { CodexAuthStatus, CodexDeviceAuth, OrgSettings } from "@/lib/types";
 
 function OverviewDeviceCodeModal({ onClose, onConnected }: { onClose: () => void; onConnected: () => void }) {
@@ -282,7 +284,6 @@ function AgentSelectionSection() {
 }
 
 export default function Overview() {
-  const [github, sentry, linear] = INTEGRATIONS;
   const queryClient = useQueryClient();
 
   const { data: integrationsResp } = useQuery({
@@ -318,20 +319,7 @@ export default function Overview() {
             Connect GitHub so the agent can access your repositories and open PRs.
           </p>
         </div>
-        <IntegrationsCard
-          items={[
-            {
-              id: github.key,
-              title: `Connect ${github.name}`,
-              description: github.description,
-              action: (
-                <Button size="sm" onClick={() => api.auth.login()} aria-label="Connect GitHub">
-                  Connect
-                </Button>
-              ),
-            },
-          ]}
-        />
+        <SourceControlIntegrationCard onConnectGitHub={() => api.auth.login()} />
       </div>
 
       {/* Step 3: Additional Integrations — optional, lower priority */}
@@ -342,41 +330,11 @@ export default function Overview() {
             Optional — connect issue and error sources to feed the agent automatically.
           </p>
         </div>
-        <IntegrationsCard
-          items={[
-            {
-              id: sentry.key,
-              title: `Connect ${sentry.name}`,
-              description: sentry.description,
-              action: (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => api.auth.loginSentry()}
-                  aria-label="Connect Sentry"
-                >
-                  Connect
-                </Button>
-              ),
-            },
-            {
-              id: linear.key,
-              title: `Connect ${linear.name}`,
-              description: linear.description,
-              action: (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  aria-label={linearIntegration ? "Linear Connected" : "Connect Linear"}
-                  loading={connectLinearMutation.isPending}
-                  disabled={Boolean(linearIntegration) || connectLinearMutation.isPending}
-                  onClick={() => connectLinearMutation.mutate()}
-                >
-                  {linearIntegration ? "Connected" : "Connect"}
-                </Button>
-              ),
-            },
-          ]}
+        <AdditionalIntegrationCards
+          linearConnected={Boolean(linearIntegration)}
+          linearLoading={connectLinearMutation.isPending}
+          onConnectSentry={() => api.auth.loginSentry()}
+          onConnectLinear={() => connectLinearMutation.mutate()}
         />
       </div>
 

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import {
+  AdditionalIntegrationCards,
+  AllIntegrationCards,
+  SourceControlIntegrationCard,
+} from "./integration-connection-cards";
+
+describe("integration connection cards", () => {
+  it("renders source control card and triggers GitHub connect", async () => {
+    const user = userEvent.setup();
+    const onConnectGitHub = vi.fn();
+
+    renderWithProviders(<SourceControlIntegrationCard onConnectGitHub={onConnectGitHub} />);
+
+    expect(screen.getByText("Connect GitHub")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
+
+    expect(onConnectGitHub).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders additional cards and supports Sentry and Linear connect", async () => {
+    const user = userEvent.setup();
+    const onConnectSentry = vi.fn();
+    const onConnectLinear = vi.fn();
+
+    renderWithProviders(
+      <AdditionalIntegrationCards
+        linearConnected={false}
+        linearLoading={false}
+        onConnectSentry={onConnectSentry}
+        onConnectLinear={onConnectLinear}
+      />
+    );
+
+    expect(screen.getByText("Connect Sentry")).toBeInTheDocument();
+    expect(screen.getByText("Connect Linear")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Connect Sentry" }));
+    await user.click(screen.getByRole("button", { name: "Connect Linear" }));
+
+    expect(onConnectSentry).toHaveBeenCalledTimes(1);
+    expect(onConnectLinear).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Linear connect when already connected", () => {
+    renderWithProviders(
+      <AllIntegrationCards
+        linearConnected
+        linearLoading={false}
+        onConnectGitHub={vi.fn()}
+        onConnectSentry={vi.fn()}
+        onConnectLinear={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Linear Connected" })).toBeDisabled();
+  });
+});

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -1,0 +1,147 @@
+import { Button } from "@/components/ui/button";
+import { IntegrationsCard } from "@/components/integrations-card";
+import { INTEGRATIONS } from "@/lib/integrations";
+
+type SourceControlIntegrationCardProps = {
+  onConnectGitHub: () => void;
+};
+
+type AdditionalIntegrationCardsProps = {
+  linearConnected: boolean;
+  linearLoading: boolean;
+  onConnectSentry: () => void;
+  onConnectLinear: () => void;
+};
+
+type AllIntegrationCardsProps = SourceControlIntegrationCardProps & AdditionalIntegrationCardsProps;
+
+export function SourceControlIntegrationCard({ onConnectGitHub }: SourceControlIntegrationCardProps) {
+  const github = INTEGRATIONS[0];
+
+  return (
+    <IntegrationsCard
+      items={[
+        {
+          id: github.key,
+          title: `Connect ${github.name}`,
+          description: github.description,
+          action: (
+            <Button size="sm" onClick={onConnectGitHub} aria-label="Connect GitHub">
+              Connect
+            </Button>
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+export function AdditionalIntegrationCards({
+  linearConnected,
+  linearLoading,
+  onConnectSentry,
+  onConnectLinear,
+}: AdditionalIntegrationCardsProps) {
+  const sentry = INTEGRATIONS[1];
+  const linear = INTEGRATIONS[2];
+
+  return (
+    <IntegrationsCard
+      items={[
+        {
+          id: sentry.key,
+          title: `Connect ${sentry.name}`,
+          description: sentry.description,
+          action: (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onConnectSentry}
+              aria-label="Connect Sentry"
+            >
+              Connect
+            </Button>
+          ),
+        },
+        {
+          id: linear.key,
+          title: `Connect ${linear.name}`,
+          description: linear.description,
+          action: (
+            <Button
+              size="sm"
+              variant="outline"
+              aria-label={linearConnected ? "Linear Connected" : "Connect Linear"}
+              loading={linearLoading}
+              disabled={linearConnected || linearLoading}
+              onClick={onConnectLinear}
+            >
+              {linearConnected ? "Connected" : "Connect"}
+            </Button>
+          ),
+        },
+      ]}
+    />
+  );
+}
+
+export function AllIntegrationCards({
+  onConnectGitHub,
+  onConnectSentry,
+  onConnectLinear,
+  linearConnected,
+  linearLoading,
+}: AllIntegrationCardsProps) {
+  const github = INTEGRATIONS[0];
+  const sentry = INTEGRATIONS[1];
+  const linear = INTEGRATIONS[2];
+
+  return (
+    <IntegrationsCard
+      items={[
+        {
+          id: github.key,
+          title: `Connect ${github.name}`,
+          description: github.description,
+          action: (
+            <Button size="sm" onClick={onConnectGitHub} aria-label="Connect GitHub">
+              Connect
+            </Button>
+          ),
+        },
+        {
+          id: sentry.key,
+          title: `Connect ${sentry.name}`,
+          description: sentry.description,
+          action: (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onConnectSentry}
+              aria-label="Connect Sentry"
+            >
+              Connect
+            </Button>
+          ),
+        },
+        {
+          id: linear.key,
+          title: `Connect ${linear.name}`,
+          description: linear.description,
+          action: (
+            <Button
+              size="sm"
+              variant="outline"
+              aria-label={linearConnected ? "Linear Connected" : "Connect Linear"}
+              loading={linearLoading}
+              disabled={linearConnected || linearLoading}
+              onClick={onConnectLinear}
+            >
+              {linearConnected ? "Connected" : "Connect"}
+            </Button>
+          ),
+        },
+      ]}
+    />
+  );
+}


### PR DESCRIPTION
Summary
- reuse the shared integration connection card components across the dashboard and settings pages so GitHub/Sentry/Linear blocks stay identical
- add dedicated source-control, additional, and combined card composites plus a Vitest suite to cover their interactions
Testing
- Not run (not requested)