### PR TITLE
Add model override for sessions and projects

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -229,7 +229,7 @@ describe('OverviewPage', () => {
 
     await user.click(screen.getByRole('radio', { name: 'Use API key' }));
 
-    await user.click(screen.getByRole('combobox', { name: 'Model' }));
+    await user.click(screen.getByRole('combobox', { name: 'Default model' }));
     await user.click(await screen.findByRole('option', { name: 'gpt-5.2-codex' }));
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 
@@ -256,12 +256,12 @@ describe('OverviewPage', () => {
 
     // Claude Code should be pre-selected, showing its env var fields
     await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: 'Model' })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: 'Default model' })).toBeInTheDocument();
     });
 
     expect(screen.queryByLabelText('Base URL')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('combobox', { name: 'Model' }));
+    await user.click(screen.getByRole('combobox', { name: 'Default model' }));
     await user.click(await screen.findByRole('option', { name: 'claude-sonnet-4-5' }));
     await user.click(screen.getByRole('button', { name: 'Save changes' }));
 

--- a/frontend/src/app/(dashboard)/projects/new/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -20,6 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { api } from "@/lib/api";
+import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
+import type { OrgSettings, Organization, SingleResponse } from "@/lib/types";
 
 export default function NewProjectPage() {
   const router = useRouter();
@@ -33,6 +35,22 @@ export default function NewProjectPage() {
   const [maxConcurrent, setMaxConcurrent] = useState(2);
   const [priority, setPriority] = useState(50);
   const [baseBranch, setBaseBranch] = useState("main");
+  const [agentType, setAgentType] = useState("");
+  const [selectedModel, setSelectedModel] = useState("");
+
+  const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
+    queryKey: ["settings"],
+    queryFn: () => api.settings.get(),
+  });
+
+  const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
+  const defaultAgentType = settings?.default_agent_type ?? "codex";
+  const effectiveAgentType = agentType || defaultAgentType;
+
+  const availableModels = useMemo(() => {
+    const agent = AGENT_TYPE_OPTIONS.find((a) => a.key === effectiveAgentType);
+    return agent?.models ?? [];
+  }, [effectiveAgentType]);
 
   const { data: reposData } = useQuery({
     queryKey: ["repositories"],
@@ -53,6 +71,8 @@ export default function NewProjectPage() {
         max_concurrent: executionMode === "parallel" ? maxConcurrent : undefined,
         priority,
         base_branch: baseBranch.trim() || undefined,
+        agent_type: agentType || undefined,
+        model: selectedModel || undefined,
       }),
     onSuccess: (response) => {
       router.push(`/projects/${response.data.id}`);
@@ -135,6 +155,46 @@ export default function NewProjectPage() {
                 ))}
               </SelectContent>
             </Select>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label>Agent</Label>
