### PR TITLE
Fix deploy error: preserve platform-provided env vars in sops exec-env

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -1,4 +1,3 @@
-DATABASE_URL=ENC[AES256_GCM,data:GiNv4Ne2LyVRDHnvR0rxFFpwUmSPc+B4byf00sOkQ6Ms3mClMv51udb8igFQaV70IiuR0QyfI7YvG2UpYwkoASdqiO7dazDXkQ==,iv:KdxZLq3y90f2swUekj5GyCmnCCP4HxMT0vb0D6zYIWA=,tag:DQB3v/+NgN6fqVaf4ueFBg==,type:str]
 PORT=ENC[AES256_GCM,data:ew7zGQ==,iv:M7eUz26/FJNZorV7vry9L/U0QGAXTat9fFIbtFfsSFY=,tag:8fa8Pmmi+ZklT+r5fJInxw==,type:str]
 LOG_LEVEL=ENC[AES256_GCM,data:WfxG3w==,iv:D4D4rwW+p4oNJJnwVtGM32ZObVhu/WFOORL2Htt+iY8=,tag:enBXo8xsS93AOQSimCtdCQ==,type:str]
 MODE=ENC[AES256_GCM,data:64jD,iv:LMINq2jNH8l91M//yBjQkVaP7ja1cTatOi4CIiLUGaU=,tag:QD+XiwUzsHK6pzQfFZCycg==,type:str]
@@ -18,7 +17,7 @@ sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_0__map_recipient=age1xyvl6ral4fq757tpnz30cuzefrpngnuv6zutjsg7wtnmza4uyqlshc2ucl
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHeHN2RlJaZmkrVG11bllj\ndmJ6VHZXTVJnMVlyV0ZhNU1XME1yb3NDMFhZClE0U3lDVEY3SXRxeldDOHJMaTFU\nejVybjJiU0NWZVZBRlVEa3NXZ250NGcKLS0tIDZLeWRwaFJrTW1IcC9COTEvRGRF\nVHUxOXh6OFVUbTBnenBnN2xoVVA1bGcKaGZqLU8vGSy0tSPPu0i79BsTjMwntWg6\nyJyaGviA3Aq+b9AKj+Gn0TxI0/puUpZFjq9w70thfDxjuVqWiKSQ0Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
-sops_lastmodified=2026-03-11T06:46:09Z
-sops_mac=ENC[AES256_GCM,data:T/2pn9f++V/nJoPtk9sBFISEmBLdQi44nr7Ydlh1IRK4UwrZA9nCa3L4C++ou66zdvGnjJ2jPdnBOKw+rtMAhAlpJl0M1XoyS0cFHz+rDFeKqy71/YSpaYgVTt9juEYISJYTy4MhWlrTXe1VQZbgMcvtEbyVDsLB+i7DvJuY3Kk=,iv:52mrFvHfEiR4pFKhzUuwvsm6sv8tIm9nzwej+jaOFeQ=,tag:cAR3mkrDR1A6kPZAZlD2Fg==,type:str]
+sops_lastmodified=2026-03-11T22:27:03Z
+sops_mac=ENC[AES256_GCM,data:OynFhZ7TjUvarDKHFPI3vknuXEnUAkjsuCabpudOaBh4Y+scMr9MKBwfmZo9l89vYUurhLhkdqfdX+lm/MjHivQtU3SSq8AJWQl/0cS7LK0rl964vIxbqAii64mogZLyerAoTuXeJQjd1jDolyK+xmdvq7crJ32h2Vly1PmoWa0=,iv:DcQQ1Pk4/dmLvtaS5L9SOIs6tsMvZYn0NLFE/tBMffk=,tag:6mQ3wGMLXi3llX1spIU1bg==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,12 +14,31 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f .env.production.enc ]; then
   # plaintext secrets to disk and sidesteps shell-quoting issues with values
   # that contain spaces or newlines (e.g. RSA private keys).
   #
+  # However, sops exec-env OVERRIDES any existing env vars with the same name.
+  # Platform-provided vars (e.g. Render's DATABASE_URL from `fromDatabase`)
+  # must take precedence over stale values in the encrypted file.  We extract
+  # the plaintext keys from the encrypted file, save any that are already set,
+  # and re-export them after sops exec-env runs.
+  #
   # exec-env doesn't support --input-type, so we symlink to a .env extension
   # that sops auto-detects as dotenv format.
+  RESTORE_CMDS=""
+  while IFS='=' read -r key _; do
+    # Skip sops metadata, empty lines, and comments.
+    [ -z "$key" ] && continue
+    [[ "$key" == sops_* ]] && continue
+    [[ "$key" == \#* ]] && continue
+    # If this key is already set in the environment, build an export command
+    # to restore it after sops exec-env overrides it.
+    if [ -n "${!key+x}" ]; then
+      RESTORE_CMDS="${RESTORE_CMDS}export $(printf '%s=%q; ' "$key" "${!key}")"
+    fi
+  done < .env.production.enc
+
   ln -sf "$(realpath .env.production.enc)" /tmp/.env.production.sops.env
   CMD=$(printf '%q ' "$@")
   exec sops exec-env /tmp/.env.production.sops.env \
-    "unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE && rm -f '$SOPS_AGE_KEY_FILE' /tmp/.env.production.sops.env && exec $CMD"
+    "${RESTORE_CMDS}unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE && rm -f '$SOPS_AGE_KEY_FILE' /tmp/.env.production.sops.env && exec $CMD"
 fi
 
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,31 +14,12 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f .env.production.enc ]; then
   # plaintext secrets to disk and sidesteps shell-quoting issues with values
   # that contain spaces or newlines (e.g. RSA private keys).
   #
-  # However, sops exec-env OVERRIDES any existing env vars with the same name.
-  # Platform-provided vars (e.g. Render's DATABASE_URL from `fromDatabase`)
-  # must take precedence over stale values in the encrypted file.  We extract
-  # the plaintext keys from the encrypted file, save any that are already set,
-  # and re-export them after sops exec-env runs.
-  #
   # exec-env doesn't support --input-type, so we symlink to a .env extension
   # that sops auto-detects as dotenv format.
-  RESTORE_CMDS=""
-  while IFS='=' read -r key _; do
-    # Skip sops metadata, empty lines, and comments.
-    [ -z "$key" ] && continue
-    [[ "$key" == sops_* ]] && continue
-    [[ "$key" == \#* ]] && continue
-    # If this key is already set in the environment, build an export command
-    # to restore it after sops exec-env overrides it.
-    if [ -n "${!key+x}" ]; then
-      RESTORE_CMDS="${RESTORE_CMDS}export $(printf '%s=%q; ' "$key" "${!key}")"
-    fi
-  done < .env.production.enc
-
   ln -sf "$(realpath .env.production.enc)" /tmp/.env.production.sops.env
   CMD=$(printf '%q ' "$@")
   exec sops exec-env /tmp/.env.production.sops.env \
-    "${RESTORE_CMDS}unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE && rm -f '$SOPS_AGE_KEY_FILE' /tmp/.env.production.sops.env && exec $CMD"
+    "unset SOPS_AGE_KEY SOPS_AGE_KEY_FILE && rm -f '$SOPS_AGE_KEY_FILE' /tmp/.env.production.sops.env && exec $CMD"
 fi
 
 exec "$@"


### PR DESCRIPTION
sops exec-env was overriding DATABASE_URL (and other vars) provided by Render's fromDatabase with stale values from .env.production.enc. We now save any env vars already set before calling sops exec-env and re-export them afterward, ensuring platform-provided values always take precedence over encrypted file values.

This fixes the deploy failures where the app was trying to connect to localhost:5432 instead of the Render-managed Postgres instance.