### PR TITLE
Make GitHub OAuth redirect URI configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ SESSION_SECRET=change-me-to-random-secret
 # GitHub OAuth (create at https://github.com/settings/applications/new)
 GITHUB_OAUTH_CLIENT_ID=
 GITHUB_OAUTH_CLIENT_SECRET=
+# Override the OAuth callback URL sent to GitHub. Defaults to BASE_URL + /api/v1/auth/github/callback.
+# Set this when BASE_URL doesn't match the callback URL registered in your GitHub OAuth App
+# (e.g. behind a reverse proxy, using a tunnel, or running on a non-standard port).
+# GITHUB_OAUTH_REDIRECT_URI=https://example.com/api/v1/auth/github/callback
 
 # Linear OAuth (create in Linear OAuth applications settings)
 LINEAR_OAUTH_CLIENT_ID=

--- a/docs/github-app-setup.md
+++ b/docs/github-app-setup.md
@@ -43,6 +43,12 @@ GITHUB_OAUTH_CLIENT_ID=your_client_id
 GITHUB_OAUTH_CLIENT_SECRET=your_client_secret
 ```
 
+If your `BASE_URL` doesn't match the callback URL registered in GitHub (e.g. you're behind a reverse proxy or using a tunnel), set the redirect URI explicitly:
+
+```env
+GITHUB_OAUTH_REDIRECT_URI=https://your-public-domain.com/api/v1/auth/github/callback
+```
+
 That's it for OAuth. This only requests `read:user` and `user:email` scopes — just enough to identify who's logging in.
 
 ## Part 2: GitHub App
@@ -197,4 +203,5 @@ Create separate GitHub OAuth Apps and GitHub Apps for development and production
 | "Resource not accessible by integration" on API calls | The app is missing a required permission — check the permissions table above and update in GitHub App settings |
 | PRs aren't being created | Verify the app is installed on the target repo and has Contents + Pull Requests write access |
 | Webhooks not arriving | Check that the webhook URL is correct and reachable. Use the Recent Deliveries tab in GitHub App settings to debug |
+| "redirect_uri is not associated with this application" | Your `BASE_URL` doesn't match the callback URL in GitHub OAuth App settings. Either update the callback URL in GitHub, or set `GITHUB_OAUTH_REDIRECT_URI` to match what's registered |
 | Private key parse error | Make sure the full PEM is included, including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` |

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -213,7 +213,7 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 
 	params := url.Values{
 		"client_id":    {h.cfg.GitHubOAuthClientID},
-		"redirect_uri": {h.cfg.BaseURL + "/api/v1/auth/github/callback"},
+		"redirect_uri": {h.cfg.GitHubOAuthRedirectURI},
 		"scope":        {"read:user,user:email"},
 		"state":        {state},
 	}

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -23,8 +23,9 @@ func TestAuthHandler_Login_Redirects(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		GitHubOAuthClientID: "test-client-id",
-		BaseURL:             "http://localhost:8080",
+		GitHubOAuthClientID:    "test-client-id",
+		BaseURL:                "http://localhost:8080",
+		GitHubOAuthRedirectURI: "http://localhost:8080/api/v1/auth/github/callback",
 	}
 	handler := NewAuthHandler(cfg, nil, nil, nil, nil)
 
@@ -900,8 +901,9 @@ func TestAuthHandler_Login_SetsInvitationCookie(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		GitHubOAuthClientID: "test-client-id",
-		BaseURL:             "http://localhost:8080",
+		GitHubOAuthClientID:    "test-client-id",
+		BaseURL:                "http://localhost:8080",
+		GitHubOAuthRedirectURI: "http://localhost:8080/api/v1/auth/github/callback",
 	}
 	handler := NewAuthHandler(cfg, nil, nil, nil, nil)
 
@@ -927,8 +929,9 @@ func TestAuthHandler_Login_NoInvitationCookieWithoutParam(t *testing.T) {
 	t.Parallel()
 
 	cfg := &config.Config{
-		GitHubOAuthClientID: "test-client-id",
-		BaseURL:             "http://localhost:8080",
+		GitHubOAuthClientID:    "test-client-id",
+		BaseURL:                "http://localhost:8080",
+		GitHubOAuthRedirectURI: "http://localhost:8080/api/v1/auth/github/callback",
 	}
 	handler := NewAuthHandler(cfg, nil, nil, nil, nil)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,9 @@ type Config struct {
 	Mode               string   `env:"MODE"                  envDefault:"all"`
 
 	// GitHub OAuth
-	GitHubOAuthClientID     string `env:"GITHUB_OAUTH_CLIENT_ID"`
-	GitHubOAuthClientSecret string `env:"GITHUB_OAUTH_CLIENT_SECRET"`
+	GitHubOAuthClientID      string `env:"GITHUB_OAUTH_CLIENT_ID"`
+	GitHubOAuthClientSecret  string `env:"GITHUB_OAUTH_CLIENT_SECRET"`
+	GitHubOAuthRedirectURI   string `env:"GITHUB_OAUTH_REDIRECT_URI"`
 
 	// Google OAuth
 	GoogleOAuthClientID     string `env:"GOOGLE_OAUTH_CLIENT_ID"`
@@ -88,6 +89,11 @@ func Load() *Config {
 	}
 	if len(cfg.CORSAllowedOrigins) == 0 {
 		cfg.CORSAllowedOrigins = []string{cfg.FrontendURL}
+	}
+
+	// Default GitHub OAuth redirect URI to BASE_URL + callback path.
+	if cfg.GitHubOAuthRedirectURI == "" {
+		cfg.GitHubOAuthRedirectURI = cfg.BaseURL + "/api/v1/auth/github/callback"
 	}
 
 	// Fall back to SessionSecret for CSRF signing if not explicitly set.


### PR DESCRIPTION
## Summary
This PR makes the GitHub OAuth redirect URI configurable via environment variable, allowing it to be customized independently from the `BASE_URL`. This is essential for deployments behind reverse proxies, tunnels, or other scenarios where the public callback URL differs from the internal base URL.

## Key Changes
- Added `GitHubOAuthRedirectURI` configuration field to support explicit redirect URI configuration via `GITHUB_OAUTH_REDIRECT_URI` environment variable
- Implemented automatic default: when not explicitly set, the redirect URI defaults to `BASE_URL + /api/v1/auth/github/callback` (preserving existing behavior)
- Updated `AuthHandler.Login()` to use the configurable redirect URI instead of hardcoding the path
- Updated all test cases to include the new configuration field for consistency
- Added comprehensive documentation in `.env.example` explaining when and how to use this setting
- Added troubleshooting guidance in `github-app-setup.md` for the common "redirect_uri is not associated with this application" error

## Implementation Details
- The configuration field is optional and backward compatible—existing deployments without the environment variable will continue to work as before
- The default value is computed during config loading, ensuring the redirect URI is always properly set
- All three test cases that configure GitHub OAuth now explicitly set the redirect URI for clarity and consistency

https://claude.ai/code/session_01N6ZAsNUPfnXMMgHjioUc5s