### PR TITLE
Design: Clarify shared container model for multi-agent sessions

### DIFF
--- a/docs/design/35-multi-agent-planning.md
+++ b/docs/design/35-multi-agent-planning.md
@@ -9,15 +9,15 @@ The goal: **a single session can have multiple coding agents running at the same
 ### What this is NOT
 
 - **Not separate sessions with a parent.** That fragments the experience — you'd have to click between session detail pages. The user wants everything in one place.
-- **Not conductor.build's model.** Conductor uses fully isolated git worktrees. We want agents within the same session context, on the same branch, with a unified view.
+- **Not isolated containers or worktrees.** Some tools give each agent its own filesystem copy. We don't. Our agents share a single container, a single filesystem, and a single branch — like two terminal tabs on the same machine. This is simpler, cheaper, and matches how the primary use cases actually work (comparing approaches, or working on different files).
 
 ---
 
 ## Design Principles
 
 1. **Single-agent by default** — Every session starts with one agent. This is identical to today. Multi-agent is opt-in, never automatic.
-2. **Same branch, container isolation** — All agents in a session target the same branch. Each runs in its own container (filesystem isolation), but commits go to the shared branch.
-3. **Threads as the unit** — Each agent within a session is a "thread" — a parallel lane of work with its own conversation, container, and diff. The session ties them together.
+2. **Shared container, shared filesystem** — All agents in a session run inside the same Docker container, on the same branch, with the same filesystem. Think of it like multiple tmux panes in the same terminal — each agent is an independent process, but they all see the same files and the same git state.
+3. **Threads as the unit** — Each agent within a session is a "thread" — a parallel lane of work with its own conversation and agent process. The session ties them together. Threads share the container and filesystem.
 4. **User-initiated, never automated** — The PM and automated systems always create single-thread sessions. Only the user adds threads, primarily to compare agents or split work.
 
 ---
