### PR TITLE
Swap search and new session button positions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -130,15 +130,6 @@ export function SessionSidebar() {
 
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
-      {/* New session button */}
-      <Link
-        href="/sessions/new"
-        className="flex items-center gap-2.5 px-4 py-3 border-b border-border/50 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <Plus className="h-4 w-4" />
-        New session
-      </Link>
-
       {/* Header */}
       <div className="px-4 pt-3 pb-2 space-y-3">
 
@@ -153,6 +144,15 @@ export function SessionSidebar() {
             className="w-full h-8 pl-8 pr-3 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
           />
         </div>
+
+        {/* New session button */}
+        <Link
+          href="/sessions/new"
+          className="flex items-center justify-center gap-2 w-full h-9 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
+        >
+          <Plus className="h-4 w-4" />
+          New session
+        </Link>
 
         {/* Filter tabs */}
         <Tabs


### PR DESCRIPTION
## Summary
Reorganized sidebar layout by moving the search bar to the top and the "+ New session" button below it. The button now has enhanced styling to make it visually prominent as the primary creation action.

## Why
This matches the mental model of modern AI apps (Claude.ai, ChatGPT, Codex) where:
- Search is a quiet utility at the top that users can safely ignore unless needed
- The creation action is visually dominant and sits adjacent to the content it creates
- This prevents the common UX friction of reaching for the search bar when trying to create a new session

## Changes
- Moved search input to top of sidebar header
- Moved "+ New session" link below search
- Enhanced button styling with border, shadow, and centered text for better visibility