### PR TITLE
Use 12-hour time format for hidden log timestamps

### DIFF
--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -16,10 +16,8 @@ function formatTimestamp(dateStr: string): string {
   const date = safeDate(dateStr);
   if (!date) return "";
   return date.toLocaleTimeString("en-US", {
-    hour12: false,
-    hour: "2-digit",
+    hour: "numeric",
     minute: "2-digit",
-    second: "2-digit",
   });
 }
 


### PR DESCRIPTION
Updates the hidden log timestamp display to match user message formatting. Changes from 24-hour format with seconds (e.g., 22:11:17) to 12-hour AM/PM format (e.g., 10:11 PM), removing seconds for consistency.

🤖 Generated with Claude Code