### PR TITLE
Rename agent settings page to 'Coding Agent'

### DIFF
--- a/frontend/src/app/(dashboard)/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/agent/page.tsx
@@ -75,8 +75,8 @@ export default function AgentPage() {
     <PageContainer size="default">
       <div className="space-y-6">
       <PageHeader
-        title="Agent"
-        description="Configure how the AI agent runs and behaves."
+        title="Coding Agent"
+        description="Configure how the coding agent runs and behaves."
       />
 
       {/* Agent Setup / Credentials */}
@@ -85,8 +85,8 @@ export default function AgentPage() {
         <Card>
           <CardContent>
             <AgentSettingsEditor
-              title="Agent provider & credentials"
-              description="Choose your default agent and configure provider API keys."
+              title="Coding agent provider & credentials"
+              description="Choose your default coding agent and configure provider API keys."
             />
           </CardContent>
         </Card>

--- a/frontend/src/components/agent-settings-editor.tsx
+++ b/frontend/src/components/agent-settings-editor.tsx
@@ -183,7 +183,7 @@ export function AgentSettingsEditor({
       </div>
 
       <div className="space-y-3">
-        <Label>Default Agent</Label>
+        <Label>Default Coding Agent</Label>
         <RadioGroup
           value={defaultAgentType}
           onValueChange={(value) => setDefaultAgentTypeOverride(value as OrgSettings["default_agent_type"])}

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -184,7 +184,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/agent")}>
                   <Bot className="h-4 w-4" />
-                  Agent
+                  Coding Agent
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/llm")}>
                   <Sparkles className="h-4 w-4" />


### PR DESCRIPTION
## Summary
Updated UI labels from 'Agent' to 'Coding Agent' throughout the settings page to distinguish the coding agent configuration from the LLM settings page.

## Changes
- Page title and description updated to reference 'Coding Agent'
- Navigation dropdown menu item renamed
- Settings section headers and labels updated

This improves clarity about what the settings on this page control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)