### PR TITLE
Standardize landing page secondary headings to sentence case and consistent sizing

### DIFF
--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -496,7 +496,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Everything Connects
+                Everything connects
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
                 Sentry errors, Linear tickets, Slack threads, your product

--- a/frontend/src/components/landing/story-section.tsx
+++ b/frontend/src/components/landing/story-section.tsx
@@ -507,7 +507,7 @@ export default function StorySection({ isDark }: StorySectionProps) {
                   Why 143
                 </p>
                 <h2
-                  className={`text-3xl sm:text-4xl md:text-[2.75rem] font-light leading-[1.15] tracking-tight ${heading}`}
+                  className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
                 >
                   Fast doesn&rsquo;t mean
                   <br />


### PR DESCRIPTION
- Change "Everything Connects" to "Everything connects" for sentence case
- Normalize story section h2 from text-3xl/4xl to text-2xl/3xl to match all other secondary headings

https://claude.ai/code/session_01EPMzEgvarhcyztd1Gsy7Ak