### PR TITLE
Design: Repository-scoped navigation with sidebar ribbons

### DIFF
--- a/docs/brainstorm-repo-organization.md
+++ b/docs/brainstorm-repo-organization.md
@@ -22,13 +22,14 @@ Today, all sessions and projects live in a single flat list. As users connect mo
 
 ## User Personas to Consider
 
-| Persona | Repos | Session Volume | Primary Need |
-|---------|-------|---------------|--------------|
-| **Solo dev, single repo** | 1 | Low-medium | Simplicity. No overhead from repo organization. |
-| **Solo dev, multi-repo** | 3-8 | Medium | Quick switching between repos. Clear separation. |
-| **Small team, monorepo** | 1 | High | Status-based filtering is more important than repo filtering. |
-| **Small team, multi-repo** | 5-15 | High | Repo-scoped views. Possibly different team members own different repos. |
-| **Org/enterprise, many repos** | 15-50+ | Very high | Must have repo scoping or it's unusable. Search, favorites, recent repos. |
+> **Key insight (updated 2025-03-15):** Most users will realistically have **1-2 repos**. Power users may reach **3-5 repos**. Having 6+ repos is a rare outlier, not a design target. This dramatically changes which approaches make sense — we should optimize for what feels great at 1-2 repos and still works at 5, rather than designing for 50.
+
+| Persona | Repos | % of Users (est.) | Session Volume | Primary Need |
+|---------|-------|--------------------|---------------|--------------|
+| **Solo dev, single repo** | 1 | ~50% | Low-medium | Simplicity. Zero overhead from repo organization. |
+| **Solo dev or small team, 2 repos** | 2 | ~25% | Medium | Clear separation without ceremony. See both at a glance. |
+| **Multi-repo user** | 3-5 | ~20% | Medium-high | Quick switching, ambient awareness across repos. |
+| **Heavy multi-repo (outlier)** | 6+ | ~5% | High | Scalable navigation. But we should NOT over-index on this persona. |
 
 ---
 
@@ -71,7 +72,7 @@ Left Nav:
 - Collapse repos by default, expand on click
 - Truncate long repo names with tooltip on hover
 
-**Verdict:** Strong for 2-8 repo users. Needs escape hatches for 1-repo and 15+ repo users.
+**Verdict:** **Strong — now the top recommendation.** With a realistic max of ~5 repos, the scaling concern (the main knock against this approach) evaporates. Five repos with nested Sessions/Projects fits comfortably in a sidebar. For 1-repo users, simply don't show the repo section — their experience is unchanged. This is the sweet spot for the actual user base.
 
 ---
 
@@ -112,7 +113,7 @@ Sessions Page:
 - Add a "sticky" repo filter that persists across Sessions ↔ Projects navigation
 - Show repo counts in the dropdown so users can spot active repos quickly
 
-**Verdict:** Safe, scalable, low-risk. But less powerful for users who live in multi-repo workflows.
+**Verdict:** **Weakened by the repo count reality.** A dropdown filter is overkill for 2-3 repos — it's an extra click to open a menu that shows two items. It hides repos behind an interaction when you could just show them all in the nav. This approach screams "enterprise software" when the reality is much simpler. Still viable as a secondary mechanism on list pages, but not recommended as the primary approach.
 
 ---
 
@@ -153,7 +154,7 @@ Left Nav:
 - Show a subtle "viewing 3 of 12 sessions (filtered to repo-a)" message
 - Keyboard shortcut to toggle scope (Cmd+K style repo switcher)
 
-**Verdict:** Best for power users and teams. Clean UX. But risks "where did my stuff go?" confusion if not carefully communicated.
+**Verdict:** **Over-abstracted for the typical user.** A dropdown that toggles between "repo-a" and "repo-b" works but feels like ceremony — you can see both repos at once in the nav, so why hide one behind a selector? The "where did my stuff go?" risk is real and the payoff (hiding 1-4 other repos) isn't worth the UX cost. Not recommended as primary approach.
 
 ---
 
@@ -198,7 +199,7 @@ Repo-A Dashboard:
 - Auto-redirect single-repo users directly to their repo dashboard
 - Add quick-action buttons on cards (e.g., "View active sessions" badge is clickable)
 
-**Verdict:** Excellent for situational awareness. Works best as a complement to another approach, not standalone.
+**Verdict:** **Not recommended.** With only 1-2 repos, a dashboard of repo cards is a useless landing page showing one or two cards. The drill-down adds navigation depth (3 clicks to a session) for no real benefit. Even at 5 repos, the Overview page can surface this information more efficiently inline rather than as a dedicated card grid.
 
 ---
 
@@ -235,7 +236,7 @@ Repo-A Dashboard:
 - Overflow menu for additional repos
 - Tab order reflects recency or activity
 
-**Verdict:** Fast and familiar, but adds UI complexity. Better suited as a feature within Sessions/Projects pages rather than a global concept.
+**Verdict:** **Not recommended.** At 2-5 repos the tabs work visually, but they create two competing navigation axes (tabs for repos + sidebar for sections) that are confusing. The sidebar ribbons (Idea 1) give the same one-click switching without the cognitive overhead of a second nav layer.
 
 ---
 
@@ -267,7 +268,7 @@ Repo-A Dashboard:
 - Smooth transitions between tiers (e.g., animate in the repo filter)
 - Feature flags for early adopters
 
-**Verdict:** Best long-term UX philosophy, but higher engineering cost and test surface.
+**Verdict:** **Interesting but unnecessary.** The progressive tiers (1 repo, 2-5, 6+, 15+) are elegant in theory, but if 95% of users land in the 1-5 range, you're building and maintaining 4 UI modes for a distribution that barely spans two of them. The simpler approach: build one UI that works for 1-5 (Idea 1 with auto-hide for single repo) and don't worry about the other tiers until real usage demands it.
 
 ---
 
@@ -310,39 +311,81 @@ Sessions Page (repo-a selected):
 - Two mental models to learn (global scope vs. inline groups)
 - URL/state management is more involved
 
-**Verdict:** Highest ceiling. This is the "Linear/Notion" approach — powerful but polished.
+**Verdict:** **Over-engineered for the actual user base.** This is the "Linear/Notion" approach and it's powerful, but it's solving for a scale that doesn't exist. Two mental models (global scope vs. inline groups), complex state management, and a repo switcher dropdown — all to manage 2-3 repos. The nav ribbons (Idea 1) give you the same scoping with far less machinery.
 
 ---
 
 ## Recommendation
 
-### For MVP (ship fast, learn):
+> **Updated 2025-03-15** — Revised based on the insight that most users have 1-2 repos, with a realistic ceiling of ~5. The original recommendation (filter dropdown + repo switcher) was over-built for this reality.
 
-**Go with Idea 2 (Filter/Group-By) + lightweight elements of Idea 3 (Repo Switcher).**
+### Primary Recommendation: Idea 1 (Repo Ribbons in Left Nav)
 
