### PR TITLE
Unify settings pages container styling

### DIFF
--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -1,20 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { renderWithProviders, screen } from '@/test/test-utils';
 import SettingsLayout from './layout';
 
-vi.mock('next/navigation', () => ({
-  usePathname: () => '/settings',
-}));
-
 describe('SettingsLayout', () => {
-  it('renders general settings header', () => {
+  it('renders children', () => {
     renderWithProviders(
       <SettingsLayout>
         <div>child content</div>
       </SettingsLayout>
     );
 
-    expect(screen.getByText('General Settings')).toBeInTheDocument();
     expect(screen.getByText('child content')).toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -1,18 +1,7 @@
-"use client";
-
-import { SettingsPageFrame } from "@/components/settings-page-frame";
-
 export default function SettingsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <SettingsPageFrame
-      title="General Settings"
-      description="Manage your organization."
-    >
-      {children}
-    </SettingsPageFrame>
-  );
+  return <>{children}</>;
 }

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -5,6 +5,8 @@ import { api } from "@/lib/api";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PageHeader } from "@/components/page-header";
+import { PageContainer } from "@/components/page-container";
 import type { Organization, SingleResponse } from "@/lib/types";
 
 export default function SettingsPage() {
@@ -14,23 +16,29 @@ export default function SettingsPage() {
   });
 
   return (
-    <div className="space-y-6">
-      <section className="space-y-3">
-        <h2 className="text-[13px] font-medium text-foreground">General</h2>
-        <Card>
-          <CardContent>
-            <div className="max-w-[560px] space-y-2">
-              <Label htmlFor="org-name">Organization Name</Label>
-              <Input
-                id="org-name"
-                value={settings?.data?.name ?? ""}
-                disabled
-                className="bg-muted"
-              />
-            </div>
-          </CardContent>
-        </Card>
-      </section>
-    </div>
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title="General Settings"
+          description="Manage your organization."
+        />
+        <section className="space-y-3">
+          <h2 className="text-[13px] font-medium text-foreground">General</h2>
+          <Card>
+            <CardContent>
+              <div className="max-w-[560px] space-y-2">
+                <Label htmlFor="org-name">Organization Name</Label>
+                <Input
+                  id="org-name"
+                  value={settings?.data?.name ?? ""}
+                  disabled
+                  className="bg-muted"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -25,6 +25,8 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/page-header";
+import { PageContainer } from "@/components/page-container";
 import { useAuth } from "@/hooks/use-auth";
 import type { User, InvitationResponse, ListResponse } from "@/lib/types";
 
@@ -122,7 +124,12 @@ export default function TeamSettingsPage() {
   };
 
   return (
-    <div className="space-y-6">
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title="Team"
+          description="Manage your team members and roles."
+        />
       {actionError && (
         <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
           {actionError}
@@ -396,6 +403,7 @@ export default function TeamSettingsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </div>
+      </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/app/(dashboard)/team/page.tsx
+++ b/frontend/src/app/(dashboard)/team/page.tsx
@@ -1,13 +1,5 @@
 import TeamSettingsPage from "../settings/team/page";
-import { SettingsPageFrame } from "@/components/settings-page-frame";
 
 export default function TeamPage() {
-  return (
-    <SettingsPageFrame
-      title="Team"
-      description="Manage members, roles, and invitations for your organization."
-    >
-      <TeamSettingsPage />
-    </SettingsPageFrame>
-  );
+  return <TeamSettingsPage />;
 }


### PR DESCRIPTION
## Summary
- Standardized all settings pages to use `PageContainer size="default"` + `PageHeader` pattern
- Removed `SettingsPageFrame` wrapper from general settings and team pages
- General Settings, Team, Integrations, Agent, and Prioritization pages now use consistent container structure

## Test plan
- Verify all settings pages (general, team, integrations, agent, prioritization) render correctly with consistent layout
- Check that the page containers and headers display properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)