### PR TITLE
Clean up frontpage copy for engineers

### DIFF
--- a/frontend/src/components/landing/cta-section.tsx
+++ b/frontend/src/components/landing/cta-section.tsx
@@ -15,27 +15,22 @@ export default function CtaSection({ isDark }: CtaSectionProps) {
         background: isDark ? "#08080f" : "#d4e6f5",
       }}
     >
-      <div className="text-center max-w-2xl space-y-6">
+      <div className="text-center max-w-2xl space-y-5">
         <h2
-          className={`text-3xl sm:text-4xl md:text-5xl font-light leading-tight tracking-tight ${
+          className={`text-2xl sm:text-3xl font-light tracking-tight ${
             isDark ? "text-white" : "text-slate-900"
           }`}
         >
-          Connect your repos.
-          <br />
-          Set your priorities.
-          <br />
-          Let the PM handle the rest.
+          Start building
         </h2>
         <p
           className={`text-sm leading-relaxed max-w-md mx-auto ${
             isDark ? "text-white/45" : "text-slate-600"
           }`}
         >
-          Bring your repos, your coding agents, and your CI pipeline. The PM
-          dispatches validated PRs on your behalf.
+          Connect your repos and your favorite coding agents.
         </p>
-        <div className="pt-2">
+        <div>
           <Button
             asChild
             className={`rounded-full px-8 py-3 text-sm font-medium transition-all ${

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -49,9 +49,8 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <p
             className={`max-w-md text-sm leading-relaxed ${isDark ? "text-white/45" : "text-slate-600"}`}
           >
-            Finds bugs worth fixing and breaks down your projects.
-            Ships the work to Claude Code, Codex, or any coding
-            agent your team runs.
+            Fix bugs and ship projects automatically. Works with
+            Claude Code, Codex, or any coding agent.
           </p>
 
           <div className="pt-2 pointer-events-auto">

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -499,9 +499,9 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                 Everything Connects
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Sentry errors, Linear tickets, support threads, and your product
-                roadmap &mdash; the PM sees your entire production surface in one
-                place.
+                Sentry errors, Linear tickets, Slack threads, your product
+                roadmap. The PM watches all of it so your team doesn&rsquo;t have
+                to.
               </p>
             </div>
             <div className="md:w-1/2 w-full max-w-[400px] md:max-w-none relative">
@@ -541,9 +541,8 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                 Goes back to sleep.
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Every few hours the PM scans for the highest-impact issues,
-                dispatches your coding agents, and ships validated PRs. No prompt
-                needed.
+                The PM scans for bugs on a loop, sends them to your coding
+                agents, and opens PRs when CI passes. No prompt needed.
               </p>
             </div>
             <div className="md:w-1/2 relative">
@@ -572,7 +571,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                   <div className="w-2.5 h-2.5 rounded-full bg-[#febc2e]" />
                   <div className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
                   <span className="ml-3 text-xs font-mono text-white/25">
-                    pm-agent &mdash; loop
+                    pm-agent · loop
                   </span>
                 </div>
                 <TerminalContent progress={termProgress} />
@@ -601,9 +600,8 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                 The PM chips away.
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Define an initiative and the PM breaks it into sequenced tasks.
-                Set priorities in plain language and it balances across bugs,
-                projects, and tech debt.
+                Describe what you want built and the PM breaks it into tasks.
+                It works through them one by one, opening PRs as it goes.
               </p>
             </div>
             <div className="md:w-1/2 relative">
@@ -655,7 +653,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                       isDark ? "text-white/20" : "text-slate-400"
                     }`}
                   >
-                    &ldquo;focus on auth this sprint&rdquo; &rarr; PM rebalances
+                    &ldquo;focus on auth this sprint&rdquo;
                   </p>
                 </div>
               </div>
@@ -678,14 +676,14 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Each engineer picks
+                Cloud agents for
                 <br />
-                their own agent
+                the whole team
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Claude Code, Codex, Gemini CLI &mdash; the PM dispatches the
-                task, your agent builds it, your CI validates it. Different
-                engineers can use different agents on the same team.
+                Agents run in the cloud, so anyone on your team can use them.
+                Each engineer picks their own, whether it&rsquo;s Claude Code,
+                Codex, or Gemini CLI.
               </p>
             </div>
             <div className="md:w-1/2 relative">


### PR DESCRIPTION
Remove emdashes and passive voice from landing page. Hero now leads with imperative copy: "Fix bugs and ship projects automatically." Step 01 switches from corporate-sounding "entire production surface" to direct "watches all of it." Steps 02–03 use plain language instead of AI-ish phrases like "dispatches validated PRs." Step 04 reframes around shared cloud agents for the team rather than individual agent choice. Final CTA simplified from 3-line header to "Start building" with short description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)