### PR TITLE
Increase backend test coverage to 78.2%

### DIFF
--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -1,12 +1,407 @@
 package adapters
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
 	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
-	"github.com/stretchr/testify/require"
+	"github.com/assembledhq/143/internal/testutil"
 )
+
+// ---------------------------------------------------------------------------
+// ClaudeCodeAdapter.Name / PreparePrompt
+// ---------------------------------------------------------------------------
+
+func TestClaudeCodeAdapter_Name(t *testing.T) {
+	t.Parallel()
+	a := NewClaudeCodeAdapter(zerolog.Nop())
+	require.Equal(t, "claude_code", a.Name())
+}
+
+func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     *agent.AgentInput
+		wantErr   bool
+		wantToken int
+	}{
+		{
+			name:    "nil input",
+			input:   nil,
+			wantErr: true,
+		},
+		{
+			name:    "nil issue",
+			input:   &agent.AgentInput{Issue: nil},
+			wantErr: true,
+		},
+		{
+			name: "low token mode",
+			input: &agent.AgentInput{
+				Issue:     &models.Issue{Title: "Bug", Source: "sentry"},
+				TokenMode: "low",
+			},
+			wantToken: lowTokenMax,
+		},
+		{
+			name: "high token mode",
+			input: &agent.AgentInput{
+				Issue:     &models.Issue{Title: "Bug", Source: "sentry"},
+				TokenMode: "high",
+			},
+			wantToken: highTokenMax,
+		},
+		{
+			name: "default token mode",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{Title: "Bug"},
+			},
+			wantToken: lowTokenMax,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := NewClaudeCodeAdapter(zerolog.Nop())
+			prompt, err := a.PreparePrompt(context.Background(), tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, prompt)
+			require.Equal(t, tt.wantToken, prompt.MaxTokens)
+			require.NotEmpty(t, prompt.SystemPrompt)
+			require.NotEmpty(t, prompt.UserPrompt)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ClaudeCodeAdapter.Execute
+// ---------------------------------------------------------------------------
+
+func TestClaudeCodeAdapter_Execute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		claudeOutput   string
+		claudeExitCode int
+		diffOutput     string
+		diffExitCode   int
+		stderrOutput   string
+		expectErr      bool
+		checkResult    func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry)
+	}{
+		{
+			name: "successful run with streaming JSON",
+			claudeOutput: `{"type":"assistant","content":"Analyzing the issue..."}
+{"type":"tool_use","tool":"edit_file"}
+{"type":"tool_result","result":"done"}
+{"type":"result","content":"Fixed the bug."}`,
+			claudeExitCode: 0,
+			diffOutput:     "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n",
+			diffExitCode:   0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 0, result.ExitCode)
+				require.Empty(t, result.Error)
+				require.Contains(t, result.Diff, "diff --git")
+				require.Contains(t, result.Summary, "Analyzing the issue...")
+				require.Contains(t, result.Summary, "Fixed the bug.")
+			},
+		},
+		{
+			name:           "non-zero exit code with stderr",
+			claudeOutput:   "",
+			claudeExitCode: 1,
+			stderrOutput:   "authentication error",
+			diffOutput:     "",
+			diffExitCode:   0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 1, result.ExitCode)
+				require.Contains(t, result.Error, "exited with code 1")
+				require.Contains(t, result.Error, "authentication error")
+			},
+		},
+		{
+			name:           "empty output",
+			claudeOutput:   "",
+			claudeExitCode: 0,
+			diffOutput:     "",
+			diffExitCode:   0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 0, result.ExitCode)
+				require.Empty(t, result.Diff)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := testutil.NewMockSandboxProvider()
+			provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				if strings.HasPrefix(cmd, "claude") {
+					_, _ = stdout.Write([]byte(tt.claudeOutput))
+					if tt.stderrOutput != "" {
+						_, _ = stderr.Write([]byte(tt.stderrOutput))
+					}
+					return tt.claudeExitCode, nil
+				}
+				if strings.HasPrefix(cmd, "git diff") {
+					_, _ = stdout.Write([]byte(tt.diffOutput))
+					return tt.diffExitCode, nil
+				}
+				return 0, nil
+			}
+
+			adapter := NewClaudeCodeAdapter(zerolog.Nop())
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace"}
+			prompt := &agent.AgentPrompt{
+				SystemPrompt: "Fix the bug.",
+				UserPrompt:   "Null pointer error.",
+				MaxTokens:    50_000,
+			}
+
+			logCh := make(chan agent.LogEntry, 100)
+			ctx := WithSandboxProvider(context.Background(), provider)
+
+			result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			close(logCh)
+			var logs []agent.LogEntry
+			for entry := range logCh {
+				logs = append(logs, entry)
+			}
+
+			tt.checkResult(t, result, logs)
+
+			// Verify prompt file was written.
+			promptData, exists := provider.Files["/workspace/.143-prompt.md"]
+			require.True(t, exists, "prompt file should have been written")
+			require.Contains(t, string(promptData), "Fix the bug.")
+		})
+	}
+}
+
+func TestClaudeCodeAdapter_Execute_ExecError(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if strings.HasPrefix(cmd, "claude") {
+			return 0, context.DeadlineExceeded
+		}
+		return 0, nil
+	}
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "exec claude CLI")
+}
+
+func TestClaudeCodeAdapter_Execute_WriteFileError(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.WriteFileFn = func(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error {
+		return context.DeadlineExceeded
+	}
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "write prompt file")
+}
+
+func TestClaudeCodeAdapter_Execute_MissingSandboxProvider(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+
+	result, err := adapter.Execute(context.Background(), sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "sandbox provider not found")
+}
+
+// ---------------------------------------------------------------------------
+// parseStreamOutput (Claude Code streaming JSON)
+// ---------------------------------------------------------------------------
+
+func TestParseStreamOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		output      string
+		checkResult func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry)
+	}{
+		{
+			name: "assistant events build summary",
+			output: `{"type":"assistant","content":"Investigating..."}
+{"type":"assistant","content":"Found the bug."}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Investigating...")
+				require.Contains(t, result.Summary, "Found the bug.")
+			},
+		},
+		{
+			name:   "tool_use event",
+			output: `{"type":"tool_use","tool":"edit_file"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "tool_use", logs[0].Level)
+				require.Contains(t, logs[0].Message, "edit_file")
+			},
+		},
+		{
+			name:   "tool_result event",
+			output: `{"type":"tool_result","result":"file updated"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Equal(t, "tool_result", logs[0].Metadata["type"])
+			},
+		},
+		{
+			name:   "error event with message field",
+			output: `{"type":"error","message":"rate limit exceeded"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "rate limit")
+			},
+		},
+		{
+			name:   "error event with content fallback",
+			output: `{"type":"error","content":"something failed"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "something failed")
+			},
+		},
+		{
+			name:   "result event with token usage",
+			output: `{"type":"result","content":"Done.","result":{"input_tokens":1000,"output_tokens":500}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Done.")
+				require.Equal(t, 1000, result.TokenUsage.InputTokens)
+				require.Equal(t, 500, result.TokenUsage.OutputTokens)
+			},
+		},
+		{
+			name:   "result event with confidence",
+			output: `{"type":"result","content":"Fixed.\n{\"confidence_score\": 0.95, \"confidence_reasoning\": \"Straightforward\", \"risk_factors\": [\"none\"]}"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.InDelta(t, 0.95, result.ConfidenceScore, 0.001)
+				require.Equal(t, "Straightforward", result.ConfidenceReasoning)
+			},
+		},
+		{
+			name:   "unknown event type logged as debug",
+			output: `{"type":"unknown_type","content":"blah"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "debug", logs[0].Level)
+			},
+		},
+		{
+			name:   "non-JSON line emitted as raw output",
+			output: `this is not json`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Contains(t, logs[0].Message, "this is not json")
+			},
+		},
+		{
+			name:   "empty output",
+			output: "",
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Empty(t, result.Summary)
+				require.Empty(t, logs)
+			},
+		},
+		{
+			name:   "blank lines are skipped",
+			output: "\n\n  \n",
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Empty(t, logs)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := &agent.AgentResult{}
+			logCh := make(chan agent.LogEntry, 100)
+			parseStreamOutput([]byte(tt.output), result, logCh)
+			close(logCh)
+
+			var logs []agent.LogEntry
+			for entry := range logCh {
+				logs = append(logs, entry)
+			}
+			tt.checkResult(t, result, logs)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildSystemPrompt
+// ---------------------------------------------------------------------------
 
 func TestBuildSystemPrompt_IncludesPMContext(t *testing.T) {
 	t.Parallel()
@@ -30,4 +425,575 @@ func TestBuildSystemPrompt_IncludesPMContext(t *testing.T) {
 	require.Contains(t, prompt, "High impact", "system prompt should include PM reasoning")
 	require.Contains(t, prompt, "Check handlers/billing.go:42", "system prompt should include PM approach")
 	require.Contains(t, prompt, "Missing nil check", "system prompt should include PM root cause")
+}
+
+func TestBuildSystemPrompt_IncludesRevisionContext(t *testing.T) {
+	t.Parallel()
+
+	input := &agent.AgentInput{
+		Issue: &models.Issue{Title: "Bug"},
+		RevisionContext: &agent.RevisionContext{
+			FormattedFeedback: "Please handle the edge case.",
+			CommentSummary:    "Missing nil check in handler",
+			PreviousDiff:      "--- a/main.go\n+++ b/main.go",
+		},
+	}
+
+	prompt := buildSystemPrompt(input)
+	require.Contains(t, prompt, "Revision Instructions")
+	require.Contains(t, prompt, "REVISION run")
+	require.Contains(t, prompt, "Please handle the edge case.")
+	require.Contains(t, prompt, "Missing nil check in handler")
+	require.Contains(t, prompt, "--- a/main.go")
+}
+
+func TestBuildSystemPrompt_IncludesContextDocs(t *testing.T) {
+	t.Parallel()
+
+	input := &agent.AgentInput{
+		Issue:       &models.Issue{Title: "Bug"},
+		ContextDocs: []string{"Use Go 1.22", "Run tests with make test"},
+	}
+
+	prompt := buildSystemPrompt(input)
+	require.Contains(t, prompt, "Repository Conventions")
+	require.Contains(t, prompt, "Use Go 1.22")
+	require.Contains(t, prompt, "Run tests with make test")
+}
+
+func TestBuildSystemPrompt_Minimal(t *testing.T) {
+	t.Parallel()
+
+	input := &agent.AgentInput{
+		Issue: &models.Issue{Title: "Bug"},
+	}
+
+	prompt := buildSystemPrompt(input)
+	require.NotEmpty(t, prompt)
+	require.NotContains(t, prompt, "Revision Instructions")
+	require.NotContains(t, prompt, "Product Manager Analysis")
+	require.NotContains(t, prompt, "Repository Conventions")
+}
+
+// ---------------------------------------------------------------------------
+// buildUserPrompt
+// ---------------------------------------------------------------------------
+
+func TestBuildUserPrompt(t *testing.T) {
+	t.Parallel()
+
+	desc := "Users see 500 errors on /api/billing"
+
+	tests := []struct {
+		name        string
+		input       *agent.AgentInput
+		wantStrings []string
+	}{
+		{
+			name: "basic issue with description",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:       "Billing crash",
+					Description: &desc,
+				},
+			},
+			wantStrings: []string{"Billing crash", "500 errors"},
+		},
+		{
+			name: "sentry issue with stack trace",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "NullPointer",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"type": "TypeError",
+									"value": "null is not an object",
+									"stacktrace": {
+										"frames": [{
+											"filename": "app.js",
+											"function": "handleRequest",
+											"lineNo": 42
+										}]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantStrings: []string{"Stack Trace", "TypeError", "handleRequest"},
+		},
+		{
+			name: "customer impact",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:                 "Error",
+					OccurrenceCount:       150,
+					AffectedCustomerCount: 25,
+				},
+			},
+			wantStrings: []string{"Customer Impact", "150", "25"},
+		},
+		{
+			name: "severity",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:    "Error",
+					Severity: "critical",
+				},
+			},
+			wantStrings: []string{"critical"},
+		},
+		{
+			name: "complexity estimate",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{Title: "Error"},
+				ComplexityEstimate: &agent.ComplexityEstimate{
+					Tier:      2,
+					Reasoning: "Multiple files affected",
+				},
+			},
+			wantStrings: []string{"Complexity Assessment", "Tier: 2", "Multiple files affected"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			prompt := buildUserPrompt(tt.input)
+			for _, s := range tt.wantStrings {
+				require.Contains(t, prompt, s)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractFileHints
+// ---------------------------------------------------------------------------
+
+func TestExtractFileHints(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     *agent.AgentInput
+		wantFiles []string
+		wantNil   bool
+	}{
+		{
+			name: "non-sentry source returns nil",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{Title: "Bug", Source: "linear"},
+			},
+			wantNil: true,
+		},
+		{
+			name: "empty raw data returns nil",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{Title: "Bug", Source: "sentry", RawData: nil},
+			},
+			wantNil: true,
+		},
+		{
+			name: "extracts filenames from sentry frames",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [
+											{"filename": "src/handler.go", "absPath": ""},
+											{"filename": "src/service.go", "absPath": "/app/src/service.go"}
+										]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantFiles: []string{"src/handler.go", "/app/src/service.go"},
+		},
+		{
+			name: "skips standard lib and vendor frames",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [
+											{"filename": "<frozen importlib>"},
+											{"filename": "node_modules/express/lib/router.js"},
+											{"filename": "site-packages/django/core/handlers.py"},
+											{"filename": "src/app.go"}
+										]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantFiles: []string{"src/app.go"},
+		},
+		{
+			name: "deduplicates paths",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [
+											{"filename": "src/app.go"},
+											{"filename": "src/app.go"}
+										]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantFiles: []string{"src/app.go"},
+		},
+		{
+			name: "skips non-exception entries",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "breadcrumbs",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [{"filename": "should_not_appear.go"}]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "invalid JSON returns nil",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:   "Bug",
+					Source:  "sentry",
+					RawData: json.RawMessage(`{not valid json`),
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "absPath preferred over filename",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [
+											{"filename": "handler.go", "absPath": "/app/src/handler.go"}
+										]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantFiles: []string{"/app/src/handler.go"},
+		},
+		{
+			name: "skips frames with empty path",
+			input: &agent.AgentInput{
+				Issue: &models.Issue{
+					Title:  "Bug",
+					Source: "sentry",
+					RawData: json.RawMessage(`{
+						"entries": [{
+							"type": "exception",
+							"data": {
+								"values": [{
+									"stacktrace": {
+										"frames": [
+											{"filename": "", "absPath": ""},
+											{"filename": "src/real.go"}
+										]
+									}
+								}]
+							}
+						}]
+					}`),
+				},
+			},
+			wantFiles: []string{"src/real.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			files := extractFileHints(tt.input)
+			if tt.wantNil {
+				require.Nil(t, files)
+			} else {
+				require.Equal(t, tt.wantFiles, files)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractStackTrace
+// ---------------------------------------------------------------------------
+
+func TestExtractStackTrace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		rawData json.RawMessage
+		want    []string // substrings expected in result
+		wantNil bool
+	}{
+		{
+			name:    "empty raw data",
+			rawData: nil,
+			wantNil: true,
+		},
+		{
+			name:    "invalid JSON",
+			rawData: json.RawMessage(`{broken`),
+			wantNil: true,
+		},
+		{
+			name: "valid sentry data",
+			rawData: json.RawMessage(`{
+				"entries": [{
+					"type": "exception",
+					"data": {
+						"values": [{
+							"type": "TypeError",
+							"value": "null is not an object",
+							"stacktrace": {
+								"frames": [{
+									"filename": "app.js",
+									"function": "handleRequest",
+									"lineNo": 42
+								},{
+									"filename": "router.js",
+									"function": "dispatch",
+									"lineNo": 100
+								}]
+							}
+						}]
+					}
+				}]
+			}`),
+			want: []string{"TypeError: null is not an object", "handleRequest", "app.js:42", "dispatch", "router.js:100"},
+		},
+		{
+			name: "skips non-exception entries",
+			rawData: json.RawMessage(`{
+				"entries": [{
+					"type": "breadcrumbs",
+					"data": {"values": []}
+				}]
+			}`),
+			wantNil: true,
+		},
+		{
+			name: "multiple exception values",
+			rawData: json.RawMessage(`{
+				"entries": [{
+					"type": "exception",
+					"data": {
+						"values": [
+							{
+								"type": "RootError",
+								"value": "connection refused",
+								"stacktrace": {"frames": [{"filename": "db.go", "function": "connect", "lineNo": 10}]}
+							},
+							{
+								"type": "WrapperError",
+								"value": "init failed",
+								"stacktrace": {"frames": [{"filename": "main.go", "function": "init", "lineNo": 5}]}
+							}
+						]
+					}
+				}]
+			}`),
+			want: []string{"RootError: connection refused", "WrapperError: init failed", "db.go:10", "main.go:5"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := extractStackTrace(tt.rawData)
+			if tt.wantNil {
+				require.Empty(t, result)
+				return
+			}
+			for _, s := range tt.want {
+				require.Contains(t, result, s)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tryExtractConfidence
+// ---------------------------------------------------------------------------
+
+func TestTryExtractConfidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		text           string
+		wantScore      float64
+		wantReasoning  string
+		wantRisks      []string
+	}{
+		{
+			name:      "no confidence block",
+			text:      "Just some regular text with no confidence data.",
+			wantScore: 0,
+		},
+		{
+			name:          "valid confidence block",
+			text:          `Here is my fix. {"confidence_score": 0.88, "confidence_reasoning": "Simple fix", "risk_factors": ["edge case"]}`,
+			wantScore:     0.88,
+			wantReasoning: "Simple fix",
+			wantRisks:     []string{"edge case"},
+		},
+		{
+			name:      "malformed JSON around confidence_score",
+			text:      `{"confidence_score": bad_value}`,
+			wantScore: 0,
+		},
+		{
+			name:      "missing braces",
+			text:      `"confidence_score": 0.5`,
+			wantScore: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := &agent.AgentResult{}
+			tryExtractConfidence(tt.text, result)
+			require.InDelta(t, tt.wantScore, result.ConfidenceScore, 0.001)
+			if tt.wantReasoning != "" {
+				require.Equal(t, tt.wantReasoning, result.ConfidenceReasoning)
+			}
+			if tt.wantRisks != nil {
+				require.Equal(t, tt.wantRisks, result.RiskFactors)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectDiff
+// ---------------------------------------------------------------------------
+
+func TestCollectDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		stdout    string
+		exitCode  int
+		execErr   error
+		wantDiff  string
+		wantErr   bool
+	}{
+		{
+			name:     "successful diff",
+			stdout:   "diff --git a/f.go b/f.go\n+fixed\n",
+			exitCode: 0,
+			wantDiff: "diff --git a/f.go b/f.go\n+fixed\n",
+		},
+		{
+			name:     "non-zero exit code",
+			exitCode: 1,
+			wantErr:  true,
+		},
+		{
+			name:    "exec error",
+			execErr: context.DeadlineExceeded,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			provider := testutil.NewMockSandboxProvider()
+			provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				if tt.execErr != nil {
+					return 0, tt.execErr
+				}
+				_, _ = stdout.Write([]byte(tt.stdout))
+				return tt.exitCode, nil
+			}
+
+			sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+			diff, err := collectDiff(context.Background(), provider, sandbox)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantDiff, diff)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// WithSandboxProvider
+// ---------------------------------------------------------------------------
+
+func TestWithSandboxProvider(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	retrieved, ok := ctx.Value(sandboxProviderKey{}).(agent.SandboxProvider)
+	require.True(t, ok)
+	require.Equal(t, provider, retrieved)
 }

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/assembledhq/143/internal/testutil"
 )
 
 func TestCodexAdapter_Name(t *testing.T) {
@@ -314,6 +316,120 @@ func TestParseCodexStreamOutput(t *testing.T) {
 				require.Equal(t, "Straightforward fix", result.ConfidenceReasoning)
 			},
 		},
+		{
+			name:   "tool_use event type variant",
+			output: `{"type":"tool_use","name":"read_file","arguments":{"path":"main.go"},"call_id":"c1"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "tool_use", logs[0].Level)
+				require.Equal(t, "read_file", logs[0].Metadata["tool"])
+				require.Equal(t, "c1", logs[0].Metadata["call_id"])
+			},
+		},
+		{
+			name:   "tool_call event type variant",
+			output: `{"type":"tool_call","name":"shell","arguments":{"command":"ls"}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "tool_use", logs[0].Level)
+				require.Equal(t, "shell", logs[0].Metadata["tool"])
+			},
+		},
+		{
+			name:   "function_call_output with name field",
+			output: `{"type":"function_call_output","name":"shell","call_id":"c2","output":"done"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Equal(t, "shell", logs[0].Metadata["tool"])
+				require.Equal(t, "c2", logs[0].Metadata["call_id"])
+			},
+		},
+		{
+			name:   "tool_result with result field fallback",
+			output: `{"type":"tool_result","call_id":"c3","result":"file contents here"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Contains(t, logs[0].Message, "file contents here")
+			},
+		},
+		{
+			name:   "result event with Result JSON token usage",
+			output: `{"type":"result","content":"All done.","result":{"input_tokens":2000,"output_tokens":800}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "All done.")
+				require.Equal(t, 2000, result.TokenUsage.InputTokens)
+				require.Equal(t, 800, result.TokenUsage.OutputTokens)
+			},
+		},
+		{
+			name: "assistant event type variant",
+			output: `{"type":"assistant","content":"Working on it..."}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Working on it...")
+			},
+		},
+		{
+			name: "text event type variant",
+			output: `{"type":"text","content":"Some text output"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Some text output")
+			},
+		},
+		{
+			name:   "error event with message fallback",
+			output: `{"type":"error","message":"out of memory"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "out of memory")
+			},
+		},
+		{
+			name:   "error event with content fallback",
+			output: `{"type":"error","content":"something broke"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "something broke")
+			},
+		},
+		{
+			name:   "unknown event type logged as debug",
+			output: `{"type":"custom_unknown","content":"whatever"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "debug", logs[0].Level)
+			},
+		},
+		{
+			name:   "non-JSON line in stream",
+			output: "some raw text that is not JSON",
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Contains(t, result.Summary, "some raw text")
+			},
+		},
+		{
+			name:   "message with empty content falls back to Message field",
+			output: `{"type":"message","message":"from message field"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "from message field")
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -334,6 +450,193 @@ func TestParseCodexStreamOutput(t *testing.T) {
 			tt.checkResult(t, result, logs)
 		})
 	}
+}
+
+func TestCodexAdapter_Execute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		codexOutput    string
+		codexExitCode  int
+		stderrOutput   string
+		diffOutput     string
+		diffExitCode   int
+		expectErr      bool
+		checkResult    func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry)
+	}{
+		{
+			name: "successful run with streaming JSON",
+			codexOutput: `{"type":"message","content":"Investigating the issue..."}
+{"type":"function_call","name":"shell","arguments":{"command":"go test ./..."},"call_id":"c1"}
+{"type":"function_call_output","call_id":"c1","output":"PASS"}
+{"type":"message","content":"Applied the fix."}
+{"type":"usage","stats":{"inputTokens":800,"outputTokens":300}}`,
+			codexExitCode: 0,
+			diffOutput:    "diff --git a/main.go b/main.go\n--- a/main.go\n+++ b/main.go\n",
+			diffExitCode:  0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 0, result.ExitCode)
+				require.Empty(t, result.Error)
+				require.Contains(t, result.Diff, "diff --git")
+				require.Contains(t, result.Summary, "Investigating the issue...")
+				require.Contains(t, result.Summary, "Applied the fix.")
+				require.Equal(t, 800, result.TokenUsage.InputTokens)
+				require.Equal(t, 300, result.TokenUsage.OutputTokens)
+			},
+		},
+		{
+			name:          "non-zero exit code with stderr",
+			codexOutput:   "",
+			codexExitCode: 1,
+			stderrOutput:  "command not found",
+			diffOutput:    "",
+			diffExitCode:  0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 1, result.ExitCode)
+				require.Contains(t, result.Error, "exited with code 1")
+				require.Contains(t, result.Error, "command not found")
+			},
+		},
+		{
+			name:          "empty output",
+			codexOutput:   "",
+			codexExitCode: 0,
+			diffOutput:    "",
+			diffExitCode:  0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Equal(t, 0, result.ExitCode)
+				require.Empty(t, result.Diff)
+			},
+		},
+		{
+			name:          "legacy JSON format",
+			codexOutput:   `{"response":"Fixed the null pointer by adding a nil check.","stats":{"inputTokens":1500,"outputTokens":500}}`,
+			codexExitCode: 0,
+			diffOutput:    "diff --git a/f.go b/f.go\n",
+			diffExitCode:  0,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "nil check")
+				require.Equal(t, 1500, result.TokenUsage.InputTokens)
+				require.Equal(t, 500, result.TokenUsage.OutputTokens)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := testutil.NewMockSandboxProvider()
+			provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				if strings.HasPrefix(cmd, "codex") {
+					_, _ = stdout.Write([]byte(tt.codexOutput))
+					if tt.stderrOutput != "" {
+						_, _ = stderr.Write([]byte(tt.stderrOutput))
+					}
+					return tt.codexExitCode, nil
+				}
+				if strings.HasPrefix(cmd, "git diff") {
+					_, _ = stdout.Write([]byte(tt.diffOutput))
+					return tt.diffExitCode, nil
+				}
+				return 0, nil
+			}
+
+			adapter := NewCodexAdapter(zerolog.Nop())
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace"}
+			prompt := &agent.AgentPrompt{
+				SystemPrompt: "Fix the bug.",
+				UserPrompt:   "Null pointer error.",
+				MaxTokens:    50_000,
+			}
+
+			logCh := make(chan agent.LogEntry, 100)
+			ctx := WithSandboxProvider(context.Background(), provider)
+
+			result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			close(logCh)
+			var logs []agent.LogEntry
+			for entry := range logCh {
+				logs = append(logs, entry)
+			}
+
+			tt.checkResult(t, result, logs)
+
+			// Verify prompt file was written.
+			promptData, exists := provider.Files["/workspace/.143-prompt.md"]
+			require.True(t, exists, "prompt file should have been written")
+			require.Contains(t, string(promptData), "Fix the bug.")
+		})
+	}
+}
+
+func TestCodexAdapter_Execute_ExecError(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if strings.HasPrefix(cmd, "codex") {
+			return 0, context.DeadlineExceeded
+		}
+		return 0, nil
+	}
+
+	adapter := NewCodexAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "exec codex CLI")
+}
+
+func TestCodexAdapter_Execute_WriteFileError(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.WriteFileFn = func(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error {
+		return context.DeadlineExceeded
+	}
+
+	adapter := NewCodexAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "write prompt file")
+}
+
+func TestCodexAdapter_Execute_MissingSandboxProvider(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewCodexAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+
+	result, err := adapter.Execute(context.Background(), sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "sandbox provider not found")
 }
 
 func TestShellEscapeCodex(t *testing.T) {

--- a/internal/services/agent/adapters/gemini_cli_test.go
+++ b/internal/services/agent/adapters/gemini_cli_test.go
@@ -247,6 +247,49 @@ func TestGeminiCLIAdapter_Execute(t *testing.T) {
 	}
 }
 
+func TestGeminiCLIAdapter_Execute_WriteFileError(t *testing.T) {
+	t.Parallel()
+
+	provider := newMockProvider()
+	provider.WriteFileFn = func(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error {
+		return context.DeadlineExceeded
+	}
+
+	adapter := NewGeminiCLIAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "write prompt file")
+}
+
+func TestGeminiCLIAdapter_Execute_ExecError(t *testing.T) {
+	t.Parallel()
+
+	provider := newMockProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if strings.HasPrefix(cmd, "gemini") {
+			return 0, context.DeadlineExceeded
+		}
+		return 0, nil
+	}
+
+	adapter := NewGeminiCLIAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "exec gemini CLI")
+}
+
 func TestGeminiCLIAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
@@ -463,6 +506,92 @@ func TestParseGeminiStreamOutput(t *testing.T) {
 				require.InDelta(t, 0.85, result.ConfidenceScore, 0.001)
 				require.Equal(t, "Simple fix", result.ConfidenceReasoning)
 				require.Equal(t, []string{"edge case"}, result.RiskFactors)
+			},
+		},
+		{
+			name:   "tool_result with name field",
+			output: `{"type":"tool_result","name":"shell","output":"PASS"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Equal(t, "shell", logs[0].Metadata["tool"])
+			},
+		},
+		{
+			name:   "tool_result with result field fallback",
+			output: `{"type":"tool_result","tool":"read","result":"file data"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Contains(t, logs[0].Message, "file data")
+			},
+		},
+		{
+			name:   "tool_use event variant",
+			output: `{"type":"tool_use","tool":"write_file","input":{"path":"f.go","content":"package main"}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "tool_use", logs[0].Level)
+				require.Equal(t, "write_file", logs[0].Metadata["tool"])
+			},
+		},
+		{
+			name:   "result event with Result JSON token usage",
+			output: `{"type":"result","content":"Complete.","result":{"input_tokens":1500,"output_tokens":600}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Complete.")
+				require.Equal(t, 1500, result.TokenUsage.InputTokens)
+				require.Equal(t, 600, result.TokenUsage.OutputTokens)
+			},
+		},
+		{
+			name:   "error event with message fallback",
+			output: `{"type":"error","message":"timeout"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "timeout")
+			},
+		},
+		{
+			name:   "error event with content fallback",
+			output: `{"type":"error","content":"crashed"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "error", logs[0].Level)
+				require.Contains(t, logs[0].Message, "crashed")
+			},
+		},
+		{
+			name:   "unknown event type",
+			output: `{"type":"custom_event","content":"data"}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "debug", logs[0].Level)
+			},
+		},
+		{
+			name:   "non-JSON line in stream",
+			output: "raw text not JSON",
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "output", logs[0].Level)
+				require.Contains(t, result.Summary, "raw text")
+			},
+		},
+		{
+			name:   "assistant event type variant",
+			output: `{"type":"assistant","message":"Using message field."}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Contains(t, result.Summary, "Using message field.")
 			},
 		},
 	}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1,0 +1,1415 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// prColumns matches the SELECT columns from pull_requests queries.
+var handlerPRColumns = []string{
+	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+	"title", "body", "status", "review_status", "merged_at", "created_at", "updated_at",
+}
+
+// sessionColumns matches the SELECT columns from sessions queries (must match sessionSelectColumns in session_store.go).
+var sessionColumns = []string{
+	"id", "issue_id", "org_id", "agent_type", "status", "autonomy_level", "token_mode",
+	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
+	"container_id", "started_at", "completed_at", "token_usage",
+	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
+	"parent_session_id", "revision_context", "error", "result_summary", "diff",
+	"pm_plan_id", "pm_approach", "pm_reasoning", "project_task_id",
+	"model_override",
+	"created_at",
+}
+
+// newMockPool creates a pgxmock pool and returns it with a cleanup.
+func newMockPool(t *testing.T) pgxmock.PgxPoolIface {
+	t.Helper()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	t.Cleanup(func() { mock.Close() })
+	return mock
+}
+
+func TestNewPRService(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.Nop()
+	svc := NewPRService(nil, nil, nil, nil, nil, nil, nil, nil, logger)
+	require.NotNil(t, svc, "NewPRService should return a non-nil service")
+	require.Equal(t, defaultGitHubAPI, svc.baseURL, "NewPRService should set the default GitHub API base URL")
+	require.NotNil(t, svc.httpClient, "NewPRService should initialize an HTTP client")
+}
+
+func TestSetBaseURL(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{}
+	svc.SetBaseURL("https://custom.api.example.com")
+	require.Equal(t, "https://custom.api.example.com", svc.baseURL, "SetBaseURL should update the base URL")
+}
+
+func TestSetReviewCommentStore(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{}
+	require.Nil(t, svc.reviewComments, "reviewComments should be nil initially")
+
+	mockPool := newMockPool(t)
+	store := db.NewReviewCommentStore(mockPool)
+	svc.SetReviewCommentStore(store)
+	require.NotNil(t, svc.reviewComments, "SetReviewCommentStore should set the review comment store")
+}
+
+func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	sessionMock := newMockPool(t)
+	issueMock := newMockPool(t)
+	deployMock := newMockPool(t)
+	jobMock := newMockPool(t)
+
+	prStore := db.NewPullRequestStore(prMock)
+	sessionStore := db.NewSessionStore(sessionMock)
+	issueStore := db.NewIssueStore(issueMock)
+	deployStore := db.NewDeployStore(deployMock)
+	jobStore := db.NewJobStore(jobMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		sessions:    sessionStore,
+		issues:       issueStore,
+		deploys:      deployStore,
+		jobs:         jobStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateStatus to merged.
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Mock: GetByID for session.
+	sessionMock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).
+				AddRow(sessionID, issueID, orgID, "claude-code", "completed", "full", "standard",
+					nil, nil, nil, nil,
+					nil, nil, nil, nil,
+					nil, nil, nil, nil,
+					nil, nil, nil, nil, nil,
+					nil, nil, nil, nil,
+					nil, // model_override
+					now),
+		)
+
+	// Mock: UpdateStatus for issue.
+	issueMock.ExpectExec("UPDATE issues SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Mock: Create deploy.
+	deployMock.ExpectQuery("INSERT INTO deploys").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "deployed_at", "created_at"}).
+				AddRow(uuid.New(), now, now),
+		)
+
+	// Mock: Enqueue job.
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()),
+		)
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 42,
+	}
+	event.PR.Merged = true
+	event.PR.Head.SHA = "abc123commit"
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestEvent should not return an error for a merged PR")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
+	require.NoError(t, sessionMock.ExpectationsWereMet(), "all session store expectations should be met")
+	require.NoError(t, issueMock.ExpectationsWereMet(), "all issue store expectations should be met")
+	require.NoError(t, deployMock.ExpectationsWereMet(), "all deploy store expectations should be met")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "all job store expectations should be met")
+}
+
+func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateStatus to closed.
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 42,
+	}
+	event.PR.Merged = false
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestEvent should not return an error for a closed-without-merge PR")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
+}
+
+func TestHandlePullRequestEvent_NonClosedAction(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	event := PullRequestEvent{
+		Action: "opened",
+		Number: 42,
+	}
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestEvent should ignore non-closed actions")
+}
+
+func TestHandlePullRequestEvent_UnknownPR(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns an error (not found).
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("no rows in result set"))
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 999,
+	}
+	event.Repository.FullName = "unknown/repo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestEvent should silently ignore unknown PRs")
+}
+
+func TestHandlePullRequestReviewEvent_ApprovedFlow(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateReviewStatus.
+	prMock.ExpectExec("UPDATE pull_requests SET review_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestReviewEvent{
+		Action: "submitted",
+	}
+	event.Review.State = "approved"
+	event.Review.User.Login = "reviewer1"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should not return an error for approved review")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
+}
+
+func TestHandlePullRequestReviewEvent_ChangesRequestedWithBody(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	reviewMock := newMockPool(t)
+	jobMock := newMockPool(t)
+
+	prStore := db.NewPullRequestStore(prMock)
+	reviewStore := db.NewReviewCommentStore(reviewMock)
+	jobStore := db.NewJobStore(jobMock)
+
+	svc := &PRService{
+		pullRequests:   prStore,
+		reviewComments: reviewStore,
+		jobs:           jobStore,
+		logger:         zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateReviewStatus.
+	prMock.ExpectExec("UPDATE pull_requests SET review_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Mock: Create review comment.
+	commentID := uuid.New()
+	reviewMock.ExpectQuery("INSERT INTO review_comments").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(commentID, now),
+		)
+
+	// Mock: Enqueue job for processing review comment.
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()),
+		)
+
+	event := PullRequestReviewEvent{
+		Action: "submitted",
+	}
+	event.Review.ID = 12345
+	event.Review.State = "changes_requested"
+	event.Review.Body = "Please fix the error handling"
+	event.Review.User.Login = "reviewer1"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should not return an error for changes_requested review")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
+	require.NoError(t, reviewMock.ExpectationsWereMet(), "all review comment store expectations should be met")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "all job store expectations should be met")
+}
+
+func TestHandlePullRequestReviewEvent_ChangesRequestedNoReviewStore(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests:   prStore,
+		reviewComments: nil, // no review comment store
+		logger:         zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateReviewStatus.
+	prMock.ExpectExec("UPDATE pull_requests SET review_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestReviewEvent{
+		Action: "submitted",
+	}
+	event.Review.State = "changes_requested"
+	event.Review.Body = "Please fix this"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should not error when reviewComments store is nil")
+}
+
+func TestHandlePullRequestReviewEvent_NonSubmittedAction(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{logger: zerolog.Nop()}
+
+	event := PullRequestReviewEvent{
+		Action: "edited",
+	}
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should ignore non-submitted actions")
+}
+
+func TestHandlePullRequestReviewEvent_UnknownReviewState(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	event := PullRequestReviewEvent{
+		Action: "submitted",
+	}
+	event.Review.State = "commented"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should return nil for unknown review states")
+}
+
+func TestHandlePullRequestReviewEvent_UnknownPR(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("no rows in result set"))
+
+	event := PullRequestReviewEvent{
+		Action: "submitted",
+	}
+	event.Review.State = "approved"
+	event.PullRequest.Number = 999
+	event.Repository.FullName = "unknown/repo"
+
+	err := svc.HandlePullRequestReviewEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewEvent should silently ignore unknown PRs")
+}
+
+func TestHandlePullRequestReviewCommentEvent_Created(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	reviewMock := newMockPool(t)
+	jobMock := newMockPool(t)
+
+	prStore := db.NewPullRequestStore(prMock)
+	reviewStore := db.NewReviewCommentStore(reviewMock)
+	jobStore := db.NewJobStore(jobMock)
+
+	svc := &PRService{
+		pullRequests:   prStore,
+		reviewComments: reviewStore,
+		jobs:           jobStore,
+		logger:         zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: Create review comment.
+	commentID := uuid.New()
+	reviewMock.ExpectQuery("INSERT INTO review_comments").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(commentID, now),
+		)
+
+	// Mock: Enqueue job.
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()),
+		)
+
+	position := 10
+	event := PullRequestReviewCommentEvent{
+		Action: "created",
+	}
+	event.Comment.ID = 67890
+	event.Comment.Body = "This variable should be renamed"
+	event.Comment.Path = "internal/main.go"
+	event.Comment.Position = &position
+	event.Comment.User.Login = "reviewer1"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewCommentEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewCommentEvent should not return an error for a created comment")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
+	require.NoError(t, reviewMock.ExpectationsWereMet(), "all review comment store expectations should be met")
+	require.NoError(t, jobMock.ExpectationsWereMet(), "all job store expectations should be met")
+}
+
+func TestHandlePullRequestReviewCommentEvent_NonCreatedAction(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{logger: zerolog.Nop()}
+
+	event := PullRequestReviewCommentEvent{
+		Action: "edited",
+	}
+
+	err := svc.HandlePullRequestReviewCommentEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewCommentEvent should ignore non-created actions")
+}
+
+func TestHandlePullRequestReviewCommentEvent_UnknownPR(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("no rows in result set"))
+
+	event := PullRequestReviewCommentEvent{
+		Action: "created",
+	}
+	event.PullRequest.Number = 999
+	event.Repository.FullName = "unknown/repo"
+
+	err := svc.HandlePullRequestReviewCommentEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewCommentEvent should silently ignore unknown PRs")
+}
+
+func TestHandlePullRequestReviewCommentEvent_NilReviewCommentStore(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests:   prStore,
+		reviewComments: nil,
+		logger:         zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	event := PullRequestReviewCommentEvent{
+		Action: "created",
+	}
+	event.Comment.ID = 67890
+	event.Comment.Body = "Some comment"
+	event.PullRequest.Number = 42
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestReviewCommentEvent(context.Background(), event)
+	require.NoError(t, err, "HandlePullRequestReviewCommentEvent should return nil when reviewComments store is nil")
+}
+
+func TestParseDiff_DeletedFileNotCapturedWithoutPath(t *testing.T) {
+	t.Parallel()
+
+	// The parser only sets currentPath from "+++ b/" lines. For deleted files
+	// that have "+++ /dev/null", no path is captured, so the file is not included.
+	diff := `diff --git a/old.go b/old.go
+deleted file mode 100644
+--- a/old.go
++++ /dev/null
+@@ -1,3 +0,0 @@
+-package old
+-
+-func OldFunc() {}`
+
+	result := parseDiff(diff)
+	require.Empty(t, result, "parser does not capture deleted files with +++ /dev/null (no path set)")
+}
+
+func TestParseDiff_MixedAddAndRemoveLines(t *testing.T) {
+	t.Parallel()
+
+	diff := `diff --git a/main.go b/main.go
+--- a/main.go
++++ b/main.go
+@@ -1,4 +1,4 @@
+ package main
+
+-import "old"
++import "new"
+
+ func main() {}`
+
+	result := parseDiff(diff)
+	require.Len(t, result, 1, "parsed diff should have 1 file")
+	require.Contains(t, result[0].Content, "import \"new\"", "content should include added lines")
+	require.NotContains(t, result[0].Content, "import \"old\"", "content should not include removed lines")
+}
+
+func TestParseDiff_ContextLines(t *testing.T) {
+	t.Parallel()
+
+	diff := `diff --git a/main.go b/main.go
+--- a/main.go
++++ b/main.go
+@@ -1,5 +1,6 @@
+ package main
+
+ import "fmt"
++import "os"
+
+ func main() {}`
+
+	result := parseDiff(diff)
+	require.Len(t, result, 1, "parsed diff should have 1 file")
+	require.Equal(t, "main.go", result[0].Path, "file path should match")
+	require.Contains(t, result[0].Content, "import \"os\"", "content should include added line")
+	require.Contains(t, result[0].Content, "package main", "content should include context lines")
+	require.Contains(t, result[0].Content, "import \"fmt\"", "content should include unchanged context lines")
+}
+
+func TestParseDiff_EmptyDiff(t *testing.T) {
+	t.Parallel()
+
+	result := parseDiff("")
+	require.Empty(t, result, "empty diff should produce empty result")
+}
+
+func TestGetPRHead(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/testorg/testrepo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{
+				"sha": "headsha123",
+				"ref": "143/fix/branch",
+			},
+		})
+		require.NoError(t, err, "mock server should encode getPRHead response")
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	sha, branch, err := svc.getPRHead(context.Background(), "test-token", "testorg", "testrepo", 42)
+	require.NoError(t, err, "getPRHead should not return an error")
+	require.Equal(t, "headsha123", sha, "getPRHead should return the correct SHA")
+	require.Equal(t, "143/fix/branch", branch, "getPRHead should return the correct branch name")
+}
+
+func TestPostComment(t *testing.T) {
+	t.Parallel()
+
+	var capturedBody map[string]string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /repos/testorg/testrepo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewDecoder(r.Body).Decode(&capturedBody)
+		require.NoError(t, err, "mock server should decode comment body")
+		err = json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		require.NoError(t, err, "mock server should encode response")
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	svc.postComment(context.Background(), "test-token", "testorg", "testrepo", 42, "Test comment body")
+	require.Equal(t, "Test comment body", capturedBody["body"], "postComment should send the correct body")
+}
+
+func TestUpdateRef(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod string
+	var capturedPath string
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /repos/testorg/testrepo/git/refs/heads/my-branch", func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		err := json.NewEncoder(w).Encode(map[string]string{"ref": "refs/heads/my-branch"})
+		require.NoError(t, err, "mock server should encode updateRef response")
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	err := svc.updateRef(context.Background(), "test-token", "testorg", "testrepo", "refs/heads/my-branch", "newsha123")
+	require.NoError(t, err, "updateRef should not return an error")
+	require.Equal(t, "PATCH", capturedMethod, "updateRef should use PATCH method")
+	require.Contains(t, capturedPath, "refs/heads/my-branch", "updateRef should call the correct path")
+}
+
+func TestDoGitHubRequest_WithBody(t *testing.T) {
+	t.Parallel()
+
+	var capturedContentType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedContentType = r.Header.Get("Content-Type")
+		_, err := w.Write([]byte(`{"result":"ok"}`))
+		require.NoError(t, err, "test server should write response")
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	body, err := svc.doGitHubRequest(context.Background(), "my-token", http.MethodPost, "/test", map[string]string{"key": "value"})
+	require.NoError(t, err, "doGitHubRequest should not return an error for valid POST request")
+	require.Equal(t, "application/json", capturedContentType, "doGitHubRequest should set Content-Type for POST requests with body")
+	require.Contains(t, string(body), "ok", "doGitHubRequest should return response body")
+}
+
+func TestFormatPRBody_WithValidationStore(t *testing.T) {
+	t.Parallel()
+
+	validationMock := newMockPool(t)
+	validationStore := db.NewValidationStore(validationMock)
+
+	logger := zerolog.Nop()
+	svc := &PRService{
+		validations: validationStore,
+		logger:      logger,
+	}
+
+	runID := uuid.New()
+	orgID := uuid.New()
+	summary := "Fixed the null pointer"
+	run := &models.Session{
+		ID:            runID,
+		OrgID:         orgID,
+		AgentType:     "claude-code",
+		ResultSummary: &summary,
+	}
+	issue := &models.Issue{
+		Source:                "sentry",
+		Severity:              "high",
+		AffectedCustomerCount: 5,
+		OccurrenceCount:       20,
+	}
+
+	// Mock: GetBySessionID returns a validation.
+	validationColumns := []string{
+		"id", "session_id", "org_id", "status",
+		"direction_check", "correctness_check", "quality_check", "security_scan",
+		"regression_test_check", "coverage_delta", "ci_check", "details",
+		"started_at", "completed_at", "created_at",
+	}
+	now := time.Now()
+	validationMock.ExpectQuery("SELECT .+ FROM validations WHERE session_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(validationColumns).
+				AddRow(uuid.New(), runID, orgID, "completed",
+					"pass", "pass", "pass", "pass",
+					"pass", json.RawMessage(`{}`), "pass", json.RawMessage(`{}`),
+					&now, &now, now),
+		)
+
+	body := svc.formatPRBody(context.Background(), run, issue)
+	require.Contains(t, body, "## Validation", "PR body should contain Validation section when validation exists")
+	require.Contains(t, body, "Direction alignment", "PR body should contain direction check row")
+	require.Contains(t, body, "Correctness", "PR body should contain correctness check row")
+	require.Contains(t, body, "Security scan", "PR body should contain security scan row")
+}
+
+func TestHandlePullRequestEvent_MergedWithUpdateStatusError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateStatus fails.
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("db connection lost"))
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 42,
+	}
+	event.PR.Merged = true
+	event.PR.Head.SHA = "abc123"
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.Error(t, err, "HandlePullRequestEvent should return an error when UpdateStatus fails for merged PR")
+	require.Contains(t, err.Error(), "update PR status to merged", "error should describe the failed operation")
+}
+
+// issueColumns for mock issue queries.
+var handlerIssueColumns = []string{
+	"id", "org_id", "external_id", "source", "source_integration_id", "repository_id",
+	"title", "description", "raw_data", "status", "first_seen_at", "last_seen_at",
+	"occurrence_count", "affected_customer_count", "severity", "tags", "fingerprint",
+	"created_at", "updated_at",
+}
+
+// repoColumns for mock repository queries.
+var handlerRepoColumns = []string{
+	"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+	"private", "language", "description", "clone_url", "installation_id", "status",
+	"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+}
+
+func TestCreatePR_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	diff := `diff --git a/main.go b/main.go
+--- a/main.go
++++ b/main.go
+@@ -1,3 +1,4 @@
+ package main
+
++import "fmt"
+ func main() {}`
+
+	diffStr := diff
+
+	run := &models.Session{
+		ID:        runID,
+		OrgID:     orgID,
+		IssueID:   issueID,
+		AgentType: "claude-code",
+		Diff:      &diffStr,
+	}
+
+	// Set up mock GitHub API server.
+	baseSHA := "basesha123"
+	blobSHA := "blobsha456"
+	treeSHA := "treesha789"
+	commitSHA := "commitsha012"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/testorg/testrepo/git/ref/heads/main", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"object": map[string]string{"sha": baseSHA},
+		})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/refs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"ref": "refs/heads/143/fix/test"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/blobs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": blobSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/trees", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": treeSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": commitSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("PATCH /repos/testorg/testrepo/git/", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]string{"ref": "updated"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/pulls", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"number":   55,
+			"html_url": "https://github.com/testorg/testrepo/pull/55",
+		})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/issues/55/labels", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode([]map[string]string{{"name": "143-generated"}})
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Set up DB mocks.
+	issueMock := newMockPool(t)
+	repoMock := newMockPool(t)
+	prMock := newMockPool(t)
+	sessionMock := newMockPool(t)
+
+	issueStore := db.NewIssueStore(issueMock)
+	repoStore := db.NewRepositoryStore(repoMock)
+	prStore := db.NewPullRequestStore(prMock)
+	sessionStore := db.NewSessionStore(sessionMock)
+
+	// Mock: issue GetByID.
+	issueMock.ExpectQuery("SELECT .+ FROM issues WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerIssueColumns).
+				AddRow(issueID, orgID, "ENG-123", "linear", nil, &repoID,
+					"Fix null pointer", nil, json.RawMessage(`{}`), "open", now, now,
+					5, 2, "high", []string{"bug"}, "fp-1",
+					now, now),
+		)
+
+	// Mock: repo GetByID.
+	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345), "testorg/testrepo", "main",
+					false, nil, nil, "https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	// Mock: PR create.
+	prMock.ExpectQuery("INSERT INTO pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).
+				AddRow(uuid.New(), now, now),
+		)
+
+	// Mock: session UpdateStatus.
+	sessionMock.ExpectExec("UPDATE sessions SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Mock: issue UpdateStatus.
+	issueMock.ExpectExec("UPDATE issues SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Create a mock token provider with cached token.
+	tokenSvc := &Service{
+		cache: make(map[int64]*cachedToken),
+	}
+	tokenSvc.cache[99] = &cachedToken{
+		Token:     "test-installation-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		pullRequests:  prStore,
+		sessions:     sessionStore,
+		issues:        issueStore,
+		repos:         repoStore,
+		logger:        zerolog.Nop(),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+
+	pr, err := svc.CreatePR(context.Background(), run)
+	require.NoError(t, err, "CreatePR should not return an error for a valid run")
+	require.NotNil(t, pr, "CreatePR should return a non-nil pull request")
+	require.Equal(t, 55, pr.GitHubPRNumber, "PR number should match the mock server response")
+	require.Equal(t, "testorg/testrepo", pr.GitHubRepo, "PR repo should match")
+	require.Equal(t, "open", pr.Status, "PR status should be open")
+}
+
+func TestCreatePR_NoDiff(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{logger: zerolog.Nop()}
+
+	// Nil diff.
+	run := &models.Session{ID: uuid.New(), Diff: nil}
+	_, err := svc.CreatePR(context.Background(), run)
+	require.Error(t, err, "CreatePR should return an error when diff is nil")
+	require.Contains(t, err.Error(), "no diff", "error should mention no diff")
+
+	// Empty diff.
+	empty := ""
+	run2 := &models.Session{ID: uuid.New(), Diff: &empty}
+	_, err = svc.CreatePR(context.Background(), run2)
+	require.Error(t, err, "CreatePR should return an error when diff is empty")
+	require.Contains(t, err.Error(), "no diff", "error should mention no diff")
+}
+
+func TestCreatePR_NoRepositoryOnIssue(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	issueMock := newMockPool(t)
+	issueStore := db.NewIssueStore(issueMock)
+
+	svc := &PRService{
+		issues: issueStore,
+		logger: zerolog.Nop(),
+	}
+
+	// Mock: issue GetByID returns issue without repository.
+	issueMock.ExpectQuery("SELECT .+ FROM issues WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerIssueColumns).
+				AddRow(issueID, orgID, "ENG-123", "linear", nil, nil, // nil repository_id
+					"Fix null pointer", nil, json.RawMessage(`{}`), "open", now, now,
+					5, 2, "high", []string{}, "fp-1",
+					now, now),
+		)
+
+	diff := "diff --git a/main.go b/main.go\n+++ b/main.go\n+package main\n"
+	run := &models.Session{
+		ID:      uuid.New(),
+		OrgID:   orgID,
+		IssueID: issueID,
+		Diff:    &diff,
+	}
+
+	_, err := svc.CreatePR(context.Background(), run)
+	require.Error(t, err, "CreatePR should return an error when issue has no repository")
+	require.Contains(t, err.Error(), "no repository", "error should mention no repository")
+}
+
+func TestPushRevision_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	prID := uuid.New()
+	issueID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	diff := `diff --git a/handler.go b/handler.go
+--- a/handler.go
++++ b/handler.go
+@@ -1,3 +1,4 @@
+ package handler
++import "errors"
+ func Handle() {}`
+
+	diffStr := diff
+	resultSummary := "Fixed error handling per review feedback"
+
+	run := &models.Session{
+		ID:            runID,
+		OrgID:         orgID,
+		IssueID:       issueID,
+		AgentType:     "claude-code",
+		Diff:          &diffStr,
+		ResultSummary: &resultSummary,
+	}
+
+	pr := &models.PullRequest{
+		ID:             prID,
+		OrgID:          orgID,
+		SessionID:     uuid.New(),
+		GitHubPRNumber: 42,
+		GitHubRepo:     "testorg/testrepo",
+	}
+
+	// Set up mock GitHub API server.
+	headSHA := "headsha123"
+	blobSHA := "blobsha456"
+	treeSHA := "treesha789"
+	commitSHA := "commitsha012"
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/testorg/testrepo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"sha": headSHA, "ref": "143/fix/my-branch"},
+		})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/blobs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": blobSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/trees", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": treeSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": commitSHA})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("PATCH /repos/testorg/testrepo/git/", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]string{"ref": "updated"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	// Set up DB mocks.
+	issueMock := newMockPool(t)
+	repoMock := newMockPool(t)
+
+	issueStore := db.NewIssueStore(issueMock)
+	repoStore := db.NewRepositoryStore(repoMock)
+
+	// Mock: issue GetByID.
+	issueMock.ExpectQuery("SELECT .+ FROM issues WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerIssueColumns).
+				AddRow(issueID, orgID, "ENG-123", "linear", nil, &repoID,
+					"Fix null pointer", nil, json.RawMessage(`{}`), "open", now, now,
+					5, 2, "high", []string{"bug"}, "fp-1",
+					now, now),
+		)
+
+	// Mock: repo GetByID.
+	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345), "testorg/testrepo", "main",
+					false, nil, nil, "https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	// Create a mock token provider with cached token.
+	tokenSvc := &Service{
+		cache: make(map[int64]*cachedToken),
+	}
+	tokenSvc.cache[99] = &cachedToken{
+		Token:     "test-installation-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		issues:        issueStore,
+		repos:         repoStore,
+		logger:        zerolog.Nop(),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+
+	err := svc.PushRevision(context.Background(), pr, run)
+	require.NoError(t, err, "PushRevision should not return an error for a valid revision")
+}
+
+func TestPushRevision_NoDiff(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{logger: zerolog.Nop()}
+
+	run := &models.Session{ID: uuid.New(), Diff: nil}
+	pr := &models.PullRequest{}
+	err := svc.PushRevision(context.Background(), pr, run)
+	require.Error(t, err, "PushRevision should return an error when diff is nil")
+	require.Contains(t, err.Error(), "no diff", "error should mention no diff")
+}
+
+func TestPushRevision_WithParentSessionID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	parentID := uuid.New()
+	prID := uuid.New()
+	issueID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	diff := `diff --git a/main.go b/main.go
+--- a/main.go
++++ b/main.go
+@@ -1 +1 @@
++package main`
+
+	diffStr := diff
+
+	run := &models.Session{
+		ID:              runID,
+		OrgID:           orgID,
+		IssueID:         issueID,
+		AgentType:       "claude-code",
+		Diff:            &diffStr,
+		ParentSessionID: &parentID,
+	}
+
+	pr := &models.PullRequest{
+		ID:             prID,
+		OrgID:          orgID,
+		GitHubPRNumber: 42,
+		GitHubRepo:     "testorg/testrepo",
+	}
+
+	// Set up mock GitHub API server.
+	var capturedCommitMsg string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/testorg/testrepo/pulls/42", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{
+			"head": map[string]string{"sha": "headsha", "ref": "143/fix/branch"},
+		})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/blobs", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": "blobsha"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/trees", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		err := json.NewEncoder(w).Encode(map[string]string{"sha": "treesha"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/git/commits", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		err := json.NewDecoder(r.Body).Decode(&body)
+		require.NoError(t, err)
+		capturedCommitMsg, _ = body["message"].(string)
+		w.WriteHeader(http.StatusCreated)
+		err = json.NewEncoder(w).Encode(map[string]string{"sha": "commitsha"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("PATCH /repos/testorg/testrepo/git/", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]string{"ref": "updated"})
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("POST /repos/testorg/testrepo/issues/42/comments", func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(map[string]any{"id": 1})
+		require.NoError(t, err)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	issueMock := newMockPool(t)
+	repoMock := newMockPool(t)
+
+	issueMock.ExpectQuery("SELECT .+ FROM issues WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerIssueColumns).
+				AddRow(issueID, orgID, "ENG-123", "linear", nil, &repoID,
+					"Fix null pointer", nil, json.RawMessage(`{}`), "open", now, now,
+					5, 2, "high", []string{}, "fp-1",
+					now, now),
+		)
+	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345), "testorg/testrepo", "main",
+					false, nil, nil, "https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	tokenSvc := &Service{cache: make(map[int64]*cachedToken)}
+	tokenSvc.cache[99] = &cachedToken{
+		Token:     "test-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		issues:        db.NewIssueStore(issueMock),
+		repos:         db.NewRepositoryStore(repoMock),
+		logger:        zerolog.Nop(),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+
+	err := svc.PushRevision(context.Background(), pr, run)
+	require.NoError(t, err, "PushRevision should not return an error with parent session ID")
+	require.Contains(t, capturedCommitMsg, parentID.String(), "commit message should reference parent session ID")
+}

--- a/internal/services/pm/coverage_boost_test.go
+++ b/internal/services/pm/coverage_boost_test.go
@@ -1,0 +1,1736 @@
+package pm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SetProjectStores ---
+
+func TestSetProjectStores(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	ps := newMockProjectStore()
+	pts := &mockProjectTaskStore{}
+	pcs := &mockProjectCycleStore{}
+
+	svc.SetProjectStores(ps, pts, pcs)
+	require.Equal(t, ps, svc.projects)
+	require.Equal(t, pts, svc.projectTasks)
+	require.Equal(t, pcs, svc.projectCycles)
+}
+
+// --- buildProjectSummaries and buildProjectSummary ---
+
+func TestBuildProjectSummaries_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	scope := "entire auth module"
+	criteria := "all tests pass"
+	phase := "implementation"
+
+	ps := newMockProjectStore(models.Project{
+		ID:                 projectID,
+		OrgID:              orgID,
+		Title:              "Auth overhaul",
+		Goal:               "improve security",
+		Scope:              &scope,
+		CompletionCriteria: &criteria,
+		Status:             models.ProjectStatusActive,
+		Priority:           1,
+		ExecutionMode:      models.ProjectExecModeParallel,
+		MaxConcurrent:      3,
+		CurrentPhase:       &phase,
+		TotalTasks:         10,
+		CompletedTasks:     5,
+		FailedTasks:        1,
+		LessonsLearned:     []string{"lesson-1"},
+		ApproachHistory:    []models.ApproachRecord{{TaskTitle: "t1", Approach: "a1", Outcome: "ok"}},
+	})
+
+	approach := "fix auth"
+	outcome := "worked"
+	complexity := "moderate"
+	confidence := "high"
+
+	pts := &mockProjectTaskStore{
+		tasks: []*models.ProjectTask{
+			{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "Pending task", Status: models.ProjectTaskStatusPending, BatchNumber: 1, Approach: &approach, Complexity: &complexity, Confidence: &confidence},
+			{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "Running task", Status: models.ProjectTaskStatusRunning, BatchNumber: 1},
+			{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "Delegated task", Status: models.ProjectTaskStatusDelegated, BatchNumber: 1},
+			{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "Completed task", Status: models.ProjectTaskStatusCompleted, BatchNumber: 1, OutcomeNotes: &outcome},
+			{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "Failed task", Status: models.ProjectTaskStatusFailed, BatchNumber: 1},
+		},
+	}
+
+	pcs := &mockProjectCycleStore{
+		cycles: []models.ProjectCycle{
+			{CycleNumber: 3, Analysis: "cycle 3 analysis", TasksCreatedThisCycle: 2, TasksCompletedThisCycle: 1, TasksFailedThisCycle: 0, CreatedAt: time.Now()},
+		},
+	}
+
+	svc := &Service{
+		projects:      ps,
+		projectTasks:  pts,
+		projectCycles: pcs,
+		logger:        zerolog.Nop(),
+	}
+
+	summaries, err := svc.buildProjectSummaries(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+
+	s := summaries[0]
+	require.Equal(t, projectID.String(), s.ID)
+	require.Equal(t, "Auth overhaul", s.Title)
+	require.Equal(t, "improve security", s.Goal)
+	require.Equal(t, "entire auth module", s.Scope)
+	require.Equal(t, "all tests pass", s.CompletionCriteria)
+	require.Equal(t, "implementation", s.CurrentPhase)
+	require.Equal(t, 1, s.Priority)
+	require.Equal(t, "active", s.Status)
+	require.Equal(t, "parallel", s.ExecutionMode)
+	require.Equal(t, 3, s.MaxConcurrent)
+	require.Equal(t, 10, s.TotalTasks)
+	require.Equal(t, 5, s.CompletedTasks)
+	require.Equal(t, 1, s.FailedTasks)
+	require.Equal(t, 50, s.ProgressPct)
+	require.Len(t, s.LessonsLearned, 1)
+	require.Len(t, s.ApproachHistory, 1)
+
+	// Check task categorization.
+	require.Len(t, s.PendingTasks, 1)
+	require.Equal(t, "Pending task", s.PendingTasks[0].Title)
+	require.Equal(t, "fix auth", s.PendingTasks[0].Approach)
+	require.Equal(t, "moderate", s.PendingTasks[0].Complexity)
+	require.Equal(t, "high", s.PendingTasks[0].Confidence)
+
+	require.Len(t, s.RunningTasks, 2) // running + delegated
+	require.Len(t, s.RecentlyCompleted, 1)
+	require.Equal(t, "worked", s.RecentlyCompleted[0].OutcomeNotes)
+	require.Len(t, s.RecentlyFailed, 1)
+
+	// Check cycles.
+	require.Len(t, s.RecentCycles, 1)
+	require.Equal(t, 3, s.RecentCycles[0].CycleNumber)
+}
+
+func TestBuildProjectSummaries_ProjectWithZeroTasks(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	ps := newMockProjectStore(models.Project{
+		ID:            projectID,
+		OrgID:         orgID,
+		Title:         "Empty project",
+		Goal:          "nothing yet",
+		Status:        models.ProjectStatusActive,
+		ExecutionMode: models.ProjectExecModeSequential,
+		TotalTasks:    0,
+	})
+	pts := &mockProjectTaskStore{}
+	pcs := &mockProjectCycleStore{}
+
+	svc := &Service{
+		projects:      ps,
+		projectTasks:  pts,
+		projectCycles: pcs,
+		logger:        zerolog.Nop(),
+	}
+
+	summaries, err := svc.buildProjectSummaries(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Len(t, summaries, 1)
+	require.Equal(t, 0, summaries[0].ProgressPct, "should not divide by zero")
+}
+
+func TestBuildProjectSummaries_TaskListError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	ps := newMockProjectStore(models.Project{
+		ID:            projectID,
+		OrgID:         orgID,
+		Title:         "Project",
+		Status:        models.ProjectStatusActive,
+		ExecutionMode: models.ProjectExecModeSequential,
+	})
+	pts := &errProjectTaskStore{err: fmt.Errorf("db connection lost")}
+	pcs := &mockProjectCycleStore{}
+
+	svc := &Service{
+		projects:      ps,
+		projectTasks:  pts,
+		projectCycles: pcs,
+		logger:        zerolog.Nop(),
+	}
+
+	// buildProjectSummaries logs errors per-project but returns what it can.
+	summaries, err := svc.buildProjectSummaries(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Len(t, summaries, 0, "should skip projects with errors")
+}
+
+type errProjectTaskStore struct {
+	err error
+}
+
+func (m *errProjectTaskStore) Create(_ context.Context, _ *models.ProjectTask) error {
+	return m.err
+}
+func (m *errProjectTaskStore) GetByID(_ context.Context, _, _ uuid.UUID) (models.ProjectTask, error) {
+	return models.ProjectTask{}, m.err
+}
+func (m *errProjectTaskStore) ListByProject(_ context.Context, _, _ uuid.UUID, _ db.ProjectTaskFilters) ([]models.ProjectTask, error) {
+	return nil, m.err
+}
+func (m *errProjectTaskStore) Update(_ context.Context, _ *models.ProjectTask) error { return m.err }
+func (m *errProjectTaskStore) CountByProjectAndStatus(_ context.Context, _, _ uuid.UUID, _ string) (int, error) {
+	return 0, m.err
+}
+func (m *errProjectTaskStore) GetMaxBatchNumber(_ context.Context, _, _ uuid.UUID) (int, error) {
+	return 0, m.err
+}
+
+// --- parsePlan additional coverage ---
+
+func TestParsePlan_NoTags(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePlan("no tags here")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tags not found")
+}
+
+func TestParsePlan_EmptyContent(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePlan("<pm-plan>   </pm-plan>")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty")
+}
+
+func TestParsePlan_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePlan("<pm-plan>{not valid json}</pm-plan>")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse pm plan json")
+}
+
+func TestParsePlan_WithProjectPlansAndSlotAllocation(t *testing.T) {
+	t.Parallel()
+
+	projectID := uuid.New()
+	issueID := uuid.New()
+
+	output := fmt.Sprintf(`<pm-plan>
+{
+  "analysis": "Test with projects",
+  "tasks": [
+    {
+      "rank": 1,
+      "issue_ids": ["%s"],
+      "title": "Fix bug",
+      "reasoning": "High impact",
+      "approach": "Fix it",
+      "risk": "Low",
+      "complexity": "simple",
+      "confidence": "high"
+    }
+  ],
+  "clusters": [],
+  "skip": [],
+  "project_plans": [
+    {
+      "project_id": "%s",
+      "cycle_analysis": "Going well",
+      "progress_pct": 75,
+      "current_phase": "testing",
+      "new_tasks": [{"title": "Write tests", "description": "Add coverage"}]
+    }
+  ],
+  "slot_allocation": {
+    "reactive": 2,
+    "projects": {"%s": 3},
+    "reasoning": "More project work needed"
+  }
+}
+</pm-plan>`, issueID, projectID, projectID)
+
+	plan, err := parsePlan(output)
+	require.NoError(t, err)
+	require.Len(t, plan.ProjectPlans, 1)
+	require.Equal(t, projectID, plan.ProjectPlans[0].ProjectID)
+	require.Equal(t, 75, plan.ProjectPlans[0].ProgressPct)
+	require.NotNil(t, plan.SlotAllocation)
+	require.Equal(t, 2, plan.SlotAllocation.Reactive)
+	require.Equal(t, 3, plan.SlotAllocation.Projects[projectID.String()])
+}
+
+func TestParsePlan_EndBeforeStart(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePlan("</pm-plan> some text <pm-plan>")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "tags not found")
+}
+
+// --- executePlan additional paths ---
+
+func TestExecutePlan_EmptyIssueIDsSkipped(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	planID := uuid.New()
+
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 5,
+		AutonomyLevel:     "auto_all",
+		DefaultAgentType:  "codex",
+	}
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &mockSessionStore{},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    planID,
+		OrgID: orgID,
+		Tasks: []Task{
+			{
+				Rank:       1,
+				IssueIDs:   []uuid.UUID{}, // empty
+				Approach:   "Approach",
+				Reasoning:  "Reason",
+				Complexity: models.PMTaskComplexitySimple,
+				Confidence: models.PMTaskConfidenceHigh,
+			},
+		},
+	}
+
+	err := svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.PMTaskStatusSkippedCapacity, plan.Tasks[0].Status, "tasks with empty issue IDs should be skipped")
+}
+
+func TestExecutePlan_LowConfidenceSkippedUnlessAutoAll(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+	planID := uuid.New()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &mockSessionStore{},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    planID,
+		OrgID: orgID,
+		Tasks: []Task{
+			{
+				Rank:       1,
+				IssueIDs:   []uuid.UUID{issue},
+				Approach:   "Approach",
+				Reasoning:  "Reason",
+				Complexity: models.PMTaskComplexitySimple,
+				Confidence: models.PMTaskConfidenceLow,
+			},
+		},
+	}
+
+	// auto_safe should skip low-confidence
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 5,
+		AutonomyLevel:     "auto_safe",
+		DefaultAgentType:  "codex",
+	}
+	err := svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.PMTaskStatusSkippedCapacity, plan.Tasks[0].Status)
+
+	// auto_all should delegate
+	plan.Tasks[0].Status = ""
+	settings.AutonomyLevel = "auto_all"
+	err = svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.PMTaskStatusDelegated, plan.Tasks[0].Status)
+}
+
+func TestExecutePlan_DefaultAgentType(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+	planID := uuid.New()
+
+	sessions := &mockSessionStore{}
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: sessions,
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    planID,
+		OrgID: orgID,
+		Tasks: []Task{
+			{
+				Rank:       1,
+				IssueIDs:   []uuid.UUID{issue},
+				Approach:   "Approach",
+				Reasoning:  "Reason",
+				Complexity: models.PMTaskComplexityModerate,
+				Confidence: models.PMTaskConfidenceHigh,
+			},
+		},
+	}
+
+	// Empty default agent type should fall back to DefaultDefaultAgentType.
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 5,
+		AutonomyLevel:     "auto_all",
+		DefaultAgentType:  "",
+	}
+	err := svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Len(t, sessions.created, 1)
+	require.Equal(t, models.DefaultDefaultAgentType, sessions.created[0].AgentType)
+	require.Equal(t, "high", sessions.created[0].TokenMode, "moderate complexity should use high token mode")
+}
+
+func TestExecutePlan_DefaultMaxConcurrentRuns(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+	planID := uuid.New()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &mockSessionStore{},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    planID,
+		OrgID: orgID,
+		Tasks: []Task{
+			{
+				Rank:       1,
+				IssueIDs:   []uuid.UUID{issue},
+				Approach:   "Approach",
+				Reasoning:  "Reason",
+				Complexity: models.PMTaskComplexitySimple,
+				Confidence: models.PMTaskConfidenceHigh,
+			},
+		},
+	}
+
+	// Zero MaxConcurrentRuns should use the default.
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 0,
+		AutonomyLevel:     "auto_all",
+		DefaultAgentType:  "codex",
+	}
+	err := svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.PMTaskStatusDelegated, plan.Tasks[0].Status)
+}
+
+func TestExecutePlan_MultipleIssuesTriaged(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue1 := uuid.New()
+	issue2 := uuid.New()
+	planID := uuid.New()
+
+	issueStore := &mockIssueStore{}
+	svc := &Service{
+		issues:   issueStore,
+		sessions: &mockSessionStore{},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    planID,
+		OrgID: orgID,
+		Tasks: []Task{
+			{
+				Rank:       1,
+				IssueIDs:   []uuid.UUID{issue1, issue2},
+				Approach:   "Approach",
+				Reasoning:  "Reason",
+				Complexity: models.PMTaskComplexitySimple,
+				Confidence: models.PMTaskConfidenceHigh,
+			},
+		},
+	}
+
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 5,
+		AutonomyLevel:     "auto_all",
+		DefaultAgentType:  "codex",
+	}
+	err := svc.executePlan(context.Background(), orgID, plan, settings, nil)
+	require.NoError(t, err)
+	require.Len(t, issueStore.updated, 2, "both issues should be marked as triaged")
+}
+
+// --- gatherContext: repo settings merge ---
+
+func TestGatherContext_WithRepoSettings(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 3,
+		ProductContext: &models.ProductContext{
+			Philosophy: "org philosophy",
+		},
+	}
+	settingsJSON, err := json.Marshal(settings)
+	require.NoError(t, err)
+
+	repoSettings := models.RepoSettings{
+		PM: &models.RepoPMSettings{
+			ProductContext: &models.ProductContext{
+				Philosophy: "repo philosophy",
+			},
+		},
+	}
+	repoSettingsJSON, err := json.Marshal(repoSettings)
+	require.NoError(t, err)
+
+	repo := &models.Repository{
+		ID:       uuid.New(),
+		OrgID:    orgID,
+		Settings: repoSettingsJSON,
+	}
+
+	svc := &Service{
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		logger:   zerolog.Nop(),
+	}
+
+	bundle, err := svc.gatherContext(context.Background(), orgID, repo)
+	require.NoError(t, err)
+	require.NotNil(t, bundle.productContext)
+	require.Equal(t, "repo philosophy", bundle.productContext.Philosophy, "repo settings should override org settings")
+}
+
+func TestGatherContext_SessionErrors(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	tests := []struct {
+		name     string
+		sessions *gatherSessionStoreMock
+		errPart  string
+	}{
+		{
+			name: "pending runs error",
+			sessions: &gatherSessionStoreMock{
+				byStatus: map[string][]models.Session{},
+				errByKey: map[string]error{"pending": fmt.Errorf("pending fail")},
+			},
+			errPart: "pending fail",
+		},
+		{
+			name: "running runs error",
+			sessions: &gatherSessionStoreMock{
+				byStatus: map[string][]models.Session{},
+				errByKey: map[string]error{"running": fmt.Errorf("running fail")},
+			},
+			errPart: "running fail",
+		},
+		{
+			name: "recent runs error",
+			sessions: &gatherSessionStoreMock{
+				byStatus: map[string][]models.Session{},
+				errByKey: map[string]error{"recent": fmt.Errorf("recent fail")},
+			},
+			errPart: "recent fail",
+		},
+		{
+			name: "count running error",
+			sessions: &gatherSessionStoreMock{
+				byStatus: map[string][]models.Session{},
+				errByKey: map[string]error{"count_running": fmt.Errorf("count fail")},
+			},
+			errPart: "count fail",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := &Service{
+				issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+				sessions: tt.sessions,
+				orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+				logger:   zerolog.Nop(),
+			}
+
+			_, err := svc.gatherContext(context.Background(), orgID, nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.errPart)
+		})
+	}
+}
+
+func TestGatherContext_TriagedIssueError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		issues: &gatherIssueStoreMock{
+			byStatus: map[string][]models.Issue{},
+			errByKey: map[string]error{"triaged": fmt.Errorf("triaged fail")},
+		},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.gatherContext(context.Background(), orgID, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "triaged fail")
+}
+
+func TestGatherContext_PRStoreError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		issues:       &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions:     &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		orgs:         &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		pullRequests: &gatherPRStoreMock{err: fmt.Errorf("pr store fail")},
+		logger:       zerolog.Nop(),
+	}
+
+	_, err := svc.gatherContext(context.Background(), orgID, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pr store fail")
+}
+
+func TestGatherContext_DecisionLogError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		issues:      &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions:    &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		orgs:        &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		decisionLog: &gatherDecisionStoreMock{err: fmt.Errorf("decision log fail")},
+		logger:      zerolog.Nop(),
+	}
+
+	_, err := svc.gatherContext(context.Background(), orgID, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decision log fail")
+}
+
+func TestGatherContext_WithProjectSummaries(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	ps := newMockProjectStore(models.Project{
+		ID:            projectID,
+		OrgID:         orgID,
+		Title:         "Test project",
+		Goal:          "test goal",
+		Status:        models.ProjectStatusActive,
+		ExecutionMode: models.ProjectExecModeSequential,
+	})
+	pts := &mockProjectTaskStore{}
+	pcs := &mockProjectCycleStore{}
+
+	svc := &Service{
+		issues:        &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions:      &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		orgs:          &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		projects:      ps,
+		projectTasks:  pts,
+		projectCycles: pcs,
+		logger:        zerolog.Nop(),
+	}
+
+	bundle, err := svc.gatherContext(context.Background(), orgID, nil)
+	require.NoError(t, err)
+	require.Len(t, bundle.pmContext.ActiveProjects, 1)
+	require.Equal(t, "Test project", bundle.pmContext.ActiveProjects[0].Title)
+}
+
+// --- canDispatchForProject: dependency_graph (default) case ---
+
+func TestCanDispatchForProject_DependencyGraphMode(t *testing.T) {
+	t.Parallel()
+
+	pts := &mockProjectTaskStore{countByStatus: map[string]int{}}
+	svc := newTestProjectService(nil, pts, nil)
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeDependencyGraph,
+	}
+
+	t.Run("no active tasks allows 1", func(t *testing.T) {
+		got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+		require.Equal(t, 1, got)
+	})
+
+	t.Run("active tasks blocks dispatch", func(t *testing.T) {
+		pts.countByStatus = map[string]int{string(models.ProjectTaskStatusRunning): 1}
+		got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+		require.Equal(t, 0, got)
+	})
+}
+
+func TestCanDispatchForProject_CountErrors(t *testing.T) {
+	t.Parallel()
+
+	pts := &errProjectTaskStore{err: fmt.Errorf("count error")}
+	svc := &Service{
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+	require.Equal(t, 0, got, "should return 0 when count errors")
+}
+
+// --- dispatchProjectTasks: project agent type override ---
+
+func TestDispatchProjectTasks_UsesProjectAgentType(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	agentType := "custom-agent"
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task with project agent type",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 1,
+		SortOrder:   1,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	sessions := &mockSessionStore{}
+	svc := &Service{
+		sessions:     sessions,
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+		AgentType:     &agentType,
+	}
+
+	settings := models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "default-agent",
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 1, dispatched)
+	require.Len(t, sessions.created, 1)
+	require.Equal(t, "custom-agent", sessions.created[0].AgentType, "should use project's agent type over default")
+}
+
+func TestDispatchProjectTasks_FallbackAgentType(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 1,
+		SortOrder:   1,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	sessions := &mockSessionStore{}
+	svc := &Service{
+		sessions:     sessions,
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	// Both project and settings agent types are empty; should fallback.
+	settings := models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "",
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 1, dispatched)
+	require.Equal(t, models.DefaultDefaultAgentType, sessions.created[0].AgentType)
+}
+
+func TestDispatchProjectTasks_RespectsSlotLimit(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	tasks := []*models.ProjectTask{
+		{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "T1", Status: models.ProjectTaskStatusPending, BatchNumber: 1, SortOrder: 1},
+		{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "T2", Status: models.ProjectTaskStatusPending, BatchNumber: 1, SortOrder: 2},
+		{ID: uuid.New(), ProjectID: projectID, OrgID: orgID, Title: "T3", Status: models.ProjectTaskStatusPending, BatchNumber: 1, SortOrder: 3},
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         tasks,
+		countByStatus: map[string]int{},
+	}
+	svc := &Service{
+		sessions:     &mockSessionStore{},
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential, // only 1 slot
+	}
+
+	settings := models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "codex",
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 1, dispatched, "sequential mode should only dispatch 1")
+}
+
+// --- recordProjectCycle: no previous cycles ---
+
+func TestRecordProjectCycle_NoPreviousCycles(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	planID := uuid.New()
+
+	pcs := &mockProjectCycleStore{
+		cycles: []models.ProjectCycle{}, // no previous cycles
+	}
+	svc := newTestProjectService(nil, nil, pcs)
+
+	pp := &ProjectPlan{
+		ProjectID:     projectID,
+		CycleAnalysis: "First cycle",
+		ProgressPct:   0,
+	}
+
+	svc.recordProjectCycle(context.Background(), orgID, pp, planID, 1, 1)
+
+	require.Len(t, pcs.created, 1)
+	require.Equal(t, 1, pcs.created[0].CycleNumber, "first cycle should be 1")
+	require.Nil(t, pcs.created[0].ProgressPct, "zero progress should produce nil progress")
+}
+
+// --- summarizeIssue with nil description ---
+
+func TestSummarizeIssue_NilDescription(t *testing.T) {
+	t.Parallel()
+
+	issue := models.Issue{
+		ID:          uuid.New(),
+		Source:      "github",
+		Title:       "Issue without description",
+		Description: nil,
+		Severity:    "low",
+		FirstSeenAt: time.Now(),
+		LastSeenAt:  time.Now(),
+	}
+
+	summary := summarizeIssue(issue)
+	require.Equal(t, "", summary.Description)
+}
+
+// --- Analyze validation paths ---
+
+func TestAnalyze_NilAdapterOrSandbox(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{adapter: nil, sandbox: nil}
+	_, err := svc.Analyze(context.Background(), uuid.New(), models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not configured")
+}
+
+func TestAnalyze_InvalidTrigger(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{},
+		sandbox: &pmSandboxMock{},
+	}
+	_, err := svc.Analyze(context.Background(), uuid.New(), models.PMTrigger("invalid"), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid trigger")
+}
+
+// --- mock repoStore for Analyze tests ---
+
+type mockRepoStore struct {
+	repos []models.Repository
+	err   error
+}
+
+func (m *mockRepoStore) ListByOrg(_ context.Context, _ uuid.UUID) ([]models.Repository, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.repos, nil
+}
+
+func TestAnalyze_NoRepositories(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{},
+		sandbox: &pmSandboxMock{},
+		repos:   &mockRepoStore{repos: []models.Repository{}},
+	}
+	_, err := svc.Analyze(context.Background(), uuid.New(), models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no repositories")
+}
+
+func TestAnalyze_RepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	repoID := uuid.New()
+	otherRepoID := uuid.New()
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: otherRepoID, Status: "active"},
+		}},
+	}
+	_, err := svc.Analyze(context.Background(), uuid.New(), models.PMTriggerCron, &repoID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found in org")
+}
+
+func TestAnalyze_RepoListError(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{},
+		sandbox: &pmSandboxMock{},
+		repos:   &mockRepoStore{err: fmt.Errorf("db error")},
+	}
+	_, err := svc.Analyze(context.Background(), uuid.New(), models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list repositories")
+}
+
+func TestAnalyze_SelectsActiveRepo(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	inactiveRepoID := uuid.New()
+	activeRepoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	// Adapter that returns a valid plan to exercise more code.
+	issueID := uuid.New()
+	planOutput := fmt.Sprintf(`<pm-plan>
+{
+  "analysis": "test",
+  "tasks": [{"rank":1,"issue_ids":["%s"],"title":"t","reasoning":"r","approach":"a","risk":"r","complexity":"simple","confidence":"high"}],
+  "clusters": [],
+  "skip": []
+}
+</pm-plan>`, issueID)
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeResult: &agent.AgentResult{Summary: planOutput}},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: inactiveRepoID, Status: "inactive", OrgID: orgID},
+			{ID: activeRepoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		plans:    &mockPlanStore{},
+		jobs:     &mockJobStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Equal(t, "test", plan.Analysis)
+}
+
+// --- OnSessionComplete: task lookup error ---
+
+func TestProjectHooks_OnSessionComplete_TaskLookupError(t *testing.T) {
+	t.Parallel()
+
+	taskID := uuid.New()
+	pts := &errProjectTaskStore{err: fmt.Errorf("task not found")}
+	hooks := NewProjectHooks(pts, nil, zerolog.Nop())
+
+	run := &models.Session{
+		ID:            uuid.New(),
+		OrgID:         uuid.New(),
+		ProjectTaskID: &taskID,
+	}
+
+	err := hooks.OnSessionComplete(context.Background(), run, "completed")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get project task")
+}
+
+// --- executeProjectPlan: project not found ---
+
+func TestExecuteProjectPlan_ProjectNotFound(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	ps := newMockProjectStore() // no projects
+	svc := newTestProjectService(ps, &mockProjectTaskStore{}, &mockProjectCycleStore{})
+
+	pp := &ProjectPlan{
+		ProjectID:     projectID,
+		CycleAnalysis: "test",
+	}
+
+	err := svc.executeProjectPlan(context.Background(), orgID, pp, models.OrgSettings{}, uuid.New())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get project")
+}
+
+// --- dispatchProjectTasks: task with approach and reasoning ---
+
+func TestDispatchProjectTasks_TaskWithApproachAndReasoning(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	approach := "my approach"
+	reasoning := "my reasoning"
+	complexity := "complex"
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task with details",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 2,
+		SortOrder:   3,
+		Approach:    &approach,
+		Reasoning:   &reasoning,
+		Complexity:  &complexity,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	sessions := &mockSessionStore{}
+	svc := &Service{
+		sessions:     sessions,
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	settings := models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "codex",
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 1, dispatched)
+	require.Len(t, sessions.created, 1)
+	require.Equal(t, "my approach", *sessions.created[0].PMApproach)
+	require.Equal(t, "my reasoning", *sessions.created[0].PMReasoning)
+	require.Equal(t, "high", sessions.created[0].TokenMode, "complex should map to high")
+}
+
+// --- dispatchProjectTasks: model override ---
+
+func TestDispatchProjectTasks_ModelOverride(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+	modelOverride := "gpt-4o"
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 1,
+		SortOrder:   1,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	sessions := &mockSessionStore{}
+	svc := &Service{
+		sessions:     sessions,
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+		ModelOverride: &modelOverride,
+	}
+
+	settings := models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "codex",
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 1, dispatched)
+	require.Equal(t, &modelOverride, sessions.created[0].ModelOverride)
+}
+
+// --- executePlan error paths ---
+
+type errSessionStore struct {
+	mockSessionStore
+	createErr error
+	countErr  error
+}
+
+func (m *errSessionStore) CountRunningByOrg(ctx context.Context, orgID uuid.UUID) (int, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	return m.mockSessionStore.CountRunningByOrg(ctx, orgID)
+}
+
+func (m *errSessionStore) Create(ctx context.Context, run *models.Session) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	return m.mockSessionStore.Create(ctx, run)
+}
+
+func TestExecutePlan_CountRunningError(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &errSessionStore{countErr: fmt.Errorf("count error")},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{ID: uuid.New(), OrgID: uuid.New()}
+	err := svc.executePlan(context.Background(), uuid.New(), plan, models.OrgSettings{MaxConcurrentRuns: 5, AutonomyLevel: "auto_all"}, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "count error")
+}
+
+func TestExecutePlan_SessionCreateError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &errSessionStore{createErr: fmt.Errorf("create error")},
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    uuid.New(),
+		OrgID: orgID,
+		Tasks: []Task{
+			{Rank: 1, IssueIDs: []uuid.UUID{issue}, Complexity: models.PMTaskComplexitySimple, Confidence: models.PMTaskConfidenceHigh},
+		},
+	}
+
+	err := svc.executePlan(context.Background(), orgID, plan, models.OrgSettings{MaxConcurrentRuns: 5, AutonomyLevel: "auto_all", DefaultAgentType: "codex"}, nil)
+	require.NoError(t, err, "session create error should not fail executePlan")
+	require.Equal(t, models.PMTaskStatusSkippedCapacity, plan.Tasks[0].Status)
+}
+
+type errJobStore struct {
+	err error
+}
+
+func (m *errJobStore) Enqueue(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+	return uuid.Nil, m.err
+}
+
+func TestExecutePlan_EnqueueError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &mockSessionStore{},
+		jobs:     &errJobStore{err: fmt.Errorf("enqueue error")},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    uuid.New(),
+		OrgID: orgID,
+		Tasks: []Task{
+			{Rank: 1, IssueIDs: []uuid.UUID{issue}, Complexity: models.PMTaskComplexitySimple, Confidence: models.PMTaskConfidenceHigh},
+		},
+	}
+
+	err := svc.executePlan(context.Background(), orgID, plan, models.OrgSettings{MaxConcurrentRuns: 5, AutonomyLevel: "auto_all", DefaultAgentType: "codex"}, nil)
+	require.NoError(t, err, "enqueue error should not fail executePlan")
+	require.Equal(t, models.PMTaskStatusSkippedCapacity, plan.Tasks[0].Status)
+}
+
+func TestExecutePlan_RunningExceedsMax(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	issue := uuid.New()
+
+	svc := &Service{
+		issues:   &mockIssueStore{},
+		sessions: &mockSessionStore{running: 10}, // running > max
+		jobs:     &mockJobStore{},
+		plans:    &mockPlanStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan := &Plan{
+		ID:    uuid.New(),
+		OrgID: orgID,
+		Tasks: []Task{
+			{Rank: 1, IssueIDs: []uuid.UUID{issue}, Complexity: models.PMTaskComplexitySimple, Confidence: models.PMTaskConfidenceHigh},
+		},
+	}
+
+	err := svc.executePlan(context.Background(), orgID, plan, models.OrgSettings{MaxConcurrentRuns: 3, AutonomyLevel: "auto_all", DefaultAgentType: "codex"}, nil)
+	require.NoError(t, err)
+	require.Equal(t, models.PMTaskStatusSkippedCapacity, plan.Tasks[0].Status, "should skip when running exceeds max")
+}
+
+// --- dispatchProjectTasks error paths ---
+
+type errSessionCreateStore struct {
+	mockSessionStore
+	createErr error
+}
+
+func (m *errSessionCreateStore) Create(_ context.Context, _ *models.Session) error {
+	return m.createErr
+}
+
+func TestDispatchProjectTasks_SessionCreateError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 1,
+		SortOrder:   1,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	svc := &Service{
+		sessions:     &errSessionCreateStore{createErr: fmt.Errorf("session create fail")},
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	settings := models.OrgSettings{AutonomyLevel: "auto_all", DefaultAgentType: "codex"}
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 0, dispatched)
+}
+
+func TestDispatchProjectTasks_EnqueueError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	pendingTask := &models.ProjectTask{
+		ID:          uuid.New(),
+		ProjectID:   projectID,
+		OrgID:       orgID,
+		Title:       "Task",
+		Status:      models.ProjectTaskStatusPending,
+		BatchNumber: 1,
+		SortOrder:   1,
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{pendingTask},
+		countByStatus: map[string]int{},
+	}
+	svc := &Service{
+		sessions:     &mockSessionStore{},
+		jobs:         &errJobStore{err: fmt.Errorf("enqueue fail")},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	settings := models.OrgSettings{AutonomyLevel: "auto_all", DefaultAgentType: "codex"}
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
+	require.Equal(t, 0, dispatched)
+}
+
+// --- Analyze with specific repo ID ---
+
+func TestAnalyze_WithSpecificRepoID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	issueID := uuid.New()
+	planOutput := fmt.Sprintf(`<pm-plan>
+{
+  "analysis": "specific repo",
+  "tasks": [{"rank":1,"issue_ids":["%s"],"title":"t","reasoning":"r","approach":"a","risk":"r","complexity":"simple","confidence":"high"}],
+  "clusters": [],
+  "skip": []
+}
+</pm-plan>`, issueID)
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeResult: &agent.AgentResult{Summary: planOutput}},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		plans:    &mockPlanStore{},
+		jobs:     &mockJobStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, &repoID)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Equal(t, "specific repo", plan.Analysis)
+}
+
+// --- Analyze with decision log entries ---
+
+func TestAnalyze_WritesDecisionLog(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3, AutonomyLevel: "auto_all", DefaultAgentType: "codex"})
+
+	issueID := uuid.New()
+	planOutput := fmt.Sprintf(`<pm-plan>
+{
+  "analysis": "with decision log",
+  "tasks": [{"rank":1,"issue_ids":["%s"],"title":"t","reasoning":"r","approach":"a","risk":"r","complexity":"simple","confidence":"high"}],
+  "clusters": [],
+  "skip": []
+}
+</pm-plan>`, issueID)
+
+	decisionLog := &gatherDecisionStoreMock{}
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeResult: &agent.AgentResult{Summary: planOutput}},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:        &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:      &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions:    &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		plans:       &mockPlanStore{},
+		jobs:        &mockJobStore{},
+		decisionLog: decisionLog,
+		logger:      zerolog.Nop(),
+	}
+
+	plan, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	require.Equal(t, models.PMPlanStatusCompleted, plan.Status)
+	require.NotNil(t, plan.CompletedAt)
+}
+
+// --- Analyze with product context ---
+
+func TestAnalyze_WithProductContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settings := models.OrgSettings{
+		MaxConcurrentRuns: 3,
+		ProductContext: &models.ProductContext{
+			Philosophy: "ship fast",
+			Direction:  "growth",
+			FocusAreas: []string{"auth"},
+			AvoidAreas: []string{"billing"},
+		},
+	}
+	settingsJSON, _ := json.Marshal(settings)
+
+	issueID := uuid.New()
+	planOutput := fmt.Sprintf(`<pm-plan>
+{
+  "analysis": "with product context",
+  "tasks": [{"rank":1,"issue_ids":["%s"],"title":"t","reasoning":"r","approach":"a","risk":"r","complexity":"simple","confidence":"high"}],
+  "clusters": [],
+  "skip": []
+}
+</pm-plan>`, issueID)
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeResult: &agent.AgentResult{Summary: planOutput}},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		plans:    &mockPlanStore{},
+		jobs:     &mockJobStore{},
+		logger:   zerolog.Nop(),
+	}
+
+	plan, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+}
+
+// --- Analyze with parse error ---
+
+func TestAnalyze_ParsePlanError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeResult: &agent.AgentResult{Summary: "no plan tags"}},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "parse plan")
+}
+
+// --- Analyze with execute error ---
+
+func TestAnalyze_ExecuteError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{executeErr: fmt.Errorf("execution failed")},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pm agent execution")
+}
+
+// --- Analyze with GitHub token ---
+
+type mockGitHubTokenProvider struct {
+	token string
+	err   error
+}
+
+func (m *mockGitHubTokenProvider) GetInstallationToken(_ context.Context, _ int64) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.token, nil
+}
+
+func TestAnalyze_GitHubTokenError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	settingsJSON, _ := json.Marshal(models.OrgSettings{MaxConcurrentRuns: 3})
+
+	svc := &Service{
+		adapter: &pmInnerAdapterMock{},
+		sandbox: &pmSandboxMock{},
+		repos: &mockRepoStore{repos: []models.Repository{
+			{ID: repoID, Status: "active", OrgID: orgID, InstallationID: 12345},
+		}},
+		orgs:     &gatherOrgStoreMock{org: models.Organization{ID: orgID, Settings: settingsJSON}},
+		issues:   &gatherIssueStoreMock{byStatus: map[string][]models.Issue{}},
+		sessions: &gatherSessionStoreMock{byStatus: map[string][]models.Session{}, count: 0},
+		github:   &mockGitHubTokenProvider{err: fmt.Errorf("token error")},
+		logger:   zerolog.Nop(),
+	}
+
+	_, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "get installation token")
+}
+
+// --- canDispatchForProject: delegated count error ---
+
+type errDelegatedCountStore struct {
+	mockProjectTaskStore
+	delegatedErr bool
+}
+
+func (m *errDelegatedCountStore) CountByProjectAndStatus(_ context.Context, _, _ uuid.UUID, status string) (int, error) {
+	if m.delegatedErr && status == string(models.ProjectTaskStatusDelegated) {
+		return 0, fmt.Errorf("delegated count error")
+	}
+	if m.countByStatus != nil {
+		return m.countByStatus[status], nil
+	}
+	return 0, nil
+}
+
+func TestCanDispatchForProject_DelegatedCountError(t *testing.T) {
+	t.Parallel()
+
+	pts := &errDelegatedCountStore{
+		delegatedErr: true,
+		mockProjectTaskStore: mockProjectTaskStore{
+			countByStatus: map[string]int{},
+		},
+	}
+	svc := &Service{
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+	require.Equal(t, 0, got, "should return 0 when delegated count errors")
+}
+
+// --- canDispatchForProject: parallel with negative remaining ---
+
+func TestCanDispatchForProject_ParallelOverCapacity(t *testing.T) {
+	t.Parallel()
+
+	pts := &mockProjectTaskStore{
+		countByStatus: map[string]int{
+			string(models.ProjectTaskStatusRunning):   5,
+			string(models.ProjectTaskStatusDelegated): 5,
+		},
+	}
+	svc := newTestProjectService(nil, pts, nil)
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeParallel,
+		MaxConcurrent: 3, // active (10) > max (3)
+	}
+
+	got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+	require.Equal(t, 0, got, "should return 0 when active exceeds max")
+}
+
+// --- dispatchProjectTasks: list pending error ---
+
+type errListProjectTaskStore struct {
+	mockProjectTaskStore
+	listErr bool
+}
+
+func (m *errListProjectTaskStore) ListByProject(_ context.Context, _, _ uuid.UUID, _ db.ProjectTaskFilters) ([]models.ProjectTask, error) {
+	if m.listErr {
+		return nil, fmt.Errorf("list pending error")
+	}
+	return m.mockProjectTaskStore.ListByProject(context.Background(), uuid.Nil, uuid.Nil, db.ProjectTaskFilters{})
+}
+
+func TestDispatchProjectTasks_ListPendingError(t *testing.T) {
+	t.Parallel()
+
+	pts := &errListProjectTaskStore{
+		listErr: true,
+		mockProjectTaskStore: mockProjectTaskStore{
+			countByStatus: map[string]int{},
+		},
+	}
+	svc := &Service{
+		sessions:     &mockSessionStore{},
+		jobs:         &mockJobStore{},
+		projectTasks: pts,
+		logger:       zerolog.Nop(),
+	}
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeSequential,
+	}
+
+	settings := models.OrgSettings{AutonomyLevel: "auto_all", DefaultAgentType: "codex"}
+	dispatched := svc.dispatchProjectTasks(context.Background(), uuid.New(), project, settings, uuid.New())
+	require.Equal(t, 0, dispatched)
+}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -4,12 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/feedback"
+	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/assembledhq/143/internal/services/pm"
+	"github.com/assembledhq/143/internal/services/prioritization"
+	"github.com/assembledhq/143/internal/services/validation"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
@@ -536,4 +541,813 @@ func TestProcessReviewCommentHandler_SkipsPatternUpdateWhenCommentAlreadyProcess
 	err := handler(context.Background(), "process_review_comment", payload)
 	require.NoError(t, err, "process_review_comment handler should succeed for already processed comments")
 	require.Equal(t, 0, patternStore.createCalls, "process_review_comment should not update patterns when comment was already processed")
+}
+
+// ---------------------------------------------------------------------------
+// newUpdateReviewPatternsHandler tests
+// ---------------------------------------------------------------------------
+
+func TestUpdateReviewPatternsHandler(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		payload   json.RawMessage
+		expectErr bool
+		errSubstr string
+	}{
+		{
+			name:      "invalid JSON returns unmarshal error",
+			payload:   json.RawMessage(`{bad json}`),
+			expectErr: true,
+			errSubstr: "unmarshal update_review_patterns payload",
+		},
+		{
+			name:      "missing org ID returns parse error",
+			payload:   json.RawMessage(`{"comment_id":"` + uuid.New().String() + `","repo":"org/repo","rule":"use gofmt","category":"style"}`),
+			expectErr: true,
+			errSubstr: "parse org ID",
+		},
+		{
+			name:      "invalid comment ID returns parse error",
+			payload:   json.RawMessage(`{"comment_id":"not-a-uuid","org_id":"` + uuid.New().String() + `","repo":"org/repo","rule":"use gofmt","category":"style"}`),
+			expectErr: true,
+			errSubstr: "parse comment ID",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			commentStore := &testFeedbackCommentStore{}
+			patternStore := &testFeedbackPatternStore{}
+			feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+			services := &Services{Feedback: feedbackService}
+
+			handler := newUpdateReviewPatternsHandler(services, zerolog.Nop())
+			err := handler(context.Background(), "update_review_patterns", tt.payload)
+
+			if tt.expectErr {
+				require.Error(t, err, "handler should return error")
+				require.Contains(t, err.Error(), tt.errSubstr, "error should contain expected substring")
+			} else {
+				require.NoError(t, err, "handler should succeed")
+			}
+		})
+	}
+}
+
+func TestUpdateReviewPatternsHandler_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	commentID := uuid.New()
+
+	commentStore := &testFeedbackCommentStore{}
+	patternStore := &testFeedbackPatternStore{}
+	feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+
+	services := &Services{Feedback: feedbackService}
+	handler := newUpdateReviewPatternsHandler(services, zerolog.Nop())
+
+	payload := json.RawMessage(`{"comment_id":"` + commentID.String() + `","org_id":"` + orgID.String() + `","repo":"org/repo","rule":"always use gofmt","category":"style"}`)
+	err := handler(context.Background(), "update_review_patterns", payload)
+	require.NoError(t, err, "update_review_patterns handler should succeed with valid payload")
+	require.Equal(t, 1, patternStore.createCalls, "should create a new pattern")
+}
+
+func TestUpdateReviewPatternsHandler_UsesJobOrgID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	commentID := uuid.New()
+
+	commentStore := &testFeedbackCommentStore{}
+	patternStore := &testFeedbackPatternStore{}
+	feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+
+	services := &Services{Feedback: feedbackService}
+	handler := newUpdateReviewPatternsHandler(services, zerolog.Nop())
+
+	ctx := withJobOrgID(context.Background(), orgID)
+	payload := json.RawMessage(`{"comment_id":"` + commentID.String() + `","repo":"org/repo","rule":"always use gofmt","category":"style"}`)
+	err := handler(ctx, "update_review_patterns", payload)
+	require.NoError(t, err, "update_review_patterns should succeed using org ID from context")
+	require.Equal(t, 1, patternStore.createCalls, "should create a new pattern")
+}
+
+// ---------------------------------------------------------------------------
+// hasServiceHandlersDependencies tests
+// ---------------------------------------------------------------------------
+
+func TestHasServiceHandlersDependencies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		services *Services
+		expected bool
+	}{
+		{
+			name:     "nil services returns false",
+			services: nil,
+			expected: false,
+		},
+		{
+			name:     "empty services returns false",
+			services: &Services{},
+			expected: false,
+		},
+		{
+			name: "missing Orchestrator returns false",
+			services: &Services{
+				Validation:      &validation.Service{},
+				PR:              &ghservice.PRService{},
+				Failure:         &agent.FailureService{},
+				SandboxProvider: &stubSandboxProvider{},
+			},
+			expected: false,
+		},
+		{
+			name: "missing Validation returns false",
+			services: &Services{
+				Orchestrator:    &agent.Orchestrator{},
+				PR:              &ghservice.PRService{},
+				Failure:         &agent.FailureService{},
+				SandboxProvider: &stubSandboxProvider{},
+			},
+			expected: false,
+		},
+		{
+			name: "missing PR returns false",
+			services: &Services{
+				Orchestrator:    &agent.Orchestrator{},
+				Validation:      &validation.Service{},
+				Failure:         &agent.FailureService{},
+				SandboxProvider: &stubSandboxProvider{},
+			},
+			expected: false,
+		},
+		{
+			name: "missing Failure returns false",
+			services: &Services{
+				Orchestrator:    &agent.Orchestrator{},
+				Validation:      &validation.Service{},
+				PR:              &ghservice.PRService{},
+				SandboxProvider: &stubSandboxProvider{},
+			},
+			expected: false,
+		},
+		{
+			name: "missing SandboxProvider returns false",
+			services: &Services{
+				Orchestrator: &agent.Orchestrator{},
+				Validation:   &validation.Service{},
+				PR:           &ghservice.PRService{},
+				Failure:      &agent.FailureService{},
+			},
+			expected: false,
+		},
+		{
+			name: "all present returns true",
+			services: &Services{
+				Orchestrator:    &agent.Orchestrator{},
+				Validation:      &validation.Service{},
+				PR:              &ghservice.PRService{},
+				Failure:         &agent.FailureService{},
+				SandboxProvider: &stubSandboxProvider{},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := hasServiceHandlersDependencies(tt.services)
+			require.Equal(t, tt.expected, result, "hasServiceHandlersDependencies should return expected result")
+		})
+	}
+}
+
+// stubSandboxProvider satisfies the agent.SandboxProvider interface for testing hasServiceHandlersDependencies.
+type stubSandboxProvider struct{}
+
+func (s *stubSandboxProvider) Name() string { return "stub" }
+func (s *stubSandboxProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+	return nil, nil
+}
+func (s *stubSandboxProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoURL, branch, token string) error {
+	return nil
+}
+func (s *stubSandboxProvider) Exec(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+	return 0, nil
+}
+func (s *stubSandboxProvider) ReadFile(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error) {
+	return nil, nil
+}
+func (s *stubSandboxProvider) WriteFile(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error {
+	return nil
+}
+func (s *stubSandboxProvider) Destroy(ctx context.Context, sb *agent.Sandbox) error {
+	return nil
+}
+func (s *stubSandboxProvider) ConnectionInfo(ctx context.Context, sb *agent.Sandbox) (*agent.SandboxConnectionInfo, error) {
+	return nil, nil
+}
+
+// ---------------------------------------------------------------------------
+// RegisterHandlers with full services tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterHandlers_WithAllServices(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	services := &Services{
+		Orchestrator:    &agent.Orchestrator{},
+		Validation:      &validation.Service{},
+		PR:              &ghservice.PRService{},
+		Failure:         &agent.FailureService{},
+		SandboxProvider: &stubSandboxProvider{},
+		Prioritization:  &prioritization.Service{},
+		Feedback:        feedback.NewService(&testFeedbackCommentStore{}, &testFeedbackPatternStore{}, &testFeedbackJobStore{}, nil, zerolog.Nop()),
+		PM:              &mockPMService{},
+	}
+
+	w := New(nil, logger, "test-node")
+	RegisterHandlers(w, stores, services, logger)
+
+	allExpected := []string{
+		"ingest_webhook",
+		"sync_sentry",
+		"prioritize",
+		"pm_analyze",
+		"run_agent",
+		"validate",
+		"open_pr",
+		"analyze_failure",
+		"process_review_comment",
+		"update_review_patterns",
+	}
+	for _, name := range allExpected {
+		_, ok := w.handlers[name]
+		require.True(t, ok, "%s handler should be registered when all services are provided", name)
+	}
+}
+
+func TestRegisterHandlers_WithOnlyPrioritization(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	services := &Services{
+		Prioritization: &prioritization.Service{},
+	}
+
+	w := New(nil, logger, "test-node")
+	RegisterHandlers(w, stores, services, logger)
+
+	_, ok := w.handlers["prioritize"]
+	require.True(t, ok, "prioritize handler should be registered")
+	_, ok = w.handlers["run_agent"]
+	require.False(t, ok, "run_agent handler should not be registered without orchestrator dependencies")
+	_, ok = w.handlers["process_review_comment"]
+	require.False(t, ok, "process_review_comment handler should not be registered without feedback service")
+}
+
+func TestRegisterHandlers_WithOnlyFeedback(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	feedbackService := feedback.NewService(&testFeedbackCommentStore{}, &testFeedbackPatternStore{}, &testFeedbackJobStore{}, nil, zerolog.Nop())
+	services := &Services{
+		Feedback: feedbackService,
+	}
+
+	w := New(nil, logger, "test-node")
+	RegisterHandlers(w, stores, services, logger)
+
+	_, ok := w.handlers["process_review_comment"]
+	require.True(t, ok, "process_review_comment handler should be registered")
+	_, ok = w.handlers["update_review_patterns"]
+	require.True(t, ok, "update_review_patterns handler should be registered")
+	_, ok = w.handlers["prioritize"]
+	require.False(t, ok, "prioritize handler should not be registered without prioritization service")
+}
+
+func TestRegisterHandlers_WithOnlyPM(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	services := &Services{
+		PM: &mockPMService{},
+	}
+
+	w := New(nil, logger, "test-node")
+	RegisterHandlers(w, stores, services, logger)
+
+	_, ok := w.handlers["pm_analyze"]
+	require.True(t, ok, "pm_analyze handler should be registered")
+	_, ok = w.handlers["prioritize"]
+	require.False(t, ok, "prioritize handler should not be registered without prioritization service")
+}
+
+// ---------------------------------------------------------------------------
+// Additional PMAnalyze handler tests
+// ---------------------------------------------------------------------------
+
+func TestPMAnalyzeHandler_InvalidTrigger(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	pmSvc := &mockPMService{}
+	services := &Services{PM: pmSvc}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	orgID := uuid.New()
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","trigger":"invalid_trigger"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.Error(t, err, "pm_analyze handler should return error for invalid trigger")
+	require.Contains(t, err.Error(), "invalid trigger", "error should mention invalid trigger")
+}
+
+func TestPMAnalyzeHandler_WithRepoID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	pmSvc := &mockPMService{}
+	services := &Services{PM: pmSvc}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","trigger":"manual","repo_id":"` + repoID.String() + `"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.NoError(t, err, "pm_analyze handler should succeed with repo ID")
+	require.Equal(t, orgID, pmSvc.calledOrgID, "should pass org ID through")
+	require.Equal(t, models.PMTriggerManual, pmSvc.trigger, "should pass manual trigger through")
+}
+
+func TestPMAnalyzeHandler_InvalidRepoID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	pmSvc := &mockPMService{}
+	services := &Services{PM: pmSvc}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	orgID := uuid.New()
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","trigger":"cron","repo_id":"not-a-uuid"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.Error(t, err, "pm_analyze handler should return error for invalid repo ID")
+	require.Contains(t, err.Error(), "parse repo ID", "error should mention repo ID")
+}
+
+func TestPMAnalyzeHandler_DefaultTrigger(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	pmSvc := &mockPMService{}
+	services := &Services{PM: pmSvc}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	orgID := uuid.New()
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.NoError(t, err, "pm_analyze handler should succeed with default trigger")
+	require.Equal(t, models.PMTriggerCron, pmSvc.trigger, "empty trigger should default to cron")
+}
+
+func TestPMAnalyzeHandler_MissingOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	pmSvc := &mockPMService{}
+	services := &Services{PM: pmSvc}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	payload := json.RawMessage(`{"trigger":"cron"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.Error(t, err, "pm_analyze handler should return error when org ID is missing")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+type mockPMServiceError struct{}
+
+func (m *mockPMServiceError) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.PMTrigger, repoID *uuid.UUID) (*pm.Plan, error) {
+	return nil, errors.New("pm analysis failed")
+}
+
+func TestPMAnalyzeHandler_ServiceError(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	services := &Services{PM: &mockPMServiceError{}}
+	handler := newPMAnalyzeHandler(stores, services, logger)
+
+	orgID := uuid.New()
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","trigger":"cron"}`)
+	err := handler(context.Background(), "pm_analyze", payload)
+	require.Error(t, err, "pm_analyze handler should return error when service fails")
+	require.Contains(t, err.Error(), "pm analysis failed", "error should contain service error message")
+}
+
+// ---------------------------------------------------------------------------
+// Additional ProcessReviewComment handler tests
+// ---------------------------------------------------------------------------
+
+func TestProcessReviewCommentHandler_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	feedbackService := feedback.NewService(&testFeedbackCommentStore{}, &testFeedbackPatternStore{}, &testFeedbackJobStore{}, nil, zerolog.Nop())
+	services := &Services{Feedback: feedbackService}
+
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	err := handler(context.Background(), "process_review_comment", json.RawMessage(`{bad`))
+	require.Error(t, err, "should return error for invalid JSON")
+	require.Contains(t, err.Error(), "unmarshal process_review_comment payload", "error should indicate unmarshal failure")
+}
+
+func TestProcessReviewCommentHandler_InvalidOrgID(t *testing.T) {
+	t.Parallel()
+
+	feedbackService := feedback.NewService(&testFeedbackCommentStore{}, &testFeedbackPatternStore{}, &testFeedbackJobStore{}, nil, zerolog.Nop())
+	services := &Services{Feedback: feedbackService}
+
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	payload := json.RawMessage(`{"comment_id":"` + uuid.New().String() + `","org_id":"not-a-uuid"}`)
+	err := handler(context.Background(), "process_review_comment", payload)
+	require.Error(t, err, "should return error for invalid org ID")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestProcessReviewCommentHandler_InvalidCommentID(t *testing.T) {
+	t.Parallel()
+
+	feedbackService := feedback.NewService(&testFeedbackCommentStore{}, &testFeedbackPatternStore{}, &testFeedbackJobStore{}, nil, zerolog.Nop())
+	services := &Services{Feedback: feedbackService}
+
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	payload := json.RawMessage(`{"comment_id":"not-a-uuid","org_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "process_review_comment", payload)
+	require.Error(t, err, "should return error for invalid comment ID")
+	require.Contains(t, err.Error(), "parse comment ID", "error should mention comment ID")
+}
+
+func TestProcessReviewCommentHandler_WithPendingComment(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	commentID := uuid.New()
+	rule := "Always validate required input fields"
+	category := "nit"
+
+	callCount := 0
+	commentStore := &testFeedbackCommentStore{
+		getByIDFn: func(ctx context.Context, gotOrgID, gotCommentID uuid.UUID) (models.ReviewComment, error) {
+			callCount++
+			return models.ReviewComment{
+				ID:              gotCommentID,
+				OrgID:           gotOrgID,
+				FilterStatus:    "pending",
+				Generalizable:   true,
+				GeneralizedRule: &rule,
+				Category:        &category,
+			}, nil
+		},
+	}
+	patternStore := &testFeedbackPatternStore{}
+	feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+
+	services := &Services{Feedback: feedbackService}
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	payload := json.RawMessage(`{"comment_id":"` + commentID.String() + `","org_id":"` + orgID.String() + `","repo":"org/repo"}`)
+
+	err := handler(context.Background(), "process_review_comment", payload)
+	require.NoError(t, err, "handler should succeed for pending comment")
+	require.Equal(t, 1, patternStore.createCalls, "should create a new pattern for pending generalizable comment")
+}
+
+func TestProcessReviewCommentHandler_NoRepoSkipsPatterns(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	commentID := uuid.New()
+
+	commentStore := &testFeedbackCommentStore{
+		getByIDFn: func(ctx context.Context, gotOrgID, gotCommentID uuid.UUID) (models.ReviewComment, error) {
+			return models.ReviewComment{
+				ID:           gotCommentID,
+				OrgID:        gotOrgID,
+				FilterStatus: "pending",
+			}, nil
+		},
+	}
+	patternStore := &testFeedbackPatternStore{}
+	feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+
+	services := &Services{Feedback: feedbackService}
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	payload := json.RawMessage(`{"comment_id":"` + commentID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(context.Background(), "process_review_comment", payload)
+	require.NoError(t, err, "handler should succeed without repo")
+	require.Equal(t, 0, patternStore.createCalls, "should not create patterns when no repo is provided")
+}
+
+func TestProcessReviewCommentHandler_GetCommentError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	commentID := uuid.New()
+
+	commentStore := &testFeedbackCommentStore{
+		getByIDFn: func(ctx context.Context, gotOrgID, gotCommentID uuid.UUID) (models.ReviewComment, error) {
+			return models.ReviewComment{}, errors.New("db connection lost")
+		},
+	}
+	patternStore := &testFeedbackPatternStore{}
+	feedbackService := feedback.NewService(commentStore, patternStore, &testFeedbackJobStore{}, nil, zerolog.Nop())
+
+	services := &Services{Feedback: feedbackService}
+	handler := newProcessReviewCommentHandler(services, zerolog.Nop())
+	payload := json.RawMessage(`{"comment_id":"` + commentID.String() + `","org_id":"` + orgID.String() + `","repo":"org/repo"}`)
+
+	err := handler(context.Background(), "process_review_comment", payload)
+	require.Error(t, err, "handler should return error when get comment fails")
+}
+
+// ---------------------------------------------------------------------------
+// Additional validate, open_pr, analyze_failure, run_agent handler tests
+// ---------------------------------------------------------------------------
+
+func TestValidateHandler_SessionFetchError(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("session not found"))
+
+	handler := newValidateHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "validate", payload)
+	require.Error(t, err, "validate handler should return error when session fetch fails")
+	require.Contains(t, err.Error(), "fetch agent run", "error should mention run fetch")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestValidateHandler_InvalidOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newValidateHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + uuid.New().String() + `","org_id":"not-a-uuid"}`)
+	err := handler(context.Background(), "validate", payload)
+	require.Error(t, err, "validate handler should return error for invalid org ID")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestValidateHandler_InvalidRunID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newValidateHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"not-a-uuid","org_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "validate", payload)
+	require.Error(t, err, "validate handler should return error for invalid run ID")
+	require.Contains(t, err.Error(), "parse agent run ID", "error should mention run ID")
+}
+
+func TestValidateHandler_MissingOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newValidateHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "validate", payload)
+	require.Error(t, err, "validate handler should return error when org ID is missing from payload and context")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestOpenPRHandler_InvalidOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newOpenPRHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + uuid.New().String() + `","org_id":"not-a-uuid"}`)
+	err := handler(context.Background(), "open_pr", payload)
+	require.Error(t, err, "open_pr handler should return error for invalid org ID")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestOpenPRHandler_InvalidRunID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newOpenPRHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"not-a-uuid","org_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "open_pr", payload)
+	require.Error(t, err, "open_pr handler should return error for invalid run ID")
+	require.Contains(t, err.Error(), "parse agent run ID", "error should mention run ID")
+}
+
+func TestAnalyzeFailureHandler_InvalidOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newAnalyzeFailureHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + uuid.New().String() + `","org_id":"not-a-uuid"}`)
+	err := handler(context.Background(), "analyze_failure", payload)
+	require.Error(t, err, "analyze_failure handler should return error for invalid org ID")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestAnalyzeFailureHandler_InvalidRunID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newAnalyzeFailureHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"not-a-uuid","org_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "analyze_failure", payload)
+	require.Error(t, err, "analyze_failure handler should return error for invalid run ID")
+	require.Contains(t, err.Error(), "parse agent run ID", "error should mention run ID")
+}
+
+func TestRunAgentHandler_MissingOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	handler := newRunAgentHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + uuid.New().String() + `"}`)
+	err := handler(context.Background(), "run_agent", payload)
+	require.Error(t, err, "run_agent handler should return error when org ID is missing")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestRunAgentHandler_FetchRunError(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("session not found"))
+
+	handler := newRunAgentHandler(stores, nil, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "run_agent", payload)
+	require.Error(t, err, "run_agent handler should return error when session fetch fails")
+	require.Contains(t, err.Error(), "fetch agent run", "error should mention run fetch")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// ---------------------------------------------------------------------------
+// parseOrgID additional tests
+// ---------------------------------------------------------------------------
+
+func TestParseOrgID_FromPayload(t *testing.T) {
+	t.Parallel()
+
+	expected := uuid.New()
+	got, err := parseOrgID(expected.String(), context.Background())
+	require.NoError(t, err, "parseOrgID should succeed with valid UUID")
+	require.Equal(t, expected, got, "should return parsed UUID")
+}
+
+func TestParseOrgID_InvalidPayloadUUID(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOrgID("not-a-uuid", context.Background())
+	require.Error(t, err, "parseOrgID should fail for invalid UUID")
+}
+
+func TestParseOrgID_FromContext(t *testing.T) {
+	t.Parallel()
+
+	expected := uuid.New()
+	ctx := withJobOrgID(context.Background(), expected)
+	got, err := parseOrgID("", ctx)
+	require.NoError(t, err, "parseOrgID should succeed with org ID in context")
+	require.Equal(t, expected, got, "should return org ID from context")
+}
+
+func TestParseOrgID_MissingEverywhere(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseOrgID("", context.Background())
+	require.Error(t, err, "parseOrgID should fail when org ID is missing from both payload and context")
+	require.Contains(t, err.Error(), "missing org ID", "error should indicate missing org ID")
+}
+
+// ---------------------------------------------------------------------------
+// Sync sentry handler: list integrations DB error
+// ---------------------------------------------------------------------------
+
+func TestSyncSentryHandler_ListIntegrationsError(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	logger := zerolog.Nop()
+
+	orgID := uuid.New()
+	mock.ExpectQuery("SELECT .* FROM integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("db error"))
+
+	handler := newSyncSentryHandler(stores, logger)
+	payload := json.RawMessage(`{"org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "sync_sentry", payload)
+	require.Error(t, err, "sync_sentry handler should return error when list integrations fails")
+	require.Contains(t, err.Error(), "list sentry integrations", "error should mention listing integrations")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// ---------------------------------------------------------------------------
+// Prioritize handler: uses org ID from context
+// ---------------------------------------------------------------------------
+
+func TestPrioritizeHandler_MissingOrgID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	issueID := uuid.New()
+	handler := newPrioritizeHandler(stores, &Services{}, zerolog.Nop())
+
+	payload := json.RawMessage(`{"issue_id":"` + issueID.String() + `"}`)
+	err := handler(context.Background(), "prioritize", payload)
+	require.Error(t, err, "prioritize handler should fail when org ID is missing")
+	require.Contains(t, err.Error(), "parse org ID", "error should mention org ID")
+}
+
+func TestPrioritizeHandler_InvalidIssueID(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	handler := newPrioritizeHandler(stores, &Services{}, zerolog.Nop())
+
+	payload := json.RawMessage(`{"issue_id":"not-a-uuid","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "prioritize", payload)
+	require.Error(t, err, "prioritize handler should fail for invalid issue ID")
+	require.Contains(t, err.Error(), "parse issue ID", "error should mention issue ID")
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -427,6 +427,9 @@ func TestWorker_RetryJob_BackoffCalculation(t *testing.T) {
 		{name: "2^2 = 4 seconds", attempt: 2, expectedSec: 4},
 		{name: "2^3 = 8 seconds", attempt: 3, expectedSec: 8},
 		{name: "2^5 = 32 seconds", attempt: 5, expectedSec: 32},
+		{name: "2^10 = 1024 seconds (cap)", attempt: 10, expectedSec: 1024},
+		{name: "attempt 11 capped at 2^10 = 1024 seconds", attempt: 11, expectedSec: 1024},
+		{name: "attempt 20 capped at 2^10 = 1024 seconds", attempt: 20, expectedSec: 1024},
 	}
 
 	for _, tt := range tests {
@@ -437,7 +440,11 @@ func TestWorker_RetryJob_BackoffCalculation(t *testing.T) {
 			defer mock.Close()
 
 			jobID := uuid.New()
-			expectedBackoff := time.Duration(1<<uint(tt.attempt)) * time.Second
+			exp := tt.attempt
+			if exp > 10 {
+				exp = 10
+			}
+			expectedBackoff := time.Duration(1<<uint(exp)) * time.Second
 			require.Equal(t, tt.expectedSec, int(expectedBackoff.Seconds()), "backoff formula should produce expected seconds")
 
 			intervalStr := fmt.Sprintf("%d seconds", tt.expectedSec)


### PR DESCRIPTION
## Summary

Adds comprehensive tests for lower-coverage packages to meet 70% minimum threshold. Backend coverage increased from 69.6% to 78.2%.

**Coverage improvements:**
- github service: 46.7% → 85.1% (+38.4%)
- agent/adapters: 56.7% → 98.2% (+41.5%)
- pm service: 57.6% → 91.0% (+33.4%)
- worker: 61.8% → 78.8% (+17.0%)

## Test coverage

- **github**: PR event handlers (merge, close, review), PR creation, and revision push flows
- **adapters**: Stream output parsing for Claude Code, Codex, and Gemini CLI adapters with error paths
- **pm**: Project analysis, task dispatch, context gathering, and plan execution logic
- **worker**: Event handler registration and job retry backoff

All tests pass with race detector enabled.