### PR TITLE
Fix OAuth redirect to return to originating page

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -933,7 +933,7 @@ describe('api client', () => {
     });
 
     it('login redirects to GitHub OAuth', () => {
-      const loc = { href: '' };
+      const loc = { href: '', pathname: '/overview' };
       Object.defineProperty(window, 'location', {
         value: loc,
         writable: true,
@@ -941,11 +941,11 @@ describe('api client', () => {
       });
 
       api.auth.login();
-      expect(loc.href).toBe('/api/v1/auth/github/login');
+      expect(loc.href).toBe('/api/v1/auth/github/login?return_to=%2Foverview');
     });
 
     it('login passes invitation param', () => {
-      const loc = { href: '' };
+      const loc = { href: '', pathname: '/integrations' };
       Object.defineProperty(window, 'location', {
         value: loc,
         writable: true,
@@ -953,11 +953,11 @@ describe('api client', () => {
       });
 
       api.auth.login('invite-123');
-      expect(loc.href).toBe('/api/v1/auth/github/login?invitation=invite-123');
+      expect(loc.href).toBe('/api/v1/auth/github/login?invitation=invite-123&return_to=%2Fintegrations');
     });
 
     it('loginGoogle redirects to Google OAuth', () => {
-      const loc = { href: '' };
+      const loc = { href: '', pathname: '/overview' };
       Object.defineProperty(window, 'location', {
         value: loc,
         writable: true,
@@ -965,11 +965,11 @@ describe('api client', () => {
       });
 
       api.auth.loginGoogle();
-      expect(loc.href).toBe('/api/v1/auth/google/login');
+      expect(loc.href).toBe('/api/v1/auth/google/login?return_to=%2Foverview');
     });
 
     it('loginGoogle passes invitation param', () => {
-      const loc = { href: '' };
+      const loc = { href: '', pathname: '/integrations' };
       Object.defineProperty(window, 'location', {
         value: loc,
         writable: true,
@@ -977,7 +977,7 @@ describe('api client', () => {
       });
 
       api.auth.loginGoogle('inv-456');
-      expect(loc.href).toBe('/api/v1/auth/google/login?invitation=inv-456');
+      expect(loc.href).toBe('/api/v1/auth/google/login?invitation=inv-456&return_to=%2Fintegrations');
     });
 
     it('loginSentry redirects to Sentry OAuth', () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -88,14 +88,16 @@ export const api = {
     login: (invitation?: string) => {
       const searchParams = new URLSearchParams();
       if (invitation) searchParams.set('invitation', invitation);
-      searchParams.set('return_to', window.location.pathname);
-      window.location.href = `${API_BASE}/api/v1/auth/github/login?${searchParams.toString()}`;
+      if (window.location.pathname) searchParams.set('return_to', window.location.pathname);
+      const qs = searchParams.toString();
+      window.location.href = `${API_BASE}/api/v1/auth/github/login${qs ? `?${qs}` : ''}`;
     },
     loginGoogle: (invitation?: string) => {
       const searchParams = new URLSearchParams();
       if (invitation) searchParams.set('invitation', invitation);
-      searchParams.set('return_to', window.location.pathname);
-      window.location.href = `${API_BASE}/api/v1/auth/google/login?${searchParams.toString()}`;
+      if (window.location.pathname) searchParams.set('return_to', window.location.pathname);
+      const qs = searchParams.toString();
+      window.location.href = `${API_BASE}/api/v1/auth/google/login${qs ? `?${qs}` : ''}`;
     },
     loginSentry: () => {
       const params = new URLSearchParams({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -86,12 +86,16 @@ export const api = {
     providers: () => get<import('./types').SingleResponse<import('./types').AuthProviders>>('/api/v1/auth/providers'),
     me: () => get<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/me'),
     login: (invitation?: string) => {
-      const params = invitation ? `?invitation=${encodeURIComponent(invitation)}` : '';
-      window.location.href = `${API_BASE}/api/v1/auth/github/login${params}`;
+      const searchParams = new URLSearchParams();
+      if (invitation) searchParams.set('invitation', invitation);
+      searchParams.set('return_to', window.location.pathname);
+      window.location.href = `${API_BASE}/api/v1/auth/github/login?${searchParams.toString()}`;
     },
     loginGoogle: (invitation?: string) => {
-      const params = invitation ? `?invitation=${encodeURIComponent(invitation)}` : '';
-      window.location.href = `${API_BASE}/api/v1/auth/google/login${params}`;
+      const searchParams = new URLSearchParams();
+      if (invitation) searchParams.set('invitation', invitation);
+      searchParams.set('return_to', window.location.pathname);
+      window.location.href = `${API_BASE}/api/v1/auth/google/login?${searchParams.toString()}`;
     },
     loginSentry: () => {
       const params = new URLSearchParams({

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -211,6 +211,17 @@ func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	if returnTo := r.URL.Query().Get("return_to"); returnTo != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "oauth_return_to",
+			Value:    returnTo,
+			Path:     "/",
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
 	params := url.Values{
 		"client_id":    {h.cfg.GitHubOAuthClientID},
 		"redirect_uri": {h.cfg.GitHubOAuthRedirectURI},
@@ -380,6 +391,17 @@ func (h *AuthHandler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 		http.SetCookie(w, &http.Cookie{
 			Name:     "pending_invitation",
 			Value:    invToken,
+			Path:     "/",
+			MaxAge:   600,
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+
+	if returnTo := r.URL.Query().Get("return_to"); returnTo != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "oauth_return_to",
+			Value:    returnTo,
 			Path:     "/",
 			MaxAge:   600,
 			HttpOnly: true,
@@ -589,7 +611,17 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	http.Redirect(w, r, h.cfg.FrontendURL, http.StatusTemporaryRedirect)
+	redirectURL := h.cfg.FrontendURL
+	if returnCookie, err := r.Cookie("oauth_return_to"); err == nil && returnCookie.Value != "" {
+		// Clear the cookie.
+		http.SetCookie(w, &http.Cookie{Name: "oauth_return_to", Value: "", Path: "/", MaxAge: -1, HttpOnly: true})
+		// Only allow relative paths to prevent open redirect.
+		if len(returnCookie.Value) > 0 && returnCookie.Value[0] == '/' {
+			redirectURL = h.cfg.FrontendURL + returnCookie.Value
+		}
+	}
+
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
 func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Request, user *models.User) {


### PR DESCRIPTION
## Summary

OAuth callbacks (GitHub and Google) now redirect users back to the page they came from instead of always redirecting to the homepage. This fixes the user experience when connecting integrations on the dashboard.

## Changes

- **Frontend**: Pass `return_to=<current_pathname>` query param when initiating OAuth flows
- **Backend**: Store redirect destination in secure HttpOnly cookie during login, read it in callback, and redirect accordingly
- **Security**: Open redirect guard prevents arbitrary external redirects (only allows relative paths)

## Test Plan

- Click "Connect GitHub" on `/overview` or `/integrations` page
- Complete OAuth flow with GitHub
- Should redirect back to the same page instead of homepage
- Same for Google OAuth flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)