### PR TITLE
Allow resuming completed and terminal sessions with follow-up messages

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -126,7 +126,7 @@ func main() {
 		go w.Start(ctx)
 		logger.Info().Msg("worker started with registered handlers")
 
-		reaper := agent.NewSessionReaper(sessionStore, snapshotStore, cfg.SessionMaxIdleAge, cfg.SessionReaperInterval, logger)
+		reaper := agent.NewSessionReaper(sessionStore, snapshotStore, cfg.SessionMaxIdleAge, cfg.SessionMaxSnapshotAge, cfg.SessionReaperInterval, logger)
 		go reaper.Run(ctx)
 
 		scheduler := cluster.NewScheduler(

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -403,6 +403,11 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
 
   const isIdle = session.status === "idle";
   const isRunning = session.status === "running";
+  const isCompleted = session.status === "completed";
+  const isPrCreated = session.status === "pr_created";
+  const isFailed = session.status === "failed";
+  const isCancelled = session.status === "cancelled";
+  const canSendMessage = isIdle || isCompleted || isPrCreated || isFailed || isCancelled;
 
   const { data: messagesData } = useQuery({
     queryKey: ["session", sessionId, "messages"],
@@ -569,7 +574,7 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (message.trim() && isIdle && !sendMutation.isPending) {
+      if (message.trim() && canSendMessage && !sendMutation.isPending) {
         sendMutation.mutate();
       }
     }
@@ -603,8 +608,8 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={isIdle ? "Send a follow-up message..." : isRunning ? "Agent is working..." : "Session is not active"}
-            disabled={!isIdle || sendMutation.isPending}
+            placeholder={canSendMessage ? "Send a follow-up message..." : isRunning ? "Agent is working..." : "Session is not active"}
+            disabled={!canSendMessage || sendMutation.isPending}
             className="min-h-[44px] max-h-[200px] resize-none"
           />
           <div className="flex flex-col gap-1">
@@ -612,7 +617,7 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
               size="icon"
               variant="default"
               className="h-8 w-8 shrink-0"
-              disabled={!message.trim() || !isIdle || sendMutation.isPending}
+              disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
               onClick={() => sendMutation.mutate()}
             >
               <ArrowUp className="h-4 w-4" />

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -407,6 +407,8 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
   const isPrCreated = session.status === "pr_created";
   const isFailed = session.status === "failed";
   const isCancelled = session.status === "cancelled";
+  // "skipped" sessions are intentionally excluded — they were never run,
+  // so there is no workspace state or context to resume from.
   const canSendMessage = isIdle || isCompleted || isPrCreated || isFailed || isCancelled;
 
   const { data: messagesData } = useQuery({

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -524,14 +524,21 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Try claiming an idle session first, then fall back to resuming a
+	// terminal session (completed/pr_created/failed/cancelled).
+	var resumed bool
 	session, err := h.runStore.ClaimIdle(r.Context(), orgID, sessionID)
 	if err != nil {
-		if _, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID); lookupErr != nil {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+		session, err = h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
+		if err != nil {
+			if _, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID); lookupErr != nil {
+				writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+				return
+			}
+			writeError(w, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or completed to send a message")
 			return
 		}
-		writeError(w, http.StatusConflict, "NOT_IDLE", "session must be idle to send a message")
-		return
+		resumed = true
 	}
 
 	user := middleware.UserFromContext(r.Context())
@@ -552,9 +559,15 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		msg.Attachments = body.Images
 	}
 
+	// On failure, revert to the original status.
+	revertStatus := string(models.SessionStatusIdle)
+	if resumed {
+		revertStatus = string(models.SessionStatusCompleted)
+	}
+
 	if err := h.messageStore.Create(r.Context(), msg); err != nil {
-		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, string(models.SessionStatusIdle)); revertErr != nil {
-			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session to idle after message creation failure")
+		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, revertStatus); revertErr != nil {
+			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session status after message creation failure")
 		}
 		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message")
 		return
@@ -566,8 +579,8 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		"org_id":     orgID.String(),
 	}
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "continue_session", payload, 5, nil); err != nil {
-		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, string(models.SessionStatusIdle)); revertErr != nil {
-			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session to idle after enqueue failure")
+		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, revertStatus); revertErr != nil {
+			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session status after enqueue failure")
 		}
 		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job")
 		return

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -526,19 +526,23 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 
 	// Try claiming an idle session first, then fall back to resuming a
 	// terminal session (completed/pr_created/failed/cancelled).
-	var resumed bool
+	var revertStatus string
 	session, err := h.runStore.ClaimIdle(r.Context(), orgID, sessionID)
 	if err != nil {
+		// Look up the session to capture its current status for revert.
+		existing, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID)
+		if lookupErr != nil {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+			return
+		}
 		session, err = h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
 		if err != nil {
-			if _, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID); lookupErr != nil {
-				writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
-				return
-			}
 			writeError(w, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or completed to send a message")
 			return
 		}
-		resumed = true
+		revertStatus = existing.Status // preserve original status for revert
+	} else {
+		revertStatus = string(models.SessionStatusIdle)
 	}
 
 	user := middleware.UserFromContext(r.Context())
@@ -557,12 +561,6 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(body.Images) > 0 {
 		msg.Attachments = body.Images
-	}
-
-	// On failure, revert to the original status.
-	revertStatus := string(models.SessionStatusIdle)
-	if resumed {
-		revertStatus = string(models.SessionStatusCompleted)
 	}
 
 	if err := h.messageStore.Create(r.Context(), msg); err != nil {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1821,7 +1821,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 					)
 				// Create message.
 				mock.ExpectQuery("INSERT INTO session_messages").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
 				// Enqueue job.
 				mock.ExpectQuery("INSERT INTO jobs").

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1745,11 +1745,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// ClaimForResume also fails (no row returned).
-				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// Fallback lookup.
+				// GetByID lookup (to capture original status for revert).
 				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
@@ -1768,6 +1764,10 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							now,
 						),
 					)
+				// ClaimForResume also fails (no row returned).
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionColumns))
 			},
 			expectedCode: http.StatusConflict,
 			expectedBody: "NOT_RESUMABLE",
@@ -1781,6 +1781,24 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
+				// GetByID lookup (to capture original status for revert).
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "completed", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
+							nil, // target_branch
+							now,
+						),
+					)
 				// ClaimForResume succeeds.
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1796,6 +1796,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
 							nil, // target_branch
+							nil, // working_branch
 							now,
 						),
 					)
