### PR TITLE
Surface PM job failures in status API and UI

### DIFF
--- a/frontend/src/components/pm/pm-status-banner.test.tsx
+++ b/frontend/src/components/pm/pm-status-banner.test.tsx
@@ -21,6 +21,7 @@ vi.mock("lucide-react", () => {
     RefreshCw: icon("RefreshCw"),
     Plus: icon("Plus"),
     Activity: icon("Activity"),
+    AlertTriangle: icon("AlertTriangle"),
     CheckCircle2: icon("CheckCircle2"),
     XCircle: icon("XCircle"),
     Clock: icon("Clock"),
@@ -179,6 +180,35 @@ describe("PMStatusBanner", () => {
     const user = userEvent.setup();
     await user.click(screen.getByText("dismiss"));
     expect(dismissError).toHaveBeenCalled();
+  });
+
+  it("shows job failure error from PM status", async () => {
+    mockUseAnalyze.mockReturnValue(defaultAnalyze());
+
+    server.use(
+      http.get("*/api/v1/pm/status", () => {
+        return HttpResponse.json({
+          data: {
+            is_running: false,
+            last_run_status: "",
+            issues_reviewed: 0,
+            success_rate: 0,
+            success_count: 0,
+            total_delegated: 0,
+            last_error: "no repositories configured for org",
+            last_failed_at: new Date().toISOString(),
+          },
+        });
+      })
+    );
+
+    renderWithProviders(<PMStatusBanner hasActivePlanSession={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Last run failed")).toBeInTheDocument();
+    });
+    expect(screen.getByText("no repositories configured for org")).toBeInTheDocument();
+    expect(screen.getByText("Attention needed")).toBeInTheDocument();
   });
 
   it("renders Manual Session link", () => {

--- a/frontend/src/components/pm/pm-status-banner.tsx
+++ b/frontend/src/components/pm/pm-status-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { RefreshCw, Plus, Clock, Activity } from "lucide-react";
+import { RefreshCw, Plus, Clock, Activity, AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
@@ -41,6 +41,7 @@ function StatusDot({ status }: { status: "running" | "completed" | "failed" | "i
 
 function deriveAgentStatus(pmStatus: PMStatus | undefined, isAnalyzing: boolean): "running" | "completed" | "failed" | "idle" {
   if (isAnalyzing || pmStatus?.is_running) return "running";
+  if (pmStatus?.last_error) return "failed";
   if (!pmStatus?.last_run_status) return "idle";
   if (pmStatus.last_run_status === "completed" || pmStatus.last_run_status === "executing") return "completed";
   if (pmStatus.last_run_status === "failed") return "failed";
@@ -140,6 +141,19 @@ export function PMStatusBanner({ hasActivePlanSession }: PMStatusBannerProps) {
         <div className="flex items-center justify-between rounded-md bg-red-50 dark:bg-red-950/30 px-3 py-2">
           <p className="text-xs text-red-700 dark:text-red-300">{analyzeError}</p>
           <button onClick={dismissError} className="text-xs text-red-500 hover:text-red-700 ml-2">dismiss</button>
+        </div>
+      )}
+
+      {!analyzeError && pmStatus?.last_error && (
+        <div className="flex items-start gap-2 rounded-md bg-red-50 dark:bg-red-950/30 px-3 py-2">
+          <AlertTriangle className="h-3.5 w-3.5 text-red-500 mt-0.5 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-medium text-red-700 dark:text-red-300">Last run failed</p>
+            <p className="text-xs text-red-600 dark:text-red-400 mt-0.5">{pmStatus.last_error}</p>
+            {pmStatus.last_failed_at && (
+              <p className="text-[11px] text-red-500/70 dark:text-red-400/60 mt-0.5">{formatTimeAgo(pmStatus.last_failed_at)}</p>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -337,6 +337,8 @@ export interface PMStatus {
   success_count: number;
   total_delegated: number;
   next_run_in?: string;
+  last_error?: string;
+  last_failed_at?: string;
 }
 
 export interface SessionsListResponse {

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -154,6 +154,19 @@ func (h *PMHandler) Status(w http.ResponseWriter, r *http.Request) {
 		status.IsRunning = latestPlan.Status == models.PMPlanStatusExecuting
 	}
 
+	// Check for recent failed pm_analyze jobs. If the latest failed job is more
+	// recent than the latest plan, surface the error so the user understands
+	// why the PM agent isn't producing results.
+	failedJob, err := h.jobStore.GetLatestFailedByType(r.Context(), orgID, "pm_analyze")
+	if err == nil && failedJob != nil {
+		// Only show the error if it's newer than the last successful plan.
+		showError := status.LastRunAt == nil || failedJob.UpdatedAt.After(*status.LastRunAt)
+		if showError {
+			status.LastError = &failedJob.LastError
+			status.LastFailedAt = &failedJob.UpdatedAt
+		}
+	}
+
 	// Get decision success rate.
 	summary, err := h.decisionLogStore.GetDecisionSummary(r.Context(), orgID)
 	if err == nil {

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -177,6 +177,11 @@ func TestPMHandler_Status(t *testing.T) {
 				),
 		)
 
+	// Mock GetLatestFailedByType — no recent failures.
+	mock.ExpectQuery("SELECT id, last_error, updated_at FROM jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "last_error", "updated_at"}))
+
 	// Mock GetDecisionSummary query.
 	mock.ExpectQuery("SELECT").
 		WithArgs(pgxmock.AnyArg()).
@@ -199,6 +204,68 @@ func TestPMHandler_Status(t *testing.T) {
 	require.Equal(t, 14, resp.Data.IssuesReviewed, "should show issues reviewed from last plan")
 	require.Equal(t, 11, resp.Data.SuccessCount, "should show success count")
 	require.Equal(t, 15, resp.Data.TotalDelegated, "should show total delegated")
+	require.Nil(t, resp.Data.LastError, "should have no error when no recent failures")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPMHandler_StatusWithJobError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	decisionLogStore := db.NewPMDecisionLogStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+
+	orgID := uuid.New()
+	now := time.Now()
+	failedAt := now.Add(5 * time.Minute) // Failed after the last plan
+
+	// Mock GetLatestByOrg — has a previous successful plan.
+	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(pmPlanColumnsWithContext).
+				AddRow(uuid.New(), orgID, "completed", "analysis",
+					json.RawMessage(`[]`), json.RawMessage(`[]`), json.RawMessage(`[]`),
+					5, 0, 0, 0, 0, 0,
+					json.RawMessage(`{}`), json.RawMessage(`{}`), "cron",
+					now, &now,
+				),
+		)
+
+	// Mock GetLatestFailedByType — has a recent failure newer than the plan.
+	mock.ExpectQuery("SELECT id, last_error, updated_at FROM jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "last_error", "updated_at"}).
+				AddRow(uuid.New(), "no repositories configured for org", failedAt),
+		)
+
+	// Mock GetDecisionSummary query.
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"total_delegated", "succeeded", "failed", "still_open"}).
+				AddRow(0, 0, 0, 0),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/status", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.Status(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "should return OK")
+
+	var resp models.SingleResponse[models.PMStatus]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
+	require.NotNil(t, resp.Data.LastError, "should include job error")
+	require.Equal(t, "no repositories configured for org", *resp.Data.LastError, "should contain the error message")
+	require.NotNil(t, resp.Data.LastFailedAt, "should include failure timestamp")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -14,6 +15,37 @@ type JobStore struct {
 
 func NewJobStore(db DBTX) *JobStore {
 	return &JobStore{db: db}
+}
+
+// LatestJobError holds the error and timestamp from the most recent failed job.
+type LatestJobError struct {
+	JobID     uuid.UUID
+	LastError string
+	UpdatedAt time.Time
+}
+
+// GetLatestFailedByType returns the most recent failed or dead_letter job for the given org and job type.
+// Returns nil, nil if no failed job exists.
+func (s *JobStore) GetLatestFailedByType(ctx context.Context, orgID uuid.UUID, jobType string) (*LatestJobError, error) {
+	query := `
+		SELECT id, last_error, updated_at
+		FROM jobs
+		WHERE org_id = @org_id AND job_type = @job_type AND status IN ('failed', 'dead_letter')
+		ORDER BY updated_at DESC
+		LIMIT 1`
+
+	var result LatestJobError
+	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"org_id":   orgID,
+		"job_type": jobType,
+	}).Scan(&result.JobID, &result.LastError, &result.UpdatedAt)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &result, nil
 }
 
 func (s *JobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {

--- a/internal/models/pm.go
+++ b/internal/models/pm.go
@@ -74,4 +74,6 @@ type PMStatus struct {
 	SuccessCount   int        `json:"success_count"`
 	TotalDelegated int        `json:"total_delegated"`
 	NextRunIn      *string    `json:"next_run_in,omitempty"`
+	LastError      *string    `json:"last_error,omitempty"`
+	LastFailedAt   *time.Time `json:"last_failed_at,omitempty"`
 }

--- a/migrations/000018_jobs_failure_lookup.down.sql
+++ b/migrations/000018_jobs_failure_lookup.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_jobs_org_type_failed;

--- a/migrations/000018_jobs_failure_lookup.up.sql
+++ b/migrations/000018_jobs_failure_lookup.up.sql
@@ -1,0 +1,4 @@
+-- Index to efficiently look up the most recent failed job by org and type.
+-- Used by the PM status endpoint to surface job errors in the UI.
+CREATE INDEX idx_jobs_org_type_failed ON jobs (org_id, job_type, updated_at DESC)
+    WHERE status IN ('failed', 'dead_letter');


### PR DESCRIPTION
## Summary
- Added `GetLatestFailedByType()` method to query the most recent failed/dead_letter job for a given org and job type
- Extended `PMStatus` model with `last_error` and `last_failed_at` fields to surface job-level failures
- Updated PM Status endpoint to check for recent failed pm_analyze jobs and only show the error if it's newer than the last successful plan
- Added database index on `(org_id, job_type, updated_at DESC) WHERE status IN ('failed', 'dead_letter')` for efficient lookup
- Updated frontend to display job errors in a red banner with error message and timestamp

## Why
When pm_analyze jobs fail before creating a plan (e.g., "no repositories configured for org"), the error was only visible in server logs. Now users see the failure immediately in the UI.

## Test Plan
- Unit tests for both success and failure paths in PM Status handler
- Frontend tests verify error display and proper status derivation
- Migration creates index for query performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)