### PR TITLE
Type-safe Issue.Source and slim manual session prompts

### DIFF
--- a/internal/api/handlers/issues.go
+++ b/internal/api/handlers/issues.go
@@ -24,7 +24,7 @@ func (h *IssueHandler) List(w http.ResponseWriter, r *http.Request) {
 	limit := queryInt(r, "limit", 50)
 	filters := db.IssueFilters{
 		Status:   r.URL.Query().Get("status"),
-		Source:   r.URL.Query().Get("source"),
+		Source:   models.IssueSource(r.URL.Query().Get("source")),
 		Severity: r.URL.Query().Get("severity"),
 		Sort:     r.URL.Query().Get("sort"),
 		Limit:    limit,

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -709,19 +709,16 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	issue := &models.Issue{
-		OrgID:                 orgID,
-		ExternalID:            "manual-" + now.UTC().Format("20060102150405") + "-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
-		Source:                "manual",
-		Title:                 title,
-		Description:           &description,
-		RawData:               rawData,
-		Status:                "open",
-		FirstSeenAt:           now,
-		LastSeenAt:            now,
-		OccurrenceCount:       1,
-		AffectedCustomerCount: 1,
-		Severity:              "medium",
-		Fingerprint:           fingerprint,
+		OrgID:       orgID,
+		ExternalID:  "manual-" + now.UTC().Format("20060102150405") + "-" + strings.ReplaceAll(uuid.NewString(), "-", ""),
+		Source:      models.IssueSourceManual,
+		Title:       title,
+		Description: &description,
+		RawData:     rawData,
+		Status:      "open",
+		FirstSeenAt: now,
+		LastSeenAt:  now,
+		Fingerprint: fingerprint,
 	}
 
 	if err := h.issueStore.Upsert(r.Context(), issue); err != nil {
@@ -743,7 +740,6 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		TokenMode:         tokenMode,
 		ModelOverride:     modelOverride,
 		TriggeredByUserID: manualTriggeredByUserID,
-		PMApproach:        &title,
 	}
 	if err := h.runStore.Create(r.Context(), session); err != nil {
 		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session")

--- a/internal/db/issue_store_test.go
+++ b/internal/db/issue_store_test.go
@@ -199,7 +199,7 @@ func TestIssueStore_Upsert(t *testing.T) {
 	issue := &models.Issue{
 		OrgID:                 uuid.New(),
 		ExternalID:            "ext-upsert",
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		Title:                 "Upsert Issue",
 		Status:                "open",
 		RawData:               json.RawMessage(`{"key":"value"}`),

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -20,7 +20,7 @@ func NewIssueStore(db DBTX) *IssueStore {
 
 type IssueFilters struct {
 	Status   string
-	Source   string
+	Source   models.IssueSource
 	Severity string
 	Sort     string
 	Limit    int

--- a/internal/models/issue_source.go
+++ b/internal/models/issue_source.go
@@ -1,0 +1,21 @@
+package models
+
+import "fmt"
+
+// IssueSource identifies the origin of an issue.
+type IssueSource string
+
+const (
+	IssueSourceSentry IssueSource = "sentry"
+	IssueSourceLinear IssueSource = "linear"
+	IssueSourceManual IssueSource = "manual"
+)
+
+func (s IssueSource) Validate() error {
+	switch s {
+	case IssueSourceSentry, IssueSourceLinear, IssueSourceManual:
+		return nil
+	default:
+		return fmt.Errorf("invalid IssueSource: %q", s)
+	}
+}

--- a/internal/models/issue_source_test.go
+++ b/internal/models/issue_source_test.go
@@ -1,0 +1,36 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssueSourceValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   IssueSource
+		wantErr bool
+	}{
+		{name: "valid sentry", value: IssueSourceSentry},
+		{name: "valid linear", value: IssueSourceLinear},
+		{name: "valid manual", value: IssueSourceManual},
+		{name: "invalid empty", value: IssueSource(""), wantErr: true},
+		{name: "invalid unknown", value: IssueSource("jira"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.value.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "Validate should return error for invalid issue source")
+				return
+			}
+			require.NoError(t, err, "Validate should succeed for valid issue source")
+		})
+	}
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -82,7 +82,7 @@ type Issue struct {
 	ID                    uuid.UUID       `db:"id" json:"id"`
 	OrgID                 uuid.UUID       `db:"org_id" json:"org_id"`
 	ExternalID            string          `db:"external_id" json:"external_id"`
-	Source                string          `db:"source" json:"source"`
+	Source                IssueSource     `db:"source" json:"source"`
 	SourceIntegrationID   *uuid.UUID      `db:"source_integration_id" json:"source_integration_id,omitempty"`
 	RepositoryID          *uuid.UUID      `db:"repository_id" json:"repository_id,omitempty"`
 	Title                 string          `db:"title" json:"title"`

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -238,10 +238,15 @@ func WithSandboxProvider(ctx context.Context, p agent.SandboxProvider) context.C
 func buildSystemPrompt(input *agent.AgentInput) string {
 	var b strings.Builder
 
-	base := prompts.CodingTaskPreamble()
-	b.WriteString(base)
-	if !strings.HasSuffix(base, "\n\n") {
-		b.WriteString("\n\n")
+	// Manual sessions skip the bug-fixing template — the user's raw message
+	// is the entire prompt. Only inject repo conventions and integration
+	// skills so the agent knows what tools and patterns are available.
+	if input.Issue.Source != models.IssueSourceManual {
+		base := prompts.CodingTaskPreamble()
+		b.WriteString(base)
+		if !strings.HasSuffix(base, "\n\n") {
+			b.WriteString("\n\n")
+		}
 	}
 
 	// Repo conventions from context docs.
@@ -282,7 +287,7 @@ func buildSystemPrompt(input *agent.AgentInput) string {
 		b.WriteString("\n\n")
 	}
 
-	// PM context: inject PM guidance when available.
+	// PM context: inject PM guidance when available (never set for manual sessions).
 	if input.PMContext != nil {
 		b.WriteString("## Product Manager Analysis\n\n")
 		if input.PMContext.Reasoning != "" {
@@ -321,6 +326,14 @@ func buildSystemPrompt(input *agent.AgentInput) string {
 
 // buildUserPrompt constructs the user prompt with issue-specific details.
 func buildUserPrompt(input *agent.AgentInput) string {
+	// Manual sessions: pass through the user's raw message without any wrapping.
+	if input.Issue.Source == models.IssueSourceManual {
+		if input.Issue.Description != nil {
+			return *input.Issue.Description
+		}
+		return input.Issue.Title
+	}
+
 	var b strings.Builder
 
 	b.WriteString(fmt.Sprintf("## Issue: %s\n\n", input.Issue.Title))
@@ -330,7 +343,7 @@ func buildUserPrompt(input *agent.AgentInput) string {
 	}
 
 	// Add stack trace from raw data if this is a Sentry issue.
-	if input.Issue.Source == "sentry" {
+	if input.Issue.Source == models.IssueSourceSentry {
 		stackTrace := extractStackTrace(input.Issue.RawData)
 		if stackTrace != "" {
 			b.WriteString(fmt.Sprintf("### Stack Trace\n\n```\n%s\n```\n\n", stackTrace))
@@ -367,7 +380,7 @@ func buildUserPrompt(input *agent.AgentInput) string {
 // extractFileHints parses the issue's raw data for file paths from
 // Sentry stack trace frames.
 func extractFileHints(input *agent.AgentInput) []string {
-	if input.Issue.Source != "sentry" || len(input.Issue.RawData) == 0 {
+	if input.Issue.Source != models.IssueSourceSentry || len(input.Issue.RawData) == 0 {
 		return nil
 	}
 

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -47,7 +47,7 @@ func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
 		{
 			name: "low token mode",
 			input: &agent.AgentInput{
-				Issue:     &models.Issue{Title: "Bug", Source: "sentry"},
+				Issue:     &models.Issue{Title: "Bug", Source: models.IssueSourceSentry},
 				TokenMode: "low",
 			},
 			wantToken: lowTokenMax,
@@ -55,7 +55,7 @@ func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
 		{
 			name: "high token mode",
 			input: &agent.AgentInput{
-				Issue:     &models.Issue{Title: "Bug", Source: "sentry"},
+				Issue:     &models.Issue{Title: "Bug", Source: models.IssueSourceSentry},
 				TokenMode: "high",
 			},
 			wantToken: highTokenMax,
@@ -509,6 +509,22 @@ func TestBuildSystemPrompt_Minimal(t *testing.T) {
 	require.NotContains(t, prompt, "Repository Conventions")
 }
 
+func TestBuildSystemPrompt_ManualSessionSkipsBaseTemplate(t *testing.T) {
+	t.Parallel()
+
+	input := &agent.AgentInput{
+		Issue:       &models.Issue{Title: "help me refactor", Source: models.IssueSourceManual},
+		ContextDocs: []string{"Use Go 1.22"},
+	}
+
+	prompt := buildSystemPrompt(input)
+	require.NotContains(t, prompt, "coding agent tasked with fixing a bug", "manual sessions should not include bug-fixing template")
+	require.NotContains(t, prompt, "testing_requirements", "manual sessions should not include testing requirements")
+	require.NotContains(t, prompt, "confidence_score", "manual sessions should not include confidence format")
+	require.Contains(t, prompt, "Repository Conventions", "manual sessions should still include repo conventions")
+	require.Contains(t, prompt, "Use Go 1.22")
+}
+
 // ---------------------------------------------------------------------------
 // buildUserPrompt
 // ---------------------------------------------------------------------------
@@ -528,6 +544,7 @@ func TestBuildUserPrompt(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:       "Billing crash",
+					Source:      models.IssueSourceSentry,
 					Description: &desc,
 				},
 			},
@@ -538,7 +555,7 @@ func TestBuildUserPrompt(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "NullPointer",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",
@@ -566,6 +583,7 @@ func TestBuildUserPrompt(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:                 "Error",
+					Source:                models.IssueSourceSentry,
 					OccurrenceCount:       150,
 					AffectedCustomerCount: 25,
 				},
@@ -577,6 +595,7 @@ func TestBuildUserPrompt(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:    "Error",
+					Source:   models.IssueSourceSentry,
 					Severity: "critical",
 				},
 			},
@@ -585,7 +604,7 @@ func TestBuildUserPrompt(t *testing.T) {
 		{
 			name: "complexity estimate",
 			input: &agent.AgentInput{
-				Issue: &models.Issue{Title: "Error"},
+				Issue: &models.Issue{Title: "Error", Source: models.IssueSourceLinear},
 				ComplexityEstimate: &agent.ComplexityEstimate{
 					Tier:      2,
 					Reasoning: "Multiple files affected",
@@ -606,6 +625,26 @@ func TestBuildUserPrompt(t *testing.T) {
 	}
 }
 
+func TestBuildUserPrompt_ManualSessionReturnsRawMessage(t *testing.T) {
+	t.Parallel()
+
+	msg := "help me improve the margins in the session"
+	input := &agent.AgentInput{
+		Issue: &models.Issue{
+			Title:       "help me improve the margins",
+			Source:      models.IssueSourceManual,
+			Description: &msg,
+		},
+	}
+
+	prompt := buildUserPrompt(input)
+	require.Equal(t, msg, prompt, "manual session should return raw user message")
+	require.NotContains(t, prompt, "## Issue:")
+	require.NotContains(t, prompt, "### Description")
+	require.NotContains(t, prompt, "Customer Impact")
+	require.NotContains(t, prompt, "Severity")
+}
+
 // ---------------------------------------------------------------------------
 // extractFileHints
 // ---------------------------------------------------------------------------
@@ -622,14 +661,14 @@ func TestExtractFileHints(t *testing.T) {
 		{
 			name: "non-sentry source returns nil",
 			input: &agent.AgentInput{
-				Issue: &models.Issue{Title: "Bug", Source: "linear"},
+				Issue: &models.Issue{Title: "Bug", Source: models.IssueSourceLinear},
 			},
 			wantNil: true,
 		},
 		{
 			name: "empty raw data returns nil",
 			input: &agent.AgentInput{
-				Issue: &models.Issue{Title: "Bug", Source: "sentry", RawData: nil},
+				Issue: &models.Issue{Title: "Bug", Source: models.IssueSourceSentry, RawData: nil},
 			},
 			wantNil: true,
 		},
@@ -638,7 +677,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",
@@ -663,7 +702,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",
@@ -690,7 +729,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",
@@ -715,7 +754,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "breadcrumbs",
@@ -737,7 +776,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:   "Bug",
-					Source:  "sentry",
+					Source:  models.IssueSourceSentry,
 					RawData: json.RawMessage(`{not valid json`),
 				},
 			},
@@ -748,7 +787,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",
@@ -772,7 +811,7 @@ func TestExtractFileHints(t *testing.T) {
 			input: &agent.AgentInput{
 				Issue: &models.Issue{
 					Title:  "Bug",
-					Source: "sentry",
+					Source: models.IssueSourceSentry,
 					RawData: json.RawMessage(`{
 						"entries": [{
 							"type": "exception",

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -48,7 +48,7 @@ func TestCodexAdapter_PreparePrompt(t *testing.T) {
 				Issue: &models.Issue{
 					Title:    "NilPointerException in user service",
 					Severity: "high",
-					Source:   "sentry",
+					Source:   models.IssueSourceSentry,
 				},
 				TokenMode: "low",
 			},
@@ -61,7 +61,7 @@ func TestCodexAdapter_PreparePrompt(t *testing.T) {
 				Issue: &models.Issue{
 					Title:    "Complex refactor needed",
 					Severity: "medium",
-					Source:   "sentry",
+					Source:   models.IssueSourceSentry,
 				},
 				TokenMode: "high",
 			},

--- a/internal/services/agent/adapters/gemini_cli_test.go
+++ b/internal/services/agent/adapters/gemini_cli_test.go
@@ -32,7 +32,7 @@ func TestGeminiCLIAdapter_PreparePrompt(t *testing.T) {
 		{
 			name: "low token mode",
 			input: &agent.AgentInput{
-				Issue:     newTestIssue("sentry", true),
+				Issue:     newTestIssue(models.IssueSourceSentry, true),
 				TokenMode: "low",
 			},
 			expectedMaxTokens: 50_000,
@@ -40,7 +40,7 @@ func TestGeminiCLIAdapter_PreparePrompt(t *testing.T) {
 		{
 			name: "high token mode",
 			input: &agent.AgentInput{
-				Issue:     newTestIssue("linear", true),
+				Issue:     newTestIssue(models.IssueSourceLinear, true),
 				TokenMode: "high",
 			},
 			expectedMaxTokens: 200_000,
@@ -80,7 +80,7 @@ func TestGeminiCLIAdapter_PreparePrompt(t *testing.T) {
 	}
 }
 
-func newTestIssue(source string, hasDescription bool) *models.Issue {
+func newTestIssue(source models.IssueSource, hasDescription bool) *models.Issue {
 	issue := &models.Issue{
 		Source: source,
 		Title:  "Test issue",

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1029,7 +1029,7 @@ func (o *Orchestrator) snapshotSession(ctx context.Context, session *models.Sess
 }
 
 func (o *Orchestrator) isInteractiveSession(issue *models.Issue) bool {
-	return issue != nil && issue.Source == "manual" && o.sessionMessages != nil && o.snapshots != nil
+	return issue != nil && issue.Source == models.IssueSourceManual && o.sessionMessages != nil && o.snapshots != nil
 }
 
 func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, orgID uuid.UUID, turnNumber int, result *AgentResult) error {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -435,7 +435,7 @@ func testIssue(orgID uuid.UUID) models.Issue {
 		ID:           uuid.MustParse("00000000-0000-0000-0000-000000000002"),
 		OrgID:        orgID,
 		ExternalID:   "SENTRY-123",
-		Source:       "sentry",
+		Source:       models.IssueSourceSentry,
 		RepositoryID: &repoID,
 		Title:        "NullPointerException in handler",
 		Description:  &desc,
@@ -1209,7 +1209,7 @@ func TestRunAgent_ManualSessionTransitionsToIdle(t *testing.T) {
 
 	orgID := testOrg()
 	issue := testIssue(orgID)
-	issue.Source = "manual"
+	issue.Source = models.IssueSourceManual
 	run := testRun(orgID, issue.ID)
 
 	d := defaultDeps()
@@ -1254,7 +1254,7 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 
 	orgID := testOrg()
 	issue := testIssue(orgID)
-	issue.Source = "manual"
+	issue.Source = models.IssueSourceManual
 	session := testRun(orgID, issue.ID)
 	session.Status = string(models.SessionStatusIdle)
 	session.CurrentTurn = 1
@@ -1364,7 +1364,7 @@ func TestContinueSession_InjectsSandboxProviderIntoContext(t *testing.T) {
 
 	orgID := testOrg()
 	issue := testIssue(orgID)
-	issue.Source = "manual"
+	issue.Source = models.IssueSourceManual
 	session := testRun(orgID, issue.ID)
 	session.Status = string(models.SessionStatusIdle)
 	session.CurrentTurn = 1

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -768,7 +768,7 @@ func formatBranchName(runID uuid.UUID, issueTitle string) string {
 
 func formatPRTitle(issue *models.Issue) string {
 	switch issue.Source {
-	case "linear":
+	case models.IssueSourceLinear:
 		return fmt.Sprintf("%s: %s", issue.ExternalID, issue.Title)
 	default:
 		return fmt.Sprintf("fix: %s", issue.Title)
@@ -778,9 +778,9 @@ func formatPRTitle(issue *models.Issue) string {
 func formatCommitMessage(issue *models.Issue) string {
 	msg := fmt.Sprintf("fix: %s", issue.Title)
 	switch issue.Source {
-	case "linear":
+	case models.IssueSourceLinear:
 		msg += fmt.Sprintf("\n\nFixes #%s", issue.ExternalID)
-	case "sentry":
+	case models.IssueSourceSentry:
 		msg += fmt.Sprintf("\n\nResolves %s", issue.ExternalID)
 	}
 	return msg

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -852,7 +852,7 @@ func buildLabels(issue *models.Issue) []string {
 		labels = append(labels, "severity:"+issue.Severity)
 	}
 	if issue.Source != "" {
-		labels = append(labels, "source:"+issue.Source)
+		labels = append(labels, "source:"+string(issue.Source))
 	}
 	return labels
 }

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -862,7 +862,7 @@ func TestFormatPRBody_WithValidationStore(t *testing.T) {
 		ResultSummary: &summary,
 	}
 	issue := &models.Issue{
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		Severity:              "high",
 		AffectedCustomerCount: 5,
 		OccurrenceCount:       20,

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -27,7 +27,7 @@ func TestFormatPRTitle(t *testing.T) {
 		{
 			name: "linear source uses external ID prefix",
 			issue: models.Issue{
-				Source:     "linear",
+				Source:     models.IssueSourceLinear,
 				ExternalID: "ENG-1234",
 				Title:      "Fix null pointer in user API",
 			},
@@ -36,7 +36,7 @@ func TestFormatPRTitle(t *testing.T) {
 		{
 			name: "sentry source uses fix prefix",
 			issue: models.Issue{
-				Source: "sentry",
+				Source: models.IssueSourceSentry,
 				Title:  "TypeError in payment handler",
 			},
 			expect: "fix: TypeError in payment handler",
@@ -44,7 +44,7 @@ func TestFormatPRTitle(t *testing.T) {
 		{
 			name: "support source uses fix prefix",
 			issue: models.Issue{
-				Source: "support",
+				Source: models.IssueSource("support"),
 				Title:  "Login button not working",
 			},
 			expect: "fix: Login button not working",
@@ -52,7 +52,7 @@ func TestFormatPRTitle(t *testing.T) {
 		{
 			name: "unknown source uses fix prefix",
 			issue: models.Issue{
-				Source: "other",
+				Source: models.IssueSource("other"),
 				Title:  "Some issue",
 			},
 			expect: "fix: Some issue",
@@ -133,7 +133,7 @@ func TestFormatCommitMessage(t *testing.T) {
 		{
 			name: "linear issue includes Fixes reference",
 			issue: models.Issue{
-				Source:     "linear",
+				Source:     models.IssueSourceLinear,
 				ExternalID: "ENG-1234",
 				Title:      "Fix null pointer",
 			},
@@ -142,7 +142,7 @@ func TestFormatCommitMessage(t *testing.T) {
 		{
 			name: "sentry issue includes Resolves reference",
 			issue: models.Issue{
-				Source:     "sentry",
+				Source:     models.IssueSourceSentry,
 				ExternalID: "SENTRY-5678",
 				Title:      "TypeError in handler",
 			},
@@ -151,7 +151,7 @@ func TestFormatCommitMessage(t *testing.T) {
 		{
 			name: "support issue has no reference",
 			issue: models.Issue{
-				Source: "support",
+				Source: models.IssueSource("support"),
 				Title:  "Login broken",
 			},
 			expect: "fix: Login broken",
@@ -179,14 +179,14 @@ func TestBuildLabels(t *testing.T) {
 			name: "all labels",
 			issue: models.Issue{
 				Severity: "high",
-				Source:   "sentry",
+				Source:   models.IssueSourceSentry,
 			},
 			expect: []string{"143-generated", "severity:high", "source:sentry"},
 		},
 		{
 			name: "no severity",
 			issue: models.Issue{
-				Source: "linear",
+				Source: models.IssueSourceLinear,
 			},
 			expect: []string{"143-generated", "source:linear"},
 		},
@@ -220,7 +220,7 @@ func TestFormatPRBody(t *testing.T) {
 		ResultSummary: &summary,
 	}
 	issue := &models.Issue{
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		Severity:              "high",
 		AffectedCustomerCount: 42,
 		OccurrenceCount:       100,
@@ -631,7 +631,7 @@ func TestFormatPRBody_WithValidation(t *testing.T) {
 		CompletedAt:   &now,
 	}
 	issue := &models.Issue{
-		Source:                "linear",
+		Source:                models.IssueSourceLinear,
 		Severity:              "critical",
 		AffectedCustomerCount: 10,
 		OccurrenceCount:       50,
@@ -659,7 +659,7 @@ func TestFormatPRBody_NilSummary(t *testing.T) {
 		AgentType: "claude-code",
 	}
 	issue := &models.Issue{
-		Source:   "sentry",
+		Source:   models.IssueSourceSentry,
 		Severity: "low",
 	}
 

--- a/internal/services/ingestion/ingest_normalized_test.go
+++ b/internal/services/ingestion/ingest_normalized_test.go
@@ -40,7 +40,7 @@ func TestIngestNormalized(t *testing.T) {
 			ni: func(integrationID uuid.UUID, now time.Time) NormalizedIssue {
 				return NormalizedIssue{
 					ExternalID:            "EXT-123",
-					Source:                "sentry",
+					Source:                models.IssueSourceSentry,
 					SourceIntegrationID:   integrationID,
 					Title:                 "Test Issue",
 					Description:           "A test issue description",
@@ -72,7 +72,7 @@ func TestIngestNormalized(t *testing.T) {
 				t.Helper()
 				require.NotNil(t, issue, "ingested issue should not be nil")
 				require.Equal(t, issueID, issue.ID, "issue ID should match upserted value")
-				require.Equal(t, "sentry", issue.Source, "source should be sentry")
+				require.Equal(t, models.IssueSourceSentry, issue.Source, "source should be sentry")
 				require.Equal(t, "EXT-123", issue.ExternalID, "external ID should match input")
 				require.Equal(t, "Test Issue", issue.Title, "title should match input")
 				require.Equal(t, "high", issue.Severity, "error severity should normalize to high")
@@ -85,7 +85,7 @@ func TestIngestNormalized(t *testing.T) {
 			ni: func(integrationID uuid.UUID, now time.Time) NormalizedIssue {
 				return NormalizedIssue{
 					ExternalID:          "EXT-456",
-					Source:              "pagerduty",
+					Source:              models.IssueSource("pagerduty"),
 					SourceIntegrationID: integrationID,
 					Title:               "Failing Issue",
 					Severity:            "critical",
@@ -110,7 +110,7 @@ func TestIngestNormalized(t *testing.T) {
 			ni: func(integrationID uuid.UUID, now time.Time) NormalizedIssue {
 				return NormalizedIssue{
 					ExternalID:          "EXT-789",
-					Source:              "github",
+					Source:              models.IssueSource("github"),
 					SourceIntegrationID: integrationID,
 					Title:               "Another Issue",
 					Severity:            "warning",

--- a/internal/services/ingestion/linear.go
+++ b/internal/services/ingestion/linear.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
 )
 
 // LinearWebhookPayload represents a Linear webhook event.

--- a/internal/services/ingestion/linear.go
+++ b/internal/services/ingestion/linear.go
@@ -86,7 +86,7 @@ func (a *LinearAdapter) ParseWebhook(integrationID uuid.UUID, payload json.RawMe
 
 	return &NormalizedIssue{
 		ExternalID:          issue.ID,
-		Source:              "linear",
+		Source:              models.IssueSourceLinear,
 		SourceIntegrationID: integrationID,
 		Title:               title,
 		Description:         issue.Description,

--- a/internal/services/ingestion/linear_test.go
+++ b/internal/services/ingestion/linear_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func TestLinearAdapter_ParseWebhook(t *testing.T) {
 			checkResult: func(t *testing.T, ni *NormalizedIssue, integrationID uuid.UUID) {
 				t.Helper()
 				require.Equal(t, "lin-123", ni.ExternalID, "should parse external ID from linear issue ID")
-				require.Equal(t, "linear", ni.Source, "source should be linear")
+				require.Equal(t, models.IssueSourceLinear, ni.Source, "source should be linear")
 				require.Equal(t, integrationID, ni.SourceIntegrationID, "should set integration ID")
 				require.Equal(t, "ENG-456: Fix authentication timeout", ni.Title, "should format title with identifier prefix")
 				require.Equal(t, "Users report session expiring too quickly", ni.Description, "should parse description")

--- a/internal/services/ingestion/sentry.go
+++ b/internal/services/ingestion/sentry.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
 )
 
 // SentryWebhookPayload represents a Sentry webhook event.

--- a/internal/services/ingestion/sentry.go
+++ b/internal/services/ingestion/sentry.go
@@ -106,7 +106,7 @@ func (a *SentryAdapter) ParseWebhook(integrationID uuid.UUID, payload json.RawMe
 
 	return &NormalizedIssue{
 		ExternalID:            issue.ID,
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		SourceIntegrationID:   integrationID,
 		Title:                 issue.Title,
 		Description:           description,

--- a/internal/services/ingestion/sentry_api.go
+++ b/internal/services/ingestion/sentry_api.go
@@ -150,7 +150,7 @@ func (c *SentryAPIClient) normalizeIssue(integrationID uuid.UUID, issue SentryIs
 
 	return NormalizedIssue{
 		ExternalID:            issue.ID,
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		SourceIntegrationID:   integrationID,
 		Title:                 issue.Title,
 		Description:           description,

--- a/internal/services/ingestion/sentry_api.go
+++ b/internal/services/ingestion/sentry_api.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
 )
 
 // SentryAPIClient fetches issues from the Sentry REST API.

--- a/internal/services/ingestion/sentry_api_test.go
+++ b/internal/services/ingestion/sentry_api_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 			expected: []NormalizedIssue{
 				{
 					ExternalID:            "100",
-					Source:                "sentry",
+					Source:                models.IssueSourceSentry,
 					Title:                 "TypeError in handler",
 					Description:           "TypeError: undefined is not a function",
 					Severity:              "high",
@@ -126,7 +127,7 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 			expected: []NormalizedIssue{
 				{
 					ExternalID:            "200",
-					Source:                "sentry",
+					Source:                models.IssueSourceSentry,
 					Title:                 "Error 1",
 					Description:           "Error 1",
 					Severity:              "high",
@@ -138,7 +139,7 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 				},
 				{
 					ExternalID:            "201",
-					Source:                "sentry",
+					Source:                models.IssueSourceSentry,
 					Title:                 "Error 2",
 					Description:           "Error 2",
 					Severity:              "medium",
@@ -217,7 +218,7 @@ func TestSentryAPIClient_FetchIssues(t *testing.T) {
 			expected: []NormalizedIssue{
 				{
 					ExternalID:            "300",
-					Source:                "sentry",
+					Source:                models.IssueSourceSentry,
 					Title:                 "After rate limit",
 					Description:           "After rate limit",
 					Severity:              "high",

--- a/internal/services/ingestion/sentry_test.go
+++ b/internal/services/ingestion/sentry_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -52,7 +53,7 @@ func TestSentryAdapter_ParseWebhook(t *testing.T) {
 			checkResult: func(t *testing.T, ni *NormalizedIssue, integrationID uuid.UUID) {
 				t.Helper()
 				require.Equal(t, "12345", ni.ExternalID, "should parse external ID from sentry issue ID")
-				require.Equal(t, "sentry", ni.Source, "source should be sentry")
+				require.Equal(t, models.IssueSourceSentry, ni.Source, "source should be sentry")
 				require.Equal(t, integrationID, ni.SourceIntegrationID, "should set integration ID")
 				require.Equal(t, "TypeError: Cannot read property 'map' of undefined", ni.Title, "should parse issue title")
 				require.Contains(t, ni.Description, "TypeError: Cannot read property 'map' of undefined", "description should contain metadata value")

--- a/internal/services/ingestion/service.go
+++ b/internal/services/ingestion/service.go
@@ -18,7 +18,7 @@ import (
 // NormalizedIssue is the intermediate form before upserting into the issues table.
 type NormalizedIssue struct {
 	ExternalID            string
-	Source                string
+	Source                models.IssueSource
 	SourceIntegrationID   uuid.UUID
 	Title                 string
 	Description           string
@@ -56,7 +56,7 @@ func NewService(
 // IngestNormalized normalizes and upserts an issue, then enqueues a prioritize job.
 func (s *Service) IngestNormalized(ctx context.Context, orgID uuid.UUID, ni NormalizedIssue) (*models.Issue, error) {
 	// Compute fingerprint for dedup
-	fingerprint := computeFingerprint(ni.Source, ni.ExternalID)
+	fingerprint := computeFingerprint(string(ni.Source), ni.ExternalID)
 
 	// Normalize severity
 	severity := normalizeSeverity(ni.Severity)
@@ -94,7 +94,7 @@ func (s *Service) IngestNormalized(ctx context.Context, orgID uuid.UUID, ni Norm
 
 	s.logger.Info().
 		Str("issue_id", issue.ID.String()).
-		Str("source", ni.Source).
+		Str("source", string(ni.Source)).
 		Str("external_id", ni.ExternalID).
 		Msg("issue ingested")
 

--- a/internal/services/pm/context.go
+++ b/internal/services/pm/context.go
@@ -256,7 +256,7 @@ func summarizeIssue(issue models.Issue) IssueSummary {
 
 	summary := IssueSummary{
 		ID:                    issue.ID.String(),
-		Source:                issue.Source,
+		Source:                string(issue.Source),
 		Title:                 issue.Title,
 		Description:           description,
 		Severity:              issue.Severity,
@@ -270,9 +270,9 @@ func summarizeIssue(issue models.Issue) IssueSummary {
 
 	// Enrich with source-specific metadata.
 	switch issue.Source {
-	case "sentry":
+	case models.IssueSourceSentry:
 		summary.StackTraceSummary = extractStackTraceSummary(issue.RawData)
-	case "linear":
+	case models.IssueSourceLinear:
 		enrichLinearMetadata(&summary, issue.RawData)
 	}
 

--- a/internal/services/pm/context_gather_test.go
+++ b/internal/services/pm/context_gather_test.go
@@ -170,7 +170,7 @@ func TestServiceGatherContext(t *testing.T) {
 				"open": {
 					{
 						ID:                    issueID,
-						Source:                "sentry",
+						Source:                models.IssueSourceSentry,
 						Title:                 "payment request panic",
 						Description:           &desc,
 						Severity:              "high",
@@ -185,7 +185,7 @@ func TestServiceGatherContext(t *testing.T) {
 				"triaged": {
 					{
 						ID:                    secondIssueID,
-						Source:                "github",
+						Source:                models.IssueSource("github"),
 						Title:                 "retry policy bug",
 						Severity:              "medium",
 						OccurrenceCount:       3,

--- a/internal/services/pm/context_helpers_test.go
+++ b/internal/services/pm/context_helpers_test.go
@@ -100,7 +100,7 @@ func TestSummarizeIssue(t *testing.T) {
 	longDescription := strings.Repeat("x", 600)
 	issue := models.Issue{
 		ID:                    uuid.New(),
-		Source:                "sentry",
+		Source:                models.IssueSourceSentry,
 		Title:                 "nil pointer panic",
 		Description:           &longDescription,
 		Severity:              "critical",

--- a/internal/services/pm/context_helpers_test.go
+++ b/internal/services/pm/context_helpers_test.go
@@ -114,7 +114,7 @@ func TestSummarizeIssue(t *testing.T) {
 
 	summary := summarizeIssue(issue)
 	require.Equal(t, issue.ID.String(), summary.ID, "summary should include issue ID")
-	require.Equal(t, issue.Source, summary.Source, "summary should include source")
+	require.Equal(t, string(issue.Source), summary.Source, "summary should include source")
 	require.Equal(t, issue.Title, summary.Title, "summary should include title")
 	require.Len(t, []rune(summary.Description), 500, "summary description should be truncated to 500 runes")
 	require.Equal(t, issue.Severity, summary.Severity, "summary should include severity")

--- a/internal/services/pm/coverage_boost_test.go
+++ b/internal/services/pm/coverage_boost_test.go
@@ -901,7 +901,7 @@ func TestSummarizeIssue_NilDescription(t *testing.T) {
 
 	issue := models.Issue{
 		ID:          uuid.New(),
-		Source:      "github",
+		Source:      models.IssueSource("github"),
 		Title:       "Issue without description",
 		Description: nil,
 		Severity:    "low",


### PR DESCRIPTION
## Summary

- Convert `Issue.Source` from string to typed `IssueSource` with constants (`IssueSourceSentry`, `IssueSourceLinear`, `IssueSourceManual`)
- Define `IssueSource.Validate()` method following existing enum patterns
- Simplify manual session prompts by removing unnecessary context

## Changes

**Manual Session Improvements:**
- Remove fake metadata (occurrence count, customer count, severity) from manual issues
- Remove `PMApproach` from manual sessions (was echoing back user message)
- Skip bug-fixing system prompt template for manual sessions
- Manual sessions now receive only raw user message plus repo conventions and integration skills

**Type Safety:**
- Update all code paths that set or compare `Issue.Source` to use typed constants
- Update `IssueFilters.Source` and `NormalizedIssue.Source` to use `IssueSource` type
- Ensures compile-time safety for issue source values across codebase

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>