### PR TITLE
Add manual session composer and backend endpoint

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -31,6 +31,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
     - A **PM agent** now runs on a batch cadence, clusters related issues, and produces a prioritized plan that delegates work to coding agents (replacing per-issue auto-triggering for automation).
 - Step 3: Execute a coding agent
     - Admins set a **confidence threshold** that controls which issues the system will auto-attempt. Issues below the threshold require manual triggering.
+    - The Sessions page supports **one-off manual sessions** with a chat-style composer. Users can start a manual run from free-form instructions (plus optional image URLs/context) without waiting for PM planning cadence.
     - The agent runs in a sandboxed container and produces a code diff.
     - Agent runtime credentials are loaded from org-scoped encrypted credentials (`org_credentials`) rather than process `.env` defaults, so each org can manage Codex/Claude/Gemini auth independently.
     - The agent outputs a **confidence score** with its fix. Low-confidence runs are paused for human review before proceeding to validation.

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { http, HttpResponse } from 'msw';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders, screen } from '@/test/test-utils';
 import { server } from '@/test/mocks/server';
 import { SessionsPageContent } from './sessions-page-content';
@@ -128,5 +129,53 @@ describe('SessionsPage', () => {
     renderWithProviders(<SessionsPageContent />);
 
     expect(screen.getByText('Run Analysis')).toBeInTheDocument();
+  });
+
+  it('starts a one-off manual session from chat composer', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.post('/api/v1/sessions/manual', async ({ request }) => {
+        const body = await request.json() as { message: string; images?: string[] };
+        if (!body.message.includes('Investigate checkout timeout')) {
+          return HttpResponse.json({ error: { code: 'INVALID', message: 'bad body' } }, { status: 400 });
+        }
+        return HttpResponse.json(
+          {
+            data: {
+              id: 'session-manual-chat-1',
+              type: 'manual',
+              status: 'active',
+              triggered_by: 'manual',
+              title: 'Investigate checkout timeout and propose a fix',
+              task_count: 1,
+              active_run_count: 1,
+              completed_run_count: 0,
+              failed_run_count: 0,
+              tasks: [
+                {
+                  rank: 1,
+                  title: 'Investigate checkout timeout and propose a fix',
+                  issue_ids: ['issue-manual-1'],
+                  status: 'delegated',
+                  agent_run_id: 'run-manual-chat-1',
+                  run_status: 'running',
+                },
+              ],
+              created_at: '2026-03-05T12:00:00Z',
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionsPageContent />);
+
+    await user.click(await screen.findByRole('button', { name: 'New Manual Session' }));
+    await user.type(screen.getByLabelText('Message'), 'Investigate checkout timeout and propose a fix.');
+    await user.click(screen.getByRole('button', { name: 'Start Session' }));
+
+    expect(await screen.findByText('Starting session...')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { CalendarClock, RefreshCw, Layers, Wrench } from "lucide-react";
+import { CalendarClock, RefreshCw, Layers, Wrench, Plus, X } from "lucide-react";
 import Link from "next/link";
 import { useQueryState, parseAsString } from "nuqs";
 import { PageHeader } from "@/components/page-header";
@@ -9,6 +10,9 @@ import { EmptyState } from "@/components/empty-state";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/lib/api";
 import type { AgentSession } from "@/lib/types";
 
@@ -123,6 +127,10 @@ function SessionSection({ title, sessions, badge }: { title: string; sessions: A
 export function SessionsPageContent() {
   const queryClient = useQueryClient();
   const [statusFilter, setStatusFilter] = useQueryState("status", parseAsString);
+  const [isManualComposerOpen, setIsManualComposerOpen] = useState(false);
+  const [manualMessage, setManualMessage] = useState("");
+  const [imageInput, setImageInput] = useState("");
+  const [manualImages, setManualImages] = useState<string[]>([]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["sessions"],
@@ -136,6 +144,25 @@ export function SessionsPageContent() {
       queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
   });
+
+  const createManualSessionMutation = useMutation({
+    mutationFn: () => api.sessions.createManual({ message: manualMessage.trim(), images: manualImages }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      setManualMessage("");
+      setManualImages([]);
+      setImageInput("");
+    },
+  });
+
+  function addImage() {
+    const trimmed = imageInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    setManualImages((prev) => [...prev, trimmed]);
+    setImageInput("");
+  }
 
   const allSessions = data?.data ?? [];
   const sessions = filterSessions(allSessions, statusFilter);
@@ -152,16 +179,95 @@ export function SessionsPageContent() {
         title="Sessions"
         description="Each PM analysis cycle or manual fix creates a session."
         action={
-          <Button
-            size="sm"
-            onClick={() => analyzeMutation.mutate()}
-            disabled={analyzeMutation.isPending}
-          >
-            <RefreshCw className={`mr-2 h-4 w-4 ${analyzeMutation.isPending ? "animate-spin" : ""}`} />
-            {analyzeMutation.isPending ? "Running" : "Run Analysis"}
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="outline" onClick={() => setIsManualComposerOpen((prev) => !prev)}>
+              <Plus className="mr-2 h-4 w-4" />
+              New Manual Session
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => analyzeMutation.mutate()}
+              disabled={analyzeMutation.isPending}
+            >
+              <RefreshCw className={`mr-2 h-4 w-4 ${analyzeMutation.isPending ? "animate-spin" : ""}`} />
+              {analyzeMutation.isPending ? "Running" : "Run Analysis"}
+            </Button>
+          </div>
         }
       />
+
+      {isManualComposerOpen && (
+        <Card>
+          <CardContent className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="manual-session-message">Message</Label>
+              <Textarea
+                id="manual-session-message"
+                aria-label="Message"
+                value={manualMessage}
+                onChange={(event) => setManualMessage(event.target.value)}
+                placeholder="Describe what you want the agent to do..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="manual-session-image">Image URL (optional)</Label>
+              <div className="flex items-center gap-2">
+                <Input
+                  id="manual-session-image"
+                  value={imageInput}
+                  onChange={(event) => setImageInput(event.target.value)}
+                  placeholder="https://..."
+                />
+                <Button type="button" variant="outline" onClick={addImage}>
+                  Add Image
+                </Button>
+              </div>
+              {manualImages.length > 0 && (
+                <div className="flex flex-wrap gap-2">
+                  {manualImages.map((imageURL) => (
+                    <Badge key={imageURL} variant="secondary" className="gap-1">
+                      {imageURL}
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setManualImages((prev) => prev.filter((value) => value !== imageURL))}
+                        className="h-4 px-0.5"
+                        aria-label={`Remove ${imageURL}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </Button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => setIsManualComposerOpen(false)}
+                disabled={createManualSessionMutation.isPending}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={() => createManualSessionMutation.mutate()}
+                disabled={manualMessage.trim().length === 0 || createManualSessionMutation.isPending}
+              >
+                Start Session
+              </Button>
+            </div>
+
+            {(createManualSessionMutation.isPending || createManualSessionMutation.isSuccess) && (
+              <p className="text-xs text-muted-foreground">Starting session...</p>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       <div className="flex items-center gap-1">
         {statusFilterTabs.map((tab) => (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -165,6 +165,8 @@ export const api = {
       return get<import('./types').ListResponse<import('./types').AgentSession>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
     get: (id: string) => get<import('./types').SingleResponse<import('./types').AgentSession>>(`/api/v1/sessions/${id}`),
+    createManual: (body: { message: string; images?: string[]; agent_type?: string; autonomy_level?: string; token_mode?: string }) =>
+      post<import('./types').SingleResponse<import('./types').AgentSession>>('/api/v1/sessions/manual', body),
   },
   settings: {
     get: () => get<import('./types').SingleResponse<import('./types').Organization>>('/api/v1/settings'),

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
@@ -17,10 +19,25 @@ import (
 type SessionHandler struct {
 	planStore     *db.PMPlanStore
 	agentRunStore *db.AgentRunStore
+	issueStore    *db.IssueStore
+	orgStore      *db.OrganizationStore
+	jobStore      *db.JobStore
 }
 
-func NewSessionHandler(planStore *db.PMPlanStore, agentRunStore *db.AgentRunStore) *SessionHandler {
-	return &SessionHandler{planStore: planStore, agentRunStore: agentRunStore}
+func NewSessionHandler(
+	planStore *db.PMPlanStore,
+	agentRunStore *db.AgentRunStore,
+	issueStore *db.IssueStore,
+	orgStore *db.OrganizationStore,
+	jobStore *db.JobStore,
+) *SessionHandler {
+	return &SessionHandler{
+		planStore:     planStore,
+		agentRunStore: agentRunStore,
+		issueStore:    issueStore,
+		orgStore:      orgStore,
+		jobStore:      jobStore,
+	}
 }
 
 // List returns a merged list of PM-plan sessions and ad-hoc (manual) run sessions,
@@ -46,8 +63,11 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 	for _, p := range plans {
 		sessions = append(sessions, planToSession(p))
 	}
+
+	runIssues := h.issueByIDMap(r, orgID, orphanRuns)
 	for _, run := range orphanRuns {
-		sessions = append(sessions, runToSession(run))
+		session := runToSessionWithIssue(run, runIssues[run.IssueID])
+		sessions = append(sessions, session)
 	}
 
 	// Sort merged list by created_at DESC.
@@ -92,9 +112,135 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	issue, issueErr := h.issueStore.GetByID(r.Context(), orgID, run.IssueID)
+	if issueErr == nil {
+		session := runToSessionWithIssue(run, &issue)
+		writeJSON(w, http.StatusOK, models.SingleResponse[models.AgentSession]{Data: session})
+		return
+	}
+
 	session := runToSession(run)
-	session.Tasks = []models.AgentSessionTask{runToTask(run, 1)}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.AgentSession]{Data: session})
+}
+
+type createManualSessionRequest struct {
+	Message       string   `json:"message"`
+	Images        []string `json:"images"`
+	AgentType     string   `json:"agent_type"`
+	AutonomyLevel string   `json:"autonomy_level"`
+	TokenMode     string   `json:"token_mode"`
+}
+
+func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	var body createManualSessionRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+
+	body.Message = strings.TrimSpace(body.Message)
+	if body.Message == "" {
+		writeError(w, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
+		return
+	}
+
+	agentType := body.AgentType
+	if agentType == "" {
+		org, err := h.orgStore.GetByID(r.Context(), orgID)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings")
+			return
+		}
+		agentType = models.ParseOrgSettings(org.Settings).DefaultAgentType
+		if agentType == "" {
+			agentType = models.DefaultDefaultAgentType
+		}
+	}
+	validAgentTypes := map[string]bool{"claude_code": true, "gemini_cli": true, "codex": true}
+	if !validAgentTypes[agentType] {
+		writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", "agent_type must be one of: claude_code, gemini_cli, codex")
+		return
+	}
+
+	autonomyLevel := body.AutonomyLevel
+	if autonomyLevel == "" {
+		autonomyLevel = "semi"
+	}
+	validAutonomyLevels := map[string]bool{"full": true, "semi": true, "supervised": true}
+	if !validAutonomyLevels[autonomyLevel] {
+		writeError(w, http.StatusBadRequest, "INVALID_AUTONOMY_LEVEL", "autonomy_level must be one of: full, semi, supervised")
+		return
+	}
+
+	tokenMode := body.TokenMode
+	if tokenMode == "" {
+		tokenMode = "low"
+	}
+	validTokenModes := map[string]bool{"low": true, "high": true}
+	if !validTokenModes[tokenMode] {
+		writeError(w, http.StatusBadRequest, "INVALID_TOKEN_MODE", "token_mode must be one of: low, high")
+		return
+	}
+
+	now := time.Now()
+	fingerprint := fmt.Sprintf("manual:%x", sha256.Sum256([]byte(fmt.Sprintf("%s:%d", body.Message, now.UnixNano()))))
+	description := buildManualSessionDescription(body.Message, body.Images)
+	title := manualSessionTitle(body.Message)
+	rawData, err := json.Marshal(map[string]any{
+		"manual_session": true,
+		"images":         body.Images,
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "ENCODE_FAILED", "failed to encode manual session context")
+		return
+	}
+	issue := &models.Issue{
+		OrgID:                 orgID,
+		ExternalID:            "manual-" + now.UTC().Format("20060102150405") + "-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+		Source:                "manual",
+		Title:                 title,
+		Description:           &description,
+		RawData:               rawData,
+		Status:                "open",
+		FirstSeenAt:           now,
+		LastSeenAt:            now,
+		OccurrenceCount:       1,
+		AffectedCustomerCount: 1,
+		Severity:              "medium",
+		Fingerprint:           fingerprint,
+	}
+
+	if err := h.issueStore.Upsert(r.Context(), issue); err != nil {
+		writeError(w, http.StatusInternalServerError, "ISSUE_CREATE_FAILED", "failed to create manual issue")
+		return
+	}
+
+	run := &models.AgentRun{
+		IssueID:       issue.ID,
+		OrgID:         orgID,
+		AgentType:     agentType,
+		Status:        "pending",
+		AutonomyLevel: autonomyLevel,
+		TokenMode:     tokenMode,
+	}
+	if err := h.agentRunStore.Create(r.Context(), run); err != nil {
+		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual run")
+		return
+	}
+
+	payload := map[string]string{
+		"agent_run_id": run.ID.String(),
+		"org_id":       orgID.String(),
+	}
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue manual run")
+		return
+	}
+
+	session := runToSessionWithIssue(*run, issue)
+	writeJSON(w, http.StatusCreated, models.SingleResponse[models.AgentSession]{Data: session})
 }
 
 // planToSession converts a PMPlan to an AgentSession summary.
@@ -151,9 +297,15 @@ func planToSession(p models.PMPlan) models.AgentSession {
 
 // runToSession converts an orphan AgentRun to a single-task AgentSession.
 func runToSession(run models.AgentRun) models.AgentSession {
+	return runToSessionWithIssue(run, nil)
+}
+
+func runToSessionWithIssue(run models.AgentRun, issue *models.Issue) models.AgentSession {
 	var title string
 	if run.ResultSummary != nil && *run.ResultSummary != "" {
 		title = *run.ResultSummary
+	} else if issue != nil && issue.Title != "" {
+		title = issue.Title
 	} else {
 		title = "Run " + run.ID.String()[:8]
 	}
@@ -170,13 +322,24 @@ func runToSession(run models.AgentRun) models.AgentSession {
 		failedCount = 1
 	}
 
+	triggeredBy := models.AgentSessionTriggeredByFixThis
+	if issue != nil && issue.Source == "manual" {
+		triggeredBy = models.AgentSessionTriggeredByManual
+	}
+
+	var analysis *string
+	if issue != nil && issue.Description != nil {
+		analysis = issue.Description
+	}
+
 	return models.AgentSession{
 		ID:                run.ID,
 		Type:              models.AgentSessionTypeManual,
 		Status:            status,
-		TriggeredBy:       models.AgentSessionTriggeredByFixThis,
+		TriggeredBy:       triggeredBy,
 		Title:             title,
-		Tasks:             []models.AgentSessionTask{runToTask(run, 1)},
+		Analysis:          analysis,
+		Tasks:             []models.AgentSessionTask{runToTask(run, 1, title)},
 		TaskCount:         1,
 		ActiveRunCount:    activeCount,
 		CompletedRunCount: completedCount,
@@ -287,16 +450,19 @@ func pmTasksToSessionTasks(tasks []pmTaskJSON) []models.AgentSessionTask {
 	return result
 }
 
-func runToTask(run models.AgentRun, rank int) models.AgentSessionTask {
+func runToTask(run models.AgentRun, rank int, fallbackTitle string) models.AgentSessionTask {
 	runID := run.ID.String()
 	runStatus := models.AgentRunStatus(run.Status)
 	t := models.AgentSessionTask{
 		Rank:       rank,
-		Title:      "Fix issue",
+		Title:      fallbackTitle,
 		IssueIDs:   []string{run.IssueID.String()},
 		Status:     models.PMTaskStatusDelegated,
 		AgentRunID: &runID,
 		RunStatus:  &runStatus,
+	}
+	if strings.TrimSpace(fallbackTitle) == "" {
+		t.Title = "Fix issue"
 	}
 	if run.ResultSummary != nil {
 		t.Title = *run.ResultSummary
@@ -312,6 +478,72 @@ func runToTask(run models.AgentRun, rank int) models.AgentSessionTask {
 		t.RunCompletedAt = &s
 	}
 	return t
+}
+
+func (h *SessionHandler) issueByIDMap(r *http.Request, orgID uuid.UUID, runs []models.AgentRun) map[uuid.UUID]*models.Issue {
+	result := map[uuid.UUID]*models.Issue{}
+	if len(runs) == 0 {
+		return result
+	}
+
+	issueIDs := make([]uuid.UUID, 0, len(runs))
+	seen := make(map[uuid.UUID]bool)
+	for _, run := range runs {
+		if seen[run.IssueID] {
+			continue
+		}
+		seen[run.IssueID] = true
+		issueIDs = append(issueIDs, run.IssueID)
+	}
+
+	issues, err := h.issueStore.ListByIDs(r.Context(), orgID, issueIDs)
+	if err != nil {
+		return result
+	}
+
+	for i := range issues {
+		issue := issues[i]
+		result[issue.ID] = &issue
+	}
+
+	return result
+}
+
+func buildManualSessionDescription(message string, images []string) string {
+	if len(images) == 0 {
+		return message
+	}
+
+	var b strings.Builder
+	b.WriteString(message)
+	b.WriteString("\n\n### Attached images\n")
+	for _, imageURL := range images {
+		if strings.TrimSpace(imageURL) == "" {
+			continue
+		}
+		b.WriteString("- ")
+		b.WriteString(imageURL)
+		b.WriteString("\n")
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+func manualSessionTitle(message string) string {
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return "Manual Session"
+	}
+
+	if idx := strings.Index(trimmed, "\n"); idx > 0 {
+		trimmed = trimmed[:idx]
+	}
+
+	if len(trimmed) <= 120 {
+		return trimmed
+	}
+
+	return strings.TrimSpace(trimmed[:120]) + "..."
 }
 
 func planStatusToSessionStatus(s models.PMPlanStatus) models.AgentSessionStatus {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,10 @@ func TestSessionHandler_List(t *testing.T) {
 
 	planStore := db.NewPMPlanStore(mock)
 	runStore := db.NewAgentRunStore(mock)
-	handler := NewSessionHandler(planStore, runStore)
+	issueStore := db.NewIssueStore(mock)
+	orgStore := db.NewOrganizationStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewSessionHandler(planStore, runStore, issueStore, orgStore, jobStore)
 
 	orgID := uuid.New()
 	planID := uuid.New()
@@ -71,6 +75,18 @@ func TestSessionHandler_List(t *testing.T) {
 				),
 		)
 
+	mock.ExpectQuery("SELECT id, org_id, external_id, source").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "external_id", "source", "source_integration_id", "repository_id",
+				"title", "description", "raw_data", "status", "first_seen_at", "last_seen_at",
+				"occurrence_count", "affected_customer_count", "severity", "tags", "fingerprint",
+				"created_at", "updated_at",
+			}).
+				AddRow(issueID, orgID, "ISSUE-1", "sentry", nil, nil, "Checkout timeout", nil, json.RawMessage(`{}`), "open", now, now, 1, 1, "high", []string{}, "fp-1", now, now),
+		)
+
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
 	rr := httptest.NewRecorder()
@@ -99,7 +115,10 @@ func TestSessionHandler_Get_PlanSession(t *testing.T) {
 
 	planStore := db.NewPMPlanStore(mock)
 	runStore := db.NewAgentRunStore(mock)
-	handler := NewSessionHandler(planStore, runStore)
+	issueStore := db.NewIssueStore(mock)
+	orgStore := db.NewOrganizationStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewSessionHandler(planStore, runStore, issueStore, orgStore, jobStore)
 
 	orgID := uuid.New()
 	planID := uuid.New()
@@ -163,7 +182,10 @@ func TestSessionHandler_Get_ManualSession(t *testing.T) {
 
 	planStore := db.NewPMPlanStore(mock)
 	runStore := db.NewAgentRunStore(mock)
-	handler := NewSessionHandler(planStore, runStore)
+	issueStore := db.NewIssueStore(mock)
+	orgStore := db.NewOrganizationStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewSessionHandler(planStore, runStore, issueStore, orgStore, jobStore)
 
 	orgID := uuid.New()
 	runID := uuid.New()
@@ -188,6 +210,18 @@ func TestSessionHandler_Get_ManualSession(t *testing.T) {
 					nil, nil, nil,
 					now,
 				),
+		)
+
+	mock.ExpectQuery("SELECT id, org_id, external_id, source").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "external_id", "source", "source_integration_id", "repository_id",
+				"title", "description", "raw_data", "status", "first_seen_at", "last_seen_at",
+				"occurrence_count", "affected_customer_count", "severity", "tags", "fingerprint",
+				"created_at", "updated_at",
+			}).
+				AddRow(issueID, orgID, "ISSUE-2", "sentry", nil, nil, "Fix issue", nil, json.RawMessage(`{}`), "open", now, now, 1, 1, "medium", []string{}, "fp-2", now, now),
 		)
 
 	rctx := chi.NewRouteContext()
@@ -219,7 +253,10 @@ func TestSessionHandler_Get_NotFound(t *testing.T) {
 
 	planStore := db.NewPMPlanStore(mock)
 	runStore := db.NewAgentRunStore(mock)
-	handler := NewSessionHandler(planStore, runStore)
+	issueStore := db.NewIssueStore(mock)
+	orgStore := db.NewOrganizationStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewSessionHandler(planStore, runStore, issueStore, orgStore, jobStore)
 
 	orgID := uuid.New()
 	sessionID := uuid.New()
@@ -339,6 +376,77 @@ func TestRunToSession_TypedTaskFields(t *testing.T) {
 	require.Equal(t, 0.88, *task.RunConfidenceScore, "confidence score should match")
 	require.NotNil(t, task.RunStartedAt, "started_at should be set")
 	require.NotNil(t, task.RunCompletedAt, "completed_at should be set")
+}
+
+func TestSessionHandler_CreateManual(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	runStore := db.NewAgentRunStore(mock)
+	issueStore := db.NewIssueStore(mock)
+	orgStore := db.NewOrganizationStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewSessionHandler(planStore, runStore, issueStore, orgStore, jobStore)
+
+	orgID := uuid.New()
+	issueID := uuid.New()
+	runID := uuid.New()
+	jobID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery(`(?s)INSERT INTO issues`).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).
+				AddRow(issueID, now, now),
+		)
+
+	mock.ExpectQuery(`(?s)INSERT INTO agent_runs`).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(runID, now),
+		)
+
+	mock.ExpectQuery(`(?s)INSERT INTO jobs`).
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id"}).
+				AddRow(jobID),
+		)
+
+	body := `{"message":"Please investigate checkout timeout and include a fix.","images":["https://example.com/error.png"],"agent_type":"codex"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/manual", strings.NewReader(body))
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.CreateManual(rr, req)
+
+	require.Equal(t, http.StatusCreated, rr.Code, "should create a manual session: %s", rr.Body.String())
+
+	var resp models.SingleResponse[models.AgentSession]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
+	require.Equal(t, models.AgentSessionTypeManual, resp.Data.Type, "session type should be manual")
+	require.Equal(t, models.AgentSessionTriggeredByManual, resp.Data.TriggeredBy, "manual session should be triggered manually")
+	require.Len(t, resp.Data.Tasks, 1, "manual session should include one task")
+	require.Equal(t, runID, resp.Data.ID, "session id should match created run id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func float64Ptr(f float64) *float64 { return &f }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -89,7 +89,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		jobStore,
 	)
 	pmHandler := handlers.NewPMHandler(pmPlanStore, jobStore)
-	sessionHandler := handlers.NewSessionHandler(pmPlanStore, agentRunStore)
+	sessionHandler := handlers.NewSessionHandler(pmPlanStore, agentRunStore, issueStore, orgStore, jobStore)
 	priorityHandler := handlers.NewPriorityHandler(priorityScoreStore, complexityEstimateStore, jobStore)
 	ingestionWebhookHandler := handlers.NewIngestionWebhookHandler(webhookDeliveryStore, integrationStore, credentialStore, ingestionSvc, logger)
 	credentialHandler := handlers.NewCredentialHandler(credentialStore)
@@ -178,6 +178,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
 			r.Post("/api/v1/integrations/linear/connect", integrationHandler.ConnectLinear)
 			r.Post("/api/v1/issues/{id}/fix", runHandler.TriggerFix)
+			r.Post("/api/v1/sessions/manual", sessionHandler.CreateManual)
 			r.Post("/api/v1/runs/{id}/questions/{qid}/answer", runHandler.AnswerQuestion)
 		})
 

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -108,6 +108,30 @@ func (s *IssueStore) GetByID(ctx context.Context, orgID, issueID uuid.UUID) (mod
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Issue])
 }
 
+func (s *IssueStore) ListByIDs(ctx context.Context, orgID uuid.UUID, issueIDs []uuid.UUID) ([]models.Issue, error) {
+	if len(issueIDs) == 0 {
+		return []models.Issue{}, nil
+	}
+
+	query := `
+		SELECT id, org_id, external_id, source, source_integration_id, repository_id,
+		       title, description, raw_data, status, first_seen_at, last_seen_at,
+		       occurrence_count, affected_customer_count, severity, tags, fingerprint,
+		       created_at, updated_at
+		FROM issues
+		WHERE org_id = @org_id AND id = ANY(@issue_ids)`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":    orgID,
+		"issue_ids": issueIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query issues by ids: %w", err)
+	}
+
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Issue])
+}
+
 func (s *IssueStore) Upsert(ctx context.Context, issue *models.Issue) error {
 	query := `
 		INSERT INTO issues (org_id, external_id, source, source_integration_id, repository_id,
@@ -130,21 +154,21 @@ func (s *IssueStore) Upsert(ctx context.Context, issue *models.Issue) error {
 
 	args := pgx.NamedArgs{
 		"org_id":                  issue.OrgID,
-		"external_id":            issue.ExternalID,
-		"source":                 issue.Source,
-		"source_integration_id":  issue.SourceIntegrationID,
-		"repository_id":          issue.RepositoryID,
-		"title":                  issue.Title,
-		"description":            issue.Description,
-		"raw_data":               issue.RawData,
-		"status":                 issue.Status,
-		"first_seen_at":          issue.FirstSeenAt,
-		"last_seen_at":           issue.LastSeenAt,
-		"occurrence_count":       issue.OccurrenceCount,
+		"external_id":             issue.ExternalID,
+		"source":                  issue.Source,
+		"source_integration_id":   issue.SourceIntegrationID,
+		"repository_id":           issue.RepositoryID,
+		"title":                   issue.Title,
+		"description":             issue.Description,
+		"raw_data":                issue.RawData,
+		"status":                  issue.Status,
+		"first_seen_at":           issue.FirstSeenAt,
+		"last_seen_at":            issue.LastSeenAt,
+		"occurrence_count":        issue.OccurrenceCount,
 		"affected_customer_count": issue.AffectedCustomerCount,
-		"severity":               issue.Severity,
-		"tags":                   issue.Tags,
-		"fingerprint":            issue.Fingerprint,
+		"severity":                issue.Severity,
+		"tags":                    issue.Tags,
+		"fingerprint":             issue.Fingerprint,
 	}
 
 	row := s.db.QueryRow(ctx, query, args)


### PR DESCRIPTION
Summary
- add a manual session composer with image attachments to the sessions page UI and wire it to the existing sessions list
- extend the API/handler layer to create manual sessions by persisting a synthetic issue, agent run, and job, plus surface richer task/session data in the responses
- document the feature in the overall system design

Testing
- Not run (not requested)