### PR TITLE
Centralize SandboxProvider context management in agent package

### DIFF
--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -185,3 +185,22 @@ type SandboxConnectionInfo struct {
 	AgentSession string            // agent-specific session ID for --resume
 	Environment  map[string]string // env vars needed for the local CLI
 }
+
+// sandboxProviderKey is the context key for injecting a SandboxProvider.
+// It lives in the agent package so both the orchestrator and adapters can
+// share it without circular imports.
+type sandboxProviderKey struct{}
+
+// WithSandboxProvider returns a context carrying the given SandboxProvider.
+// The orchestrator injects the provider before calling adapter.Execute,
+// and adapters retrieve it via SandboxProviderFromContext.
+func WithSandboxProvider(ctx context.Context, p SandboxProvider) context.Context {
+	return context.WithValue(ctx, sandboxProviderKey{}, p)
+}
+
+// SandboxProviderFromContext retrieves the SandboxProvider from the context.
+// Returns nil if no provider is set.
+func SandboxProviderFromContext(ctx context.Context) SandboxProvider {
+	p, _ := ctx.Value(sandboxProviderKey{}).(SandboxProvider)
+	return p
+}

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -66,8 +66,8 @@ func (a *ClaudeCodeAdapter) PreparePrompt(ctx context.Context, input *agent.Agen
 
 // Execute runs the Claude Code CLI inside the sandbox and streams output.
 func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
-	provider, ok := ctx.Value(sandboxProviderKey{}).(agent.SandboxProvider)
-	if !ok {
+	provider := agent.SandboxProviderFromContext(ctx)
+	if provider == nil {
 		return nil, fmt.Errorf("sandbox provider not found in context")
 	}
 
@@ -228,14 +228,10 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	return result, nil
 }
 
-// sandboxProviderKey is the context key for injecting a SandboxProvider.
-type sandboxProviderKey struct{}
-
-// WithSandboxProvider returns a context with the given SandboxProvider attached.
-// The Execute method retrieves the provider from context to write files
-// and run commands in the sandbox.
+// WithSandboxProvider re-exports agent.WithSandboxProvider for backward compatibility.
+// Callers should prefer agent.WithSandboxProvider directly.
 func WithSandboxProvider(ctx context.Context, p agent.SandboxProvider) context.Context {
-	return context.WithValue(ctx, sandboxProviderKey{}, p)
+	return agent.WithSandboxProvider(ctx, p)
 }
 
 // buildSystemPrompt constructs the system prompt with instructions and context.

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -1027,7 +1027,7 @@ func TestWithSandboxProvider(t *testing.T) {
 	provider := testutil.NewMockSandboxProvider()
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	retrieved, ok := ctx.Value(sandboxProviderKey{}).(agent.SandboxProvider)
-	require.True(t, ok)
+	retrieved := agent.SandboxProviderFromContext(ctx)
+	require.NotNil(t, retrieved)
 	require.Equal(t, provider, retrieved)
 }

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -58,8 +58,8 @@ func (a *CodexAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInpu
 
 // Execute runs the Codex CLI inside the sandbox and streams output.
 func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
-	provider, ok := ctx.Value(sandboxProviderKey{}).(agent.SandboxProvider)
-	if !ok {
+	provider := agent.SandboxProviderFromContext(ctx)
+	if provider == nil {
 		return nil, fmt.Errorf("sandbox provider not found in context")
 	}
 

--- a/internal/services/agent/adapters/gemini_cli.go
+++ b/internal/services/agent/adapters/gemini_cli.go
@@ -59,8 +59,8 @@ func (a *GeminiCLIAdapter) PreparePrompt(ctx context.Context, input *agent.Agent
 
 // Execute runs the Gemini CLI inside the sandbox and streams output.
 func (a *GeminiCLIAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
-	provider, ok := ctx.Value(sandboxProviderKey{}).(agent.SandboxProvider)
-	if !ok {
+	provider := agent.SandboxProviderFromContext(ctx)
+	if provider == nil {
 		return nil, fmt.Errorf("sandbox provider not found in context")
 	}
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -367,7 +367,8 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		o.streamLogs(ctx, run.ID, run.OrgID, run.CurrentTurn, logCh)
 	}()
 
-	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	execCtx := WithSandboxProvider(ctx, o.provider)
+	result, err := adapter.Execute(execCtx, sandbox, prompt, logCh)
 	close(logCh)
 	logWg.Wait()
 
@@ -618,7 +619,8 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		o.streamLogs(ctx, session.ID, session.OrgID, turnNumber, logCh)
 	}()
 
-	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	execCtx := WithSandboxProvider(ctx, o.provider)
+	result, err := adapter.Execute(execCtx, sandbox, prompt, logCh)
 	close(logCh)
 	logWg.Wait()
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1313,3 +1313,96 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Equal(t, models.MessageRoleAssistant, messages[1].Role, "assistant reply should be stored for the continued turn")
 	require.Equal(t, 2, messages[1].TurnNumber, "assistant reply should use the new turn number")
 }
+
+// ---------------------------------------------------------------------------
+// WithSandboxProvider / SandboxProviderFromContext
+// ---------------------------------------------------------------------------
+
+func TestWithSandboxProvider_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	ctx := agent.WithSandboxProvider(context.Background(), provider)
+
+	got := agent.SandboxProviderFromContext(ctx)
+	require.NotNil(t, got, "provider should be retrievable from context")
+	require.Equal(t, provider, got)
+}
+
+func TestSandboxProviderFromContext_ReturnsNilWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	got := agent.SandboxProviderFromContext(context.Background())
+	require.Nil(t, got, "should return nil when no provider is set")
+}
+
+func TestRunAgent_InjectsSandboxProviderIntoContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		p := agent.SandboxProviderFromContext(ctx)
+		require.NotNil(t, p, "RunAgent must inject the SandboxProvider into the adapter's context")
+		return &agent.AgentResult{
+			Summary:         "ok",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+		}, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.NoError(t, err)
+}
+
+func TestContinueSession_InjectsSandboxProviderIntoContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = "manual"
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	session.SnapshotKey = strPtr("snapshots/test/session.tar")
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Follow up",
+		},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("snap"))), nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		p := agent.SandboxProviderFromContext(ctx)
+		require.NotNil(t, p, "ContinueSession must inject the SandboxProvider into the adapter's context")
+		return &agent.AgentResult{
+			Summary:         "continued",
+			ConfidenceScore: 0.85,
+			ExitCode:        0,
+		}, nil
+	}
+	d.snapshots.data = map[string][]byte{
+		*session.SnapshotKey: []byte("restored-snapshot"),
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
This PR refactors the SandboxProvider context injection pattern by moving the context key and helper functions from individual adapters to the central `agent` package. This eliminates code duplication and provides a single source of truth for context management across all adapters.

## Key Changes
- **Moved context management to agent package**: Added `sandboxProviderKey`, `WithSandboxProvider()`, and `SandboxProviderFromContext()` to `internal/services/agent/adapter.go`
- **Updated all adapters**: Modified ClaudeCodeAdapter, CodexAdapter, and GeminiCLIAdapter to use `agent.SandboxProviderFromContext()` instead of direct context value retrieval
- **Maintained backward compatibility**: ClaudeCodeAdapter's `WithSandboxProvider()` now re-exports the agent package function
- **Updated orchestrator**: Modified `RunAgent()` and `ContinueSession()` to inject the provider via the centralized `WithSandboxProvider()` function
- **Updated tests**: Modified `TestWithSandboxProvider()` to use the new centralized retrieval function

## Implementation Details
- The context key is now a private type in the agent package, preventing accidental misuse
- All adapters consistently use `SandboxProviderFromContext()` which safely returns nil if no provider is set
- The orchestrator injects the provider once before calling `adapter.Execute()`, ensuring all adapters have access without circular import dependencies
- This pattern allows the orchestrator and adapters to share the provider without tight coupling

https://claude.ai/code/session_01JhSU7rcqWK92gNNog37uGy