### PR TITLE
Design: Repository-scoped navigation with header context switcher

### DIFF
--- a/frontend/src/app/(dashboard)/projects/projects-page-content.tsx
+++ b/frontend/src/app/(dashboard)/projects/projects-page-content.tsx
@@ -224,14 +224,15 @@ const columns: ColumnDef<Project>[] = [
 export function ProjectsPageContent() {
   const router = useRouter();
   const [statusFilter, setStatusFilter] = useQueryState("status", parseAsString);
+  const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const isScheduledFilter = statusFilter === "scheduled";
   const apiStatus = statusFilter && statusFilter !== "all" && !isScheduledFilter ? statusFilter : undefined;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["projects", apiStatus],
-    queryFn: () => api.projects.list({ status: apiStatus }),
+    queryKey: ["projects", apiStatus, repo],
+    queryFn: () => api.projects.list({ status: apiStatus, repository_id: repo ?? undefined }),
     refetchInterval: 10000,
   });
 

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -232,11 +232,12 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
 export function SessionsPageContent() {
   const router = useRouter();
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
+  const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["sessions"],
-    queryFn: () => api.sessions.list({ limit: 50 }),
+    queryKey: ["sessions", repo],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
     refetchInterval: 10000,
   });
 

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { AuthenticatedLayout } from "./authenticated-layout";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
 
 const { pushMock, replaceMock, logoutMock } = vi.hoisted(() => ({
   pushMock: vi.fn(),
@@ -95,5 +97,35 @@ describe("AuthenticatedLayout", () => {
     await user.click(await screen.findByRole("menuitem", { name: "Coding Agent" }));
 
     expect(pushMock).toHaveBeenCalledWith("/agent");
+  });
+
+  it("does not show repo context switcher when org has only 1 repo", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              repository_id: "repo-1",
+              full_name: "acme/api-server",
+              active_session_count: 0,
+              latest_session_status: null,
+              active_project_count: 0,
+            },
+          ],
+          meta: {},
+        });
+      })
+    );
+
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    // Wait for the query to settle, then verify the switcher is NOT rendered
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -29,6 +29,7 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { api } from "@/lib/api";
 import { useEffect } from "react";
