### PR TITLE
Fix frontend tests by mocking useSearchParams

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -9,6 +9,7 @@ const pushMock = vi.fn();
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 describe('ManualSessionCreatePage', () => {


### PR DESCRIPTION
## Summary
Fixed 8 failing tests in sessions/new/page.test.tsx by adding the missing `useSearchParams` export to the `next/navigation` mock.

## Test Status
All tests now pass. The tests were failing because NuqsTestingAdapter requires `useSearchParams` from next/navigation, but the test mock only exported `useRouter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)