### PR TITLE
Fix timeline dots to show only one active at a time

### DIFF
--- a/frontend/src/components/landing/story-section.tsx
+++ b/frontend/src/components/landing/story-section.tsx
@@ -548,7 +548,7 @@ export default function StorySection({ isDark }: StorySectionProps) {
                 isDark={isDark}
                 inView={inView}
                 delay={0.3}
-                active={activeIndex >= 0}
+                active={activeIndex === 0}
               />
               <Milestone
                 year="October 1943"
@@ -556,7 +556,7 @@ export default function StorySection({ isDark }: StorySectionProps) {
                 isDark={isDark}
                 inView={inView}
                 delay={0.45}
-                active={activeIndex >= 1}
+                active={activeIndex === 1}
               />
               <Milestone
                 year="November 1943"
@@ -564,7 +564,7 @@ export default function StorySection({ isDark }: StorySectionProps) {
                 isDark={isDark}
                 inView={inView}
                 delay={0.6}
-                active={activeIndex >= 2}
+                active={activeIndex === 2}
               />
             </div>
 


### PR DESCRIPTION
Changed the timeline milestone active condition from >= to === so only the current milestone is highlighted in blue when scrolling, instead of all milestones up to the current one. This ensures a single active blue dot moves down the timeline as the user scrolls.