### PR TITLE
Display next automatic PM agent run time in sessions page

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -235,7 +235,7 @@ export function SessionsPageContent() {
             </div>
             <p className="mt-4 text-[13px] font-medium text-foreground">No sessions yet</p>
             <p className="mt-1 max-w-sm text-center text-[13px] text-muted-foreground">
-              Click <span className="font-medium text-foreground">Run PM agent</span> to review your issues and create sessions, or start a <span className="font-medium text-foreground">manual session</span> to fix a specific issue.
+              The PM agent runs automatically on a schedule. Click <span className="font-medium text-foreground">Run now</span> above to start it immediately, or create a <span className="font-medium text-foreground">manual session</span> for a specific issue.
             </p>
             <div className="flex items-center gap-2 mt-4">
               <Button variant="outline" size="sm" asChild>

--- a/frontend/src/components/pm/pm-status-banner.test.tsx
+++ b/frontend/src/components/pm/pm-status-banner.test.tsx
@@ -25,6 +25,7 @@ vi.mock("lucide-react", () => {
     CheckCircle2: icon("CheckCircle2"),
     XCircle: icon("XCircle"),
     Clock: icon("Clock"),
+    Timer: icon("Timer"),
   };
 });
 
@@ -52,7 +53,7 @@ describe("PMStatusBanner", () => {
       expect(screen.getByText("PM Agent")).toBeInTheDocument();
     });
     expect(screen.getByText("Idle")).toBeInTheDocument();
