### PR TITLE
Fix PR loading state to prevent diff viewer from showing simultaneously

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -362,11 +362,9 @@ function ChangesTab({ session, sessionId }: { session: Session; sessionId: strin
         </Card>
       )}
 
-      {prLoading && (
+      {prLoading ? (
         <div className="text-center text-sm text-muted-foreground py-2">Loading PR details...</div>
-      )}
-
-      {session.diff ? (
+      ) : session.diff ? (
         <DiffViewer diff={session.diff} />
       ) : (
         <div className="py-8 text-center text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
Fixed a conditional rendering issue in the ChangesTab component where the loading state and diff viewer could both be displayed at the same time.

## Key Changes
- Converted separate conditional blocks into a ternary operator chain to ensure mutually exclusive rendering
- Changed `{prLoading && (...)}` followed by `{session.diff ? (...)}` to `{prLoading ? (...) : session.diff ? (...)}` 
- This ensures that when `prLoading` is true, only the loading message is shown, and the diff viewer is only rendered when loading is complete and diff data exists

## Implementation Details
The original code had two independent conditional statements that could both evaluate to true simultaneously. By restructuring into a ternary operator chain, we establish proper precedence: loading state takes priority, followed by the diff viewer, with a fallback message if neither condition is met.

https://claude.ai/code/session_012uMxUBXY5ZVTQNYTeyCQev