+              <Select
+                value={agentType}
+                onValueChange={(value) => {
+                  setAgentType(value);
+                  setSelectedModel("");
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder={`Default (${AGENT_TYPE_OPTIONS.find((a) => a.key === defaultAgentType)?.label ?? defaultAgentType})`} />
+                </SelectTrigger>
+                <SelectContent>
+                  {AGENT_TYPE_OPTIONS.map((agent) => (
+                    <SelectItem key={agent.key} value={agent.key}>
+                      {agent.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>Model</Label>
+              <Select value={selectedModel} onValueChange={setSelectedModel}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Default model" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableModels.map((model) => (
+                    <SelectItem key={model} value={model}>
+                      {model}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { Mic, Plus, X, ImagePlus, Paperclip, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -16,8 +16,17 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/lib/api";
+import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
+import type { OrgSettings, Organization, SingleResponse } from "@/lib/types";
 
 type DictationResult = {
   transcript: string;
@@ -61,9 +70,28 @@ export function ManualSessionCreatePageContent() {
   const [imageURL, setImageURL] = useState("");
   const [isDictating, setIsDictating] = useState(false);
   const [dictationError, setDictationError] = useState<string | null>(null);
+  const [selectedModel, setSelectedModel] = useState("");
+
+  const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
+    queryKey: ["settings"],
+    queryFn: () => api.settings.get(),
+  });
+
+  const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
+  const defaultAgentType = settings?.default_agent_type ?? "codex";
+
+  const availableModels = useMemo(() => {
+    const agentType = AGENT_TYPE_OPTIONS.find((a) => a.key === defaultAgentType);
+    return agentType?.models ?? [];
+  }, [defaultAgentType]);
 
   const createManualSessionMutation = useMutation({
-    mutationFn: () => api.sessions.createManual({ message: message.trim(), images: attachments }),
+    mutationFn: () =>
+      api.sessions.createManual({
+        message: message.trim(),
+        images: attachments,
+        ...(selectedModel ? { model: selectedModel } : {}),
+      }),
     onSuccess: (response) => {
       router.push(`/sessions/${response.data.id}`);
     },
@@ -266,6 +294,21 @@ export function ManualSessionCreatePageContent() {
                   onChange={onUploadChange}
                 />
                 <p className="text-xs text-muted-foreground">Attach files or screenshots</p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <Select value={selectedModel} onValueChange={setSelectedModel}>
+                  <SelectTrigger className="h-8 w-[180px] text-xs" aria-label="Model override">
+                    <SelectValue placeholder="Default model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableModels.map((model) => (
+                      <SelectItem key={model} value={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
 
               <div className="flex items-center gap-2">

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -36,7 +36,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
     label: "Codex",
     envVars: [
       { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
-      { name: "OPENAI_MODEL", label: "Model", options: [...AVAILABLE_CODEX_MODELS] },
+      { name: "OPENAI_MODEL", label: "Default model", options: [...AVAILABLE_CODEX_MODELS] },
       { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)" },
     ],
   },
@@ -47,7 +47,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
       { name: "ANTHROPIC_API_KEY", label: "API Key", sensitive: true },
       {
         name: "ANTHROPIC_MODEL",
-        label: "Model",
+        label: "Default model",
         options: [...AVAILABLE_CLAUDE_CODE_MODELS],
       },
       {
@@ -66,7 +66,7 @@ const AGENT_TYPES: { key: string; label: string; envVars: AgentEnvVar[] }[] = [
       { name: "GEMINI_API_KEY", label: "API Key", sensitive: true },
       {
         name: "GEMINI_MODEL",
-        label: "Model",
+        label: "Default model",
         options: [...AVAILABLE_GEMINI_CLI_MODELS],
       },
     ],

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -182,7 +182,7 @@ export const api = {
       return get<import('./types').SessionsListResponse>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
     get: (id: string) => get<import('./types').SingleResponse<import('./types').AgentSession>>(`/api/v1/sessions/${id}`),
-    createManual: (body: { message: string; images?: string[]; agent_type?: string; autonomy_level?: string; token_mode?: string }) =>
+    createManual: (body: { message: string; images?: string[]; agent_type?: string; model?: string; autonomy_level?: string; token_mode?: string }) =>
       post<import('./types').SingleResponse<import('./types').AgentSession>>('/api/v1/sessions/manual', body),
   },
   settings: {
@@ -252,7 +252,7 @@ export const api = {
       return get<import('./types').ListResponse<import('./types').Project>>(`/api/v1/projects${qs ? `?${qs}` : ''}`);
     },
     get: (id: string) => get<import('./types').SingleResponse<import('./types').ProjectDetail>>(`/api/v1/projects/${id}`),
-    create: (body: { title: string; goal: string; repository_id: string; scope?: string; completion_criteria?: string; execution_mode?: string; max_concurrent?: number; priority?: number; base_branch?: string }) =>
+    create: (body: { title: string; goal: string; repository_id: string; scope?: string; completion_criteria?: string; execution_mode?: string; max_concurrent?: number; priority?: number; base_branch?: string; agent_type?: string; model?: string }) =>
       post<import('./types').SingleResponse<import('./types').Project>>('/api/v1/projects', body),
     update: (id: string, body: Record<string, unknown>) =>
       patch<import('./types').SingleResponse<import('./types').Project>>(`/api/v1/projects/${id}`, body),

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -48,6 +48,13 @@ export const PM_MODELS_BY_PROVIDER: Record<string, { label: string; models: read
 
 export const DEFAULT_PM_MODEL = CLAUDE_CODE_MODEL_SONNET;
 
+// Agent types with their labels and available models, for use in session/project creation forms.
+export const AGENT_TYPE_OPTIONS: { key: string; label: string; models: readonly string[] }[] = [
+  { key: "codex", label: "Codex", models: AVAILABLE_CODEX_MODELS },
+  { key: "claude_code", label: "Claude Code", models: AVAILABLE_CLAUDE_CODE_MODELS },
+  { key: "gemini_cli", label: "Gemini CLI", models: AVAILABLE_GEMINI_CLI_MODELS },
+];
+
 // All PM models across every provider (for validation / backward compat).
 export const AVAILABLE_PM_MODELS = [
   ...LEGACY_PM_ALIASES,

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -173,6 +173,8 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MaxConcurrent      *int    `json:"max_concurrent"`
 		Priority           *int    `json:"priority"`
 		BaseBranch         *string `json:"base_branch"`
+		AgentType          *string `json:"agent_type"`
+		Model              *string `json:"model"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -215,6 +217,23 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		baseBranch = *req.BaseBranch
 	}
 
+	validAgentTypes := map[string]bool{"claude_code": true, "gemini_cli": true, "codex": true}
+	if req.AgentType != nil && *req.AgentType != "" && !validAgentTypes[*req.AgentType] {
+		writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", "agent_type must be one of: claude_code, gemini_cli, codex")
+		return
+	}
+
+	if req.Model != nil && *req.Model != "" {
+		agentType := "claude_code"
+		if req.AgentType != nil && *req.AgentType != "" {
+			agentType = *req.AgentType
+		}
+		if err := models.ValidateModelForAgentType(agentType, *req.Model); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_MODEL", err.Error())
+			return
+		}
+	}
+
 	project := models.Project{
 		OrgID:              orgID,
 		RepositoryID:       repoID,
@@ -228,6 +247,8 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		MaxConcurrent:      maxConcurrent,
 		AutoMerge:          false,
 		BaseBranch:         baseBranch,
+		AgentType:          req.AgentType,
+		ModelOverride:      req.Model,
 		CreatedBy:          &user.ID,
 	}
 

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -28,6 +28,7 @@ func projectColumns() []string {
 		"current_phase", "lessons_learned", "approach_history",
 		"total_tasks", "completed_tasks", "failed_tasks",
 		"proposed_by_pm", "source_issue_ids", "proposal_reasoning",
+		"agent_type", "model_override",
 		"created_by", "created_at", "updated_at", "completed_at",
 	}
 }
@@ -40,6 +41,7 @@ func newProjectRow(id, orgID, repoID uuid.UUID, status models.ProjectStatus, now
 		nil, []byte("[]"), []byte("[]"),
 		0, 0, 0,
 		false, []uuid.UUID{}, nil,
+		nil, nil, // agent_type, model_override
 		&createdBy, now, now, nil,
 	}
 }
@@ -505,7 +507,8 @@ func TestProjectHandler_Create(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
 
 	body, _ := json.Marshal(map[string]string{

--- a/internal/api/handlers/runs_test.go
+++ b/internal/api/handlers/runs_test.go
@@ -41,7 +41,7 @@ var agentRunColumns = []string{
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_run_id", "revision_context", "error", "result_summary", "diff",
 	"pm_plan_id", "pm_approach", "pm_reasoning",
-	"project_task_id",
+	"project_task_id", "model_override",
 	"created_at",
 }
 
@@ -71,6 +71,7 @@ func TestRunHandler_List(t *testing.T) {
 							nil, nil, nil, nil, nil,
 							nil, nil, nil,
 							nil, // project_task_id
+							nil, // model_override
 							now,
 						),
 					)
@@ -148,6 +149,7 @@ func TestRunHandler_Get(t *testing.T) {
 							nil, nil, nil, nil, nil,
 							nil, nil, nil,
 							nil, // project_task_id
+							nil, // model_override
 							now,
 						),
 					)
@@ -221,13 +223,13 @@ func triggerFixIssueMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 			),
 		)
 
-	// Mock agent run create (13 named args)
+	// Mock agent run create (14 named args)
 	runID := uuid.New()
 	mock.ExpectQuery("INSERT INTO agent_runs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)
@@ -268,13 +270,13 @@ func triggerFixIssueAndOrgDefaultMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID
 				AddRow(orgID, "Acme", []byte(settings), now, now),
 		)
 
-	// Mock agent run create (13 named args)
+	// Mock agent run create (14 named args)
 	runID := uuid.New()
 	mock.ExpectQuery("INSERT INTO agent_runs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -148,6 +148,7 @@ type createManualSessionRequest struct {
 	Message       string   `json:"message"`
 	Images        []string `json:"images"`
 	AgentType     string   `json:"agent_type"`
+	Model         string   `json:"model"`
 	AutonomyLevel string   `json:"autonomy_level"`
 	TokenMode     string   `json:"token_mode"`
 }
@@ -183,6 +184,15 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	if !validAgentTypes[agentType] {
 		writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", "agent_type must be one of: claude_code, gemini_cli, codex")
 		return
+	}
+
+	var modelOverride *string
+	if body.Model != "" {
+		if err := models.ValidateModelForAgentType(agentType, body.Model); err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_MODEL", err.Error())
+			return
+		}
+		modelOverride = &body.Model
 	}
 
 	autonomyLevel := body.AutonomyLevel
@@ -245,6 +255,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		Status:        "pending",
 		AutonomyLevel: autonomyLevel,
 		TokenMode:     tokenMode,
+		ModelOverride: modelOverride,
 	}
 	if err := h.agentRunStore.Create(r.Context(), run); err != nil {
 		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual run")

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -75,6 +75,7 @@ func TestSessionHandler_List(t *testing.T) {
 					nil, nil, nil, strPtr("Fixed payment bug"), nil,
 					nil, nil, nil,
 					nil, // project_task_id
+				nil, // model_override
 					earlier,
 				),
 		)
@@ -155,6 +156,7 @@ func TestSessionHandler_Get_PlanSession(t *testing.T) {
 					nil, nil, nil, strPtr("Fixed auth issue"), nil,
 					&planID, nil, nil,
 					nil, // project_task_id
+				nil, // model_override
 					now,
 				),
 		)
@@ -215,6 +217,7 @@ func TestSessionHandler_Get_ManualSession(t *testing.T) {
 					nil, nil, nil, nil, nil,
 					nil, nil, nil,
 					nil, // project_task_id
+				nil, // model_override
 					now,
 				),
 		)
@@ -422,7 +425,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(),
 		).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).

--- a/internal/db/agent_run_store_test.go
+++ b/internal/db/agent_run_store_test.go
@@ -19,7 +19,7 @@ var agentRunColumns = []string{
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_run_id", "revision_context", "error", "result_summary", "diff",
 	"pm_plan_id", "pm_approach", "pm_reasoning",
-	"project_task_id",
+	"project_task_id", "model_override",
 	"created_at",
 }
 
@@ -32,6 +32,7 @@ func newAgentRunRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil, json.RawMessage(`{}`), nil, nil, nil,
 		nil, nil, nil,
 		nil, // project_task_id
+		nil, // model_override
 		now,
 	}
 }
@@ -226,7 +227,7 @@ func TestAgentRunStore_Create(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),
@@ -263,7 +264,7 @@ func TestAgentRunStore_Create_AllowsNilIssueID(t *testing.T) {
 		WithArgs(nil, pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),

--- a/internal/db/agent_runs.go
+++ b/internal/db/agent_runs.go
@@ -92,11 +92,13 @@ func (s *AgentRunStore) Create(ctx context.Context, run *models.AgentRun) error 
 	query := `
 		INSERT INTO agent_runs (
 			issue_id, org_id, agent_type, status, autonomy_level, token_mode, complexity_tier,
-			parent_run_id, revision_context, pm_plan_id, pm_approach, pm_reasoning, project_task_id
+			parent_run_id, revision_context, pm_plan_id, pm_approach, pm_reasoning, project_task_id,
+			model_override
 		)
 		VALUES (
 			@issue_id, @org_id, @agent_type, @status, @autonomy_level, @token_mode, @complexity_tier,
-			@parent_run_id, @revision_context, @pm_plan_id, @pm_approach, @pm_reasoning, @project_task_id
+			@parent_run_id, @revision_context, @pm_plan_id, @pm_approach, @pm_reasoning, @project_task_id,
+			@model_override
 		)
 		RETURNING id, created_at`
 
@@ -119,6 +121,7 @@ func (s *AgentRunStore) Create(ctx context.Context, run *models.AgentRun) error 
 		"pm_approach":      run.PMApproach,
 		"pm_reasoning":     run.PMReasoning,
 		"project_task_id":  run.ProjectTaskID,
+		"model_override":   run.ModelOverride,
 	}
 
 	row := s.db.QueryRow(ctx, query, args)

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -19,6 +19,7 @@ var projectTestColumns = []string{
 	"current_phase", "lessons_learned", "approach_history",
 	"total_tasks", "completed_tasks", "failed_tasks",
 	"proposed_by_pm", "source_issue_ids", "proposal_reasoning",
+	"agent_type", "model_override",
 	"created_by", "created_at", "updated_at", "completed_at",
 }
 
@@ -29,6 +30,7 @@ func newProjectRow(projectID, orgID, repoID uuid.UUID, now time.Time) []interfac
 		nil, json.RawMessage(`[]`), json.RawMessage(`[]`),
 		0, 0, 0,
 		false, []uuid.UUID{}, nil,
+		nil, nil,
 		nil, now, now, nil,
 	}
 }
@@ -53,9 +55,9 @@ func TestProjectStore_Create(t *testing.T) {
 	require.NoError(t, err, "should create mock pool")
 	defer mock.Close()
 
-	// Create has 19 named args
+	// Create has 21 named args (including agent_type and model_override)
 	mock.ExpectQuery("INSERT INTO projects").
-		WithArgs(anyArgs(19)...).
+		WithArgs(anyArgs(21)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(projectID, now, now))
 
 	store := NewProjectStore(mock)

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -31,6 +31,7 @@ const projectColumns = `id, org_id, repository_id, title, goal, scope, completio
 	current_phase, lessons_learned, approach_history,
 	total_tasks, completed_tasks, failed_tasks,
 	proposed_by_pm, source_issue_ids, proposal_reasoning,
+	agent_type, model_override,
 	created_by, created_at, updated_at, completed_at`
 
 func scanProject(row pgx.Row) (models.Project, error) {
@@ -44,6 +45,7 @@ func scanProject(row pgx.Row) (models.Project, error) {
 		&p.CurrentPhase, &lessonsRaw, &approachRaw,
 		&p.TotalTasks, &p.CompletedTasks, &p.FailedTasks,
 		&p.ProposedByPM, &sourceIssueIDs, &p.ProposalReasoning,
+		&p.AgentType, &p.ModelOverride,
 		&p.CreatedBy, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
 	)
 	if err != nil {
@@ -74,6 +76,7 @@ func scanProjects(rows pgx.Rows) ([]models.Project, error) {
 			&p.CurrentPhase, &lessonsRaw, &approachRaw,
 			&p.TotalTasks, &p.CompletedTasks, &p.FailedTasks,
 			&p.ProposedByPM, &sourceIssueIDs, &p.ProposalReasoning,
+			&p.AgentType, &p.ModelOverride,
 			&p.CreatedBy, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
 		)
 		if err != nil {
@@ -111,13 +114,15 @@ func (s *ProjectStore) Create(ctx context.Context, p *models.Project) error {
 			org_id, repository_id, title, goal, scope, completion_criteria,
 			status, priority, execution_mode, max_concurrent, auto_merge, base_branch,
 			current_phase, lessons_learned, approach_history,
-			proposed_by_pm, source_issue_ids, proposal_reasoning, created_by
+			proposed_by_pm, source_issue_ids, proposal_reasoning, created_by,
+			agent_type, model_override
 		)
 		VALUES (
 			@org_id, @repository_id, @title, @goal, @scope, @completion_criteria,
 			@status, @priority, @execution_mode, @max_concurrent, @auto_merge, @base_branch,
 			@current_phase, @lessons_learned, @approach_history,
-			@proposed_by_pm, @source_issue_ids, @proposal_reasoning, @created_by
+			@proposed_by_pm, @source_issue_ids, @proposal_reasoning, @created_by,
+			@agent_type, @model_override
 		)
 		RETURNING id, created_at, updated_at`
 
@@ -141,6 +146,8 @@ func (s *ProjectStore) Create(ctx context.Context, p *models.Project) error {
 		"source_issue_ids":    p.SourceIssueIDs,
 		"proposal_reasoning":  p.ProposalReasoning,
 		"created_by":          p.CreatedBy,
+		"agent_type":          p.AgentType,
+		"model_override":      p.ModelOverride,
 	})
 	return row.Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt)
 }

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -100,6 +100,42 @@ func IsSupportedCodexModel(model string) bool {
 	return false
 }
 
+// ValidateModelForAgentType checks whether the given model is valid for the given agent type.
+func ValidateModelForAgentType(agentType, model string) error {
+	switch agentType {
+	case "codex":
+		if !IsSupportedCodexModel(model) {
+			return fmt.Errorf("model must be one of: %v", AvailableCodexModels)
+		}
+	case "claude_code":
+		if !IsSupportedClaudeCodeModel(model) {
+			return fmt.Errorf("model must be one of: %v", AvailableClaudeCodeModels)
+		}
+	case "gemini_cli":
+		if !IsSupportedGeminiCLIModel(model) {
+			return fmt.Errorf("model must be one of: %v", AvailableGeminiCLIModels)
+		}
+	default:
+		return fmt.Errorf("unknown agent type: %s", agentType)
+	}
+	return nil
+}
+
+// ModelEnvVarForAgentType returns the environment variable name used to set the model
+// for the given agent type.
+func ModelEnvVarForAgentType(agentType string) string {
+	switch agentType {
+	case "codex":
+		return "OPENAI_MODEL"
+	case "claude_code":
+		return "ANTHROPIC_MODEL"
+	case "gemini_cli":
+		return "GEMINI_MODEL"
+	default:
+		return ""
+	}
+}
+
 func ValidateSettingsModels(settings OrgSettings) error {
 	if settings.PMModel != "" && !IsSupportedPMModel(settings.PMModel) {
 		return fmt.Errorf("pm_model must be one of: %v", AvailablePMModels)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -121,6 +121,7 @@ type AgentRun struct {
 	PMApproach           *string         `db:"pm_approach" json:"pm_approach,omitempty"`
 	PMReasoning          *string         `db:"pm_reasoning" json:"pm_reasoning,omitempty"`
 	ProjectTaskID        *uuid.UUID      `db:"project_task_id" json:"project_task_id,omitempty"`
+	ModelOverride        *string         `db:"model_override" json:"model_override,omitempty"`
 	CreatedAt            time.Time       `db:"created_at" json:"created_at"`
 }
 

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -31,6 +31,8 @@ type Project struct {
 	ProposedByPM       bool             `db:"proposed_by_pm" json:"proposed_by_pm"`
 	SourceIssueIDs     []uuid.UUID      `json:"source_issue_ids,omitempty"`
 	ProposalReasoning  *string          `db:"proposal_reasoning" json:"proposal_reasoning,omitempty"`
+	AgentType          *string          `db:"agent_type" json:"agent_type,omitempty"`
+	ModelOverride      *string          `db:"model_override" json:"model_override,omitempty"`
 	CreatedBy          *uuid.UUID       `db:"created_by" json:"created_by,omitempty"`
 	CreatedAt          time.Time        `db:"created_at" json:"created_at"`
 	UpdatedAt          time.Time        `db:"updated_at" json:"updated_at"`

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -242,6 +242,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.AgentRun) error
 	if sandboxCfg.Env == nil {
 		sandboxCfg.Env = make(map[string]string)
 	}
+	// Apply per-run model override if set.
+	if run.ModelOverride != nil && *run.ModelOverride != "" {
+		if envVar := models.ModelEnvVarForAgentType(run.AgentType); envVar != "" {
+			sandboxCfg.Env[envVar] = *run.ModelOverride
+		}
+	}
 	if _, ok := sandboxCfg.Env["HOME"]; !ok {
 		sandboxCfg.Env["HOME"] = sandboxCfg.WorkDir
 	}

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -140,6 +140,9 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 	}
 
 	agentType := settings.DefaultAgentType
+	if project.AgentType != nil && *project.AgentType != "" {
+		agentType = *project.AgentType
+	}
 	if agentType == "" {
 		agentType = models.DefaultDefaultAgentType
 	}
@@ -179,6 +182,7 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 			PMApproach:    &approach,
 			PMReasoning:   &reasoning,
 			ProjectTaskID: &task.ID,
+			ModelOverride: project.ModelOverride,
 		}
 		if err := s.agentRuns.Create(ctx, run); err != nil {
 			s.logger.Error().Err(err).Str("task_id", task.ID.String()).Msg("failed to create agent run for project task")

--- a/migrations/000013_model_override.down.sql
+++ b/migrations/000013_model_override.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE projects DROP COLUMN IF EXISTS model_override;
+ALTER TABLE projects DROP COLUMN IF EXISTS agent_type;
+ALTER TABLE agent_runs DROP COLUMN IF EXISTS model_override;

--- a/migrations/000013_model_override.up.sql
+++ b/migrations/000013_model_override.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE agent_runs ADD COLUMN model_override TEXT;
+ALTER TABLE projects ADD COLUMN agent_type TEXT;
+ALTER TABLE projects ADD COLUMN model_override TEXT;


### PR DESCRIPTION
Users can now override the default organization model when creating new sessions or projects.

The Model dropdown in agent settings is relabeled to Default model to clarify it applies organization-wide.

Backend schema adds model_override and agent_type columns to projects and agent_runs. Frontend provides agent and model selection in both project and session creation flows.

Test plan: Verify model dropdown updates available options based on selected agent type. Create a project with custom model and confirm the agent uses it.