@@ -46,10 +46,7 @@ CREATE TABLE session_threads (
     -- Execution state
     status          TEXT NOT NULL DEFAULT 'pending',
     -- pending, running, idle, awaiting_input, completed, failed, cancelled
-    container_id    TEXT,
-    agent_session_id TEXT,                     -- external agent session ID
-    sandbox_state   TEXT NOT NULL DEFAULT 'none',
-    snapshot_key    TEXT,
+    agent_session_id TEXT,                     -- external agent session ID (process within shared container)
     current_turn    INT NOT NULL DEFAULT 0,
     last_activity_at TIMESTAMPTZ,
 
@@ -85,9 +82,10 @@ Messages with `thread_id = NULL` are session-level messages (e.g., the initial i
 
 ### Modified: `sessions` table
 
-Sessions get lighter. Per-agent fields (`agent_session_id`, `sandbox_state`, `snapshot_key`, `container_id`) move to threads. The session keeps:
+Sessions get lighter. The `agent_session_id` moves to threads. Container-level fields (`container_id`, `sandbox_state`, `snapshot_key`) stay on the session since all threads share the same container. The session keeps:
 
 - Identity: `id`, `org_id`, `issue_id`
+- Container: `container_id`, `sandbox_state`, `snapshot_key` (shared by all threads)
 - Lifecycle: `status` (derived from thread statuses — active if any thread is active)
 - Metadata: `triggered_by_user_id`, `pm_plan_id`, `project_task_id`
 - The existing `agent_type` field becomes the "default" agent type (used for single-thread sessions for backwards compatibility)
@@ -203,10 +201,10 @@ Design details:
 
 ### What happens after clicking "Add"
 
-1. New thread starts immediately in its own container, on the same branch
+1. A new agent process starts inside the session's existing container — same filesystem, same branch, same working directory. No new container is created.
 2. If this is the first additional thread, the layout transitions from single-pane to split-pane (animation: the existing chat slides left, new column slides in from right)
 3. The new thread appears as the rightmost column, with the `[+]` button shifting further right
-4. The new agent begins working immediately
+4. The new agent begins working immediately — it can see the current state of the repo, including any uncommitted changes from the first agent
 
 ---
 
@@ -329,7 +327,7 @@ Users add threads to a **running or idle session** via the `[+]` button. The flo
 1. User starts a normal single-agent session (no change from today)
 2. While watching the agent work, user decides they want a second agent — maybe to compare approaches, or to work on a different part of the problem
 3. User clicks `[+]`, picks an agent type, writes a label and optional instructions
-4. New thread starts immediately in its own container, on the same branch
+4. A new agent process starts inside the same container — no new container, no filesystem copy. It's like opening a second terminal tab.
 5. The layout splits into side-by-side columns
 
 This is intentionally the *only* way to create multi-thread sessions. We don't add multi-thread options to the session creation form, and we don't have the system auto-create threads. The mental model is simple: **start with one agent, add more if you want.**
@@ -362,25 +360,59 @@ The most common multi-thread workflow:
 
 1. Session starts with Claude working on a bug fix
 2. User adds a Codex thread with the same instructions
-3. Both agents work in parallel — user watches side-by-side
+3. Both agents work in parallel in the same container — user watches side-by-side
 4. Claude finishes first with a clean fix. Codex is still working.
 5. User reviews Claude's diff in the column. Looks good.
-6. User ends the Codex thread via `[⋯]` → "Cancel thread" (discards Codex's in-progress changes)
-7. Session continues with just Claude's changes → PR
+6. User ends the Codex thread via `[⋯]` → "End thread" (stops the agent process)
+7. Session continues with the changes on the branch → PR
 
-The inverse is also fine — user might prefer Codex's approach and cancel Claude's thread instead.
+Since both agents share the filesystem, the user can also let both finish and then review the combined result. There's no "discard" step needed — the branch simply has all the commits from both agents, and the user can ask an agent to revert anything they don't want.
+
+The inverse is also fine — user might prefer Codex's approach and end Claude's thread instead.
+
+### The "split work" flow
+
+The other common workflow:
+
+1. Session starts with Claude working on backend API endpoints
+2. User adds a Codex thread with instructions to build the frontend UI
+3. Both agents work simultaneously — Claude creates `handlers/audit.go`, Codex creates `app/audit/page.tsx`
+4. Because they share the filesystem, Codex can see the API types Claude defined and import them
+5. Both threads complete. The branch has a coherent set of changes — backend + frontend — ready for PR
+
+This flow works naturally because the agents see each other's file changes in real time, just like two developers pairing on the same machine.
 
 ---
 
-## Branch & Merge Strategy
+## Shared Container Model
 
-All threads in a session work on the **same branch**. Each thread's container starts from the same commit. When a thread finishes:
+All threads in a session run as **separate agent processes inside the same Docker container**. They share the filesystem, the git repo, and the branch. This is the mental model of two tmux panes pointed at the same directory.
 
-1. Thread commits its changes to the branch
-2. If another thread already committed, the thread rebases/merges before pushing
-3. Conflicts are flagged to the user (thread goes to `awaiting_input`)
+### Why shared container
 
-This is the simplest model. If conflicts are common, we can add file-scope enforcement (thread A can only touch files in `internal/`, thread B only in `frontend/`), but start without it.
+1. **No merge conflicts by default.** Both agents see the same files in real time. If agent A writes `parser.go` and agent B reads it a moment later, B sees A's changes. This is the natural behavior users expect — it's how two developers working on the same machine would operate.
+2. **No branch gymnastics.** No sub-branches, no rebasing, no cherry-picking, no "which thread's commits do we keep." There's one branch, one working tree, one set of commits. The agents commit to it as they work, just like two people would.
+3. **Dramatically simpler infrastructure.** No container-per-thread provisioning, no filesystem snapshots, no copy-on-write. Adding a thread is starting a process, not spinning up a VM.
+4. **The primary use cases don't conflict.** Users will mostly use multi-thread to (a) get two reviews/approaches on the same problem, or (b) work on different parts of the codebase simultaneously (backend + frontend). Neither case involves two agents editing the same file at the same time.
+
+### What about file conflicts?
+
+In rare cases, two agents might edit the same file simultaneously. This is handled the same way it would be if two developers were pair-programming on the same machine:
+
+- Agents use standard file read/write operations. The last write wins at the filesystem level.
+- If an agent's coding tool detects the file changed since it last read it, the agent should re-read and reconcile — this is standard behavior for tools like Claude Code that check file state before editing.
+- For the "compare agents" use case (same instructions, different agents), the user typically cancels one thread before it commits anyway. The agents are racing to produce a solution, not collaborating on one.
+
+We explicitly do **not** add file locking, file-scope enforcement, or conflict detection in v1. The shared filesystem model is simple, and the use cases don't demand it. If we see users hitting conflicts in practice, we can add advisory file scopes later.
+
+### Git workflow
+
+Since all agents share the same working tree:
+
+- Agents commit directly to the session's branch as they work
+- All commits appear in a single linear history on the branch
+- The diff for each thread is tracked by recording which commits belong to which thread (via commit metadata or the `session_threads.diff` field)
+- Cancelling a thread doesn't require reverting commits — the user can simply stop the agent. If the cancelled thread already committed changes the user doesn't want, they can ask the remaining agent to revert them, or we can offer a "Revert thread's commits" action in the `[⋯]` menu
 
 ---
 
@@ -428,8 +460,7 @@ Threads don't affect project concurrency. A session with 3 threads still counts 
 
 ## Open Questions
 
-1. **Discarding a thread's changes**: When the user cancels a thread (the "compare and pick" flow), how do we cleanly discard that thread's commits from the branch? Revert commits? Keep each thread on a sub-branch until the user picks?
-2. **Thread-to-thread awareness**: Can thread A see what thread B has done? Currently no (separate containers). Should we add a "sync" step where a thread pulls the latest from the branch?
-3. **Cost visibility**: Should we show per-thread cost in the column header? Should the `[+]` popover show an estimated cost warning?
-4. **Validation**: Run validation per-thread (each thread's diff independently) or once on the combined result? Per-thread catches issues earlier; combined catches integration issues.
-5. **Thread limit**: Default max is 4 threads per session. Too low limits the compare-3-agents use case. Too high risks cost surprise.
+1. **Cost visibility**: Should we show per-thread cost in the column header? Should the `[+]` popover show an estimated cost warning?
+2. **Validation**: Run validation per-thread (each thread's diff independently) or once on the combined result? Per-thread catches issues earlier; combined catches integration issues.
+3. **Thread limit**: Default max is 4 threads per session. Too low limits the compare-3-agents use case. Too high risks cost surprise.
+4. **Commit attribution**: How do we attribute commits to specific threads? Options: (a) convention-based commit message tags, (b) a mapping table `thread_commits(thread_id, commit_sha)`, (c) record the diff at thread completion time and don't track individual commits.


### PR DESCRIPTION
Clarifies that all agents in a multi-agent session run inside the same Docker container with a shared filesystem, not isolated containers. This is simpler and cheaper, and naturally supports the primary use cases: comparing agent approaches and splitting work (backend/frontend). Agents see each other's file changes in real time, like tmux panes on the same machine. Removed the "Branch & Merge Strategy" section and replaced it with "Shared Container Model" that explains why this approach works and handles the rare case of file conflicts. Updated open questions to remove ones resolved by this model and added commit attribution as the remaining open question.