+import { RepoContextSwitcher } from "@/components/repo-context-switcher";
 
 const navItems = [
   { label: "Overview", icon: LayoutDashboard, href: "/overview" },
@@ -108,10 +109,11 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     <div className="flex h-screen">
       <aside className="w-64 border-r border-border bg-sidebar flex flex-col relative">
         <div className="absolute inset-0 bg-gradient-to-b from-primary/[0.03] to-transparent pointer-events-none" />
-        <div className="relative px-5 py-5">
+        <div className="relative px-5 py-5 flex items-center gap-2">
           <Link href="/overview" className="text-base font-bold tracking-tight text-sidebar-foreground">
             143.dev
           </Link>
+          <RepoContextSwitcher />
         </div>
         <nav className="relative flex-1 px-2.5 space-y-0.5">
           {navItems.map((item) => {

--- a/frontend/src/components/repo-context-switcher.test.tsx
+++ b/frontend/src/components/repo-context-switcher.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { RepoContextSwitcher } from "./repo-context-switcher";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
@@ -9,57 +9,72 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
 }));
 
+const twoRepos = [
+  {
+    repository_id: "repo-1",
+    full_name: "acme/api-server",
+    active_session_count: 3,
+    latest_session_status: "running",
+    active_project_count: 2,
+  },
+  {
+    repository_id: "repo-2",
+    full_name: "acme/web-app",
+    active_session_count: 0,
+    latest_session_status: null,
+    active_project_count: 0,
+  },
+];
+
+const fourRepos = [
+  ...twoRepos,
+  {
+    repository_id: "repo-3",
+    full_name: "acme/mobile-app",
+    active_session_count: 1,
+    latest_session_status: "needs_human_guidance",
+    active_project_count: 1,
+  },
+  {
+    repository_id: "repo-4",
+    full_name: "acme/infra",
+    active_session_count: 0,
+    latest_session_status: "failed",
+    active_project_count: 0,
+  },
+];
+
+function mockSummary(data: typeof twoRepos) {
+  server.use(
+    http.get("/api/v1/repositories/summary", () => {
+      return HttpResponse.json({ data, meta: {} });
+    })
+  );
+}
+
 describe("RepoContextSwitcher", () => {
   it("renders nothing when org has only 1 repo", async () => {
-    server.use(
-      http.get("/api/v1/repositories/summary", () => {
-        return HttpResponse.json({
-          data: [
-            {
-              repository_id: "repo-1",
-              full_name: "acme/api-server",
-              active_session_count: 0,
-              latest_session_status: null,
-              active_project_count: 0,
-            },
-          ],
-          meta: {},
-        });
-      })
-    );
+    mockSummary([twoRepos[0]]);
 
     const { container } = renderWithProviders(<RepoContextSwitcher />);
 
-    // Wait for query to resolve then verify nothing is rendered
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders nothing when org has zero repos", async () => {
+    mockSummary([]);
+
+    const { container } = renderWithProviders(<RepoContextSwitcher />);
+
     await waitFor(() => {
       expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
     });
   });
 
   it("renders the context switcher when org has 2+ repos", async () => {
-    server.use(
-      http.get("/api/v1/repositories/summary", () => {
-        return HttpResponse.json({
-          data: [
-            {
-              repository_id: "repo-1",
-              full_name: "acme/api-server",
-              active_session_count: 3,
-              latest_session_status: "running",
-              active_project_count: 2,
-            },
-            {
-              repository_id: "repo-2",
-              full_name: "acme/web-app",
-              active_session_count: 0,
-              latest_session_status: null,
-              active_project_count: 0,
-            },
-          ],
-          meta: {},
-        });
-      })
-    );
+    mockSummary(twoRepos);
 
     renderWithProviders(<RepoContextSwitcher />);
 
@@ -67,44 +82,88 @@ describe("RepoContextSwitcher", () => {
       expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
     });
 
-    // Default label should be "All repositories"
     expect(screen.getByText("All repositories")).toBeInTheDocument();
   });
 
-  it("shows 'All repositories' as default selected state", async () => {
-    server.use(
-      http.get("/api/v1/repositories/summary", () => {
-        return HttpResponse.json({
-          data: [
-            { repository_id: "repo-1", full_name: "acme/api-server", active_session_count: 0, latest_session_status: null, active_project_count: 0 },
-            { repository_id: "repo-2", full_name: "acme/web-app", active_session_count: 0, latest_session_status: null, active_project_count: 0 },
-          ],
-          meta: {},
-        });
-      })
-    );
+  it("opens dropdown and shows repo items on click", async () => {
+    mockSummary(twoRepos);
+    const user = userEvent.setup();
 
     renderWithProviders(<RepoContextSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText("All repositories")).toBeInTheDocument();
+      expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("repo-context-switcher"));
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/api-server")).toBeInTheDocument();
+      expect(screen.getByText("acme/web-app")).toBeInTheDocument();
     });
   });
 
-  it("renders nothing when org has zero repos", async () => {
-    server.use(
-      http.get("/api/v1/repositories/summary", () => {
-        return HttpResponse.json({
-          data: [],
-          meta: {},
-        });
-      })
-    );
+  it("shows active session count badge for repos with active sessions", async () => {
+    mockSummary(twoRepos);
+    const user = userEvent.setup();
 
-    const { container } = renderWithProviders(<RepoContextSwitcher />);
+    renderWithProviders(<RepoContextSwitcher />);
 
     await waitFor(() => {
-      expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
+      expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("repo-context-switcher"));
+
+    await waitFor(() => {
+      expect(screen.getByText("3")).toBeInTheDocument();
+    });
+  });
+
+  it("shows search input when 4+ repos and filters results", async () => {
+    mockSummary(fourRepos);
+    const user = userEvent.setup();
+
+    renderWithProviders(<RepoContextSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("repo-context-switcher"));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Search repos...")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("Search repos..."), "mobile");
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/mobile-app")).toBeInTheDocument();
+      expect(screen.queryByText("acme/api-server")).not.toBeInTheDocument();
+    });
+  });
+
+  it("selects a repo when clicking a menu item", async () => {
+    mockSummary(twoRepos);
+    const user = userEvent.setup();
+
+    renderWithProviders(<RepoContextSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("repo-context-switcher"));
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/api-server")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("acme/api-server"));
+
+    await waitFor(() => {
+      expect(screen.getByText("api-server")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/repo-context-switcher.test.tsx
+++ b/frontend/src/components/repo-context-switcher.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
+import { RepoContextSwitcher } from "./repo-context-switcher";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/sessions",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+describe("RepoContextSwitcher", () => {
+  it("renders nothing when org has only 1 repo", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              repository_id: "repo-1",
+              full_name: "acme/api-server",
+              active_session_count: 0,
+              latest_session_status: null,
+              active_project_count: 0,
+            },
+          ],
+          meta: {},
+        });
+      })
+    );
+
+    const { container } = renderWithProviders(<RepoContextSwitcher />);
+
+    // Wait for query to resolve then verify nothing is rendered
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders the context switcher when org has 2+ repos", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () => {
+        return HttpResponse.json({
+          data: [
+            {
+              repository_id: "repo-1",
+              full_name: "acme/api-server",
+              active_session_count: 3,
+              latest_session_status: "running",
+              active_project_count: 2,
+            },
+            {
+              repository_id: "repo-2",
+              full_name: "acme/web-app",
+              active_session_count: 0,
+              latest_session_status: null,
+              active_project_count: 0,
+            },
+          ],
+          meta: {},
+        });
+      })
+    );
+
+    renderWithProviders(<RepoContextSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("repo-context-switcher")).toBeInTheDocument();
+    });
+
+    // Default label should be "All repositories"
+    expect(screen.getByText("All repositories")).toBeInTheDocument();
+  });
+
+  it("shows 'All repositories' as default selected state", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () => {
+        return HttpResponse.json({
+          data: [
+            { repository_id: "repo-1", full_name: "acme/api-server", active_session_count: 0, latest_session_status: null, active_project_count: 0 },
+            { repository_id: "repo-2", full_name: "acme/web-app", active_session_count: 0, latest_session_status: null, active_project_count: 0 },
+          ],
+          meta: {},
+        });
+      })
+    );
+
+    renderWithProviders(<RepoContextSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByText("All repositories")).toBeInTheDocument();
+    });
+  });
+
+  it("renders nothing when org has zero repos", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () => {
+        return HttpResponse.json({
+          data: [],
+          meta: {},
+        });
+      })
+    );
+
+    const { container } = renderWithProviders(<RepoContextSwitcher />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="repo-context-switcher"]')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/repo-context-switcher.test.tsx
+++ b/frontend/src/components/repo-context-switcher.test.tsx
@@ -141,6 +141,9 @@ describe("RepoContextSwitcher", () => {
     await waitFor(() => {
       expect(screen.getByText("acme/mobile-app")).toBeInTheDocument();
       expect(screen.queryByText("acme/api-server")).not.toBeInTheDocument();
+      // "All repositories" menu item is hidden during search (only the trigger label remains)
+      const allReposElements = screen.getAllByText("All repositories");
+      expect(allReposElements).toHaveLength(1); // only the trigger, not the menu item
     });
   });
 

