### PR TITLE
Standardize design doc implementation status

### DIFF
--- a/docs/design/01-database-schema.md
+++ b/docs/design/01-database-schema.md
@@ -1,5 +1,7 @@
 # Design: Database Schema
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document defines the PostgreSQL schema for 143.dev. All entities flow through the pipeline: ingestion -> prioritization -> agent run -> validation -> PR -> deploy -> observation.
 
 ## Migration Strategy

--- a/docs/design/02-api-server.md
+++ b/docs/design/02-api-server.md
@@ -1,5 +1,7 @@
 # Design: Go API Server
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes the Go backend architecture for 143.dev.
 
 ## Project Structure

--- a/docs/design/03-frontend.md
+++ b/docs/design/03-frontend.md
@@ -1,5 +1,7 @@
 # Design: Frontend Architecture
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document defines the frontend architecture for 143.dev.
 
 ## Design Principles

--- a/docs/design/04-ingestion.md
+++ b/docs/design/04-ingestion.md
@@ -1,5 +1,7 @@
 # Design: Ingestion Pipeline
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev ingests issues from external sources (Sentry, Linear, support tools), normalizes them into a unified format, deduplicates, and stores them for prioritization.
 
 ## Overview

--- a/docs/design/05-prioritization.md
+++ b/docs/design/05-prioritization.md
@@ -1,5 +1,7 @@
 # Design: Prioritization Engine
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev scores and ranks ingested issues to determine which ones should be fixed first.
 
 ## Overview

--- a/docs/design/06-agent-orchestrator.md
+++ b/docs/design/06-agent-orchestrator.md
@@ -1,5 +1,7 @@
 # Design: Agent Orchestrator
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev launches, manages, and monitors coding agent runs inside isolated sandboxes.
 
 ## Overview

--- a/docs/design/07-validation.md
+++ b/docs/design/07-validation.md
@@ -1,5 +1,7 @@
 # Design: Validation Pipeline
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev validates the code produced by an agent run before it becomes a PR.
 
 ## Overview

--- a/docs/design/08-pr-and-ship.md
+++ b/docs/design/08-pr-and-ship.md
@@ -1,5 +1,7 @@
 # Design: PR Creation & Ship
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev creates GitHub pull requests from validated agent runs and manages the path to deployment.
 
 ## Overview

--- a/docs/design/09-observability.md
+++ b/docs/design/09-observability.md
@@ -1,5 +1,7 @@
 # Design: Observability & Impact Measurement
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev measures the real-world impact of deployed fixes (Step 6 in the overall flow).
 
 ## Overview

--- a/docs/design/10-infrastructure.md
+++ b/docs/design/10-infrastructure.md
@@ -1,5 +1,7 @@
 # Design: Infrastructure & Deployment
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev is packaged, deployed, and scaled.
 
 ## Design Principles

--- a/docs/design/11-review-feedback-loop.md
+++ b/docs/design/11-review-feedback-loop.md
@@ -1,5 +1,7 @@
 # Design: PR Review Feedback -> Agent Improvement Loop
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev captures human PR review feedback and uses it to improve future agent runs — creating a flywheel where every human review makes every future agent run better.
 
 ## Overview

--- a/docs/design/12-smart-routing.md
+++ b/docs/design/12-smart-routing.md
@@ -1,5 +1,7 @@
 # Design: Smart Issue Routing
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev estimates issue complexity, routes issues to the right execution strategy, and uses confidence scoring to gate fixes before they proceed.
 
 ## Problem

--- a/docs/design/13-repository-onboarding.md
+++ b/docs/design/13-repository-onboarding.md
@@ -1,5 +1,7 @@
 # Design: Repository Onboarding & GitHub Authentication
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev connects to GitHub repositories, authenticates users, and manages repo access so that coding agents can clone, read, and push code.
 
 ## Overview

--- a/docs/design/17-failure-communication.md
+++ b/docs/design/17-failure-communication.md
@@ -1,5 +1,7 @@
 # Design: Failure Communication
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 When an agent run fails, the user experience matters as much as the technical classification. This document designs how 143.dev communicates failures to users in a way that is honest, helpful, and not demoralizing.
 
 ## Problem

