### PR TITLE
Refactor filter tabs to use Tabs component

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -57,11 +57,11 @@ describe('ProjectSidebar', () => {
     renderWithProviders(<ProjectSidebar />);
     await screen.findByText('Test Project');
 
-    expect(screen.getByRole('button', { name: /All/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Active/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Draft/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Done/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Paused/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /All/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Active/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Draft/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Done/ })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Paused/ })).toBeInTheDocument();
   });
 
   it('has search input', () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { projectStatusConfig, projectStatusDotColor } from "@/lib/types";
 import type { Project } from "@/lib/types";
@@ -101,39 +102,35 @@ export function ProjectSidebar() {
         </div>
 
         {/* Filter tabs */}
-        <div className="flex items-center gap-0.5 overflow-x-auto">
-          {filterTabs.map((tab) => {
-            const isSelected = currentFilter === tab.value;
-            const count =
-              tab.value === "active" ? activeCount
-              : tab.value === "paused" ? pausedCount
-              : tab.value === "scheduled" ? scheduledCount
-              : 0;
-            return (
-              <button
-                key={tab.value}
-                className={cn(
-                  "px-2 py-1 rounded-md text-[11px] font-medium transition-colors whitespace-nowrap",
-                  isSelected
-                    ? "bg-background text-foreground shadow-sm border border-border/50"
-                    : "text-muted-foreground hover:text-foreground hover:bg-background/50"
-                )}
-                onClick={() => setActiveFilter(tab.value === "all" ? null : tab.value)}
-              >
-                {tab.label}
-                {count > 0 && (
-                  <span className={cn(
-                    "ml-1 rounded-full text-white text-[9px] leading-none px-1.5 py-0.5",
-                    tab.value === "active" ? "bg-primary"
-                    : tab.value === "scheduled" ? "bg-purple-500"
-                    : tab.value === "paused" ? "bg-orange-500"
-                    : "bg-primary"
-                  )}>{count}</span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        <Tabs
+          value={currentFilter}
+          onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
+          className="gap-0"
+        >
+          <TabsList size="sm" className="overflow-x-auto">
+            {filterTabs.map((tab) => {
+              const count =
+                tab.value === "active" ? activeCount
+                : tab.value === "paused" ? pausedCount
+                : tab.value === "scheduled" ? scheduledCount
+                : 0;
+              return (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  {tab.label}
+                  {count > 0 && (
+                    <span className={cn(
+                      "rounded-full text-white text-[9px] leading-none px-1.5 py-0.5",
+                      tab.value === "active" ? "bg-primary"
+                      : tab.value === "scheduled" ? "bg-purple-500"
+                      : tab.value === "paused" ? "bg-orange-500"
+                      : "bg-primary"
+                    )}>{count}</span>
+                  )}
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+        </Tabs>
       </div>
 
       {/* Project list */}

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -65,7 +65,7 @@ describe('SessionSidebar', () => {
 
     await screen.findByText('Fixed TypeError by adding null check');
 
-    expect(screen.getByRole('button', { name: 'All' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
     expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Done').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Failed').length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -8,6 +8,7 @@ import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
@@ -154,38 +155,34 @@ export function SessionSidebar() {
         </div>
 
         {/* Filter tabs */}
-        <div className="flex items-center gap-0.5 overflow-x-auto">
-          {filterTabs.map((tab) => {
-            const isSelected = currentFilter === tab.value;
-            const count =
-              tab.value === "active" ? activeSessions.length
-              : tab.value === "failed" ? failedSessions.length
-              : tab.value === "needs_human_guidance" ? guidanceSessions.length
-              : 0;
-            return (
-              <button
-                key={tab.value}
-                className={cn(
-                  "px-2 py-1 rounded-md text-[11px] font-medium transition-colors whitespace-nowrap",
-                  isSelected
-                    ? "bg-background text-foreground shadow-sm border border-border/50"
-                    : "text-muted-foreground hover:text-foreground hover:bg-background/50"
-                )}
-                onClick={() => setActiveFilter(tab.value === "all" ? null : tab.value)}
-              >
-                {tab.label}
-                {count > 0 && (
-                  <span className={cn(
-                    "ml-1 rounded-full text-white text-[9px] leading-none px-1.5 py-0.5",
-                    tab.value === "failed" ? "bg-destructive"
-                    : tab.value === "needs_human_guidance" ? "bg-orange-500"
-                    : "bg-primary"
-                  )}>{count}</span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+        <Tabs
+          value={currentFilter}
+          onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
+          className="gap-0"
+        >
+          <TabsList size="sm" className="overflow-x-auto">
+            {filterTabs.map((tab) => {
+              const count =
+                tab.value === "active" ? activeSessions.length
+                : tab.value === "failed" ? failedSessions.length
+                : tab.value === "needs_human_guidance" ? guidanceSessions.length
+                : 0;
+              return (
+                <TabsTrigger key={tab.value} value={tab.value}>
+                  {tab.label}
+                  {count > 0 && (
+                    <span className={cn(
+                      "rounded-full text-white text-[9px] leading-none px-1.5 py-0.5",
+                      tab.value === "failed" ? "bg-destructive"
+                      : tab.value === "needs_human_guidance" ? "bg-orange-500"
+                      : "bg-primary"
+                    )}>{count}</span>
+                  )}
+                </TabsTrigger>
+              );
+            })}
+          </TabsList>
+        </Tabs>
       </div>
 
       {/* Session list */}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -33,9 +33,14 @@ const tabsListVariants = cva(
         default: "bg-muted",
         line: "gap-1 bg-transparent",
       },
+      size: {
+        default: "",
+        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 p-0 rounded-none bg-transparent",
+      },
     },
     defaultVariants: {
       variant: "default",
+      size: "default",
     },
   }
 )
@@ -43,6 +48,7 @@ const tabsListVariants = cva(
 function TabsList({
   className,
   variant = "default",
+  size = "default",
   ...props
 }: React.ComponentProps<typeof TabsPrimitive.List> &
   VariantProps<typeof tabsListVariants>) {
@@ -50,7 +56,8 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       data-variant={variant}
-      className={cn(tabsListVariants({ variant }), className)}
+      data-size={size}
+      className={cn(tabsListVariants({ variant, size }), className)}
       {...props}
     />
   )
@@ -64,7 +71,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 group-data-[size=sm]/tabs-list:h-auto group-data-[size=sm]/tabs-list:flex-none group-data-[size=sm]/tabs-list:text-[11px] group-data-[size=sm]/tabs-list:gap-1",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
         "after:absolute after:opacity-0 after:transition-opacity after:bg-[image:var(--gradient-primary)] after:rounded-full group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",


### PR DESCRIPTION
## Summary

Replace duplicate custom filter tab implementations in SessionSidebar and ProjectSidebar with the existing TabsList/TabsTrigger component. Adds a size="sm" variant for compact sidebar styling to maintain the compact 11px font and spacing.

## Benefits

- Eliminates duplicate styling code across two sidebars
- Provides cursor-pointer, keyboard navigation, and ARIA semantics automatically
- Makes count badges render cleanly next to tab labels
- Centralizes tab component behavior for consistency across the frontend

## Test Plan

- ✓ Both sidebar tests updated to query for `role="tab"` instead of `role="button"`
- ✓ All 16 sidebar tests pass
- Count badges display inline with tab text using existing gap-1 spacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)