--- a/frontend/src/components/repo-context-switcher.tsx
+++ b/frontend/src/components/repo-context-switcher.tsx
@@ -94,13 +94,17 @@ export function RepoContextSwitcher() {
             />
           </div>
         )}
-        <DropdownMenuItem
-          onClick={() => setRepo(null)}
-          className={cn(!repo && "font-medium")}
-        >
-          All repositories
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
+        {!search && (
+          <>
+            <DropdownMenuItem
+              onClick={() => setRepo(null)}
+              className={cn(!repo && "font-medium")}
+            >
+              All repositories
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
         {filtered.map((r) => (
           <DropdownMenuItem
             key={r.repository_id}

--- a/frontend/src/components/repo-context-switcher.tsx
+++ b/frontend/src/components/repo-context-switcher.tsx
@@ -11,13 +11,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { api } from "@/lib/api";
 import { useEffect, useState } from "react";
 
 function StatusDot({ status }: { status: string | null }) {
   if (!status) return null;
 
-  if (status === "running") {
+  if (status === "running" || status === "pending") {
     return (
       <span className="relative flex h-2 w-2">
         <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
@@ -84,12 +85,11 @@ export function RepoContextSwitcher() {
       <DropdownMenuContent align="start" className="w-64">
         {showSearch && (
           <div className="px-2 pb-1.5">
-            <input
+            <Input
               type="text"
               placeholder="Search repos..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
               onClick={(e) => e.stopPropagation()}
             />
           </div>

--- a/frontend/src/components/repo-context-switcher.tsx
+++ b/frontend/src/components/repo-context-switcher.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useQueryState } from "nuqs";
+import { ChevronDown, GitBranch } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { api } from "@/lib/api";
+import { useEffect, useState } from "react";
+
+function StatusDot({ status }: { status: string | null }) {
+  if (!status) return null;
+
+  if (status === "running") {
+    return (
+      <span className="relative flex h-2 w-2">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+      </span>
+    );
+  }
+
+  if (status === "needs_human_guidance" || status === "awaiting_input") {
+    return <span className="inline-flex rounded-full h-2 w-2 bg-amber-500" />;
+  }
+
+  if (status === "failed" || status === "cancelled") {
+    return <span className="inline-flex rounded-full h-2 w-2 bg-red-500" />;
+  }
+
+  return null;
+}
+
+export function RepoContextSwitcher() {
+  const { data: summariesData } = useQuery({
+    queryKey: ["repositories", "summary"],
+    queryFn: () => api.repositories.summary(),
+    refetchInterval: 10_000,
+  });
+
+  const [repo, setRepo] = useQueryState("repo");
+  const [search, setSearch] = useState("");
+
+  const summaries = summariesData?.data;
+
+  // If selected repo no longer exists in summaries (e.g. disconnected), reset
+  useEffect(() => {
+    if (repo && summaries && !summaries.find((r) => r.repository_id === repo)) {
+      setRepo(null);
+    }
+  }, [repo, summaries, setRepo]);
+
+  // Don't render for single-repo orgs
+  if (!summaries || summaries.length < 2) return null;
+
+  const selectedRepo = summaries.find((r) => r.repository_id === repo);
+  const label = selectedRepo
+    ? selectedRepo.full_name.split("/").pop()
+    : "All repositories";
+
+  const showSearch = summaries.length >= 4;
+  const filtered = search
+    ? summaries.filter((r) =>
+        r.full_name.toLowerCase().includes(search.toLowerCase())
+      )
+    : summaries;
+
+  return (
+    <DropdownMenu onOpenChange={(open) => { if (!open) setSearch(""); }}>
+      <DropdownMenuTrigger
+        className="flex items-center gap-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-sidebar-accent"
+        data-testid="repo-context-switcher"
+      >
+        <span>{label}</span>
+        <ChevronDown className="h-3.5 w-3.5 opacity-50" />
+        {selectedRepo && <StatusDot status={selectedRepo.latest_session_status} />}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        {showSearch && (
+          <div className="px-2 pb-1.5">
+            <input
+              type="text"
+              placeholder="Search repos..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+        )}
+        <DropdownMenuItem
+          onClick={() => setRepo(null)}
+          className={cn(!repo && "font-medium")}
+        >
+          All repositories
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {filtered.map((r) => (
+          <DropdownMenuItem
+            key={r.repository_id}
+            onClick={() => setRepo(r.repository_id)}
+            className={cn(
+              "flex items-center gap-2",
+              repo === r.repository_id && "font-medium"
+            )}
+          >
+            <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+            <span className="truncate flex-1" title={r.full_name}>
+              {r.full_name}
+            </span>
+            {r.active_session_count > 0 && (
+              <span className="text-[10px] rounded-full bg-primary/10 text-primary px-1.5 py-0.5 font-medium tabular-nums">
+                {r.active_session_count}
+              </span>
+            )}
+            <StatusDot status={r.latest_session_status} />
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -119,6 +119,7 @@ export const api = {
     update: (id: string, data: Record<string, unknown>) =>
       patch<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}`, data),
     delete: (id: string) => del(`/api/v1/repositories/${id}`),
+    summary: () => get<import('./types').ListResponse<import('./types').RepoSummary>>('/api/v1/repositories/summary'),
   },
   issues: {
     list: (params?: { status?: string; source?: string; severity?: string; sort?: string; cursor?: string; limit?: number }) => {
@@ -169,11 +170,12 @@ export const api = {
       del(`/api/v1/pm/documents/${docId}`),
   },
   sessions: {
-    list: (params?: { status?: string; cursor?: string; limit?: number }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit) searchParams.set('limit', String(params.limit));
+      if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Session>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
@@ -292,11 +294,12 @@ export const api = {
     revokeInvitation: (id: string) => del<void>(`/api/v1/team/invitations/${id}`),
   },
   projects: {
-    list: (params?: { status?: string; cursor?: string; limit?: number }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit) searchParams.set('limit', String(params.limit));
+      if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Project>>(`/api/v1/projects${qs ? `?${qs}` : ''}`);
     },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -407,6 +407,14 @@ export interface ResolvedCredential {
   masked_key?: string;
 }
 
+export interface RepoSummary {
+  repository_id: string;
+  full_name: string;
+  active_session_count: number;
+  latest_session_status: string | null;
+  active_project_count: number;
+}
+
 export interface ListResponse<T> {
   data: T[];
   meta: {

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -229,6 +229,13 @@ export const handlers = [
     } satisfies ListResponse<User>);
   }),
 
+  http.get('/api/v1/repositories/summary', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    });
+  }),
+
   http.get('/api/v1/pm/decisions', () => {
     return HttpResponse.json({
       data: [],

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -81,6 +81,15 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 		Cursor: r.URL.Query().Get("cursor"),
 	}
 
+	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
+		repoID, err := uuid.Parse(repoIDStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+			return
+		}
+		filters.RepositoryID = repoID
+	}
+
 	projects, err := h.projectStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list projects")

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -121,6 +121,48 @@ func TestProjectHandler_List(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestProjectHandler_List_WithRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewProjectHandler(db.NewProjectStore(mock), nil, nil, nil, nil)
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM projects WHERE org_id .+ AND repository_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(projectColumns()))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects?repository_id="+repoID.String(), nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Contains(t, rr.Body.String(), `"data":[]`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectHandler_List_InvalidRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	handler := NewProjectHandler(nil, nil, nil, nil, nil)
+	orgID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects?repository_id=not-a-uuid", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "INVALID_REPOSITORY_ID")
+}
+
 // --- Get handler tests ---
 
 func TestProjectHandler_Get_NotFound(t *testing.T) {

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -9,6 +9,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 type RepositoryHandler struct {
@@ -52,6 +53,7 @@ func (h *RepositoryHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	dbSummaries, err := h.repoStore.GetSummary(r.Context(), orgID)
 	if err != nil {
+		zerolog.Ctx(r.Context()).Error().Err(err).Msg("failed to get repository summary")
 		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get repository summary")
 		return
 	}

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -50,15 +50,22 @@ func (h *RepositoryHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 func (h *RepositoryHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
-	summaries, err := h.repoStore.GetSummary(r.Context(), orgID)
+	dbSummaries, err := h.repoStore.GetSummary(r.Context(), orgID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get repository summary")
 		return
 	}
-	if summaries == nil {
-		summaries = []db.RepoSummary{}
+	summaries := make([]models.RepoSummary, len(dbSummaries))
+	for i, s := range dbSummaries {
+		summaries[i] = models.RepoSummary{
+			RepositoryID:        s.RepositoryID,
+			FullName:            s.FullName,
+			ActiveSessionCount:  s.ActiveSessionCount,
+			LatestSessionStatus: s.LatestSessionStatus,
+			ActiveProjectCount:  s.ActiveProjectCount,
+		}
 	}
-	writeJSON(w, http.StatusOK, models.ListResponse[db.RepoSummary]{Data: summaries})
+	writeJSON(w, http.StatusOK, models.ListResponse[models.RepoSummary]{Data: summaries})
 }
 
 func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -48,6 +48,19 @@ func (h *RepositoryHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Repository]{Data: repo})
 }
 
+func (h *RepositoryHandler) Summary(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	summaries, err := h.repoStore.GetSummary(r.Context(), orgID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get repository summary")
+		return
+	}
+	if summaries == nil {
+		summaries = []db.RepoSummary{}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[db.RepoSummary]{Data: summaries})
+}
+
 func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -312,7 +312,7 @@ func TestRepositoryHandler_Summary(t *testing.T) {
 			handler.Summary(w, req)
 			require.Equal(t, tt.expectedCode, w.Code, "should return expected status code")
 
-			var resp models.ListResponse[db.RepoSummary]
+			var resp models.ListResponse[models.RepoSummary]
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err, "response body should be valid JSON")
 			require.Equal(t, tt.expectedLen, len(resp.Data), "should return expected number of summaries")

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -247,6 +247,80 @@ func TestRepositoryHandler_Update(t *testing.T) {
 	}
 }
 
+func TestRepositoryHandler_Summary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupMock    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID)
+		expectedCode int
+		expectedLen  int
+	}{
+		{
+			name: "returns summary successfully",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				repoID := uuid.New()
+				latestStatus := "running"
+				cols := []string{
+					"repository_id", "full_name", "active_session_count",
+					"latest_session_status", "active_project_count",
+				}
+				mock.ExpectQuery("SELECT .+ FROM repositories r").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(cols).AddRow(repoID, "org/repo", 2, &latestStatus, 1),
+					)
+			},
+			expectedCode: http.StatusOK,
+			expectedLen:  1,
+		},
+		{
+			name: "returns empty list when no repositories",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				cols := []string{
+					"repository_id", "full_name", "active_session_count",
+					"latest_session_status", "active_project_count",
+				}
+				mock.ExpectQuery("SELECT .+ FROM repositories r").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(cols))
+			},
+			expectedCode: http.StatusOK,
+			expectedLen:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgxmock pool without error")
+			defer mock.Close()
+
+			orgID := uuid.New()
+			store := db.NewRepositoryStore(mock)
+			handler := NewRepositoryHandler(store)
+
+			tt.setupMock(mock, orgID)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/summary", nil)
+			ctx := middleware.WithOrgID(req.Context(), orgID)
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			handler.Summary(w, req)
+			require.Equal(t, tt.expectedCode, w.Code, "should return expected status code")
+
+			var resp models.ListResponse[db.RepoSummary]
+			err = json.Unmarshal(w.Body.Bytes(), &resp)
+			require.NoError(t, err, "response body should be valid JSON")
+			require.Equal(t, tt.expectedLen, len(resp.Data), "should return expected number of summaries")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
 func TestRepositoryHandler_Delete_Success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -250,17 +250,18 @@ func TestRepositoryHandler_Update(t *testing.T) {
 func TestRepositoryHandler_Summary(t *testing.T) {
 	t.Parallel()
 
+	repoID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	latestStatus := "running"
+
 	tests := []struct {
 		name         string
 		setupMock    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID)
 		expectedCode int
-		expectedLen  int
+		expected     []models.RepoSummary
 	}{
 		{
 			name: "returns summary successfully",
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
-				repoID := uuid.New()
-				latestStatus := "running"
 				cols := []string{
 					"repository_id", "full_name", "active_session_count",
 					"latest_session_status", "active_project_count",
@@ -272,7 +273,15 @@ func TestRepositoryHandler_Summary(t *testing.T) {
 					)
 			},
 			expectedCode: http.StatusOK,
-			expectedLen:  1,
+			expected: []models.RepoSummary{
+				{
+					RepositoryID:        repoID,
+					FullName:            "org/repo",
+					ActiveSessionCount:  2,
+					LatestSessionStatus: &latestStatus,
+					ActiveProjectCount:  1,
+				},
+			},
 		},
 		{
 			name: "returns empty list when no repositories",
@@ -286,7 +295,7 @@ func TestRepositoryHandler_Summary(t *testing.T) {
 					WillReturnRows(pgxmock.NewRows(cols))
 			},
 			expectedCode: http.StatusOK,
-			expectedLen:  0,
+			expected:     []models.RepoSummary{},
 		},
 	}
 
@@ -315,7 +324,7 @@ func TestRepositoryHandler_Summary(t *testing.T) {
 			var resp models.ListResponse[models.RepoSummary]
 			err = json.Unmarshal(w.Body.Bytes(), &resp)
 			require.NoError(t, err, "response body should be valid JSON")
-			require.Equal(t, tt.expectedLen, len(resp.Data), "should return expected number of summaries")
+			require.Equal(t, tt.expected, resp.Data, "should return expected summaries")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -68,6 +68,15 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		Cursor: r.URL.Query().Get("cursor"),
 	}
 
+	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
+		repoID, err := uuid.Parse(repoIDStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+			return
+		}
+		filters.RepositoryID = repoID
+	}
+
 	runs, err := h.runStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list runs")
@@ -582,8 +591,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	// with the generated title before returning the response.
 	if h.llmClient != nil {
 		if err := h.generateSessionTitle(r.Context(), session, orgID, body.Message); err != nil {
-			writeError(w, http.StatusInternalServerError, "TITLE_GENERATION_FAILED", fmt.Sprintf("failed to generate session title: %v", err))
-			return
+			zerolog.Ctx(r.Context()).Warn().Err(err).Str("session_id", session.ID.String()).Msg("failed to generate session title")
 		}
 	}
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -126,6 +126,71 @@ func TestSessionHandler_List(t *testing.T) {
 	}
 }
 
+func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	now := time.Now()
+	runID := uuid.New()
+	issueID := uuid.New()
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ issue_id IN").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				runID, issueID, orgID, "claude-code", "completed", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil,
+				nil, nil, nil,
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions?repository_id="+repoID.String(), nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should return 200 when filtering by repository_id")
+
+	var resp models.ListResponse[models.Session]
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "response body should be valid JSON")
+	require.Equal(t, 1, len(resp.Data), "should return filtered sessions")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_List_InvalidRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions?repository_id=not-a-uuid", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "should return 400 for invalid repository_id")
+	require.Contains(t, w.Body.String(), "INVALID_REPOSITORY_ID", "error code should indicate invalid repository_id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionHandler_Get(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1456,7 +1456,7 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
+func TestSessionHandler_CreateManual_LLMError_StillReturns201(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -1519,8 +1519,8 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 	// WaitGroup confirms the LLM was called synchronously.
 	llmClient.wg.Wait()
 
-	require.Equal(t, http.StatusInternalServerError, w.Code)
-	require.Contains(t, w.Body.String(), "TITLE_GENERATION_FAILED")
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.Contains(t, w.Body.String(), "id")
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -193,6 +193,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/settings/credentials/team", userCredentialHandler.ListTeamDefaults)
 
 			r.Get("/api/v1/repositories", repoHandler.List)
+			r.Get("/api/v1/repositories/summary", repoHandler.Summary)
 			r.Get("/api/v1/repositories/{id}", repoHandler.Get)
 			r.Get("/api/v1/integrations", integrationHandler.ListIntegrations)
 			r.Get("/api/v1/issues", issueHandler.List)

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -413,6 +413,33 @@ func TestProjectStore_UpdateNextRunAt(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestProjectStore_ListByOrg_WithRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM projects WHERE org_id .+ AND repository_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(projectTestColumns).
+				AddRow(newProjectRow(uuid.New(), orgID, repoID, now)...),
+		)
+
+	store := NewProjectStore(mock)
+	projects, err := store.ListByOrg(context.Background(), orgID, ProjectFilters{
+		RepositoryID: repoID,
+	})
+	require.NoError(t, err, "ListByOrg with RepositoryID should not return an error")
+	require.Len(t, projects, 1, "should return one project")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestProjectStore_UpdateProgress(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -21,9 +21,10 @@ func NewProjectStore(db DBTX) *ProjectStore {
 }
 
 type ProjectFilters struct {
-	Status string
-	Limit  int
-	Cursor string
+	Status       string
+	Limit        int
+	Cursor       string
+	RepositoryID uuid.UUID
 }
 
 // projectColumns is the column list shared across all project queries.
@@ -187,6 +188,10 @@ func (s *ProjectStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters P
 	if filters.Status != "" {
 		query += ` AND status = @status`
 		args["status"] = filters.Status
+	}
+	if filters.RepositoryID != uuid.Nil {
+		query += ` AND repository_id = @repository_id`
+		args["repository_id"] = filters.RepositoryID
 	}
 	if filters.Cursor != "" {
 		cursorID, err := uuid.Parse(filters.Cursor)

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -164,11 +164,11 @@ func (s *RepositoryStore) DisconnectByInstallationID(ctx context.Context, instal
 
 // RepoSummary contains aggregated counts for the repo context switcher.
 type RepoSummary struct {
-	RepositoryID       uuid.UUID `db:"repository_id" json:"repository_id"`
-	FullName           string    `db:"full_name" json:"full_name"`
-	ActiveSessionCount int       `db:"active_session_count" json:"active_session_count"`
-	LatestSessionStatus *string  `db:"latest_session_status" json:"latest_session_status"`
-	ActiveProjectCount int       `db:"active_project_count" json:"active_project_count"`
+	RepositoryID        uuid.UUID `db:"repository_id"`
+	FullName            string    `db:"full_name"`
+	ActiveSessionCount  int       `db:"active_session_count"`
+	LatestSessionStatus *string   `db:"latest_session_status"`
+	ActiveProjectCount  int       `db:"active_project_count"`
 }
 
 func (s *RepositoryStore) GetSummary(ctx context.Context, orgID uuid.UUID) ([]RepoSummary, error) {
@@ -179,12 +179,7 @@ func (s *RepositoryStore) GetSummary(ctx context.Context, orgID uuid.UUID) ([]Re
 			COUNT(DISTINCT s.id) FILTER (
 				WHERE s.status IN ('running', 'pending', 'needs_human_guidance', 'awaiting_input')
 			) AS active_session_count,
-			(
-				SELECT s2.status FROM sessions s2
-				JOIN issues i2 ON s2.issue_id = i2.id
-				WHERE i2.repository_id = r.id AND s2.org_id = r.org_id
-				ORDER BY s2.created_at DESC LIMIT 1
-			) AS latest_session_status,
+			latest_s.status AS latest_session_status,
 			COUNT(DISTINCT p.id) FILTER (
 				WHERE p.status IN ('active', 'planning')
 			) AS active_project_count
@@ -192,8 +187,14 @@ func (s *RepositoryStore) GetSummary(ctx context.Context, orgID uuid.UUID) ([]Re
 		LEFT JOIN issues i ON i.repository_id = r.id
 		LEFT JOIN sessions s ON s.issue_id = i.id
 		LEFT JOIN projects p ON p.repository_id = r.id AND p.org_id = r.org_id
+		LEFT JOIN LATERAL (
+			SELECT s2.status FROM sessions s2
+			JOIN issues i2 ON s2.issue_id = i2.id
+			WHERE i2.repository_id = r.id AND s2.org_id = r.org_id
+			ORDER BY s2.created_at DESC LIMIT 1
+		) latest_s ON true
 		WHERE r.org_id = @org_id AND r.status = 'active'
-		GROUP BY r.id, r.full_name
+		GROUP BY r.id, r.full_name, latest_s.status
 		ORDER BY active_session_count DESC, r.full_name ASC`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -162,6 +162,47 @@ func (s *RepositoryStore) DisconnectByInstallationID(ctx context.Context, instal
 	return err
 }
 
+// RepoSummary contains aggregated counts for the repo context switcher.
+type RepoSummary struct {
+	RepositoryID       uuid.UUID `db:"repository_id" json:"repository_id"`
+	FullName           string    `db:"full_name" json:"full_name"`
+	ActiveSessionCount int       `db:"active_session_count" json:"active_session_count"`
+	LatestSessionStatus *string  `db:"latest_session_status" json:"latest_session_status"`
+	ActiveProjectCount int       `db:"active_project_count" json:"active_project_count"`
+}
+
+func (s *RepositoryStore) GetSummary(ctx context.Context, orgID uuid.UUID) ([]RepoSummary, error) {
+	query := `
+		SELECT
+			r.id AS repository_id,
+			r.full_name,
+			COUNT(DISTINCT s.id) FILTER (
+				WHERE s.status IN ('running', 'pending', 'needs_human_guidance', 'awaiting_input')
+			) AS active_session_count,
+			(
+				SELECT s2.status FROM sessions s2
+				JOIN issues i2 ON s2.issue_id = i2.id
+				WHERE i2.repository_id = r.id AND s2.org_id = r.org_id
+				ORDER BY s2.created_at DESC LIMIT 1
+			) AS latest_session_status,
+			COUNT(DISTINCT p.id) FILTER (
+				WHERE p.status IN ('active', 'planning')
+			) AS active_project_count
+		FROM repositories r
+		LEFT JOIN issues i ON i.repository_id = r.id
+		LEFT JOIN sessions s ON s.issue_id = i.id
+		LEFT JOIN projects p ON p.repository_id = r.id AND p.org_id = r.org_id
+		WHERE r.org_id = @org_id AND r.status = 'active'
+		GROUP BY r.id, r.full_name
+		ORDER BY active_session_count DESC, r.full_name ASC`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
+	if err != nil {
+		return nil, fmt.Errorf("query repository summary: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[RepoSummary])
+}
+
 func (s *RepositoryStore) DisconnectByGitHubID(ctx context.Context, installationID, githubID int64) error {
 	query := `
 		UPDATE repositories

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -184,8 +184,8 @@ func (s *RepositoryStore) GetSummary(ctx context.Context, orgID uuid.UUID) ([]Re
 				WHERE p.status IN ('active', 'planning')
 			) AS active_project_count
 		FROM repositories r
-		LEFT JOIN issues i ON i.repository_id = r.id
-		LEFT JOIN sessions s ON s.issue_id = i.id
+		LEFT JOIN issues i ON i.repository_id = r.id AND i.org_id = r.org_id
+		LEFT JOIN sessions s ON s.issue_id = i.id AND s.org_id = r.org_id
 		LEFT JOIN projects p ON p.repository_id = r.id AND p.org_id = r.org_id
 		LEFT JOIN LATERAL (
 			SELECT s2.status FROM sessions s2

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -247,6 +247,67 @@ func TestRepositoryStore_UpsertFromGitHub(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestRepositoryStore_GetSummary(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+	orgID := uuid.New()
+	repoID := uuid.New()
+	latestStatus := "running"
+
+	summaryColumns := []string{
+		"repository_id", "full_name", "active_session_count",
+		"latest_session_status", "active_project_count",
+	}
+
+	mock.ExpectQuery("SELECT .+ FROM repositories r").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(summaryColumns).
+				AddRow(repoID, "org/repo", 3, &latestStatus, 1),
+		)
+
+	summaries, err := store.GetSummary(context.Background(), orgID)
+	require.NoError(t, err, "GetSummary should not return an error")
+	require.Len(t, summaries, 1, "should return one summary")
+	require.Equal(t, repoID, summaries[0].RepositoryID, "should return the correct repository ID")
+	require.Equal(t, "org/repo", summaries[0].FullName, "should return the correct full name")
+	require.Equal(t, 3, summaries[0].ActiveSessionCount, "should return the correct active session count")
+	require.NotNil(t, summaries[0].LatestSessionStatus, "latest session status should not be nil")
+	require.Equal(t, "running", *summaries[0].LatestSessionStatus, "should return the correct latest session status")
+	require.Equal(t, 1, summaries[0].ActiveProjectCount, "should return the correct active project count")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryStore_GetSummary_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+	orgID := uuid.New()
+
+	summaryColumns := []string{
+		"repository_id", "full_name", "active_session_count",
+		"latest_session_status", "active_project_count",
+	}
+
+	mock.ExpectQuery("SELECT .+ FROM repositories r").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(summaryColumns))
+
+	summaries, err := store.GetSummary(context.Background(), orgID)
+	require.NoError(t, err, "GetSummary should not return an error for empty result")
+	require.Empty(t, summaries, "should return empty summaries")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestRepositoryStore_DisconnectByInstallationID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -23,7 +23,7 @@ type SessionFilters struct {
 	Limit        int
 	Cursor       string
 	AdHocOnly    bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
-	RepositoryID uuid.UUID // When non-nil, filter sessions by repository via issues table.
+	RepositoryID uuid.UUID // When non-zero, filter sessions by repository via issues table.
 }
 
 const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-000000000000'::uuid) AS issue_id,
@@ -38,19 +38,14 @@ const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-00
 func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters SessionFilters) ([]models.Session, error) {
 	args := pgx.NamedArgs{"org_id": orgID}
 
-	var query string
-	if filters.RepositoryID != uuid.Nil {
-		query = `
-		SELECT ` + sessionSelectColumns + `
-		FROM sessions
-		WHERE org_id = @org_id
-		AND issue_id IN (SELECT id FROM issues WHERE repository_id = @repository_id)`
-		args["repository_id"] = filters.RepositoryID
-	} else {
-		query = `
+	query := `
 		SELECT ` + sessionSelectColumns + `
 		FROM sessions
 		WHERE org_id = @org_id`
+
+	if filters.RepositoryID != uuid.Nil {
+		query += ` AND issue_id IN (SELECT id FROM issues WHERE repository_id = @repository_id)`
+		args["repository_id"] = filters.RepositoryID
 	}
 
 	if filters.Status != "" {

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -44,7 +44,7 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 		WHERE org_id = @org_id`
 
 	if filters.RepositoryID != uuid.Nil {
-		query += ` AND issue_id IN (SELECT id FROM issues WHERE repository_id = @repository_id)`
+		query += ` AND issue_id IN (SELECT id FROM issues WHERE repository_id = @repository_id AND org_id = @org_id)`
 		args["repository_id"] = filters.RepositoryID
 	}
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -19,10 +19,11 @@ func NewSessionStore(db DBTX) *SessionStore {
 }
 
 type SessionFilters struct {
-	Status    models.SessionStatus
-	Limit     int
-	Cursor    string
-	AdHocOnly bool // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
+	Status       models.SessionStatus
+	Limit        int
+	Cursor       string
+	AdHocOnly    bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
+	RepositoryID uuid.UUID // When non-nil, filter sessions by repository via issues table.
 }
 
 const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-000000000000'::uuid) AS issue_id,
@@ -35,12 +36,22 @@ const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-00
 	model_override, triggered_by_user_id, created_at`
 
 func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters SessionFilters) ([]models.Session, error) {
-	query := `
+	args := pgx.NamedArgs{"org_id": orgID}
+
+	var query string
+	if filters.RepositoryID != uuid.Nil {
+		query = `
+		SELECT ` + sessionSelectColumns + `
+		FROM sessions
+		WHERE org_id = @org_id
+		AND issue_id IN (SELECT id FROM issues WHERE repository_id = @repository_id)`
+		args["repository_id"] = filters.RepositoryID
+	} else {
+		query = `
 		SELECT ` + sessionSelectColumns + `
 		FROM sessions
 		WHERE org_id = @org_id`
-
-	args := pgx.NamedArgs{"org_id": orgID}
+	}
 
 	if filters.Status != "" {
 		query += ` AND status = @status`

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1,0 +1,91 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+var sessionTestColumns = []string{
+	"id", "issue_id", "org_id", "agent_type", "status", "autonomy_level", "token_mode",
+	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
+	"container_id", "started_at", "completed_at", "token_usage",
+	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
+	"parent_session_id", "revision_context", "error", "result_summary", "diff",
+	"pm_plan_id", "pm_approach", "pm_reasoning",
+	"project_task_id", "model_override", "triggered_by_user_id",
+	"created_at",
+}
+
+func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []interface{} {
+	return []interface{}{
+		sessionID, issueID, orgID, "claude-code", "completed", "supervised", "standard",
+		nil, nil, nil, nil,
+		nil, &now, &now, nil,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil, nil,
+		nil, nil, nil,
+		nil, nil, nil,
+		now,
+	}
+}
+
+func TestSessionStore_ListByOrg_WithRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	repoID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ issue_id IN \\(SELECT id FROM issues WHERE repository_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(sessionID, issueID, orgID, now)...),
+		)
+
+	sessions, err := store.ListByOrg(context.Background(), orgID, SessionFilters{
+		RepositoryID: repoID,
+	})
+	require.NoError(t, err, "ListByOrg with RepositoryID should not return an error")
+	require.Len(t, sessions, 1, "should return one session")
+	require.Equal(t, sessionID, sessions[0].ID, "should return the correct session ID")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionStore_ListByOrg_WithoutRepositoryID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(sessionID, issueID, orgID, now)...),
+		)
+
+	sessions, err := store.ListByOrg(context.Background(), orgID, SessionFilters{})
+	require.NoError(t, err, "ListByOrg without RepositoryID should not return an error")
+	require.Len(t, sessions, 1, "should return one session")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -68,6 +68,15 @@ type Repository struct {
 	UpdatedAt      time.Time       `db:"updated_at" json:"updated_at"`
 }
 
+// RepoSummary is the API model for repository summary data in the context switcher.
+type RepoSummary struct {
+	RepositoryID        uuid.UUID `json:"repository_id"`
+	FullName            string    `json:"full_name"`
+	ActiveSessionCount  int       `json:"active_session_count"`
+	LatestSessionStatus *string   `json:"latest_session_status"`
+	ActiveProjectCount  int       `json:"active_project_count"`
+}
+
 // Issue is the unified, normalized issue from any source.
 type Issue struct {
 	ID                    uuid.UUID       `db:"id" json:"id"`


### PR DESCRIPTION
## Summary

Adds a repository context switcher dropdown in the sidebar header, allowing users to filter Sessions and Projects pages by repository. Introduces a new GET /api/v1/repositories/summary endpoint that aggregates active session counts and project counts per repo, displayed with live status indicators. Both Sessions and Projects list endpoints now accept an optional ?repository_id= query parameter for scoped filtering. Includes comprehensive test coverage across database stores and API handlers.

## Additional fixes

- Treat LLM title generation failure as non-fatal (logs warning instead of returning 500 after session is already created).

🤖 Generated with [Claude Code](https://claude.ai/code)