### PR TITLE
Simplify session filter tabs to 4 core states

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -66,9 +66,9 @@ describe('SessionSidebar', () => {
     await screen.findByText('Fixed TypeError by adding null check');
 
     expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
-    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Needs attention').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Working').length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText('Done').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Failed').length).toBeGreaterThanOrEqual(1);
   });
 
   it('shows status indicators for sessions', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -38,6 +38,7 @@ const filterTabs = [
   { value: "done", label: "Done" },
 ];
 
+// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / DoneStatuses.
 const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
 const workingStatuses = ["pending", "running"];
 const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
@@ -106,7 +107,9 @@ export function SessionSidebar() {
   const currentFilter = activeFilter ?? "all";
   const statusParam = filterToStatusParam(currentFilter);
 
-  // Fetch all sessions (for tab counts and the "all" view).
+  // Fetch all sessions (for tab badge counts and the "all" view).
+  // Also fetches a filtered query when a tab is active — see sessions-page-content
+  // for the rationale on the double-fetch tradeoff.
   const { data: allData, isLoading } = useQuery({
     queryKey: queryKeys.sessions.list(repo),
     queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -33,22 +33,23 @@ const statusConfig: Record<string, { dot: string; label: string }> = {
 
 const filterTabs = [
   { value: "all", label: "All" },
-  { value: "active", label: "Active" },
-  { value: "needs_human_guidance", label: "Guidance" },
-  { value: "failed", label: "Failed" },
+  { value: "needs_attention", label: "Needs attention" },
+  { value: "working", label: "Working" },
   { value: "done", label: "Done" },
 ];
 
-const activeStatuses = new Set(["pending", "running", "awaiting_input"]);
-const doneStatuses = new Set(["completed", "pr_created"]);
+const needsAttentionStatuses = new Set(["awaiting_input", "needs_human_guidance", "failed"]);
+const workingStatuses = new Set(["pending", "running"]);
+const doneStatuses = new Set(["completed", "pr_created", "cancelled", "skipped", "idle"]);
 
-function isActive(s: Session): boolean {
-  return activeStatuses.has(s.status);
+function isWorking(s: Session): boolean {
+  return workingStatuses.has(s.status);
 }
 
 function filterSessions(sessions: Session[], filter: string | null): Session[] {
   if (!filter || filter === "all") return sessions;
-  if (filter === "active") return sessions.filter(isActive);
+  if (filter === "needs_attention") return sessions.filter((s) => needsAttentionStatuses.has(s.status));
+  if (filter === "working") return sessions.filter(isWorking);
   if (filter === "done") return sessions.filter((s) => doneStatuses.has(s.status));
   return sessions.filter((s) => s.status === filter);
 }
@@ -111,9 +112,8 @@ export function SessionSidebar() {
   const allSessions = data?.data ?? [];
   const currentFilter = activeFilter ?? "all";
 
-  const activeSessions = allSessions.filter(isActive);
-  const failedSessions = allSessions.filter((s) => s.status === "failed");
-  const guidanceSessions = allSessions.filter((s) => s.status === "needs_human_guidance");
+  const needsAttentionSessions = allSessions.filter((s) => needsAttentionStatuses.has(s.status));
+  const workingSessions = allSessions.filter(isWorking);
 
   const filteredSessions = useMemo(
     () => filterSessions(allSessions, activeFilter),
@@ -163,9 +163,8 @@ export function SessionSidebar() {
           <TabsList size="sm" className="overflow-x-auto">
             {filterTabs.map((tab) => {
               const count =
-                tab.value === "active" ? activeSessions.length
-                : tab.value === "failed" ? failedSessions.length
-                : tab.value === "needs_human_guidance" ? guidanceSessions.length
+                tab.value === "needs_attention" ? needsAttentionSessions.length
+                : tab.value === "working" ? workingSessions.length
                 : 0;
               return (
                 <TabsTrigger key={tab.value} value={tab.value}>
@@ -173,8 +172,7 @@ export function SessionSidebar() {
                   {count > 0 && (
                     <span className={cn(
                       "rounded-full text-white text-[9px] leading-none px-1.5 py-0.5",
-                      tab.value === "failed" ? "bg-destructive"
-                      : tab.value === "needs_human_guidance" ? "bg-orange-500"
+                      tab.value === "needs_attention" ? "bg-orange-500"
                       : "bg-primary"
                     )}>{count}</span>
                   )}
@@ -202,7 +200,7 @@ export function SessionSidebar() {
           </Link>
         )}
 
-        {(currentFilter === "all" || currentFilter === "active") &&
+        {(currentFilter === "all" || currentFilter === "working") &&
           optimisticSessions.map((os) => (
             <OptimisticSessionRow key={os.id} session={os} />
           ))}
@@ -222,7 +220,7 @@ export function SessionSidebar() {
         {displayedSessions.map((session) => {
           const isSelected = selectedId === session.id;
           const cfg = statusConfig[session.status] || statusConfig.pending;
-          const isActiveSession = activeStatuses.has(session.status);
+          const isWorkingSession = workingStatuses.has(session.status);
           const ts = session.completed_at || session.started_at || session.created_at;
 
           return (
@@ -239,7 +237,7 @@ export function SessionSidebar() {
               <div className="flex items-start gap-2.5 min-w-0">
                 {/* Status dot */}
                 <div className="mt-1.5 shrink-0">
-                  {isActiveSession ? (
+                  {isWorkingSession ? (
                     <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
                   ) : (
                     <StatusDot color={cfg.dot} />

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -38,20 +38,20 @@ const filterTabs = [
   { value: "done", label: "Done" },
 ];
 
-const needsAttentionStatuses = new Set(["awaiting_input", "needs_human_guidance", "failed"]);
-const workingStatuses = new Set(["pending", "running"]);
-const doneStatuses = new Set(["completed", "pr_created", "cancelled", "skipped", "idle"]);
+const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
+const workingStatuses = ["pending", "running"];
+const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
 
-function isWorking(s: Session): boolean {
-  return workingStatuses.has(s.status);
-}
+const needsAttentionSet = new Set(needsAttentionStatuses);
+const workingSet = new Set(workingStatuses);
 
-function filterSessions(sessions: Session[], filter: string | null): Session[] {
-  if (!filter || filter === "all") return sessions;
-  if (filter === "needs_attention") return sessions.filter((s) => needsAttentionStatuses.has(s.status));
-  if (filter === "working") return sessions.filter(isWorking);
-  if (filter === "done") return sessions.filter((s) => doneStatuses.has(s.status));
-  return sessions.filter((s) => s.status === filter);
+/** Map a filter tab value to the comma-separated status string for the API. */
+function filterToStatusParam(filter: string | null): string | undefined {
+  if (!filter || filter === "all") return undefined;
+  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
+  if (filter === "working") return workingStatuses.join(",");
+  if (filter === "done") return doneStatuses.join(",");
+  return filter;
 }
 
 function sessionTitle(session: Session): string {
@@ -103,21 +103,35 @@ export function SessionSidebar() {
 
   const { optimisticSessions } = useOptimisticSessions();
 
-  const { data, isLoading } = useQuery({
+  const currentFilter = activeFilter ?? "all";
+  const statusParam = filterToStatusParam(currentFilter);
+
+  // Fetch all sessions (for tab counts and the "all" view).
+  const { data: allData, isLoading } = useQuery({
     queryKey: queryKeys.sessions.list(repo),
     queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
     refetchInterval: 10000,
   });
 
-  const allSessions = data?.data ?? [];
-  const currentFilter = activeFilter ?? "all";
+  // Fetch filtered sessions from the backend when a specific tab is selected.
+  const { data: filteredData } = useQuery({
+    queryKey: [...queryKeys.sessions.list(repo), statusParam],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam }),
+    refetchInterval: 10000,
+    enabled: !!statusParam,
+  });
 
-  const needsAttentionSessions = allSessions.filter((s) => needsAttentionStatuses.has(s.status));
-  const workingSessions = allSessions.filter(isWorking);
+  const allSessions = allData?.data ?? [];
+
+  const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
+  const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
 
   const filteredSessions = useMemo(
-    () => filterSessions(allSessions, activeFilter),
-    [allSessions, activeFilter],
+    () => {
+      if (statusParam && filteredData) return filteredData.data;
+      return allSessions;
+    },
+    [allSessions, filteredData, statusParam],
   );
 
   const displayedSessions = useMemo(() => {
@@ -220,7 +234,7 @@ export function SessionSidebar() {
         {displayedSessions.map((session) => {
           const isSelected = selectedId === session.id;
           const cfg = statusConfig[session.status] || statusConfig.pending;
-          const isWorkingSession = workingStatuses.has(session.status);
+          const isWorkingSession = workingSet.has(session.status);
           const ts = session.completed_at || session.started_at || session.created_at;
 
           return (

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -51,18 +51,18 @@ const statusConfig: Record<string, { dot: string; text: string; bg: string; labe
 
 const filterTabs = [
   { value: "all", label: "All" },
-  { value: "active", label: "Active" },
-  { value: "needs_human_guidance", label: "Needs guidance" },
-  { value: "failed", label: "Failed" },
+  { value: "needs_attention", label: "Needs attention" },
+  { value: "working", label: "Working" },
   { value: "done", label: "Done" },
   { value: "decisions", label: "Decisions" },
 ];
 
-const activeStatuses = new Set(["pending", "running", "awaiting_input"]);
-const doneStatuses = new Set(["completed", "pr_created"]);
+const needsAttentionStatuses = new Set(["awaiting_input", "needs_human_guidance", "failed"]);
+const workingStatuses = new Set(["pending", "running"]);
+const doneStatuses = new Set(["completed", "pr_created", "cancelled", "skipped", "idle"]);
 
-function isActive(s: Session): boolean {
-  return activeStatuses.has(s.status);
+function isWorking(s: Session): boolean {
+  return workingStatuses.has(s.status);
 }
 
 // ---------------------------------------------------------------------------
@@ -71,7 +71,8 @@ function isActive(s: Session): boolean {
 
 function filterSessions(sessions: Session[], filter: string | null): Session[] {
   if (!filter || filter === "all") return sessions;
-  if (filter === "active") return sessions.filter(isActive);
+  if (filter === "needs_attention") return sessions.filter((s) => needsAttentionStatuses.has(s.status));
+  if (filter === "working") return sessions.filter(isWorking);
   if (filter === "done") return sessions.filter((s) => doneStatuses.has(s.status));
   return sessions.filter((s) => s.status === filter);
 }
@@ -87,9 +88,9 @@ function sessionTitle(session: Session): string {
 // ---------------------------------------------------------------------------
 
 function SessionStatusDot({ status }: { status: string }) {
-  const active = activeStatuses.has(status);
+  const working = workingStatuses.has(status);
   const cfg = statusConfig[status] || statusConfig.pending;
-  if (active) {
+  if (working) {
     return <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />;
   }
   return <StatusDot color={cfg.dot} />;
@@ -235,9 +236,8 @@ export function SessionsPageContent() {
   const currentFilter = activeFilter ?? "all";
   const showDecisions = currentFilter === "decisions";
 
-  const activeSessions = allSessions.filter(isActive);
-  const failedSessions = allSessions.filter((s) => s.status === "failed");
-  const guidanceSessions = allSessions.filter((s) => s.status === "needs_human_guidance");
+  const needsAttentionSessions = allSessions.filter((s) => needsAttentionStatuses.has(s.status));
+  const workingSessions = allSessions.filter(isWorking);
 
   const filteredSessions = useMemo(
     () => (showDecisions ? [] : filterSessions(allSessions, activeFilter)),
@@ -262,16 +262,15 @@ export function SessionsPageContent() {
         description="Each agent execution creates a session."
       />
 
-      <PMStatusBanner hasActivePlanSession={activeSessions.length > 0} />
+      <PMStatusBanner hasActivePlanSession={workingSessions.length > 0} />
 
       {/* ── Tab filters ────────────────────────────────────────────── */}
       <div className="flex items-center gap-0 border-b border-border">
         {filterTabs.map((tab) => {
           const isSelected = currentFilter === tab.value;
           const count =
-            tab.value === "active" ? activeSessions.length
-            : tab.value === "failed" ? failedSessions.length
-            : tab.value === "needs_human_guidance" ? guidanceSessions.length
+            tab.value === "needs_attention" ? needsAttentionSessions.length
+            : tab.value === "working" ? workingSessions.length
             : 0;
           return (
             <button
@@ -287,8 +286,7 @@ export function SessionsPageContent() {
                 {tab.label}
                 {count > 0 && (
                   <span className={`rounded-full text-white text-[10px] leading-none px-1.5 py-0.5 font-normal ${
-                    tab.value === "failed" ? "bg-destructive"
-                    : tab.value === "needs_human_guidance" ? "bg-orange-500"
+                    tab.value === "needs_attention" ? "bg-orange-500"
                     : "bg-primary"
                   }`}>{count}</span>
                 )}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -57,24 +57,20 @@ const filterTabs = [
   { value: "decisions", label: "Decisions" },
 ];
 
-const needsAttentionStatuses = new Set(["awaiting_input", "needs_human_guidance", "failed"]);
-const workingStatuses = new Set(["pending", "running"]);
-const doneStatuses = new Set(["completed", "pr_created", "cancelled", "skipped", "idle"]);
+const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
+const workingStatuses = ["pending", "running"];
+const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
 
-function isWorking(s: Session): boolean {
-  return workingStatuses.has(s.status);
-}
+const needsAttentionSet = new Set(needsAttentionStatuses);
+const workingSet = new Set(workingStatuses);
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function filterSessions(sessions: Session[], filter: string | null): Session[] {
-  if (!filter || filter === "all") return sessions;
-  if (filter === "needs_attention") return sessions.filter((s) => needsAttentionStatuses.has(s.status));
-  if (filter === "working") return sessions.filter(isWorking);
-  if (filter === "done") return sessions.filter((s) => doneStatuses.has(s.status));
-  return sessions.filter((s) => s.status === filter);
+/** Map a filter tab value to the comma-separated status string for the API. */
+function filterToStatusParam(filter: string | null): string | undefined {
+  if (!filter || filter === "all" || filter === "decisions") return undefined;
+  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
+  if (filter === "working") return workingStatuses.join(",");
+  if (filter === "done") return doneStatuses.join(",");
+  return filter;
 }
 
 function sessionTitle(session: Session): string {
@@ -88,7 +84,7 @@ function sessionTitle(session: Session): string {
 // ---------------------------------------------------------------------------
 
 function SessionStatusDot({ status }: { status: string }) {
-  const working = workingStatuses.has(status);
+  const working = workingSet.has(status);
   const cfg = statusConfig[status] || statusConfig.pending;
   if (working) {
     return <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />;
@@ -219,10 +215,23 @@ export function SessionsPageContent() {
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
 
-  const { data, isLoading, error } = useQuery({
+  const currentFilter = activeFilter ?? "all";
+  const showDecisions = currentFilter === "decisions";
+  const statusParam = filterToStatusParam(currentFilter);
+
+  // Fetch all sessions (for tab counts and the "all" view).
+  const { data: allData, isLoading, error } = useQuery({
     queryKey: ["sessions", repo],
     queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
     refetchInterval: 10000,
+  });
+
+  // Fetch filtered sessions from the backend when a specific tab is selected.
+  const { data: filteredData } = useQuery({
+    queryKey: ["sessions", repo, statusParam],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam }),
+    refetchInterval: 10000,
+    enabled: !!statusParam,
   });
 
   const { data: membersData } = useQuery({
@@ -230,18 +239,19 @@ export function SessionsPageContent() {
     queryFn: () => api.team.listMembers(),
   });
 
-  const allSessions = data?.data ?? [];
+  const allSessions = allData?.data ?? [];
   const members = membersData?.data ?? [];
 
-  const currentFilter = activeFilter ?? "all";
-  const showDecisions = currentFilter === "decisions";
-
-  const needsAttentionSessions = allSessions.filter((s) => needsAttentionStatuses.has(s.status));
-  const workingSessions = allSessions.filter(isWorking);
+  const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
+  const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
 
   const filteredSessions = useMemo(
-    () => (showDecisions ? [] : filterSessions(allSessions, activeFilter)),
-    [allSessions, activeFilter, showDecisions],
+    () => {
+      if (showDecisions) return [];
+      if (statusParam && filteredData) return filteredData.data;
+      return allSessions;
+    },
+    [allSessions, filteredData, statusParam, showDecisions],
   );
 
   const columns = useMemo(() => buildColumns(members), [members]);

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -57,6 +57,7 @@ const filterTabs = [
   { value: "decisions", label: "Decisions" },
 ];
 
+// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / DoneStatuses.
 const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
 const workingStatuses = ["pending", "running"];
 const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
@@ -219,7 +220,13 @@ export function SessionsPageContent() {
   const showDecisions = currentFilter === "decisions";
   const statusParam = filterToStatusParam(currentFilter);
 
-  // Fetch all sessions (for tab counts and the "all" view).
+  // Fetch all sessions (for tab badge counts and the "all" view).
+  // We also fetch a filtered query below when a tab is active. The two queries
+  // run in parallel on a 10s interval. The "all" query is cheap (limit 50) and
+  // needed for accurate badge counts; the filtered query ensures the displayed
+  // list reflects the correct server-side results even when total sessions exceed
+  // the limit. If polling cost becomes a concern, consider a dedicated
+  // /sessions/counts endpoint.
   const { data: allData, isLoading, error } = useQuery({
     queryKey: ["sessions", repo],
     queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -72,9 +72,17 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	limit := queryInt(r, "limit", 50)
 	filters := db.SessionFilters{
-		Status: models.SessionStatus(r.URL.Query().Get("status")),
 		Limit:  limit,
 		Cursor: r.URL.Query().Get("cursor"),
+	}
+
+	if statusParam := r.URL.Query().Get("status"); statusParam != "" {
+		for _, s := range strings.Split(statusParam, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				filters.Statuses = append(filters.Statuses, models.SessionStatus(s))
+			}
+		}
 	}
 
 	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -79,9 +79,15 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 	if statusParam := r.URL.Query().Get("status"); statusParam != "" {
 		for _, s := range strings.Split(statusParam, ",") {
 			s = strings.TrimSpace(s)
-			if s != "" {
-				filters.Statuses = append(filters.Statuses, models.SessionStatus(s))
+			if s == "" {
+				continue
 			}
+			status := models.SessionStatus(s)
+			if err := status.Validate(); err != nil {
+				writeError(w, http.StatusBadRequest, "INVALID_STATUS", "invalid status: "+s)
+				return
+			}
+			filters.Statuses = append(filters.Statuses, status)
 		}
 	}
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -196,6 +196,72 @@ func TestSessionHandler_List_InvalidRepositoryID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionHandler_List_InvalidStatus(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions?status=bogus", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "should return 400 for invalid status")
+	require.Contains(t, w.Body.String(), "INVALID_STATUS", "error code should indicate invalid status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	now := time.Now()
+	runID := uuid.New()
+	issueID := uuid.New()
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ AND status = ANY").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				runID, issueID, orgID, "claude-code", "pending", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, &now, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil,
+				nil, nil,
+				nil, // triggered_by_user_id
+				nil, 0, nil, "none", nil,
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions?status=pending,running", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.List(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should return 200 for comma-separated statuses")
+
+	var resp models.ListResponse[models.Session]
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err, "response body should be valid JSON")
+	require.Equal(t, 1, len(resp.Data), "should return filtered sessions")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionHandler_Get(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -79,7 +79,7 @@ func TestSessionStore_ListByOrg(t *testing.T) {
 		},
 		{
 			name:    "returns filtered agent runs by status",
-			filters: SessionFilters{Status: models.SessionStatusRunning},
+			filters: SessionFilters{Statuses: []models.SessionStatus{models.SessionStatusRunning}},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ AND status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -91,6 +91,20 @@ func TestSessionStore_ListByOrg(t *testing.T) {
 			expected: 1,
 		},
 		{
+			name:    "returns filtered agent runs by multiple statuses",
+			filters: SessionFilters{Statuses: []models.SessionStatus{models.SessionStatusPending, models.SessionStatusRunning}},
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ AND status = ANY").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).
+							AddRow(newSessionRow(runID1, issueID, orgID, now)...).
+							AddRow(newSessionRow(runID2, issueID, orgID, now)...),
+					)
+			},
+			expected: 2,
+		},
+		{
 			name:    "returns only ad-hoc runs when AdHocOnly is true",
 			filters: SessionFilters{AdHocOnly: true},
 			setupMock: func(mock pgxmock.PgxPoolIface) {

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -20,7 +20,7 @@ func NewSessionStore(db DBTX) *SessionStore {
 }
 
 type SessionFilters struct {
-	Status       models.SessionStatus
+	Statuses     []models.SessionStatus // When non-empty, filter to sessions matching any of these statuses.
 	Limit        int
 	Cursor       string
 	AdHocOnly    bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
@@ -50,9 +50,16 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 		args["repository_id"] = filters.RepositoryID
 	}
 
-	if filters.Status != "" {
+	if len(filters.Statuses) == 1 {
 		query += ` AND status = @status`
-		args["status"] = string(filters.Status)
+		args["status"] = string(filters.Statuses[0])
+	} else if len(filters.Statuses) > 1 {
+		statusStrings := make([]string, len(filters.Statuses))
+		for i, s := range filters.Statuses {
+			statusStrings[i] = string(s)
+		}
+		query += ` AND status = ANY(@statuses)`
+		args["statuses"] = statusStrings
 	}
 	if filters.AdHocOnly {
 		query += ` AND pm_plan_id IS NULL`

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -36,6 +36,17 @@ func (s SessionStatus) Validate() error {
 	}
 }
 
+// Status groups used by the frontend filter tabs. Defined here so the backend
+// is the source of truth; the frontend arrays must stay in sync.
+var (
+	// NeedsAttentionStatuses are statuses where user action is required.
+	NeedsAttentionStatuses = []SessionStatus{SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance, SessionStatusFailed}
+	// WorkingStatuses are statuses where the agent is actively executing.
+	WorkingStatuses = []SessionStatus{SessionStatusPending, SessionStatusRunning}
+	// DoneStatuses are terminal or parked statuses.
+	DoneStatuses = []SessionStatus{SessionStatusCompleted, SessionStatusPRCreated, SessionStatusCancelled, SessionStatusSkipped, SessionStatusIdle}
+)
+
 // SandboxState tracks the lifecycle of a session's sandbox.
 type SandboxState string
 

--- a/internal/services/pm/context.go
+++ b/internal/services/pm/context.go
@@ -66,17 +66,13 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 		issueSummaries = append(issueSummaries, summarizeIssue(issue))
 	}
 
-	pendingRuns, err := s.sessions.ListByOrg(ctx, orgID, db.SessionFilters{Status: models.SessionStatusPending, Limit: 50})
+	inFlight, err := s.sessions.ListByOrg(ctx, orgID, db.SessionFilters{
+		Statuses: []models.SessionStatus{models.SessionStatusPending, models.SessionStatusRunning},
+		Limit:    50,
+	})
 	if err != nil {
 		return nil, err
 	}
-	runningRuns, err := s.sessions.ListByOrg(ctx, orgID, db.SessionFilters{Status: models.SessionStatusRunning, Limit: 50})
-	if err != nil {
-		return nil, err
-	}
-	inFlight := make([]models.Session, 0, len(pendingRuns)+len(runningRuns))
-	inFlight = append(inFlight, pendingRuns...)
-	inFlight = append(inFlight, runningRuns...)
 
 	inFlightSummaries := make([]RunSummary, 0, len(inFlight))
 	for _, run := range inFlight {

--- a/internal/services/pm/context.go
+++ b/internal/services/pm/context.go
@@ -66,6 +66,8 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 		issueSummaries = append(issueSummaries, summarizeIssue(issue))
 	}
 
+	// Fetch pending + running sessions in a single query. Results are ordered by
+	// created_at DESC (interleaved), which is fine since we only summarize them.
 	inFlight, err := s.sessions.ListByOrg(ctx, orgID, db.SessionFilters{
 		Statuses: []models.SessionStatus{models.SessionStatusPending, models.SessionStatusRunning},
 		Limit:    50,

--- a/internal/services/pm/context_gather_test.go
+++ b/internal/services/pm/context_gather_test.go
@@ -48,11 +48,21 @@ func (m *gatherSessionStoreMock) Create(ctx context.Context, run *models.Session
 }
 
 func (m *gatherSessionStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.SessionFilters) ([]models.Session, error) {
-	key := string(filters.Status)
-	if err := m.errByKey[key]; err != nil {
-		return nil, err
+	var result []models.Session
+	for _, s := range filters.Statuses {
+		key := string(s)
+		if err := m.errByKey[key]; err != nil {
+			return nil, err
+		}
+		result = append(result, m.byStatus[key]...)
 	}
-	return m.byStatus[key], nil
+	if len(filters.Statuses) == 0 {
+		if err := m.errByKey[""]; err != nil {
+			return nil, err
+		}
+		return m.byStatus[""], nil
+	}
+	return result, nil
 }
 
 func (m *gatherSessionStoreMock) ListRecentByOrg(ctx context.Context, orgID uuid.UUID, statuses []string, limit int) ([]models.Session, error) {


### PR DESCRIPTION
## Summary
Replaces the previous 5-tab filter structure (All, Active, Needs guidance, Failed, Done) with a clearer mental model that maps directly to user workflows: Needs attention (awaiting_input, needs_human_guidance, failed), Working (pending, running), and Done (completed, pr_created, cancelled, skipped, idle).

## Why
The old tabs were confusing because "Active" included states that weren't actively doing work, "Guidance" was jargony, and "Failed" was separate from other attention-requiring states. The new structure groups states by what action the user should take or expect.

## Changes
- Idle sessions moved to Done (treated as paused multi-turn, not abandoned)
- Animated status dots only pulse for Working states
- Badge colors simplified: orange for Needs attention, blue for Working
- Applied consistently to both main sessions page and sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
