### PR TITLE
Fix connected count to reflect completed setup stages

### DIFF
--- a/frontend/src/app/(dashboard)/overview/page.test.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.test.tsx
@@ -88,7 +88,7 @@ describe('OverviewPage', () => {
   it('renders the progress indicator', () => {
     renderWithProviders(<Overview />);
 
-    expect(screen.getByText(/of 4 connected/)).toBeInTheDocument();
+    expect(screen.getByText(/of 2 connected/)).toBeInTheDocument();
   });
 
   it('shows a single coding agent card with dropdown defaulting to Codex', async () => {

--- a/frontend/src/app/(dashboard)/overview/page.tsx
+++ b/frontend/src/app/(dashboard)/overview/page.tsx
@@ -234,13 +234,11 @@ export default function Overview() {
     (integration) => integration.provider === "linear" && integration.status === "active"
   );
 
-  // Count connected steps (agent + GitHub required; sentry/linear optional but counted)
+  // Count completed setup stages (step 1: coding agent, step 2: integrations)
   const connectedCount =
     (agentConnected ? 1 : 0) +
-    (githubIntegration ? 1 : 0) +
-    (sentryIntegration ? 1 : 0) +
-    (linearIntegration ? 1 : 0);
-  const totalCount = 4;
+    (githubIntegration ? 1 : 0);
+  const totalCount = 2;
   const allRequiredConnected = agentConnected && Boolean(githubIntegration);
 
   return (


### PR DESCRIPTION
Change the progress counter from 'X of 4' to 'X of 2' to show only completed setup stages (coding agent + GitHub) instead of counting all individual integrations. This aligns with the actual setup flow where optional integrations (Sentry, Linear) don't affect the completion status.

The progress bar now accurately reflects the 2-step onboarding process rather than inflating the count with optional integrations.