### PR TITLE
Fix Render deploy error with RSA private key

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,15 +9,13 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f .env.production.enc ]; then
   echo "$SOPS_AGE_KEY" > "$SOPS_AGE_KEY_FILE"
   chmod 600 "$SOPS_AGE_KEY_FILE"
 
-  sops --decrypt --input-type dotenv --output-type dotenv .env.production.enc > /tmp/.env.production
-  set -a
-  # shellcheck disable=SC1091
-  source /tmp/.env.production
-  set +a
-
-  # Clean up plaintext secrets from disk
-  rm -f /tmp/.env.production "$SOPS_AGE_KEY_FILE"
-  unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE
+  # sops exec-env decrypts the file and sets each key=value pair as an
+  # environment variable, then runs the given command.  This avoids writing
+  # plaintext secrets to disk and sidesteps shell-quoting issues with values
+  # that contain spaces or newlines (e.g. RSA private keys).
+  CMD=$(printf '%q ' "$@")
+  exec sops exec-env --input-type dotenv .env.production.enc \
+    "unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE && rm -f '$SOPS_AGE_KEY_FILE' && exec $CMD"
 fi
 
 exec "$@"


### PR DESCRIPTION
## Summary

Fixed the Render deploy failure caused by unquoted multiline environment variables in the decrypted `.env.production` file.

Instead of writing plaintext secrets to a temporary dotenv file and sourcing it (which causes shell parsing errors for values containing spaces like RSA private keys), the entrypoint now uses `sops exec-env` to set all decrypted values as environment variables directly.

## Benefits

- Avoids writing plaintext secrets to disk
- Sidesteps shell-quoting issues with multiline or space-containing values
- Simpler, cleaner code

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>