### PR TITLE
Fix SOPS decryption of dotenv-formatted secrets

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,7 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f .env.production.enc ]; then
   echo "$SOPS_AGE_KEY" > "$SOPS_AGE_KEY_FILE"
   chmod 600 "$SOPS_AGE_KEY_FILE"
 
-  sops --decrypt .env.production.enc > /tmp/.env.production
+  sops --decrypt --input-type dotenv --output-type dotenv .env.production.enc > /tmp/.env.production
   set -a
   # shellcheck disable=SC1091
   source /tmp/.env.production


### PR DESCRIPTION
## Summary

SOPS determines file format by extension. The `.env.production.enc` file uses dotenv format (key=ENC[...] pairs) but has a `.enc` extension, causing SOPS to default to JSON parsing. This fails with "Error unmarshalling input json: invalid character 'D'" on deploy.

## Fix

Added explicit `--input-type dotenv --output-type dotenv` flags to the sops command so SOPS correctly handles the dotenv format regardless of file extension.

## Test Plan

- Deploy to Render/Fly and verify SOPS successfully decrypts the encrypted secrets
- Confirm the app starts without "Error unmarshalling input json" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)