### PR TITLE
Design: Audit Logs - Production-grade audit trail system

### DIFF
--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -84,7 +84,8 @@ CREATE TABLE audit_logs (
     ip_address      inet,                      -- source IP for user-initiated actions
     user_agent      text,                      -- browser/client user-agent for user-initiated actions
 
-    -- Correlation
+    -- Correlation (no FK intentionally — audit entries must survive if the
+    -- referenced session or project is deleted)
     session_id      uuid,                      -- links to sessions table when action is session-related
     project_id      uuid,                      -- links to projects table when action is project-related
 
@@ -134,6 +135,16 @@ DROP TRIGGER IF EXISTS audit_logs_immutable ON audit_logs;
 DROP FUNCTION IF EXISTS prevent_audit_logs_modification();
 DROP TABLE IF EXISTS audit_logs;
 ALTER TABLE IF EXISTS audit_log_legacy RENAME TO audit_log;
+
+-- Re-create the immutability function in case it was dropped by a later migration.
+-- Using CREATE OR REPLACE so this is safe even if it still exists from 000001.
+CREATE OR REPLACE FUNCTION prevent_audit_log_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_log is append-only: % operations are not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
 CREATE TRIGGER audit_log_immutable
     BEFORE UPDATE OR DELETE ON audit_log
     FOR EACH ROW
@@ -315,6 +326,29 @@ const (
     AuditActionAuthRegister AuditAction = "auth.register"
 )
 
+// AuditAction.Validate checks that the action is a known value.
+func (a AuditAction) Validate() error {
+    switch a {
+    case AuditActionSessionCreated, AuditActionSessionStarted, AuditActionSessionCompleted,
+        AuditActionSessionFailed, AuditActionSessionCancelled, AuditActionSessionStatusChanged,
+        AuditActionSessionQuestionCreated, AuditActionSessionQuestionAnswered, AuditActionSessionResumedLocally,
+        AuditActionProjectCreated, AuditActionProjectUpdated, AuditActionProjectDeleted,
+        AuditActionProjectStarted, AuditActionProjectPaused, AuditActionProjectResumed,
+        AuditActionProjectApproved, AuditActionProjectDismissed, AuditActionProjectRunTriggered,
+        AuditActionProjectCycleCompleted, AuditActionProjectTaskCreated, AuditActionProjectTaskUpdated,
+        AuditActionProjectTaskDeleted, AuditActionProjectTaskRetried,
+        AuditActionIssueCreated, AuditActionIssueReprioritized,
+        AuditActionPMAnalysisTriggered, AuditActionPMPlanCreated, AuditActionPMDecisionMade,
+        AuditActionSettingsUpdated, AuditActionTeamMemberInvited, AuditActionTeamMemberRoleChanged,
+        AuditActionTeamMemberRemoved, AuditActionTeamInvitationRevoked, AuditActionTeamInvitationAccepted,
+        AuditActionIntegrationConnected, AuditActionCredentialUpdated, AuditActionCredentialDeleted,
+        AuditActionAuthLogin, AuditActionAuthLogout, AuditActionAuthRegister:
+        return nil
+    default:
+        return fmt.Errorf("invalid AuditAction: %q", a)
+    }
+}
+
 // AuditResourceType identifies the type of resource an action targets.
 type AuditResourceType string
 
@@ -332,6 +366,18 @@ const (
     AuditResourceCredential  AuditResourceType = "credential"
     AuditResourceUser        AuditResourceType = "user"
 )
+
+func (t AuditResourceType) Validate() error {
+    switch t {
+    case AuditResourceSession, AuditResourceProject, AuditResourceProjectTask,
+        AuditResourceIssue, AuditResourcePMPlan, AuditResourcePMDecision,
+        AuditResourceSettings, AuditResourceTeamMember, AuditResourceInvitation,
+        AuditResourceIntegration, AuditResourceCredential, AuditResourceUser:
+        return nil
+    default:
+        return fmt.Errorf("invalid AuditResourceType: %q", t)
+    }
+}
 ```
 
 ### 5.2 Model (`internal/models/audit.go`)
@@ -341,7 +387,7 @@ package models
 
 import (
     "encoding/json"
-    "net"
+    "net/netip"
     "time"
 
     "github.com/google/uuid"
@@ -359,7 +405,7 @@ type AuditLog struct {
     ResourceID   *string           `db:"resource_id" json:"resource_id,omitempty"`
     Details      json.RawMessage   `db:"details" json:"details,omitempty"`
     RequestID    *string           `db:"request_id" json:"request_id,omitempty"`
-    IPAddress    net.IP            `db:"ip_address" json:"ip_address,omitempty"`
+    IPAddress    *netip.Addr       `db:"ip_address" json:"ip_address,omitempty"`
     UserAgent    *string           `db:"user_agent" json:"user_agent,omitempty"`
     SessionID    *uuid.UUID        `db:"session_id" json:"session_id,omitempty"`
     ProjectID    *uuid.UUID        `db:"project_id" json:"project_id,omitempty"`
@@ -369,18 +415,34 @@ type AuditLog struct {
 
 ### 5.3 Store (`internal/db/audit_log_store.go`)
 
+> **Note**: The `whereClause` helper below is defined in a shared file
+> `internal/db/where_clause.go` so that other stores (`SessionStore`,
+> `IssueStore`, `ProjectStore`, etc.) can adopt it to replace their ad-hoc
+> `query += " AND ..."` concatenation. The audit log store is the first
+> consumer.
+
 ```go
 package db
 
 import (
     "context"
     "fmt"
+    "strconv"
     "strings"
 
     "github.com/assembledhq/143/internal/models"
     "github.com/google/uuid"
     "github.com/jackc/pgx/v5"
 )
+
+// escapeLike escapes SQL LIKE meta-characters (%, _) so that user-supplied
+// values are matched literally.
+func escapeLike(s string) string {
+    s = strings.ReplaceAll(s, `\`, `\\`)
+    s = strings.ReplaceAll(s, `%`, `\%`)
+    s = strings.ReplaceAll(s, `_`, `\_`)
+    return s
+}
 
 type AuditLogStore struct {
     db DBTX
@@ -441,9 +503,10 @@ type AuditLogFilters struct {
     Cursor       string                   // cursor for keyset pagination (bigserial id)
 }
 
-// whereClause is a small helper that accumulates WHERE conditions and named args.
-// It eliminates the error-prone pattern of manually concatenating " AND ..." fragments
-// and ensures every condition is joined consistently.
+// whereClause is a shared helper (internal/db/where_clause.go) that accumulates
+// WHERE conditions and named args. It eliminates the error-prone pattern of
+// manually concatenating " AND ..." fragments and ensures every condition is
+// joined consistently. Other stores should adopt this instead of ad-hoc concatenation.
 type whereClause struct {
     conditions []string
     args       pgx.NamedArgs
@@ -456,10 +519,6 @@ func newWhereClause() *whereClause {
 func (w *whereClause) add(condition string, name string, value interface{}) {
     w.conditions = append(w.conditions, condition)
     w.args[name] = value
-}
-
-func (w *whereClause) addRaw(condition string) {
-    w.conditions = append(w.conditions, condition)
 }
 
 func (w *whereClause) build() (string, pgx.NamedArgs) {
@@ -484,7 +543,7 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
         w.add("action = @action", "action", filters.Action)
     }
     if filters.ActionPrefix != "" {
-        w.add("action LIKE @action_prefix", "action_prefix", filters.ActionPrefix+"%")
+        w.add("action LIKE @action_prefix ESCAPE '\\'", "action_prefix", escapeLike(filters.ActionPrefix)+"%")
     }
     if filters.ResourceType != "" {
         w.add("resource_type = @resource_type", "resource_type", filters.ResourceType)
@@ -505,7 +564,11 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
         w.add("created_at <= @until", "until", *filters.Until)
     }
     if filters.Cursor != "" {
-        w.add("id < @cursor", "cursor", filters.Cursor)
+        cursorID, err := strconv.ParseInt(filters.Cursor, 10, 64)
+        if err != nil {
+            return nil, fmt.Errorf("invalid cursor %q: %w", filters.Cursor, err)
+        }
+        w.add("id < @cursor", "cursor", cursorID)
     }
 
     where, args := w.build()
@@ -541,23 +604,27 @@ package db
 import (
     "context"
     "encoding/json"
-    "net"
+    "log/slog"
+    "net/netip"
 
     "github.com/assembledhq/143/internal/models"
     "github.com/google/uuid"
 )
 
 // AuditEmitter provides convenience methods for emitting audit log entries.
+// All Emit* methods log errors internally and never return them, so callers
+// can treat emission as fire-and-forget without discarding errors silently.
 type AuditEmitter struct {
-    store *AuditLogStore
+    store  *AuditLogStore
+    logger *slog.Logger
 }
 
-func NewAuditEmitter(store *AuditLogStore) *AuditEmitter {
-    return &AuditEmitter{store: store}
+func NewAuditEmitter(store *AuditLogStore, logger *slog.Logger) *AuditEmitter {
+    return &AuditEmitter{store: store, logger: logger}
 }
 
 // EmitUserAction logs an action performed by an authenticated user.
-func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionParams) error {
+func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionParams) {
     entry := &models.AuditLog{
         OrgID:        params.OrgID,
         ActorType:    models.AuditActorUser,
@@ -573,7 +640,13 @@ func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionPara
         SessionID:    params.SessionID,
         ProjectID:    params.ProjectID,
     }
-    return e.store.Create(ctx, entry)
+    if err := e.store.Create(ctx, entry); err != nil {
+        e.logger.ErrorContext(ctx, "failed to emit audit log",
+            "action", params.Action,
+            "actor_id", params.UserID,
+            "error", err,
+        )
+    }
 }
 
 type UserActionParams struct {
@@ -584,14 +657,14 @@ type UserActionParams struct {
     ResourceID   *string
     Details      json.RawMessage
     RequestID    *string
-    IPAddress    net.IP
+    IPAddress    *netip.Addr
     UserAgent    *string
     SessionID    *uuid.UUID
     ProjectID    *uuid.UUID
 }
 
 // EmitSystemAction logs an action performed by a system process (PM agent, scheduler, etc.).
-func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemActionParams) error {
+func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemActionParams) {
     entry := &models.AuditLog{
         OrgID:        params.OrgID,
         ActorType:    models.AuditActorSystem,
@@ -603,7 +676,13 @@ func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemAction
         SessionID:    params.SessionID,
         ProjectID:    params.ProjectID,
     }
-    return e.store.Create(ctx, entry)
+    if err := e.store.Create(ctx, entry); err != nil {
+        e.logger.ErrorContext(ctx, "failed to emit audit log",
+            "action", params.Action,
+            "actor_id", params.ActorID,
+            "error", err,
+        )
+    }
 }
 
 type SystemActionParams struct {
@@ -728,9 +807,9 @@ Audit entries are emitted **after** the primary operation succeeds. If the opera
 func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
     // ... existing logic to create session and enqueue job ...
 
-    // Emit audit entry (fire-and-forget; failure is logged, not returned to user)
+    // Emit audit entry (fire-and-forget; the emitter logs errors internally)
     resID := session.ID.String()
-    _ = h.auditEmitter.EmitUserAction(r.Context(), db.UserActionParams{
+    h.auditEmitter.EmitUserAction(r.Context(), db.UserActionParams{
         OrgID:        orgID,
         UserID:       user.ID,
         Action:       models.AuditActionSessionCreated,
@@ -738,7 +817,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
         ResourceID:   &resID,
         Details:      json.RawMessage(`{"issue_id":"` + issueID.String() + `"}`),
         RequestID:    requestIDFromContext(r.Context()),
-        IPAddress:    net.ParseIP(r.RemoteAddr),
+        IPAddress:    addrFromRequest(r), // returns *netip.Addr parsed from r.RemoteAddr
         UserAgent:    stringPtr(r.UserAgent()),
         SessionID:    &session.ID,
     })

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -227,7 +227,114 @@ This taxonomy is **not enforced at the database level** (it's `text`, not an enu
 
 ## 5. Go Model & Store
 
-### 5.1 Model (`internal/models/audit.go`)
+### 5.1 Enums (`internal/models/audit_enums.go`)
+
+Following the codebase convention (see `session_enums.go`, `pm_enums.go`), all categorical fields use typed strings with validation.
+
+```go
+package models
+
+import "fmt"
+
+// AuditActorType identifies who or what performed an audited action.
+type AuditActorType string
+
+const (
+    AuditActorUser    AuditActorType = "user"
+    AuditActorAgent   AuditActorType = "agent"
+    AuditActorSystem  AuditActorType = "system"
+    AuditActorWebhook AuditActorType = "webhook"
+)
+
+func (t AuditActorType) Validate() error {
+    switch t {
+    case AuditActorUser, AuditActorAgent, AuditActorSystem, AuditActorWebhook:
+        return nil
+    default:
+        return fmt.Errorf("invalid AuditActorType: %q", t)
+    }
+}
+
+// AuditAction identifies the specific action that was performed.
+// Follows a resource.verb naming convention.
+type AuditAction string
+
+const (
+    // Session actions
+    AuditActionSessionCreated          AuditAction = "session.created"
+    AuditActionSessionStarted          AuditAction = "session.started"
+    AuditActionSessionCompleted        AuditAction = "session.completed"
+    AuditActionSessionFailed           AuditAction = "session.failed"
+    AuditActionSessionCancelled        AuditAction = "session.cancelled"
+    AuditActionSessionStatusChanged    AuditAction = "session.status_changed"
+    AuditActionSessionQuestionCreated  AuditAction = "session.question.created"
+    AuditActionSessionQuestionAnswered AuditAction = "session.question.answered"
+    AuditActionSessionResumedLocally   AuditAction = "session.resumed_locally"
+
+    // Project actions
+    AuditActionProjectCreated        AuditAction = "project.created"
+    AuditActionProjectUpdated        AuditAction = "project.updated"
+    AuditActionProjectDeleted        AuditAction = "project.deleted"
+    AuditActionProjectStarted        AuditAction = "project.started"
+    AuditActionProjectPaused         AuditAction = "project.paused"
+    AuditActionProjectResumed        AuditAction = "project.resumed"
+    AuditActionProjectApproved       AuditAction = "project.approved"
+    AuditActionProjectDismissed      AuditAction = "project.dismissed"
+    AuditActionProjectRunTriggered   AuditAction = "project.run_triggered"
+    AuditActionProjectCycleCompleted AuditAction = "project.cycle_completed"
+    AuditActionProjectTaskCreated    AuditAction = "project.task.created"
+    AuditActionProjectTaskUpdated    AuditAction = "project.task.updated"
+    AuditActionProjectTaskDeleted    AuditAction = "project.task.deleted"
+    AuditActionProjectTaskRetried    AuditAction = "project.task.retried"
+
+    // Issue actions
+    AuditActionIssueCreated       AuditAction = "issue.created"
+    AuditActionIssueReprioritized AuditAction = "issue.reprioritized"
+
+    // PM actions
+    AuditActionPMAnalysisTriggered AuditAction = "pm.analysis_triggered"
+    AuditActionPMPlanCreated       AuditAction = "pm.plan_created"
+    AuditActionPMDecisionMade      AuditAction = "pm.decision_made"
+
+    // Team & settings actions
+    AuditActionSettingsUpdated        AuditAction = "settings.updated"
+    AuditActionTeamMemberInvited      AuditAction = "team.member_invited"
+    AuditActionTeamMemberRoleChanged  AuditAction = "team.member_role_changed"
+    AuditActionTeamMemberRemoved      AuditAction = "team.member_removed"
+    AuditActionTeamInvitationRevoked  AuditAction = "team.invitation_revoked"
+    AuditActionTeamInvitationAccepted AuditAction = "team.invitation_accepted"
+
+    // Integration & credential actions
+    AuditActionIntegrationConnected AuditAction = "integration.connected"
+    AuditActionCredentialUpdated    AuditAction = "credential.updated"
+    AuditActionCredentialDeleted    AuditAction = "credential.deleted"
+
+    // Auth actions
+    AuditActionAuthLogin    AuditAction = "auth.login"
+    AuditActionAuthLogout   AuditAction = "auth.logout"
+    AuditActionAuthRegister AuditAction = "auth.register"
+)
+
+// AuditResourceType identifies the type of resource an action targets.
+type AuditResourceType string
+
+const (
+    AuditResourceSession     AuditResourceType = "session"
+    AuditResourceProject     AuditResourceType = "project"
+    AuditResourceProjectTask AuditResourceType = "project_task"
+    AuditResourceIssue       AuditResourceType = "issue"
+    AuditResourcePMPlan      AuditResourceType = "pm_plan"
+    AuditResourcePMDecision  AuditResourceType = "pm_decision"
+    AuditResourceSettings    AuditResourceType = "settings"
+    AuditResourceTeamMember  AuditResourceType = "team_member"
+    AuditResourceInvitation  AuditResourceType = "invitation"
+    AuditResourceIntegration AuditResourceType = "integration"
+    AuditResourceCredential  AuditResourceType = "credential"
+    AuditResourceUser        AuditResourceType = "user"
+)
+```
+
+### 5.2 Model (`internal/models/audit.go`)
 
 ```go
 package models
@@ -242,33 +349,25 @@ import (
 
 // AuditLog represents an immutable audit trail entry.
 type AuditLog struct {
-    ID           int64           `db:"id" json:"id"`
-    OrgID        uuid.UUID       `db:"org_id" json:"org_id"`
-    ActorType    string          `db:"actor_type" json:"actor_type"`
-    ActorID      string          `db:"actor_id" json:"actor_id"`
-    UserID       *uuid.UUID      `db:"user_id" json:"user_id,omitempty"`
-    Action       string          `db:"action" json:"action"`
-    ResourceType string          `db:"resource_type" json:"resource_type"`
-    ResourceID   *string         `db:"resource_id" json:"resource_id,omitempty"`
-    Details      json.RawMessage `db:"details" json:"details,omitempty"`
-    RequestID    *string         `db:"request_id" json:"request_id,omitempty"`
-    IPAddress    net.IP          `db:"ip_address" json:"ip_address,omitempty"`
-    UserAgent    *string         `db:"user_agent" json:"user_agent,omitempty"`
-    SessionID    *uuid.UUID      `db:"session_id" json:"session_id,omitempty"`
-    ProjectID    *uuid.UUID      `db:"project_id" json:"project_id,omitempty"`
-    CreatedAt    time.Time       `db:"created_at" json:"created_at"`
+    ID           int64             `db:"id" json:"id"`
+    OrgID        uuid.UUID         `db:"org_id" json:"org_id"`
+    ActorType    AuditActorType    `db:"actor_type" json:"actor_type"`
+    ActorID      string            `db:"actor_id" json:"actor_id"`
+    UserID       *uuid.UUID        `db:"user_id" json:"user_id,omitempty"`
+    Action       AuditAction       `db:"action" json:"action"`
+    ResourceType AuditResourceType `db:"resource_type" json:"resource_type"`
+    ResourceID   *string           `db:"resource_id" json:"resource_id,omitempty"`
+    Details      json.RawMessage   `db:"details" json:"details,omitempty"`
+    RequestID    *string           `db:"request_id" json:"request_id,omitempty"`
+    IPAddress    net.IP            `db:"ip_address" json:"ip_address,omitempty"`
+    UserAgent    *string           `db:"user_agent" json:"user_agent,omitempty"`
+    SessionID    *uuid.UUID        `db:"session_id" json:"session_id,omitempty"`
+    ProjectID    *uuid.UUID        `db:"project_id" json:"project_id,omitempty"`
+    CreatedAt    time.Time         `db:"created_at" json:"created_at"`
 }
-
-// Actor type constants.
-const (
-    ActorTypeUser    = "user"
-    ActorTypeAgent   = "agent"
-    ActorTypeSystem  = "system"
-    ActorTypeWebhook = "webhook"
-)
 ```
 
-### 5.2 Store (`internal/db/audit_log_store.go`)
+### 5.3 Store (`internal/db/audit_log_store.go`)
 
 ```go
 package db
@@ -276,6 +375,7 @@ package db
 import (
     "context"
     "fmt"
+    "strings"
 
     "github.com/assembledhq/143/internal/models"
     "github.com/google/uuid"
@@ -327,78 +427,95 @@ func (s *AuditLogStore) Create(ctx context.Context, entry *models.AuditLog) erro
 
 // AuditLogFilters controls listing/search behavior.
 type AuditLogFilters struct {
-    ActorType    string     // filter by actor type
-    UserID       *uuid.UUID // filter by specific user
-    Action       string     // filter by action (exact match)
-    ActionPrefix string     // filter by action prefix (e.g. "session." matches all session actions)
-    ResourceType string     // filter by resource type
-    ResourceID   string     // filter by specific resource
-    SessionID    *uuid.UUID // filter by correlated session
-    ProjectID    *uuid.UUID // filter by correlated project
-    Since        *string    // ISO 8601 timestamp lower bound
-    Until        *string    // ISO 8601 timestamp upper bound
+    ActorType    models.AuditActorType    // filter by actor type
+    UserID       *uuid.UUID               // filter by specific user
+    Action       models.AuditAction       // filter by action (exact match)
+    ActionPrefix string                   // filter by action prefix (e.g. "session." matches all session actions)
+    ResourceType models.AuditResourceType // filter by resource type
+    ResourceID   string                   // filter by specific resource
+    SessionID    *uuid.UUID               // filter by correlated session
+    ProjectID    *uuid.UUID               // filter by correlated project
+    Since        *string                  // ISO 8601 timestamp lower bound
+    Until        *string                  // ISO 8601 timestamp upper bound
     Limit        int
-    Cursor       string     // cursor for keyset pagination (bigserial id)
+    Cursor       string                   // cursor for keyset pagination (bigserial id)
+}
+
+// whereClause is a small helper that accumulates WHERE conditions and named args.
+// It eliminates the error-prone pattern of manually concatenating " AND ..." fragments
+// and ensures every condition is joined consistently.
+type whereClause struct {
+    conditions []string
+    args       pgx.NamedArgs
+}
+
+func newWhereClause() *whereClause {
+    return &whereClause{args: pgx.NamedArgs{}}
+}
+
+func (w *whereClause) add(condition string, name string, value interface{}) {
+    w.conditions = append(w.conditions, condition)
+    w.args[name] = value
+}
+
+func (w *whereClause) addRaw(condition string) {
+    w.conditions = append(w.conditions, condition)
+}
+
+func (w *whereClause) build() (string, pgx.NamedArgs) {
+    if len(w.conditions) == 0 {
+        return "", w.args
+    }
+    return " WHERE " + strings.Join(w.conditions, " AND "), w.args
 }
 
 // List returns audit log entries for an organization, filtered and paginated.
 func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters AuditLogFilters) ([]models.AuditLog, error) {
+    w := newWhereClause()
+    w.add("org_id = @org_id", "org_id", orgID)
+
+    if filters.ActorType != "" {
+        w.add("actor_type = @actor_type", "actor_type", filters.ActorType)
+    }
+    if filters.UserID != nil {
+        w.add("user_id = @user_id", "user_id", *filters.UserID)
+    }
+    if filters.Action != "" {
+        w.add("action = @action", "action", filters.Action)
+    }
+    if filters.ActionPrefix != "" {
+        w.add("action LIKE @action_prefix", "action_prefix", filters.ActionPrefix+"%")
+    }
+    if filters.ResourceType != "" {
+        w.add("resource_type = @resource_type", "resource_type", filters.ResourceType)
+    }
+    if filters.ResourceID != "" {
+        w.add("resource_id = @resource_id", "resource_id", filters.ResourceID)
+    }
+    if filters.SessionID != nil {
+        w.add("session_id = @session_id", "session_id", *filters.SessionID)
+    }
+    if filters.ProjectID != nil {
+        w.add("project_id = @project_id", "project_id", *filters.ProjectID)
+    }
+    if filters.Since != nil {
+        w.add("created_at >= @since", "since", *filters.Since)
+    }
+    if filters.Until != nil {
+        w.add("created_at <= @until", "until", *filters.Until)
+    }
+    if filters.Cursor != "" {
+        w.add("id < @cursor", "cursor", filters.Cursor)
+    }
+
+    where, args := w.build()
+
     query := `
         SELECT id, org_id, actor_type, actor_id, user_id,
                action, resource_type, resource_id,
                details, request_id, ip_address, user_agent,
                session_id, project_id, created_at
-        FROM audit_logs
-        WHERE org_id = @org_id`
-
-    args := pgx.NamedArgs{"org_id": orgID}
-
-    if filters.ActorType != "" {
-        query += ` AND actor_type = @actor_type`
-        args["actor_type"] = filters.ActorType
-    }
-    if filters.UserID != nil {
-        query += ` AND user_id = @user_id`
-        args["user_id"] = *filters.UserID
-    }
-    if filters.Action != "" {
-        query += ` AND action = @action`
-        args["action"] = filters.Action
-    }
-    if filters.ActionPrefix != "" {
-        query += ` AND action LIKE @action_prefix`
-        args["action_prefix"] = filters.ActionPrefix + "%"
-    }
-    if filters.ResourceType != "" {
-        query += ` AND resource_type = @resource_type`
-        args["resource_type"] = filters.ResourceType
-    }
-    if filters.ResourceID != "" {
-        query += ` AND resource_id = @resource_id`
-        args["resource_id"] = filters.ResourceID
-    }
-    if filters.SessionID != nil {
-        query += ` AND session_id = @session_id`
-        args["session_id"] = *filters.SessionID
-    }
-    if filters.ProjectID != nil {
-        query += ` AND project_id = @project_id`
-        args["project_id"] = *filters.ProjectID
-    }
-    if filters.Since != nil {
-        query += ` AND created_at >= @since`
-        args["since"] = *filters.Since
-    }
-    if filters.Until != nil {
-        query += ` AND created_at <= @until`
-        args["until"] = *filters.Until
-    }
-    if filters.Cursor != "" {
-        query += ` AND id < @cursor`
-        args["cursor"] = filters.Cursor
-    }
-
-    query += ` ORDER BY id DESC`
+        FROM audit_logs` + where + ` ORDER BY id DESC`
 
     limit := filters.Limit
     if limit <= 0 || limit > 200 {
@@ -414,7 +531,7 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
 }
 ```
 
-### 5.3 Emitter helper (`internal/db/audit_emitter.go`)
+### 5.4 Emitter helper (`internal/db/audit_emitter.go`)
 
 To reduce boilerplate at call sites, provide a convenience layer:
 
@@ -424,6 +541,7 @@ package db
 import (
     "context"
     "encoding/json"
+    "net"
 
     "github.com/assembledhq/143/internal/models"
     "github.com/google/uuid"
@@ -439,11 +557,10 @@ func NewAuditEmitter(store *AuditLogStore) *AuditEmitter {
 }
 
 // EmitUserAction logs an action performed by an authenticated user.
-// Extracts request context (request ID, IP, user-agent) from the provided values.
 func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionParams) error {
     entry := &models.AuditLog{
         OrgID:        params.OrgID,
-        ActorType:    models.ActorTypeUser,
+        ActorType:    models.AuditActorUser,
         ActorID:      params.UserID.String(),
         UserID:       &params.UserID,
         Action:       params.Action,
@@ -462,8 +579,8 @@ func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionPara
 type UserActionParams struct {
     OrgID        uuid.UUID
     UserID       uuid.UUID
-    Action       string
-    ResourceType string
+    Action       models.AuditAction
+    ResourceType models.AuditResourceType
     ResourceID   *string
     Details      json.RawMessage
     RequestID    *string
@@ -477,7 +594,7 @@ type UserActionParams struct {
 func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemActionParams) error {
     entry := &models.AuditLog{
         OrgID:        params.OrgID,
-        ActorType:    models.ActorTypeSystem,
+        ActorType:    models.AuditActorSystem,
         ActorID:      params.ActorID,
         Action:       params.Action,
         ResourceType: params.ResourceType,
@@ -492,8 +609,8 @@ func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemAction
 type SystemActionParams struct {
     OrgID        uuid.UUID
     ActorID      string // e.g. "pm_agent", "scheduler", "validator"
-    Action       string
-    ResourceType string
+    Action       models.AuditAction
+    ResourceType models.AuditResourceType
     ResourceID   *string
     Details      json.RawMessage
     SessionID    *uuid.UUID
@@ -520,11 +637,11 @@ Audit log listing is restricted to **admin** role. This is sensitive data — or
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `actor_type` | string | Filter by actor type (`user`, `agent`, `system`, `webhook`) |
+| `actor_type` | `AuditActorType` | Filter by actor type (`user`, `agent`, `system`, `webhook`) |
 | `user_id` | uuid | Filter by specific user |
-| `action` | string | Exact action match (e.g. `session.created`) |
+| `action` | `AuditAction` | Exact action match (e.g. `session.created`) |
 | `action_prefix` | string | Action prefix match (e.g. `session.` returns all session actions) |
-| `resource_type` | string | Filter by resource type |
+| `resource_type` | `AuditResourceType` | Filter by resource type |
 | `resource_id` | string | Filter by specific resource |
 | `session_id` | uuid | Filter by correlated session |
 | `project_id` | uuid | Filter by correlated project |
@@ -616,8 +733,8 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
     _ = h.auditEmitter.EmitUserAction(r.Context(), db.UserActionParams{
         OrgID:        orgID,
         UserID:       user.ID,
-        Action:       "session.created",
-        ResourceType: "session",
+        Action:       models.AuditActionSessionCreated,
+        ResourceType: models.AuditResourceSession,
         ResourceID:   &resID,
         Details:      json.RawMessage(`{"issue_id":"` + issueID.String() + `"}`),
         RequestID:    requestIDFromContext(r.Context()),

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -44,7 +44,7 @@ We need a production-grade audit log that captures **all significant state chang
 4. **Optional user linkage** — When a human user is the actor, `user_id` provides a typed foreign key for joins. When the actor is a system process, `user_id` is NULL and `actor_type` + `actor_id` provide identification.
 5. **Structured but extensible** — Core fields use constrained vocabularies (enums for `actor_type`, `action`, `resource_type`). The `details` JSONB field captures action-specific context without schema changes.
 6. **Low-friction instrumentation** — Emitting audit entries should be a single function call. The audit store should accept context and extract org/user automatically where possible.
-7. **Query-first indexing** — Indexes are designed around the access patterns defined in section 6, not speculative.
+7. **Query-first indexing** — Indexes are designed around the access patterns defined in section 6 (API), not speculative.
 
 ---
 
@@ -93,7 +93,7 @@ CREATE TABLE audit_logs (
 );
 
 -- -----------------------------------------------------------------------
--- Indexes (designed for the query patterns in section 6)
+-- Indexes (designed for the query patterns in section 6, API)
 -- -----------------------------------------------------------------------
 
 -- Primary listing: "show me the audit trail for this org, newest first"
@@ -131,6 +131,7 @@ CREATE TRIGGER audit_logs_immutable
 ### 3.2 Down migration: `000019_audit_logs.down.sql`
 
 ```sql
+DROP FUNCTION IF EXISTS delete_expired_audit_logs(uuid, int);
 DROP TRIGGER IF EXISTS audit_logs_immutable ON audit_logs;
 DROP FUNCTION IF EXISTS prevent_audit_logs_modification();
 DROP TABLE IF EXISTS audit_logs;
@@ -394,6 +395,11 @@ import (
 )
 
 // AuditLog represents an immutable audit trail entry.
+//
+// Note on IPAddress: PostgreSQL's `inet` type includes a netmask, so pgx v5
+// natively scans it into netip.Prefix, not netip.Addr. During implementation,
+// either register a custom pgx type for netip.Addr, or change this field to
+// *netip.Prefix and extract the address via .Addr() where needed.
 type AuditLog struct {
     ID           int64             `db:"id" json:"id"`
     OrgID        uuid.UUID         `db:"org_id" json:"org_id"`
@@ -421,7 +427,6 @@ package db
 import (
     "context"
     "fmt"
-    "strconv"
     "time"
 
     "github.com/assembledhq/143/internal/models"
@@ -495,7 +500,8 @@ type AuditLogFilters struct {
     Since        *time.Time               // lower bound on created_at (parsed from ISO 8601 at the handler)
     Until        *time.Time               // upper bound on created_at (parsed from ISO 8601 at the handler)
     Limit        int
-    Cursor       string                   // cursor for keyset pagination (bigserial id)
+    CursorTime   *time.Time               // cursor: created_at of last item on previous page
+    CursorID     *int64                    // cursor: id of last item on previous page (tiebreaker)
 }
 
 // List returns audit log entries for an organization, filtered and paginated.
@@ -533,12 +539,9 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
     if filters.Until != nil {
         w.add("created_at <= @until", "until", *filters.Until)
     }
-    if filters.Cursor != "" {
-        cursorID, err := strconv.ParseInt(filters.Cursor, 10, 64)
-        if err != nil {
-            return nil, fmt.Errorf("invalid cursor %q: %w", filters.Cursor, err)
-        }
-        w.add("id < @cursor", "cursor", cursorID)
+    if filters.CursorTime != nil && filters.CursorID != nil {
+        w.add("(created_at, id) < (@cursor_time, @cursor_id)", "cursor_time", *filters.CursorTime)
+        w.args["cursor_id"] = *filters.CursorID
     }
 
     where, args := w.build()
@@ -548,7 +551,7 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
                action, resource_type, resource_id,
                details, request_id, ip_address, user_agent,
                session_id, project_id, created_at
-        FROM audit_logs` + where + ` ORDER BY id DESC`
+        FROM audit_logs` + where + ` ORDER BY created_at DESC, id DESC`
 
     limit := filters.Limit
     if limit <= 0 || limit > 200 {
@@ -561,6 +564,27 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
         return nil, fmt.Errorf("query audit logs: %w", err)
     }
     return pgx.CollectRows(rows, pgx.RowToStructByName[models.AuditLog])
+}
+
+// GetByID returns a single audit log entry by ID, scoped to an organization.
+func (s *AuditLogStore) GetByID(ctx context.Context, orgID uuid.UUID, id int64) (*models.AuditLog, error) {
+    query := `
+        SELECT id, org_id, actor_type, actor_id, user_id,
+               action, resource_type, resource_id,
+               details, request_id, ip_address, user_agent,
+               session_id, project_id, created_at
+        FROM audit_logs
+        WHERE org_id = @org_id AND id = @id`
+
+    rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID, "id": id})
+    if err != nil {
+        return nil, fmt.Errorf("query audit log by id: %w", err)
+    }
+    entry, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.AuditLog])
+    if err != nil {
+        return nil, fmt.Errorf("get audit log %d: %w", id, err)
+    }
+    return &entry, nil
 }
 ```
 
@@ -811,7 +835,7 @@ Audit log listing is restricted to **admin** role. This is sensitive data — or
 | `since` | ISO 8601 | Lower bound on `created_at` |
 | `until` | ISO 8601 | Upper bound on `created_at` |
 | `limit` | int | Page size (default 50, max 200) |
-| `cursor` | string | Cursor for keyset pagination (entry ID) |
+| `cursor` | string | Opaque cursor for keyset pagination (base64-encoded `created_at,id`) |
 
 ### 6.3 Response format
 
@@ -840,7 +864,7 @@ Audit log listing is restricted to **admin** role. This is sensitive data — or
     }
   ],
   "meta": {
-    "next_cursor": "12846"
+    "next_cursor": "MjAyNi0wMy0xNVQxNDozMDowMFosMTI4NDY="
   }
 }
 ```

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -97,7 +97,9 @@ CREATE TABLE audit_logs (
 -- -----------------------------------------------------------------------
 
 -- Primary listing: "show me the audit trail for this org, newest first"
-CREATE INDEX idx_audit_logs_org_created ON audit_logs (org_id, created_at DESC);
+-- Includes id DESC so the (created_at, id) composite cursor can be satisfied
+-- by an index-only backward scan without an extra sort step.
+CREATE INDEX idx_audit_logs_org_created ON audit_logs (org_id, created_at DESC, id DESC);
 
 -- Resource drill-down: "show me all actions on this specific resource"
 CREATE INDEX idx_audit_logs_resource ON audit_logs (org_id, resource_type, resource_id, created_at DESC);
@@ -519,6 +521,9 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
         w.add("action = @action", "action", filters.Action)
     }
     if filters.ActionPrefix != "" {
+        // ESCAPE '\\' is explicit for clarity — PostgreSQL's default LIKE
+        // escape character is also backslash, but stating it explicitly
+        // makes the intent obvious and guards against non-default settings.
         w.add("action LIKE @action_prefix ESCAPE '\\'", "action_prefix", escapeLike(filters.ActionPrefix)+"%")
     }
     if filters.ResourceType != "" {
@@ -541,7 +546,7 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
     }
     if filters.CursorTime != nil && filters.CursorID != nil {
         w.add("(created_at, id) < (@cursor_time, @cursor_id)", "cursor_time", *filters.CursorTime)
-        w.args["cursor_id"] = *filters.CursorID
+        w.addArg("cursor_id", *filters.CursorID)
     }
 
     where, args := w.build()
@@ -567,6 +572,8 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
 }
 
 // GetByID returns a single audit log entry by ID, scoped to an organization.
+// Returns pgx.ErrNoRows (wrapped) when the entry does not exist, so callers
+// can use errors.Is(err, pgx.ErrNoRows) to distinguish 404 from 500.
 func (s *AuditLogStore) GetByID(ctx context.Context, orgID uuid.UUID, id int64) (*models.AuditLog, error) {
     query := `
         SELECT id, org_id, actor_type, actor_id, user_id,
@@ -580,6 +587,8 @@ func (s *AuditLogStore) GetByID(ctx context.Context, orgID uuid.UUID, id int64) 
     if err != nil {
         return nil, fmt.Errorf("query audit log by id: %w", err)
     }
+    // pgx.CollectOneRow returns pgx.ErrNoRows when no row matches.
+    // We wrap with %w so the caller can check errors.Is(err, pgx.ErrNoRows).
     entry, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.AuditLog])
     if err != nil {
         return nil, fmt.Errorf("get audit log %d: %w", id, err)
@@ -616,6 +625,13 @@ func newWhereClause() *whereClause {
 
 func (w *whereClause) add(condition string, name string, value interface{}) {
     w.conditions = append(w.conditions, condition)
+    w.args[name] = value
+}
+
+// addArg registers an additional named argument without appending a new
+// condition. Use this when a single condition references multiple parameters
+// (e.g. a composite cursor: "(created_at, id) < (@cursor_time, @cursor_id)").
+func (w *whereClause) addArg(name string, value interface{}) {
     w.args[name] = value
 }
 
@@ -872,12 +888,120 @@ Audit log listing is restricted to **admin** role. This is sensitive data — or
 ### 6.4 Handler (`internal/api/handlers/audit_logs.go`)
 
 ```go
+package handlers
+
+import (
+    "encoding/base64"
+    "errors"
+    "fmt"
+    "net/http"
+    "strconv"
+    "strings"
+    "time"
+
+    "github.com/assembledhq/143/internal/db"
+    "github.com/go-chi/chi/v5"
+    "github.com/jackc/pgx/v5"
+)
+
 type AuditLogHandler struct {
     store *db.AuditLogStore
 }
 
 func NewAuditLogHandler(store *db.AuditLogStore) *AuditLogHandler {
     return &AuditLogHandler{store: store}
+}
+
+// --- Cursor encode/decode ---------------------------------------------------
+
+// encodeCursor produces an opaque, base64-encoded cursor from the last row's
+// created_at and id. Format: "RFC3339Nano,id" → base64.
+func encodeCursor(createdAt time.Time, id int64) string {
+    raw := fmt.Sprintf("%s,%d", createdAt.UTC().Format(time.RFC3339Nano), id)
+    return base64.StdEncoding.EncodeToString([]byte(raw))
+}
+
+// decodeCursor is the inverse of encodeCursor. It returns the created_at
+// timestamp and id embedded in the cursor, or an error if the format is
+// invalid.
+func decodeCursor(cursor string) (time.Time, int64, error) {
+    b, err := base64.StdEncoding.DecodeString(cursor)
+    if err != nil {
+        return time.Time{}, 0, fmt.Errorf("invalid cursor encoding: %w", err)
+    }
+    parts := strings.SplitN(string(b), ",", 2)
+    if len(parts) != 2 {
+        return time.Time{}, 0, fmt.Errorf("invalid cursor format")
+    }
+    t, err := time.Parse(time.RFC3339Nano, parts[0])
+    if err != nil {
+        return time.Time{}, 0, fmt.Errorf("invalid cursor timestamp: %w", err)
+    }
+    id, err := strconv.ParseInt(parts[1], 10, 64)
+    if err != nil {
+        return time.Time{}, 0, fmt.Errorf("invalid cursor id: %w", err)
+    }
+    return t, id, nil
+}
+
+// --- List handler (sketch) --------------------------------------------------
+
+// List handles GET /api/v1/audit-logs. It parses query parameters into
+// AuditLogFilters, calls the store, and builds the paginated response
+// including the next_cursor.
+func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
+    // ... parse orgID from auth context, parse filter query params ...
+
+    var filters db.AuditLogFilters
+    // ... populate filters from query params ...
+
+    if cursor := r.URL.Query().Get("cursor"); cursor != "" {
+        t, id, err := decodeCursor(cursor)
+        if err != nil {
+            http.Error(w, "invalid cursor", http.StatusBadRequest)
+            return
+        }
+        filters.CursorTime = &t
+        filters.CursorID = &id
+    }
+
+    entries, err := h.store.List(r.Context(), orgID, filters)
+    // ... handle err ...
+
+    // Build next_cursor from the last entry in the page.
+    var nextCursor *string
+    if len(entries) == filters.Limit {
+        last := entries[len(entries)-1]
+        c := encodeCursor(last.CreatedAt, last.ID)
+        nextCursor = &c
+    }
+
+    // ... render JSON response with data + meta.next_cursor ...
+}
+
+// --- Get handler (sketch) ---------------------------------------------------
+
+// Get handles GET /api/v1/audit-logs/{id}.
+func (h *AuditLogHandler) Get(w http.ResponseWriter, r *http.Request) {
+    // ... parse orgID from auth context ...
+
+    id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
+    if err != nil {
+        http.Error(w, "invalid id", http.StatusBadRequest)
+        return
+    }
+
+    entry, err := h.store.GetByID(r.Context(), orgID, id)
+    if err != nil {
+        if errors.Is(err, pgx.ErrNoRows) {
+            http.Error(w, "not found", http.StatusNotFound)
+            return
+        }
+        // ... handle internal error ...
+        return
+    }
+
+    // ... render JSON response ...
 }
 ```
 
@@ -1036,6 +1160,13 @@ AS $$
 DECLARE
     deleted bigint;
 BEGIN
+    -- Guard: refuse non-positive retention to prevent accidental mass deletion.
+    -- This is a SECURITY DEFINER function that disables the immutability
+    -- trigger, so we must be defensive about the inputs it accepts.
+    IF retention_days <= 0 THEN
+        RAISE EXCEPTION 'retention_days must be positive, got %', retention_days;
+    END IF;
+
     -- Temporarily disable the immutability trigger for this transaction.
     -- Note: ALTER TABLE ... DISABLE/ENABLE TRIGGER is transactional in
     -- Postgres, so if the transaction rolls back the trigger is restored
@@ -1060,8 +1191,12 @@ The Go cleanup job calls this function per-org using the configured retention:
 
 ```go
 // In the scheduled cleanup worker:
+retention := org.Settings.AuditLogRetentionDays
+if retention <= 0 {
+    retention = 90 // default; the SQL function also rejects non-positive values
+}
 _, err := db.Exec(ctx, `SELECT delete_expired_audit_logs(@org_id, @retention)`,
-    pgx.NamedArgs{"org_id": org.ID, "retention": org.Settings.AuditLogRetentionDays})
+    pgx.NamedArgs{"org_id": org.ID, "retention": retention})
 ```
 
 ---

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -428,21 +428,12 @@ import (
     "context"
     "fmt"
     "strconv"
-    "strings"
+    "time"
 
     "github.com/assembledhq/143/internal/models"
     "github.com/google/uuid"
     "github.com/jackc/pgx/v5"
 )
-
-// escapeLike escapes SQL LIKE meta-characters (%, _) so that user-supplied
-// values are matched literally.
-func escapeLike(s string) string {
-    s = strings.ReplaceAll(s, `\`, `\\`)
-    s = strings.ReplaceAll(s, `%`, `\%`)
-    s = strings.ReplaceAll(s, `_`, `\_`)
-    return s
-}
 
 type AuditLogStore struct {
     db DBTX
@@ -455,6 +446,16 @@ func NewAuditLogStore(db DBTX) *AuditLogStore {
 // Create inserts a new audit log entry. This is the only write operation —
 // the table is append-only (enforced by DB trigger).
 func (s *AuditLogStore) Create(ctx context.Context, entry *models.AuditLog) error {
+    if err := entry.ActorType.Validate(); err != nil {
+        return err
+    }
+    if err := entry.Action.Validate(); err != nil {
+        return err
+    }
+    if err := entry.ResourceType.Validate(); err != nil {
+        return err
+    }
+
     query := `
         INSERT INTO audit_logs (
             org_id, actor_type, actor_id, user_id,
@@ -497,16 +498,19 @@ type AuditLogFilters struct {
     ResourceID   string                   // filter by specific resource
     SessionID    *uuid.UUID               // filter by correlated session
     ProjectID    *uuid.UUID               // filter by correlated project
-    Since        *string                  // ISO 8601 timestamp lower bound
-    Until        *string                  // ISO 8601 timestamp upper bound
+    Since        *time.Time               // lower bound on created_at (parsed from ISO 8601 at the handler)
+    Until        *time.Time               // upper bound on created_at (parsed from ISO 8601 at the handler)
     Limit        int
     Cursor       string                   // cursor for keyset pagination (bigserial id)
 }
 
-// whereClause is a shared helper (internal/db/where_clause.go) that accumulates
-// WHERE conditions and named args. It eliminates the error-prone pattern of
-// manually concatenating " AND ..." fragments and ensures every condition is
-// joined consistently. Other stores should adopt this instead of ad-hoc concatenation.
+// The following types and functions live in the shared file
+// internal/db/where_clause.go (not in audit_log_store.go).
+
+// whereClause accumulates WHERE conditions and named args. It eliminates the
+// error-prone pattern of manually concatenating " AND ..." fragments and
+// ensures every condition is joined consistently. Other stores should adopt
+// this instead of ad-hoc concatenation.
 type whereClause struct {
     conditions []string
     args       pgx.NamedArgs
@@ -527,6 +531,17 @@ func (w *whereClause) build() (string, pgx.NamedArgs) {
     }
     return " WHERE " + strings.Join(w.conditions, " AND "), w.args
 }
+
+// escapeLike escapes SQL LIKE meta-characters (%, _) so that user-supplied
+// values are matched literally.
+func escapeLike(s string) string {
+    s = strings.ReplaceAll(s, `\`, `\\`)
+    s = strings.ReplaceAll(s, `%`, `\%`)
+    s = strings.ReplaceAll(s, `_`, `\_`)
+    return s
+}
+
+// --- end of internal/db/where_clause.go ---
 
 // List returns audit log entries for an organization, filtered and paginated.
 func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters AuditLogFilters) ([]models.AuditLog, error) {
@@ -695,6 +710,72 @@ type SystemActionParams struct {
     SessionID    *uuid.UUID
     ProjectID    *uuid.UUID
 }
+
+// EmitAgentAction logs an action performed by an agent (e.g. session completion, question creation).
+func (e *AuditEmitter) EmitAgentAction(ctx context.Context, params AgentActionParams) {
+    entry := &models.AuditLog{
+        OrgID:        params.OrgID,
+        ActorType:    models.AuditActorAgent,
+        ActorID:      params.AgentRunID,
+        Action:       params.Action,
+        ResourceType: params.ResourceType,
+        ResourceID:   params.ResourceID,
+        Details:      params.Details,
+        SessionID:    params.SessionID,
+        ProjectID:    params.ProjectID,
+    }
+    if err := e.store.Create(ctx, entry); err != nil {
+        e.logger.ErrorContext(ctx, "failed to emit audit log",
+            "action", params.Action,
+            "actor_id", params.AgentRunID,
+            "error", err,
+        )
+    }
+}
+
+type AgentActionParams struct {
+    OrgID        uuid.UUID
+    AgentRunID   string // the agent run UUID
+    Action       models.AuditAction
+    ResourceType models.AuditResourceType
+    ResourceID   *string
+    Details      json.RawMessage
+    SessionID    *uuid.UUID
+    ProjectID    *uuid.UUID
+}
+
+// EmitWebhookAction logs an action triggered by an external webhook (e.g. issue ingestion).
+func (e *AuditEmitter) EmitWebhookAction(ctx context.Context, params WebhookActionParams) {
+    entry := &models.AuditLog{
+        OrgID:        params.OrgID,
+        ActorType:    models.AuditActorWebhook,
+        ActorID:      params.ProviderName,
+        Action:       params.Action,
+        ResourceType: params.ResourceType,
+        ResourceID:   params.ResourceID,
+        Details:      params.Details,
+        RequestID:    params.RequestID,
+        IPAddress:    params.IPAddress,
+    }
+    if err := e.store.Create(ctx, entry); err != nil {
+        e.logger.ErrorContext(ctx, "failed to emit audit log",
+            "action", params.Action,
+            "actor_id", params.ProviderName,
+            "error", err,
+        )
+    }
+}
+
+type WebhookActionParams struct {
+    OrgID        uuid.UUID
+    ProviderName string // e.g. "linear", "sentry", "github"
+    Action       models.AuditAction
+    ResourceType models.AuditResourceType
+    ResourceID   *string
+    Details      json.RawMessage
+    RequestID    *string
+    IPAddress    *netip.Addr
+}
 ```
 
 ---
@@ -798,7 +879,36 @@ Audit entries should be emitted at the **handler/service boundary** — the poin
 - **Worker job handlers**: For system-initiated actions (e.g. PM plan creation, session completion)
 - **Webhook handlers**: For externally-triggered actions (e.g. issue ingestion)
 
-### 7.2 Emission pattern
+### 7.2 Helper functions
+
+Two small helpers are used at call sites to extract request context:
+
+```go
+// requestIDFromContext returns the chi middleware.RequestID value, if present.
+func requestIDFromContext(ctx context.Context) *string {
+    id, ok := ctx.Value(middleware.RequestIDKey).(string)
+    if !ok || id == "" {
+        return nil
+    }
+    return &id
+}
+
+// addrFromRequest parses the client IP from r.RemoteAddr (which may include
+// a port, e.g. "192.168.1.1:54321") and returns it as a *netip.Addr.
+func addrFromRequest(r *http.Request) *netip.Addr {
+    host, _, err := net.SplitHostPort(r.RemoteAddr)
+    if err != nil {
+        host = r.RemoteAddr // no port suffix
+    }
+    addr, err := netip.ParseAddr(host)
+    if err != nil {
+        return nil
+    }
+    return &addr
+}
+```
+
+### 7.3 Emission pattern
 
 Audit entries are emitted **after** the primary operation succeeds. If the operation fails, no audit entry is written. This prevents phantom entries.
 
@@ -809,26 +919,27 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 
     // Emit audit entry (fire-and-forget; the emitter logs errors internally)
     resID := session.ID.String()
+    details, _ := json.Marshal(map[string]string{"issue_id": issueID.String()})
     h.auditEmitter.EmitUserAction(r.Context(), db.UserActionParams{
         OrgID:        orgID,
         UserID:       user.ID,
         Action:       models.AuditActionSessionCreated,
         ResourceType: models.AuditResourceSession,
         ResourceID:   &resID,
-        Details:      json.RawMessage(`{"issue_id":"` + issueID.String() + `"}`),
+        Details:      details,
         RequestID:    requestIDFromContext(r.Context()),
-        IPAddress:    addrFromRequest(r), // returns *netip.Addr parsed from r.RemoteAddr
+        IPAddress:    addrFromRequest(r),
         UserAgent:    stringPtr(r.UserAgent()),
         SessionID:    &session.ID,
     })
 }
 ```
 
-### 7.3 Fire-and-forget semantics
+### 7.4 Fire-and-forget semantics
 
 Audit log emission **must not** block or fail the primary operation. If the audit insert fails (e.g. DB connection issue), the error is logged via the structured logger but the API response is unaffected. This is a deliberate trade-off: we prefer occasional missing audit entries over degraded user experience.
 
-### 7.4 Priority instrumentation order
+### 7.5 Priority instrumentation order
 
 Instrument these high-value actions first:
 
@@ -880,7 +991,42 @@ Default retention: **90 days**. Configurable per org via `organizations.settings
 }
 ```
 
-A scheduled job (`audit_log_cleanup`) runs daily, deletes entries older than the retention period. The immutability trigger allows deletes only through a superuser/migration path — the cleanup job would bypass the trigger via a session-level `SET LOCAL` or a dedicated cleanup function.
+A scheduled job (`audit_log_cleanup`) runs daily, deleting entries older than the retention period. Because the immutability trigger blocks `DELETE`, the cleanup uses a `SECURITY DEFINER` function that temporarily disables the trigger within a transaction:
+
+```sql
+-- Included in the 000019 migration alongside the table creation.
+CREATE OR REPLACE FUNCTION delete_expired_audit_logs(retention_days int)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    deleted bigint;
+BEGIN
+    -- Temporarily disable the immutability trigger for this transaction.
+    ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_immutable;
+
+    DELETE FROM audit_logs
+    WHERE created_at < now() - make_interval(days => retention_days);
+
+    GET DIAGNOSTICS deleted = ROW_COUNT;
+
+    -- Re-enable the trigger before committing.
+    ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_immutable;
+
+    RETURN deleted;
+END;
+$$;
+```
+
+The Go cleanup job calls this function per-org using the configured retention:
+
+```go
+// In the scheduled cleanup worker:
+_, err := db.Exec(ctx, `SELECT delete_expired_audit_logs(@retention)`,
+    pgx.NamedArgs{"retention": org.Settings.AuditLogRetentionDays})
+```
 
 ---
 

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -1,0 +1,702 @@
+# Design: Audit Logs
+
+**Status**: Proposal
+**Depends on**: [01-database-schema.md](01-database-schema.md), [02-api-server.md](02-api-server.md)
+
+---
+
+## 1. Problem Statement
+
+Today, 143 has a basic `audit_log` table (created in migration `000001`) with minimal structure:
+
+```sql
+CREATE TABLE audit_log (
+    id            bigserial   PRIMARY KEY,
+    org_id        uuid        NOT NULL REFERENCES organizations(id),
+    actor_type    text        NOT NULL,
+    actor_id      text        NOT NULL,
+    action        text        NOT NULL,
+    resource_type text        NOT NULL,
+    resource_id   uuid,
+    details       jsonb,
+    created_at    timestamptz NOT NULL DEFAULT now()
+);
+```
+
+This table exists but is **not wired into the application** — no Go model, no store, no handler, and no code paths emit audit entries. Additionally, it lacks:
+
+- **Optional user association**: `actor_id` is an opaque `text` field with no foreign key, making it impossible to join with `users` to answer "who did what"
+- **Structured action taxonomy**: No defined vocabulary for actions, making queries unreliable
+- **IP/user-agent tracking**: No request context for security forensics
+- **Correlation**: No way to tie an audit entry to the session, project, or job that triggered it
+- **Retention policy**: No TTL or partitioning strategy for high-volume tables
+- **Query patterns**: Missing indexes for common access patterns (by actor, by action, time-range scans)
+
+We need a production-grade audit log that captures **all significant state changes** — whether initiated by a user, an agent, the PM system, a webhook, or a scheduled job — and makes them queryable for compliance, debugging, and operational visibility.
+
+---
+
+## 2. Design Principles
+
+1. **Append-only and immutable** — Audit logs must never be updated or deleted through the application. The existing immutability trigger is preserved and extended.
+2. **Organization-scoped** — Every entry belongs to exactly one organization. All queries filter by `org_id`.
+3. **Actor-agnostic** — The system must attribute actions to users, agents, system processes, and external webhooks uniformly.
+4. **Optional user linkage** — When a human user is the actor, `user_id` provides a typed foreign key for joins. When the actor is a system process, `user_id` is NULL and `actor_type` + `actor_id` provide identification.
+5. **Structured but extensible** — Core fields use constrained vocabularies (enums for `actor_type`, `action`, `resource_type`). The `details` JSONB field captures action-specific context without schema changes.
+6. **Low-friction instrumentation** — Emitting audit entries should be a single function call. The audit store should accept context and extract org/user automatically where possible.
+7. **Query-first indexing** — Indexes are designed around the access patterns defined in section 6, not speculative.
+
+---
+
+## 3. Schema
+
+### 3.1 Migration: `000019_audit_logs.up.sql`
+
+The new `audit_logs` table replaces the existing `audit_log` table. A migration renames the old table for data preservation, then creates the new one.
+
+```sql
+-- =============================================================================
+-- Rename legacy audit_log table (preserve existing data)
+-- =============================================================================
+ALTER TABLE audit_log RENAME TO audit_log_legacy;
+DROP TRIGGER IF EXISTS audit_log_immutable ON audit_log_legacy;
+
+-- =============================================================================
+-- audit_logs (new)
+-- =============================================================================
+CREATE TABLE audit_logs (
+    id              bigserial       PRIMARY KEY,
+    org_id          uuid            NOT NULL REFERENCES organizations(id),
+
+    -- Actor identification
+    actor_type      text            NOT NULL,  -- 'user', 'agent', 'system', 'webhook'
+    actor_id        text            NOT NULL,  -- user UUID, agent run UUID, 'pm_agent', 'scheduler', provider name, etc.
+    user_id         uuid            REFERENCES users(id),  -- nullable; set when actor is a user
+
+    -- What happened
+    action          text            NOT NULL,  -- e.g. 'session.created', 'project.started', 'settings.updated'
+    resource_type   text            NOT NULL,  -- e.g. 'session', 'project', 'issue', 'settings', 'team_member'
+    resource_id     text,                      -- text (not uuid) to support non-uuid identifiers (e.g. provider names)
+
+    -- Context
+    details         jsonb,                     -- action-specific payload (before/after values, parameters, etc.)
+    request_id      text,                      -- correlates with chi middleware.RequestID for HTTP-initiated actions
+    ip_address      inet,                      -- source IP for user-initiated actions
+    user_agent      text,                      -- browser/client user-agent for user-initiated actions
+
+    -- Correlation
+    session_id      uuid,                      -- links to sessions table when action is session-related
+    project_id      uuid,                      -- links to projects table when action is project-related
+
+    created_at      timestamptz     NOT NULL DEFAULT now()
+);
+
+-- -----------------------------------------------------------------------
+-- Indexes (designed for the query patterns in section 6)
+-- -----------------------------------------------------------------------
+
+-- Primary listing: "show me the audit trail for this org, newest first"
+CREATE INDEX idx_audit_logs_org_created ON audit_logs (org_id, created_at DESC);
+
+-- Resource drill-down: "show me all actions on this specific resource"
+CREATE INDEX idx_audit_logs_resource ON audit_logs (org_id, resource_type, resource_id, created_at DESC);
+
+-- Actor drill-down: "show me everything this user did"
+CREATE INDEX idx_audit_logs_user ON audit_logs (org_id, user_id, created_at DESC) WHERE user_id IS NOT NULL;
+
+-- Action filtering: "show me all session.created events"
+CREATE INDEX idx_audit_logs_action ON audit_logs (org_id, action, created_at DESC);
+
+-- Correlation: "show me all audit entries for this session/project"
+CREATE INDEX idx_audit_logs_session ON audit_logs (session_id, created_at DESC) WHERE session_id IS NOT NULL;
+CREATE INDEX idx_audit_logs_project ON audit_logs (project_id, created_at DESC) WHERE project_id IS NOT NULL;
+
+-- -----------------------------------------------------------------------
+-- Immutability trigger (same pattern as legacy table)
+-- -----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION prevent_audit_logs_modification()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION 'audit_logs is append-only: % operations are not allowed', TG_OP;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER audit_logs_immutable
+    BEFORE UPDATE OR DELETE ON audit_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_logs_modification();
+```
+
+### 3.2 Down migration: `000019_audit_logs.down.sql`
+
+```sql
+DROP TRIGGER IF EXISTS audit_logs_immutable ON audit_logs;
+DROP FUNCTION IF EXISTS prevent_audit_logs_modification();
+DROP TABLE IF EXISTS audit_logs;
+ALTER TABLE IF EXISTS audit_log_legacy RENAME TO audit_log;
+CREATE TRIGGER audit_log_immutable
+    BEFORE UPDATE OR DELETE ON audit_log
+    FOR EACH ROW
+    EXECUTE FUNCTION prevent_audit_log_modification();
+```
+
+---
+
+## 4. Action Taxonomy
+
+Actions follow a `resource.verb` naming convention. This keeps them grep-friendly and naturally groups by resource type.
+
+### 4.1 Session actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `session.created` | user | User triggered a fix or created a manual session |
+| `session.started` | system | Agent execution began |
+| `session.completed` | agent | Agent finished successfully |
+| `session.failed` | agent | Agent run failed |
+| `session.cancelled` | user | User cancelled a running session |
+| `session.status_changed` | system | Any status transition not covered above |
+| `session.question.created` | agent | Agent asked a clarifying question |
+| `session.question.answered` | user | User answered a question |
+| `session.resumed_locally` | user | User took over a session via CLI |
+
+### 4.2 Project actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `project.created` | user | User created a project |
+| `project.updated` | user | User modified project fields |
+| `project.deleted` | user | User deleted a project |
+| `project.started` | user | User transitioned project to active |
+| `project.paused` | user | User paused a project |
+| `project.resumed` | user | User resumed a paused project |
+| `project.approved` | user | User approved a proposed project |
+| `project.dismissed` | user | User dismissed/cancelled a project |
+| `project.run_triggered` | user | User triggered an immediate PM cycle |
+| `project.cycle_completed` | system | PM cycle completed for project |
+| `project.task.created` | user/system | Task added to project |
+| `project.task.updated` | user | User modified a task |
+| `project.task.deleted` | user | User removed a task |
+| `project.task.retried` | user | User retried a failed task |
+
+### 4.3 Issue actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `issue.created` | webhook | Issue ingested from external source |
+| `issue.reprioritized` | user | Admin triggered re-prioritization |
+
+### 4.4 PM actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `pm.analysis_triggered` | user | Admin triggered PM analysis |
+| `pm.plan_created` | system | PM agent produced a plan |
+| `pm.decision_made` | system | PM made a delegate/skip/cluster decision |
+
+### 4.5 Team & settings actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `settings.updated` | user | Admin changed org settings |
+| `team.member_invited` | user | Admin invited a team member |
+| `team.member_role_changed` | user | Admin changed a member's role |
+| `team.member_removed` | user | Admin removed a team member |
+| `team.invitation_revoked` | user | Admin revoked an invitation |
+| `team.invitation_accepted` | user | New member accepted an invitation |
+
+### 4.6 Integration & credential actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `integration.connected` | user | User connected an integration (Linear, Sentry, GitHub, Slack) |
+| `credential.updated` | user | Admin updated agent credentials |
+| `credential.deleted` | user | Admin deleted agent credentials |
+
+### 4.7 Auth actions
+
+| Action | Actor Type | Description |
+|--------|-----------|-------------|
+| `auth.login` | user | User logged in |
+| `auth.logout` | user | User logged out |
+| `auth.register` | user | New user registered |
+
+This taxonomy is **not enforced at the database level** (it's `text`, not an enum). The vocabulary is enforced in Go constants and documented here. This allows new actions to be added without migrations.
+
+---
+
+## 5. Go Model & Store
+
+### 5.1 Model (`internal/models/audit.go`)
+
+```go
+package models
+
+import (
+    "encoding/json"
+    "net"
+    "time"
+
+    "github.com/google/uuid"
+)
+
+// AuditLog represents an immutable audit trail entry.
+type AuditLog struct {
+    ID           int64           `db:"id" json:"id"`
+    OrgID        uuid.UUID       `db:"org_id" json:"org_id"`
+    ActorType    string          `db:"actor_type" json:"actor_type"`
+    ActorID      string          `db:"actor_id" json:"actor_id"`
+    UserID       *uuid.UUID      `db:"user_id" json:"user_id,omitempty"`
+    Action       string          `db:"action" json:"action"`
+    ResourceType string          `db:"resource_type" json:"resource_type"`
+    ResourceID   *string         `db:"resource_id" json:"resource_id,omitempty"`
+    Details      json.RawMessage `db:"details" json:"details,omitempty"`
+    RequestID    *string         `db:"request_id" json:"request_id,omitempty"`
+    IPAddress    net.IP          `db:"ip_address" json:"ip_address,omitempty"`
+    UserAgent    *string         `db:"user_agent" json:"user_agent,omitempty"`
+    SessionID    *uuid.UUID      `db:"session_id" json:"session_id,omitempty"`
+    ProjectID    *uuid.UUID      `db:"project_id" json:"project_id,omitempty"`
+    CreatedAt    time.Time       `db:"created_at" json:"created_at"`
+}
+
+// Actor type constants.
+const (
+    ActorTypeUser    = "user"
+    ActorTypeAgent   = "agent"
+    ActorTypeSystem  = "system"
+    ActorTypeWebhook = "webhook"
+)
+```
+
+### 5.2 Store (`internal/db/audit_log_store.go`)
+
+```go
+package db
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/assembledhq/143/internal/models"
+    "github.com/google/uuid"
+    "github.com/jackc/pgx/v5"
+)
+
+type AuditLogStore struct {
+    db DBTX
+}
+
+func NewAuditLogStore(db DBTX) *AuditLogStore {
+    return &AuditLogStore{db: db}
+}
+
+// Create inserts a new audit log entry. This is the only write operation —
+// the table is append-only (enforced by DB trigger).
+func (s *AuditLogStore) Create(ctx context.Context, entry *models.AuditLog) error {
+    query := `
+        INSERT INTO audit_logs (
+            org_id, actor_type, actor_id, user_id,
+            action, resource_type, resource_id,
+            details, request_id, ip_address, user_agent,
+            session_id, project_id
+        ) VALUES (
+            @org_id, @actor_type, @actor_id, @user_id,
+            @action, @resource_type, @resource_id,
+            @details, @request_id, @ip_address, @user_agent,
+            @session_id, @project_id
+        )
+        RETURNING id, created_at`
+
+    row := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+        "org_id":        entry.OrgID,
+        "actor_type":    entry.ActorType,
+        "actor_id":      entry.ActorID,
+        "user_id":       entry.UserID,
+        "action":        entry.Action,
+        "resource_type": entry.ResourceType,
+        "resource_id":   entry.ResourceID,
+        "details":       entry.Details,
+        "request_id":    entry.RequestID,
+        "ip_address":    entry.IPAddress,
+        "user_agent":    entry.UserAgent,
+        "session_id":    entry.SessionID,
+        "project_id":    entry.ProjectID,
+    })
+    return row.Scan(&entry.ID, &entry.CreatedAt)
+}
+
+// AuditLogFilters controls listing/search behavior.
+type AuditLogFilters struct {
+    ActorType    string     // filter by actor type
+    UserID       *uuid.UUID // filter by specific user
+    Action       string     // filter by action (exact match)
+    ActionPrefix string     // filter by action prefix (e.g. "session." matches all session actions)
+    ResourceType string     // filter by resource type
+    ResourceID   string     // filter by specific resource
+    SessionID    *uuid.UUID // filter by correlated session
+    ProjectID    *uuid.UUID // filter by correlated project
+    Since        *string    // ISO 8601 timestamp lower bound
+    Until        *string    // ISO 8601 timestamp upper bound
+    Limit        int
+    Cursor       string     // cursor for keyset pagination (bigserial id)
+}
+
+// List returns audit log entries for an organization, filtered and paginated.
+func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters AuditLogFilters) ([]models.AuditLog, error) {
+    query := `
+        SELECT id, org_id, actor_type, actor_id, user_id,
+               action, resource_type, resource_id,
+               details, request_id, ip_address, user_agent,
+               session_id, project_id, created_at
+        FROM audit_logs
+        WHERE org_id = @org_id`
+
+    args := pgx.NamedArgs{"org_id": orgID}
+
+    if filters.ActorType != "" {
+        query += ` AND actor_type = @actor_type`
+        args["actor_type"] = filters.ActorType
+    }
+    if filters.UserID != nil {
+        query += ` AND user_id = @user_id`
+        args["user_id"] = *filters.UserID
+    }
+    if filters.Action != "" {
+        query += ` AND action = @action`
+        args["action"] = filters.Action
+    }
+    if filters.ActionPrefix != "" {
+        query += ` AND action LIKE @action_prefix`
+        args["action_prefix"] = filters.ActionPrefix + "%"
+    }
+    if filters.ResourceType != "" {
+        query += ` AND resource_type = @resource_type`
+        args["resource_type"] = filters.ResourceType
+    }
+    if filters.ResourceID != "" {
+        query += ` AND resource_id = @resource_id`
+        args["resource_id"] = filters.ResourceID
+    }
+    if filters.SessionID != nil {
+        query += ` AND session_id = @session_id`
+        args["session_id"] = *filters.SessionID
+    }
+    if filters.ProjectID != nil {
+        query += ` AND project_id = @project_id`
+        args["project_id"] = *filters.ProjectID
+    }
+    if filters.Since != nil {
+        query += ` AND created_at >= @since`
+        args["since"] = *filters.Since
+    }
+    if filters.Until != nil {
+        query += ` AND created_at <= @until`
+        args["until"] = *filters.Until
+    }
+    if filters.Cursor != "" {
+        query += ` AND id < @cursor`
+        args["cursor"] = filters.Cursor
+    }
+
+    query += ` ORDER BY id DESC`
+
+    limit := filters.Limit
+    if limit <= 0 || limit > 200 {
+        limit = 50
+    }
+    query += fmt.Sprintf(` LIMIT %d`, limit)
+
+    rows, err := s.db.Query(ctx, query, args)
+    if err != nil {
+        return nil, fmt.Errorf("query audit logs: %w", err)
+    }
+    return pgx.CollectRows(rows, pgx.RowToStructByName[models.AuditLog])
+}
+```
+
+### 5.3 Emitter helper (`internal/db/audit_emitter.go`)
+
+To reduce boilerplate at call sites, provide a convenience layer:
+
+```go
+package db
+
+import (
+    "context"
+    "encoding/json"
+
+    "github.com/assembledhq/143/internal/models"
+    "github.com/google/uuid"
+)
+
+// AuditEmitter provides convenience methods for emitting audit log entries.
+type AuditEmitter struct {
+    store *AuditLogStore
+}
+
+func NewAuditEmitter(store *AuditLogStore) *AuditEmitter {
+    return &AuditEmitter{store: store}
+}
+
+// EmitUserAction logs an action performed by an authenticated user.
+// Extracts request context (request ID, IP, user-agent) from the provided values.
+func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionParams) error {
+    entry := &models.AuditLog{
+        OrgID:        params.OrgID,
+        ActorType:    models.ActorTypeUser,
+        ActorID:      params.UserID.String(),
+        UserID:       &params.UserID,
+        Action:       params.Action,
+        ResourceType: params.ResourceType,
+        ResourceID:   params.ResourceID,
+        Details:      params.Details,
+        RequestID:    params.RequestID,
+        IPAddress:    params.IPAddress,
+        UserAgent:    params.UserAgent,
+        SessionID:    params.SessionID,
+        ProjectID:    params.ProjectID,
+    }
+    return e.store.Create(ctx, entry)
+}
+
+type UserActionParams struct {
+    OrgID        uuid.UUID
+    UserID       uuid.UUID
+    Action       string
+    ResourceType string
+    ResourceID   *string
+    Details      json.RawMessage
+    RequestID    *string
+    IPAddress    net.IP
+    UserAgent    *string
+    SessionID    *uuid.UUID
+    ProjectID    *uuid.UUID
+}
+
+// EmitSystemAction logs an action performed by a system process (PM agent, scheduler, etc.).
+func (e *AuditEmitter) EmitSystemAction(ctx context.Context, params SystemActionParams) error {
+    entry := &models.AuditLog{
+        OrgID:        params.OrgID,
+        ActorType:    models.ActorTypeSystem,
+        ActorID:      params.ActorID,
+        Action:       params.Action,
+        ResourceType: params.ResourceType,
+        ResourceID:   params.ResourceID,
+        Details:      params.Details,
+        SessionID:    params.SessionID,
+        ProjectID:    params.ProjectID,
+    }
+    return e.store.Create(ctx, entry)
+}
+
+type SystemActionParams struct {
+    OrgID        uuid.UUID
+    ActorID      string // e.g. "pm_agent", "scheduler", "validator"
+    Action       string
+    ResourceType string
+    ResourceID   *string
+    Details      json.RawMessage
+    SessionID    *uuid.UUID
+    ProjectID    *uuid.UUID
+}
+```
+
+---
+
+## 6. API
+
+### 6.1 Endpoints
+
+All audit log endpoints are **read-only** and require authentication.
+
+| Method | Path | Role | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/v1/audit-logs` | admin | List audit logs with filters |
+| `GET` | `/api/v1/audit-logs/{id}` | admin | Get a single audit log entry |
+
+Audit log listing is restricted to **admin** role. This is sensitive data — org members and viewers should not have access to the full audit trail.
+
+### 6.2 Query parameters for `GET /api/v1/audit-logs`
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `actor_type` | string | Filter by actor type (`user`, `agent`, `system`, `webhook`) |
+| `user_id` | uuid | Filter by specific user |
+| `action` | string | Exact action match (e.g. `session.created`) |
+| `action_prefix` | string | Action prefix match (e.g. `session.` returns all session actions) |
+| `resource_type` | string | Filter by resource type |
+| `resource_id` | string | Filter by specific resource |
+| `session_id` | uuid | Filter by correlated session |
+| `project_id` | uuid | Filter by correlated project |
+| `since` | ISO 8601 | Lower bound on `created_at` |
+| `until` | ISO 8601 | Upper bound on `created_at` |
+| `limit` | int | Page size (default 50, max 200) |
+| `cursor` | string | Cursor for keyset pagination (entry ID) |
+
+### 6.3 Response format
+
+```json
+{
+  "data": [
+    {
+      "id": 12847,
+      "org_id": "550e8400-e29b-41d4-a716-446655440000",
+      "actor_type": "user",
+      "actor_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+      "user_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+      "action": "project.started",
+      "resource_type": "project",
+      "resource_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "details": {
+        "previous_status": "draft",
+        "new_status": "active"
+      },
+      "request_id": "req-abc123",
+      "ip_address": "192.168.1.100",
+      "user_agent": "Mozilla/5.0 ...",
+      "session_id": null,
+      "project_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "created_at": "2026-03-15T14:30:00Z"
+    }
+  ],
+  "meta": {
+    "next_cursor": "12846"
+  }
+}
+```
+
+### 6.4 Handler (`internal/api/handlers/audit_logs.go`)
+
+```go
+type AuditLogHandler struct {
+    store *db.AuditLogStore
+}
+
+func NewAuditLogHandler(store *db.AuditLogStore) *AuditLogHandler {
+    return &AuditLogHandler{store: store}
+}
+```
+
+### 6.5 Router registration
+
+```go
+// Admin-only routes
+r.Group(func(r chi.Router) {
+    r.Use(middleware.RequireRole("admin"))
+
+    r.Get("/api/v1/audit-logs", auditLogHandler.List)
+    r.Get("/api/v1/audit-logs/{id}", auditLogHandler.Get)
+    // ... existing admin routes ...
+})
+```
+
+---
+
+## 7. Instrumentation Strategy
+
+### 7.1 Where to emit audit entries
+
+Audit entries should be emitted at the **handler/service boundary** — the point where a user or system action translates into a state change. This is typically:
+
+- **API handlers**: For user-initiated actions (e.g. `sessionHandler.TriggerFix`, `projectHandler.Start`)
+- **Worker job handlers**: For system-initiated actions (e.g. PM plan creation, session completion)
+- **Webhook handlers**: For externally-triggered actions (e.g. issue ingestion)
+
+### 7.2 Emission pattern
+
+Audit entries are emitted **after** the primary operation succeeds. If the operation fails, no audit entry is written. This prevents phantom entries.
+
+```go
+// Example: in sessionHandler.TriggerFix
+func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
+    // ... existing logic to create session and enqueue job ...
+
+    // Emit audit entry (fire-and-forget; failure is logged, not returned to user)
+    resID := session.ID.String()
+    _ = h.auditEmitter.EmitUserAction(r.Context(), db.UserActionParams{
+        OrgID:        orgID,
+        UserID:       user.ID,
+        Action:       "session.created",
+        ResourceType: "session",
+        ResourceID:   &resID,
+        Details:      json.RawMessage(`{"issue_id":"` + issueID.String() + `"}`),
+        RequestID:    requestIDFromContext(r.Context()),
+        IPAddress:    net.ParseIP(r.RemoteAddr),
+        UserAgent:    stringPtr(r.UserAgent()),
+        SessionID:    &session.ID,
+    })
+}
+```
+
+### 7.3 Fire-and-forget semantics
+
+Audit log emission **must not** block or fail the primary operation. If the audit insert fails (e.g. DB connection issue), the error is logged via the structured logger but the API response is unaffected. This is a deliberate trade-off: we prefer occasional missing audit entries over degraded user experience.
+
+### 7.4 Priority instrumentation order
+
+Instrument these high-value actions first:
+
+1. **Auth events** — `auth.login`, `auth.logout`, `auth.register`
+2. **Session lifecycle** — `session.created`, `session.completed`, `session.failed`, `session.cancelled`
+3. **Team management** — `team.member_invited`, `team.member_role_changed`, `team.member_removed`
+4. **Settings & credentials** — `settings.updated`, `credential.updated`, `credential.deleted`
+5. **Project lifecycle** — `project.created`, `project.started`, `project.paused`, `project.deleted`
+6. **Everything else** — PM actions, webhook ingestion, question answers
+
+---
+
+## 8. Retention & Scaling Considerations
+
+### 8.1 Volume estimates
+
+| Action category | Estimated frequency | Volume/month (100 orgs) |
+|----------------|--------------------|-----------------------|
+| Auth events | ~5-50/day/org | ~150K |
+| Session lifecycle | ~10-100/day/org | ~300K |
+| Project actions | ~1-20/day/org | ~60K |
+| Team/settings | ~1-5/day/org | ~15K |
+| Webhook ingestion | ~10-500/day/org | ~1.5M |
+| **Total** | | **~2M/month** |
+
+At this volume, a single unpartitioned table with proper indexes will handle reads and writes comfortably for the first year.
+
+### 8.2 Future: time-based partitioning
+
+When the table exceeds ~50M rows, partition by month on `created_at`:
+
+```sql
+-- Future migration (not included in initial rollout)
+CREATE TABLE audit_logs (
+    ...
+) PARTITION BY RANGE (created_at);
+
+CREATE TABLE audit_logs_2026_03 PARTITION OF audit_logs
+    FOR VALUES FROM ('2026-03-01') TO ('2026-04-01');
+```
+
+### 8.3 Retention policy
+
+Default retention: **90 days**. Configurable per org via `organizations.settings`:
+
+```json
+{
+  "audit_log_retention_days": 90
+}
+```
+
+A scheduled job (`audit_log_cleanup`) runs daily, deletes entries older than the retention period. The immutability trigger allows deletes only through a superuser/migration path — the cleanup job would bypass the trigger via a session-level `SET LOCAL` or a dedicated cleanup function.
+
+---
+
+## 9. Migration from Legacy Table
+
+The migration renames `audit_log` to `audit_log_legacy`. No data migration is performed — the legacy table has minimal data and a different schema. After the new system is stable (30 days), a follow-up migration drops `audit_log_legacy`.
+
+---
+
+## 10. What This Design Does NOT Include
+
+- **Real-time streaming of audit events** — SSE/WebSocket streaming is out of scope. The table is queryable via API.
+- **Export to external SIEM** — Future work. The structured schema makes it straightforward to build a CDC pipeline or export job.
+- **Automatic revert capabilities** — Audit logs record what happened; they do not provide undo. Revert functionality (e.g. reverting a session's commits) is a separate feature.
+- **Frontend UI for audit logs** — A dedicated audit log viewer page is out of scope for the initial implementation. Admins can query via API.

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -326,7 +326,7 @@ const (
     AuditActionAuthRegister AuditAction = "auth.register"
 )
 
-// AuditAction.Validate checks that the action is a known value.
+// Validate checks that the action is a known value.
 func (a AuditAction) Validate() error {
     switch a {
     case AuditActionSessionCreated, AuditActionSessionStarted, AuditActionSessionCompleted,
@@ -415,12 +415,6 @@ type AuditLog struct {
 
 ### 5.3 Store (`internal/db/audit_log_store.go`)
 
-> **Note**: The `whereClause` helper below is defined in a shared file
-> `internal/db/where_clause.go` so that other stores (`SessionStore`,
-> `IssueStore`, `ProjectStore`, etc.) can adopt it to replace their ad-hoc
-> `query += " AND ..."` concatenation. The audit log store is the first
-> consumer.
-
 ```go
 package db
 
@@ -504,45 +498,6 @@ type AuditLogFilters struct {
     Cursor       string                   // cursor for keyset pagination (bigserial id)
 }
 
-// The following types and functions live in the shared file
-// internal/db/where_clause.go (not in audit_log_store.go).
-
-// whereClause accumulates WHERE conditions and named args. It eliminates the
-// error-prone pattern of manually concatenating " AND ..." fragments and
-// ensures every condition is joined consistently. Other stores should adopt
-// this instead of ad-hoc concatenation.
-type whereClause struct {
-    conditions []string
-    args       pgx.NamedArgs
-}
-
-func newWhereClause() *whereClause {
-    return &whereClause{args: pgx.NamedArgs{}}
-}
-
-func (w *whereClause) add(condition string, name string, value interface{}) {
-    w.conditions = append(w.conditions, condition)
-    w.args[name] = value
-}
-
-func (w *whereClause) build() (string, pgx.NamedArgs) {
-    if len(w.conditions) == 0 {
-        return "", w.args
-    }
-    return " WHERE " + strings.Join(w.conditions, " AND "), w.args
-}
-
-// escapeLike escapes SQL LIKE meta-characters (%, _) so that user-supplied
-// values are matched literally.
-func escapeLike(s string) string {
-    s = strings.ReplaceAll(s, `\`, `\\`)
-    s = strings.ReplaceAll(s, `%`, `\%`)
-    s = strings.ReplaceAll(s, `_`, `\_`)
-    return s
-}
-
-// --- end of internal/db/where_clause.go ---
-
 // List returns audit log entries for an organization, filtered and paginated.
 func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters AuditLogFilters) ([]models.AuditLog, error) {
     w := newWhereClause()
@@ -609,7 +564,55 @@ func (s *AuditLogStore) List(ctx context.Context, orgID uuid.UUID, filters Audit
 }
 ```
 
-### 5.4 Emitter helper (`internal/db/audit_emitter.go`)
+### 5.4 Shared query builder (`internal/db/where_clause.go`)
+
+The `whereClause` helper is defined in a shared file so that other stores (`SessionStore`, `IssueStore`, `ProjectStore`, etc.) can adopt it to replace their ad-hoc `query += " AND ..."` concatenation. The audit log store is the first consumer.
+
+```go
+package db
+
+import (
+    "strings"
+
+    "github.com/jackc/pgx/v5"
+)
+
+// whereClause accumulates WHERE conditions and named args. It eliminates the
+// error-prone pattern of manually concatenating " AND ..." fragments and
+// ensures every condition is joined consistently. Other stores should adopt
+// this instead of ad-hoc concatenation.
+type whereClause struct {
+    conditions []string
+    args       pgx.NamedArgs
+}
+
+func newWhereClause() *whereClause {
+    return &whereClause{args: pgx.NamedArgs{}}
+}
+
+func (w *whereClause) add(condition string, name string, value interface{}) {
+    w.conditions = append(w.conditions, condition)
+    w.args[name] = value
+}
+
+func (w *whereClause) build() (string, pgx.NamedArgs) {
+    if len(w.conditions) == 0 {
+        return "", w.args
+    }
+    return " WHERE " + strings.Join(w.conditions, " AND "), w.args
+}
+
+// escapeLike escapes SQL LIKE meta-characters (%, _) so that user-supplied
+// values are matched literally.
+func escapeLike(s string) string {
+    s = strings.ReplaceAll(s, `\`, `\\`)
+    s = strings.ReplaceAll(s, `%`, `\%`)
+    s = strings.ReplaceAll(s, `_`, `\_`)
+    return s
+}
+```
+
+### 5.5 Emitter helper (`internal/db/audit_emitter.go`)
 
 To reduce boilerplate at call sites, provide a convenience layer:
 
@@ -881,9 +884,14 @@ Audit entries should be emitted at the **handler/service boundary** — the poin
 
 ### 7.2 Helper functions
 
-Two small helpers are used at call sites to extract request context:
+Three small helpers are used at call sites to extract request context:
 
 ```go
+// stringPtr returns a pointer to a string value. Used for optional fields.
+func stringPtr(s string) *string {
+    return &s
+}
+
 // requestIDFromContext returns the chi middleware.RequestID value, if present.
 func requestIDFromContext(ctx context.Context) *string {
     id, ok := ctx.Value(middleware.RequestIDKey).(string)
@@ -995,7 +1003,7 @@ A scheduled job (`audit_log_cleanup`) runs daily, deleting entries older than th
 
 ```sql
 -- Included in the 000019 migration alongside the table creation.
-CREATE OR REPLACE FUNCTION delete_expired_audit_logs(retention_days int)
+CREATE OR REPLACE FUNCTION delete_expired_audit_logs(target_org_id uuid, retention_days int)
 RETURNS bigint
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -1005,14 +1013,18 @@ DECLARE
     deleted bigint;
 BEGIN
     -- Temporarily disable the immutability trigger for this transaction.
+    -- Note: ALTER TABLE ... DISABLE/ENABLE TRIGGER is transactional in
+    -- Postgres, so if the transaction rolls back the trigger is restored
+    -- automatically. A crash before commit also rolls back, so the trigger
+    -- remains enabled. This is safe without additional EXCEPTION handling.
     ALTER TABLE audit_logs DISABLE TRIGGER audit_logs_immutable;
 
     DELETE FROM audit_logs
-    WHERE created_at < now() - make_interval(days => retention_days);
+    WHERE org_id = target_org_id
+      AND created_at < now() - make_interval(days => retention_days);
 
     GET DIAGNOSTICS deleted = ROW_COUNT;
 
-    -- Re-enable the trigger before committing.
     ALTER TABLE audit_logs ENABLE TRIGGER audit_logs_immutable;
 
     RETURN deleted;
@@ -1024,8 +1036,8 @@ The Go cleanup job calls this function per-org using the configured retention:
 
 ```go
 // In the scheduled cleanup worker:
-_, err := db.Exec(ctx, `SELECT delete_expired_audit_logs(@retention)`,
-    pgx.NamedArgs{"retention": org.Settings.AuditLogRetentionDays})
+_, err := db.Exec(ctx, `SELECT delete_expired_audit_logs(@org_id, @retention)`,
+    pgx.NamedArgs{"org_id": org.ID, "retention": org.Settings.AuditLogRetentionDays})
 ```
 
 ---


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive design document for a production-grade audit logging system. The document specifies the schema, data model, API, and instrumentation strategy for capturing and querying all significant state changes across the application.

## Key Changes

- **Database Schema** (`000019_audit_logs.up.sql`): New `audit_logs` table with structured fields for actor identification, action taxonomy, resource tracking, and request context. Includes immutability trigger and 6 purpose-built indexes for common query patterns (org listing, resource drill-down, actor filtering, action filtering, session/project correlation).

- **Go Models & Enums** (`internal/models/audit_enums.go`, `internal/models/audit.go`): Typed enums for `AuditActorType`, `AuditAction`, and `AuditResourceType` with validation. Comprehensive action taxonomy covering sessions, projects, issues, PM decisions, team management, integrations, and auth events.

- **Data Access Layer** (`internal/db/audit_log_store.go`): `AuditLogStore` with `Create()` for append-only writes and `List()` with flexible filtering (by actor, action, resource, time range, correlation IDs). Keyset pagination support via cursor-based navigation.

- **Query Builder Utility** (`internal/db/where_clause.go`): Reusable `whereClause` helper to eliminate ad-hoc SQL concatenation and ensure consistent condition joining across stores.

- **Audit Emission Layer** (`internal/db/audit_emitter.go`): `AuditEmitter` with fire-and-forget convenience methods (`EmitUserAction`, `EmitSystemAction`, `EmitAgentAction`, `EmitWebhookAction`) that log errors internally without blocking primary operations.

- **API Endpoints** (`internal/api/handlers/audit_logs.go`): Read-only REST API with `GET /api/v1/audit-logs` (list with filters) and `GET /api/v1/audit-logs/{id}` (single entry). Admin-only access. Opaque base64-encoded cursor pagination.

- **Retention & Cleanup**: `delete_expired_audit_logs()` SQL function with configurable per-org retention (default 90 days). Safely disables immutability trigger within a transaction for cleanup operations.

## Notable Implementation Details

- **Actor-agnostic design**: Supports users, agents, system processes, and webhooks uniformly via `actor_type` + `actor_id`, with optional `user_id` foreign key for typed user linkage.

- **Append-only enforcement**: Database trigger prevents UPDATE/DELETE operations; cleanup uses `SECURITY DEFINER` function to temporarily disable trigger within a transaction.

- **No speculative indexing**: All 6 indexes are designed around documented access patterns (section 6, API) rather than guesses.

- **Fire-and-forget semantics**: Audit emission never blocks or fails the primary operation; errors are logged internally.

- **Extensible action taxonomy**: Actions use `resource.verb` naming convention and are stored as `text` (not enum), allowing new actions to be added without migrations.

- **Structured but flexible details**: Core fields use constrained vocabularies; action-specific context captured in JSONB `details` field without schema changes.

- **Keyset pagination**: Cursor-based pagination using `(created_at DESC, id DESC)` composite index for efficient large-table scans without offset.

This design is production-ready and includes volume estimates (~2M audit entries/month at 100 orgs), future partitioning strategy, and a clear instrumentation roadmap prioritizing high-value actions (auth, sessions, team management).

https://claude.ai/code/session_01YRUXave3rt5mg6rFbbGx3y