### PR TITLE
Expose shared model constants for agents

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -250,8 +250,8 @@ describe('OverviewPage', () => {
 
     await user.click(screen.getByRole('radio', { name: 'Use API key' }));
 
-    await user.clear(screen.getByLabelText('Model'));
-    await user.type(screen.getByLabelText('Model'), 'codex-mini');
+    await user.click(screen.getByRole('combobox', { name: 'Model' }));
+    await user.click(await screen.findByRole('option', { name: 'gpt-5.2-codex' }));
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
     await waitFor(() => {

--- a/frontend/src/app/(dashboard)/prioritization/page.tsx
+++ b/frontend/src/app/(dashboard)/prioritization/page.tsx
@@ -13,13 +13,14 @@ import { Slider } from "@/components/ui/slider";
 import { PageHeader } from "@/components/page-header";
 import { X } from "lucide-react";
 import type { Organization, OrgSettings, SingleResponse } from "@/lib/types";
+import { DEFAULT_PM_MODEL } from "@/lib/model-constants";
 
 const DEFAULT_SETTINGS: Pick<
   Required<OrgSettings>,
   "pm_schedule_hours" | "pm_model" | "priority_weights" | "min_priority_threshold" | "product_direction" | "product_context"
 > = {
   pm_schedule_hours: 4,
-  pm_model: "sonnet",
+  pm_model: DEFAULT_PM_MODEL,
   priority_weights: {
     customer_impact: 0.35,
     severity: 0.25,
@@ -172,7 +173,7 @@ export default function PrioritizationPage() {
                   id="pm-model"
                   value={pmModel}
                   onChange={(e) => setPmModel(e.target.value)}
-                  placeholder="sonnet"
+                  placeholder={DEFAULT_PM_MODEL}
                 />
                 <p className="text-xs text-muted-foreground">
                   The LLM model used for PM planning.

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -16,6 +16,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { AVAILABLE_CLAUDE_CODE_MODELS, AVAILABLE_CODEX_MODELS, AVAILABLE_GEMINI_CLI_MODELS } from "@/lib/model-constants";
 import type { CodexDeviceAuth, OrgSettings, Organization, SingleResponse } from "@/lib/types";
 
 interface AgentEnvVar {
@@ -34,7 +35,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
     label: "Codex",
     envVars: [
       { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
-      { name: "OPENAI_MODEL", label: "Model", placeholder: "e.g. codex-mini, o3" },
+      { name: "OPENAI_MODEL", label: "Model", options: [...AVAILABLE_CODEX_MODELS] },
       { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
     ],
   },
@@ -46,7 +47,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
       {
         name: "ANTHROPIC_MODEL",
         label: "Model",
-        options: ["claude-sonnet-4-5", "claude-opus-4-1", "claude-3-5-haiku-latest"],
+        options: [...AVAILABLE_CLAUDE_CODE_MODELS],
       },
       {
         name: "ANTHROPIC_BASE_URL",
@@ -65,7 +66,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
       {
         name: "GEMINI_MODEL",
         label: "Model",
-        options: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+        options: [...AVAILABLE_GEMINI_CLI_MODELS],
       },
     ],
   },
@@ -438,7 +439,7 @@ export function AgentSettingsEditor({
             <div className="space-y-2 rounded-lg border p-4">
               <h4 className="text-sm font-medium">API key configuration</h4>
               <p className="text-xs text-muted-foreground">
-                Enter API key, model, and optional base URL below. This method does not support gpt-5.3-codex.
+                Enter API key, model, and optional base URL below.
               </p>
             </div>
           )}

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AVAILABLE_CODEX_MODELS,
+  AVAILABLE_CLAUDE_CODE_MODELS,
+  AVAILABLE_GEMINI_CLI_MODELS,
+  AVAILABLE_PM_MODELS,
+  DEFAULT_PM_MODEL,
+  PM_MODEL_SONNET,
+} from "./model-constants";
+
+describe("model constants", () => {
+  it("uses sonnet as the PM default", () => {
+    expect(DEFAULT_PM_MODEL).toBe(PM_MODEL_SONNET);
+  });
+
+  it("includes supported PM aliases", () => {
+    expect(AVAILABLE_PM_MODELS).toEqual(["opus", "sonnet", "haiku"]);
+  });
+
+  it("includes latest Claude Code model aliases", () => {
+    expect(AVAILABLE_CLAUDE_CODE_MODELS).toEqual([
+      "claude-opus-4-6",
+      "claude-sonnet-4-5",
+      "claude-haiku-4-5",
+    ]);
+  });
+
+  it("includes latest Gemini CLI models", () => {
+    expect(AVAILABLE_GEMINI_CLI_MODELS).toEqual([
+      "gemini-3-pro-preview",
+      "gemini-3-flash-preview",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+    ]);
+  });
+
+  it("includes latest Codex models", () => {
+    expect(AVAILABLE_CODEX_MODELS).toEqual([
+      "gpt-5.3-codex",
+      "gpt-5.2-codex",
+      "gpt-5-codex",
+      "gpt-5.3-codex-spark",
+    ]);
+  });
+});

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -1,0 +1,40 @@
+export const PM_MODEL_OPUS = "opus";
+export const PM_MODEL_SONNET = "sonnet";
+export const PM_MODEL_HAIKU = "haiku";
+
+export const AVAILABLE_PM_MODELS = [PM_MODEL_OPUS, PM_MODEL_SONNET, PM_MODEL_HAIKU] as const;
+export const DEFAULT_PM_MODEL = PM_MODEL_SONNET;
+
+export const CLAUDE_CODE_MODEL_OPUS = "claude-opus-4-6";
+export const CLAUDE_CODE_MODEL_SONNET = "claude-sonnet-4-5";
+export const CLAUDE_CODE_MODEL_HAIKU = "claude-haiku-4-5";
+
+export const AVAILABLE_CLAUDE_CODE_MODELS = [
+  CLAUDE_CODE_MODEL_OPUS,
+  CLAUDE_CODE_MODEL_SONNET,
+  CLAUDE_CODE_MODEL_HAIKU,
+] as const;
+
+export const GEMINI_CLI_MODEL_GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview";
+export const GEMINI_CLI_MODEL_GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview";
+export const GEMINI_CLI_MODEL_GEMINI_2_5_PRO = "gemini-2.5-pro";
+export const GEMINI_CLI_MODEL_GEMINI_2_5_FLASH = "gemini-2.5-flash";
+
+export const AVAILABLE_GEMINI_CLI_MODELS = [
+  GEMINI_CLI_MODEL_GEMINI_3_PRO_PREVIEW,
+  GEMINI_CLI_MODEL_GEMINI_3_FLASH_PREVIEW,
+  GEMINI_CLI_MODEL_GEMINI_2_5_PRO,
+  GEMINI_CLI_MODEL_GEMINI_2_5_FLASH,
+] as const;
+
+export const CODEX_MODEL_GPT_5_3_CODEX = "gpt-5.3-codex";
+export const CODEX_MODEL_GPT_5_2_CODEX = "gpt-5.2-codex";
+export const CODEX_MODEL_GPT_5_CODEX = "gpt-5-codex";
+export const CODEX_MODEL_GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
+
+export const AVAILABLE_CODEX_MODELS = [
+  CODEX_MODEL_GPT_5_3_CODEX,
+  CODEX_MODEL_GPT_5_2_CODEX,
+  CODEX_MODEL_GPT_5_CODEX,
+  CODEX_MODEL_GPT_5_3_CODEX_SPARK,
+] as const;

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -45,6 +45,18 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if req.Settings != nil {
+		var parsedSettings models.OrgSettings
+		if err := json.Unmarshal(*req.Settings, &parsedSettings); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid settings JSON")
+			return
+		}
+		if err := models.ValidateSettingsModels(parsedSettings); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
+			return
+		}
+	}
+
 	org, err := h.orgStore.GetByID(r.Context(), orgID)
 	if err != nil {
 		writeError(w, http.StatusNotFound, "NOT_FOUND", "organization not found")

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -140,6 +140,45 @@ func TestSettingsHandler_Update(t *testing.T) {
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "INVALID_JSON",
 		},
+		{
+			name: "returns bad request for invalid pm_model",
+			body: `{"settings":{"pm_model":"bad-model"}}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				// no DB calls expected
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "INVALID_SETTINGS",
+		},
+		{
+			name: "returns bad request for invalid codex model in agent_config",
+			body: `{"settings":{"agent_config":{"codex":{"OPENAI_MODEL":"not-a-model"}}}}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				// no DB calls expected
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "INVALID_SETTINGS",
+		},
+		{
+			name: "updates successfully with supported models",
+			body: `{"settings":{"pm_model":"sonnet","agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"},"claude_code":{"ANTHROPIC_MODEL":"claude-sonnet-4-5"},"gemini_cli":{"GEMINI_MODEL":"gemini-3-pro-preview"}}}}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(orgColumns()).AddRow(
+							orgID, "Test Org", json.RawMessage(`{}`), now, now,
+						),
+					)
+				mock.ExpectQuery("UPDATE organizations").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows([]string{"updated_at"}).AddRow(now),
+					)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: "gpt-5.3-codex",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,7 @@ func (c *Config) AgentEnv() map[string]map[string]string {
 	result := make(map[string]map[string]string)
 
 	// Claude Code needs ANTHROPIC_API_KEY.
-	// ANTHROPIC_MODEL selects the model (e.g. "opus", "sonnet", "claude-opus-4-6").
+	// ANTHROPIC_MODEL selects the model (e.g. "opus", "sonnet", "claude-opus-4-6", "claude-sonnet-4-5").
 	if c.AnthropicAPIKey != "" {
 		env := map[string]string{"ANTHROPIC_API_KEY": c.AnthropicAPIKey}
 		if c.AnthropicBaseURL != "" {
@@ -131,7 +131,8 @@ func (c *Config) AgentEnv() map[string]map[string]string {
 
 	// Codex needs OPENAI_API_KEY.
 	// OPENAI_MODEL is not natively supported by Codex CLI (it uses config.toml),
-	// but we pass it so the adapter can use it in the --model flag.
+	// but we pass it so the adapter can use it in the --model flag
+	// (e.g. "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5-codex").
 	if c.OpenAIAPIKey != "" {
 		env := map[string]string{"OPENAI_API_KEY": c.OpenAIAPIKey}
 		if c.OpenAIBaseURL != "" {
@@ -144,7 +145,7 @@ func (c *Config) AgentEnv() map[string]map[string]string {
 	}
 
 	// Gemini CLI needs GEMINI_API_KEY.
-	// GEMINI_MODEL selects the model (e.g. "gemini-2.5-pro", "gemini-2.5-flash").
+	// GEMINI_MODEL selects the model (e.g. "gemini-3-pro-preview", "gemini-3-flash-preview", "gemini-2.5-pro").
 	if c.GeminiAPIKey != "" {
 		env := map[string]string{"GEMINI_API_KEY": c.GeminiAPIKey}
 		if c.GeminiModel != "" {

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 const (
 	PMModelOpus   = "opus"
 	PMModelSonnet = "sonnet"
@@ -42,4 +44,71 @@ var AvailableCodexModels = []string{
 	CodexModelGPT52Codex,
 	CodexModelGPT5Codex,
 	CodexModelGPT53CodexSpark,
+}
+
+func IsSupportedPMModel(model string) bool {
+	for _, supportedModel := range AvailablePMModels {
+		if model == supportedModel {
+			return true
+		}
+	}
+	return false
+}
+
+func IsSupportedClaudeCodeModel(model string) bool {
+	if IsSupportedPMModel(model) {
+		return true
+	}
+	for _, supportedModel := range AvailableClaudeCodeModels {
+		if model == supportedModel {
+			return true
+		}
+	}
+	return false
+}
+
+func IsSupportedGeminiCLIModel(model string) bool {
+	for _, supportedModel := range AvailableGeminiCLIModels {
+		if model == supportedModel {
+			return true
+		}
+	}
+	return false
+}
+
+func IsSupportedCodexModel(model string) bool {
+	for _, supportedModel := range AvailableCodexModels {
+		if model == supportedModel {
+			return true
+		}
+	}
+	return false
+}
+
+func ValidateSettingsModels(settings OrgSettings) error {
+	if settings.PMModel != "" && !IsSupportedPMModel(settings.PMModel) {
+		return fmt.Errorf("pm_model must be one of: %v", AvailablePMModels)
+	}
+
+	for agentType, envVars := range settings.AgentConfig {
+		switch agentType {
+		case "codex":
+			model := envVars["OPENAI_MODEL"]
+			if model != "" && !IsSupportedCodexModel(model) {
+				return fmt.Errorf("agent_config.codex.OPENAI_MODEL must be one of: %v", AvailableCodexModels)
+			}
+		case "claude_code":
+			model := envVars["ANTHROPIC_MODEL"]
+			if model != "" && !IsSupportedClaudeCodeModel(model) {
+				return fmt.Errorf("agent_config.claude_code.ANTHROPIC_MODEL must be one of: %v or %v", AvailablePMModels, AvailableClaudeCodeModels)
+			}
+		case "gemini_cli":
+			model := envVars["GEMINI_MODEL"]
+			if model != "" && !IsSupportedGeminiCLIModel(model) {
+				return fmt.Errorf("agent_config.gemini_cli.GEMINI_MODEL must be one of: %v", AvailableGeminiCLIModels)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -1,0 +1,45 @@
+package models
+
+const (
+	PMModelOpus   = "opus"
+	PMModelSonnet = "sonnet"
+	PMModelHaiku  = "haiku"
+)
+
+var AvailablePMModels = []string{PMModelOpus, PMModelSonnet, PMModelHaiku}
+
+const (
+	ClaudeCodeModelOpus   = "claude-opus-4-6"
+	ClaudeCodeModelSonnet = "claude-sonnet-4-5"
+	ClaudeCodeModelHaiku  = "claude-haiku-4-5"
+)
+
+var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku}
+
+const (
+	GeminiCLIModelGemini3ProPreview   = "gemini-3-pro-preview"
+	GeminiCLIModelGemini3FlashPreview = "gemini-3-flash-preview"
+	GeminiCLIModelGemini25Pro         = "gemini-2.5-pro"
+	GeminiCLIModelGemini25Flash       = "gemini-2.5-flash"
+)
+
+var AvailableGeminiCLIModels = []string{
+	GeminiCLIModelGemini3ProPreview,
+	GeminiCLIModelGemini3FlashPreview,
+	GeminiCLIModelGemini25Pro,
+	GeminiCLIModelGemini25Flash,
+}
+
+const (
+	CodexModelGPT53Codex      = "gpt-5.3-codex"
+	CodexModelGPT52Codex      = "gpt-5.2-codex"
+	CodexModelGPT5Codex       = "gpt-5-codex"
+	CodexModelGPT53CodexSpark = "gpt-5.3-codex-spark"
+)
+
+var AvailableCodexModels = []string{
+	CodexModelGPT53Codex,
+	CodexModelGPT52Codex,
+	CodexModelGPT5Codex,
+	CodexModelGPT53CodexSpark,
+}

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -42,3 +42,80 @@ func TestCodexModelConstants(t *testing.T) {
 		"AvailableCodexModels should include the latest Codex model family",
 	)
 }
+
+func TestValidateSettingsModels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		settings OrgSettings
+		wantErr  bool
+	}{
+		{
+			name: "accepts valid pm and agent models",
+			settings: OrgSettings{
+				PMModel: PMModelSonnet,
+				AgentConfig: AgentEnvConfig{
+					"codex":       {"OPENAI_MODEL": CodexModelGPT53Codex},
+					"claude_code": {"ANTHROPIC_MODEL": ClaudeCodeModelSonnet},
+					"gemini_cli":  {"GEMINI_MODEL": GeminiCLIModelGemini3ProPreview},
+				},
+			},
+		},
+		{
+			name: "accepts claude alias values",
+			settings: OrgSettings{
+				AgentConfig: AgentEnvConfig{
+					"claude_code": {"ANTHROPIC_MODEL": PMModelOpus},
+				},
+			},
+		},
+		{
+			name: "rejects invalid pm model",
+			settings: OrgSettings{
+				PMModel: "invalid-model",
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects invalid codex model",
+			settings: OrgSettings{
+				AgentConfig: AgentEnvConfig{
+					"codex": {"OPENAI_MODEL": "invalid-model"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects invalid claude model",
+			settings: OrgSettings{
+				AgentConfig: AgentEnvConfig{
+					"claude_code": {"ANTHROPIC_MODEL": "invalid-model"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rejects invalid gemini model",
+			settings: OrgSettings{
+				AgentConfig: AgentEnvConfig{
+					"gemini_cli": {"GEMINI_MODEL": "invalid-model"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ValidateSettingsModels(testCase.settings)
+			if testCase.wantErr {
+				require.Error(t, err, "ValidateSettingsModels should return an error for invalid models")
+				return
+			}
+			require.NoError(t, err, "ValidateSettingsModels should accept supported models")
+		})
+	}
+}

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -1,0 +1,44 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPMModelConstants(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, PMModelSonnet, DefaultPMModel, "DefaultPMModel should use PMModelSonnet")
+	require.Equal(t, []string{PMModelOpus, PMModelSonnet, PMModelHaiku}, AvailablePMModels, "AvailablePMModels should expose all supported PM aliases")
+}
+
+func TestClaudeCodeModelConstants(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		[]string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku},
+		AvailableClaudeCodeModels,
+		"AvailableClaudeCodeModels should be ordered by capability",
+	)
+}
+
+func TestGeminiCLIModelConstants(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		[]string{GeminiCLIModelGemini3ProPreview, GeminiCLIModelGemini3FlashPreview, GeminiCLIModelGemini25Pro, GeminiCLIModelGemini25Flash},
+		AvailableGeminiCLIModels,
+		"AvailableGeminiCLIModels should include current Gemini 3 and 2.5 options",
+	)
+}
+
+func TestCodexModelConstants(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t,
+		[]string{CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
+		AvailableCodexModels,
+		"AvailableCodexModels should include the latest Codex model family",
+	)
+}

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -46,7 +46,7 @@ const (
 	DefaultMinPriorityThreshold = 30.0
 	DefaultDefaultAgentType     = "codex"
 	DefaultPMScheduleHours      = 4
-	DefaultPMModel              = "sonnet"
+	DefaultPMModel              = PMModelSonnet
 
 	DefaultWeightCustomerImpact = 0.35
 	DefaultWeightSeverity       = 0.25


### PR DESCRIPTION
Summary
- introduce frontend and backend constants for PM, Claude Code, Gemini CLI, and Codex model names
- wire the prioritization page and agent settings editor to use the shared defaults/options
- document the new constants through unit tests on both sides and surface them in the config comments

Testing
- Not run (not requested)