### PR TITLE
Remove cards from credential sections on ChatGPT settings

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -245,6 +245,9 @@ describe('OverviewPage', () => {
       expect(screen.getByText('Configure coding agent')).toBeInTheDocument();
     });
 
+    expect(screen.getByText('Credential method').closest('div.space-y-3')).not.toHaveClass('bg-card');
+    expect(screen.getByRole('heading', { name: 'Sign in with ChatGPT', level: 4 }).closest('div.space-y-3')).not.toHaveClass('border');
+
     expect(screen.getByText('Best for gpt-5.3-codex model access.')).toBeInTheDocument();
     expect(screen.queryByText('Recommended')).not.toBeInTheDocument();
 

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -362,7 +362,7 @@ export function AgentSettingsEditor({
 
       {defaultAgentType === "codex" && (
         <div className="space-y-4">
-          <div className="space-y-3 rounded-lg border bg-card p-4">
+          <div className="space-y-3">
             <Label>Credential method</Label>
             <RadioGroup
               value={codexCredentialMethod}
@@ -404,7 +404,7 @@ export function AgentSettingsEditor({
           </div>
 
           {codexCredentialMethod === "chatgpt" ? (
-            <div className="space-y-3 rounded-lg border p-4">
+            <div className="space-y-3">
               <div className="flex items-center justify-between">
                 <div>
                   <h4 className="text-sm font-medium">Sign in with ChatGPT</h4>
@@ -436,7 +436,7 @@ export function AgentSettingsEditor({
               </div>
             </div>
           ) : (
-            <div className="space-y-2 rounded-lg border p-4">
+            <div className="space-y-2">
               <h4 className="text-sm font-medium">API key configuration</h4>
               <p className="text-xs text-muted-foreground">
                 Enter API key, model, and optional base URL below.


### PR DESCRIPTION
Summary
- ensure the credential method section and both ChatGPT sign-in and API key forms render without the card styling requested
- adjust the overview integration test to assert the Credential method area and heading parent containers no longer use card/border classes

Testing
- Not run (not requested)