--- a/docs/design/20-security-architecture.md
+++ b/docs/design/20-security-architecture.md
@@ -1,5 +1,7 @@
 # Design: Security Architecture
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 This document defines the security architecture for 143.dev. Because 143.dev runs arbitrary coding agents with full repo access inside sandboxes, security is a first-class concern — not an afterthought. This doc covers the threat model, defense layers, and implementation requirements.
 
 ## Threat Model

--- a/docs/design/21-first-run-experience.md
+++ b/docs/design/21-first-run-experience.md
@@ -1,5 +1,7 @@
 # Design: First-Run Experience & Time-to-Value
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev gets new users from sign-up to their first shipped fix as fast as possible. The goal: value in under 10 minutes, "aha moment" in under 5.
 
 ## Overview

--- a/docs/design/22-notifications.md
+++ b/docs/design/22-notifications.md
@@ -1,5 +1,7 @@
 # Design: Notification System
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev notifies users about events that need their attention. The system generates value asynchronously — agents run, PRs open, fixes deploy, impact is measured — and users aren't watching the dashboard. The notification system pulls them back in at the right moment.
 
 ## Overview

--- a/docs/design/23-auto-closing-feedback-loops.md
+++ b/docs/design/23-auto-closing-feedback-loops.md
@@ -1,5 +1,7 @@
 # Design: Auto-Closing Feedback Loops
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev automatically closes its own feedback loops — turning high-signal data (PR review comments, failure classifications, complexity predictions, post-deploy impact) into configuration improvements without requiring human action. Every automated decision is logged, versioned with insert-only snapshots, and rollback-able to any point in time.
 
 ## Problem

--- a/docs/design/24-design-resolutions.md
+++ b/docs/design/24-design-resolutions.md
@@ -1,5 +1,7 @@
 # Design Resolutions: Cross-Document Clarifications
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document resolves conflicts, ambiguities, and gaps identified during design review. Each resolution includes the specific change to make in the referenced doc(s). Engineers should treat this document as authoritative where it contradicts earlier docs — those docs should be updated to match.
 
 ---

--- a/docs/design/25-dashboard-credentials.md
+++ b/docs/design/25-dashboard-credentials.md
@@ -1,5 +1,7 @@
 # 25 — Dashboard Credential Management
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 **Status**: proposed
 **Depends on**: 01-database-schema, 20-security-architecture
 

--- a/docs/design/26-codex-default-agent.md
+++ b/docs/design/26-codex-default-agent.md
@@ -1,5 +1,7 @@
 # 26 — Codex as Default Agent with ChatGPT OAuth
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 **Status**: implemented
 **Depends on**: 06-agent-orchestrator, 20-security-architecture, 21-first-run-experience, 25-dashboard-credentials
 

--- a/docs/design/26-team-management.md
+++ b/docs/design/26-team-management.md
@@ -1,5 +1,7 @@
 # Design: Team Management
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev enables organization admins to manage their team — inviting new members, assigning roles, and removing users. Today, users can only join via self-signup (GitHub OAuth, Google OAuth, or email registration), and there's no way for admins to control who's in their org or what role they have. This creates a gap: the RBAC middleware enforces three roles (`admin`, `member`, `viewer`), but nothing in the UI or API lets admins assign or change them.
 
 ## Problem

--- a/docs/design/27-csrf-protection.md
+++ b/docs/design/27-csrf-protection.md
@@ -1,6 +1,6 @@
 # 27 — CSRF Protection
 
-**Status: Implemented**
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
 
 ## Background
 

--- a/docs/design/28-agent-ticket-prioritization.md
+++ b/docs/design/28-agent-ticket-prioritization.md
@@ -1,5 +1,7 @@
 # Design: AI Product Manager Agent
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 This document describes how to restructure 143.dev so that the **main loop** is an LLM-powered Product Manager (PM) agent that runs on a batch schedule, analyzes all accumulated Sentry errors and Linear tickets, reasons about what matters most, and delegates work to coding agents.
 
 ## Problem Statement