-Specifically:
-1. Add a **repo filter dropdown** to both Sessions and Projects pages, next to existing status filters
-2. When a repo is selected, **persist it in URL params** (`?repo=repo-id`) using the existing `nuqs` setup
-3. In "All repos" mode, add **repo badges** on each session/project row (the `full_name` from the repository)
-4. Optionally add a **"Group by repo"** toggle that sections the list by repo with collapsible headers
-5. On the **Overview page**, add per-repo summary cards showing active session count, project count, and health status
+**Go with Idea 1 (Repo Ribbons)** as the primary and likely only approach needed.
 
-This gives you:
-- **Zero overhead** for single-repo users (dropdown shows one option, badges are redundant, so hide both)
-- **Useful filtering** for multi-repo users
-- **Low implementation cost** (you already have repo data on projects via `repository_id`, and sessions via their linked issues)
-- **Data to inform the next step** (track which repos people filter to most, whether they use group-by, etc.)
+The main concern with nav ribbons was always scaling — but that concern evaporates when the realistic max is 5 repos. Five repos with nested Sessions/Projects is ~15 lines of sidebar nav, which is completely comfortable.
 
-### For V2 (after learning from MVP):
+#### How it works by repo count:
 
-If usage data shows that users frequently filter to one repo and stay there, upgrade to **Idea 7 (Hybrid)** with a proper global repo switcher in the sidebar. This is a natural evolution: the filter dropdown graduates to a first-class navigation element.
+**For 1 repo (majority of users):**
+- No change to current UI whatsoever
+- No repo section in the nav
+- Sessions and Projects show everything (already scoped to one repo implicitly)
+- These users never even know repo organization exists
 
-If usage data shows users prefer the birds-eye view, lean into **Idea 4 (Repo Cards)** on the Overview page and keep the flat lists with filters on Sessions/Projects.
+**For 2-5 repos:**
+- Repos appear in the sidebar below the main nav items
+- Each repo expands/collapses to show Sessions and Projects counts
+- Clicking a repo's Sessions shows a scoped list
+- Top-level "Sessions" and "Projects" nav items remain as the "all repos" view
+- Status dots/counts on each repo give ambient awareness without clicking
 
-### What I'd avoid:
+```
+├── Overview
+├── Sessions (7)         ← all repos
+├── Projects (4)         ← all repos
+├── ─────────────
+├── owner/repo-a    ● 3
+│   ├── Sessions
+│   └── Projects
+├── owner/repo-b      1
+│   ├── Sessions
+│   └── Projects
+```
 
-- **Idea 1 (Nav Ribbons)** as the primary approach — it front-loads complexity and doesn't scale. Fine as a complement for pinned/favorite repos later.
-- **Idea 5 (Tabs)** — creates two competing navigation axes and is hard to evolve.
+The status dots and counts give ambient awareness ("repo-a has 3 active sessions, one needs attention") without clicking into anything.
+
+**On the list pages themselves:** Add a subtle repo badge on each session/project row so users in the "all repos" view can tell which repo an item belongs to. No dropdown filter needed — the nav handles scoping.
+
+#### Why this wins now:
+
+- **Simplest possible change** for the actual user base
+- **Zero overhead** for single-repo users (auto-hidden)
+- **One-click scoping** for multi-repo users (no dropdown ceremony)
+- **Ambient awareness** across repos without navigating anywhere
+- **Familiar pattern** (GitHub sidebar, Slack channels, VS Code explorer)
+- **Low implementation cost** — just nav items with filtered list views
+- **No complex state management** — scoping is just a route/URL, not global state
+
+### What I would NOT recommend (given ~1-5 repos reality):
+
+| Idea | Why it's now a poor fit |
+|------|------------------------|
+| **Idea 2: Filter Dropdown** | Overkill. A dropdown that shows 2 items feels like enterprise software. Hides repos behind an interaction when you could just show them all. |
+| **Idea 3: Global Repo Switcher** | Over-abstracted. A selector toggling between 2 repos is ceremony, not efficiency. You can see both repos in the nav — why hide one? Also risks "where did my stuff go?" confusion. |
+| **Idea 4: Repo Cards Dashboard** | A dashboard showing 1-2 cards is a useless landing page. Adds navigation depth for no benefit. |
+| **Idea 5: Tabs/Workspaces** | Creates two competing navigation axes. The sidebar ribbons give the same one-click switching without the cognitive overhead. |
+| **Idea 6: Progressive Disclosure** | Building 4 UI modes for a distribution that barely spans 2 of them. Just build one UI that works for 1-5. |
+| **Idea 7: Hybrid Switcher + Grouping** | Two mental models, complex state management, and a repo switcher dropdown — all to manage 2-3 repos. The nav ribbons give the same scoping with far less machinery. |
+
+### If we're wrong about repo counts:
+
+If usage data eventually shows a meaningful segment of users with 6+ repos, the nav ribbons degrade gracefully:
+- Add a **"pinned repos"** concept so users curate which repos appear expanded
+- Collapse non-pinned repos into a compact list
+- Add a small search/filter within the repo section
+
+This is a natural evolution of Idea 1, not a rewrite. But don't build it until the data says you need it.
 
 ---
 

