### PR TITLE
Add optimistic session creation with placeholder UI

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState } from "react";
 import { SessionSidebar } from "./session-sidebar";
 import { ResizeHandle } from "@/components/resize-handle";
+import { OptimisticSessionsProvider } from "@/contexts/optimistic-sessions";
 
 const MIN_SIDEBAR = 240;
 const MAX_SIDEBAR = 480;
@@ -16,18 +17,20 @@ export default function SessionsLayout({ children }: { children: React.ReactNode
   }, []);
 
   return (
-    <div className="flex h-[calc(100vh-theme(spacing.6)*2)] -mx-8 -my-6 lg:-mx-10">
-      {/* Session list sidebar */}
-      <div style={{ width: sidebarWidth }} className="shrink-0">
-        <SessionSidebar />
-      </div>
+    <OptimisticSessionsProvider>
+      <div className="flex h-[calc(100vh-theme(spacing.6)*2)] -mx-8 -my-6 lg:-mx-10">
+        {/* Session list sidebar */}
+        <div style={{ width: sidebarWidth }} className="shrink-0">
+          <SessionSidebar />
+        </div>
 
-      <ResizeHandle onResize={handleSidebarResize} />
+        <ResizeHandle onResize={handleSidebarResize} />
 
-      {/* Main content area */}
-      <div className="flex-1 min-w-0 overflow-auto">
-        {children}
+        {/* Main content area */}
+        <div className="flex-1 min-w-0 overflow-auto">
+          {children}
+        </div>
       </div>
-    </div>
+    </OptimisticSessionsProvider>
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowUp, Mic, Plus, X, ImagePlus, Paperclip } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
@@ -23,8 +23,10 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
-import type { OrgSettings, Organization, Session, SessionsListResponse, SingleResponse } from "@/lib/types";
+import { useOptimisticSessions } from "@/contexts/optimistic-sessions";
+import type { OrgSettings, Organization, SingleResponse } from "@/lib/types";
 
 type DictationResult = {
   transcript: string;
@@ -58,10 +60,10 @@ function readFileAsDataURL(file: File): Promise<string> {
 
 export function ManualSessionCreatePageContent() {
   const router = useRouter();
-  const queryClient = useQueryClient();
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const optimisticIdRef = useRef<string | null>(null);
 
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<string[]>([]);
@@ -72,8 +74,10 @@ export function ManualSessionCreatePageContent() {
   const [selectedModel, setSelectedModel] = useState("");
   const [creationError, setCreationError] = useState<string | null>(null);
 
+  const { addOptimisticSession, removeOptimisticSession } = useOptimisticSessions();
+
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
-    queryKey: ["settings"],
+    queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
 
@@ -92,71 +96,28 @@ export function ManualSessionCreatePageContent() {
         images: attachments,
         ...(selectedModel ? { model: selectedModel } : {}),
       }),
-    onMutate: async () => {
+    onMutate: () => {
       setCreationError(null);
-
-      // Cancel in-flight session list fetches so they don't overwrite our optimistic update
-      await queryClient.cancelQueries({ queryKey: ["sessions"] });
-
-      // Snapshot the previous session list for rollback
-      const previousSessions = queryClient.getQueriesData<SessionsListResponse>({ queryKey: ["sessions"] });
-
-      // Build an optimistic session entry
-      const optimisticSession: Session = {
-        id: `optimistic-${Date.now()}`,
-        issue_id: "",
-        org_id: "",
-        agent_type: defaultAgentType,
-        status: "pending",
-        autonomy_level: "full",
-        token_mode: "low",
-        current_turn: 0,
-        sandbox_state: "",
-        pm_approach: message.trim().length > 80 ? message.trim().slice(0, 80) + "..." : message.trim(),
-        created_at: new Date().toISOString(),
-      };
-
-      // Prepend optimistic session to all session list query caches
-      queryClient.setQueriesData<SessionsListResponse>(
-        { queryKey: ["sessions"] },
-        (old) => {
-          if (!old) return { data: [optimisticSession], meta: {} };
-          return { ...old, data: [optimisticSession, ...old.data] };
-        },
-      );
-
-      return { previousSessions };
+      const title = message.trim().length > 80
+        ? message.trim().slice(0, 80) + "..."
+        : message.trim();
+      optimisticIdRef.current = addOptimisticSession(title);
     },
     onSuccess: (response) => {
-      // Replace the optimistic entry with the real session data
-      queryClient.setQueriesData<SessionsListResponse>(
-        { queryKey: ["sessions"] },
-        (old) => {
-          if (!old) return old;
-          return {
-            ...old,
-            data: old.data.map((s) =>
-              s.id.startsWith("optimistic-") ? response.data : s,
-            ),
-          };
-        },
-      );
+      if (optimisticIdRef.current) {
+        removeOptimisticSession(optimisticIdRef.current);
+        optimisticIdRef.current = null;
+      }
       router.push(`/sessions/${response.data.id}`);
     },
-    onError: (_error, _variables, context) => {
-      // Roll back to the previous session list
-      if (context?.previousSessions) {
-        for (const [queryKey, data] of context.previousSessions) {
-          queryClient.setQueryData(queryKey, data);
-        }
+    onError: (error) => {
+      if (optimisticIdRef.current) {
+        removeOptimisticSession(optimisticIdRef.current);
+        optimisticIdRef.current = null;
       }
       setCreationError(
-        _error instanceof Error ? _error.message : "Could not start session. Please try again.",
+        error instanceof Error ? error.message : "Could not start session. Please try again.",
       );
-    },
-    onSettled: () => {
-      // Refetch to ensure we're in sync with the server
-      queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
   });
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Mic, Plus, X, ImagePlus, Paperclip } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
@@ -24,7 +24,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/lib/api";
 import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
-import type { OrgSettings, Organization, SingleResponse } from "@/lib/types";
+import type { OrgSettings, Organization, Session, SessionsListResponse, SingleResponse } from "@/lib/types";
 
 type DictationResult = {
   transcript: string;
@@ -58,6 +58,7 @@ function readFileAsDataURL(file: File): Promise<string> {
 
 export function ManualSessionCreatePageContent() {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
@@ -69,6 +70,7 @@ export function ManualSessionCreatePageContent() {
   const [isDictating, setIsDictating] = useState(false);
   const [dictationError, setDictationError] = useState<string | null>(null);
   const [selectedModel, setSelectedModel] = useState("");
+  const [creationError, setCreationError] = useState<string | null>(null);
 
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: ["settings"],
@@ -90,8 +92,71 @@ export function ManualSessionCreatePageContent() {
         images: attachments,
         ...(selectedModel ? { model: selectedModel } : {}),
       }),
+    onMutate: async () => {
+      setCreationError(null);
+
+      // Cancel in-flight session list fetches so they don't overwrite our optimistic update
+      await queryClient.cancelQueries({ queryKey: ["sessions"] });
+
+      // Snapshot the previous session list for rollback
+      const previousSessions = queryClient.getQueriesData<SessionsListResponse>({ queryKey: ["sessions"] });
+
+      // Build an optimistic session entry
+      const optimisticSession: Session = {
+        id: `optimistic-${Date.now()}`,
+        issue_id: "",
+        org_id: "",
+        agent_type: defaultAgentType,
+        status: "pending",
+        autonomy_level: "full",
+        token_mode: "low",
+        current_turn: 0,
+        sandbox_state: "",
+        pm_approach: message.trim().length > 80 ? message.trim().slice(0, 80) + "..." : message.trim(),
+        created_at: new Date().toISOString(),
+      };
+
+      // Prepend optimistic session to all session list query caches
+      queryClient.setQueriesData<SessionsListResponse>(
+        { queryKey: ["sessions"] },
+        (old) => {
+          if (!old) return { data: [optimisticSession], meta: {} };
+          return { ...old, data: [optimisticSession, ...old.data] };
+        },
+      );
+
+      return { previousSessions };
+    },
     onSuccess: (response) => {
+      // Replace the optimistic entry with the real session data
+      queryClient.setQueriesData<SessionsListResponse>(
+        { queryKey: ["sessions"] },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            data: old.data.map((s) =>
+              s.id.startsWith("optimistic-") ? response.data : s,
+            ),
+          };
+        },
+      );
       router.push(`/sessions/${response.data.id}`);
+    },
+    onError: (_error, _variables, context) => {
+      // Roll back to the previous session list
+      if (context?.previousSessions) {
+        for (const [queryKey, data] of context.previousSessions) {
+          queryClient.setQueryData(queryKey, data);
+        }
+      }
+      setCreationError(
+        _error instanceof Error ? _error.message : "Could not start session. Please try again.",
+      );
+    },
+    onSettled: () => {
+      // Refetch to ensure we're in sync with the server
+      queryClient.invalidateQueries({ queryKey: ["sessions"] });
     },
   });
 
@@ -326,8 +391,8 @@ export function ManualSessionCreatePageContent() {
             {dictationError && (
               <p className="pt-2 text-xs text-destructive">{dictationError}</p>
             )}
-            {createManualSessionMutation.isError && (
-              <p className="pt-2 text-xs text-destructive">Could not start session. Please try again.</p>
+            {(createManualSessionMutation.isError || creationError) && (
+              <p className="pt-2 text-xs text-destructive">{creationError || "Could not start session. Please try again."}</p>
             )}
           </CardContent>
         </Card>

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -63,7 +63,6 @@ export function ManualSessionCreatePageContent() {
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
-  const optimisticIdRef = useRef<string | null>(null);
 
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<string[]>([]);
@@ -101,19 +100,15 @@ export function ManualSessionCreatePageContent() {
       const title = message.trim().length > 80
         ? message.trim().slice(0, 80) + "..."
         : message.trim();
-      optimisticIdRef.current = addOptimisticSession(title);
+      return { optimisticId: addOptimisticSession(title) };
     },
-    onSuccess: (response) => {
-      if (optimisticIdRef.current) {
-        removeOptimisticSession(optimisticIdRef.current);
-        optimisticIdRef.current = null;
-      }
+    onSuccess: (response, _variables, context) => {
+      removeOptimisticSession(context.optimisticId);
       router.push(`/sessions/${response.data.id}`);
     },
-    onError: (error) => {
-      if (optimisticIdRef.current) {
-        removeOptimisticSession(optimisticIdRef.current);
-        optimisticIdRef.current = null;
+    onError: (error, _variables, context) => {
+      if (context?.optimisticId) {
+        removeOptimisticSession(context.optimisticId);
       }
       setCreationError(
         error instanceof Error ? error.message : "Could not start session. Please try again.",
@@ -352,8 +347,8 @@ export function ManualSessionCreatePageContent() {
             {dictationError && (
               <p className="pt-2 text-xs text-destructive">{dictationError}</p>
             )}
-            {(createManualSessionMutation.isError || creationError) && (
-              <p className="pt-2 text-xs text-destructive">{creationError || "Could not start session. Please try again."}</p>
+            {creationError && (
+              <p className="pt-2 text-xs text-destructive">{creationError}</p>
             )}
           </CardContent>
         </Card>

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -169,7 +169,7 @@ describe('ManualSessionCreatePage', () => {
     await user.click(screen.getByRole('button', { name: 'Start session' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Could not start session. Please try again.')).toBeInTheDocument();
+      expect(screen.getByText('server error')).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -8,6 +8,8 @@ import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import type { Session } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -70,6 +72,35 @@ function formatTimeAgo(dateStr: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Optimistic (unsaved) session row
+// ---------------------------------------------------------------------------
+
+function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
+  const cfg = statusConfig.pending;
+  return (
+    <div className="block rounded-lg px-3 py-2.5 mb-0.5">
+      <div className="flex items-start gap-2.5 min-w-0">
+        <div className="mt-1.5 shrink-0">
+          <span className="relative flex h-2 w-2">
+            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary/60 opacity-75" />
+            <span className="relative inline-flex rounded-full h-2 w-2 bg-primary" />
+          </span>
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-[13px] font-medium text-foreground truncate leading-snug">
+            {session.title}
+          </p>
+          <div className="flex items-center gap-2 mt-0.5">
+            <span className="text-[11px] text-muted-foreground">{cfg.label}</span>
+            <span className="text-[11px] text-muted-foreground/50">just now</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Sidebar component
 // ---------------------------------------------------------------------------
 
@@ -81,8 +112,10 @@ export function SessionSidebar() {
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
 
+  const { optimisticSessions } = useOptimisticSessions();
+
   const { data, isLoading } = useQuery({
-    queryKey: ["sessions", repo],
+    queryKey: queryKeys.sessions.list(repo),
     queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
     refetchInterval: 10000,
   });
@@ -184,6 +217,10 @@ export function SessionSidebar() {
             </div>
           </Link>
         )}
+
+        {optimisticSessions.map((os) => (
+          <OptimisticSessionRow key={os.id} session={os} />
+        ))}
 
         {isLoading && (
           <div className="px-2 py-8 text-center text-[12px] text-muted-foreground">

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -218,9 +218,10 @@ export function SessionSidebar() {
           </Link>
         )}
 
-        {optimisticSessions.map((os) => (
-          <OptimisticSessionRow key={os.id} session={os} />
-        ))}
+        {(currentFilter === "all" || currentFilter === "active") &&
+          optimisticSessions.map((os) => (
+            <OptimisticSessionRow key={os.id} session={os} />
+          ))}
 
         {isLoading && (
           <div className="px-2 py-8 text-center text-[12px] text-muted-foreground">

--- a/frontend/src/contexts/optimistic-sessions.tsx
+++ b/frontend/src/contexts/optimistic-sessions.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { createContext, useCallback, useContext, useState } from "react";
+
+/**
+ * Minimal shape for a session that hasn't been saved to the backend yet.
+ * Only includes the fields the sidebar needs to render a placeholder entry.
+ *
+ * If the sidebar starts displaying additional fields, add them here so the
+ * compiler reminds callers to supply them.
+ */
+export interface OptimisticSession {
+  /** Temporary client-side id (e.g. "optimistic-<timestamp>"). */
+  id: string;
+  /** Text shown as the session title in the sidebar. */
+  title: string;
+  status: "pending";
+  created_at: string;
+}
+
+interface OptimisticSessionsContextValue {
+  optimisticSessions: OptimisticSession[];
+  /** Add a placeholder session. Returns the temporary id. */
+  addOptimisticSession: (title: string) => string;
+  /** Remove a placeholder (on success or error). */
+  removeOptimisticSession: (id: string) => void;
+}
+
+const OptimisticSessionsContext = createContext<OptimisticSessionsContextValue | null>(null);
+
+export function OptimisticSessionsProvider({ children }: { children: React.ReactNode }) {
+  const [sessions, setSessions] = useState<OptimisticSession[]>([]);
+
+  const addOptimisticSession = useCallback((title: string) => {
+    const id = `optimistic-${Date.now()}`;
+    setSessions((prev) => [
+      { id, title, status: "pending" as const, created_at: new Date().toISOString() },
+      ...prev,
+    ]);
+    return id;
+  }, []);
+
+  const removeOptimisticSession = useCallback((id: string) => {
+    setSessions((prev) => prev.filter((s) => s.id !== id));
+  }, []);
+
+  return (
+    <OptimisticSessionsContext.Provider value={{ optimisticSessions: sessions, addOptimisticSession, removeOptimisticSession }}>
+      {children}
+    </OptimisticSessionsContext.Provider>
+  );
+}
+
+export function useOptimisticSessions() {
+  const ctx = useContext(OptimisticSessionsContext);
+  if (!ctx) {
+    throw new Error("useOptimisticSessions must be used within an OptimisticSessionsProvider");
+  }
+  return ctx;
+}

--- a/frontend/src/contexts/optimistic-sessions.tsx
+++ b/frontend/src/contexts/optimistic-sessions.tsx
@@ -32,7 +32,7 @@ export function OptimisticSessionsProvider({ children }: { children: React.React
   const [sessions, setSessions] = useState<OptimisticSession[]>([]);
 
   const addOptimisticSession = useCallback((title: string) => {
-    const id = `optimistic-${Date.now()}`;
+    const id = `optimistic-${crypto.randomUUID()}`;
     setSessions((prev) => [
       { id, title, status: "pending" as const, created_at: new Date().toISOString() },
       ...prev,

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -3,6 +3,9 @@
  *
  * Using a single source of truth for query keys prevents typo-based bugs and
  * makes it easy to invalidate related caches consistently.
+ *
+ * NOTE: Adoption is incremental — many files still use inline string arrays.
+ * When touching a file that uses hardcoded query keys, migrate them here.
  */
 export const queryKeys = {
   sessions: {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,0 +1,22 @@
+/**
+ * Centralized React Query key factories.
+ *
+ * Using a single source of truth for query keys prevents typo-based bugs and
+ * makes it easy to invalidate related caches consistently.
+ */
+export const queryKeys = {
+  sessions: {
+    all: ["sessions"] as const,
+    list: (repo?: string | null) => ["sessions", repo] as const,
+    detail: (id: string) => ["session", id] as const,
+    validation: (id: string) => ["session", id, "validation"] as const,
+    pr: (id: string) => ["session", id, "pr"] as const,
+    messages: (id: string) => ["session", id, "messages"] as const,
+  },
+  settings: {
+    all: ["settings"] as const,
+  },
+  team: {
+    members: ["team", "members"] as const,
+  },
+} as const;

--- a/frontend/src/test/test-utils.tsx
+++ b/frontend/src/test/test-utils.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, type RenderOptions } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
+import { OptimisticSessionsProvider } from '@/contexts/optimistic-sessions';
 
 function createTestQueryClient() {
   return new QueryClient({
@@ -19,7 +20,9 @@ function TestProviders({ children }: { children: React.ReactNode }) {
   return (
     <NuqsTestingAdapter>
       <QueryClientProvider client={queryClient}>
-        {children}
+        <OptimisticSessionsProvider>
+          {children}
+        </OptimisticSessionsProvider>
       </QueryClientProvider>
     </NuqsTestingAdapter>
   );
@@ -41,7 +44,9 @@ function renderWithProviders(
       return (
         <NuqsTestingAdapter searchParams={searchParams}>
           <QueryClientProvider client={queryClient}>
-            {children}
+            <OptimisticSessionsProvider>
+              {children}
+            </OptimisticSessionsProvider>
           </QueryClientProvider>
         </NuqsTestingAdapter>
       );


### PR DESCRIPTION
## Summary
This PR implements optimistic UI updates for session creation, allowing users to see a placeholder session in the sidebar immediately after initiating creation, before the backend confirms the request.

## Key Changes

- **New Context for Optimistic Sessions** (`optimistic-sessions.tsx`)
  - Created `OptimisticSessionsContext` to manage temporary placeholder sessions
  - Provides `addOptimisticSession()` and `removeOptimisticSession()` functions
  - Placeholder sessions use temporary IDs (e.g., "optimistic-<timestamp>") and include a "pending" status

- **Updated Session Sidebar** (`session-sidebar.tsx`)
  - Added `OptimisticSessionRow` component to render placeholder sessions with a pulsing indicator
  - Integrated optimistic sessions into the sidebar list, displayed above fetched sessions
  - Updated query key to use centralized `queryKeys` factory

- **Enhanced Manual Session Creation** (`manual-session-create-page-content.tsx`)
  - Added `onMutate` hook to create optimistic session before API request
  - Added `onError` hook to remove optimistic session on failure and display error message
  - Improved error handling with dedicated `creationError` state
  - Updated query keys to use centralized factory

- **Layout Provider Setup** (`layout.tsx`)
  - Wrapped sessions layout with `OptimisticSessionsProvider` to make context available to all child components

- **Centralized Query Keys** (`query-keys.ts`)
  - Created query key factory to prevent typos and enable consistent cache invalidation
  - Organized keys by domain (sessions, settings, team)

## Implementation Details

- Optimistic sessions are displayed with a pulsing blue indicator to distinguish them from confirmed sessions
- The placeholder title is truncated to 80 characters if the message is longer
- Optimistic sessions are automatically removed on both success (after navigation) and error
- Uses React Query's mutation lifecycle hooks (`onMutate`, `onSuccess`, `onError`) for proper state management

https://claude.ai/code/session_01RThdbZo1xMHqJUoq8NCnoW