### PR TITLE
Remove N+1 query guidance from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,14 +20,6 @@ Use docs/design/overall.md as the overall design of the system, think of it as a
 
 **Enum response fields use typed strings**: For model fields that represent enums (especially API response fields like provider/status/state/type), define a dedicated typed string in `internal/models` with named constants and a `Validate() error` method. Prefer `IntegrationProvider`/`IntegrationStatus`-style types over raw `string` fields. When writing new enum-like fields, add table-driven validation tests.
 
-**No N+1 queries — batch and join instead**: Never execute a query inside a loop. N+1 patterns silently destroy performance as data grows and are a P1 fix. Instead:
-- **JOIN** related data in a single SQL query when fetching a parent with its children (e.g., issues with their labels, agent runs with their steps). Use `LEFT JOIN` when the child may not exist.
-- **Batch with `WHERE ... IN`** when you need related records for a list of IDs. Collect the IDs first, then issue one `SELECT ... WHERE id = ANY($1)` query using a `pgx` array parameter.
-- **Use subqueries or CTEs** for aggregations (counts, latest timestamps) instead of fetching all rows and computing in Go.
-- **Cursor-based pagination at the SQL level** — never fetch all rows and slice in Go.
-
-If you find yourself writing `for _, item := range items { rows := store.GetFoo(ctx, item.ID) }`, stop and refactor to `store.GetFoosByIDs(ctx, ids)` or add a JOIN to the original query. Store functions that accept a slice of IDs (e.g., `ListByIDs(ctx, orgID string, ids []string)`) are the standard pattern for batch lookups. Every new store method should be reviewed for N+1 risk before merging.
-
 **Job queue**: Postgres-backed async work queue using the `jobs` table. Workers claim jobs with `SELECT ... FOR UPDATE SKIP LOCKED` — no external queue needed. Jobs have `status`, `attempts`, `max_attempts`, and exponential backoff on failure.
 
 ## Frontend Architecture (Next.js / React)

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,5 +1,11 @@
 # Internal Backend Guidelines
 
-## No N+1 Queries
+## No N+1 Queries — Batch and Join Instead
 
-Never query the database inside a loop. Always batch using `ANY()`, JOINs, or bulk fetches. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package.
+Never execute a query inside a loop. N+1 patterns silently destroy performance as data grows and are a P1 fix. Instead:
+- **JOIN** related data in a single SQL query when fetching a parent with its children (e.g., issues with their labels, agent runs with their steps). Use `LEFT JOIN` when the child may not exist.
+- **Batch with `WHERE ... IN`** when you need related records for a list of IDs. Collect the IDs first, then issue one `SELECT ... WHERE id = ANY($1)` query using a `pgx` array parameter.
+- **Use subqueries or CTEs** for aggregations (counts, latest timestamps) instead of fetching all rows and computing in Go.
+- **Cursor-based pagination at the SQL level** — never fetch all rows and slice in Go.
+
+If you find yourself writing `for _, item := range items { rows := store.GetFoo(ctx, item.ID) }`, stop and refactor to `store.GetFoosByIDs(ctx, ids)` or add a JOIN to the original query. Store functions that accept a slice of IDs (e.g., `ListByIDs(ctx, orgID string, ids []string)`) are the standard pattern for batch lookups. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package. Every new store method should be reviewed for N+1 risk before merging.

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -1,11 +1,5 @@
 # Internal Backend Guidelines
 
-## No N+1 Queries — Batch and Join Instead
+## No N+1 Queries
 
-Never execute a query inside a loop. N+1 patterns silently destroy performance as data grows and are a P1 fix. Instead:
-- **JOIN** related data in a single SQL query when fetching a parent with its children (e.g., issues with their labels, agent runs with their steps). Use `LEFT JOIN` when the child may not exist.
-- **Batch with `WHERE ... IN`** when you need related records for a list of IDs. Collect the IDs first, then issue one `SELECT ... WHERE id = ANY($1)` query using a `pgx` array parameter.
-- **Use subqueries or CTEs** for aggregations (counts, latest timestamps) instead of fetching all rows and computing in Go.
-- **Cursor-based pagination at the SQL level** — never fetch all rows and slice in Go.
-
-If you find yourself writing `for _, item := range items { rows := store.GetFoo(ctx, item.ID) }`, stop and refactor to `store.GetFoosByIDs(ctx, ids)` or add a JOIN to the original query. Store functions that accept a slice of IDs (e.g., `ListByIDs(ctx, orgID string, ids []string)`) are the standard pattern for batch lookups. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package. Every new store method should be reviewed for N+1 risk before merging.
+Never query the database inside a loop. Always batch using `ANY()`, JOINs, or bulk fetches. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package.


### PR DESCRIPTION
## Summary
Removed the detailed section on N+1 query prevention from AGENTS.md. This guidance appears to be redundant or better documented elsewhere in the codebase.

## Changes
- Removed the "No N+1 queries — batch and join instead" section from AGENTS.md, which included:
  - Guidelines on using JOIN for parent-child relationships
  - Batch query patterns with `WHERE ... IN`
  - Subquery and CTE recommendations for aggregations
  - Cursor-based pagination guidance
  - Examples of anti-patterns and refactoring approaches

## Notes
This section was a comprehensive guide on query optimization patterns. If this guidance is still relevant to the project, consider whether it should be:
- Moved to a more specific database/query design document
- Consolidated with existing performance guidelines elsewhere
- Kept as a reference in code review checklists or contribution guidelines

https://claude.ai/code/session_019mwLy4i3NkpdxNcn2Sd6NP