### PR TITLE
Replace turn labels with human-readable timestamps

### DIFF
--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
-import { ChatTimeline } from "./chat-timeline";
+import { describe, expect, it, vi } from "vitest";
+import { ChatTimeline, formatMessageTime } from "./chat-timeline";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
 
@@ -27,6 +27,30 @@ function makeLog(overrides: Partial<SessionLog> & { id: number; level: string })
     ...overrides,
   };
 }
+
+describe("formatMessageTime", () => {
+  it("returns time only for today's date", () => {
+    const now = new Date();
+    const todayISO = now.toISOString();
+    const result = formatMessageTime(todayISO);
+    // Should contain a colon (time) but not a month abbreviation
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+    expect(result).not.toMatch(/Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec/);
+  });
+
+  it("returns date and time for a past date", () => {
+    const result = formatMessageTime("2024-06-15T14:30:00Z");
+    // Should contain both a month and a time
+    expect(result).toMatch(/Jun/);
+    expect(result).toMatch(/15/);
+    expect(result).toMatch(/\d{1,2}:\d{2}/);
+  });
+
+  it("returns empty string for invalid date", () => {
+    expect(formatMessageTime("")).toBe("");
+    expect(formatMessageTime("not-a-date")).toBe("");
+  });
+});
 
 describe("ChatTimeline", () => {
   it("renders message bubbles", () => {

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -6,8 +6,14 @@ import { Badge } from "@/components/ui/badge";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
 
+function safeDate(dateStr: string): Date | null {
+  const d = new Date(dateStr);
+  return isNaN(d.getTime()) ? null : d;
+}
+
 function formatTimestamp(dateStr: string): string {
-  const date = new Date(dateStr);
+  const date = safeDate(dateStr);
+  if (!date) return "";
   return date.toLocaleTimeString("en-US", {
     hour12: false,
     hour: "2-digit",
@@ -133,6 +139,28 @@ function HiddenLogsGroup({ logs }: { logs: SessionLog[] }) {
   );
 }
 
+export function formatMessageTime(dateStr: string): string {
+  const date = safeDate(dateStr);
+  if (!date) return "";
+  const now = new Date();
+  const isToday =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (isToday) {
+    return date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
 function MessageBubble({ msg }: { msg: SessionMessage }) {
   return (
     <div className={`flex ${msg.role === "user" ? "justify-end" : "justify-start"}`}>
@@ -151,7 +179,7 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
               : "text-muted-foreground"
           }`}
         >
-          Turn {msg.turn_number}
+          {formatMessageTime(msg.created_at)}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Replace 'Turn 0' / 'Turn N' labels on message bubbles with smart timestamps.

**Today's messages** show time only (e.g. '11:59 PM'), while **older messages** show date and time (e.g. 'Mar 18, 11:59 PM') — matching the pattern users expect from chat apps like iMessage and Slack.

Adds defensive date parsing to gracefully handle invalid timestamps. Includes unit tests for the new formatMessageTime function.