### PR TITLE
Remove bottom gap on sessions and project pages

### DIFF
--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -223,9 +223,9 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           )}
         </div>
       </aside>
-      <main className="flex-1 overflow-auto bg-background relative">
+      <main className="flex-1 overflow-auto bg-background relative flex flex-col">
         <div className="pointer-events-none fixed inset-0 bg-[radial-gradient(ellipse_at_top_right,oklch(0.6_0.1_270_/_3%)_0%,transparent_50%)]" />
-        <div className="relative max-w-none px-8 py-6 lg:px-10">
+        <div className="relative max-w-none px-8 py-6 lg:px-10 flex-1">
           {children}
         </div>
       </main>

--- a/frontend/src/components/sidebar-layout.tsx
+++ b/frontend/src/components/sidebar-layout.tsx
@@ -20,7 +20,7 @@ export function SidebarLayout({ sidebar, children }: SidebarLayoutProps) {
   }, []);
 
   return (
-    <div className="flex h-[calc(100vh-theme(spacing.6)*2)] -mx-8 -my-6 lg:-mx-10">
+    <div className="flex h-full -mx-8 -my-6 lg:-mx-10">
       <div style={{ width: sidebarWidth }} className="shrink-0">
         {sidebar}
       </div>


### PR DESCRIPTION
Fixed the layout gap at the bottom of sessions and project pages by replacing the brittle viewport-based height calculation with proper flex-based layout. The SidebarLayout now uses `h-full` to fill available space, and the content wrapper uses `flex-1` to properly distribute vertical space without leaving gaps.