### PR TITLE
Mount Docker socket to server container for sandbox creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - go_mod_cache:/go/pkg/mod
       - go_build_cache:/root/.cache/go-build
       - go_bin_cache:/go/bin  # cache compiled binaries (e.g. air) across restarts
+      - /var/run/docker.sock:/var/run/docker.sock  # allow server to create sandbox containers
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Allows the server container to create sandbox containers by mounting the host's Docker daemon socket at /var/run/docker.sock. This fixes the 'Cannot connect to the Docker daemon' error that occurs when trying to spawn sandbox containers.