### PR TITLE
Add visual feedback to Codex device code Copy button

### DIFF
--- a/frontend/src/components/codex-device-code-modal.test.tsx
+++ b/frontend/src/components/codex-device-code-modal.test.tsx
@@ -114,4 +114,35 @@ describe("CodexDeviceCodeModal", () => {
 
     expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
   });
+
+  it("shows 'Copied' feedback after clicking Copy", async () => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+
+    server.use(
+      http.post(INITIATE_URL, () => {
+        return HttpResponse.json({ data: mockDeviceAuth });
+      }),
+      http.get(STATUS_URL, () => {
+        return HttpResponse.json({ data: { status: "pending" } });
+      }),
+    );
+
+    render(<CodexDeviceCodeModal onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ABCD-1234")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: /copy/i })).toBeInTheDocument();
+    expect(screen.queryByText("Copied")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /copy/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Copied")).toBeInTheDocument();
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("ABCD-1234");
+  });
 });

--- a/frontend/src/components/codex-device-code-modal.tsx
+++ b/frontend/src/components/codex-device-code-modal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { Check, Copy } from "lucide-react";
 import type { CodexDeviceAuth } from "@/lib/types";
 
 export function CodexDeviceCodeModal({
@@ -16,6 +17,8 @@ export function CodexDeviceCodeModal({
   const [status, setStatus] = useState<string>("initiating");
   const [error, setError] = useState("");
   const [timeLeft, setTimeLeft] = useState(0);
+  const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const pollRef = useRef<NodeJS.Timeout | null>(null);
   const timerRef = useRef<NodeJS.Timeout | null>(null);
   const onConnectedRef = useRef(onConnected);
@@ -81,6 +84,7 @@ export function CodexDeviceCodeModal({
     return () => {
       if (pollRef.current) clearInterval(pollRef.current);
       if (timerRef.current) clearInterval(timerRef.current);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
     };
   }, [status]);
 
@@ -102,7 +106,32 @@ export function CodexDeviceCodeModal({
               <p className="text-sm text-muted-foreground">2. Enter this code:</p>
               <div className="flex items-center gap-2">
                 <code className="rounded-md border bg-muted px-4 py-2 text-2xl font-mono font-bold tracking-widest">{deviceAuth.user_code}</code>
-                <Button size="sm" variant="outline" onClick={() => navigator.clipboard.writeText(deviceAuth.user_code)}>Copy</Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="min-w-[90px] transition-all duration-200"
+                  onClick={() => {
+                    navigator.clipboard.writeText(deviceAuth.user_code).then(() => {
+                      setCopied(true);
+                      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+                      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+                    }).catch(() => {
+                      // Clipboard write failed — don't show "Copied"
+                    });
+                  }}
+                >
+                  {copied ? (
+                    <span className="flex items-center gap-1.5 text-green-600">
+                      <Check className="h-3.5 w-3.5" />
+                      Copied
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1.5">
+                      <Copy className="h-3.5 w-3.5" />
+                      Copy
+                    </span>
+                  )}
+                </Button>
               </div>
             </div>
             <div className="space-y-2">


### PR DESCRIPTION
## Summary
Adds "Copied" feedback with a checkmark icon that displays for 2 seconds after clicking Copy, following modern app UX patterns (Linear, Vercel). Includes error handling so "Copied" only shows on successful clipboard writes, and comprehensive test coverage.

## Changes
- Icon + text swap from "Copy" to "Copied" with green checkmark on button click
- Error handling for clipboard write failures via `.catch()`
- 2-second auto-revert timeout with proper cleanup
- New test asserting copy feedback behavior
- Fixed button width to prevent layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)