### PR TITLE
Increase badge spacing between status and timestamp

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -208,11 +208,11 @@ export function ProjectSidebar() {
                     {project.title}
                   </p>
 
-                  <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[11px] text-muted-foreground">
+                  <div className="flex items-center gap-3 mt-0.5">
+                    <span className="text-[11px] text-muted-foreground shrink-0">
                       {cfg.label}
                     </span>
-                    <span className="text-[11px] text-muted-foreground/50">
+                    <span className="text-[11px] text-muted-foreground/50 truncate">
                       {formatTimeAgo(ts)}
                     </span>
                   </div>

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -77,8 +77,8 @@ function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
           <p className="text-[13px] font-medium text-foreground truncate leading-snug">
             {session.title}
           </p>
-          <div className="flex items-center gap-2 mt-0.5">
-            <span className="text-[11px] text-muted-foreground">{cfg.label}</span>
+          <div className="flex items-center gap-3 mt-0.5">
+            <span className="text-[11px] text-muted-foreground shrink-0">{cfg.label}</span>
             <span className="text-[11px] text-muted-foreground/50">just now</span>
           </div>
         </div>
@@ -254,11 +254,11 @@ export function SessionSidebar() {
                   <p className="text-[13px] font-medium text-foreground truncate leading-snug">
                     {sessionTitle(session)}
                   </p>
-                  <div className="flex items-center gap-2 mt-0.5">
-                    <span className="text-[11px] text-muted-foreground">
+                  <div className="flex items-center gap-3 mt-0.5">
+                    <span className="text-[11px] text-muted-foreground shrink-0">
                       {cfg.label}
                     </span>
-                    <span className="text-[11px] text-muted-foreground/50">
+                    <span className="text-[11px] text-muted-foreground/50 truncate">
                       {formatTimeAgo(ts)}
                     </span>
                   </div>


### PR DESCRIPTION
## Summary
Increase spacing between status badges and timestamp labels from gap-2 (8px) to gap-3 (12px) in session and project sidebars. This prevents badges from appearing cramped when session/project names are long.

## Changes
- Updated both session and project sidebar badge layouts with improved spacing
- Added shrink-0 to status badges to prevent compression
- Added truncate to timestamps for better overflow handling