### PR TITLE
Improve error logging for all non-2xx responses

### DIFF
--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -33,7 +33,7 @@ func (rw *responseWriter) Flush() {
 }
 
 func (rw *responseWriter) captureErrorDetails(responseBody []byte) {
-	if rw.status < http.StatusInternalServerError {
+	if rw.status < http.StatusBadRequest {
 		return
 	}
 
@@ -55,6 +55,8 @@ func Logging(logger zerolog.Logger) func(http.Handler) http.Handler {
 			logEvent := logger.Info()
 			if rw.status >= http.StatusInternalServerError {
 				logEvent = logger.Error()
+			} else if rw.status >= http.StatusBadRequest {
+				logEvent = logger.Warn()
 			}
 
 			logEvent.
@@ -64,7 +66,7 @@ func Logging(logger zerolog.Logger) func(http.Handler) http.Handler {
 				Int("status", rw.status).
 				Dur("duration", time.Since(start))
 
-			if rw.status >= http.StatusInternalServerError {
+			if rw.status >= http.StatusBadRequest {
 				if rw.errorResponse != nil && rw.errorResponse.Error.Code != "" {
 					logEvent = logEvent.Str("error_code", rw.errorResponse.Error.Code)
 				}

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -77,7 +77,7 @@ func TestLogging_ErrorResponsesAreLoggedAtErrorLevel(t *testing.T) {
 		expectedErrorMessage string
 	}{
 		{
-			name: "500 response logs error details",
+			name: "500 response logs error details at error level",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusInternalServerError)
@@ -86,6 +86,36 @@ func TestLogging_ErrorResponsesAreLoggedAtErrorLevel(t *testing.T) {
 			expectedLevel:        "error",
 			expectedErrorCode:    "AUTH_INITIATE_FAILED",
 			expectedErrorMessage: "failed to initiate device auth",
+		},
+		{
+			name: "400 response logs error details at warn level",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				_, _ = w.Write([]byte(`{"error":{"code":"INVALID_BODY","message":"missing required field"}}`))
+			},
+			expectedLevel:        "warn",
+			expectedErrorCode:    "INVALID_BODY",
+			expectedErrorMessage: "missing required field",
+		},
+		{
+			name: "401 response logs error details at warn level",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":{"code":"UNAUTHORIZED","message":"invalid session"}}`))
+			},
+			expectedLevel:        "warn",
+			expectedErrorCode:    "UNAUTHORIZED",
+			expectedErrorMessage: "invalid session",
+		},
+		{
+			name: "404 response logs at warn level without error details",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte("not found"))
+			},
+			expectedLevel: "warn",
 		},
 		{
 			name: "200 response stays info level",
@@ -123,10 +153,10 @@ func TestLogging_ErrorResponsesAreLoggedAtErrorLevel(t *testing.T) {
 			require.Equal(t, tt.expectedLevel, logEvent["level"], "logging middleware should use expected log level")
 
 			if tt.expectedErrorCode != "" {
-				require.Equal(t, tt.expectedErrorCode, logEvent["error_code"], "logging middleware should include API error code for 5xx responses")
+				require.Equal(t, tt.expectedErrorCode, logEvent["error_code"], "logging middleware should include API error code for error responses")
 			}
 			if tt.expectedErrorMessage != "" {
-				require.Equal(t, tt.expectedErrorMessage, logEvent["error_message"], "logging middleware should include API error message for 5xx responses")
+				require.Equal(t, tt.expectedErrorMessage, logEvent["error_message"], "logging middleware should include API error message for error responses")
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Log all client and server errors (4xx and 5xx) with appropriate severity levels and extract error details for visibility into failed requests.

## Changes
- Capture error response bodies for all 4xx and 5xx responses (previously only 5xx)
- Categorize logs by severity: 5xx as Error, 4xx as Warn, 2xx/3xx as Info
- Extract error codes and messages from response bodies for all errors
- Add test coverage for 400, 401, and 404 responses

This provides better observability into auth failures, validation errors, and other client-side issues.