### PR TITLE
Allow configurable container runtime for sandboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ tmp/
 
 # Build output
 bin/
+server
 coverage.html
 
 # Go module/build caches (if created locally)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -222,7 +222,7 @@ func buildServices(
 		logger.Error().Err(err).Msg("Docker not available — all Phase 3+ services disabled")
 		return nil
 	}
-	sandboxProvider := providers.NewDockerProvider(dockerCli, logger)
+	sandboxProvider := providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime(cfg.SandboxRuntime))
 
 	// LLM client (optional — validation/prioritization degrade gracefully without it).
 	llmClient, err := llm.NewClient(cfg.LLMConfig(), logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,9 @@ type Config struct {
 	GeminiAPIKey string `env:"GEMINI_API_KEY"`
 	GeminiModel  string `env:"GEMINI_MODEL"`
 
+	// Sandbox
+	SandboxRuntime string `env:"SANDBOX_RUNTIME" envDefault:"runc"`
+
 	// Interactive session snapshots
 	SnapshotStorageDir    string        `env:"SNAPSHOT_STORAGE_DIR"    envDefault:".data/snapshots"`
 	SessionMaxIdleAge     time.Duration `env:"SESSION_MAX_IDLE_AGE"    envDefault:"2h"`


### PR DESCRIPTION
## Summary

Adds `SANDBOX_RUNTIME` environment variable to allow configuration of the OCI container runtime (runc or runsc) instead of hardcoding runsc. Defaults to runc, enabling manual sessions to work on systems without gVisor installed.

## Changes

- Added `SandboxRuntime` config field with `SANDBOX_RUNTIME` env var (defaults to runc)
- Pass runtime config to DockerProvider during initialization

This fixes the error "unknown or invalid runtime name: runsc" when gVisor is not available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)