--- a/docs/brainstorm-repo-organization.md
+++ b/docs/brainstorm-repo-organization.md
@@ -1,0 +1,377 @@
+# Brainstorm: Organizing Sessions & Projects by Repository
+
+**Date:** 2025-03-15
+**Status:** Brainstorm / RFC
+
+---
+
+## Problem Statement
+
+Today, all sessions and projects live in a single flat list. As users connect more repositories, these lists become noisy and hard to navigate. Users need a way to focus on work relevant to a specific repo without losing the ability to see everything at once.
+
+---
+
+## Current State
+
+- **Sessions** are listed flat with status-based filter tabs (All, Active, Needs Guidance, Failed, Done, Decisions). When "All" is selected, they group automatically by status. Sessions link to repos indirectly through issues.
+- **Projects** are listed flat with status-based filter tabs (All, Active, Scheduled, Draft, Completed, Paused). Projects link directly to a `repository_id`.
+- **Left Nav** has three main items: Overview, Sessions, Projects. No repo awareness.
+- **Repo Settings** exist at `/repositories/[id]` but are admin/config pages, not navigational anchors.
+
+---
+
+## User Personas to Consider
+
+| Persona | Repos | Session Volume | Primary Need |
+|---------|-------|---------------|--------------|
+| **Solo dev, single repo** | 1 | Low-medium | Simplicity. No overhead from repo organization. |
+| **Solo dev, multi-repo** | 3-8 | Medium | Quick switching between repos. Clear separation. |
+| **Small team, monorepo** | 1 | High | Status-based filtering is more important than repo filtering. |
+| **Small team, multi-repo** | 5-15 | High | Repo-scoped views. Possibly different team members own different repos. |
+| **Org/enterprise, many repos** | 15-50+ | Very high | Must have repo scoping or it's unusable. Search, favorites, recent repos. |
+
+---
+
+## Ideas
+
+### Idea 1: Repo Ribbons in Left Nav (User's Idea A)
+
+**Concept:** Add a list of connected repositories in the left sidebar. Each repo expands to show its own Sessions and Projects sub-nav items. Clicking "Sessions" under "repo-x" shows only sessions for that repo.
+
+```
+Left Nav:
+├── Overview
+├── Sessions (all)
+├── Projects (all)
+├── ─────────────
+├── owner/repo-a
+│   ├── Sessions
+│   └── Projects
+├── owner/repo-b
+│   ├── Sessions
+│   └── Projects
+└── Settings ▾
+```
+
+**Pros:**
+- Always visible, one-click access to any repo's work
+- Familiar pattern (GitHub, GitLab, Slack channels)
+- Clear mental model: "I'm looking at repo X's stuff"
+- Status indicators (pinging dots) can be per-repo, giving at-a-glance awareness
+
+**Cons:**
+- Doesn't scale past ~8-10 repos without scrolling or collapsing
+- Adds visual weight for single-repo users who get no benefit
+- Duplicates nav items (Sessions appears N+1 times)
+- Sidebar width (currently w-64) may feel cramped with long repo names like `organization/my-very-long-repo-name`
+
+**Mitigations:**
+- Auto-hide the repo section when only 1 repo is connected
+- Add a "starred/pinned repos" concept so heavy users can curate
+- Collapse repos by default, expand on click
+- Truncate long repo names with tooltip on hover
+
+**Verdict:** Strong for 2-8 repo users. Needs escape hatches for 1-repo and 15+ repo users.
+
+---
+
+### Idea 2: Repo as Filter/Group-By on List Pages (User's Idea B)
+
+**Concept:** Keep the nav simple. Add a repo filter dropdown or group-by toggle on the Sessions and Projects pages themselves. Similar to how status filtering works today.
+
+```
+Sessions Page:
+┌──────────────────────────────────────────┐
+│ Sessions                                  │
+│ [All] [Active] [Failed] [Done]           │
+│ Repo: [All repos ▾]  ← new filter       │
+│                                          │
+│ ▸ owner/repo-a (3 active)               │
+│   • Session abc...                        │
+│   • Session def...                        │
+│ ▸ owner/repo-b (1 active)               │
+│   • Session ghi...                        │
+└──────────────────────────────────────────┘
+```
+
+**Pros:**
+- Minimal UI change, low implementation cost
+- Composes naturally with existing status filters (repo + status)
+- Zero overhead for single-repo users (filter just doesn't appear or shows one option)
+- Scales to any number of repos (dropdown can search/scroll)
+- Familiar pattern (Jira, Linear, Sentry all do filter-based scoping)
+
+**Cons:**
+- Two clicks to scope (open dropdown, select repo) vs. one click with nav ribbons
+- No cross-page persistence unless repo filter is stored in URL or global state
+- Loses ambient awareness of other repos' status while filtered
+- Group-by repo can create very long pages if many repos have active work
+
+**Mitigations:**
+- Persist selected repo filter in URL params (already using `nuqs` for status)
+- Add a "sticky" repo filter that persists across Sessions ↔ Projects navigation
+- Show repo counts in the dropdown so users can spot active repos quickly
+
+**Verdict:** Safe, scalable, low-risk. But less powerful for users who live in multi-repo workflows.
+
+---
+
+### Idea 3: Repo Switcher (Global Context Selector)
+
+**Concept:** A prominent repo switcher at the top of the sidebar (or in a top bar) that sets a global context. When a repo is selected, ALL pages (Overview, Sessions, Projects) are scoped to that repo. An "All repos" option shows everything.
+
+```
+Left Nav:
+┌─────────────────────┐
+│ [owner/repo-a  ▾]   │  ← global repo selector
+├─────────────────────┤
+│ Overview             │
+│ Sessions             │
+│ Projects             │
+│                      │
+│ Repo Settings        │  ← contextual, shows for selected repo
+└─────────────────────┘
+```
+
+**Pros:**
+- Clean, minimal UI. One control governs everything.
+- Matches mental model of "I'm working on repo X right now"
+- Overview page becomes per-repo dashboard (very powerful)
+- Scales infinitely (selector is a searchable dropdown)
+- Single-repo users never even see it (auto-selects their one repo)
+- Familiar from: Vercel (project switcher), AWS (region selector), Datadog (environment selector)
+
+**Cons:**
+- Hides cross-repo awareness entirely when scoped
+- "All repos" mode needs to be obvious and easy to return to
+- Global state is tricky — URL encoding, deep links, sharing links
+- Users may not realize they're filtered and wonder where sessions went
+
+**Mitigations:**
+- Persist in URL: `/sessions?repo=repo-a` or use path prefix `/repo-a/sessions`
+- Show a colored banner or indicator when scoped to a specific repo
+- Show a subtle "viewing 3 of 12 sessions (filtered to repo-a)" message
+- Keyboard shortcut to toggle scope (Cmd+K style repo switcher)
+
+**Verdict:** Best for power users and teams. Clean UX. But risks "where did my stuff go?" confusion if not carefully communicated.
+
+---
+
+### Idea 4: Repo-First Dashboard (Repo Cards → Drill Down)
+
+**Concept:** The main landing page shows repo cards with summary stats. Clicking a repo drills into a repo-specific view with its sessions, projects, and settings. A breadcrumb or back button returns to the overview.
+
+```
+Overview Page:
+┌──────────────┐  ┌──────────────┐  ┌──────────────┐
+│ owner/repo-a │  │ owner/repo-b │  │ owner/repo-c │
+│              │  │              │  │              │
+│ 3 active     │  │ 1 active     │  │ idle         │
+│ 2 projects   │  │ 0 projects   │  │ 1 project    │
+│ ● running    │  │ ⚠ guidance   │  │ ○ quiet      │
+└──────────────┘  └──────────────┘  └──────────────┘
+
+→ Click "repo-a" →
+
+Repo-A Dashboard:
+├── Sessions (scoped)
+├── Projects (scoped)
+├── Issues
+└── Settings
+```
+
+**Pros:**
+- Gives birds-eye view across all repos at once
+- Natural drill-down flow
+- Each repo becomes a "workspace" with full context
+- Great for checking in on multiple repos quickly ("which repo needs attention?")
+- Could show health indicators, last activity, confidence scores per repo
+
+**Cons:**
+- Adds a navigation layer (overview → repo → sessions/projects)
+- Three clicks to reach a specific session (overview → repo → sessions → session)
+- Doesn't help if user wants to see all sessions across repos at once
+- Single-repo users get a useless overview page with one card
+
+**Mitigations:**
+- Keep top-level Sessions/Projects nav items for cross-repo views
+- Auto-redirect single-repo users directly to their repo dashboard
+- Add quick-action buttons on cards (e.g., "View active sessions" badge is clickable)
+
+**Verdict:** Excellent for situational awareness. Works best as a complement to another approach, not standalone.
+
+---
+
+### Idea 5: Tabs/Workspaces Per Repo
+
+**Concept:** Horizontal tabs at the top of the content area, one per repo. Users can pin repos they care about. Each tab maintains its own scroll position and filter state.
+
+```
+┌─────────────┬─────────────┬─────────────┬─────┐
+│ All repos   │ repo-a      │ repo-b      │  +  │
+└─────────────┴─────────────┴─────────────┴─────┘
+┌──────────────────────────────────────────────────┐
+│ Sessions for repo-a                               │
+│ [All] [Active] [Failed] [Done]                   │
+│ ...                                              │
+└──────────────────────────────────────────────────┘
+```
+
+**Pros:**
+- Very fast switching (single click, always visible)
+- Each tab can maintain independent filter state
+- "All repos" tab always available
+- Browser-tab metaphor is universally understood
+- Can show status indicators on tabs (colored dot, count badge)
+
+**Cons:**
+- Takes up vertical space
+- Doesn't scale past 5-6 tabs visually
+- Interacts awkwardly with Sessions/Projects nav (two axes of navigation)
+- Adds complexity to URL state management
+
+**Mitigations:**
+- Pin/unpin repos to control which tabs appear
+- Overflow menu for additional repos
+- Tab order reflects recency or activity
+
+**Verdict:** Fast and familiar, but adds UI complexity. Better suited as a feature within Sessions/Projects pages rather than a global concept.
+
+---
+
+### Idea 6: Smart Defaults with Progressive Disclosure
+
+**Concept:** Don't force a structure. Instead, use intelligence to surface what matters. Default view is a smart feed sorted by relevance/recency. Repo grouping appears progressively as the user's repo count grows.
+
+```
+1 repo:   Flat list, no repo UI at all
+2-5 repos: Subtle repo badges on items + optional group-by toggle
+6+ repos:  Group-by repo default + repo filter dropdown
+15+ repos: Full repo switcher + search
+```
+
+**Pros:**
+- Zero complexity for new/simple users
+- Adapts to user's actual scale
+- Avoids premature abstraction
+- Each tier builds on the previous one
+
+**Cons:**
+- Inconsistent UI across user segments (support/docs complexity)
+- Users who grow from 1 → 5 repos experience UI shifts
+- Harder to build and test (multiple modes)
+- Power users can't "opt in" to advanced features early
+
+**Mitigations:**
+- Allow manual override in settings ("always show repo organization")
+- Smooth transitions between tiers (e.g., animate in the repo filter)
+- Feature flags for early adopters
+
+**Verdict:** Best long-term UX philosophy, but higher engineering cost and test surface.
+
+---
+
+### Idea 7: Hybrid — Repo Switcher + Inline Grouping
+
+**Concept:** Combine the global repo switcher (Idea 3) with inline repo grouping on list pages (Idea 2). The switcher sets a persistent scope, but in "All repos" mode, items are grouped by repo with collapsible sections.
+
+```
+Left Nav:
+┌─────────────────────┐
+│ [All repos      ▾]  │
+├─────────────────────┤
+│ Overview             │
+│ Sessions (7)         │
+│ Projects (4)         │
+
+Sessions Page (All repos mode):
+│ ▾ owner/repo-a          3 active │
+│   • Session: Fix auth bug    ●   │
+│   • Session: Add tests       ●   │
+│ ▾ owner/repo-b          1 active │
+│   • Session: Update deps     ●   │
+
+Sessions Page (repo-a selected):
+│ [All] [Active] [Failed] [Done]   │
+│ • Session: Fix auth bug      ●   │
+│ • Session: Add tests         ●   │
+│ • Session: Refactor API      ✓   │
+```
+
+**Pros:**
+- Best of both worlds: ambient awareness + focused work
+- "All repos" mode gives cross-repo overview with structure
+- Scoped mode gives clean, focused lists
+- Scales from 1 to 50+ repos
+- Single-repo users: switcher auto-selects, they never think about it
+
+**Cons:**
+- Most complex to implement
+- Two mental models to learn (global scope vs. inline groups)
+- URL/state management is more involved
+
+**Verdict:** Highest ceiling. This is the "Linear/Notion" approach — powerful but polished.
+
+---
+
+## Recommendation
+
+### For MVP (ship fast, learn):
+
+**Go with Idea 2 (Filter/Group-By) + lightweight elements of Idea 3 (Repo Switcher).**
+
+Specifically:
+1. Add a **repo filter dropdown** to both Sessions and Projects pages, next to existing status filters
+2. When a repo is selected, **persist it in URL params** (`?repo=repo-id`) using the existing `nuqs` setup
+3. In "All repos" mode, add **repo badges** on each session/project row (the `full_name` from the repository)
+4. Optionally add a **"Group by repo"** toggle that sections the list by repo with collapsible headers
+5. On the **Overview page**, add per-repo summary cards showing active session count, project count, and health status
+
+This gives you:
+- **Zero overhead** for single-repo users (dropdown shows one option, badges are redundant, so hide both)
+- **Useful filtering** for multi-repo users
+- **Low implementation cost** (you already have repo data on projects via `repository_id`, and sessions via their linked issues)
+- **Data to inform the next step** (track which repos people filter to most, whether they use group-by, etc.)
+
+### For V2 (after learning from MVP):
+
+If usage data shows that users frequently filter to one repo and stay there, upgrade to **Idea 7 (Hybrid)** with a proper global repo switcher in the sidebar. This is a natural evolution: the filter dropdown graduates to a first-class navigation element.
+
+If usage data shows users prefer the birds-eye view, lean into **Idea 4 (Repo Cards)** on the Overview page and keep the flat lists with filters on Sessions/Projects.
+
+### What I'd avoid:
+
+- **Idea 1 (Nav Ribbons)** as the primary approach — it front-loads complexity and doesn't scale. Fine as a complement for pinned/favorite repos later.
+- **Idea 5 (Tabs)** — creates two competing navigation axes and is hard to evolve.
+
+---
+
+## Implementation Considerations
+
+### Data availability
+- **Projects** already have `repository_id` — grouping/filtering is straightforward
+- **Sessions** link to repos through `issue_id → issue.repository_id` — you may need to denormalize `repository_id` onto sessions, or join through issues in the API
+
+### API changes needed
+- Add `repository_id` filter param to `GET /api/v1/sessions`
+- Add `repository_id` filter param to `GET /api/v1/projects` (if not already supported)
+- Consider a `GET /api/v1/repositories/summary` endpoint that returns per-repo counts (active sessions, projects, etc.) for the overview cards
+
+### URL state
+- Extend `nuqs` usage: `?status=active&repo=abc123`
+- Consider using repo `full_name` slug in URL for readability: `?repo=owner/repo-name`
+
+### Performance
+- Repo list should be cached/memoized (it changes rarely)
+- Group-by-repo rendering should use virtualization if >50 items
+- Per-repo counts can be derived client-side from existing list data initially, then moved to a dedicated API if performance becomes an issue
+
+---
+
+## Open Questions
+
+1. Should the repo filter be **cross-page persistent** (selecting repo-a on Sessions also filters Projects)? This is more powerful but adds global state complexity.
+2. Should the **Overview page** become repo-aware? Per-repo dashboards could be very valuable but are a bigger lift.
+3. How do **issues** fit in? Today they're accessed through the PM decisions flow. Should they also be repo-grouped?
+4. Should repo organization also affect **notifications/alerts**? (e.g., "repo-a has a failing session" vs. generic "a session failed")
+5. For teams: should repo scoping intersect with **team member assignment**? (e.g., "show me sessions for repos I own")

--- a/docs/brainstorm-repo-organization.md
+++ b/docs/brainstorm-repo-organization.md
@@ -391,30 +391,12 @@ This is a natural evolution of Idea 1, not a rewrite. But don't build it until t
 
 ## Implementation Considerations
 
-### Data availability
-- **Projects** already have `repository_id` — grouping/filtering is straightforward
-- **Sessions** link to repos through `issue_id → issue.repository_id` — you may need to denormalize `repository_id` onto sessions, or join through issues in the API
-
-### API changes needed
-- Add `repository_id` filter param to `GET /api/v1/sessions`
-- Add `repository_id` filter param to `GET /api/v1/projects` (if not already supported)
-- Consider a `GET /api/v1/repositories/summary` endpoint that returns per-repo counts (active sessions, projects, etc.) for the overview cards
-
-### URL state
-- Extend `nuqs` usage: `?status=active&repo=abc123`
-- Consider using repo `full_name` slug in URL for readability: `?repo=owner/repo-name`
-
-### Performance
-- Repo list should be cached/memoized (it changes rarely)
-- Group-by-repo rendering should use virtualization if >50 items
-- Per-repo counts can be derived client-side from existing list data initially, then moved to a dedicated API if performance becomes an issue
+See [34-repo-ribbons-nav.md](design/34-repo-ribbons-nav.md) for the full PRD with API specs, SQL queries, frontend implementation details, and edge cases.
 
 ---
 
 ## Open Questions
 
-1. Should the repo filter be **cross-page persistent** (selecting repo-a on Sessions also filters Projects)? This is more powerful but adds global state complexity.
-2. Should the **Overview page** become repo-aware? Per-repo dashboards could be very valuable but are a bigger lift.
-3. How do **issues** fit in? Today they're accessed through the PM decisions flow. Should they also be repo-grouped?
-4. Should repo organization also affect **notifications/alerts**? (e.g., "repo-a has a failing session" vs. generic "a session failed")
-5. For teams: should repo scoping intersect with **team member assignment**? (e.g., "show me sessions for repos I own")
+1. How do **issues** fit in? Today they're accessed through the PM decisions flow. Should they also be repo-grouped?
+2. Should repo organization also affect **notifications/alerts**? (e.g., "repo-a has a failing session" vs. generic "a session failed")
+3. For teams: should repo scoping intersect with **team member assignment**? (e.g., "show me sessions for repos I own")

--- a/docs/design/34-repo-ribbons-nav.md
+++ b/docs/design/34-repo-ribbons-nav.md
@@ -91,6 +91,7 @@ Each repo row in the sidebar contains:
   - Pulsing blue: a session for this repo is currently `running`
   - Solid green: most recent session `completed` successfully
   - Solid amber: a session is in `needs_human_guidance` or `awaiting_input`
+  - Solid red: most recent session `failed` or `cancelled`
   - No dot: idle (no recent activity)
 - **Active count:** Number of sessions in `running`, `pending`, `needs_human_guidance`, or `awaiting_input` status. Hidden when 0.
 
@@ -147,6 +148,8 @@ This is the same Sessions page, but filtered to only show sessions linked to tha
 - **"Clear filter" affordance:** A small `×` button or "Viewing repo-name — show all" link at the top of the list, so users can easily return to the unfiltered view.
 
 Same pattern for Projects: `/projects?repo={repository_id}`.
+
+> **Naming note:** The user-facing URL param is `repo` (short, readable). The backend API query param is `repository_id` (matches the DB column). The frontend translates between them: `useQueryState('repo')` provides the value, which is passed as `repository_id` to the API client.
 
 ### 3.4 Overview Page
 
@@ -280,6 +283,8 @@ WHERE r.org_id = @org_id AND r.status = 'active'
 GROUP BY r.id, r.full_name
 ORDER BY active_session_count DESC, r.full_name ASC;
 ```
+
+> **Scaling note:** The `latest_session_status` correlated subquery runs once per repository row. At 5 repos this is negligible, but if repo count grows significantly, rewrite as a window function or `LATERAL JOIN` to avoid per-row scans.
 
 **Caching:** This endpoint is polled alongside PM status (every 30s). At our scale the query is fast, but if needed, results can be cached server-side with a 30s TTL.
 

--- a/docs/design/34-repo-ribbons-nav.md
+++ b/docs/design/34-repo-ribbons-nav.md
@@ -1,0 +1,501 @@
+# 34 - Repo Ribbons: Repository-Scoped Navigation
+
+> Give multi-repo users one-click access to repo-scoped Sessions and Projects in the sidebar, while keeping single-repo users' experience unchanged.
+
+**Status:** Proposal
+**Depends on:** [03-frontend.md](03-frontend.md), [29-projects.md](29-projects.md), [30-pm-agent-ux-elevation.md](30-pm-agent-ux-elevation.md)
+
+---
+
+## 1. Problem
+
+Today, all Sessions and Projects live in flat lists. When a user connects a second repository, their Sessions page shows work from both repos interleaved. There is no way to focus on one repo's work without manually scanning titles, and no ambient visibility into which repos have active or failing sessions.
+
+This matters now because the product is growing beyond single-repo usage — but not by much. Based on expected usage patterns:
+
+| Segment | Repos | Est. % of users |
+|---------|-------|-----------------|
+| Single repo | 1 | ~50% |
+| Two repos | 2 | ~25% |
+| Multi-repo | 3-5 | ~20% |
+| Heavy multi-repo | 6+ | ~5% |
+
+**The key constraint:** most users have 1-2 repos. We need a design that adds zero overhead for single-repo users, feels great at 2-3 repos, and still works at 5. We are explicitly NOT designing for 50-repo enterprise scale — if that becomes real, we'll evolve from this foundation.
+
+---
+
+## 2. Design Principles
+
+1. **Invisible for one** — Single-repo users should see zero change. No repo section, no badges, no new concepts.
+2. **Visible for two+** — The moment a second repo is connected, repo-scoped navigation appears automatically.
+3. **One click, not two** — Scoping to a repo should be a single nav click, not "open dropdown → select repo."
+4. **Ambient awareness** — Users should see which repos have active work without clicking into anything.
+5. **Additive, not restructuring** — The top-level Sessions and Projects nav items stay as "all repos" views. Repo ribbons add scoped shortcuts below them.
+
+---
+
+## 3. What Changes
+
+### 3.1 Sidebar Navigation
+
+When the org has **2+ connected repositories**, a repo section appears in the sidebar below the main nav items, separated by a divider.
+
+**Current sidebar (unchanged for 1 repo):**
+```
+┌──────────────────────────┐
+│  143.dev                 │
+├──────────────────────────┤
+│  Overview                │
+│  Sessions  ●             │
+│  Projects                │
+│                          │
+│  ┌──────────────────┐    │
+│  │ 👤 User ▾        │    │
+│  └──────────────────┘    │
+└──────────────────────────┘
+```
+
+**New sidebar (2+ repos):**
+```
+┌──────────────────────────┐
+│  143.dev                 │
+├──────────────────────────┤
+│  Overview                │
+│  Sessions (7) ●          │  ← all repos, unchanged
+│  Projects (4)            │  ← all repos, unchanged
+│  ────────────────────    │  ← divider (new)
+│  acme/api-server    ● 3  │  ← repo row: name, dot, active count
+│    Sessions              │    ← scoped sub-nav (collapsed by default)
+│    Projects              │
+│  acme/web-app        1   │
+│    Sessions              │
+│    Projects              │
+│                          │
+│  ┌──────────────────┐    │
+│  │ 👤 User ▾        │    │
+│  └──────────────────┘    │
+└──────────────────────────┘
+```
+
+#### Repo row anatomy
+
+Each repo row in the sidebar contains:
+
+```
+[icon] owner/repo-name    [status-dot] [active-count]
+```
+
+- **Icon:** `GitBranch` from lucide-react (14px, muted)
+- **Repo name:** `full_name` from the Repository model, displayed as `owner/repo`. Truncated with `text-ellipsis` if longer than available width; full name shown on hover via `title` attribute.
+- **Status dot:** Same dot system as the Sessions nav item:
+  - Pulsing blue: a session for this repo is currently `running`
+  - Solid green: most recent session `completed` successfully
+  - Solid amber: a session is in `needs_human_guidance` or `awaiting_input`
+  - No dot: idle (no recent activity)
+- **Active count:** Number of sessions in `running`, `pending`, `needs_human_guidance`, or `awaiting_input` status. Hidden when 0.
+
+#### Expand/collapse behavior
+
+- Repos are **collapsed by default** — only the repo row is visible, not the sub-nav items.
+- Clicking the repo row **toggles expand/collapse**, revealing Sessions and Projects sub-links.
+- Clicking a sub-link (Sessions or Projects) navigates to the repo-scoped list.
+- Expand/collapse state is stored in `localStorage` so it persists across page loads (key: `sidebar-repo-expanded-{repoId}`).
+- If a user is currently on a repo-scoped page (e.g., `/sessions?repo=abc`), that repo auto-expands in the sidebar.
+
+#### Ordering
+
+Repos are sorted by:
+1. Active session count (descending) — repos with active work surface first
+2. Alphabetical by `full_name` (ascending) — stable fallback
+
+This means the "hottest" repo is always at the top of the repo section.
+
+### 3.2 List Pages: Repo Badge on Rows
+
+When the org has 2+ repos, add a subtle repo badge to each row on the Sessions and Projects list pages. This helps users scanning the "all repos" view understand which repo an item belongs to.
+
+**Sessions list row (current):**
+```
+● Active  PM Analysis · 3 tasks · 1 running                    2h ago
+```
+
+**Sessions list row (new, 2+ repos):**
+```
+● Active  PM Analysis · 3 tasks · 1 running       api-server   2h ago
+```
+
+- Badge shows the **repo short name** (just the repo portion of `owner/repo`, e.g., `api-server` not `acme/api-server`). Full name on hover.
+- Styled as muted text, `text-xs`, positioned to the left of the timestamp.
+- Hidden when org has only 1 repo.
+
+**Projects list row** follows the same pattern. The project already has a `repository_id` so the data is trivially available.
+
+### 3.3 Repo-Scoped List Views
+
+When a user clicks "Sessions" under a specific repo in the sidebar, they navigate to:
+
+```
+/sessions?repo={repository_id}
+```
+
+This is the same Sessions page, but filtered to only show sessions linked to that repository. The page behavior:
+
+- **URL param:** `repo` query parameter, managed with `nuqs` (already used for `status` filtering).
+- **Page title:** Shows `Sessions — {repo short name}` instead of just `Sessions`.
+- **Filter tabs:** All existing status filter tabs (All, Active, Needs Guidance, Failed, Done, Decisions) still work — they compose with the repo filter.
+- **Breadcrumb/context:** No breadcrumb needed. The sidebar's expanded repo and highlighted sub-link make the context clear.
+- **"Clear filter" affordance:** A small `×` button or "Viewing repo-name — show all" link at the top of the list, so users can easily return to the unfiltered view.
+
+Same pattern for Projects: `/projects?repo={repository_id}`.
+
+### 3.4 Overview Page
+
+No changes to the Overview page in this iteration. The sidebar repo ribbons already provide ambient awareness (active counts, status dots). A per-repo overview dashboard can be explored later if usage data supports it.
+
+---
+
+## 4. What Does NOT Change
+
+- **Single-repo users** see zero UI changes. The repo section, badges, and scoped views all require 2+ repos to appear.
+- **Top-level Sessions and Projects nav items** remain as the "all repos" entry point. They are not removed or demoted.
+- **Session detail pages** are unchanged. The `/sessions/{id}` page shows the same content regardless of how you got there.
+- **Repo settings pages** (`/repositories/[id]`) remain in their current location, accessed through the settings flow.
+- **PM agent behavior** is unaffected. The PM still analyzes across all repos.
+- **URL structure** for non-scoped views is unchanged. `/sessions` without a `?repo` param shows all repos.
+
+---
+
+## 5. Data Model & API Changes
+
+### 5.1 Sessions → Repository Relationship
+
+**Current state:** Sessions have no direct `repository_id`. They connect to repositories indirectly through issues:
+
+```
+sessions.issue_id → issues.repository_id → repositories.id
+```
+
+**Decision: Join through issues, don't denormalize (yet).**
+
+For the sidebar counts and list filtering, we need to resolve session → repo. Two options:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A: JOIN through issues** | No schema change. Single source of truth. | Slightly more complex queries. JOIN on every list call. |
+| **B: Denormalize `repository_id` onto sessions** | Simple queries. Can index directly. | Schema migration. Must keep in sync. Backfill needed. |
+
+**Go with A for now.** At our expected scale (low hundreds of sessions per org), the JOIN is trivial. If performance becomes an issue, we can denormalize later with a migration + backfill — but don't pay that complexity cost upfront.
+
+### 5.2 API Changes
+
+#### `GET /api/v1/sessions` — Add `repository_id` filter
+
+**New optional query param:** `repository_id` (uuid)
+
+When provided, the query becomes:
+
+```sql
+SELECT s.* FROM sessions s
+INNER JOIN issues i ON s.issue_id = i.id
+WHERE s.org_id = @org_id
+  AND i.repository_id = @repository_id
+  [AND s.status = @status]  -- existing filter
+ORDER BY s.created_at DESC
+```
+
+When not provided, behavior is unchanged (all sessions for the org).
+
+**Backend file:** `internal/db/session_store.go` — update `ListByOrg` to accept optional `RepositoryID` in `SessionFilters`.
+
+**Handler file:** `internal/api/handlers/sessions.go` — parse `repository_id` from query params, pass to store.
+
+#### `GET /api/v1/projects` — Add `repository_id` filter
+
+**New optional query param:** `repository_id` (uuid)
+
+Simpler than sessions since projects already have a direct `repository_id` column:
+
+```sql
+SELECT * FROM projects
+WHERE org_id = @org_id
+  AND repository_id = @repository_id
+  [AND status = @status]
+ORDER BY priority ASC, created_at DESC, id DESC
+```
+
+**Backend file:** `internal/db/projects.go` — update `ListByOrg` to accept optional `RepositoryID` in `ProjectFilters`.
+
+**Handler file:** `internal/api/handlers/projects.go` — parse `repository_id` from query params, pass to store.
+
+#### `GET /api/v1/repositories/summary` — New endpoint
+
+Returns per-repo session counts for the sidebar. This powers the active count badges and status dots without the frontend needing to fetch all sessions.
+
+**Request:** `GET /api/v1/repositories/summary`
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "repository_id": "uuid-1",
+      "full_name": "acme/api-server",
+      "active_session_count": 3,
+      "latest_session_status": "running",
+      "active_project_count": 2
+    },
+    {
+      "repository_id": "uuid-2",
+      "full_name": "acme/web-app",
+      "active_session_count": 1,
+      "latest_session_status": "completed",
+      "active_project_count": 0
+    }
+  ]
+}
+```
+
+**SQL:**
+```sql
+SELECT
+  r.id AS repository_id,
+  r.full_name,
+  COUNT(DISTINCT s.id) FILTER (
+    WHERE s.status IN ('running', 'pending', 'needs_human_guidance', 'awaiting_input')
+  ) AS active_session_count,
+  (
+    SELECT s2.status FROM sessions s2
+    JOIN issues i2 ON s2.issue_id = i2.id
+    WHERE i2.repository_id = r.id AND s2.org_id = r.org_id
+    ORDER BY s2.created_at DESC LIMIT 1
+  ) AS latest_session_status,
+  COUNT(DISTINCT p.id) FILTER (
+    WHERE p.status IN ('active', 'planning')
+  ) AS active_project_count
+FROM repositories r
+LEFT JOIN issues i ON i.repository_id = r.id
+LEFT JOIN sessions s ON s.issue_id = i.id
+LEFT JOIN projects p ON p.repository_id = r.id AND p.org_id = r.org_id
+WHERE r.org_id = @org_id AND r.status = 'active'
+GROUP BY r.id, r.full_name
+ORDER BY active_session_count DESC, r.full_name ASC;
+```
+
+**Caching:** This endpoint is polled alongside PM status (every 30s). At our scale the query is fast, but if needed, results can be cached server-side with a 30s TTL.
+
+### 5.3 Frontend API Client Changes
+
+**File:** `frontend/src/lib/api.ts`
+
+```typescript
+// Add to sessions
+sessions: {
+  list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => ...
+}
+
+// Add to projects
+projects: {
+  list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => ...
+}
+
+// Add to repositories
+repositories: {
+  ...existing,
+  summary: () => get<ListResponse<RepoSummary>>('/api/v1/repositories/summary'),
+}
+```
+
+### 5.4 New Frontend Types
+
+**File:** `frontend/src/lib/types.ts`
+
+```typescript
+export interface RepoSummary {
+  repository_id: string;
+  full_name: string;
+  active_session_count: number;
+  latest_session_status: string;
+  active_project_count: number;
+}
+```
+
+---
+
+## 6. Frontend Implementation
+
+### 6.1 Sidebar Component Changes
+
+**File:** `frontend/src/components/authenticated-layout.tsx`
+
+This is the main change. The `AuthenticatedLayout` component needs to:
+
+1. **Fetch repo summary data** — new `useQuery` for `api.repositories.summary()`, polled every 30s (same interval as PM status).
+2. **Conditionally render repo section** — only when `repoSummaries.length >= 2`.
+3. **Render repo rows** — with expand/collapse, status dots, and active counts.
+4. **Render sub-nav items** — Sessions and Projects links scoped to each repo.
+
+**Expand/collapse state:**
+
+```typescript
+// In AuthenticatedLayout
+const [expandedRepos, setExpandedRepos] = useState<Set<string>>(() => {
+  // Initialize from localStorage
+  const stored = localStorage.getItem('sidebar-expanded-repos');
+  return stored ? new Set(JSON.parse(stored)) : new Set();
+});
+
+// Auto-expand repo when on a repo-scoped page
+const currentRepoId = searchParams.get('repo');
+useEffect(() => {
+  if (currentRepoId && !expandedRepos.has(currentRepoId)) {
+    setExpandedRepos(prev => new Set(prev).add(currentRepoId));
+  }
+}, [currentRepoId]);
+```
+
+**Active state highlighting:**
+
+A repo's sub-nav "Sessions" link is highlighted when:
+- `pathname === '/sessions'` AND `searchParams.get('repo') === repoId`
+
+Same logic for Projects.
+
+### 6.2 Sessions & Projects List Pages
+
+**Repo filter via URL param:**
+
+Both pages already use `nuqs` for the `status` query param. Add `repo` as a second param:
+
+```typescript
+const [repo] = useQueryState('repo');
+
+// Pass to API call
+const { data } = useQuery({
+  queryKey: ['sessions', { status, repo }],
+  queryFn: () => api.sessions.list({ status, repository_id: repo }),
+});
+```
+
+**Page title:**
+
+```typescript
+// Fetch repo name for title
+const repoName = repoSummaries?.find(r => r.repository_id === repo)?.full_name;
+const pageTitle = repo && repoName
+  ? `Sessions — ${repoName.split('/')[1]}`
+  : 'Sessions';
+```
+
+**Repo badge on rows:**
+
+Add a `<span>` to each session/project row showing the repo short name. The session row component needs the repo name, which can be resolved client-side by joining `session.issue_id` → issues data, or more practically by including `repository_full_name` in the session list API response (see section 6.3).
+
+### 6.3 Enriching Session List Response
+
+To show repo badges on session rows without N+1 lookups, the `GET /api/v1/sessions` response should include the repository name.
+
+**Option: Add to the list query JOIN.**
+
+Extend the sessions list query to JOIN through issues to repositories and return `repository_full_name`:
+
+```sql
+SELECT s.*, r.full_name AS repository_full_name
+FROM sessions s
+LEFT JOIN issues i ON s.issue_id = i.id
+LEFT JOIN repositories r ON i.repository_id = r.id
+WHERE s.org_id = @org_id
+```
+
+This adds the repo name to each session in the API response. The frontend `Session` type gets an optional `repository_full_name?: string` field.
+
+This is preferable to a separate lookup because:
+- It's one query, no N+1
+- The JOIN is cheap (sessions already reference issues by FK)
+- It's backwards-compatible (new field, no breaking changes)
+
+---
+
+## 7. Edge Cases
+
+### Manual sessions without issues
+
+Some sessions (manual "Fix This" sessions) may be created without a pre-existing issue, or the issue might not have a `repository_id`. These sessions:
+- Won't appear under any repo ribbon (they have no repo association)
+- Will still appear in the top-level "Sessions" view (all repos)
+- The repo badge on the row will be absent — that's fine, it degrades gracefully
+
+### Repo gets disconnected
+
+If a user disconnects a repository:
+- Its ribbon disappears from the sidebar
+- Sessions and Projects linked to it still appear in the "all repos" views
+- The `?repo=` filter for that repo returns an empty list (no special handling needed)
+
+### User has exactly 1 repo
+
+The entire feature is invisible. No repo section, no badges, no scoped views. The existing UI is 100% unchanged. The `repositories/summary` endpoint still returns data (1 item), but the sidebar component simply doesn't render the repo section when `repoSummaries.length < 2`.
+
+### Long repo names
+
+The sidebar is `w-64` (256px). Repo names like `my-organization/my-very-long-repository-name` will be truncated with `truncate` (text-overflow: ellipsis). The full name is available on hover via the `title` attribute. The active count and status dot are always visible (they're positioned with `ml-auto` and don't get truncated).
+
+---
+
+## 8. Implementation Order
+
+| Step | What | Where | Depends on |
+|------|------|-------|------------|
+| 1 | Add `repository_id` filter to sessions list query | `internal/db/session_store.go` | — |
+| 2 | Add `repository_id` filter to projects list query | `internal/db/projects.go` | — |
+| 3 | Add `repository_id` query param parsing to session + project handlers | `internal/api/handlers/sessions.go`, `projects.go` | Steps 1-2 |
+| 4 | Create `/api/v1/repositories/summary` endpoint | `internal/api/handlers/repositories.go`, `internal/db/repository_store.go` | — |
+| 5 | Enrich session list response with `repository_full_name` | `internal/db/session_store.go`, `internal/api/handlers/sessions.go` | Step 1 |
+| 6 | Add `RepoSummary` type and API methods to frontend | `frontend/src/lib/types.ts`, `frontend/src/lib/api.ts` | Steps 3-5 |
+| 7 | Add repo ribbon section to sidebar | `frontend/src/components/authenticated-layout.tsx` | Step 6 |
+| 8 | Add `repo` query param support to Sessions page | `frontend/src/app/(dashboard)/sessions/page.tsx` | Step 6 |
+| 9 | Add `repo` query param support to Projects page | `frontend/src/app/(dashboard)/projects/page.tsx` | Step 6 |
+| 10 | Add repo badge to session and project list rows | Session/project row components | Steps 5, 8-9 |
+
+**Steps 1, 2, and 4 can be done in parallel** (independent backend work).
+**Steps 8 and 9 can be done in parallel** (independent page work).
+
+Estimated scope: ~2-3 days of focused work for one full-stack engineer.
+
+---
+
+## 9. Future Considerations (NOT in this iteration)
+
+These are explicitly out of scope but worth noting as natural evolutions:
+
+- **Per-repo Overview dashboard** — if users frequently scope to one repo and stay, the Overview page could become repo-aware.
+- **Pinned/starred repos** — if a user reaches 6+ repos, let them pin favorites to the top of the repo section. The ribbon UI supports this naturally.
+- **Repo-scoped notifications** — "repo-a has a failing session" instead of generic "a session failed."
+- **Repo search in sidebar** — for the rare 10+ repo user, add a small search input above the repo list.
+- **Denormalizing `repository_id` onto sessions** — if the JOIN through issues becomes a performance issue, add the column with a migration + backfill.
+
+---
+
+## 10. Non-Goals
+
+- **Repo tabs or horizontal nav** — creates two competing navigation axes. The sidebar handles scoping.
+- **Global repo context switcher** — over-abstracted for 2-5 repos. You can see all repos in the nav; no need to hide them behind a dropdown.
+- **Filter dropdown on list pages** — overkill at this scale. An extra click to open a menu showing 2 items isn't good UX.
+- **Progressive disclosure / adaptive UI** — building 4 UI modes for a user distribution that spans 2 of them. One UI that works for 1-5 is simpler.
+- **Changes to the PM agent** — this is purely a navigation/presentation change.
+
+---
+
+## 11. Summary
+
+| Area | Current | Proposed |
+|------|---------|----------|
+| Sidebar nav | Overview, Sessions, Projects | Same + repo ribbons section below divider (2+ repos only) |
+| Repo visibility | None in nav | Each repo shown with status dot + active count |
+| Scoping to a repo | Not possible | Click repo → Sessions in sidebar |
+| All-repos view | Default (only option) | Still default, still top-level nav items |
+| Session list rows | No repo indicator | Repo badge (short name) on each row (2+ repos only) |
+| Project list rows | No repo indicator | Repo badge (short name) on each row (2+ repos only) |
+| Single-repo users | Current UI | Identical — zero changes |
+| API: sessions | No repo filter | Optional `repository_id` query param |
+| API: projects | No repo filter | Optional `repository_id` query param |
+| API: new endpoint | — | `GET /api/v1/repositories/summary` for sidebar data |


### PR DESCRIPTION
## Summary

Add design documentation for repository-scoped navigation in the sidebar, enabling multi-repo users to quickly access Sessions and Projects filtered to specific repositories while keeping single-repo users' experience unchanged.

## Changes

- **34-repo-ribbons-nav.md** — Complete PRD for the feature including:
  - Problem statement and design principles
  - Sidebar UI changes (repo ribbons with status dots and active counts)
  - List page enhancements (repo badges on rows, scoped views via `?repo=` query param)
  - Data model and API changes:
    - New `repository_id` filter on `GET /api/v1/sessions` and `GET /api/v1/projects`
    - New `GET /api/v1/repositories/summary` endpoint for sidebar data
    - Enriched session list response with `repository_full_name`
  - Frontend implementation details (sidebar component, expand/collapse state, URL param handling)
  - Edge cases (manual sessions without issues, disconnected repos, long repo names)
  - Implementation order and estimated scope (~2-3 days)

- **brainstorm-repo-organization.md** — Brainstorm document exploring 7 different approaches:
  - Repo ribbons in left nav (recommended)
  - Repo filter dropdown
  - Global repo switcher
  - Repo-first dashboard
  - Tabs/workspaces per repo
  - Progressive disclosure
  - Hybrid switcher + inline grouping
  - Recommendation rationale based on realistic user distribution (50% single-repo, 25% two-repo, 20% multi-repo 3-5, 5% 6+)

## Key Design Decisions

- **Invisible for single-repo users** — No UI changes when only one repo is connected
- **Visible for 2+ repos** — Repo section auto-appears in sidebar with expand/collapse
- **One-click scoping** — Click repo → Sessions in sidebar, no dropdown ceremony
- **Ambient awareness** — Status dots and active counts visible without navigation
- **Additive, not restructuring** — Top-level Sessions/Projects remain as "all repos" views
- **No denormalization yet** — Join sessions through issues to repositories; denormalize only if performance data demands it

## Implementation Notes

- Estimated scope: 2-3 days for one full-stack engineer
- Backend work (API filters, summary endpoint) can be parallelized with frontend (sidebar component, list page changes)
- Gracefully degrades for edge cases (manual sessions without issues, disconnected repos, long repo names)
- Future evolution path identified (pinned repos, repo search) without over-engineering for current user base

https://claude.ai/code/session_019uPhdd41sAkDkHYnsKCeoB