@@ -1814,6 +1815,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
 							nil, // target_branch
+							nil, // working_branch
 							now,
 						),
 					)

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1737,11 +1737,15 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			expectedBody: "MISSING_MESSAGE",
 		},
 		{
-			name: "rejects when session is not idle",
+			name: "rejects when session is not idle or resumable",
 			body: `{"message":"More work"}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
 				now := time.Now()
 				// ClaimIdle fails (no row returned).
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionColumns))
+				// ClaimForResume also fails (no row returned).
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
@@ -1766,7 +1770,46 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 					)
 			},
 			expectedCode: http.StatusConflict,
-			expectedBody: "NOT_IDLE",
+			expectedBody: "NOT_RESUMABLE",
+		},
+		{
+			name: "sends message to completed session via ClaimForResume",
+			body: `{"message":"Continue working on this"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				now := time.Now()
+				// ClaimIdle fails (no row returned).
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionColumns))
+				// ClaimForResume succeeds.
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
+							nil, // target_branch
+							now,
+						),
+					)
+				// Create message.
+				mock.ExpectQuery("INSERT INTO session_messages").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+				// Enqueue job.
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+			},
+			expectedCode: http.StatusCreated,
+			expectedBody: "Continue working on this",
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	SnapshotStorageDir    string        `env:"SNAPSHOT_STORAGE_DIR"    envDefault:".data/snapshots"`
 	SessionMaxIdleAge     time.Duration `env:"SESSION_MAX_IDLE_AGE"    envDefault:"2h"`
 	SessionReaperInterval time.Duration `env:"SESSION_REAPER_INTERVAL" envDefault:"5m"`
+	SessionMaxSnapshotAge time.Duration `env:"SESSION_MAX_SNAPSHOT_AGE" envDefault:"720h"` // 30 days
 }
 
 // Load reads configuration from env files and environment variables.

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -210,6 +210,26 @@ func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
 }
 