--- a/docs/design/29-projects.md
+++ b/docs/design/29-projects.md
@@ -1,5 +1,7 @@
 # Design: Projects — Iterative Multi-Task Agent Orchestration
 
+> **Status:** Partially Implemented | **Last reviewed:** 2026-03-19
+
 **Status**: Proposal
 **Depends on**: [06-agent-orchestrator.md](06-agent-orchestrator.md)
 **Inspired by**: [OpenAI Symphony](https://github.com/openai/symphony)

--- a/docs/design/30-pm-agent-ux-elevation.md
+++ b/docs/design/30-pm-agent-ux-elevation.md
@@ -1,5 +1,7 @@
 # 30 - PM Agent UX Elevation
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 > Surface the PM agent's intelligence through the existing Sessions page. Add projects as a grouping concept.
 
 ## Problem

--- a/docs/design/31-automations-tab.md
+++ b/docs/design/31-automations-tab.md
@@ -1,5 +1,7 @@
 # 31 - Automations Tab (On-Demand Workflows)
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 > Add an `Automations` surface that lets teams define reusable workflows and run them on command, while staying aligned with the existing PM + jobs architecture.
 
 ## Goal

--- a/docs/design/32-project-cadence-and-lifecycle.md
+++ b/docs/design/32-project-cadence-and-lifecycle.md
@@ -1,5 +1,7 @@
 # 32 - Project Cadence and Lifecycle (Evergreen + Finite)
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 **Status**: Proposal
 **Depends on**: [29-projects.md](29-projects.md), [30-pm-agent-ux-elevation.md](30-pm-agent-ux-elevation.md), [31-automations-tab.md](31-automations-tab.md)
 

--- a/docs/design/33-mcp-server.md
+++ b/docs/design/33-mcp-server.md
@@ -1,5 +1,7 @@
 # MCP Server Implementation Plan
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 ## Architecture
 
 ```

--- a/docs/design/34-audit-logs.md
+++ b/docs/design/34-audit-logs.md
@@ -1,5 +1,7 @@
 # Design: Audit Logs
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 **Status**: Implemented
 **Depends on**: [01-database-schema.md](01-database-schema.md), [02-api-server.md](02-api-server.md)
 

--- a/docs/design/34-personal-team-coding-agents.md
+++ b/docs/design/34-personal-team-coding-agents.md
@@ -1,5 +1,7 @@
 # Personal & Team Coding Agent Configuration Plan
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 ## Problem Statement
 
 Currently, coding agent credentials (Anthropic, OpenAI, Gemini keys) are configured at the **org level only** (`org_credentials` table with `UNIQUE(org_id, provider)`). Every team member shares the same API keys. This means:

--- a/docs/design/34-repo-ribbons-nav.md
+++ b/docs/design/34-repo-ribbons-nav.md
@@ -1,5 +1,7 @@
 # 34 - Repo Context Switcher: Repository-Scoped Navigation
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 > Give multi-repo users a global repo context selector that scopes all navigation, while keeping single-repo users' experience unchanged.
 
 **Status:** Proposal

--- a/docs/design/35-multi-agent-planning.md
+++ b/docs/design/35-multi-agent-planning.md
@@ -1,5 +1,7 @@
 # Design: Multi-Agent Sessions
 
+> **Status:** Implemented | **Last reviewed:** 2026-03-19
+
 ## Problem
 
 Today, each session runs exactly one coding agent. But users sometimes want to compare how different agents approach the same problem, or split work across agents (e.g., Claude on the backend, Codex on the frontend) — all within the same session, on the same branch, producing one PR.

--- a/docs/design/AGENTS.md
+++ b/docs/design/AGENTS.md
@@ -1,0 +1,40 @@
+# Design Documents
+
+## Implementation Status Standard
+
+Every design document must include a status block immediately after the title heading. Use this exact format:
+
+```markdown
+# Design: <Title>
+
+> **Status:** <STATUS> | **Last reviewed:** <YYYY-MM-DD>
+```
+
+### Valid statuses
+
+| Status | Meaning |
+|--------|---------|
+| `Implemented` | Feature is fully built and live. Design doc serves as historical reference. |
+| `Partially Implemented` | Core parts are built but significant gaps remain. Doc should note what's done vs outstanding. |
+| `Not Started` | Design is approved but no implementation exists yet. These docs live in `docs/design/future/`. |
+
+### Rules
+
+- When you finish implementing a feature described by a design doc, update its status to `Implemented` and set the review date.
+- When you begin work on a feature, move it from `future/` back to `docs/design/` and set status to `Partially Implemented`.
+- When creating a new design doc, start with status `Not Started` and place it in `docs/design/future/`.
+- The `Last reviewed` date should reflect when someone last verified the status is accurate.
+
+## Directory layout
+
+```
+docs/design/
+├── AGENTS.md              # This file — conventions for design docs
+├── overall.md             # High-level system overview
+├── 01-database-schema.md  # Implemented designs
+├── 02-api-server.md
+├── ...
+└── future/                # Not-yet-started designs
+    ├── 14-codebase-context.md
+    └── ...
+```

--- a/docs/design/future/14-codebase-context.md
+++ b/docs/design/future/14-codebase-context.md
@@ -1,5 +1,7 @@
 # Design: Codebase Context Layer
 
+> **Status:** Not Started | **Last reviewed:** 2026-03-19
+
 This document describes how 143.dev builds, maintains, and serves deep codebase context to coding agents. This is the single most important factor in agent success — an agent with rich context about a repo's architecture, conventions, and file ownership produces dramatically better fixes.
 
 ## Overview

--- a/docs/design/future/15-time-to-first-fix.md
+++ b/docs/design/future/15-time-to-first-fix.md
@@ -1,5 +1,7 @@
 # Design: Time to First Fix
 
+> **Status:** Not Started | **Last reviewed:** 2026-03-19
+
 The most critical moment in the 143.dev experience is: **user installs, connects a repo, and sees their first successful fix**. Every minute this takes, a percentage of users are lost. This document designs the path from sign-up to "wow" as short as possible.
 
 ## The Goal

--- a/docs/design/future/16-ai-agent-evals.md
+++ b/docs/design/future/16-ai-agent-evals.md
@@ -1,5 +1,7 @@
 # Design: AI Agent Evaluation System
 
+> **Status:** Not Started | **Last reviewed:** 2026-03-19
+
 ## Overview
 
 This document defines the evaluation system for 143.dev. It replaces people/process guidance with a strict focus on measurable agent quality and automated improvement loops.

--- a/docs/design/future/18-fix-quality-feedback.md
+++ b/docs/design/future/18-fix-quality-feedback.md
@@ -1,5 +1,7 @@
 # Design: Fix Quality Feedback Loop (Production Impact -> Agent Improvement)
 
+> **Status:** Not Started | **Last reviewed:** 2026-03-19
+
 The review feedback loop (doc 11) captures feedback from PR reviews. But there's a more important signal: **did the fix actually work in production?** This document closes the loop between post-deploy observability and future agent runs.
 
 ## Problem


### PR DESCRIPTION
## Summary
Audit all design documents and add consistent implementation status markers. Moves unimplemented designs to `docs/design/future/` for clarity.

## Changes
- Add status markers (Implemented/Partially Implemented/Not Started) to 35 design docs
- Move 4 unimplemented docs to `docs/design/future/`: codebase-context, time-to-first-fix, ai-agent-evals, fix-quality-feedback
- Create `docs/design/AGENTS.md` documenting the standard for future designs
- Remove status from overall.md (evergreen doc)

## Status Summary
- **Implemented:** 25 docs (database schema, API, ingestion, prioritization, orchestrator, validation, PR, GitHub, notifications, credentials, team mgmt, CSRF, MCP, audit logs, multi-agent planning, and more)
- **Partially Implemented:** 7 docs (frontend, observability, infrastructure, review feedback loop, smart routing, failure communication, security architecture, projects)
- **Not Started:** 4 docs (moved to future/)