-    expect(screen.getByText("Run PM agent")).toBeInTheDocument();
+    expect(screen.getByText("Run now")).toBeInTheDocument();
   });
 
   it("renders running state", () => {
@@ -140,6 +141,33 @@ describe("PMStatusBanner", () => {
 
     await waitFor(() => {
       expect(screen.getByText("10 reviewed")).toBeInTheDocument();
+    });
+  });
+
+  it("shows next automatic run time", async () => {
+    mockUseAnalyze.mockReturnValue(defaultAnalyze());
+
+    server.use(
+      http.get("*/api/v1/pm/status", () => {
+        return HttpResponse.json({
+          data: {
+            is_running: false,
+            last_run_at: "2026-03-01T10:00:00Z",
+            last_run_status: "completed",
+            issues_reviewed: 5,
+            next_run_in: "in 2h 30m",
+            success_rate: 0,
+            success_count: 0,
+            total_delegated: 0,
+          },
+        });
+      })
+    );
+
+    renderWithProviders(<PMStatusBanner hasActivePlanSession={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Next run in 2h 30m")).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/pm/pm-status-banner.tsx
+++ b/frontend/src/components/pm/pm-status-banner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { RefreshCw, Plus, Clock, Activity } from "lucide-react";
+import { RefreshCw, Plus, Clock, Activity, Timer } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
@@ -115,6 +115,12 @@ export function PMStatusBanner({ hasActivePlanSession }: PMStatusBannerProps) {
                 {pmStatus.issues_reviewed} reviewed
               </span>
             )}
+            {pmStatus.next_run_in && (
+              <span className="flex items-center gap-1">
+                <Timer className="h-3 w-3" />
+                Next run {pmStatus.next_run_in}
+              </span>
+            )}
           </div>
         )}
 
@@ -130,9 +136,10 @@ export function PMStatusBanner({ hasActivePlanSession }: PMStatusBannerProps) {
             className="h-7 text-[12px]"
             onClick={handleAnalyze}
             disabled={isPending || isAnalyzing}
+            title="Run the PM agent now without waiting for the next scheduled run"
           >
             <RefreshCw className={`mr-1 h-3 w-3 ${isPending || isAnalyzing ? "animate-spin" : ""}`} />
-            {isPending ? "Starting..." : isAnalyzing ? "Running..." : "Run PM agent"}
+            {isPending ? "Starting..." : isAnalyzing ? "Running..." : "Run now"}
           </Button>
         </div>
       </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -337,6 +337,7 @@ export interface PMStatus {
   success_count: number;
   total_delegated: number;
   next_run_in?: string;
+  next_run_at?: string;
   last_error?: string;
   last_failed_at?: string;
 }

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -1,7 +1,10 @@
 package handlers
 
 import (
+	"fmt"
+	"math"
 	"net/http"
+	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
@@ -14,10 +17,11 @@ type PMHandler struct {
 	planStore        *db.PMPlanStore
 	decisionLogStore *db.PMDecisionLogStore
 	jobStore         *db.JobStore
+	orgStore         *db.OrganizationStore
 }
 
-func NewPMHandler(planStore *db.PMPlanStore, decisionLogStore *db.PMDecisionLogStore, jobStore *db.JobStore) *PMHandler {
-	return &PMHandler{planStore: planStore, decisionLogStore: decisionLogStore, jobStore: jobStore}
+func NewPMHandler(planStore *db.PMPlanStore, decisionLogStore *db.PMDecisionLogStore, jobStore *db.JobStore, orgStore *db.OrganizationStore) *PMHandler {
+	return &PMHandler{planStore: planStore, decisionLogStore: decisionLogStore, jobStore: jobStore, orgStore: orgStore}
 }
 
 // Analyze enqueues a PM analysis job.
@@ -177,11 +181,35 @@ func (h *PMHandler) Status(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Estimate next run from org settings (pm_schedule_hours).
+	// Compute next automatic run time from org settings (pm_schedule_hours).
 	if status.LastRunAt != nil && !status.IsRunning {
-		// Default schedule is 4 hours; compute approximate next run.
-		nextRunIn := "in ~4h"
-		status.NextRunIn = &nextRunIn
+		scheduleHours := models.DefaultPMScheduleHours
+		if h.orgStore != nil {
+			org, err := h.orgStore.GetByID(r.Context(), orgID)
+			if err == nil {
+				settings := models.ParseOrgSettings(org.Settings)
+				scheduleHours = settings.PMScheduleHours
+			}
+		}
+
+		nextRunAt := status.LastRunAt.Add(time.Duration(scheduleHours) * time.Hour)
+		status.NextRunAt = &nextRunAt
+
+		remaining := time.Until(nextRunAt)
+		if remaining <= 0 {
+			nextRunIn := "soon"
+			status.NextRunIn = &nextRunIn
+		} else {
+			hours := int(math.Floor(remaining.Hours()))
+			mins := int(math.Floor(remaining.Minutes())) % 60
+			var nextRunIn string
+			if hours > 0 {
+				nextRunIn = fmt.Sprintf("in %dh %dm", hours, mins)
+			} else {
+				nextRunIn = fmt.Sprintf("in %dm", mins)
+			}
+			status.NextRunIn = &nextRunIn
+		}
 	}
 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PMStatus]{Data: status})

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -34,7 +34,7 @@ func TestPMHandler_AnalyzeEnqueuesJob(t *testing.T) {
 	jobStore := db.NewJobStore(mock)
 	planStore := db.NewPMPlanStore(mock)
 	decisionLogStore := db.NewPMDecisionLogStore(mock)
-	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
 
 	orgID := uuid.New()
 	jobID := uuid.New()
@@ -64,7 +64,7 @@ func TestPMHandler_ListPlans(t *testing.T) {
 	jobStore := db.NewJobStore(mock)
 	planStore := db.NewPMPlanStore(mock)
 	decisionLogStore := db.NewPMDecisionLogStore(mock)
-	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
 
 	orgID := uuid.New()
 	now := time.Now()
@@ -102,7 +102,7 @@ func TestPMHandler_Decisions(t *testing.T) {
 	planStore := db.NewPMPlanStore(mock)
 	decisionLogStore := db.NewPMDecisionLogStore(mock)
 	jobStore := db.NewJobStore(mock)
-	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
 
 	orgID := uuid.New()
 	planID := uuid.New()
@@ -159,7 +159,7 @@ func TestPMHandler_Status(t *testing.T) {
 	planStore := db.NewPMPlanStore(mock)
 	decisionLogStore := db.NewPMDecisionLogStore(mock)
 	jobStore := db.NewJobStore(mock)
-	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
 
 	orgID := uuid.New()
 	now := time.Now()
@@ -218,7 +218,7 @@ func TestPMHandler_StatusWithJobError(t *testing.T) {
 	planStore := db.NewPMPlanStore(mock)
 	decisionLogStore := db.NewPMDecisionLogStore(mock)
 	jobStore := db.NewJobStore(mock)
-	handler := NewPMHandler(planStore, decisionLogStore, jobStore)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
 
 	orgID := uuid.New()
 	now := time.Now()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -118,7 +118,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		orgStore,
 		jobStore,
 	)
-	pmHandler := handlers.NewPMHandler(pmPlanStore, pmDecisionLogStore, jobStore)
+	pmHandler := handlers.NewPMHandler(pmPlanStore, pmDecisionLogStore, jobStore, orgStore)
 	priorityHandler := handlers.NewPriorityHandler(priorityScoreStore, complexityEstimateStore, jobStore)
 	ingestionWebhookHandler := handlers.NewIngestionWebhookHandler(webhookDeliveryStore, integrationStore, credentialStore, ingestionSvc, logger)
 	credentialHandler := handlers.NewCredentialHandler(credentialStore)

--- a/internal/models/pm.go
+++ b/internal/models/pm.go
@@ -74,6 +74,7 @@ type PMStatus struct {
 	SuccessCount   int        `json:"success_count"`
 	TotalDelegated int        `json:"total_delegated"`
 	NextRunIn      *string    `json:"next_run_in,omitempty"`
+	NextRunAt      *time.Time `json:"next_run_at,omitempty"`
 	LastError      *string    `json:"last_error,omitempty"`
 	LastFailedAt   *time.Time `json:"last_failed_at,omitempty"`
 }


### PR DESCRIPTION
Show when the PM agent will automatically run next in the status banner,
computed from the last run time and org pm_schedule_hours setting. Rename
the "Run PM agent" button to "Run now" to make it clear users can kick
off a new job immediately without waiting for the schedule.

https://claude.ai/code/session_01WjBV4m9zrpHcT8wy7H74Vw