### PR TITLE
Add dedicated title column to sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -352,6 +352,6 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findByText('PM context');
     expect(screen.getByText('High impact bug')).toBeInTheDocument();
-    expect(screen.getByText('Quick null check fix')).toBeInTheDocument();
+    expect(screen.getAllByText('Quick null check fix').length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -28,7 +28,7 @@ import { buildTimeline } from "@/lib/timeline";
 import type { Session, SessionLog, SessionMessage, User, Validation } from "@/lib/types";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
-import { cn } from "@/lib/utils";
+import { cn, sessionTitle } from "@/lib/utils";
 
 const statusConfig: Record<string, { color: string; label: string }> = {
   pending: { color: "bg-muted text-muted-foreground", label: "Pending" },
@@ -705,7 +705,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
               <h1 className="text-sm font-semibold text-foreground truncate">
-                {session.result_summary || session.pm_approach || `Session ${session.id.slice(0, 8)}`}
+                {sessionTitle(session)}
               </h1>
               <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[11px] font-medium shrink-0 ${status.color}`}>
                 {status.label}

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
-import { cn, formatTimeAgo } from "@/lib/utils";
+import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
@@ -53,12 +53,6 @@ function filterToStatusParam(filter: string | null): string | undefined {
   if (filter === "working") return workingStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
-}
-
-function sessionTitle(session: Session): string {
-  if (session.result_summary) return session.result_summary;
-  if (session.pm_approach) return session.pm_approach;
-  return `Session ${session.id.slice(0, 8)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -28,7 +28,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api } from "@/lib/api";
-import { formatTimeAgo } from "@/lib/utils";
+import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import type { Session, User } from "@/lib/types";
 
@@ -72,12 +72,6 @@ function filterToStatusParam(filter: string | null): string | undefined {
   if (filter === "working") return workingStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
-}
-
-function sessionTitle(session: Session): string {
-  if (session.result_summary) return session.result_summary;
-  if (session.pm_approach) return session.pm_approach;
-  return `Session ${session.id.slice(0, 8)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -100,6 +100,7 @@ export interface Session {
   failure_retry_advised?: boolean;
   parent_session_id?: string;
   pm_plan_id?: string;
+  title?: string;
   pm_approach?: string;
   pm_reasoning?: string;
   project_task_id?: string;

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,8 +1,16 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import type { Session } from "@/lib/types"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function sessionTitle(session: Session): string {
+  if (session.title) return session.title;
+  if (session.pm_approach) return session.pm_approach;
+  if (session.result_summary) return session.result_summary;
+  return `Session ${session.id.slice(0, 8)}`;
 }
 
 export function formatTimeAgo(dateStr: string): string {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -754,6 +754,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		TokenMode:         tokenMode,
 		ModelOverride:     modelOverride,
 		TriggeredByUserID: manualTriggeredByUserID,
+		Title:             &title,
 	}
 	if err := h.runStore.Create(r.Context(), session); err != nil {
 		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session")
@@ -802,7 +803,7 @@ func (h *SessionHandler) generateSessionTitle(parent context.Context, session *m
 	if err := h.runStore.UpdateTitle(ctx, orgID, session.ID, generated); err != nil {
 		return fmt.Errorf("update title: %w", err)
 	}
-	session.PMApproach = &generated
+	session.Title = &generated
 	return nil
 }
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -239,7 +239,7 @@ func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
 				nil, &now, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil,

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -45,7 +45,7 @@ var sessionColumns = []string{
 	"container_id", "started_at", "completed_at", "token_usage",
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_session_id", "revision_context", "error", "result_summary", "diff",
-	"pm_plan_id", "pm_approach", "pm_reasoning",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
 	"created_at",
@@ -75,7 +75,7 @@ func TestSessionHandler_List(t *testing.T) {
 							nil, &now, &now, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, // project_task_id
 							nil, // model_override
 							nil, // triggered_by_user_id
@@ -152,7 +152,7 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, &now, &now, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
@@ -288,7 +288,7 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil, &now, nil, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, // project_task_id
 							nil, // model_override
 							nil, // triggered_by_user_id
@@ -372,7 +372,7 @@ func triggerFixIssueMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)
@@ -419,7 +419,7 @@ func triggerFixIssueAndOrgDefaultMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)
@@ -994,7 +994,7 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, &now, &now, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
@@ -1075,7 +1075,7 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, &now, &now, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
@@ -1129,7 +1129,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, &now, &now, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
@@ -1147,7 +1147,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, &now, &now, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
@@ -1230,7 +1230,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 				// Mock job enqueue (6 named args)
@@ -1272,7 +1272,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 				// Mock job enqueue
@@ -1370,7 +1370,7 @@ func TestSessionHandler_EndSession_EnqueuesValidation(t *testing.T) {
 				nil, &now, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil, nil, nil, nil,
-				nil, nil, nil,
+				nil, nil, nil, nil,
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
@@ -1515,7 +1515,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, &now, nil, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", nil,
@@ -1548,7 +1548,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, &now, &now, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
@@ -1623,7 +1623,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, &now, nil, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
@@ -1669,7 +1669,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, &now, nil, nil,
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
-							nil, nil, nil,
+							nil, nil, nil, nil,
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
@@ -1822,7 +1822,7 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue
@@ -1832,7 +1832,7 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
 
 	// Mock UpdateTitle call
-	mock.ExpectExec("UPDATE sessions SET pm_approach").
+	mock.ExpectExec("UPDATE sessions SET title").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -1852,8 +1852,8 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 	var resp models.SingleResponse[models.Session]
 	err = json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
-	require.NotNil(t, resp.Data.PMApproach)
-	require.Equal(t, "Fix authentication login flow", *resp.Data.PMApproach)
+	require.NotNil(t, resp.Data.Title)
+	require.Equal(t, "Fix authentication login flow", *resp.Data.Title)
 
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -1900,7 +1900,7 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -20,7 +20,7 @@ var sessionColumns = []string{
 	"container_id", "started_at", "completed_at", "token_usage",
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_session_id", "revision_context", "error", "result_summary", "diff",
-	"pm_plan_id", "pm_approach", "pm_reasoning",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at",
 	"sandbox_state", "snapshot_key",
@@ -34,7 +34,7 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil, nil, nil, json.RawMessage(`{}`),
 		nil, nil, []string{}, nil,
 		nil, json.RawMessage(`{}`), nil, nil, nil,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 		nil, // project_task_id
 		nil, // model_override
 		nil, // triggered_by_user_id

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -251,7 +251,7 @@ func TestSessionStore_Create(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),
@@ -288,7 +288,7 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 		WithArgs(nil, pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -33,7 +33,7 @@ const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-00
 	container_id, started_at, completed_at, token_usage,
 	failure_explanation, failure_category, failure_next_steps, failure_retry_advised,
 	parent_session_id, revision_context, error, result_summary, diff,
-	pm_plan_id, pm_approach, pm_reasoning, project_task_id,
+	pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 	model_override, triggered_by_user_id, agent_session_id, current_turn, last_activity_at,
 	sandbox_state, snapshot_key, created_at`
 
@@ -107,12 +107,12 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 	query := `
 		INSERT INTO sessions (
 			issue_id, org_id, agent_type, status, autonomy_level, token_mode, complexity_tier,
-			parent_session_id, revision_context, pm_plan_id, pm_approach, pm_reasoning, project_task_id,
+			parent_session_id, revision_context, pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 			model_override, triggered_by_user_id
 		)
 		VALUES (
 			@issue_id, @org_id, @agent_type, @status, @autonomy_level, @token_mode, @complexity_tier,
-			@parent_session_id, @revision_context, @pm_plan_id, @pm_approach, @pm_reasoning, @project_task_id,
+			@parent_session_id, @revision_context, @pm_plan_id, @title, @pm_approach, @pm_reasoning, @project_task_id,
 			@model_override, @triggered_by_user_id
 		)
 		RETURNING id, created_at`
@@ -133,6 +133,7 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 		"parent_session_id":     run.ParentSessionID,
 		"revision_context":      run.RevisionContext,
 		"pm_plan_id":            run.PMPlanID,
+		"title":                 run.Title,
 		"pm_approach":           run.PMApproach,
 		"pm_reasoning":          run.PMReasoning,
 		"project_task_id":       run.ProjectTaskID,
@@ -229,11 +230,11 @@ func (s *SessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID
 }
 
 func (s *SessionStore) UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error {
-	query := `UPDATE sessions SET pm_approach = @pm_approach WHERE id = @id AND org_id = @org_id`
+	query := `UPDATE sessions SET title = @title WHERE id = @id AND org_id = @org_id`
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
-		"id":          sessionID,
-		"org_id":      orgID,
-		"pm_approach": title,
+		"id":     sessionID,
+		"org_id": orgID,
+		"title":  title,
 	})
 	return err
 }

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
@@ -111,3 +113,96 @@ func TestSessionStore_UpdateTitle(t *testing.T) {
 	require.NoError(t, err, "UpdateTitle should not return an error")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestSessionStore_CountRunningByOrg(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+
+	mock.ExpectQuery("SELECT count\\(\\*\\) FROM sessions WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(3))
+
+	count, err := store.CountRunningByOrg(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_ListByIDs_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+
+	sessions, err := store.ListByIDs(context.Background(), orgID, []uuid.UUID{})
+	require.NoError(t, err)
+	require.Nil(t, sessions)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_ListByIDs(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ id = ANY").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(sessionID, issueID, orgID, now)...),
+		)
+
+	sessions, err := store.ListByIDs(context.Background(), orgID, []uuid.UUID{sessionID})
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.Equal(t, sessionID, sessions[0].ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_UpdateResult(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	result := &models.SessionResult{
+		TokenUsage:    json.RawMessage(`{"input": 100}`),
+		ResultSummary: stringPtr("Fixed the bug"),
+	}
+
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateResult(context.Background(), orgID, sessionID, "completed", result)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func stringPtr(s string) *string { return &s }

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -91,3 +91,23 @@ func TestSessionStore_ListByOrg_WithoutRepositoryID(t *testing.T) {
 	require.Len(t, sessions, 1, "should return one session")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+func TestSessionStore_UpdateTitle(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectExec("UPDATE sessions SET title").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateTitle(context.Background(), orgID, sessionID, "Fix auth flow")
+	require.NoError(t, err, "UpdateTitle should not return an error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -16,7 +16,7 @@ var sessionTestColumns = []string{
 	"container_id", "started_at", "completed_at", "token_usage",
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_session_id", "revision_context", "error", "result_summary", "diff",
-	"pm_plan_id", "pm_approach", "pm_reasoning",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
 	"created_at",
@@ -29,7 +29,7 @@ func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []in
 		nil, &now, &now, nil,
 		nil, nil, nil, nil,
 		nil, nil, nil, nil, nil,
-		nil, nil, nil,
+		nil, nil, nil, nil,
 		nil, nil, nil,
 		nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 		now,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -127,6 +127,7 @@ type Session struct {
 	ResultSummary        *string         `db:"result_summary" json:"result_summary,omitempty"`
 	Diff                 *string         `db:"diff" json:"diff,omitempty"`
 	PMPlanID             *uuid.UUID      `db:"pm_plan_id" json:"pm_plan_id,omitempty"`
+	Title                *string         `db:"title" json:"title,omitempty"`
 	PMApproach           *string         `db:"pm_approach" json:"pm_approach,omitempty"`
 	PMReasoning          *string         `db:"pm_reasoning" json:"pm_reasoning,omitempty"`
 	ProjectTaskID        *uuid.UUID      `db:"project_task_id" json:"project_task_id,omitempty"`

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -323,7 +323,7 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 				logCh <- agent.LogEntry{
 					Timestamp: time.Now(),
 					Level:     "tool_use",
-					Message:   fmt.Sprintf("using tool: command_execution"),
+					Message:   "using tool: command_execution",
 					Metadata:  metadata,
 				}
 				if event.Item.AggregatedOutput != "" {
@@ -634,7 +634,7 @@ func parseCodexStreamOutput(output []byte, result *agent.AgentResult, logCh chan
 					logCh <- agent.LogEntry{
 						Timestamp: time.Now(),
 						Level:     "tool_use",
-						Message:   fmt.Sprintf("using tool: command_execution"),
+						Message:   "using tool: command_execution",
 						Metadata:  metadata,
 					}
 					if event.Item.AggregatedOutput != "" {

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -31,7 +31,7 @@ var sessionColumns = []string{
 	"container_id", "started_at", "completed_at", "token_usage",
 	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
 	"parent_session_id", "revision_context", "error", "result_summary", "diff",
-	"pm_plan_id", "pm_approach", "pm_reasoning", "project_task_id",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning", "project_task_id",
 	"model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
 	"created_at",
@@ -130,7 +130,7 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 					nil, nil, nil, nil,
 					nil, nil, nil, nil,
 					nil, nil, nil, nil, nil,
-					nil, nil, nil, nil,
+					nil, nil, nil, nil, nil,
 					nil, // model_override
 					nil, // triggered_by_user_id
 					nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key

--- a/internal/services/pm/coverage_boost_test.go
+++ b/internal/services/pm/coverage_boost_test.go
@@ -1135,6 +1135,7 @@ func TestDispatchProjectTasks_TaskWithApproachAndReasoning(t *testing.T) {
 	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, settings, uuid.New())
 	require.Equal(t, 1, dispatched)
 	require.Len(t, sessions.created, 1)
+	require.NotNil(t, sessions.created[0].Title, "session title should be set")
 	require.Equal(t, "my approach", *sessions.created[0].PMApproach)
 	require.Equal(t, "my reasoning", *sessions.created[0].PMReasoning)
 	require.Equal(t, "high", sessions.created[0].TokenMode, "complex should map to high")

--- a/internal/services/pm/execute.go
+++ b/internal/services/pm/execute.go
@@ -61,6 +61,7 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 			AutonomyLevel: string(settings.AutonomyLevel),
 			TokenMode:     tokenModeFromComplexity(task.Complexity),
 			PMPlanID:      &plan.ID,
+			Title:         &task.Title,
 			PMApproach:    &task.Approach,
 			PMReasoning:   &task.Reasoning,
 		}

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -179,6 +179,7 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 			AutonomyLevel: string(settings.AutonomyLevel),
 			TokenMode:     tokenModeFromTaskComplexity(task.Complexity),
 			PMPlanID:      &planID,
+			Title:         &task.Title,
 			PMApproach:    &approach,
 			PMReasoning:   &reasoning,
 			ProjectTaskID: &task.ID,

--- a/internal/services/pm/service_test.go
+++ b/internal/services/pm/service_test.go
@@ -134,6 +134,7 @@ func TestExecutePlan_DelegatesWithinCapacity(t *testing.T) {
 	require.Len(t, runStore.created, 1, "should create one agent run")
 	require.NotNil(t, runStore.created[0].PMPlanID, "created run should link to PM plan")
 	require.Equal(t, planID, *runStore.created[0].PMPlanID, "PM plan ID should be set")
+	require.NotNil(t, runStore.created[0].Title, "session title should be set")
 	require.NotNil(t, runStore.created[0].PMApproach, "PM approach should be set")
 	require.NotNil(t, runStore.created[0].PMReasoning, "PM reasoning should be set")
 }

--- a/migrations/000024_session_title.down.sql
+++ b/migrations/000024_session_title.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions DROP COLUMN title;

--- a/migrations/000024_session_title.up.sql
+++ b/migrations/000024_session_title.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE sessions ADD COLUMN title TEXT;
+
+-- Backfill: copy pm_approach into title for manually created sessions
+-- (those without a PM plan), so existing sessions display correctly.
+UPDATE sessions SET title = pm_approach
+WHERE pm_plan_id IS NULL AND pm_approach IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `title TEXT` column to sessions table for explicit session naming
- Manual sessions use LLM-generated titles, PM-created sessions use task titles
- Separates session naming from `pm_approach` (which stores PM agent guidance)
- Extracts duplicate `sessionTitle()` function to shared `lib/utils.ts`
- Includes migration backfill for existing manually-created sessions

## Test plan
- All existing tests pass with updated column counts and assertions
- New title field displays correctly in session sidebar and detail views
- PM-delegated sessions now have both title and approach metadata