### PR TITLE
Fix audit log padding and alignment

### DIFF
--- a/frontend/src/app/(dashboard)/settings/audit-log/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/audit-log/page.tsx
@@ -210,7 +210,7 @@ export default function AuditLogPage() {
                   />
                 ))}
               </div>
-              <div className="flex items-center justify-between border-t border-border/50 px-3 py-2">
+              <div className="flex items-center justify-between border-t border-border/50 px-6 py-2">
                 {cursors.length > 0 ? (
                   <Button
                     variant="ghost"

--- a/frontend/src/components/audit/audit-log-entry.tsx
+++ b/frontend/src/components/audit/audit-log-entry.tsx
@@ -108,7 +108,7 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
             setExpanded(!expanded);
           }
         }}
-        className="flex w-full items-start gap-2 px-4 py-3.5 text-left text-sm hover:bg-muted/30 transition-all duration-150 h-auto rounded-none"
+        className="flex w-full items-start gap-2 px-6 py-3.5 text-left text-sm hover:bg-muted/30 transition-all duration-150 h-auto rounded-none"
         disabled={!onSelect && !hasDetails}
       >
         <span className="shrink-0 w-14 text-xs text-muted-foreground/70 pt-0.5 tabular-nums">
@@ -130,7 +130,7 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
         )}
       </Button>
       {expanded && hasDetails && (
-        <div className="px-3 pb-3 pl-[4.5rem]">
+        <div className="px-6 pb-3 pl-[4.5rem]">
           <div className="rounded-md bg-muted/30 border border-border/50 p-3 text-xs">
             <div className="space-y-1.5">
               {Object.entries(entry.details!).map(([key, value]) => (

--- a/frontend/src/components/audit/audit-log-timeline.tsx
+++ b/frontend/src/components/audit/audit-log-timeline.tsx
@@ -72,7 +72,7 @@ export function AuditLogTimeline({
           <AuditLogEntry key={entry.id} entry={entry} members={members} />
         ))}
       </div>
-      <div className="flex items-center justify-between px-3 py-2">
+      <div className="flex items-center justify-between px-6 py-2">
         {cursors.length > 0 && (
           <Button
             variant="ghost"

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -77,7 +77,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title }: AuditL
         variant="ghost"
         size="sm"
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 hover:text-muted-foreground transition-all duration-150 h-auto px-1.5 py-0.5"
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 hover:text-muted-foreground transition-all duration-150 h-auto px-1.5 py-0.5 -ml-1.5"
       >
         <Clock className="h-3 w-3" />
         <span>


### PR DESCRIPTION
Align audit log entries and controls with the sidesheet's default padding (p-6). Updated entry rows from px-4 to px-6, and pagination/details sections from px-3 to px-6. Adjusted the trigger button with -ml-1.5 to align the 'Updated' text flush with the heading above.