### PR TITLE
Show real integration logos on connection cards

### DIFF
--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -14,6 +14,7 @@ describe("integration connection cards", () => {
     renderWithProviders(<SourceControlIntegrationCard onConnectGitHub={onConnectGitHub} />);
 
     expect(screen.getByText("GitHub")).toBeInTheDocument();
+    expect(screen.getByAltText("GitHub logo")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub" }));
 
@@ -36,6 +37,8 @@ describe("integration connection cards", () => {
 
     expect(screen.getByText("Sentry")).toBeInTheDocument();
     expect(screen.getByText("Linear")).toBeInTheDocument();
+    expect(screen.getByAltText("Sentry logo")).toBeInTheDocument();
+    expect(screen.getByAltText("Linear logo")).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Connect Sentry" }));
     await user.click(screen.getByRole("button", { name: "Connect Linear" }));

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -1,8 +1,8 @@
-import { GitBranch, Bug, SquareKanban } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { IntegrationsCard } from "@/components/integrations-card";
-import { INTEGRATIONS } from "@/lib/integrations";
+import { getIntegrationByKey } from "@/lib/integrations";
 
 type SourceControlIntegrationCardProps = {
   onConnectGitHub: () => void;
@@ -17,8 +17,21 @@ type AdditionalIntegrationCardsProps = {
 
 type AllIntegrationCardsProps = SourceControlIntegrationCardProps & AdditionalIntegrationCardsProps;
 
+function IntegrationLogo({ name, src }: { name: string; src: string }) {
+  return (
+    <Image
+      src={src}
+      alt={`${name} logo`}
+      className="h-6 w-6 rounded-sm object-contain"
+      width={24}
+      height={24}
+      unoptimized
+    />
+  );
+}
+
 export function SourceControlIntegrationCard({ onConnectGitHub }: SourceControlIntegrationCardProps) {
-  const github = INTEGRATIONS[0];
+  const github = getIntegrationByKey("github");
 
   return (
     <IntegrationsCard
@@ -27,7 +40,7 @@ export function SourceControlIntegrationCard({ onConnectGitHub }: SourceControlI
           id: github.key,
           title: github.name,
           description: github.description,
-          icon: <GitBranch className="h-5 w-5" />,
+          logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
           action: (
             <Button size="sm" onClick={onConnectGitHub} aria-label="Connect GitHub">
@@ -46,8 +59,8 @@ export function AdditionalIntegrationCards({
   onConnectSentry,
   onConnectLinear,
 }: AdditionalIntegrationCardsProps) {
-  const sentry = INTEGRATIONS[1];
-  const linear = INTEGRATIONS[2];
+  const sentry = getIntegrationByKey("sentry");
+  const linear = getIntegrationByKey("linear");
 
   return (
     <IntegrationsCard
@@ -56,7 +69,7 @@ export function AdditionalIntegrationCards({
           id: sentry.key,
           title: sentry.name,
           description: sentry.description,
-          icon: <Bug className="h-5 w-5" />,
+          logo: <IntegrationLogo name={sentry.name} src={sentry.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
           action: (
             <Button
@@ -73,7 +86,7 @@ export function AdditionalIntegrationCards({
           id: linear.key,
           title: linear.name,
           description: linear.description,
-          icon: <SquareKanban className="h-5 w-5" />,
+          logo: <IntegrationLogo name={linear.name} src={linear.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
           action: (
             <Button
@@ -100,9 +113,9 @@ export function AllIntegrationCards({
   linearConnected,
   linearLoading,
 }: AllIntegrationCardsProps) {
-  const github = INTEGRATIONS[0];
-  const sentry = INTEGRATIONS[1];
-  const linear = INTEGRATIONS[2];
+  const github = getIntegrationByKey("github");
+  const sentry = getIntegrationByKey("sentry");
+  const linear = getIntegrationByKey("linear");
 
   return (
     <IntegrationsCard
@@ -111,7 +124,7 @@ export function AllIntegrationCards({
           id: github.key,
           title: github.name,
           description: github.description,
-          icon: <GitBranch className="h-5 w-5" />,
+          logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
           action: (
             <Button size="sm" onClick={onConnectGitHub} aria-label="Connect GitHub">
@@ -123,7 +136,7 @@ export function AllIntegrationCards({
           id: sentry.key,
           title: sentry.name,
           description: sentry.description,
-          icon: <Bug className="h-5 w-5" />,
+          logo: <IntegrationLogo name={sentry.name} src={sentry.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
           action: (
             <Button
@@ -140,7 +153,7 @@ export function AllIntegrationCards({
           id: linear.key,
           title: linear.name,
           description: linear.description,
-          icon: <SquareKanban className="h-5 w-5" />,
+          logo: <IntegrationLogo name={linear.name} src={linear.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
           action: (
             <Button

--- a/frontend/src/components/integrations-card.tsx
+++ b/frontend/src/components/integrations-card.tsx
@@ -6,7 +6,7 @@ type IntegrationsCardItem = {
   title: string;
   description: string;
   action: ReactNode;
-  icon?: ReactNode;
+  logo?: ReactNode;
   badge?: ReactNode;
 };
 
@@ -20,15 +20,11 @@ export function IntegrationsCard({ items }: IntegrationsCardProps) {
       {items.map((item) => (
         <Card key={item.id} className="py-0" data-testid="integration-card">
           <CardContent className="flex items-center justify-between gap-4 py-4">
-            <div className="flex items-center gap-3 min-w-0 flex-1">
-              {item.icon && (
-                <div className="flex shrink-0 items-center justify-center h-9 w-9 rounded-lg bg-muted text-muted-foreground">
-                  {item.icon}
-                </div>
-              )}
-              <div className="min-w-0 flex-1">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              {item.logo ? <div className="shrink-0">{item.logo}</div> : null}
+              <div className="min-w-0">
                 <div className="flex items-center gap-2">
-                  <p className="text-sm font-medium text-foreground">{item.title}</p>
+                <p className="text-sm font-medium text-foreground">{item.title}</p>
                   {item.badge}
                 </div>
                 <p className="mt-0.5 text-sm text-muted-foreground">{item.description}</p>

--- a/frontend/src/lib/integrations.ts
+++ b/frontend/src/lib/integrations.ts
@@ -4,6 +4,7 @@ export type IntegrationDefinition = {
   key: IntegrationKey;
   name: string;
   description: string;
+  logoSrc: string;
 };
 
 export const INTEGRATIONS: IntegrationDefinition[] = [
@@ -11,15 +12,26 @@ export const INTEGRATIONS: IntegrationDefinition[] = [
     key: "github",
     name: "GitHub",
     description: "Sync repositories and open PRs.",
+    logoSrc: "https://logo.clearbit.com/github.com",
   },
   {
     key: "sentry",
     name: "Sentry",
     description: "Pull errors and auto-generate fixes.",
+    logoSrc: "https://logo.clearbit.com/sentry.io",
   },
   {
     key: "linear",
     name: "Linear",
     description: "Sync issues and auto-assign fixes.",
+    logoSrc: "https://logo.clearbit.com/linear.app",
   },
 ];
+
+export function getIntegrationByKey(key: IntegrationKey): IntegrationDefinition {
+  const integration = INTEGRATIONS.find((integrationDefinition) => integrationDefinition.key === key);
+  if (!integration) {
+    throw new Error(`missing integration definition for key: ${key}`);
+  }
+  return integration;
+}


### PR DESCRIPTION
Summary
- pull logo URLs into the integration definitions and add a helper for looking up each integration by key
- render the real logos inside the integration connection cards and expose them on the reusable cards component
- extend the connection card tests to assert the logos are present alongside the buttons

Testing
- Not run (not requested)