### PR TITLE
Fix UI text casing to sentence case

### DIFF
--- a/frontend/src/app/(dashboard)/my-agents/page.test.tsx
+++ b/frontend/src/app/(dashboard)/my-agents/page.test.tsx
@@ -75,7 +75,7 @@ describe('MyAgentsPage', () => {
 
   it('renders page header', async () => {
     renderWithProviders(<MyAgentsPage />);
-    expect(screen.getByText('My Agents')).toBeInTheDocument();
+    expect(screen.getByText('My agents')).toBeInTheDocument();
   });
 
   it('shows all four provider cards in My Keys tab', async () => {

--- a/frontend/src/app/(dashboard)/my-agents/page.tsx
+++ b/frontend/src/app/(dashboard)/my-agents/page.tsx
@@ -150,7 +150,7 @@ export default function MyAgentsPage() {
     <PageContainer size="default">
       <div className="space-y-6">
         <PageHeader
-          title="My Agents"
+          title="My agents"
           description="Manage your personal coding agent API keys. Your keys are used first, falling back to team defaults, then organization keys."
         />
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -104,7 +104,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
         <CardContent className="pt-6">
           <div className="grid grid-cols-2 gap-5 text-sm">
             <div>
-              <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Status</span>
+              <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Status</span>
               <div className="mt-1">
                 <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium ${status.color}`}>
                   {isActive && (
@@ -118,12 +118,12 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
               </div>
             </div>
             <div>
-              <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Agent Type</span>
+              <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Agent Type</span>
               <p className="mt-1 font-medium">{agentTypeLabels[session.agent_type] || session.agent_type}</p>
             </div>
             {session.triggered_by_user_id && (
               <div>
-                <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Triggered by</span>
+                <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Triggered by</span>
                 <p className="mt-1 font-medium">
                   {members.find((m) => m.id === session.triggered_by_user_id)?.name || "Unknown user"}
                 </p>
@@ -131,22 +131,22 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             )}
             {session.confidence_score != null && (
               <div>
-                <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Confidence</span>
+                <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Confidence</span>
                 <p className={`mt-1 font-medium ${confidenceColor(session.confidence_score)}`}>
                   {(session.confidence_score * 100).toFixed(0)}%
                 </p>
               </div>
             )}
             <div>
-              <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Duration</span>
+              <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Duration</span>
               <p className="mt-1 font-medium">{formatDuration(session.started_at, session.completed_at)}</p>
             </div>
             <div>
-              <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Started</span>
+              <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Started</span>
               <p className="mt-1">{formatTimestamp(session.started_at)}</p>
             </div>
             <div>
-              <span className="text-xs font-medium text-muted-foreground/70 uppercase tracking-wider">Completed</span>
+              <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Completed</span>
               <p className="mt-1">{formatTimestamp(session.completed_at)}</p>
             </div>
           </div>

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -362,7 +362,7 @@ export function SessionsPageContent() {
         <div className="rounded-lg border border-border bg-card overflow-hidden">
           {/* Count header */}
           <div className="flex items-center justify-between px-4 py-2.5 border-b border-border/50 bg-muted/30">
-            <span className="text-[11px] font-semibold text-muted-foreground/70 uppercase tracking-widest">
+            <span className="text-[11px] font-semibold text-muted-foreground/70 tracking-widest">
               {filteredSessions.length} session{filteredSessions.length !== 1 ? "s" : ""}
             </span>
           </div>

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -69,7 +69,7 @@ describe("AuthenticatedLayout", () => {
 
     expect(await screen.findByRole("menuitem", { name: "General" })).toBeInTheDocument();
     expect(await screen.findByRole("menuitem", { name: "Integrations" })).toBeInTheDocument();
-    expect(await screen.findByRole("menuitem", { name: "Coding Agent" })).toBeInTheDocument();
+    expect(await screen.findByRole("menuitem", { name: "Coding agent" })).toBeInTheDocument();
     expect(await screen.findByRole("menuitem", { name: "Prioritization" })).toBeInTheDocument();
     expect(await screen.findByRole("menuitem", { name: "Team" })).toBeInTheDocument();
   });
@@ -94,7 +94,7 @@ describe("AuthenticatedLayout", () => {
     expect(pushMock).toHaveBeenCalledWith("/settings");
 
     await user.click(screen.getByRole("button", { name: /Alex Doe/ }));
-    await user.click(await screen.findByRole("menuitem", { name: "Coding Agent" }));
+    await user.click(await screen.findByRole("menuitem", { name: "Coding agent" }));
 
     expect(pushMock).toHaveBeenCalledWith("/agent");
   });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -187,11 +187,11 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/agent")}>
                   <Bot className="h-4 w-4" />
-                  Coding Agent
+                  Coding agent
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/my-agents")}>
                   <KeyRound className="h-4 w-4" />
-                  My Agents
+                  My agents
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => router.push("/llm")}>
                   <Sparkles className="h-4 w-4" />

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -65,7 +65,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-muted-foreground h-9 px-3 text-left align-middle font-medium whitespace-nowrap text-[11px] uppercase tracking-wider [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-muted-foreground h-9 px-3 text-left align-middle font-medium whitespace-nowrap text-[11px] tracking-wider [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Removed CSS `uppercase` transforms from table headers and labels throughout the UI
- Changed menu items from "Coding Agent" and "My Agents" to sentence case ("Coding agent", "My agents")
- Affects sessions table, session details page, and settings dropdown menu

## Files Changed
Table headers, session detail labels, and navigation menu items now use sentence case styling instead of uppercase transforms.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>