### PR TITLE
Switch default LLM to gpt-5.4-mini and add reasoning_effort support

### DIFF
--- a/frontend/src/app/(dashboard)/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/llm/page.tsx
@@ -95,6 +95,7 @@ export default function LLMPage() {
 
   // Form state
   const [llmModel, setLlmModel] = useState(DEFAULT_LLM_MODEL);
+  const [reasoningEffort, setReasoningEffort] = useState<string>("");
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
   const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
@@ -107,6 +108,7 @@ export default function LLMPage() {
   if (settingsData && settingsData !== prevSettingsRef) {
     setPrevSettingsRef(settingsData);
     setLlmModel(orgSettings.llm_model || DEFAULT_LLM_MODEL);
+    setReasoningEffort(orgSettings.llm_reasoning_effort || "");
   }
 
   // Determine which providers are configured (org-level or platform-level)
@@ -178,7 +180,10 @@ export default function LLMPage() {
 
   function handleSaveModel() {
     modelMutation.mutate({
-      settings: { llm_model: llmModel },
+      settings: {
+        llm_model: llmModel,
+        llm_reasoning_effort: reasoningEffort || "",
+      },
     });
   }
 
@@ -337,6 +342,24 @@ export default function LLMPage() {
                   <p className="text-xs text-muted-foreground">
                     The model used for validation, prioritization, and other general LLM tasks.
                     Only models from configured providers are shown.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="reasoning-effort">Reasoning effort</Label>
+                  <Select value={reasoningEffort || "none"} onValueChange={(v) => setReasoningEffort(v === "none" ? "" : v)}>
+                    <SelectTrigger id="reasoning-effort" aria-label="Reasoning effort">
+                      <SelectValue placeholder="Default (none)" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Default (none)</SelectItem>
+                      <SelectItem value="low">Low</SelectItem>
+                      <SelectItem value="medium">Medium</SelectItem>
+                      <SelectItem value="high">High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    Controls how much reasoning the model uses. Lower values reduce latency and cost.
+                    Only applies to models that support reasoning.
                   </p>
                 </div>
               </div>

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -6,9 +6,11 @@ import {
   AVAILABLE_GEMINI_CLI_MODELS,
   AVAILABLE_PM_MODELS,
   DEFAULT_PM_MODEL,
+  DEFAULT_LLM_MODEL,
   CLAUDE_CODE_MODEL_SONNET,
   LEGACY_PM_ALIASES,
   PM_MODELS_BY_PROVIDER,
+  LLM_MODELS_BY_PROVIDER,
 } from "./model-constants";
 
 describe("model constants", () => {
@@ -56,5 +58,20 @@ describe("model constants", () => {
       "gpt-5-codex",
       "gpt-5.3-codex-spark",
     ]);
+  });
+
+  it("uses gpt-5.4-mini as the default LLM model", () => {
+    expect(DEFAULT_LLM_MODEL).toBe("gpt-5.4-mini");
+  });
+
+  it("LLM_MODELS_BY_PROVIDER includes gpt-5.4-mini in openai and openrouter", () => {
+    expect(LLM_MODELS_BY_PROVIDER.openai.models).toContain("gpt-5.4-mini");
+    expect(LLM_MODELS_BY_PROVIDER.openrouter.models).toContain("gpt-5.4-mini");
+  });
+
+  it("LLM_MODELS_BY_PROVIDER maps providers to their models", () => {
+    expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "openrouter"]);
+    expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toContain("claude-sonnet-4-5");
+    expect(LLM_MODELS_BY_PROVIDER.openai.models).toContain("gpt-4o");
   });
 });

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -69,11 +69,11 @@ export const AVAILABLE_PM_MODELS = [
 // in internal/models/agent_model_constants.go). Keep both in sync.
 export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[] }> = {
   anthropic: { label: "Anthropic", models: ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"] },
-  openai: { label: "OpenAI", models: ["gpt-4o", "gpt-4o-mini", "o3-mini"] },
-  openrouter: { label: "OpenRouter", models: ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "o3-mini"] },
+  openai: { label: "OpenAI", models: ["gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"] },
+  openrouter: { label: "OpenRouter", models: ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"] },
 };
 
-export const DEFAULT_LLM_MODEL = "claude-sonnet-4-5";
+export const DEFAULT_LLM_MODEL = "gpt-5.4-mini";
 
 // OpenAI credential api_type value.
 export const OPENAI_API_TYPE_CHAT = "chat";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -247,6 +247,7 @@ export interface OrgSettings {
   product_direction?: string;
   product_context?: ProductContext;
   llm_model?: string;
+  llm_reasoning_effort?: 'low' | 'medium' | 'high' | '';
   agent_config?: Record<string, Record<string, string>>;
   default_agent_type?: 'codex' | 'claude_code' | 'gemini_cli';
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,8 +56,9 @@ type Config struct {
 	EncryptionMasterKey string `env:"ENCRYPTION_MASTER_KEY"`
 
 	// LLM
-	LLMModel          string `env:"LLM_MODEL"`
-	AnthropicAPIKey   string `env:"ANTHROPIC_API_KEY"`
+	LLMModel           string `env:"LLM_MODEL"`
+	LLMReasoningEffort string `env:"LLM_REASONING_EFFORT"`
+	AnthropicAPIKey    string `env:"ANTHROPIC_API_KEY"`
 	AnthropicBaseURL  string `env:"ANTHROPIC_BASE_URL"`
 	AnthropicModel    string `env:"ANTHROPIC_MODEL"`
 	OpenAIAPIKey      string `env:"OPENAI_API_KEY"`
@@ -126,7 +127,8 @@ func Load() *Config {
 // LLMConfig returns the llm.Config derived from this Config.
 func (c *Config) LLMConfig() llm.Config {
 	return llm.Config{
-		Model:             c.LLMModel,
+		Model:             llm.ModelName(c.LLMModel),
+		ReasoningEffort:   llm.ReasoningEffort(c.LLMReasoningEffort),
 		AnthropicAPIKey:   c.AnthropicAPIKey,
 		AnthropicBaseURL:  c.AnthropicBaseURL,
 		OpenAIAPIKey:      c.OpenAIAPIKey,
@@ -281,9 +283,13 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		providers = append(providers, "openrouter")
 	}
 
-	if c.LLMModel != "" && len(providers) > 0 {
+	llmModel := c.LLMModel
+	if llmModel == "" {
+		llmModel = "(default: gpt-5.4-mini)"
+	}
+	if len(providers) > 0 {
 		logger.Info().
-			Str("model", c.LLMModel).
+			Str("model", llmModel).
 			Strs("providers", providers).
 			Int("chain_length", len(providers)).
 			Msg("LLM configured")
@@ -293,7 +299,7 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 			Msg("LLM model set but no provider API keys configured — LLM checks will be skipped")
 	} else {
 		logger.Warn().
-			Msg("LLM not configured (set LLM_MODEL + at least one provider API key) — LLM checks will be skipped")
+			Msg("LLM not configured (set at least one provider API key) — LLM checks will be skipped")
 	}
 
 	if c.SessionSecret == "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"testing"
 
+	"github.com/assembledhq/143/internal/llm"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -69,7 +70,7 @@ func TestLoad_LLMConfig(t *testing.T) {
 	cfg := Load()
 	llmCfg := cfg.LLMConfig()
 
-	require.Equal(t, "claude-sonnet-4-5", llmCfg.Model)
+	require.Equal(t, llm.ModelName("claude-sonnet-4-5"), llmCfg.Model)
 	require.Equal(t, "sk-ant-test", llmCfg.AnthropicAPIKey)
 	require.Equal(t, "sk-or-test", llmCfg.OpenRouterAPIKey)
 	require.Equal(t, "chat", llmCfg.OpenAIAPIType, "OpenAI API type should default to chat")

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // AnthropicProvider implements Provider using the Anthropic Messages API.
@@ -48,7 +50,15 @@ func NewAnthropicProvider(apiKey string, opts ...AnthropicOption) *AnthropicProv
 
 func (p *AnthropicProvider) Name() string { return "anthropic" }
 
-func (p *AnthropicProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string) (string, error) {
+func (p *AnthropicProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
+	if reasoningEffort != "" {
+		// Anthropic does not support reasoning_effort; log so callers know it was ignored.
+		log.Ctx(ctx).Warn().
+			Str("provider", "anthropic").
+			Str("model", model).
+			Str("reasoning_effort", string(reasoningEffort)).
+			Msg("reasoning_effort is not supported by Anthropic — ignoring")
+	}
 	reqBody := anthropicRequest{
 		Model:     model,
 		System:    systemPrompt,

--- a/internal/llm/anthropic_test.go
+++ b/internal/llm/anthropic_test.go
@@ -35,7 +35,7 @@ func TestAnthropicProvider_Complete_Success(t *testing.T) {
 	p := NewAnthropicProvider("test-key", WithAnthropicBaseURL(server.URL), WithAnthropicHTTPClient(server.Client()))
 	require.Equal(t, "anthropic", p.Name(), "provider name should be anthropic")
 
-	resp, err := p.Complete(context.Background(), "test-model", "system", "user prompt")
+	resp, err := p.Complete(context.Background(), "test-model", "system", "user prompt", "")
 	require.NoError(t, err, "should complete without error")
 	require.Equal(t, "hello from anthropic", resp, "should return text content")
 }
@@ -50,7 +50,7 @@ func TestAnthropicProvider_Complete_RateLimit(t *testing.T) {
 	defer server.Close()
 
 	p := NewAnthropicProvider("key", WithAnthropicBaseURL(server.URL), WithAnthropicHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on rate limit")
 	require.ErrorIs(t, err, ErrRateLimit, "should wrap rate limit error")
 }
@@ -65,7 +65,7 @@ func TestAnthropicProvider_Complete_ServerError(t *testing.T) {
 	defer server.Close()
 
 	p := NewAnthropicProvider("key", WithAnthropicBaseURL(server.URL), WithAnthropicHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on server error")
 	require.ErrorIs(t, err, ErrServerError, "should wrap server error")
 }
@@ -80,7 +80,7 @@ func TestAnthropicProvider_Complete_AuthError(t *testing.T) {
 	defer server.Close()
 
 	p := NewAnthropicProvider("bad-key", WithAnthropicBaseURL(server.URL), WithAnthropicHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on auth failure")
 	require.ErrorIs(t, err, ErrAuthError, "should wrap auth error")
 }
@@ -97,7 +97,7 @@ func TestAnthropicProvider_Complete_NoTextContent(t *testing.T) {
 	defer server.Close()
 
 	p := NewAnthropicProvider("key", WithAnthropicBaseURL(server.URL), WithAnthropicHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error when no text content")
 	require.Contains(t, err.Error(), "no text content", "error should mention missing text content")
 }

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/rs/zerolog"
 )
 
@@ -26,15 +27,16 @@ type chainLink struct {
 // It tries providers in order, falling back on retryable errors (rate limits,
 // server errors) but stopping on non-retryable errors (auth, bad request).
 type FallbackClient struct {
-	chain  []chainLink
-	logger zerolog.Logger
+	chain           []chainLink
+	reasoningEffort ReasoningEffort
+	logger          zerolog.Logger
 }
 
 func (c *FallbackClient) Complete(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
 	var lastErr error
 
 	for i, link := range c.chain {
-		resp, err := link.provider.Complete(ctx, link.modelID, systemPrompt, userPrompt)
+		resp, err := link.provider.Complete(ctx, link.modelID, systemPrompt, userPrompt, c.reasoningEffort)
 		if err == nil {
 			if i > 0 {
 				c.logger.Info().
@@ -66,7 +68,12 @@ func (c *FallbackClient) Complete(ctx context.Context, systemPrompt, userPrompt 
 type Config struct {
 	// Model is the human-friendly model name (e.g., "claude-sonnet-4-5", "gpt-4o").
 	// The registry maps this to provider-specific model IDs and fallback chains.
-	Model string
+	Model ModelName
+
+	// ReasoningEffort controls how much reasoning the model should use.
+	// Only applies to providers/models that support it (e.g., OpenAI reasoning models).
+	// Leave empty to use the provider's default.
+	ReasoningEffort ReasoningEffort
 
 	// Anthropic API credentials.
 	AnthropicAPIKey  string
@@ -92,10 +99,10 @@ type Config struct {
 
 // NewClient creates a FallbackClient from config.
 // It builds providers from the configured API keys and assembles a fallback
-// chain for the requested model. Returns nil if no model is configured.
+// chain for the requested model. Defaults to the default model if none is specified.
 func NewClient(cfg Config, logger zerolog.Logger) (Client, error) {
 	if cfg.Model == "" {
-		return nil, nil
+		cfg.Model = ModelName(models.DefaultLLMModel)
 	}
 
 	timeout := cfg.Timeout
@@ -160,16 +167,16 @@ func NewClient(cfg Config, logger zerolog.Logger) (Client, error) {
 	}
 
 	logger.Info().
-		Str("model", cfg.Model).
+		Str("model", string(cfg.Model)).
 		Int("chain_length", len(chain)).
 		Msg("LLM client initialized")
 
-	return &FallbackClient{chain: chain, logger: logger}, nil
+	return &FallbackClient{chain: chain, reasoningEffort: cfg.ReasoningEffort, logger: logger}, nil
 }
 
 // UnknownModelError indicates the requested model is not in the registry.
 type UnknownModelError struct {
-	Model string
+	Model ModelName
 }
 
 func (e *UnknownModelError) Error() string {
@@ -178,7 +185,7 @@ func (e *UnknownModelError) Error() string {
 
 // NoProvidersError indicates no configured providers can serve the requested model.
 type NoProvidersError struct {
-	Model string
+	Model ModelName
 }
 
 func (e *NoProvidersError) Error() string {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -20,7 +20,7 @@ type mockProvider struct {
 
 func (m *mockProvider) Name() string { return m.name }
 
-func (m *mockProvider) Complete(_ context.Context, model, systemPrompt, userPrompt string) (string, error) {
+func (m *mockProvider) Complete(_ context.Context, model, systemPrompt, userPrompt string, _ ReasoningEffort) (string, error) {
 	m.callCount++
 	if m.err != nil {
 		return "", m.err
@@ -177,12 +177,14 @@ func TestIsRetryable(t *testing.T) {
 	require.False(t, IsRetryable(nil))
 }
 
-func TestNewClient_NilWhenNoModel(t *testing.T) {
+func TestNewClient_DefaultsModelWhenEmpty(t *testing.T) {
 	t.Parallel()
 
-	client, err := NewClient(Config{}, zerolog.Nop())
-	require.NoError(t, err)
-	require.Nil(t, client)
+	// No API keys configured, so it will default the model but fail to find providers.
+	_, err := NewClient(Config{}, zerolog.Nop())
+	require.Error(t, err)
+	var npe *NoProvidersError
+	require.ErrorAs(t, err, &npe)
 }
 
 func TestNewClient_ErrorWhenNoProviders(t *testing.T) {
@@ -297,7 +299,7 @@ func TestNoProvidersError_Error(t *testing.T) {
 func TestRegisterModel(t *testing.T) {
 	t.Parallel()
 
-	customModel := "test-custom-model"
+	customModel := ModelName("test-custom-model")
 	entries := []providerModel{
 		{ProviderName: "anthropic", ModelID: "custom-id"},
 	}

--- a/internal/llm/openai_chat.go
+++ b/internal/llm/openai_chat.go
@@ -48,15 +48,23 @@ func NewOpenAIChatProvider(apiKey string, opts ...OpenAIChatOption) *OpenAIChatP
 
 func (p *OpenAIChatProvider) Name() string { return "openai_chat" }
 
-func (p *OpenAIChatProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string) (string, error) {
+func (p *OpenAIChatProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
 	messages := []chatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userPrompt},
 	}
 
+	// Only include reasoning_effort for models that support it. Sending it
+	// to non-reasoning models (e.g. gpt-4o) may cause a 400 error.
+	var effort ReasoningEffort
+	if modelSupportsReasoningEffort(model) {
+		effort = reasoningEffort
+	}
+
 	reqBody := chatCompletionsRequest{
-		Model:    model,
-		Messages: messages,
+		Model:           model,
+		Messages:        messages,
+		ReasoningEffort: effort,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -96,9 +104,12 @@ func (p *OpenAIChatProvider) Complete(ctx context.Context, model, systemPrompt, 
 	return result.Choices[0].Message.Content, nil
 }
 
+// chatCompletionsRequest is the OpenAI Chat Completions request body.
+// It is also used by OpenRouterProvider, which uses the same API format.
 type chatCompletionsRequest struct {
-	Model    string        `json:"model"`
-	Messages []chatMessage `json:"messages"`
+	Model           string        `json:"model"`
+	Messages        []chatMessage `json:"messages"`
+	ReasoningEffort ReasoningEffort `json:"reasoning_effort,omitempty"`
 }
 
 type chatMessage struct {

--- a/internal/llm/openai_chat_test.go
+++ b/internal/llm/openai_chat_test.go
@@ -34,7 +34,7 @@ func TestOpenAIChatProvider_Complete_Success(t *testing.T) {
 	p := NewOpenAIChatProvider("test-key", WithOpenAIChatBaseURL(server.URL), WithOpenAIChatHTTPClient(server.Client()))
 	require.Equal(t, "openai_chat", p.Name(), "provider name should be openai_chat")
 
-	resp, err := p.Complete(context.Background(), "gpt-4o", "system", "user prompt")
+	resp, err := p.Complete(context.Background(), "gpt-4o", "system", "user prompt", "")
 	require.NoError(t, err, "should complete without error")
 	require.Equal(t, "hello from openai", resp, "should return message content")
 }
@@ -49,9 +49,53 @@ func TestOpenAIChatProvider_Complete_NoChoices(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenAIChatProvider("key", WithOpenAIChatBaseURL(server.URL), WithOpenAIChatHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error when no choices")
 	require.Contains(t, err.Error(), "no choices", "error should mention missing choices")
+}
+
+func TestOpenAIChatProvider_Complete_ReasoningEffort(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req chatCompletionsRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req), "should decode request")
+		require.Equal(t, ReasoningEffort("low"), req.ReasoningEffort, "should include reasoning_effort in request")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(chatCompletionsResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "response"}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAIChatProvider("key", WithOpenAIChatBaseURL(server.URL), WithOpenAIChatHTTPClient(server.Client()))
+	resp, err := p.Complete(context.Background(), "gpt-5.4-mini", "sys", "user", ReasoningEffort("low"))
+	require.NoError(t, err, "should complete without error")
+	require.Equal(t, "response", resp, "should return message content")
+}
+
+func TestOpenAIChatProvider_Complete_ReasoningEffortOmitted(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Decode as raw JSON to check omitempty behavior.
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&raw), "should decode request")
+		_, hasEffort := raw["reasoning_effort"]
+		require.False(t, hasEffort, "reasoning_effort should be omitted when empty")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(chatCompletionsResponse{
+			Choices: []chatChoice{{Message: chatMessage{Content: "response"}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewOpenAIChatProvider("key", WithOpenAIChatBaseURL(server.URL), WithOpenAIChatHTTPClient(server.Client()))
+	resp, err := p.Complete(context.Background(), "gpt-4o", "sys", "user", "")
+	require.NoError(t, err, "should complete without error")
+	require.Equal(t, "response", resp, "should return message content")
 }
 
 func TestOpenAIChatProvider_Complete_ServerError(t *testing.T) {
@@ -64,7 +108,7 @@ func TestOpenAIChatProvider_Complete_ServerError(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenAIChatProvider("key", WithOpenAIChatBaseURL(server.URL), WithOpenAIChatHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on server error")
 	require.ErrorIs(t, err, ErrServerError, "should wrap server error")
 }

--- a/internal/llm/openai_responses.go
+++ b/internal/llm/openai_responses.go
@@ -48,11 +48,19 @@ func NewOpenAIResponsesProvider(apiKey string, opts ...OpenAIResponsesOption) *O
 
 func (p *OpenAIResponsesProvider) Name() string { return "openai_responses" }
 
-func (p *OpenAIResponsesProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string) (string, error) {
+func (p *OpenAIResponsesProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
+	// Only include reasoning_effort for models that support it. Sending it
+	// to non-reasoning models (e.g. gpt-4o) may cause a 400 error.
+	var effort ReasoningEffort
+	if modelSupportsReasoningEffort(model) {
+		effort = reasoningEffort
+	}
+
 	reqBody := responsesRequest{
-		Model:        model,
-		Instructions: systemPrompt,
-		Input:        userPrompt,
+		Model:           model,
+		Instructions:    systemPrompt,
+		Input:           userPrompt,
+		ReasoningEffort: effort,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
@@ -100,9 +108,10 @@ func (p *OpenAIResponsesProvider) Complete(ctx context.Context, model, systemPro
 }
 
 type responsesRequest struct {
-	Model        string `json:"model"`
-	Instructions string `json:"instructions,omitempty"`
-	Input        string `json:"input"`
+	Model           string `json:"model"`
+	Instructions    string `json:"instructions,omitempty"`
+	Input           string `json:"input"`
+	ReasoningEffort ReasoningEffort `json:"reasoning_effort,omitempty"`
 }
 
 type responsesResponse struct {

--- a/internal/llm/openai_responses_test.go
+++ b/internal/llm/openai_responses_test.go
@@ -36,7 +36,7 @@ func TestOpenAIResponsesProvider_Complete_Success(t *testing.T) {
 	p := NewOpenAIResponsesProvider("test-key", WithOpenAIResponsesBaseURL(server.URL), WithOpenAIResponsesHTTPClient(server.Client()))
 	require.Equal(t, "openai_responses", p.Name(), "provider name should be openai_responses")
 
-	resp, err := p.Complete(context.Background(), "gpt-4o", "system", "user prompt")
+	resp, err := p.Complete(context.Background(), "gpt-4o", "system", "user prompt", "")
 	require.NoError(t, err, "should complete without error")
 	require.Equal(t, "hello from responses", resp, "should return text content")
 }
@@ -51,7 +51,7 @@ func TestOpenAIResponsesProvider_Complete_NoTextContent(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenAIResponsesProvider("key", WithOpenAIResponsesBaseURL(server.URL), WithOpenAIResponsesHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error when no text content")
 	require.Contains(t, err.Error(), "no text content", "error should mention missing text content")
 }
@@ -66,7 +66,7 @@ func TestOpenAIResponsesProvider_Complete_RateLimit(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenAIResponsesProvider("key", WithOpenAIResponsesBaseURL(server.URL), WithOpenAIResponsesHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on rate limit")
 	require.ErrorIs(t, err, ErrRateLimit, "should wrap rate limit error")
 }

--- a/internal/llm/openrouter.go
+++ b/internal/llm/openrouter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -63,16 +64,24 @@ func NewOpenRouterProvider(apiKey string, opts ...OpenRouterOption) *OpenRouterP
 
 func (p *OpenRouterProvider) Name() string { return "openrouter" }
 
-func (p *OpenRouterProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string) (string, error) {
+func (p *OpenRouterProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
 	// OpenRouter uses the OpenAI Chat Completions format.
 	messages := []chatMessage{
 		{Role: "system", Content: systemPrompt},
 		{Role: "user", Content: userPrompt},
 	}
 
+	// Only include reasoning_effort for OpenAI models. Non-OpenAI upstreams
+	// (e.g. Anthropic) may reject the unknown field with a 400 error.
+	var effort ReasoningEffort
+	if strings.HasPrefix(model, "openai/") {
+		effort = reasoningEffort
+	}
+
 	reqBody := chatCompletionsRequest{
-		Model:    model,
-		Messages: messages,
+		Model:           model,
+		Messages:        messages,
+		ReasoningEffort: effort,
 	}
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/llm/openrouter_test.go
+++ b/internal/llm/openrouter_test.go
@@ -34,7 +34,7 @@ func TestOpenRouterProvider_Complete_Success(t *testing.T) {
 	)
 	require.Equal(t, "openrouter", p.Name(), "provider name should be openrouter")
 
-	resp, err := p.Complete(context.Background(), "anthropic/claude-sonnet-4-5", "system", "user prompt")
+	resp, err := p.Complete(context.Background(), "anthropic/claude-sonnet-4-5", "system", "user prompt", "")
 	require.NoError(t, err, "should complete without error")
 	require.Equal(t, "hello from openrouter", resp, "should return message content")
 }
@@ -54,7 +54,7 @@ func TestOpenRouterProvider_Complete_NoHeaders(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenRouterProvider("key", WithOpenRouterBaseURL(server.URL), WithOpenRouterHTTPClient(server.Client()))
-	resp, err := p.Complete(context.Background(), "model", "sys", "user")
+	resp, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.NoError(t, err, "should complete without error")
 	require.Equal(t, "ok", resp, "should return message content")
 }
@@ -69,7 +69,7 @@ func TestOpenRouterProvider_Complete_ServerError(t *testing.T) {
 	defer server.Close()
 
 	p := NewOpenRouterProvider("key", WithOpenRouterBaseURL(server.URL), WithOpenRouterHTTPClient(server.Client()))
-	_, err := p.Complete(context.Background(), "model", "sys", "user")
+	_, err := p.Complete(context.Background(), "model", "sys", "user", "")
 	require.Error(t, err, "should return error on server error")
 	require.ErrorIs(t, err, ErrServerError, "should wrap server error")
 }

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -4,16 +4,34 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/assembledhq/143/internal/models"
 )
+
+// ModelName is an alias for the canonical models.ModelName type.
+type ModelName = models.ModelName
+
+// ReasoningEffort is an alias for the canonical models.ReasoningEffort type.
+type ReasoningEffort = models.ReasoningEffort
 
 // Provider represents a single LLM API backend (Anthropic, OpenAI, etc.).
 // Each provider handles its own request/response marshaling.
 type Provider interface {
 	// Complete sends a prompt to the LLM and returns the text response.
-	Complete(ctx context.Context, model, systemPrompt, userPrompt string) (string, error)
+	Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error)
 
 	// Name returns the provider identifier (e.g., "anthropic", "openai_chat").
 	Name() string
+}
+
+// modelSupportsReasoningEffort returns true if the given model ID is known to
+// support the reasoning_effort parameter. Unsupported models (e.g. gpt-4o)
+// may reject the parameter with a 400 error.
+func modelSupportsReasoningEffort(model string) bool {
+	// o-series reasoning models and gpt-5+ models support reasoning_effort.
+	// Legacy models (gpt-4o, gpt-4o-mini) do not.
+	return strings.HasPrefix(model, "o") || strings.HasPrefix(model, "gpt-5")
 }
 
 // Sentinel errors for fallback classification.

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -21,7 +21,7 @@ type providerModel struct {
 // providers — if Anthropic is down directly, OpenRouter's Anthropic route is
 // likely also affected. However, OpenRouter can route to alternative models,
 // so it serves as a useful last-resort fallback.
-var defaultChains = map[string][]providerModel{
+var defaultChains = map[ModelName][]providerModel{
 	// Anthropic models — primary: Anthropic API, cross-provider fallback, then OpenRouter.
 	"claude-opus-4-6": {
 		{ProviderName: "anthropic", ModelID: "claude-opus-4-6"},
@@ -61,6 +61,12 @@ var defaultChains = map[string][]providerModel{
 		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-5-20250929"},
 		{ProviderName: "openrouter", ModelID: "openai/o3-mini"},
 	},
+	"gpt-5.4-mini": {
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
+		{ProviderName: "openrouter", ModelID: "openai/gpt-5.4-mini"},
+	},
 	"gpt-5-nano": {
 		{ProviderName: "openai_chat", ModelID: "gpt-5-nano"},
 		{ProviderName: "openai_responses", ModelID: "gpt-5-nano"},
@@ -71,7 +77,7 @@ var defaultChains = map[string][]providerModel{
 // buildChain constructs an ordered fallback chain for the requested model,
 // filtering to only providers that are available (configured with API keys).
 // Returns an error if no providers are available for the requested model.
-func buildChain(model string, available map[string]Provider) ([]chainLink, error) {
+func buildChain(model ModelName, available map[string]Provider) ([]chainLink, error) {
 	chainsMu.RLock()
 	entries, ok := defaultChains[model]
 	chainsMu.RUnlock()
@@ -99,7 +105,7 @@ func buildChain(model string, available map[string]Provider) ([]chainLink, error
 
 // RegisterModel adds or replaces a model's provider chain in the registry.
 // This allows custom models to be added at runtime.
-func RegisterModel(model string, entries []providerModel) {
+func RegisterModel(model ModelName, entries []providerModel) {
 	chainsMu.Lock()
 	defaultChains[model] = entries
 	chainsMu.Unlock()

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -136,6 +136,15 @@ func ModelEnvVarForAgentType(agentType AgentType) string {
 	}
 }
 
+// ModelName is a user-facing model identifier (e.g., "claude-sonnet-4-5", "gpt-4o").
+// The LLM registry maps these to provider-specific model IDs.
+type ModelName string
+
+// DefaultLLMModel is the server-side default when no LLM_MODEL env var or
+// org setting is configured. Keep in sync with DEFAULT_LLM_MODEL in
+// frontend/src/lib/model-constants.ts.
+const DefaultLLMModel = "gpt-5.4-mini"
+
 // AvailableLLMModels lists all models supported by the general-purpose LLM system.
 // Keep in sync with frontend/src/lib/model-constants.ts (LLM_MODELS_BY_PROVIDER).
 var AvailableLLMModels = []string{
@@ -144,6 +153,8 @@ var AvailableLLMModels = []string{
 	"claude-haiku-4-5",
 	"gpt-4o",
 	"gpt-4o-mini",
+	"gpt-5.4-mini",
+	"gpt-5-nano",
 	"o3-mini",
 }
 
@@ -153,8 +164,8 @@ var AvailableLLMModels = []string{
 func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
 		"anthropic":  {"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"},
-		"openai":     {"gpt-4o", "gpt-4o-mini", "o3-mini"},
-		"openrouter": {"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "o3-mini"},
+		"openai":     {"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"},
+		"openrouter": {"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"},
 	}
 }
 
@@ -170,6 +181,9 @@ func IsSupportedLLMModel(model string) bool {
 func ValidateSettingsModels(settings OrgSettings) error {
 	if settings.LLMModel != "" && !IsSupportedLLMModel(settings.LLMModel) {
 		return fmt.Errorf("llm_model must be one of: %v", AvailableLLMModels)
+	}
+	if err := settings.LLMReasoningEffort.Validate(); err != nil {
+		return err
 	}
 	if settings.PMModel != "" && !IsSupportedPMModel(settings.PMModel) {
 		return fmt.Errorf("pm_model must be one of: %v", AvailablePMModels)

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -54,7 +54,7 @@ func TestLLMModelConstants(t *testing.T) {
 
 	require.Equal(t, []string{
 		"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5",
-		"gpt-4o", "gpt-4o-mini", "o3-mini",
+		"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini",
 	}, AvailableLLMModels, "AvailableLLMModels should contain all supported LLM models")
 }
 
@@ -67,7 +67,7 @@ func TestLLMModelsByProvider(t *testing.T) {
 	require.Contains(t, byProvider, "openai")
 	require.Contains(t, byProvider, "openrouter")
 	require.Equal(t, []string{"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"}, byProvider["anthropic"])
-	require.Equal(t, []string{"gpt-4o", "gpt-4o-mini", "o3-mini"}, byProvider["openai"])
+	require.Equal(t, []string{"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"}, byProvider["openai"])
 }
 
 func TestIsSupportedLLMModel(t *testing.T) {
@@ -169,6 +169,19 @@ func TestValidateSettingsModels(t *testing.T) {
 			settings: OrgSettings{
 				LLMModel: "gpt-4o",
 			},
+		},
+		{
+			name: "accepts valid reasoning effort",
+			settings: OrgSettings{
+				LLMReasoningEffort: ReasoningEffortLow,
+			},
+		},
+		{
+			name: "rejects invalid reasoning effort",
+			settings: OrgSettings{
+				LLMReasoningEffort: "invalid",
+			},
+			wantErr: true,
 		},
 		{
 			name: "rejects invalid llm model",

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -49,6 +49,26 @@ func (a AgentType) Validate() error {
 // values are maps of env var name → value.
 type AgentEnvConfig map[string]map[string]string
 
+// ReasoningEffort controls how much reasoning a model should use.
+// Valid values: "low", "medium", "high", or "" (default/none).
+type ReasoningEffort string
+
+const (
+	ReasoningEffortLow    ReasoningEffort = "low"
+	ReasoningEffortMedium ReasoningEffort = "medium"
+	ReasoningEffortHigh   ReasoningEffort = "high"
+)
+
+// Validate returns an error if the reasoning effort is not a recognized value.
+func (r ReasoningEffort) Validate() error {
+	switch r {
+	case "", ReasoningEffortLow, ReasoningEffortMedium, ReasoningEffortHigh:
+		return nil
+	default:
+		return fmt.Errorf("invalid reasoning effort: %q", r)
+	}
+}
+
 // OrgSettings is the strongly-typed representation of organizations.settings JSONB.
 type OrgSettings struct {
 	AutonomyLevel        AutonomyLevel        `json:"autonomy_level"`
@@ -63,6 +83,7 @@ type OrgSettings struct {
 	PMScheduleHours      int                  `json:"pm_schedule_hours"`
 	PMModel              string               `json:"pm_model"`
 	LLMModel             string               `json:"llm_model"`
+	LLMReasoningEffort   ReasoningEffort      `json:"llm_reasoning_effort,omitempty"`
 	AgentConfig          AgentEnvConfig       `json:"agent_config,omitempty"`
 	DefaultAgentType     AgentType            `json:"default_agent_type,omitempty"`
 	AuditRetentionDays   int                  `json:"audit_retention_days,omitempty"`

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -176,6 +176,36 @@ func TestAgentType_Validate(t *testing.T) {
 	require.Error(t, AgentType("").Validate())
 }
 
+func TestReasoningEffort_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		effort  ReasoningEffort
+		wantErr bool
+	}{
+		{name: "empty is valid", effort: ""},
+		{name: "low is valid", effort: ReasoningEffortLow},
+		{name: "medium is valid", effort: ReasoningEffortMedium},
+		{name: "high is valid", effort: ReasoningEffortHigh},
+		{name: "rejects invalid value", effort: "invalid", wantErr: true},
+		{name: "rejects unknown value", effort: "max", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.effort.Validate()
+			if tt.wantErr {
+				require.Error(t, err, "Validate should reject invalid reasoning effort")
+			} else {
+				require.NoError(t, err, "Validate should accept valid reasoning effort")
+			}
+		})
+	}
+}
+
 func TestConfidenceThresholdsForAutonomy(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Switches the default general-purpose LLM model from claude-sonnet-4-5 to gpt-5.4-mini, adds reasoning_effort parameter configuration across the LLM stack, and fixes 5 code review issues.

## Changes

**Backend**: Updated LLM provider interface to accept reasoning_effort parameter. OpenAI providers guard against sending it to non-reasoning models. Config defaults model to gpt-5.4-mini when unset but providers available. Registry updated with gpt-5.4-mini and gpt-5-nano fallback chains.

**Frontend**: Added UI dropdown selector for reasoning effort (low/medium/high/none) on LLM settings page. Updated model lists to match backend.

**Code Quality**: Added table-driven validation tests for ReasoningEffort, moved ModelName type to internal/models, updated LogStatus messaging to reflect new default behavior.

## Test plan

- Backend: `go test ./internal/llm/... ./internal/models/... ./internal/config/...` passes
- Frontend: Type checking and lint validation pass
- Fallback chains work correctly for gpt-5.4-mini (primary OpenAI, secondary anthropic/openrouter)
- Reasoning effort only sent to models that support it (o-series, gpt-5+)

🤖 Generated with [Claude Code](https://claude.ai/code)