### PR TITLE
Remove redundant Terminal icon from session log entries

### DIFF
--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, AlertTriangle, Terminal, Wrench } from "lucide-react";
+import { ChevronRight, AlertTriangle, Wrench } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
@@ -111,7 +111,6 @@ function HiddenLogsGroup({ logs }: { logs: SessionLog[] }) {
         className="flex items-center gap-2 w-full text-left py-1.5 px-2 rounded-md hover:bg-muted/50 transition-colors text-xs group"
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-150 ${open ? "rotate-90" : ""}`} />
-        <Terminal className="h-3 w-3 text-muted-foreground shrink-0" />
         <span className="text-muted-foreground">
           {logs.length} log {logs.length === 1 ? "entry" : "entries"}
         </span>


### PR DESCRIPTION
## Summary

Remove the Terminal icon from hidden log entries that was visually combining with the ChevronRight to create a double-caret appearance.

## Details

The Terminal icon (`>_`) was appearing directly next to the disclosure ChevronRight (`>`), creating redundant visual affordance. The chevron alone is sufficient to indicate the collapsible disclosure, and the "N log entries" label is clear enough without the icon.

This cleans up the UI while maintaining the same functionality.