+// ClaimForResume atomically transitions a terminal session to running so it
+// can be resumed with a follow-up message. Used when a user sends a message
+// to a completed/failed/cancelled/pr_created session.
+func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
+	query := `
+		UPDATE sessions
+		SET status = 'running', completed_at = NULL
+		WHERE id = @id AND org_id = @org_id AND status IN ('completed', 'pr_created', 'failed', 'cancelled')
+		RETURNING ` + sessionSelectColumns
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	})
+	if err != nil {
+		return models.Session{}, fmt.Errorf("claim terminal session for resume: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+}
+
 func (s *SessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error {
 	query := `
 		UPDATE sessions
@@ -376,18 +396,15 @@ func (s *SessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessionID
 	return err
 }
 
-// ListStaleSessions returns sessions whose snapshots should be cleaned up:
-// idle sessions that have been inactive too long, OR completed/failed sessions
-// that still have snapshots (e.g. after EndSession or normal completion).
-func (s *SessionStore) ListStaleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error) {
+// ListStaleIdleSessions returns idle sessions that have been inactive longer
+// than the idle timeout. These sessions should be transitioned to completed
+// but their snapshots are preserved for later resumption.
+func (s *SessionStore) ListStaleIdleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error) {
 	query := `
 		SELECT ` + sessionSelectColumns + `
 		FROM sessions
-		WHERE sandbox_state = 'snapshotted'
-		  AND (
-		    (status = 'idle' AND last_activity_at < @older_than)
-		    OR status IN ('completed', 'failed', 'cancelled')
-		  )
+		WHERE status = 'idle'
+		  AND last_activity_at < @older_than
 		ORDER BY last_activity_at ASC NULLS FIRST
 		LIMIT 100`
 
@@ -395,7 +412,28 @@ func (s *SessionStore) ListStaleSessions(ctx context.Context, olderThan time.Tim
 		"older_than": olderThan,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("query stale sessions: %w", err)
+		return nil, fmt.Errorf("query stale idle sessions: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
+}
+
+// ListExpiredSnapshots returns non-active sessions whose snapshots have
+// exceeded the maximum snapshot age and should be cleaned up from storage.
+func (s *SessionStore) ListExpiredSnapshots(ctx context.Context, olderThan time.Time) ([]models.Session, error) {
+	query := `
+		SELECT ` + sessionSelectColumns + `
+		FROM sessions
+		WHERE sandbox_state = 'snapshotted'
+		  AND last_activity_at < @older_than
+		  AND status NOT IN ('running', 'idle')
+		ORDER BY last_activity_at ASC NULLS FIRST
+		LIMIT 100`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"older_than": olderThan,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query expired snapshots: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
 }

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -799,11 +799,11 @@ func (o *Orchestrator) buildResumeContext(session *models.Session, issue *models
 
 	// Include the original issue description for context (especially
 	// important for non-manual sessions that may have no prior messages).
-	if issue != nil && issue.Description != "" {
+	if issue != nil && issue.Description != nil && *issue.Description != "" {
 		b.WriteString("## Original issue\n\n**")
 		b.WriteString(issue.Title)
 		b.WriteString("**\n\n")
-		b.WriteString(issue.Description)
+		b.WriteString(*issue.Description)
 		b.WriteString("\n\n")
 	}
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -653,18 +653,41 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		// reconstruct the prior state.
 		log.Info().Msg("continuing session without snapshot, starting fresh")
 
-		if err := o.setupFreshSandbox(ctx, session, sandbox); err != nil {
+		issue, repoFullName, err := o.setupFreshSandbox(ctx, session, sandbox)
+		if err != nil {
 			o.failRun(ctx, session, fmt.Sprintf("setup fresh sandbox: %s", err))
 			return fmt.Errorf("setup fresh sandbox: %w", err)
 		}
 
-		// Build a prompt that includes conversation history and the stored diff.
-		enrichedMessage := o.buildResumeContext(session, messages, userMessage)
-		prompt = &AgentPrompt{
-			Continuation: false,
-			UserMessage:  enrichedMessage,
-			MaxTokens:    tokenLimitForMode(session.TokenMode),
+		// Build a full prompt via PreparePrompt so the agent gets the system
+		// prompt with integration skills, memory, and repo conventions.
+		input := &AgentInput{
+			Issue:     &issue,
+			TokenMode: session.TokenMode,
 		}
+		input.IntegrationSkills = o.buildIntegrationSkills(ctx, session.OrgID)
+		if o.memory != nil && repoFullName != "" {
+			memResult, memErr := o.memory.GetContextMemories(ctx, MemoryContextRequest{
+				OrgID: session.OrgID,
+				Repo:  repoFullName,
+			})
+			if memErr != nil {
+				log.Warn().Err(memErr).Str("repo", repoFullName).Msg("failed to retrieve memories for resume context")
+			} else if memResult != nil && memResult.Formatted != "" {
+				input.ContextDocs = append(input.ContextDocs, memResult.Formatted)
+			}
+		}
+
+		basePrompt, err := adapter.PreparePrompt(ctx, input)
+		if err != nil {
+			o.failRun(ctx, session, fmt.Sprintf("prepare prompt for resume: %s", err))
+			return fmt.Errorf("prepare prompt for resume: %w", err)
+		}
+
+		// Override UserPrompt with resume context (conversation history + diff).
+		basePrompt.UserPrompt = o.buildResumeContext(session, &issue, messages, userMessage)
+		basePrompt.Continuation = false
+		prompt = basePrompt
 	}
 
 	// 6. Execute agent with log streaming.
@@ -716,30 +739,33 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 }
 
 // setupFreshSandbox clones the session's repository into the sandbox when no
-// snapshot is available. Handles sessions with or without a repository.
-func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Session, sandbox *Sandbox) error {
+// snapshot is available. Returns the issue (for prompt building) and the repo
+// full name (for memory lookup). Handles sessions with or without a repository.
+func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Session, sandbox *Sandbox) (models.Issue, string, error) {
 	// Fetch the issue to get repository info.
 	issue, err := o.issues.GetByID(ctx, session.OrgID, session.IssueID)
 	if err != nil {
-		return fmt.Errorf("fetch issue: %w", err)
+		return models.Issue{}, "", fmt.Errorf("fetch issue: %w", err)
 	}
 
 	// Clone repo if the session has one.
+	var repoFullName string
 	if issue.RepositoryID != nil {
 		repo, err := o.repositories.GetByID(ctx, session.OrgID, *issue.RepositoryID)
 		if err != nil {
-			return fmt.Errorf("fetch repository: %w", err)
+			return models.Issue{}, "", fmt.Errorf("fetch repository: %w", err)
 		}
+		repoFullName = repo.FullName
 		branch := repo.DefaultBranch
 		if session.TargetBranch != nil && *session.TargetBranch != "" {
 			branch = *session.TargetBranch
 		}
 		token, err := o.github.GetInstallationToken(ctx, repo.InstallationID)
 		if err != nil {
-			return fmt.Errorf("get installation token: %w", err)
+			return models.Issue{}, "", fmt.Errorf("get installation token: %w", err)
 		}
 		if err := o.provider.CloneRepo(ctx, sandbox, repo.CloneURL, branch, token); err != nil {
-			return fmt.Errorf("clone repo: %w", err)
+			return models.Issue{}, "", fmt.Errorf("clone repo: %w", err)
 		}
 	}
 
@@ -747,23 +773,39 @@ func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Se
 	if session.AgentType == models.AgentTypeCodex {
 		injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
 		if err != nil {
-			return fmt.Errorf("codex auth injection: %w", err)
+			return models.Issue{}, "", fmt.Errorf("codex auth injection: %w", err)
 		}
 		if !injected {
-			return fmt.Errorf("no credentials for codex agent")
+			return models.Issue{}, "", fmt.Errorf("no credentials for codex agent")
 		}
 	}
 
-	return nil
+	return issue, repoFullName, nil
 }
 
-// buildResumeContext constructs the user message for a resumed session that
-// has no snapshot. It includes conversation history and the stored diff so
-// the agent understands the prior state and can re-apply changes.
-func (o *Orchestrator) buildResumeContext(session *models.Session, messages []models.SessionMessage, latestUserMessage string) string {
+// maxDiffCharsInPrompt is the maximum number of characters from a stored diff
+// to include in a resume prompt. Larger diffs are truncated to avoid blowing
+// up the agent's token budget.
+const maxDiffCharsInPrompt = 50000
+
+// buildResumeContext constructs the user prompt for a resumed session that has
+// no snapshot. It includes the issue description, conversation history, and
+// the stored diff so the agent understands the prior state and can re-apply
+// changes.
+func (o *Orchestrator) buildResumeContext(session *models.Session, issue *models.Issue, messages []models.SessionMessage, latestUserMessage string) string {
 	var b bytes.Buffer
 
 	b.WriteString("This is a continuation of a previous session. The previous workspace state is not available, so you are starting from a fresh clone.\n\n")
+
+	// Include the original issue description for context (especially
+	// important for non-manual sessions that may have no prior messages).
+	if issue != nil && issue.Description != "" {
+		b.WriteString("## Original issue\n\n**")
+		b.WriteString(issue.Title)
+		b.WriteString("**\n\n")
+		b.WriteString(issue.Description)
+		b.WriteString("\n\n")
+	}
 
 	// Include conversation history if available.
 	if len(messages) > 1 { // >1 because the latest user message is always present
@@ -777,11 +819,21 @@ func (o *Orchestrator) buildResumeContext(session *models.Session, messages []mo
 		}
 	}
 
-	// Include the stored diff if available.
+	// Include the stored diff if available, truncating if very large.
 	if session.Diff != nil && *session.Diff != "" {
+		diff := *session.Diff
+		truncated := false
+		if len(diff) > maxDiffCharsInPrompt {
+			diff = diff[:maxDiffCharsInPrompt]
+			truncated = true
+		}
 		b.WriteString("## Previous code changes (git diff)\n\nThe following diff was produced in the previous session. Please re-apply these changes as needed:\n\n```diff\n")
-		b.WriteString(*session.Diff)
-		b.WriteString("\n```\n\n")
+		b.WriteString(diff)
+		b.WriteString("\n```\n")
+		if truncated {
+			b.WriteString("\n**Note:** The diff was truncated due to size. The full diff had additional changes not shown above.\n")
+		}
+		b.WriteString("\n")
 	}
 
 	// Include the result summary if available.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -531,12 +531,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		Int("turn", session.CurrentTurn).
 		Logger()
 
-	if session.SnapshotKey == nil || *session.SnapshotKey == "" {
-		return fmt.Errorf("session has no snapshot to restore")
-	}
-	if o.snapshots == nil {
-		return fmt.Errorf("snapshot store not configured")
-	}
+	// Determine whether we can restore from a snapshot or need a fresh start.
+	hasSnapshot := session.SnapshotKey != nil && *session.SnapshotKey != "" &&
+		o.snapshots != nil &&
+		session.SandboxState != string(models.SandboxStateDestroyed)
 
 	// 1. Update status to running.
 	if err := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, "running"); err != nil {
@@ -572,7 +570,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("no user message found")
 	}
 
-	// 4. Create sandbox and restore snapshot.
+	// 4. Create sandbox.
 	sandboxCfg := DefaultSandboxConfig()
 	sandboxCfg.Env = o.resolveAgentEnv(ctx, session.OrgID, session.AgentType, session.TriggeredByUserID)
 	if sandboxCfg.Env == nil {
@@ -598,56 +596,78 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		}
 	}()
 
-	// Restore snapshot from S3.
-	snapshotReader, snapshotWriter := io.Pipe()
-	var restoreErr error
-	var restoreWg sync.WaitGroup
-	restoreWg.Add(1)
-	go func() {
-		defer restoreWg.Done()
-		restoreErr = o.snapshots.Load(ctx, *session.SnapshotKey, snapshotWriter)
-		_ = snapshotWriter.Close()
-	}()
+	// 5. Set up the workspace — either restore snapshot or clone fresh.
+	var prompt *AgentPrompt
+	if hasSnapshot {
+		// Path A: Restore snapshot from storage — preserves all git changes.
+		snapshotReader, snapshotWriter := io.Pipe()
+		var restoreErr error
+		var restoreWg sync.WaitGroup
+		restoreWg.Add(1)
+		go func() {
+			defer restoreWg.Done()
+			restoreErr = o.snapshots.Load(ctx, *session.SnapshotKey, snapshotWriter)
+			_ = snapshotWriter.Close()
+		}()
 
-	if err := o.provider.Restore(ctx, sandbox, snapshotReader); err != nil {
-		// Close the reader to unblock the goroutine writing to the pipe.
-		_ = snapshotReader.Close()
+		if err := o.provider.Restore(ctx, sandbox, snapshotReader); err != nil {
+			_ = snapshotReader.Close()
+			restoreWg.Wait()
+			o.failRun(ctx, session, fmt.Sprintf("restore snapshot: %s", err))
+			return fmt.Errorf("restore snapshot: %w", err)
+		}
 		restoreWg.Wait()
-		o.failRun(ctx, session, fmt.Sprintf("restore snapshot: %s", err))
-		return fmt.Errorf("restore snapshot: %w", err)
-	}
-	restoreWg.Wait()
-	if restoreErr != nil {
-		o.failRun(ctx, session, fmt.Sprintf("load snapshot from storage: %s", restoreErr))
-		return fmt.Errorf("load snapshot: %w", restoreErr)
-	}
-
-	// 5. Re-inject Codex auth.json (primary auth mechanism).
-	if session.AgentType == models.AgentTypeCodex {
-		injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
-		if err != nil {
-			o.failRun(ctx, session, fmt.Sprintf("codex auth injection failed: %s", err))
-			return fmt.Errorf("codex auth injection: %w", err)
+		if restoreErr != nil {
+			o.failRun(ctx, session, fmt.Sprintf("load snapshot from storage: %s", restoreErr))
+			return fmt.Errorf("load snapshot: %w", restoreErr)
 		}
-		if !injected {
-			o.failRun(ctx, session, "no credentials configured for codex: connect ChatGPT from the Overview page")
-			return fmt.Errorf("no credentials for codex agent")
+
+		// Re-inject Codex auth.json if needed.
+		if session.AgentType == models.AgentTypeCodex {
+			injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
+			if err != nil {
+				o.failRun(ctx, session, fmt.Sprintf("codex auth injection failed: %s", err))
+				return fmt.Errorf("codex auth injection: %w", err)
+			}
+			if !injected {
+				o.failRun(ctx, session, "no credentials configured for codex: connect ChatGPT from the Overview page")
+				return fmt.Errorf("no credentials for codex agent")
+			}
+		}
+
+		var resumeSessionID string
+		if session.AgentSessionID != nil {
+			resumeSessionID = *session.AgentSessionID
+		}
+		prompt = &AgentPrompt{
+			Continuation:    true,
+			ResumeSessionID: resumeSessionID,
+			UserMessage:     userMessage,
+			MaxTokens:       tokenLimitForMode(session.TokenMode),
+		}
+
+		log.Info().Msg("continuing session with snapshot restore")
+	} else {
+		// Path B: No snapshot available — clone repo fresh and provide
+		// conversation history + stored diff as context so the agent can
+		// reconstruct the prior state.
+		log.Info().Msg("continuing session without snapshot, starting fresh")
+
+		if err := o.setupFreshSandbox(ctx, session, sandbox); err != nil {
+			o.failRun(ctx, session, fmt.Sprintf("setup fresh sandbox: %s", err))
+			return fmt.Errorf("setup fresh sandbox: %w", err)
+		}
+
+		// Build a prompt that includes conversation history and the stored diff.
+		enrichedMessage := o.buildResumeContext(session, messages, userMessage)
+		prompt = &AgentPrompt{
+			Continuation: false,
+			UserMessage:  enrichedMessage,
+			MaxTokens:    tokenLimitForMode(session.TokenMode),
 		}
 	}
 
-	// 6. Build the resume prompt.
-	var resumeSessionID string
-	if session.AgentSessionID != nil {
-		resumeSessionID = *session.AgentSessionID
-	}
-	prompt := &AgentPrompt{
-		Continuation:    true,
-		ResumeSessionID: resumeSessionID,
-		UserMessage:     userMessage,
-		MaxTokens:       tokenLimitForMode(session.TokenMode),
-	}
-
-	// 7. Execute agent with log streaming.
+	// 6. Execute agent with log streaming.
 	turnNumber := session.CurrentTurn + 1
 	logCh := make(chan LogEntry, 100)
 	var logWg sync.WaitGroup
@@ -667,18 +687,18 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("execute agent on continue: %w", err)
 	}
 
-	// 8. Create assistant message with result summary.
+	// 7. Create assistant message with result summary.
 	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, turnNumber, result); err != nil {
 		log.Warn().Err(err).Msg("failed to create assistant message")
 	}
 
-	// 9. Snapshot again.
+	// 8. Snapshot again.
 	newSnapshotKey, snapshotErr := o.snapshotSession(ctx, session, sandbox, result)
 	if snapshotErr != nil {
 		log.Warn().Err(snapshotErr).Msg("failed to snapshot session after continue")
 	}
 
-	// 10. Update turn complete — sets status to idle.
+	// 9. Update turn complete — sets status to idle.
 	agentSessionID := result.AgentSessionID
 	if agentSessionID == "" && session.AgentSessionID != nil {
 		agentSessionID = *session.AgentSessionID
@@ -693,6 +713,88 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 
 	log.Info().Int("turn", turnNumber).Msg("session turn completed, now idle")
 	return nil
+}
+
+// setupFreshSandbox clones the session's repository into the sandbox when no
+// snapshot is available. Handles sessions with or without a repository.
+func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Session, sandbox *Sandbox) error {
+	// Fetch the issue to get repository info.
+	issue, err := o.issues.GetByID(ctx, session.OrgID, session.IssueID)
+	if err != nil {
+		return fmt.Errorf("fetch issue: %w", err)
+	}
+
+	// Clone repo if the session has one.
+	if issue.RepositoryID != nil {
+		repo, err := o.repositories.GetByID(ctx, session.OrgID, *issue.RepositoryID)
+		if err != nil {
+			return fmt.Errorf("fetch repository: %w", err)
+		}
+		branch := repo.DefaultBranch
+		if session.TargetBranch != nil && *session.TargetBranch != "" {
+			branch = *session.TargetBranch
+		}
+		token, err := o.github.GetInstallationToken(ctx, repo.InstallationID)
+		if err != nil {
+			return fmt.Errorf("get installation token: %w", err)
+		}
+		if err := o.provider.CloneRepo(ctx, sandbox, repo.CloneURL, branch, token); err != nil {
+			return fmt.Errorf("clone repo: %w", err)
+		}
+	}
+
+	// Inject Codex auth if needed.
+	if session.AgentType == models.AgentTypeCodex {
+		injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
+		if err != nil {
+			return fmt.Errorf("codex auth injection: %w", err)
+		}
+		if !injected {
+			return fmt.Errorf("no credentials for codex agent")
+		}
+	}
+
+	return nil
+}
+
+// buildResumeContext constructs the user message for a resumed session that
+// has no snapshot. It includes conversation history and the stored diff so
+// the agent understands the prior state and can re-apply changes.
+func (o *Orchestrator) buildResumeContext(session *models.Session, messages []models.SessionMessage, latestUserMessage string) string {
+	var b bytes.Buffer
+
+	b.WriteString("This is a continuation of a previous session. The previous workspace state is not available, so you are starting from a fresh clone.\n\n")
+
+	// Include conversation history if available.
+	if len(messages) > 1 { // >1 because the latest user message is always present
+		b.WriteString("## Previous conversation history\n\n")
+		for _, msg := range messages[:len(messages)-1] {
+			role := "User"
+			if msg.Role == models.MessageRoleAssistant {
+				role = "Assistant"
+			}
+			b.WriteString(fmt.Sprintf("**%s:** %s\n\n", role, msg.Content))
+		}
+	}
+
+	// Include the stored diff if available.
+	if session.Diff != nil && *session.Diff != "" {
+		b.WriteString("## Previous code changes (git diff)\n\nThe following diff was produced in the previous session. Please re-apply these changes as needed:\n\n```diff\n")
+		b.WriteString(*session.Diff)
+		b.WriteString("\n```\n\n")
+	}
+
+	// Include the result summary if available.
+	if session.ResultSummary != nil && *session.ResultSummary != "" {
+		b.WriteString("## Previous session summary\n\n")
+		b.WriteString(*session.ResultSummary)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("## New message\n\n")
+	b.WriteString(latestUserMessage)
+
+	return b.String()
 }
 
 func outcomeFromRunStatus(status string) models.PMDecisionOutcome {

--- a/internal/services/agent/reaper.go
+++ b/internal/services/agent/reaper.go
@@ -11,34 +11,37 @@ import (
 	"github.com/assembledhq/143/internal/services/storage"
 )
 
-// SessionReaper periodically cleans up stale session snapshots from object
-// storage. It handles two cases:
-//   - Idle sessions that have been inactive for longer than maxIdleAge
-//   - Completed/failed/cancelled sessions that still have snapshots
+// SessionReaper periodically cleans up stale sessions and expired snapshots
+// in two phases:
+//   - Phase 1: Transition idle sessions to completed (keep snapshots)
+//   - Phase 2: Delete snapshots that have exceeded the max snapshot age
 type SessionReaper struct {
-	sessions      StaleSessionLister
-	snapshotStore storage.SnapshotStore
-	maxIdleAge    time.Duration
-	interval      time.Duration
-	logger        zerolog.Logger
+	sessions       StaleSessionLister
+	snapshotStore  storage.SnapshotStore
+	maxIdleAge     time.Duration
+	maxSnapshotAge time.Duration
+	interval       time.Duration
+	logger         zerolog.Logger
 }
 
 // StaleSessionLister is the subset of the session store used by the reaper.
 type StaleSessionLister interface {
-	ListStaleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error)
+	ListStaleIdleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error)
+	ListExpiredSnapshots(ctx context.Context, olderThan time.Time) ([]models.Session, error)
 	UpdateStatus(ctx context.Context, orgID, sessionID uuid.UUID, status string) error
 	UpdateSandboxState(ctx context.Context, orgID, sessionID uuid.UUID, state string) error
 }
 
 // NewSessionReaper creates a reaper that runs every interval, cleaning up
-// sessions idle for longer than maxIdleAge.
-func NewSessionReaper(sessions StaleSessionLister, snapshotStore storage.SnapshotStore, maxIdleAge, interval time.Duration, logger zerolog.Logger) *SessionReaper {
+// sessions idle for longer than maxIdleAge and snapshots older than maxSnapshotAge.
+func NewSessionReaper(sessions StaleSessionLister, snapshotStore storage.SnapshotStore, maxIdleAge, maxSnapshotAge, interval time.Duration, logger zerolog.Logger) *SessionReaper {
 	return &SessionReaper{
-		sessions:      sessions,
-		snapshotStore: snapshotStore,
-		maxIdleAge:    maxIdleAge,
-		interval:      interval,
-		logger:        logger,
+		sessions:       sessions,
+		snapshotStore:  snapshotStore,
+		maxIdleAge:     maxIdleAge,
+		maxSnapshotAge: maxSnapshotAge,
+		interval:       interval,
+		logger:         logger,
 	}
 }
 
@@ -50,6 +53,7 @@ func (r *SessionReaper) Run(ctx context.Context) {
 	r.logger.Info().
 		Dur("interval", r.interval).
 		Dur("max_idle", r.maxIdleAge).
+		Dur("max_snapshot_age", r.maxSnapshotAge).
 		Msg("snapshot reaper started")
 
 	for {
@@ -64,35 +68,42 @@ func (r *SessionReaper) Run(ctx context.Context) {
 }
 
 func (r *SessionReaper) reap(ctx context.Context) {
-	cutoff := time.Now().Add(-r.maxIdleAge)
-	sessions, err := r.sessions.ListStaleSessions(ctx, cutoff)
+	// Phase 1: Transition stale idle sessions to completed (keep snapshots).
+	idleCutoff := time.Now().Add(-r.maxIdleAge)
+	staleSessions, err := r.sessions.ListStaleIdleSessions(ctx, idleCutoff)
 	if err != nil {
-		r.logger.Error().Err(err).Msg("reaper: failed to list stale sessions")
+		r.logger.Error().Err(err).Msg("reaper: failed to list stale idle sessions")
+	} else {
+		for _, s := range staleSessions {
+			if err := r.sessions.UpdateStatus(ctx, s.OrgID, s.ID, string(models.SessionStatusCompleted)); err != nil {
+				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to mark session completed")
+				continue
+			}
+			r.logger.Info().
+				Str("session_id", s.ID.String()).
+				Msg("reaper: transitioned idle session to completed")
+		}
+	}
+
+	// Phase 2: Delete snapshots that have exceeded the max snapshot age.
+	snapshotCutoff := time.Now().Add(-r.maxSnapshotAge)
+	expiredSnapshots, err := r.sessions.ListExpiredSnapshots(ctx, snapshotCutoff)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("reaper: failed to list expired snapshots")
 		return
 	}
 
-	if len(sessions) == 0 {
-		return
+	if len(expiredSnapshots) > 0 {
+		r.logger.Info().Int("count", len(expiredSnapshots)).Msg("reaper: cleaning up expired snapshots")
 	}
 
-	r.logger.Info().Int("count", len(sessions)).Msg("reaper: cleaning up stale snapshots")
-
-	for _, s := range sessions {
+	for _, s := range expiredSnapshots {
 		if s.SnapshotKey != nil && *s.SnapshotKey != "" {
 			if err := r.snapshotStore.Delete(ctx, *s.SnapshotKey); err != nil {
 				r.logger.Error().Err(err).
 					Str("session_id", s.ID.String()).
 					Str("snapshot_key", *s.SnapshotKey).
 					Msg("reaper: failed to delete snapshot")
-				continue
-			}
-		}
-
-		// Only set status to completed for idle sessions; completed/failed
-		// sessions should keep their existing status.
-		if s.Status == string(models.SessionStatusIdle) {
-			if err := r.sessions.UpdateStatus(ctx, s.OrgID, s.ID, string(models.SessionStatusCompleted)); err != nil {
-				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to mark session completed")
 				continue
 			}
 		}
@@ -105,6 +116,6 @@ func (r *SessionReaper) reap(ctx context.Context) {
 		r.logger.Info().
 			Str("session_id", s.ID.String()).
 			Str("status", s.Status).
-			Msg("reaper: cleaned up stale session")
+			Msg("reaper: cleaned up expired snapshot")
 	}
 }

--- a/internal/services/agent/reaper_test.go
+++ b/internal/services/agent/reaper_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// mockStaleSessionLister implements StaleSessionLister for testing.
-type mockStaleSessionLister struct {
+// reaperMockSessionLister implements StaleSessionLister for testing.
+type reaperMockSessionLister struct {
 	staleIdleSessions []models.Session
 	expiredSnapshots  []models.Session
 	listIdleErr       error
@@ -39,34 +39,34 @@ type sandboxUpdate struct {
 	state     string
 }
 
-func (m *mockStaleSessionLister) ListStaleIdleSessions(_ context.Context, _ time.Time) ([]models.Session, error) {
+func (m *reaperMockSessionLister) ListStaleIdleSessions(_ context.Context, _ time.Time) ([]models.Session, error) {
 	return m.staleIdleSessions, m.listIdleErr
 }
 
-func (m *mockStaleSessionLister) ListExpiredSnapshots(_ context.Context, _ time.Time) ([]models.Session, error) {
+func (m *reaperMockSessionLister) ListExpiredSnapshots(_ context.Context, _ time.Time) ([]models.Session, error) {
 	return m.expiredSnapshots, m.listExpiredErr
 }
 
-func (m *mockStaleSessionLister) UpdateStatus(_ context.Context, orgID, sessionID uuid.UUID, status string) error {
+func (m *reaperMockSessionLister) UpdateStatus(_ context.Context, orgID, sessionID uuid.UUID, status string) error {
 	m.updatedStatuses = append(m.updatedStatuses, statusUpdate{orgID: orgID, sessionID: sessionID, status: status})
 	return m.updateStatusErr
 }
 
-func (m *mockStaleSessionLister) UpdateSandboxState(_ context.Context, orgID, sessionID uuid.UUID, state string) error {
+func (m *reaperMockSessionLister) UpdateSandboxState(_ context.Context, orgID, sessionID uuid.UUID, state string) error {
 	m.updatedSandboxes = append(m.updatedSandboxes, sandboxUpdate{orgID: orgID, sessionID: sessionID, state: state})
 	return m.updateSandboxErr
 }
 
-// mockSnapshotStore implements storage.SnapshotStore for testing.
-type mockSnapshotStore struct {
+// reaperMockSnapshotStore implements storage.SnapshotStore for testing.
+type reaperMockSnapshotStore struct {
 	deletedKeys []string
 	deleteErr   error
 }
 
-func (m *mockSnapshotStore) Save(_ context.Context, _ string, _ io.Reader) error { return nil }
-func (m *mockSnapshotStore) Load(_ context.Context, _ string, _ io.Writer) error { return nil }
+func (m *reaperMockSnapshotStore) Save(_ context.Context, _ string, _ io.Reader) error { return nil }
+func (m *reaperMockSnapshotStore) Load(_ context.Context, _ string, _ io.Writer) error { return nil }
 
-func (m *mockSnapshotStore) Delete(_ context.Context, key string) error {
+func (m *reaperMockSnapshotStore) Delete(_ context.Context, key string) error {
 	m.deletedKeys = append(m.deletedKeys, key)
 	return m.deleteErr
 }
@@ -79,14 +79,14 @@ func TestReapPhase1_TransitionsIdleSessionsToCompleted(t *testing.T) {
 	sessionID2 := uuid.New()
 	snapshotKey := "snap-key-1"
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		staleIdleSessions: []models.Session{
 			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusIdle), SnapshotKey: &snapshotKey},
 			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusIdle)},
 		},
 		expiredSnapshots: nil, // No expired snapshots in this test.
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -114,14 +114,14 @@ func TestReapPhase2_DeletesExpiredSnapshots(t *testing.T) {
 	snapshotKey1 := "snap-key-1"
 	snapshotKey2 := "snap-key-2"
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		staleIdleSessions: nil, // No idle sessions in this test.
 		expiredSnapshots: []models.Session{
 			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey1},
 			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey2},
 		},
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -146,12 +146,12 @@ func TestReapPhase2_SkipsSessionsWithNilSnapshotKey(t *testing.T) {
 	orgID := uuid.New()
 	sessionID := uuid.New()
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		expiredSnapshots: []models.Session{
 			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: nil},
 		},
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -170,12 +170,12 @@ func TestReapPhase2_SkipsSessionsWithEmptySnapshotKey(t *testing.T) {
 	sessionID := uuid.New()
 	emptyKey := ""
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		expiredSnapshots: []models.Session{
 			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &emptyKey},
 		},
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -193,7 +193,7 @@ func TestReapBothPhases(t *testing.T) {
 	expiredSessionID := uuid.New()
 	snapshotKey := "expired-snap"
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		staleIdleSessions: []models.Session{
 			{ID: idleSessionID, OrgID: orgID, Status: string(models.SessionStatusIdle)},
 		},
@@ -201,7 +201,7 @@ func TestReapBothPhases(t *testing.T) {
 			{ID: expiredSessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey},
 		},
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -226,13 +226,13 @@ func TestReapPhase1Error_StillRunsPhase2(t *testing.T) {
 	sessionID := uuid.New()
 	snapshotKey := "snap-key"
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		listIdleErr: errors.New("db error"),
 		expiredSnapshots: []models.Session{
 			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey},
 		},
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -249,13 +249,13 @@ func TestReapPhase2Error_ListExpiredSnapshots(t *testing.T) {
 	orgID := uuid.New()
 	sessionID := uuid.New()
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		staleIdleSessions: []models.Session{
 			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusIdle)},
 		},
 		listExpiredErr: errors.New("db error"),
 	}
-	snapStore := &mockSnapshotStore{}
+	snapStore := &reaperMockSnapshotStore{}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())
@@ -278,13 +278,13 @@ func TestReapPhase2_SnapshotDeleteError_SkipsSession(t *testing.T) {
 	key1 := "key-1"
 	key2 := "key-2"
 
-	mock := &mockStaleSessionLister{
+	mock := &reaperMockSessionLister{
 		expiredSnapshots: []models.Session{
 			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &key1},
 			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &key2},
 		},
 	}
-	snapStore := &mockSnapshotStore{deleteErr: errors.New("s3 error")}
+	snapStore := &reaperMockSnapshotStore{deleteErr: errors.New("s3 error")}
 
 	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
 	reaper.reap(context.Background())

--- a/internal/services/agent/reaper_test.go
+++ b/internal/services/agent/reaper_test.go
@@ -1,0 +1,296 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStaleSessionLister implements StaleSessionLister for testing.
+type mockStaleSessionLister struct {
+	staleIdleSessions []models.Session
+	expiredSnapshots  []models.Session
+	listIdleErr       error
+	listExpiredErr    error
+	updateStatusErr   error
+	updateSandboxErr  error
+
+	updatedStatuses  []statusUpdate
+	updatedSandboxes []sandboxUpdate
+}
+
+type statusUpdate struct {
+	orgID     uuid.UUID
+	sessionID uuid.UUID
+	status    string
+}
+
+type sandboxUpdate struct {
+	orgID     uuid.UUID
+	sessionID uuid.UUID
+	state     string
+}
+
+func (m *mockStaleSessionLister) ListStaleIdleSessions(_ context.Context, _ time.Time) ([]models.Session, error) {
+	return m.staleIdleSessions, m.listIdleErr
+}
+
+func (m *mockStaleSessionLister) ListExpiredSnapshots(_ context.Context, _ time.Time) ([]models.Session, error) {
+	return m.expiredSnapshots, m.listExpiredErr
+}
+
+func (m *mockStaleSessionLister) UpdateStatus(_ context.Context, orgID, sessionID uuid.UUID, status string) error {
+	m.updatedStatuses = append(m.updatedStatuses, statusUpdate{orgID: orgID, sessionID: sessionID, status: status})
+	return m.updateStatusErr
+}
+
+func (m *mockStaleSessionLister) UpdateSandboxState(_ context.Context, orgID, sessionID uuid.UUID, state string) error {
+	m.updatedSandboxes = append(m.updatedSandboxes, sandboxUpdate{orgID: orgID, sessionID: sessionID, state: state})
+	return m.updateSandboxErr
+}
+
+// mockSnapshotStore implements storage.SnapshotStore for testing.
+type mockSnapshotStore struct {
+	deletedKeys []string
+	deleteErr   error
+}
+
+func (m *mockSnapshotStore) Save(_ context.Context, _ string, _ io.Reader) error { return nil }
+func (m *mockSnapshotStore) Load(_ context.Context, _ string, _ io.Writer) error { return nil }
+
+func (m *mockSnapshotStore) Delete(_ context.Context, key string) error {
+	m.deletedKeys = append(m.deletedKeys, key)
+	return m.deleteErr
+}
+
+func TestReapPhase1_TransitionsIdleSessionsToCompleted(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID1 := uuid.New()
+	sessionID2 := uuid.New()
+	snapshotKey := "snap-key-1"
+
+	mock := &mockStaleSessionLister{
+		staleIdleSessions: []models.Session{
+			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusIdle), SnapshotKey: &snapshotKey},
+			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusIdle)},
+		},
+		expiredSnapshots: nil, // No expired snapshots in this test.
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 1 should update status to completed for both sessions.
+	require.Len(t, mock.updatedStatuses, 2)
+	assert.Equal(t, string(models.SessionStatusCompleted), mock.updatedStatuses[0].status)
+	assert.Equal(t, sessionID1, mock.updatedStatuses[0].sessionID)
+	assert.Equal(t, string(models.SessionStatusCompleted), mock.updatedStatuses[1].status)
+	assert.Equal(t, sessionID2, mock.updatedStatuses[1].sessionID)
+
+	// Phase 1 should NOT delete any snapshots.
+	assert.Empty(t, snapStore.deletedKeys, "phase 1 should not delete snapshots")
+
+	// Phase 1 should NOT update sandbox state.
+	assert.Empty(t, mock.updatedSandboxes, "phase 1 should not update sandbox state")
+}
+
+func TestReapPhase2_DeletesExpiredSnapshots(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID1 := uuid.New()
+	sessionID2 := uuid.New()
+	snapshotKey1 := "snap-key-1"
+	snapshotKey2 := "snap-key-2"
+
+	mock := &mockStaleSessionLister{
+		staleIdleSessions: nil, // No idle sessions in this test.
+		expiredSnapshots: []models.Session{
+			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey1},
+			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey2},
+		},
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 2 should delete both snapshots.
+	require.Len(t, snapStore.deletedKeys, 2)
+	assert.Equal(t, "snap-key-1", snapStore.deletedKeys[0])
+	assert.Equal(t, "snap-key-2", snapStore.deletedKeys[1])
+
+	// Phase 2 should update sandbox state to destroyed.
+	require.Len(t, mock.updatedSandboxes, 2)
+	assert.Equal(t, string(models.SandboxStateDestroyed), mock.updatedSandboxes[0].state)
+	assert.Equal(t, string(models.SandboxStateDestroyed), mock.updatedSandboxes[1].state)
+
+	// Phase 2 should NOT update status (sessions are already completed).
+	assert.Empty(t, mock.updatedStatuses, "phase 2 should not update session status")
+}
+
+func TestReapPhase2_SkipsSessionsWithNilSnapshotKey(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock := &mockStaleSessionLister{
+		expiredSnapshots: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: nil},
+		},
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// No snapshot to delete.
+	assert.Empty(t, snapStore.deletedKeys)
+	// But sandbox state should still be updated.
+	require.Len(t, mock.updatedSandboxes, 1)
+	assert.Equal(t, string(models.SandboxStateDestroyed), mock.updatedSandboxes[0].state)
+}
+
+func TestReapPhase2_SkipsSessionsWithEmptySnapshotKey(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	emptyKey := ""
+
+	mock := &mockStaleSessionLister{
+		expiredSnapshots: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &emptyKey},
+		},
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	assert.Empty(t, snapStore.deletedKeys)
+	require.Len(t, mock.updatedSandboxes, 1)
+	assert.Equal(t, string(models.SandboxStateDestroyed), mock.updatedSandboxes[0].state)
+}
+
+func TestReapBothPhases(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	idleSessionID := uuid.New()
+	expiredSessionID := uuid.New()
+	snapshotKey := "expired-snap"
+
+	mock := &mockStaleSessionLister{
+		staleIdleSessions: []models.Session{
+			{ID: idleSessionID, OrgID: orgID, Status: string(models.SessionStatusIdle)},
+		},
+		expiredSnapshots: []models.Session{
+			{ID: expiredSessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey},
+		},
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 1: idle session transitioned to completed.
+	require.Len(t, mock.updatedStatuses, 1)
+	assert.Equal(t, idleSessionID, mock.updatedStatuses[0].sessionID)
+	assert.Equal(t, string(models.SessionStatusCompleted), mock.updatedStatuses[0].status)
+
+	// Phase 2: expired snapshot deleted and sandbox state updated.
+	require.Len(t, snapStore.deletedKeys, 1)
+	assert.Equal(t, "expired-snap", snapStore.deletedKeys[0])
+	require.Len(t, mock.updatedSandboxes, 1)
+	assert.Equal(t, expiredSessionID, mock.updatedSandboxes[0].sessionID)
+	assert.Equal(t, string(models.SandboxStateDestroyed), mock.updatedSandboxes[0].state)
+}
+
+func TestReapPhase1Error_StillRunsPhase2(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	snapshotKey := "snap-key"
+
+	mock := &mockStaleSessionLister{
+		listIdleErr: errors.New("db error"),
+		expiredSnapshots: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &snapshotKey},
+		},
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 1 failed, but phase 2 should still run.
+	require.Len(t, snapStore.deletedKeys, 1)
+	assert.Equal(t, "snap-key", snapStore.deletedKeys[0])
+	require.Len(t, mock.updatedSandboxes, 1)
+}
+
+func TestReapPhase2Error_ListExpiredSnapshots(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock := &mockStaleSessionLister{
+		staleIdleSessions: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusIdle)},
+		},
+		listExpiredErr: errors.New("db error"),
+	}
+	snapStore := &mockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 1 should still work.
+	require.Len(t, mock.updatedStatuses, 1)
+	assert.Equal(t, string(models.SessionStatusCompleted), mock.updatedStatuses[0].status)
+
+	// Phase 2 had an error listing, so no snapshots deleted.
+	assert.Empty(t, snapStore.deletedKeys)
+	assert.Empty(t, mock.updatedSandboxes)
+}
+
+func TestReapPhase2_SnapshotDeleteError_SkipsSession(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID1 := uuid.New()
+	sessionID2 := uuid.New()
+	key1 := "key-1"
+	key2 := "key-2"
+
+	mock := &mockStaleSessionLister{
+		expiredSnapshots: []models.Session{
+			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &key1},
+			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusCompleted), SnapshotKey: &key2},
+		},
+	}
+	snapStore := &mockSnapshotStore{deleteErr: errors.New("s3 error")}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Both keys attempted.
+	require.Len(t, snapStore.deletedKeys, 2)
+	// Sandbox state should NOT be updated because delete failed.
+	assert.Empty(t, mock.updatedSandboxes)
+}


### PR DESCRIPTION
## Summary
Users can now send follow-up messages to sessions in terminal states (completed, failed, cancelled, pr_created), allowing them to resume work. Sessions restore the previous snapshot if available, or start fresh with context from the prior conversation and code changes.

## Changes
- Frontend: Enable message input for terminal session states
- Backend: Add ClaimForResume to atomically transition terminal sessions to running
- Orchestrator: Support snapshot restoration or fresh clone with conversation/diff context
- Config: Add SESSION_MAX_SNAPSHOT_AGE for 30-day default snapshot retention
- Reaper: Two-phase cleanup — idle→completed transition, then snapshot deletion by age

## Test plan
- [x] Send message to idle session (existing behavior)
- [x] Send message to completed session with snapshot (new)
- [x] Reject messages to sessions in invalid states (new test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)