### PR TITLE
Add N+1 query prevention guidelines to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,14 @@ Use docs/design/overall.md as the overall design of the system, think of it as a
 
 **Enum response fields use typed strings**: For model fields that represent enums (especially API response fields like provider/status/state/type), define a dedicated typed string in `internal/models` with named constants and a `Validate() error` method. Prefer `IntegrationProvider`/`IntegrationStatus`-style types over raw `string` fields. When writing new enum-like fields, add table-driven validation tests.
 
+**No N+1 queries — batch and join instead**: Never execute a query inside a loop. N+1 patterns silently destroy performance as data grows and are a P1 fix. Instead:
+- **JOIN** related data in a single SQL query when fetching a parent with its children (e.g., issues with their labels, agent runs with their steps). Use `LEFT JOIN` when the child may not exist.
+- **Batch with `WHERE ... IN`** when you need related records for a list of IDs. Collect the IDs first, then issue one `SELECT ... WHERE id = ANY($1)` query using a `pgx` array parameter.
+- **Use subqueries or CTEs** for aggregations (counts, latest timestamps) instead of fetching all rows and computing in Go.
+- **Cursor-based pagination at the SQL level** — never fetch all rows and slice in Go.
+
+If you find yourself writing `for _, item := range items { rows := store.GetFoo(ctx, item.ID) }`, stop and refactor to `store.GetFoosByIDs(ctx, ids)` or add a JOIN to the original query. Store functions that accept a slice of IDs (e.g., `ListByIDs(ctx, orgID string, ids []string)`) are the standard pattern for batch lookups. Every new store method should be reviewed for N+1 risk before merging.
+
 **Job queue**: Postgres-backed async work queue using the `jobs` table. Workers claim jobs with `SELECT ... FOR UPDATE SKIP LOCKED` — no external queue needed. Jobs have `status`, `attempts`, `max_attempts`, and exponential backoff on failure.
 
 ## Frontend Architecture (Next.js / React)


### PR DESCRIPTION
## Summary
Added comprehensive documentation guidelines to prevent N+1 query patterns in the codebase. This establishes clear standards for database query optimization and batch operations.

## Key Changes
- **N+1 Query Prevention Section**: Added a new guideline section that explicitly prohibits executing queries inside loops and marks N+1 patterns as P1 fixes
- **Recommended Patterns**: Documented four primary approaches for avoiding N+1 queries:
  - `JOIN` operations for fetching parents with their children in a single query
  - Batch queries using `WHERE ... IN` with `pgx` array parameters for related records
  - Subqueries and CTEs for aggregations instead of in-application computation
  - Cursor-based pagination at the SQL level
- **Store Method Standards**: Established that store functions accepting slices of IDs (e.g., `ListByIDs(ctx, orgID string, ids []string)`) are the standard pattern for batch lookups
- **Code Review Requirement**: Added requirement that every new store method must be reviewed for N+1 risk before merging

## Implementation Details
The guidelines provide concrete examples of anti-patterns to avoid (e.g., `for _, item := range items { rows := store.GetFoo(ctx, item.ID) }`) and the refactored approach using batch operations. This establishes a clear performance standard for the codebase as it scales.

https://claude.ai/code/session_01Xh94ujGAHnVcYaCUSHf3HF