### PR TITLE
Show connected GitHub repos on integrations page

### DIFF
--- a/frontend/src/app/(dashboard)/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/integrations/page.tsx
@@ -11,6 +11,10 @@ export default function IntegrationsPage() {
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
   });
+  const { data: reposResp } = useQuery({
+    queryKey: ["repositories"],
+    queryFn: () => api.repositories.list(),
+  });
   const githubIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "github" && integration.status === "active"
   );
@@ -21,6 +25,10 @@ export default function IntegrationsPage() {
     (integration) => integration.provider === "linear" && integration.status === "active"
   );
 
+  const connectedRepoNames = (reposResp?.data ?? [])
+    .filter((r) => r.status === "active")
+    .map((r) => r.full_name);
+
   return (
     <PageContainer size="default">
       <div className="space-y-6">
@@ -30,6 +38,7 @@ export default function IntegrationsPage() {
         />
       <AllIntegrationCards
         githubConnected={Boolean(githubIntegration)}
+        githubRepoNames={connectedRepoNames}
         sentryConnected={Boolean(sentryIntegration)}
         linearConnected={Boolean(linearIntegration)}
         linearLoading={false}

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -48,6 +48,31 @@ describe("integration connection cards", () => {
     expect(onConnectLinear).toHaveBeenCalledTimes(1);
   });
 
+  it("shows connected repo names when GitHub is connected", () => {
+    renderWithProviders(
+      <SourceControlIntegrationCard
+        githubConnected
+        githubRepoNames={["acme/api", "acme/web"]}
+        onConnectGitHub={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("acme/api")).toBeInTheDocument();
+    expect(screen.getByText("acme/web")).toBeInTheDocument();
+  });
+
+  it("does not show repo names when GitHub is not connected", () => {
+    renderWithProviders(
+      <SourceControlIntegrationCard
+        githubConnected={false}
+        githubRepoNames={["acme/api"]}
+        onConnectGitHub={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("acme/api")).not.toBeInTheDocument();
+  });
+
   it("disables Linear connect when already connected", () => {
     renderWithProviders(
       <AllIntegrationCards

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -6,6 +6,7 @@ import { getIntegrationByKey } from "@/lib/integrations";
 
 type SourceControlIntegrationCardProps = {
   githubConnected: boolean;
+  githubRepoNames?: string[];
   onConnectGitHub: () => void;
 };
 
@@ -18,6 +19,22 @@ type AdditionalIntegrationCardsProps = {
 };
 
 type AllIntegrationCardsProps = SourceControlIntegrationCardProps & AdditionalIntegrationCardsProps;
+
+function ConnectedReposList({ repoNames }: { repoNames: string[] }) {
+  if (repoNames.length === 0) return null;
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-1.5">
+      {repoNames.map((name) => (
+        <span
+          key={name}
+          className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+        >
+          {name}
+        </span>
+      ))}
+    </div>
+  );
+}
 
 function IntegrationLogo({ name, src }: { name: string; src: string }) {
   return (
@@ -34,7 +51,7 @@ function IntegrationLogo({ name, src }: { name: string; src: string }) {
   );
 }
 
-export function SourceControlIntegrationCard({ githubConnected, onConnectGitHub }: SourceControlIntegrationCardProps) {
+export function SourceControlIntegrationCard({ githubConnected, githubRepoNames = [], onConnectGitHub }: SourceControlIntegrationCardProps) {
   const github = getIntegrationByKey("github");
 
   return (
@@ -46,6 +63,7 @@ export function SourceControlIntegrationCard({ githubConnected, onConnectGitHub 
           description: github.description,
           logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
+          extra: githubConnected ? <ConnectedReposList repoNames={githubRepoNames} /> : undefined,
           action: (
             <Button
               size="sm"
@@ -120,6 +138,7 @@ export function AllIntegrationCards({
   onConnectSentry,
   onConnectLinear,
   githubConnected,
+  githubRepoNames = [],
   sentryConnected,
   linearConnected,
   linearLoading,
@@ -137,6 +156,7 @@ export function AllIntegrationCards({
           description: github.description,
           logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
+          extra: githubConnected ? <ConnectedReposList repoNames={githubRepoNames} /> : undefined,
           action: (
             <Button
               size="sm"

--- a/frontend/src/components/integrations-card.tsx
+++ b/frontend/src/components/integrations-card.tsx
@@ -8,6 +8,7 @@ type IntegrationsCardItem = {
   action: ReactNode;
   logo?: ReactNode;
   badge?: ReactNode;
+  extra?: ReactNode;
 };
 
 type IntegrationsCardProps = {
@@ -28,6 +29,7 @@ export function IntegrationsCard({ items }: IntegrationsCardProps) {
                   {item.badge}
                 </div>
                 <p className="mt-0.5 text-sm text-muted-foreground">{item.description}</p>
+                {item.extra}
               </div>
             </div>
             <div className="shrink-0">{item.action}</div>


### PR DESCRIPTION
## Summary
Shows connected GitHub repository names as pills on the integrations settings page instead of just "Connected". Users can now clearly see which repos are integrated at a glance.

## Changes
- Fetch active repositories on the integrations page and pass them to the GitHub card
- Add `extra` field to integration card items for supplementary content
- Display repo names as styled pills below the GitHub description when connected
- Add tests verifying repos display only when GitHub is connected

## Test plan
- Verify GitHub card shows repo name pills when connected
- Verify repo names don't display when GitHub is not connected