### PR TITLE
Implement consistent error logging throughout backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 )
 
 require (
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.48.0
-	golang.org/x/sync v0.19.0
 )
 
 require (
@@ -77,6 +76,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
+	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -10,7 +10,7 @@ Use `zerolog` for all log output. Never use `fmt.Printf`, `fmt.Println`, or the 
 
 ### Rule: Always use `writeError` for error responses — it logs automatically
 
-`writeError` in `handlers/helpers.go` both logs and writes the JSON error response. It logs at `Error` level for 5xx and `Warn` level for 4xx, using the request-scoped logger (enriched with `org_id`, `user_id`, `request_id`).
+`writeError` in `handlers/helpers.go` both logs and writes the JSON error response. It logs at `Error` level for 5xx and `Info` level for 4xx, using the request-scoped logger (enriched with `org_id`, `user_id`, `request_id`).
 
 ```go
 // Signature:
@@ -22,7 +22,7 @@ if err != nil {
     return
 }
 
-// 4xx — no error variable needed, but the code+message are still logged at Warn:
+// 4xx — no error variable needed, but the code+message are still logged at Info:
 writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid widget ID")
 ```
 

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -3,3 +3,81 @@
 ## No N+1 Queries
 
 Never query the database inside a loop. Always batch using `ANY()`, JOINs, or bulk fetches. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package.
+
+## Error Logging
+
+Use `zerolog` for all log output. Never use `fmt.Printf`, `fmt.Println`, or the standard `log` package in production code paths.
+
+### Rule: Always use `writeError` for error responses — it logs automatically
+
+`writeError` in `handlers/helpers.go` both logs and writes the JSON error response. It logs at `Error` level for 5xx and `Warn` level for 4xx, using the request-scoped logger (enriched with `org_id`, `user_id`, `request_id`).
+
+```go
+// Signature:
+//   writeError(w, r, status, code, message, errs ...error)
+
+// 500 — pass the error as the last argument so it appears in logs:
+if err != nil {
+    writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create widget", err)
+    return
+}
+
+// 4xx — no error variable needed, but the code+message are still logged at Warn:
+writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid widget ID")
+```
+
+Do NOT add a separate `zerolog.Ctx(r.Context()).Error()` line before `writeError` — that would double-log.
+
+### Rule: Use request-scoped loggers in HTTP handlers
+
+When logging outside of `writeError` (e.g., warnings for best-effort failures), use `zerolog.Ctx(r.Context())` — never `h.logger`. The request-scoped logger is enriched with `org_id`, `user_id`, and `request_id` by the `LogContext` middleware, so all log entries are automatically correlated.
+
+```go
+// CORRECT — includes org_id, user_id, request_id
+zerolog.Ctx(r.Context()).Warn().Err(err).Msg("best-effort operation failed")
+
+// WRONG — missing request context
+h.logger.Warn().Err(err).Msg("best-effort operation failed")
+```
+
+The `h.logger` field is acceptable in non-HTTP contexts (background goroutines, initialization) where there is no request context.
+
+### Rule: Use injected loggers in services
+
+Services receive a `zerolog.Logger` via their constructor. Use `s.logger` for all logging — never import `github.com/rs/zerolog/log` (the global logger). The global logger lacks structured context like `org_id`.
+
+```go
+// CORRECT
+s.logger.Warn().Err(err).Msg("operation failed")
+
+// WRONG — global logger, no context
+log.Warn().Err(err).Msg("operation failed")
+```
+
+### Rule: Log best-effort failures at Warn level
+
+When an operation is best-effort (e.g., updating job status after the job already ran, recording a webhook delivery), log failures at `Warn` level so they are visible but don't trigger error alerts:
+
+```go
+if _, err := w.db.Exec(ctx, `UPDATE jobs SET status = 'succeeded' ...`, jobID); err != nil {
+    w.logger.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to mark job as succeeded")
+}
+```
+
+### Rule: Never silently discard errors
+
+Avoid `_, _ = someFunc()` or `_ = someFunc()` without either logging or commenting why the error is intentionally ignored. If an error truly cannot be handled, add a log line or a comment:
+
+```go
+// Intentionally ignored: body is optional, fields default below.
+_ = json.NewDecoder(r.Body).Decode(&body)
+```
+
+### Log level guidelines
+
+| Level | When to use |
+|-------|-------------|
+| `Error` | Unexpected failures that indicate bugs or infrastructure issues (DB errors, failed API calls returning 500) |
+| `Warn` | Degraded but recoverable situations (best-effort cleanup failed, fallback triggered, token refresh failed) |
+| `Info` | Significant business events (job completed, session created, auth flow completed) |
+| `Debug` | Verbose diagnostic output (skipped auto-trigger gates, cache hits/misses) |

--- a/internal/api/handlers/audit_helpers.go
+++ b/internal/api/handlers/audit_helpers.go
@@ -105,4 +105,3 @@ func parseClientIP(r *http.Request) *netip.Prefix {
 	}
 	return nil
 }
-

--- a/internal/api/handlers/audit_helpers.go
+++ b/internal/api/handlers/audit_helpers.go
@@ -105,3 +105,4 @@ func parseClientIP(r *http.Request) *netip.Prefix {
 	}
 	return nil
 }
+

--- a/internal/api/handlers/audit_logs.go
+++ b/internal/api/handlers/audit_logs.go
@@ -82,7 +82,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if uid := q.Get("user_id"); uid != "" {
 		parsed, err := uuid.Parse(uid)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_USER_ID", "invalid user_id parameter")
+			writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid user_id parameter")
 			return
 		}
 		filters.UserID = &parsed
@@ -90,7 +90,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if sid := q.Get("session_id"); sid != "" {
 		parsed, err := uuid.Parse(sid)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SESSION_ID", "invalid session_id parameter")
+			writeError(w, r, http.StatusBadRequest, "INVALID_SESSION_ID", "invalid session_id parameter")
 			return
 		}
 		filters.SessionID = &parsed
@@ -98,7 +98,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if pid := q.Get("project_id"); pid != "" {
 		parsed, err := uuid.Parse(pid)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_PROJECT_ID", "invalid project_id parameter")
+			writeError(w, r, http.StatusBadRequest, "INVALID_PROJECT_ID", "invalid project_id parameter")
 			return
 		}
 		filters.ProjectID = &parsed
@@ -106,7 +106,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if since := q.Get("since"); since != "" {
 		t, err := time.Parse(time.RFC3339, since)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SINCE", "invalid since parameter, expected ISO 8601")
+			writeError(w, r, http.StatusBadRequest, "INVALID_SINCE", "invalid since parameter, expected ISO 8601")
 			return
 		}
 		filters.Since = &t
@@ -114,7 +114,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if until := q.Get("until"); until != "" {
 		t, err := time.Parse(time.RFC3339, until)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_UNTIL", "invalid until parameter, expected ISO 8601")
+			writeError(w, r, http.StatusBadRequest, "INVALID_UNTIL", "invalid until parameter, expected ISO 8601")
 			return
 		}
 		filters.Until = &t
@@ -122,7 +122,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 	if cursor := q.Get("cursor"); cursor != "" {
 		t, id, err := decodeAuditCursor(cursor)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_CURSOR", "invalid cursor")
+			writeError(w, r, http.StatusBadRequest, "INVALID_CURSOR", "invalid cursor")
 			return
 		}
 		filters.CursorTime = &t
@@ -131,7 +131,7 @@ func (h *AuditLogHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	entries, err := h.store.List(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list audit logs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list audit logs", err)
 		return
 	}
 	if entries == nil {
@@ -156,17 +156,17 @@ func (h *AuditLogHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid audit log ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid audit log ID")
 		return
 	}
 
 	entry, err := h.store.GetByID(r.Context(), orgID, id)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "audit log entry not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "audit log entry not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "GET_FAILED", "failed to get audit log entry")
+		writeError(w, r, http.StatusInternalServerError, "GET_FAILED", "failed to get audit log entry", err)
 		return
 	}
 

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -64,7 +64,7 @@ func (h *AuthHandler) Providers(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) Me(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"data": user})
@@ -80,7 +80,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		Invitation string `json:"invitation"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
@@ -88,27 +88,27 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 	body.Name = strings.TrimSpace(body.Name)
 
 	if body.Name == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_NAME", "Name is required.")
+		writeError(w, r, http.StatusBadRequest, "MISSING_NAME", "Name is required.")
 		return
 	}
 	if _, err := mail.ParseAddress(body.Email); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_EMAIL", "Invalid email address.")
+		writeError(w, r, http.StatusBadRequest, "INVALID_EMAIL", "Invalid email address.")
 		return
 	}
 	if len(body.Password) < 8 {
-		writeError(w, http.StatusBadRequest, "WEAK_PASSWORD", "Password must be at least 8 characters.")
+		writeError(w, r, http.StatusBadRequest, "WEAK_PASSWORD", "Password must be at least 8 characters.")
 		return
 	}
 
 	// Check for existing user
 	if _, err := h.userStore.GetByEmail(r.Context(), body.Email); err == nil {
-		writeError(w, http.StatusConflict, "EMAIL_EXISTS", "An account with this email already exists.")
+		writeError(w, r, http.StatusConflict, "EMAIL_EXISTS", "An account with this email already exists.")
 		return
 	}
 
 	hash, err := bcrypt.GenerateFromPassword([]byte(body.Password), bcrypt.DefaultCost)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to hash password")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to hash password", err)
 		return
 	}
 
@@ -121,11 +121,11 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 
 		user, invErr, registerErr := h.createInvitedUserWithPassword(r.Context(), body.Invitation, body.Email, body.Name, hashStr)
 		if invErr != nil {
-			writeError(w, invErr.status, invErr.code, invErr.message)
+			writeError(w, r, invErr.status, invErr.code, invErr.message)
 			return
 		}
 		if registerErr != nil {
-			writeError(w, http.StatusInternalServerError, "USER_CREATE_FAILED", "failed to create user")
+			writeError(w, r, http.StatusInternalServerError, "USER_CREATE_FAILED", "failed to create user", registerErr)
 			return
 		}
 		h.emitAuthEvent(r, user, models.AuditActionAuthRegister)
@@ -139,7 +139,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		Settings: json.RawMessage(`{}`),
 	}
 	if err := h.orgStore.Create(r.Context(), org); err != nil {
-		writeError(w, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.")
+		writeError(w, r, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.", err)
 		return
 	}
 
@@ -151,7 +151,7 @@ func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
 		PasswordHash: &hashStr,
 	}
 	if err := h.userStore.CreateWithPassword(r.Context(), user); err != nil {
-		writeError(w, http.StatusInternalServerError, "USER_CREATE_FAILED", "failed to create user")
+		writeError(w, r, http.StatusInternalServerError, "USER_CREATE_FAILED", "failed to create user", err)
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *AuthHandler) EmailLogin(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"` // #nosec G117 -- request body field
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
@@ -174,17 +174,17 @@ func (h *AuthHandler) EmailLogin(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.userStore.GetByEmail(r.Context(), body.Email)
 	if err != nil {
-		writeError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password.")
+		writeError(w, r, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password.")
 		return
 	}
 
 	if user.PasswordHash == nil {
-		writeError(w, http.StatusUnauthorized, "OAUTH_ONLY", "This account uses social login. Please sign in with GitHub or Google.")
+		writeError(w, r, http.StatusUnauthorized, "OAUTH_ONLY", "This account uses social login. Please sign in with GitHub or Google.")
 		return
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte(body.Password)); err != nil {
-		writeError(w, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password.")
+		writeError(w, r, http.StatusUnauthorized, "INVALID_CREDENTIALS", "Invalid email or password.")
 		return
 	}
 
@@ -197,7 +197,7 @@ func (h *AuthHandler) EmailLogin(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) Login(w http.ResponseWriter, r *http.Request) {
 	state, err := setOAuthState(w, githubOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate state", err)
 		return
 	}
 
@@ -251,14 +251,14 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// Exchange code for access token
 	tokenResp, err := h.exchangeGitHubCode(code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	// Fetch GitHub user
 	ghUser, err := h.fetchGitHubUser(tokenResp.AccessToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "GITHUB_API_FAILED", "failed to fetch GitHub user")
+		writeError(w, r, http.StatusInternalServerError, "GITHUB_API_FAILED", "failed to fetch GitHub user", err)
 		return
 	}
 
@@ -276,7 +276,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		existingUser.GitHubLogin = &ghUser.Login
 		existingUser.AvatarURL = &ghUser.AvatarURL
 		if upsertErr := h.userStore.UpsertFromGitHub(r.Context(), &existingUser); upsertErr != nil {
-			writeError(w, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user")
+			writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user", upsertErr)
 			return
 		}
 		h.emitAuthEvent(r, &existingUser, models.AuditActionAuthLogin)
@@ -287,7 +287,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	// Try email match for account linking
 	if emailUser, emailErr := h.userStore.GetByEmail(r.Context(), email); emailErr == nil {
 		if linkErr := h.userStore.LinkGitHubAccount(r.Context(), emailUser.ID, emailUser.OrgID, ghUser.ID, ghUser.Login, ghUser.AvatarURL); linkErr != nil {
-			writeError(w, http.StatusInternalServerError, "LINK_FAILED", "failed to link GitHub account")
+			writeError(w, r, http.StatusInternalServerError, "LINK_FAILED", "failed to link GitHub account", linkErr)
 			return
 		}
 		h.emitAuthEvent(r, &emailUser, models.AuditActionAuthLogin)
@@ -318,7 +318,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			Settings: json.RawMessage(`{}`),
 		}
 		if createErr := h.orgStore.Create(r.Context(), org); createErr != nil {
-			writeError(w, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.")
+			writeError(w, r, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.", createErr)
 			return
 		}
 		orgID = org.ID
@@ -344,11 +344,11 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			},
 		)
 		if invErr != nil {
-			writeError(w, invErr.status, invErr.code, invErr.message)
+			writeError(w, r, invErr.status, invErr.code, invErr.message)
 			return
 		}
 		if createErr != nil {
-			writeError(w, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user")
+			writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user", createErr)
 			return
 		}
 		h.emitAuthEvent(r, createdUser, models.AuditActionAuthRegister)
@@ -357,7 +357,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.userStore.UpsertFromGitHub(r.Context(), user); err != nil {
-		writeError(w, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user")
+		writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user", err)
 		return
 	}
 
@@ -370,7 +370,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	state, err := setOAuthState(w, googleOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate state", err)
 		return
 	}
 
@@ -417,14 +417,14 @@ func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 	// Exchange code for access token
 	tokenResp, err := h.exchangeGoogleCode(code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	// Fetch Google user info
 	gUser, err := h.fetchGoogleUser(tokenResp.AccessToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "GOOGLE_API_FAILED", "failed to fetch Google user")
+		writeError(w, r, http.StatusInternalServerError, "GOOGLE_API_FAILED", "failed to fetch Google user", err)
 		return
 	}
 
@@ -437,7 +437,7 @@ func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 
 	if emailUser, emailErr := h.userStore.GetByEmail(r.Context(), gUser.Email); emailErr == nil {
 		if linkErr := h.userStore.LinkGoogleAccount(r.Context(), emailUser.ID, emailUser.OrgID, gUser.Sub, gUser.Picture); linkErr != nil {
-			writeError(w, http.StatusInternalServerError, "LINK_FAILED", "failed to link Google account")
+			writeError(w, r, http.StatusInternalServerError, "LINK_FAILED", "failed to link Google account", linkErr)
 			return
 		}
 		h.emitAuthEvent(r, &emailUser, models.AuditActionAuthLogin)
@@ -472,7 +472,7 @@ func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 			Settings: json.RawMessage(`{}`),
 		}
 		if createErr := h.orgStore.Create(r.Context(), org); createErr != nil {
-			writeError(w, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.")
+			writeError(w, r, http.StatusInternalServerError, "ORG_CREATE_FAILED", "Failed to create organization.", createErr)
 			return
 		}
 		orgID = org.ID
@@ -497,11 +497,11 @@ func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 			},
 		)
 		if invErr != nil {
-			writeError(w, invErr.status, invErr.code, invErr.message)
+			writeError(w, r, invErr.status, invErr.code, invErr.message)
 			return
 		}
 		if createErr != nil {
-			writeError(w, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user")
+			writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user", createErr)
 			return
 		}
 		h.emitAuthEvent(r, createdUser, models.AuditActionAuthRegister)
@@ -510,7 +510,7 @@ func (h *AuthHandler) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.userStore.UpsertFromGoogle(r.Context(), user); err != nil {
-		writeError(w, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user")
+		writeError(w, r, http.StatusInternalServerError, "USER_UPSERT_FAILED", "failed to upsert user", err)
 		return
 	}
 
@@ -522,7 +522,7 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("session_token")
 	if err == nil {
 		if deleteErr := h.sessionStore.DeleteByToken(r.Context(), cookie.Value); deleteErr != nil {
-			writeError(w, http.StatusInternalServerError, "SESSION_DELETE_FAILED", "failed to delete session")
+			writeError(w, r, http.StatusInternalServerError, "SESSION_DELETE_FAILED", "failed to delete session", deleteErr)
 			return
 		}
 	}
@@ -556,7 +556,7 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Request, user *models.User) {
 	sessionToken, err := generateRandomString(32)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate session token")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate session token", err)
 		return
 	}
 	session := &models.AuthSession{
@@ -566,7 +566,7 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 	}
 	if err := h.sessionStore.Create(r.Context(), session); err != nil {
-		writeError(w, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session")
+		writeError(w, r, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session", err)
 		return
 	}
 
@@ -580,7 +580,7 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 	})
 
 	if err := middleware.SetCSRFCookie(w, r, []byte(h.cfg.CSRFSigningKey)); err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate CSRF token")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate CSRF token", err)
 		return
 	}
 
@@ -600,7 +600,7 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Request, user *models.User) {
 	sessionToken, err := generateRandomString(32)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate session token")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate session token", err)
 		return
 	}
 	session := &models.AuthSession{
@@ -610,7 +610,7 @@ func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Req
 		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 	}
 	if err := h.sessionStore.Create(r.Context(), session); err != nil {
-		writeError(w, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session")
+		writeError(w, r, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session", err)
 		return
 	}
 
@@ -624,7 +624,7 @@ func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Req
 	})
 
 	if err := middleware.SetCSRFCookie(w, r, []byte(h.cfg.CSRFSigningKey)); err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate CSRF token")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate CSRF token", err)
 		return
 	}
 

--- a/internal/api/handlers/codex_auth.go
+++ b/internal/api/handlers/codex_auth.go
@@ -26,8 +26,7 @@ func (h *CodexAuthHandler) Initiate(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := h.svc.InitiateDeviceAuth(r.Context(), orgID)
 	if err != nil {
-		h.logger.Error().Err(err).Str("org_id", orgID.String()).Msg("failed to initiate codex device auth")
-		writeError(w, http.StatusInternalServerError, "AUTH_INITIATE_FAILED", "failed to initiate device auth")
+		writeError(w, r, http.StatusInternalServerError, "AUTH_INITIATE_FAILED", "failed to initiate device auth", err)
 		return
 	}
 
@@ -40,7 +39,7 @@ func (h *CodexAuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 
 	status, err := h.svc.PollForToken(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "AUTH_STATUS_FAILED", "failed to check auth status")
+		writeError(w, r, http.StatusInternalServerError, "AUTH_STATUS_FAILED", "failed to check auth status", err)
 		return
 	}
 
@@ -52,7 +51,7 @@ func (h *CodexAuthHandler) Disconnect(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if err := h.svc.Disconnect(r.Context(), orgID); err != nil {
-		writeError(w, http.StatusInternalServerError, "AUTH_DISCONNECT_FAILED", "failed to disconnect ChatGPT")
+		writeError(w, r, http.StatusInternalServerError, "AUTH_DISCONNECT_FAILED", "failed to disconnect ChatGPT", err)
 		return
 	}
 

--- a/internal/api/handlers/codex_auth_test.go
+++ b/internal/api/handlers/codex_auth_test.go
@@ -126,6 +126,7 @@ func TestCodexAuthHandler_Initiate_Error(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/settings/codex-auth/initiate", nil)
 	req = codexAddOrgContext(req)
+	req = req.WithContext(logger.WithContext(req.Context()))
 	w := httptest.NewRecorder()
 
 	handler.Initiate(w, req)
@@ -135,7 +136,7 @@ func TestCodexAuthHandler_Initiate_Error(t *testing.T) {
 	var resp map[string]interface{}
 	err := json.NewDecoder(w.Body).Decode(&resp)
 	require.NoError(t, err, "error response should be valid JSON")
-	require.Contains(t, logBuf.String(), "failed to initiate codex device auth", "initiate error should be logged with context")
+	require.Contains(t, logBuf.String(), "failed to initiate device auth", "initiate error should be logged with context")
 	require.Contains(t, logBuf.String(), "device auth request", "initiate error log should include wrapped service error details")
 }
 

--- a/internal/api/handlers/credentials.go
+++ b/internal/api/handlers/credentials.go
@@ -43,7 +43,7 @@ func (h *CredentialHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	summaries, err := h.store.ListSummaries(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list credentials")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list credentials", err)
 		return
 	}
 	if summaries == nil {
@@ -59,30 +59,30 @@ func (h *CredentialHandler) Update(w http.ResponseWriter, r *http.Request) {
 	provider := models.ProviderName(providerStr)
 
 	if !provider.Valid() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unknown provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unknown provider: "+providerStr)
 		return
 	}
 
 	// Read the raw JSON body, then parse into the correct typed config.
 	var raw json.RawMessage
 	if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	cfg, err := models.ParseProviderConfig(provider, raw)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
 		return
 	}
 
 	if err := cfg.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
 		return
 	}
 
 	if err := h.store.Upsert(r.Context(), orgID, cfg); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPSERT_FAILED", "failed to save credential")
+		writeError(w, r, http.StatusInternalServerError, "UPSERT_FAILED", "failed to save credential", err)
 		return
 	}
 
@@ -98,12 +98,12 @@ func (h *CredentialHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	provider := models.ProviderName(providerStr)
 
 	if !provider.Valid() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unknown provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unknown provider: "+providerStr)
 		return
 	}
 
 	if err := h.store.Disable(r.Context(), orgID, provider); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to disable credential")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to disable credential", err)
 		return
 	}
 

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
 )
 
 type HealthHandler struct {
@@ -22,6 +23,7 @@ func (h *HealthHandler) Healthz(w http.ResponseWriter, r *http.Request) {
 func (h *HealthHandler) Readyz(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := h.pool.Ping(r.Context()); err != nil {
+		zerolog.Ctx(r.Context()).Warn().Err(err).Msg("readiness check failed: database unavailable")
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = w.Write([]byte(`{"status":"not ready","error":"database unavailable"}`))
 		return

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -24,13 +24,14 @@ func queryInt(r *http.Request, key string, defaultVal int) int {
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		http.Error(w, `{"error":{"code":"ENCODE_ERROR","message":"failed to encode response"}}`, http.StatusInternalServerError)
-	}
+	// Encode directly to the response writer. If encoding fails, the status
+	// header is already sent so we can only log — http.Error would attempt a
+	// second WriteHeader which is a no-op and prints a warning.
+	_ = json.NewEncoder(w).Encode(v)
 }
 
 // writeError logs the error and writes a JSON error response. It logs at Error
-// level for 5xx status codes and Warn level for 4xx. If an error is provided
+// level for 5xx status codes and Info level for 4xx. If an error is provided
 // via errs, it is attached to the log entry with .Err().
 func writeError(w http.ResponseWriter, r *http.Request, status int, code, message string, errs ...error) {
 	logger := zerolog.Ctx(r.Context()).With().Str("code", code).Int("status", status).Logger()
@@ -38,7 +39,7 @@ func writeError(w http.ResponseWriter, r *http.Request, status int, code, messag
 	if status >= 500 {
 		evt = logger.Error()
 	} else {
-		evt = logger.Warn()
+		evt = logger.Info()
 	}
 	if len(errs) > 0 && errs[0] != nil {
 		evt = evt.Err(errs[0])

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/assembledhq/143/internal/models"
+	"github.com/rs/zerolog"
 )
 
 func queryInt(r *http.Request, key string, defaultVal int) int {
@@ -28,7 +29,22 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 }
 
-func writeError(w http.ResponseWriter, status int, code, message string) {
+// writeError logs the error and writes a JSON error response. It logs at Error
+// level for 5xx status codes and Warn level for 4xx. If an error is provided
+// via errs, it is attached to the log entry with .Err().
+func writeError(w http.ResponseWriter, r *http.Request, status int, code, message string, errs ...error) {
+	logger := zerolog.Ctx(r.Context()).With().Str("code", code).Int("status", status).Logger()
+	var evt *zerolog.Event
+	if status >= 500 {
+		evt = logger.Error()
+	} else {
+		evt = logger.Warn()
+	}
+	if len(errs) > 0 && errs[0] != nil {
+		evt = evt.Err(errs[0])
+	}
+	evt.Msg(message)
+
 	writeJSON(w, status, models.ErrorResponse{
 		Error: models.ErrorDetail{Code: code, Message: message},
 	})

--- a/internal/api/handlers/helpers_test.go
+++ b/internal/api/handlers/helpers_test.go
@@ -93,7 +93,8 @@ func TestWriteError(t *testing.T) {
 	t.Parallel()
 
 	w := httptest.NewRecorder()
-	writeError(w, http.StatusBadRequest, "BAD_REQUEST", "something went wrong")
+	r := httptest.NewRequest(http.MethodGet, "/test", nil)
+	writeError(w, r, http.StatusBadRequest, "BAD_REQUEST", "something went wrong")
 
 	require.Equal(t, http.StatusBadRequest, w.Code, "should return expected status code")
 	require.Contains(t, w.Body.String(), "BAD_REQUEST", "should contain error code")

--- a/internal/api/handlers/ingestion_webhooks.go
+++ b/internal/api/handlers/ingestion_webhooks.go
@@ -67,32 +67,32 @@ var providerSignatureHeader = map[string]string{
 func (h *IngestionWebhookHandler) handleProvider(w http.ResponseWriter, r *http.Request, provider string) {
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "READ_FAILED", "failed to read request body")
+		writeError(w, r, http.StatusBadRequest, "READ_FAILED", "failed to read request body")
 		return
 	}
 
 	// Get integration ID from query param or header
 	integrationIDStr := r.URL.Query().Get("integration_id")
 	if integrationIDStr == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_INTEGRATION", "integration_id query parameter required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_INTEGRATION", "integration_id query parameter required")
 		return
 	}
 	integrationID, err := uuid.Parse(integrationIDStr)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid integration_id")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid integration_id")
 		return
 	}
 
 	// Look up integration to get org_id
 	integration, err := h.integrationStore.GetByID(r.Context(), integrationID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "integration not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "integration not found")
 		return
 	}
 
 	// Verify webhook signature using per-org credential from DB.
 	if err := h.verifyProviderSignature(r.Context(), integration.OrgID, provider, body, r.Header); err != nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", err.Error())
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", err.Error())
 		return
 	}
 
@@ -106,7 +106,7 @@ func (h *IngestionWebhookHandler) handleProvider(w http.ResponseWriter, r *http.
 		Status:        "received",
 	}
 	if err := h.webhookStore.Create(r.Context(), delivery); err != nil {
-		h.logger.Error().Err(err).Msg("failed to record webhook delivery")
+		zerolog.Ctx(r.Context()).Error().Err(err).Msg("failed to record webhook delivery")
 	}
 
 	// Parse and ingest
@@ -125,8 +125,7 @@ func (h *IngestionWebhookHandler) handleProvider(w http.ResponseWriter, r *http.
 		if markErr := h.webhookStore.MarkProcessed(r.Context(), delivery, &errMsg); markErr != nil {
 			zerolog.Ctx(r.Context()).Warn().Err(markErr).Msg("failed to mark webhook processed")
 		}
-		h.logger.Error().Err(err).Str("provider", provider).Msg("failed to parse webhook")
-		writeError(w, http.StatusBadRequest, "PARSE_FAILED", "failed to parse webhook payload")
+		writeError(w, r, http.StatusBadRequest, "PARSE_FAILED", "failed to parse webhook payload")
 		return
 	}
 
@@ -145,8 +144,7 @@ func (h *IngestionWebhookHandler) handleProvider(w http.ResponseWriter, r *http.
 		if markErr := h.webhookStore.MarkProcessed(r.Context(), delivery, &errMsg); markErr != nil {
 			zerolog.Ctx(r.Context()).Warn().Err(markErr).Msg("failed to mark webhook processed")
 		}
-		h.logger.Error().Err(err).Str("provider", provider).Msg("failed to ingest issue")
-		writeError(w, http.StatusInternalServerError, "INGEST_FAILED", "failed to ingest issue")
+		writeError(w, r, http.StatusInternalServerError, "INGEST_FAILED", "failed to ingest issue", err)
 		return
 	}
 
@@ -185,10 +183,10 @@ func (h *IngestionWebhookHandler) verifyProviderSignature(
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// No credential configured — skip verification (dev mode)
-			h.logger.Debug().Err(err).Str("provider", provider).Msg("no webhook credential configured, skipping signature verification")
+			zerolog.Ctx(ctx).Debug().Err(err).Str("provider", provider).Msg("no webhook credential configured, skipping signature verification")
 			return nil
 		}
-		h.logger.Error().Err(err).Str("provider", provider).Msg("failed to load webhook credential")
+		zerolog.Ctx(ctx).Error().Err(err).Str("provider", provider).Msg("failed to load webhook credential")
 		return fmt.Errorf("failed to load webhook credential")
 	}
 

--- a/internal/api/handlers/ingestion_webhooks.go
+++ b/internal/api/handlers/ingestion_webhooks.go
@@ -125,7 +125,7 @@ func (h *IngestionWebhookHandler) handleProvider(w http.ResponseWriter, r *http.
 		if markErr := h.webhookStore.MarkProcessed(r.Context(), delivery, &errMsg); markErr != nil {
 			zerolog.Ctx(r.Context()).Warn().Err(markErr).Msg("failed to mark webhook processed")
 		}
-		writeError(w, r, http.StatusBadRequest, "PARSE_FAILED", "failed to parse webhook payload")
+		writeError(w, r, http.StatusBadRequest, "PARSE_FAILED", "failed to parse webhook payload", err)
 		return
 	}
 

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -43,12 +43,12 @@ const (
 	// OAuth state cookie names — each flow gets its own cookie so concurrent
 	// flows cannot collide. Integration cookies use the _integration_ infix to
 	// distinguish them from the user-auth cookies in auth.go.
-	githubOAuthStateCookie              = "github_oauth_state"
-	googleOAuthStateCookie              = "google_oauth_state"
-	linearIntegrationOAuthStateCookie   = "linear_integration_oauth_state"
-	sentryIntegrationOAuthStateCookie   = "sentry_integration_oauth_state"
-	githubIntegrationOAuthStateCookie   = "github_integration_oauth_state"
-	slackIntegrationOAuthStateCookie    = "slack_integration_oauth_state"
+	githubOAuthStateCookie            = "github_oauth_state"
+	googleOAuthStateCookie            = "google_oauth_state"
+	linearIntegrationOAuthStateCookie = "linear_integration_oauth_state"
+	sentryIntegrationOAuthStateCookie = "sentry_integration_oauth_state"
+	githubIntegrationOAuthStateCookie = "github_integration_oauth_state"
+	slackIntegrationOAuthStateCookie  = "slack_integration_oauth_state"
 )
 
 type integrationCredentialStore interface {
@@ -88,10 +88,10 @@ type linearViewerResponse struct {
 // --- Slack types ---
 
 type slackTokenResponse struct {
-	AccessToken string          `json:"access_token"`
-	TokenType   string          `json:"token_type"`
-	Scope       string          `json:"scope"`
-	Team        slackTeamInfo   `json:"team"`
+	AccessToken string        `json:"access_token"`
+	TokenType   string        `json:"token_type"`
+	Scope       string        `json:"scope"`
+	Team        slackTeamInfo `json:"team"`
 }
 
 type slackTeamInfo struct {
@@ -236,7 +236,7 @@ func (h *IntegrationHandler) ListIntegrations(w http.ResponseWriter, r *http.Req
 	orgID := middleware.OrgIDFromContext(r.Context())
 	integrations, err := h.integrationStore.ListByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list integrations")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list integrations", err)
 		return
 	}
 	if integrations == nil {
@@ -250,23 +250,23 @@ func (h *IntegrationHandler) DisconnectIntegration(w http.ResponseWriter, r *htt
 	orgID := middleware.OrgIDFromContext(r.Context())
 	provider := models.IntegrationProvider(chi.URLParam(r, "provider"))
 	if err := provider.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "invalid integration provider")
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "invalid integration provider")
 		return
 	}
 
 	activeIntegrations, err := h.integrationStore.ListByOrgAndProvider(r.Context(), orgID, string(provider))
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to look up integration")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to look up integration", err)
 		return
 	}
 	if len(activeIntegrations) == 0 {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "no active integration found for this provider")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "no active integration found for this provider")
 		return
 	}
 
 	for _, integration := range activeIntegrations {
 		if err := h.integrationStore.UpdateStatus(r.Context(), orgID, integration.ID, string(models.IntegrationStatusInactive)); err != nil {
-			writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disconnect integration")
+			writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disconnect integration", err)
 			return
 		}
 	}
@@ -280,13 +280,13 @@ func (h *IntegrationHandler) DisconnectIntegration(w http.ResponseWriter, r *htt
 
 func (h *IntegrationHandler) StartLinearOAuth(w http.ResponseWriter, r *http.Request) {
 	if h.linearClientID == "" || h.linearSecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "LINEAR_OAUTH_NOT_CONFIGURED", "linear oauth is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "LINEAR_OAUTH_NOT_CONFIGURED", "linear oauth is not configured")
 		return
 	}
 
 	state, err := setOAuthState(w, linearIntegrationOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state", err)
 		return
 	}
 
@@ -309,20 +309,20 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 
 	token, err := h.exchangeLinearCode(r.Context(), code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	workspaceID, workspaceName, err := h.fetchLinearWorkspace(r.Context(), token.AccessToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LINEAR_API_FAILED", "failed to fetch linear workspace")
+		writeError(w, r, http.StatusInternalServerError, "LINEAR_API_FAILED", "failed to fetch linear workspace", err)
 		return
 	}
 
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if h.credentialStore == nil {
-		writeError(w, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
+		writeError(w, r, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
 		return
 	}
 
@@ -334,12 +334,12 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 		WorkspaceName: workspaceName,
 	}
 	if err := h.credentialStore.Upsert(r.Context(), orgID, linearConfig); err != nil {
-		writeError(w, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store linear credential")
+		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store linear credential", err)
 		return
 	}
 
 	if _, _, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderLinear); err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration", err)
 		return
 	}
 
@@ -350,7 +350,7 @@ func (h *IntegrationHandler) ConnectLinear(w http.ResponseWriter, r *http.Reques
 	orgID := middleware.OrgIDFromContext(r.Context())
 	integration, created, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderLinear)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_LINEAR_FAILED", "failed to connect linear integration", err)
 		return
 	}
 	if created {
@@ -366,13 +366,13 @@ func (h *IntegrationHandler) ConnectLinear(w http.ResponseWriter, r *http.Reques
 
 func (h *IntegrationHandler) StartSentryOAuth(w http.ResponseWriter, r *http.Request) {
 	if h.sentryClientID == "" || h.sentrySecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "SENTRY_OAUTH_NOT_CONFIGURED", "sentry oauth is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "SENTRY_OAUTH_NOT_CONFIGURED", "sentry oauth is not configured")
 		return
 	}
 
 	state, err := setOAuthState(w, sentryIntegrationOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state", err)
 		return
 	}
 
@@ -395,20 +395,20 @@ func (h *IntegrationHandler) HandleSentryOAuthCallback(w http.ResponseWriter, r 
 
 	token, err := h.exchangeSentryCode(r.Context(), code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	orgSlug, orgName, err := h.fetchSentryOrganization(r.Context(), token.AccessToken)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "SENTRY_API_FAILED", "failed to fetch sentry organization")
+		writeError(w, r, http.StatusInternalServerError, "SENTRY_API_FAILED", "failed to fetch sentry organization", err)
 		return
 	}
 
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if h.credentialStore == nil {
-		writeError(w, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
+		writeError(w, r, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
 		return
 	}
 
@@ -420,12 +420,12 @@ func (h *IntegrationHandler) HandleSentryOAuthCallback(w http.ResponseWriter, r 
 		OrgName:      orgName,
 	}
 	if err := h.credentialStore.Upsert(r.Context(), orgID, sentryConfig); err != nil {
-		writeError(w, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store sentry credential")
+		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store sentry credential", err)
 		return
 	}
 
 	if _, _, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderSentry); err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_SENTRY_FAILED", "failed to connect sentry integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_SENTRY_FAILED", "failed to connect sentry integration", err)
 		return
 	}
 
@@ -436,7 +436,7 @@ func (h *IntegrationHandler) ConnectSentry(w http.ResponseWriter, r *http.Reques
 	orgID := middleware.OrgIDFromContext(r.Context())
 	integration, created, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderSentry)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_SENTRY_FAILED", "failed to connect sentry integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_SENTRY_FAILED", "failed to connect sentry integration", err)
 		return
 	}
 	if created {
@@ -459,7 +459,7 @@ func (h *IntegrationHandler) StartGitHubOAuth(w http.ResponseWriter, r *http.Req
 	if h.githubAppSlug != "" {
 		state, err := setOAuthState(w, githubIntegrationOAuthStateCookie)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state")
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state", err)
 			return
 		}
 
@@ -469,13 +469,13 @@ func (h *IntegrationHandler) StartGitHubOAuth(w http.ResponseWriter, r *http.Req
 	}
 
 	if h.githubClientID == "" || h.githubSecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "GITHUB_OAUTH_NOT_CONFIGURED", "github integration oauth is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_OAUTH_NOT_CONFIGURED", "github integration oauth is not configured")
 		return
 	}
 
 	state, err := setOAuthState(w, githubIntegrationOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state", err)
 		return
 	}
 
@@ -497,14 +497,14 @@ func (h *IntegrationHandler) HandleGitHubOAuthCallback(w http.ResponseWriter, r 
 
 	token, err := h.exchangeGitHubCode(r.Context(), code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if h.credentialStore == nil {
-		writeError(w, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
+		writeError(w, r, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
 		return
 	}
 
@@ -514,12 +514,12 @@ func (h *IntegrationHandler) HandleGitHubOAuthCallback(w http.ResponseWriter, r 
 		Scope:       token.Scope,
 	}
 	if err := h.credentialStore.Upsert(r.Context(), orgID, ghConfig); err != nil {
-		writeError(w, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store github credential")
+		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store github credential", err)
 		return
 	}
 
 	if _, _, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderGitHub); err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration", err)
 		return
 	}
 
@@ -536,7 +536,7 @@ func (h *IntegrationHandler) HandleGitHubAppInstalled(w http.ResponseWriter, r *
 
 	integration, _, err := h.ensureIntegration(ctx, orgID, models.IntegrationProviderGitHub)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration", err)
 		return
 	}
 
@@ -616,17 +616,17 @@ func (h *IntegrationHandler) SyncGitHubRepos(w http.ResponseWriter, r *http.Requ
 	orgID := middleware.OrgIDFromContext(ctx)
 
 	if h.githubService == nil || h.repoStore == nil {
-		writeError(w, http.StatusServiceUnavailable, "GITHUB_APP_NOT_CONFIGURED", "github app is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_NOT_CONFIGURED", "github app is not configured")
 		return
 	}
 
 	integrations, err := h.integrationStore.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_INTEGRATIONS_FAILED", "failed to list integrations")
+		writeError(w, r, http.StatusInternalServerError, "LIST_INTEGRATIONS_FAILED", "failed to list integrations", err)
 		return
 	}
 	if len(integrations) == 0 {
-		writeError(w, http.StatusNotFound, "NO_GITHUB_INTEGRATION", "no active github integration found")
+		writeError(w, r, http.StatusNotFound, "NO_GITHUB_INTEGRATION", "no active github integration found")
 		return
 	}
 
@@ -638,26 +638,26 @@ func (h *IntegrationHandler) SyncGitHubRepos(w http.ResponseWriter, r *http.Requ
 	}
 	if integration.Config != nil {
 		if err := json.Unmarshal(integration.Config, &config); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_CONFIG", "failed to parse integration config")
+			writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", "failed to parse integration config")
 			return
 		}
 	}
 	if config.InstallationID == 0 {
-		writeError(w, http.StatusBadRequest, "MISSING_INSTALLATION_ID", "integration config missing installation_id")
+		writeError(w, r, http.StatusBadRequest, "MISSING_INSTALLATION_ID", "integration config missing installation_id")
 		return
 	}
 
 	token, err := h.githubService.GetInstallationToken(ctx, config.InstallationID)
 	if err != nil {
 		zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to get installation token for sync")
-		writeError(w, http.StatusBadGateway, "TOKEN_FAILED", "failed to get github installation token")
+		writeError(w, r, http.StatusBadGateway, "TOKEN_FAILED", "failed to get github installation token")
 		return
 	}
 
 	repos, err := h.listInstallationRepos(ctx, token)
 	if err != nil {
 		zerolog.Ctx(ctx).Warn().Err(err).Msg("failed to list installation repos for sync")
-		writeError(w, http.StatusBadGateway, "LIST_REPOS_FAILED", "failed to list github repositories")
+		writeError(w, r, http.StatusBadGateway, "LIST_REPOS_FAILED", "failed to list github repositories")
 		return
 	}
 
@@ -745,7 +745,7 @@ func (h *IntegrationHandler) ConnectGitHub(w http.ResponseWriter, r *http.Reques
 	orgID := middleware.OrgIDFromContext(r.Context())
 	integration, created, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderGitHub)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_GITHUB_FAILED", "failed to connect github integration", err)
 		return
 	}
 	if created {
@@ -761,13 +761,13 @@ func (h *IntegrationHandler) ConnectGitHub(w http.ResponseWriter, r *http.Reques
 
 func (h *IntegrationHandler) StartSlackOAuth(w http.ResponseWriter, r *http.Request) {
 	if h.slackClientID == "" || h.slackSecret == "" {
-		writeError(w, http.StatusServiceUnavailable, "SLACK_OAUTH_NOT_CONFIGURED", "slack oauth is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "SLACK_OAUTH_NOT_CONFIGURED", "slack oauth is not configured")
 		return
 	}
 
 	state, err := setOAuthState(w, slackIntegrationOAuthStateCookie)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to generate oauth state", err)
 		return
 	}
 
@@ -789,14 +789,14 @@ func (h *IntegrationHandler) HandleSlackOAuthCallback(w http.ResponseWriter, r *
 
 	token, err := h.exchangeSlackCode(r.Context(), code)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	if h.credentialStore == nil {
-		writeError(w, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
+		writeError(w, r, http.StatusInternalServerError, "CREDENTIAL_STORE_UNAVAILABLE", "credential store unavailable")
 		return
 	}
 
@@ -807,12 +807,12 @@ func (h *IntegrationHandler) HandleSlackOAuthCallback(w http.ResponseWriter, r *
 		Scope:       token.Scope,
 	}
 	if err := h.credentialStore.Upsert(r.Context(), orgID, slackConfig); err != nil {
-		writeError(w, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store slack credential")
+		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store slack credential", err)
 		return
 	}
 
 	if _, _, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderSlack); err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_SLACK_FAILED", "failed to connect slack integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_SLACK_FAILED", "failed to connect slack integration", err)
 		return
 	}
 
@@ -823,7 +823,7 @@ func (h *IntegrationHandler) ConnectSlack(w http.ResponseWriter, r *http.Request
 	orgID := middleware.OrgIDFromContext(r.Context())
 	integration, created, err := h.ensureIntegration(r.Context(), orgID, models.IntegrationProviderSlack)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "CONNECT_SLACK_FAILED", "failed to connect slack integration")
+		writeError(w, r, http.StatusInternalServerError, "CONNECT_SLACK_FAILED", "failed to connect slack integration", err)
 		return
 	}
 	if created {
@@ -839,21 +839,21 @@ func (h *IntegrationHandler) ListSlackChannels(w http.ResponseWriter, r *http.Re
 
 	cred, err := h.getSlackCredential(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "SLACK_NOT_CONNECTED", "slack integration not connected")
+		writeError(w, r, http.StatusBadRequest, "SLACK_NOT_CONNECTED", "slack integration not connected")
 		return
 	}
 
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet,
 		slackAPIURL+"/conversations.list?types=public_channel&exclude_archived=true&limit=200", nil)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create request")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to create request", err)
 		return
 	}
 	req.Header.Set("Authorization", "Bearer "+cred.AccessToken)
 
 	resp, err := h.client.Do(req)
 	if err != nil {
-		writeError(w, http.StatusBadGateway, "SLACK_API_FAILED", "failed to fetch channels")
+		writeError(w, r, http.StatusBadGateway, "SLACK_API_FAILED", "failed to fetch channels")
 		return
 	}
 	defer resp.Body.Close()
@@ -867,11 +867,11 @@ func (h *IntegrationHandler) ListSlackChannels(w http.ResponseWriter, r *http.Re
 		Error string `json:"error,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&slackResp); err != nil {
-		writeError(w, http.StatusInternalServerError, "DECODE_FAILED", "failed to decode slack response")
+		writeError(w, r, http.StatusInternalServerError, "DECODE_FAILED", "failed to decode slack response", err)
 		return
 	}
 	if !slackResp.OK {
-		writeError(w, http.StatusBadGateway, "SLACK_API_ERROR", slackResp.Error)
+		writeError(w, r, http.StatusBadGateway, "SLACK_API_ERROR", slackResp.Error)
 		return
 	}
 
@@ -903,19 +903,19 @@ func (h *IntegrationHandler) UpdateSlackChannels(w http.ResponseWriter, r *http.
 		ChannelIDs []string `json:"channel_ids"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
 	cred, err := h.getSlackCredential(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "SLACK_NOT_CONNECTED", "slack integration not connected")
+		writeError(w, r, http.StatusBadRequest, "SLACK_NOT_CONNECTED", "slack integration not connected")
 		return
 	}
 
 	cred.ChannelIDs = body.ChannelIDs
 	if err := h.credentialStore.Upsert(r.Context(), orgID, *cred); err != nil {
-		writeError(w, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to update slack channels")
+		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to update slack channels", err)
 		return
 	}
 
@@ -951,7 +951,7 @@ func setOAuthState(w http.ResponseWriter, cookieName string) (string, error) {
 func validateOAuthCallback(w http.ResponseWriter, r *http.Request, cookieName string) (code string, ok bool) {
 	stateCookie, err := r.Cookie(cookieName)
 	if err != nil || stateCookie.Value != r.URL.Query().Get("state") {
-		writeError(w, http.StatusBadRequest, "INVALID_STATE", "OAuth state mismatch")
+		writeError(w, r, http.StatusBadRequest, "INVALID_STATE", "OAuth state mismatch")
 		return "", false
 	}
 
@@ -966,7 +966,7 @@ func validateOAuthCallback(w http.ResponseWriter, r *http.Request, cookieName st
 
 	code = r.URL.Query().Get("code")
 	if code == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_CODE", "missing authorization code")
+		writeError(w, r, http.StatusBadRequest, "MISSING_CODE", "missing authorization code")
 		return "", false
 	}
 

--- a/internal/api/handlers/issues.go
+++ b/internal/api/handlers/issues.go
@@ -33,7 +33,7 @@ func (h *IssueHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	issues, err := h.issueStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list issues")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list issues", err)
 		return
 	}
 	if issues == nil {
@@ -55,13 +55,13 @@ func (h *IssueHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	issueID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
 		return
 	}
 
 	issue, err := h.issueStore.GetByID(r.Context(), orgID, issueID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "issue not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "issue not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Issue]{Data: issue})

--- a/internal/api/handlers/memory.go
+++ b/internal/api/handlers/memory.go
@@ -31,7 +31,7 @@ func (h *MemoryHandler) ListByRepo(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repo := chi.URLParam(r, "*")
 	if repo == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_REPO", "repo path is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_REPO", "repo path is required")
 		return
 	}
 
@@ -44,7 +44,7 @@ func (h *MemoryHandler) ListByRepo(w http.ResponseWriter, r *http.Request) {
 
 	memories, err := h.memoryStore.ListByRepo(r.Context(), orgID, repo, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list memories")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list memories", err)
 		return
 	}
 	if memories == nil {
@@ -67,7 +67,7 @@ func (h *MemoryHandler) UpdateStatus(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	memoryID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid memory ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid memory ID")
 		return
 	}
 
@@ -75,18 +75,18 @@ func (h *MemoryHandler) UpdateStatus(w http.ResponseWriter, r *http.Request) {
 		Status string `json:"status"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Status != "active" && req.Status != "dismissed" {
-		writeError(w, http.StatusBadRequest, "INVALID_STATUS", "status must be 'active' or 'dismissed'")
+		writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", "status must be 'active' or 'dismissed'")
 		return
 	}
 
 	memory, err := h.memoryStore.UpdateMemoryAndGet(r.Context(), orgID, memoryID, nil, &req.Status)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update memory status")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update memory status", err)
 		return
 	}
 
@@ -98,7 +98,7 @@ func (h *MemoryHandler) UpdateRule(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	memoryID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid memory ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid memory ID")
 		return
 	}
 
@@ -106,18 +106,18 @@ func (h *MemoryHandler) UpdateRule(w http.ResponseWriter, r *http.Request) {
 		Rule string `json:"rule"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Rule == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_RULE", "rule text is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_RULE", "rule text is required")
 		return
 	}
 
 	memory, err := h.memoryStore.UpdateMemoryAndGet(r.Context(), orgID, memoryID, &req.Rule, nil)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update memory rule")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update memory rule", err)
 		return
 	}
 
@@ -144,7 +144,7 @@ func (h *MemoryHandler) ListComments(w http.ResponseWriter, r *http.Request) {
 
 	comments, err := h.commentStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list review comments")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list review comments", err)
 		return
 	}
 	if comments == nil {
@@ -174,12 +174,12 @@ func (h *MemoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		FilePatterns []string `json:"file_patterns,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Rule == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_RULE", "rule text is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_RULE", "rule text is required")
 		return
 	}
 	if req.Category == "" {
@@ -189,18 +189,18 @@ func (h *MemoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 		req.Scope = "repo"
 	}
 	if req.Scope != "repo" && req.Scope != "org" {
-		writeError(w, http.StatusBadRequest, "INVALID_SCOPE", "scope must be 'repo' or 'org'")
+		writeError(w, r, http.StatusBadRequest, "INVALID_SCOPE", "scope must be 'repo' or 'org'")
 		return
 	}
 	if req.Scope == "repo" && req.Repo == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_REPO", "repo is required for repo-scoped memories")
+		writeError(w, r, http.StatusBadRequest, "MISSING_REPO", "repo is required for repo-scoped memories")
 		return
 	}
 
 	// Validate file patterns are syntactically valid globs.
 	for _, pattern := range req.FilePatterns {
 		if pattern == "" {
-			writeError(w, http.StatusBadRequest, "INVALID_PATTERN", "file patterns must not be empty")
+			writeError(w, r, http.StatusBadRequest, "INVALID_PATTERN", "file patterns must not be empty")
 			return
 		}
 		// Strip "**" segments before validation since filepath.Match doesn't
@@ -211,31 +211,31 @@ func (h *MemoryHandler) Create(w http.ResponseWriter, r *http.Request) {
 			continue // pure recursive glob, always valid
 		}
 		if testPattern == "" {
-			writeError(w, http.StatusBadRequest, "INVALID_PATTERN", fmt.Sprintf("invalid glob pattern %q: trailing separator after **", pattern))
+			writeError(w, r, http.StatusBadRequest, "INVALID_PATTERN", fmt.Sprintf("invalid glob pattern %q: trailing separator after **", pattern))
 			return
 		}
 		if _, err := filepath.Match(testPattern, ""); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_PATTERN", fmt.Sprintf("invalid glob pattern %q: %v", pattern, err))
+			writeError(w, r, http.StatusBadRequest, "INVALID_PATTERN", fmt.Sprintf("invalid glob pattern %q: %v", pattern, err))
 			return
 		}
 	}
 
 	memory := &models.Memory{
-		OrgID:           orgID,
-		Repo:            req.Repo,
-		Rule:            req.Rule,
-		Category:        req.Category,
+		OrgID:            orgID,
+		Repo:             req.Repo,
+		Rule:             req.Rule,
+		Category:         req.Category,
 		SourceCommentIDs: []uuid.UUID{},
-		OccurrenceCount: 1,
-		Status:          "active", // manual memories start active
-		ManuallyCurated: true,
-		Scope:           req.Scope,
-		Source:          "manual",
-		FilePatterns:    req.FilePatterns,
+		OccurrenceCount:  1,
+		Status:           "active", // manual memories start active
+		ManuallyCurated:  true,
+		Scope:            req.Scope,
+		Source:           "manual",
+		FilePatterns:     req.FilePatterns,
 	}
 
 	if err := h.memoryStore.Create(r.Context(), memory); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create memory")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create memory", err)
 		return
 	}
 

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -41,7 +41,7 @@ func (h *PMHandler) Analyze(w http.ResponseWriter, r *http.Request) {
 	}
 	jobID, err := h.jobStore.Enqueue(r.Context(), orgID, "default", "pm_analyze", payload, 5, nil)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue pm analyze job")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue pm analyze job", err)
 		return
 	}
 
@@ -62,7 +62,7 @@ func (h *PMHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	plans, err := h.planStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list pm plans")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list pm plans", err)
 		return
 	}
 	if plans == nil {
@@ -84,13 +84,13 @@ func (h *PMHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	planID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid plan ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid plan ID")
 		return
 	}
 
 	plan, err := h.planStore.GetByID(r.Context(), orgID, planID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "plan not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "plan not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PMPlan]{Data: plan})
@@ -101,7 +101,7 @@ func (h *PMHandler) Latest(w http.ResponseWriter, r *http.Request) {
 
 	plan, err := h.planStore.GetLatestByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "plan not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "plan not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PMPlan]{Data: plan})
@@ -109,7 +109,7 @@ func (h *PMHandler) Latest(w http.ResponseWriter, r *http.Request) {
 
 // decisionsResponse is the response for the decisions endpoint.
 type decisionsResponse struct {
-	Data    []models.PMDecisionView `json:"data"`
+	Data    []models.PMDecisionView  `json:"data"`
 	Summary models.PMDecisionSummary `json:"summary"`
 	Meta    models.PaginationMeta    `json:"meta"`
 }
@@ -126,7 +126,7 @@ func (h *PMHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 
 	decisions, err := h.decisionLogStore.ListDecisionViews(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list pm decisions")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list pm decisions", err)
 		return
 	}
 	if decisions == nil {
@@ -135,7 +135,7 @@ func (h *PMHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 
 	summary, err := h.decisionLogStore.GetDecisionSummary(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get decision summary")
+		writeError(w, r, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get decision summary", err)
 		return
 	}
 

--- a/internal/api/handlers/pm_documents.go
+++ b/internal/api/handlers/pm_documents.go
@@ -24,7 +24,7 @@ func (h *PMDocumentHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	docs, err := h.store.ListByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list PM documents")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list PM documents", err)
 		return
 	}
 	if docs == nil {
@@ -42,22 +42,22 @@ func (h *PMDocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 
 	var req struct {
-		Title      string           `json:"title"`
-		Content    *string          `json:"content"`
-		DocType    *string          `json:"doc_type"`
-		SourceType *string          `json:"source_type"`
-		SourceURL  *string          `json:"source_url"`
-		SourceID   *string          `json:"source_id"`
-		SourceMeta json.RawMessage  `json:"source_meta,omitempty"`
+		Title      string          `json:"title"`
+		Content    *string         `json:"content"`
+		DocType    *string         `json:"doc_type"`
+		SourceType *string         `json:"source_type"`
+		SourceURL  *string         `json:"source_url"`
+		SourceID   *string         `json:"source_id"`
+		SourceMeta json.RawMessage `json:"source_meta,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Title == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "title is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "title is required")
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h *PMDocumentHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.store.Create(r.Context(), &doc); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create PM document")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create PM document", err)
 		return
 	}
 
@@ -100,13 +100,13 @@ func (h *PMDocumentHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	docID, err := uuid.Parse(chi.URLParam(r, "docId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
 		return
 	}
 
 	doc, err := h.store.GetByID(r.Context(), orgID, docID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "document not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "document not found")
 		return
 	}
 
@@ -117,28 +117,28 @@ func (h *PMDocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	docID, err := uuid.Parse(chi.URLParam(r, "docId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
 		return
 	}
 
 	doc, err := h.store.GetByID(r.Context(), orgID, docID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "document not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "document not found")
 		return
 	}
 
 	var req struct {
-		Title      *string          `json:"title"`
-		Content    *string          `json:"content"`
-		DocType    *string          `json:"doc_type"`
-		SourceType *string          `json:"source_type"`
-		SourceURL  *string          `json:"source_url"`
-		SourceID   *string          `json:"source_id"`
-		SourceMeta json.RawMessage  `json:"source_meta,omitempty"`
+		Title      *string         `json:"title"`
+		Content    *string         `json:"content"`
+		DocType    *string         `json:"doc_type"`
+		SourceType *string         `json:"source_type"`
+		SourceURL  *string         `json:"source_url"`
+		SourceID   *string         `json:"source_id"`
+		SourceMeta json.RawMessage `json:"source_meta,omitempty"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
@@ -165,7 +165,7 @@ func (h *PMDocumentHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.store.Update(r.Context(), &doc); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update PM document")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update PM document", err)
 		return
 	}
 
@@ -176,17 +176,17 @@ func (h *PMDocumentHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	docID, err := uuid.Parse(chi.URLParam(r, "docId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid document ID")
 		return
 	}
 
 	if _, err := h.store.GetByID(r.Context(), orgID, docID); err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "document not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "document not found")
 		return
 	}
 
 	if err := h.store.Delete(r.Context(), orgID, docID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete PM document")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete PM document", err)
 		return
 	}
 

--- a/internal/api/handlers/priority.go
+++ b/internal/api/handlers/priority.go
@@ -34,13 +34,13 @@ func (h *PriorityHandler) GetPriorityScore(w http.ResponseWriter, r *http.Reques
 	orgID := middleware.OrgIDFromContext(r.Context())
 	issueID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
 		return
 	}
 
 	score, err := h.priorityScores.GetByIssueID(r.Context(), orgID, issueID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "priority score not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "priority score not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PriorityScore]{Data: score})
@@ -51,13 +51,13 @@ func (h *PriorityHandler) GetComplexity(w http.ResponseWriter, r *http.Request) 
 	orgID := middleware.OrgIDFromContext(r.Context())
 	issueID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
 		return
 	}
 
 	estimate, err := h.complexityEstimates.GetByIssueID(r.Context(), orgID, issueID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "complexity estimate not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "complexity estimate not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.ComplexityEstimate]{Data: estimate})
@@ -72,7 +72,7 @@ func (h *PriorityHandler) ListPriorityScores(w http.ResponseWriter, r *http.Requ
 
 	scores, err := h.priorityScores.ListByOrg(r.Context(), orgID, eligibleOnly, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list priority scores")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list priority scores", err)
 		return
 	}
 	if scores == nil {
@@ -90,7 +90,7 @@ func (h *PriorityHandler) Reprioritize(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	issueID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
 		return
 	}
 
@@ -100,10 +100,9 @@ func (h *PriorityHandler) Reprioritize(w http.ResponseWriter, r *http.Request) {
 		"org_id":   orgID.String(),
 	}, 3, &dedupeKey)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue prioritize job")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue prioritize job", err)
 		return
 	}
 
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
 }
-

--- a/internal/api/handlers/project_ai.go
+++ b/internal/api/handlers/project_ai.go
@@ -38,7 +38,7 @@ func NewProjectAnalysisHandler(
 
 // AnalysisRequest is the request body for project analysis suggestions.
 type AnalysisRequest struct {
-	Target string  `json:"target"`           // "spec", "design", "tasks", or "all"
+	Target string  `json:"target"`            // "spec", "design", "tasks", or "all"
 	SpecID *string `json:"spec_id,omitempty"` // for spec-specific analysis
 	Prompt *string `json:"prompt,omitempty"`  // additional user instruction
 }
@@ -50,7 +50,7 @@ type AnalysisResponse struct {
 }
 
 type AnalysisSuggestion struct {
-	Type        string `json:"type"`     // "addition", "revision", "question", "task"
+	Type        string `json:"type"` // "addition", "revision", "question", "task"
 	Title       string `json:"title"`
 	Description string `json:"description"`
 	Priority    string `json:"priority"` // "high", "medium", "low"
@@ -61,40 +61,40 @@ func (h *ProjectAnalysisHandler) Improve(w http.ResponseWriter, r *http.Request)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	project, err := h.projectStore.GetByID(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
 	var req AnalysisRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Target == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "target is required (spec, design, or tasks)")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "target is required (spec, design, or tasks)")
 		return
 	}
 
 	specs, err := h.specStore.ListByProject(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_SPECS_FAILED", "failed to list project specs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_SPECS_FAILED", "failed to list project specs", err)
 		return
 	}
 	attachments, err := h.attachmentStore.ListByProject(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_ATTACHMENTS_FAILED", "failed to list project attachments")
+		writeError(w, r, http.StatusInternalServerError, "LIST_ATTACHMENTS_FAILED", "failed to list project attachments", err)
 		return
 	}
 	tasks, err := h.taskStore.ListByProject(r.Context(), orgID, projectID, db.ProjectTaskFilters{})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_TASKS_FAILED", "failed to list project tasks")
+		writeError(w, r, http.StatusInternalServerError, "LIST_TASKS_FAILED", "failed to list project tasks", err)
 		return
 	}
 

--- a/internal/api/handlers/project_attachments.go
+++ b/internal/api/handlers/project_attachments.go
@@ -31,13 +31,13 @@ func (h *ProjectAttachmentHandler) List(w http.ResponseWriter, r *http.Request) 
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	attachments, err := h.attachmentStore.ListByProject(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list attachments")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list attachments", err)
 		return
 	}
 	if attachments == nil {
@@ -55,13 +55,13 @@ func (h *ProjectAttachmentHandler) Create(w http.ResponseWriter, r *http.Request
 	user := middleware.UserFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	// Verify project exists
 	if _, err := h.projectStore.GetByID(r.Context(), orgID, projectID); err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
@@ -76,17 +76,17 @@ func (h *ProjectAttachmentHandler) Create(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.FileName == "" || req.FileURL == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "file_name and file_url are required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "file_name and file_url are required")
 		return
 	}
 
 	if !strings.HasPrefix(req.FileURL, "https://") && !strings.HasPrefix(req.FileURL, "http://") {
-		writeError(w, http.StatusBadRequest, "INVALID_URL", "file_url must start with https:// or http://")
+		writeError(w, r, http.StatusBadRequest, "INVALID_URL", "file_url must start with https:// or http://")
 		return
 	}
 
@@ -114,7 +114,7 @@ func (h *ProjectAttachmentHandler) Create(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.attachmentStore.Create(r.Context(), &attachment); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create attachment")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create attachment", err)
 		return
 	}
 
@@ -125,22 +125,22 @@ func (h *ProjectAttachmentHandler) Update(w http.ResponseWriter, r *http.Request
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	attachmentID, err := uuid.Parse(chi.URLParam(r, "attachmentId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid attachment ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid attachment ID")
 		return
 	}
 
 	attachment, err := h.attachmentStore.GetByID(r.Context(), orgID, attachmentID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "attachment not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "attachment not found")
 		return
 	}
 	if attachment.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "attachment not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "attachment not found")
 		return
 	}
 
@@ -151,7 +151,7 @@ func (h *ProjectAttachmentHandler) Update(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
@@ -166,7 +166,7 @@ func (h *ProjectAttachmentHandler) Update(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.attachmentStore.Update(r.Context(), &attachment); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update attachment")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update attachment", err)
 		return
 	}
 
@@ -177,26 +177,26 @@ func (h *ProjectAttachmentHandler) Delete(w http.ResponseWriter, r *http.Request
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	attachmentID, err := uuid.Parse(chi.URLParam(r, "attachmentId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid attachment ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid attachment ID")
 		return
 	}
 	attachment, err := h.attachmentStore.GetByID(r.Context(), orgID, attachmentID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "attachment not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "attachment not found")
 		return
 	}
 	if attachment.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "attachment not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "attachment not found")
 		return
 	}
 
 	if err := h.attachmentStore.Delete(r.Context(), orgID, attachmentID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete attachment")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete attachment", err)
 		return
 	}
 

--- a/internal/api/handlers/project_generate.go
+++ b/internal/api/handlers/project_generate.go
@@ -33,25 +33,25 @@ type GenerateProjectResponse struct {
 
 func (h *ProjectGenerateHandler) Generate(w http.ResponseWriter, r *http.Request) {
 	if h.llmClient == nil {
-		writeError(w, http.StatusServiceUnavailable, "LLM_NOT_CONFIGURED", "AI project generation is not available — no LLM provider configured")
+		writeError(w, r, http.StatusServiceUnavailable, "LLM_NOT_CONFIGURED", "AI project generation is not available — no LLM provider configured")
 		return
 	}
 
 	var req GenerateProjectRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	desc := strings.TrimSpace(req.Description)
 	if desc == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "description is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "description is required")
 		return
 	}
 
 	response, err := h.llmClient.Complete(r.Context(), prompts.ProjectGeneratePrompt(), desc)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LLM_ERROR", "failed to generate project: "+err.Error())
+		writeError(w, r, http.StatusInternalServerError, "LLM_ERROR", "failed to generate project: "+err.Error(), err)
 		return
 	}
 
@@ -67,7 +67,7 @@ func (h *ProjectGenerateHandler) Generate(w http.ResponseWriter, r *http.Request
 
 	var result GenerateProjectResponse
 	if err := json.Unmarshal([]byte(cleaned), &result); err != nil {
-		writeError(w, http.StatusInternalServerError, "PARSE_ERROR", "failed to parse AI response")
+		writeError(w, r, http.StatusInternalServerError, "PARSE_ERROR", "failed to parse AI response", err)
 		return
 	}
 

--- a/internal/api/handlers/project_specs.go
+++ b/internal/api/handlers/project_specs.go
@@ -30,13 +30,13 @@ func (h *ProjectSpecHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	specs, err := h.specStore.ListByProject(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list specs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list specs", err)
 		return
 	}
 	if specs == nil {
@@ -54,12 +54,12 @@ func (h *ProjectSpecHandler) Create(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	if _, err := h.projectStore.GetByID(r.Context(), orgID, projectID); err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
@@ -70,12 +70,12 @@ func (h *ProjectSpecHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Title == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "title is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "title is required")
 		return
 	}
 
@@ -99,7 +99,7 @@ func (h *ProjectSpecHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.specStore.Create(r.Context(), &spec); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create spec")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create spec", err)
 		return
 	}
 
@@ -110,22 +110,22 @@ func (h *ProjectSpecHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	specID, err := uuid.Parse(chi.URLParam(r, "specId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
 		return
 	}
 
 	spec, err := h.specStore.GetByID(r.Context(), orgID, specID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 	if spec.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 
@@ -136,22 +136,22 @@ func (h *ProjectSpecHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	specID, err := uuid.Parse(chi.URLParam(r, "specId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
 		return
 	}
 
 	spec, err := h.specStore.GetByID(r.Context(), orgID, specID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 	if spec.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h *ProjectSpecHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
@@ -177,7 +177,7 @@ func (h *ProjectSpecHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.specStore.Update(r.Context(), &spec); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update spec")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update spec", err)
 		return
 	}
 
@@ -188,26 +188,26 @@ func (h *ProjectSpecHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	specID, err := uuid.Parse(chi.URLParam(r, "specId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid spec ID")
 		return
 	}
 	spec, err := h.specStore.GetByID(r.Context(), orgID, specID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 	if spec.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "spec not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "spec not found")
 		return
 	}
 
 	if err := h.specStore.Delete(r.Context(), orgID, specID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete spec")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete spec", err)
 		return
 	}
 

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -90,7 +90,7 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
 		repoID, err := uuid.Parse(repoIDStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return
 		}
 		filters.RepositoryID = repoID
@@ -98,7 +98,7 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	projects, err := h.projectStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list projects")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list projects", err)
 		return
 	}
 	if projects == nil {
@@ -120,19 +120,19 @@ func (h *ProjectHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	project, err := h.projectStore.GetByID(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
 	tasks, err := h.projectTaskStore.ListByProject(r.Context(), orgID, projectID, db.ProjectTaskFilters{})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_TASKS_FAILED", "failed to list project tasks")
+		writeError(w, r, http.StatusInternalServerError, "LIST_TASKS_FAILED", "failed to list project tasks", err)
 		return
 	}
 	if tasks == nil {
@@ -141,7 +141,7 @@ func (h *ProjectHandler) Get(w http.ResponseWriter, r *http.Request) {
 
 	cycles, err := h.projectCycleStore.ListByProject(r.Context(), orgID, projectID, 10)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_CYCLES_FAILED", "failed to list project cycles")
+		writeError(w, r, http.StatusInternalServerError, "LIST_CYCLES_FAILED", "failed to list project cycles", err)
 		return
 	}
 	if cycles == nil {
@@ -152,7 +152,7 @@ func (h *ProjectHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if h.attachmentStore != nil {
 		attachments, err = h.attachmentStore.ListByProject(r.Context(), orgID, projectID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "LIST_ATTACHMENTS_FAILED", "failed to list project attachments")
+			writeError(w, r, http.StatusInternalServerError, "LIST_ATTACHMENTS_FAILED", "failed to list project attachments", err)
 			return
 		}
 	}
@@ -164,7 +164,7 @@ func (h *ProjectHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if h.specStore != nil {
 		specs, err = h.specStore.ListByProject(r.Context(), orgID, projectID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "LIST_SPECS_FAILED", "failed to list project specs")
+			writeError(w, r, http.StatusInternalServerError, "LIST_SPECS_FAILED", "failed to list project specs", err)
 			return
 		}
 	}
@@ -205,18 +205,18 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Title == "" || req.Goal == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "title and goal are required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "title and goal are required")
 		return
 	}
 
 	repoID, err := uuid.Parse(req.RepositoryID)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 		return
 	}
 
@@ -224,7 +224,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.ExecutionMode != nil {
 		execMode = models.ProjectExecMode(*req.ExecutionMode)
 		if err := execMode.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_EXECUTION_MODE", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_EXECUTION_MODE", err.Error())
 			return
 		}
 	}
@@ -246,7 +246,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	if req.AgentType != nil && *req.AgentType != "" {
 		if err := models.AgentType(*req.AgentType).Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
 			return
 		}
 	}
@@ -257,7 +257,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 			agentType = models.AgentType(*req.AgentType)
 		}
 		if err := models.ValidateModelForAgentType(agentType, *req.Model); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_MODEL", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_MODEL", err.Error())
 			return
 		}
 	}
@@ -270,7 +270,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ScheduleInterval != nil && *req.ScheduleInterval > 0 {
 		if *req.ScheduleInterval > 365 {
-			writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE_INTERVAL", "schedule_interval must be between 1 and 365")
+			writeError(w, r, http.StatusBadRequest, "INVALID_SCHEDULE_INTERVAL", "schedule_interval must be between 1 and 365")
 			return
 		}
 		scheduleInterval = *req.ScheduleInterval
@@ -278,7 +278,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if req.ScheduleUnit != nil && *req.ScheduleUnit != "" {
 		scheduleUnit = *req.ScheduleUnit
 		if err := models.ScheduleUnit(scheduleUnit).Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE_UNIT", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_SCHEDULE_UNIT", err.Error())
 			return
 		}
 	}
@@ -314,7 +314,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.projectStore.Create(r.Context(), &project); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create project")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create project", err)
 		return
 	}
 
@@ -327,13 +327,13 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	project, err := h.projectStore.GetByID(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
@@ -355,7 +355,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
@@ -374,11 +374,11 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.Status != nil {
 		newStatus := models.ProjectStatus(*req.Status)
 		if err := newStatus.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_STATUS", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", err.Error())
 			return
 		}
 		if !validStatusTransition(project.Status, newStatus) {
-			writeError(w, http.StatusBadRequest, "INVALID_TRANSITION", "invalid status transition")
+			writeError(w, r, http.StatusBadRequest, "INVALID_TRANSITION", "invalid status transition")
 			return
 		}
 		project.Status = newStatus
@@ -389,7 +389,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.ExecutionMode != nil {
 		execMode := models.ProjectExecMode(*req.ExecutionMode)
 		if err := execMode.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_EXECUTION_MODE", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_EXECUTION_MODE", err.Error())
 			return
 		}
 		project.ExecutionMode = execMode
@@ -408,7 +408,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.ScheduleInterval != nil && *req.ScheduleInterval > 0 {
 		if *req.ScheduleInterval > 365 {
-			writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE_INTERVAL", "schedule_interval must be between 1 and 365")
+			writeError(w, r, http.StatusBadRequest, "INVALID_SCHEDULE_INTERVAL", "schedule_interval must be between 1 and 365")
 			return
 		}
 		project.ScheduleInterval = *req.ScheduleInterval
@@ -416,7 +416,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.ScheduleUnit != nil && *req.ScheduleUnit != "" {
 		unit := models.ScheduleUnit(*req.ScheduleUnit)
 		if err := unit.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE_UNIT", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_SCHEDULE_UNIT", err.Error())
 			return
 		}
 		project.ScheduleUnit = *req.ScheduleUnit
@@ -437,7 +437,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.projectStore.Update(r.Context(), &project); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update project")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update project", err)
 		return
 	}
 
@@ -450,12 +450,12 @@ func (h *ProjectHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	if err := h.projectStore.UpdateStatus(r.Context(), orgID, projectID, string(models.ProjectStatusCancelled)); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to cancel project")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to cancel project", err)
 		return
 	}
 
@@ -487,25 +487,25 @@ func (h *ProjectHandler) Dismiss(w http.ResponseWriter, r *http.Request) {
 // RunNow enqueues an immediate project_cycle job for the project.
 func (h *ProjectHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 	if h.jobStore == nil {
-		writeError(w, http.StatusServiceUnavailable, "NOT_CONFIGURED", "job store not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "NOT_CONFIGURED", "job store not configured")
 		return
 	}
 
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	project, err := h.projectStore.GetByID(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
 	if project.Status != models.ProjectStatusActive {
-		writeError(w, http.StatusBadRequest, "INVALID_STATUS", "project must be active to run")
+		writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", "project must be active to run")
 		return
 	}
 
@@ -516,7 +516,7 @@ func (h *ProjectHandler) RunNow(w http.ResponseWriter, r *http.Request) {
 	}
 	jobID, err := h.jobStore.Enqueue(r.Context(), orgID, "default", "project_cycle", payload, 5, &dedupeKey)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue project cycle job")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue project cycle job", err)
 		return
 	}
 
@@ -531,23 +531,23 @@ func (h *ProjectHandler) transitionStatus(w http.ResponseWriter, r *http.Request
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	project, err := h.projectStore.GetByID(r.Context(), orgID, projectID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
 	if !validStatusTransition(project.Status, target) {
-		writeError(w, http.StatusBadRequest, "INVALID_TRANSITION", "invalid status transition")
+		writeError(w, r, http.StatusBadRequest, "INVALID_TRANSITION", "invalid status transition")
 		return
 	}
 
 	if err := h.projectStore.UpdateStatus(r.Context(), orgID, projectID, string(target)); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update project status")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update project status", err)
 		return
 	}
 
@@ -584,13 +584,13 @@ func (h *ProjectHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
 	// Verify project exists
 	if _, err := h.projectStore.GetByID(r.Context(), orgID, projectID); err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "project not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "project not found")
 		return
 	}
 
@@ -601,12 +601,12 @@ func (h *ProjectHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Title == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_FIELD", "title is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_FIELD", "title is required")
 		return
 	}
 
@@ -626,7 +626,7 @@ func (h *ProjectHandler) CreateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.projectTaskStore.Create(r.Context(), &task); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create task")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create task", err)
 		return
 	}
 
@@ -645,22 +645,22 @@ func (h *ProjectHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	taskID, err := uuid.Parse(chi.URLParam(r, "taskId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
 		return
 	}
 
 	task, err := h.projectTaskStore.GetByID(r.Context(), orgID, taskID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 	if task.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 
@@ -673,7 +673,7 @@ func (h *ProjectHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
@@ -689,7 +689,7 @@ func (h *ProjectHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 	if req.Status != nil {
 		newStatus := models.ProjectTaskStatus(*req.Status)
 		if err := newStatus.Validate(); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_STATUS", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", err.Error())
 			return
 		}
 		task.Status = newStatus
@@ -699,7 +699,7 @@ func (h *ProjectHandler) UpdateTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.projectTaskStore.Update(r.Context(), &task); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update task")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update task", err)
 		return
 	}
 
@@ -717,27 +717,27 @@ func (h *ProjectHandler) DeleteTask(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	taskID, err := uuid.Parse(chi.URLParam(r, "taskId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
 		return
 	}
 
 	task, err := h.projectTaskStore.GetByID(r.Context(), orgID, taskID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 	if task.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 
 	if err := h.projectTaskStore.Delete(r.Context(), orgID, taskID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete task")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete task", err)
 		return
 	}
 
@@ -755,27 +755,27 @@ func (h *ProjectHandler) RetryTask(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 	taskID, err := uuid.Parse(chi.URLParam(r, "taskId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid task ID")
 		return
 	}
 
 	task, err := h.projectTaskStore.GetByID(r.Context(), orgID, taskID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 	if task.ProjectID != projectID {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "task not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "task not found")
 		return
 	}
 
 	if task.Status != models.ProjectTaskStatusFailed {
-		writeError(w, http.StatusBadRequest, "INVALID_STATUS", "only failed tasks can be retried")
+		writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", "only failed tasks can be retried")
 		return
 	}
 
@@ -783,7 +783,7 @@ func (h *ProjectHandler) RetryTask(w http.ResponseWriter, r *http.Request) {
 	task.RetryCount++
 
 	if err := h.projectTaskStore.Update(r.Context(), &task); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to retry task")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to retry task", err)
 		return
 	}
 
@@ -803,7 +803,7 @@ func (h *ProjectHandler) ListCycles(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	projectID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid project ID")
 		return
 	}
 
@@ -811,7 +811,7 @@ func (h *ProjectHandler) ListCycles(w http.ResponseWriter, r *http.Request) {
 
 	cycles, err := h.projectCycleStore.ListByProject(r.Context(), orgID, projectID, limit)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list cycles")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list cycles", err)
 		return
 	}
 	if cycles == nil {
@@ -828,13 +828,13 @@ func (h *ProjectHandler) GetCycle(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	cycleID, err := uuid.Parse(chi.URLParam(r, "cycleId"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid cycle ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid cycle ID")
 		return
 	}
 
 	cycle, err := h.projectCycleStore.GetByID(r.Context(), orgID, cycleID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "cycle not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "cycle not found")
 		return
 	}
 

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -9,7 +9,6 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 )
 
 type RepositoryHandler struct {
@@ -24,7 +23,7 @@ func (h *RepositoryHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repos, err := h.repoStore.ListByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list repositories")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list repositories", err)
 		return
 	}
 	if repos == nil {
@@ -37,13 +36,13 @@ func (h *RepositoryHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
 		return
 	}
 
 	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "repository not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "repository not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Repository]{Data: repo})
@@ -53,8 +52,7 @@ func (h *RepositoryHandler) Summary(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	dbSummaries, err := h.repoStore.GetSummary(r.Context(), orgID)
 	if err != nil {
-		zerolog.Ctx(r.Context()).Error().Err(err).Msg("failed to get repository summary")
-		writeError(w, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get repository summary")
+		writeError(w, r, http.StatusInternalServerError, "SUMMARY_FAILED", "failed to get repository summary", err)
 		return
 	}
 	summaries := make([]models.RepoSummary, len(dbSummaries))
@@ -74,7 +72,7 @@ func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
 		return
 	}
 
@@ -83,13 +81,13 @@ func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Settings *json.RawMessage `json:"settings"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "repository not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "repository not found")
 		return
 	}
 
@@ -100,12 +98,12 @@ func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// Validate PM settings if present.
 		repoSettings, parseErr := models.ParseRepoSettings(*req.Settings)
 		if parseErr != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SETTINGS", "invalid settings JSON")
+			writeError(w, r, http.StatusBadRequest, "INVALID_SETTINGS", "invalid settings JSON")
 			return
 		}
 		if repoSettings.PM != nil {
 			if err := models.ValidateRepoPMSettings(*repoSettings.PM); err != nil {
-				writeError(w, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
+				writeError(w, r, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
 				return
 			}
 		}
@@ -113,7 +111,7 @@ func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.repoStore.Update(r.Context(), &repo); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update repository")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update repository", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Repository]{Data: repo})
@@ -123,12 +121,12 @@ func (h *RepositoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
 		return
 	}
 
 	if err := h.repoStore.Delete(r.Context(), orgID, repoID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete repository")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete repository", err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)

--- a/internal/api/handlers/session_threads.go
+++ b/internal/api/handlers/session_threads.go
@@ -40,7 +40,7 @@ func (h *SessionThreadHandler) CreateThread(w http.ResponseWriter, r *http.Reque
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 
@@ -52,13 +52,13 @@ func (h *SessionThreadHandler) CreateThread(w http.ResponseWriter, r *http.Reque
 		FileScope    []string `json:"file_scope"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
 	body.Label = strings.TrimSpace(body.Label)
 	if body.Label == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_LABEL", "label is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_LABEL", "label is required")
 		return
 	}
 
@@ -74,19 +74,19 @@ func (h *SessionThreadHandler) CreateThread(w http.ResponseWriter, r *http.Reque
 	if err != nil {
 		switch {
 		case errors.Is(err, db.ErrThreadLimitReached):
-			writeError(w, http.StatusConflict, "THREAD_LIMIT", "maximum of 4 threads per session")
+			writeError(w, r, http.StatusConflict, "THREAD_LIMIT", "maximum of 4 threads per session")
 		case errors.Is(err, thread.ErrSessionNotFound):
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 		case errors.Is(err, thread.ErrSessionTerminal):
-			writeError(w, http.StatusConflict, "SESSION_TERMINAL", "cannot add threads to a completed session")
+			writeError(w, r, http.StatusConflict, "SESSION_TERMINAL", "cannot add threads to a completed session")
 		case errors.Is(err, thread.ErrInvalidAgentType):
-			writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
 		case errors.Is(err, thread.ErrInvalidModel):
-			writeError(w, http.StatusBadRequest, "INVALID_MODEL", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_MODEL", err.Error())
 		case errors.Is(err, thread.ErrEnqueueFailed):
-			writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue thread agent job")
+			writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue thread agent job", err)
 		default:
-			writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create thread")
+			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create thread", err)
 		}
 		return
 	}
@@ -99,17 +99,17 @@ func (h *SessionThreadHandler) ListThreads(w http.ResponseWriter, r *http.Reques
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 
 	threads, err := h.svc.ListThreads(r.Context(), orgID, sessionID)
 	if err != nil {
 		if errors.Is(err, thread.ErrSessionNotFound) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list threads")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list threads", err)
 		return
 	}
 	if threads == nil {
@@ -124,18 +124,18 @@ func (h *SessionThreadHandler) GetThread(w http.ResponseWriter, r *http.Request)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 	threadID, err := uuid.Parse(chi.URLParam(r, "tid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
 		return
 	}
 
 	t, err := h.svc.GetThread(r.Context(), orgID, sessionID, threadID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "thread not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
 		return
 	}
 
@@ -148,12 +148,12 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 	threadID, err := uuid.Parse(chi.URLParam(r, "tid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
 		return
 	}
 
@@ -162,12 +162,12 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 		Images  []string `json:"images"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 	body.Message = strings.TrimSpace(body.Message)
 	if body.Message == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
 		return
 	}
 
@@ -188,13 +188,13 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 	if err != nil {
 		switch {
 		case errors.Is(err, thread.ErrThreadNotFound):
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "thread not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
 		case errors.Is(err, thread.ErrThreadNotIdle):
-			writeError(w, http.StatusConflict, "NOT_IDLE", "thread must be idle to send a message")
+			writeError(w, r, http.StatusConflict, "NOT_IDLE", "thread must be idle to send a message")
 		case errors.Is(err, thread.ErrEnqueueFailed):
-			writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_thread job")
+			writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_thread job", err)
 		default:
-			writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message")
+			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 		}
 		return
 	}
@@ -208,22 +208,22 @@ func (h *SessionThreadHandler) GetThreadMessages(w http.ResponseWriter, r *http.
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 	threadID, err := uuid.Parse(chi.URLParam(r, "tid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
 		return
 	}
 
 	messages, err := h.svc.GetMessages(r.Context(), orgID, sessionID, threadID)
 	if err != nil {
 		if errors.Is(err, thread.ErrThreadNotFound) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "thread not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list thread messages")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list thread messages", err)
 		return
 	}
 	if messages == nil {
@@ -238,12 +238,12 @@ func (h *SessionThreadHandler) EndThread(w http.ResponseWriter, r *http.Request)
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 	threadID, err := uuid.Parse(chi.URLParam(r, "tid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
 		return
 	}
 
@@ -251,11 +251,11 @@ func (h *SessionThreadHandler) EndThread(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		switch {
 		case errors.Is(err, thread.ErrThreadNotFound):
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "thread not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
 		case errors.Is(err, thread.ErrThreadCannotBeEnded):
-			writeError(w, http.StatusConflict, "INVALID_STATUS", "thread cannot be ended in its current state")
+			writeError(w, r, http.StatusConflict, "INVALID_STATUS", "thread cannot be ended in its current state")
 		default:
-			writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to end thread")
+			writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to end thread", err)
 		}
 		return
 	}
@@ -269,22 +269,22 @@ func (h *SessionThreadHandler) GetThreadLogs(w http.ResponseWriter, r *http.Requ
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 	threadID, err := uuid.Parse(chi.URLParam(r, "tid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid thread ID")
 		return
 	}
 
 	logs, err := h.svc.GetLogs(r.Context(), orgID, sessionID, threadID)
 	if err != nil {
 		if errors.Is(err, thread.ErrThreadNotFound) {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "thread not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list thread logs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list thread logs", err)
 		return
 	}
 	if logs == nil {

--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -23,11 +23,11 @@ import (
 // --- Mock stores implementing the thread service interfaces ---
 
 type mockThreadStore struct {
-	createFn       func(ctx context.Context, t *models.SessionThread, max int) error
-	getByIDFn      func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
+	createFn        func(ctx context.Context, t *models.SessionThread, max int) error
+	getByIDFn       func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
 	listBySessionFn func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
-	claimIdleFn    func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
-	updateStatusFn func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
+	claimIdleFn     func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
+	updateStatusFn  func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
 }
 
 func (m *mockThreadStore) Create(ctx context.Context, t *models.SessionThread, max int) error {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -91,7 +91,7 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 			}
 			status := models.SessionStatus(s)
 			if err := status.Validate(); err != nil {
-				writeError(w, http.StatusBadRequest, "INVALID_STATUS", "invalid status: "+s)
+				writeError(w, r, http.StatusBadRequest, "INVALID_STATUS", "invalid status: "+s)
 				return
 			}
 			filters.Statuses = append(filters.Statuses, status)
@@ -101,7 +101,7 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
 		repoID, err := uuid.Parse(repoIDStr)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return
 		}
 		filters.RepositoryID = repoID
@@ -109,7 +109,7 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 
 	runs, err := h.runStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list runs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list runs", err)
 		return
 	}
 	if runs == nil {
@@ -131,13 +131,13 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	run, err := h.runStore.GetByID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "run not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "run not found")
 		return
 	}
 
@@ -145,7 +145,7 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	if h.threadStore != nil {
 		threads, err := h.threadStore.ListBySession(r.Context(), orgID, runID)
 		if err != nil {
-			h.logger.Warn().Err(err).Str("session_id", runID.String()).Msg("failed to load threads for session")
+			zerolog.Ctx(r.Context()).Warn().Err(err).Str("session_id", runID.String()).Msg("failed to load threads for session")
 		}
 		if threads == nil {
 			threads = []models.SessionThread{}
@@ -163,14 +163,14 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	issueID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid issue ID")
 		return
 	}
 
 	// Verify the issue exists.
 	_, err = h.issueStore.GetByID(r.Context(), orgID, issueID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "issue not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "issue not found")
 		return
 	}
 
@@ -187,7 +187,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	if agentType == "" {
 		org, err := h.orgStore.GetByID(r.Context(), orgID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings")
+			writeError(w, r, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings", err)
 			return
 		}
 		orgSettings, parseErr := models.ParseOrgSettings(org.Settings)
@@ -200,7 +200,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err := agentType.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
 		return
 	}
 
@@ -210,7 +210,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	}
 	validAutonomyLevels := map[string]bool{"full": true, "semi": true, "supervised": true}
 	if !validAutonomyLevels[autonomyLevel] {
-		writeError(w, http.StatusBadRequest, "INVALID_AUTONOMY_LEVEL", "autonomy_level must be one of: full, semi, supervised")
+		writeError(w, r, http.StatusBadRequest, "INVALID_AUTONOMY_LEVEL", "autonomy_level must be one of: full, semi, supervised")
 		return
 	}
 
@@ -220,7 +220,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	}
 	validTokenModes := map[string]bool{"low": true, "high": true}
 	if !validTokenModes[tokenMode] {
-		writeError(w, http.StatusBadRequest, "INVALID_TOKEN_MODE", "token_mode must be one of: low, high")
+		writeError(w, r, http.StatusBadRequest, "INVALID_TOKEN_MODE", "token_mode must be one of: low, high")
 		return
 	}
 
@@ -239,7 +239,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		TriggeredByUserID: triggeredByUserID,
 	}
 	if err := h.runStore.Create(r.Context(), run); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create agent run")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create agent run", err)
 		return
 	}
 
@@ -249,7 +249,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		"org_id":     orgID.String(),
 	}
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue agent run job")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue agent run job", err)
 		return
 	}
 
@@ -265,20 +265,20 @@ func (h *SessionHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	// Verify run exists and belongs to org.
 	_, err = h.runStore.GetByID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "run not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "run not found")
 		return
 	}
 
 	logs, err := h.logStore.ListByRunID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list logs")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list logs", err)
 		return
 	}
 	if logs == nil {
@@ -295,14 +295,14 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	// Verify run exists.
 	run, err := h.runStore.GetByID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "run not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "run not found")
 		return
 	}
 
@@ -315,7 +315,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 
 	sw := sse.NewWriter(w)
 	if sw == nil {
-		writeError(w, http.StatusInternalServerError, "SSE_NOT_SUPPORTED", "streaming not supported")
+		writeError(w, r, http.StatusInternalServerError, "SSE_NOT_SUPPORTED", "streaming not supported")
 		return
 	}
 
@@ -328,7 +328,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	var lastSeenID int64
 	for _, log := range logs {
 		if err := sw.WriteData(log); err != nil {
-			h.logger.Error().Err(err).Str("session_id", runID.String()).Msg("failed to write log event to SSE stream")
+			zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to write log event to SSE stream")
 			return
 		}
 		lastSeenID = log.ID
@@ -337,7 +337,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	// Send initial status event with the current session state.
 	lastStatus := run.Status
 	if err := sw.WriteEvent(sse.EventStatus, run); err != nil {
-		h.logger.Error().Err(err).Str("session_id", runID.String()).Msg("failed to write initial status event to SSE stream")
+		zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to write initial status event to SSE stream")
 		return
 	}
 	sw.Flush()
@@ -362,7 +362,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 			}
 			for _, log := range newLogs {
 				if err := sw.WriteData(log); err != nil {
-					h.logger.Error().Err(err).Str("session_id", runID.String()).Msg("failed to write log event to SSE stream")
+					zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to write log event to SSE stream")
 					return
 				}
 				lastSeenID = log.ID
@@ -372,7 +372,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 			if run.Status != lastStatus {
 				lastStatus = run.Status
 				if err := sw.WriteEvent(sse.EventStatus, run); err != nil {
-					h.logger.Error().Err(err).Str("session_id", runID.String()).Msg("failed to write status event to SSE stream")
+					zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to write status event to SSE stream")
 					return
 				}
 			}
@@ -381,7 +381,7 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 
 			if isTerminalStatus(run.Status) {
 				if err := sw.WriteEvent(sse.EventDone, run); err != nil {
-					h.logger.Error().Err(err).Str("session_id", runID.String()).Msg("failed to write done event to SSE stream")
+					zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to write done event to SSE stream")
 					return
 				}
 				sw.Flush()
@@ -396,13 +396,13 @@ func (h *SessionHandler) GetValidation(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	v, err := h.validationStore.GetBySessionID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "validation not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "validation not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Validation]{Data: v})
@@ -413,13 +413,13 @@ func (h *SessionHandler) GetPullRequest(w http.ResponseWriter, r *http.Request) 
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	pr, err := h.pullRequestStore.GetBySessionID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "pull request not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "pull request not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PullRequest]{Data: pr})
@@ -430,13 +430,13 @@ func (h *SessionHandler) ListQuestions(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
 		return
 	}
 
 	questions, err := h.questionStore.ListByRunID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list questions")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list questions", err)
 		return
 	}
 	if questions == nil {
@@ -453,13 +453,13 @@ func (h *SessionHandler) AnswerQuestion(w http.ResponseWriter, r *http.Request) 
 	orgID := middleware.OrgIDFromContext(r.Context())
 	qID, err := uuid.Parse(chi.URLParam(r, "qid"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid question ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid question ID")
 		return
 	}
 
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
 	}
 
@@ -467,22 +467,22 @@ func (h *SessionHandler) AnswerQuestion(w http.ResponseWriter, r *http.Request) 
 		Answer string `json:"answer"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 	if body.Answer == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_ANSWER", "answer is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_ANSWER", "answer is required")
 		return
 	}
 
 	if err := h.questionStore.Answer(r.Context(), orgID, qID, body.Answer, user.ID); err != nil {
-		writeError(w, http.StatusInternalServerError, "ANSWER_FAILED", "failed to answer question")
+		writeError(w, r, http.StatusInternalServerError, "ANSWER_FAILED", "failed to answer question", err)
 		return
 	}
 
 	question, err := h.questionStore.GetByID(r.Context(), orgID, qID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "FETCH_FAILED", "failed to fetch updated question")
+		writeError(w, r, http.StatusInternalServerError, "FETCH_FAILED", "failed to fetch updated question", err)
 		return
 	}
 
@@ -501,12 +501,12 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 
 	if h.messageStore == nil {
-		writeError(w, http.StatusNotImplemented, "NOT_CONFIGURED", "multi-turn sessions not configured")
+		writeError(w, r, http.StatusNotImplemented, "NOT_CONFIGURED", "multi-turn sessions not configured")
 		return
 	}
 
@@ -515,12 +515,12 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		Images  []string `json:"images"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 	body.Message = strings.TrimSpace(body.Message)
 	if body.Message == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
 		return
 	}
 
@@ -532,12 +532,12 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		// Look up the session to capture its current status for revert.
 		existing, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID)
 		if lookupErr != nil {
-			writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 			return
 		}
 		session, err = h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
 		if err != nil {
-			writeError(w, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or completed to send a message")
+			writeError(w, r, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or completed to send a message")
 			return
 		}
 		revertStatus = existing.Status // preserve original status for revert
@@ -567,7 +567,7 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, revertStatus); revertErr != nil {
 			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session status after message creation failure")
 		}
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 		return
 	}
 
@@ -580,7 +580,7 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, revertStatus); revertErr != nil {
 			zerolog.Ctx(r.Context()).Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session status after enqueue failure")
 		}
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job", err)
 		return
 	}
 
@@ -592,7 +592,7 @@ func (h *SessionHandler) ListMessages(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 
@@ -604,13 +604,13 @@ func (h *SessionHandler) ListMessages(w http.ResponseWriter, r *http.Request) {
 	// Verify session exists and belongs to org.
 	_, err = h.runStore.GetByID(r.Context(), orgID, sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 		return
 	}
 
 	messages, err := h.messageStore.ListBySession(r.Context(), orgID, sessionID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list messages")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list messages", err)
 		return
 	}
 	if messages == nil {
@@ -625,23 +625,23 @@ func (h *SessionHandler) EndSession(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
 		return
 	}
 
 	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "session not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
 		return
 	}
 
 	if session.Status != string(models.SessionStatusIdle) {
-		writeError(w, http.StatusConflict, "NOT_IDLE", "only idle sessions can be ended")
+		writeError(w, r, http.StatusConflict, "NOT_IDLE", "only idle sessions can be ended")
 		return
 	}
 
 	if err := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, string(models.SessionStatusCompleted)); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to end session")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to end session", err)
 		return
 	}
 
@@ -651,7 +651,7 @@ func (h *SessionHandler) EndSession(w http.ResponseWriter, r *http.Request) {
 	}
 	dedupeKey := fmt.Sprintf("validate:%s", sessionID)
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "validate", payload, 5, &dedupeKey); err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue validation")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue validation", err)
 		return
 	}
 
@@ -685,13 +685,13 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		Branch        string   `json:"branch"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
 	body.Message = strings.TrimSpace(body.Message)
 	if body.Message == "" {
-		writeError(w, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
+		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
 		return
 	}
 
@@ -701,11 +701,11 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	if body.RepositoryID != "" {
 		parsed, err := uuid.Parse(body.RepositoryID)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return
 		}
 		if _, err := h.repoStore.GetByID(r.Context(), orgID, parsed); err != nil {
-			writeError(w, http.StatusNotFound, "REPOSITORY_NOT_FOUND", "repository not found")
+			writeError(w, r, http.StatusNotFound, "REPOSITORY_NOT_FOUND", "repository not found")
 			return
 		}
 		repoID = &parsed
@@ -715,7 +715,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	if body.Branch != "" {
 		b := strings.TrimSpace(body.Branch)
 		if !isValidGitRef(b) {
-			writeError(w, http.StatusBadRequest, "INVALID_BRANCH", "branch contains invalid characters")
+			writeError(w, r, http.StatusBadRequest, "INVALID_BRANCH", "branch contains invalid characters")
 			return
 		}
 		targetBranch = &b
@@ -725,7 +725,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	if agentType == "" {
 		org, err := h.orgStore.GetByID(r.Context(), orgID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings")
+			writeError(w, r, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings", err)
 			return
 		}
 		orgSettings, parseErr := models.ParseOrgSettings(org.Settings)
@@ -738,14 +738,14 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err := agentType.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_AGENT_TYPE", err.Error())
 		return
 	}
 
 	var modelOverride *string
 	if body.Model != "" {
 		if err := models.ValidateModelForAgentType(agentType, body.Model); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_MODEL", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_MODEL", err.Error())
 			return
 		}
 		modelOverride = &body.Model
@@ -757,7 +757,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	}
 	validAutonomyLevels := map[string]bool{"full": true, "semi": true, "supervised": true}
 	if !validAutonomyLevels[autonomyLevel] {
-		writeError(w, http.StatusBadRequest, "INVALID_AUTONOMY_LEVEL", "autonomy_level must be one of: full, semi, supervised")
+		writeError(w, r, http.StatusBadRequest, "INVALID_AUTONOMY_LEVEL", "autonomy_level must be one of: full, semi, supervised")
 		return
 	}
 
@@ -767,7 +767,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	}
 	validTokenModes := map[string]bool{"low": true, "high": true}
 	if !validTokenModes[tokenMode] {
-		writeError(w, http.StatusBadRequest, "INVALID_TOKEN_MODE", "token_mode must be one of: low, high")
+		writeError(w, r, http.StatusBadRequest, "INVALID_TOKEN_MODE", "token_mode must be one of: low, high")
 		return
 	}
 
@@ -780,7 +780,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		"images":         body.Images,
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ENCODE_FAILED", "failed to encode manual session context")
+		writeError(w, r, http.StatusInternalServerError, "ENCODE_FAILED", "failed to encode manual session context", err)
 		return
 	}
 	issue := &models.Issue{
@@ -798,7 +798,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.issueStore.Upsert(r.Context(), issue); err != nil {
-		writeError(w, http.StatusInternalServerError, "ISSUE_CREATE_FAILED", "failed to create manual issue")
+		writeError(w, r, http.StatusInternalServerError, "ISSUE_CREATE_FAILED", "failed to create manual issue", err)
 		return
 	}
 
@@ -822,7 +822,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		RepositoryID:      repoID,
 	}
 	if err := h.runStore.Create(r.Context(), session); err != nil {
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session", err)
 		return
 	}
 
@@ -831,7 +831,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		"org_id":     orgID.String(),
 	}
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
-		writeError(w, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue manual session")
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue manual session", err)
 		return
 	}
 
@@ -839,7 +839,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	// request doesn't block for too long).
 	if h.llmClient != nil {
 		if err := h.generateSessionTitle(r.Context(), session, orgID, body.Message); err != nil {
-			writeError(w, http.StatusInternalServerError, "TITLE_GENERATION_FAILED", "failed to generate session title")
+			writeError(w, r, http.StatusInternalServerError, "TITLE_GENERATION_FAILED", "failed to generate session title", err)
 			return
 		}
 	}

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -78,9 +78,9 @@ func TestSessionHandler_List(t *testing.T) {
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
 							nil, nil, nil, nil,
-							nil, // project_task_id
-							nil, // model_override
-							nil, // triggered_by_user_id
+							nil,                      // project_task_id
+							nil,                      // model_override
+							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 							nil, // target_branch
 							nil, // working_branch
@@ -159,7 +159,7 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil,
-				nil, // triggered_by_user_id
+				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 				nil, // target_branch
 				nil, // working_branch
@@ -300,9 +300,9 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil, nil, nil, nil,
 							nil, nil, nil, nil, nil,
 							nil, nil, nil, nil,
-							nil, // project_task_id
-							nil, // model_override
-							nil, // triggered_by_user_id
+							nil,                      // project_task_id
+							nil,                      // model_override
+							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 							nil, // target_branch
 							nil, // working_branch
@@ -1012,7 +1012,7 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil,
-				nil, // triggered_by_user_id
+				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 				nil, // target_branch
 				nil, // working_branch
@@ -1096,7 +1096,7 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil,
-				nil, // triggered_by_user_id
+				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 				nil, // target_branch
 				nil, // working_branch
@@ -1153,7 +1153,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil,
-				nil, // triggered_by_user_id
+				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 				nil, // target_branch
 				nil, // working_branch
@@ -1174,7 +1174,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil, nil, nil, nil,
 				nil, nil, nil, nil,
 				nil, nil,
-				nil, // triggered_by_user_id
+				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
 				nil, // target_branch
 				nil, // working_branch

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -29,7 +29,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	org, err := h.orgStore.GetByID(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "organization not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "organization not found")
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Organization]{Data: org})
@@ -62,25 +62,25 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		Settings *json.RawMessage `json:"settings"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	if req.Settings != nil {
 		var parsedSettings models.OrgSettings
 		if err := json.Unmarshal(*req.Settings, &parsedSettings); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid settings JSON")
+			writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid settings JSON")
 			return
 		}
 		if err := models.ValidateSettingsModels(parsedSettings); err != nil {
-			writeError(w, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
+			writeError(w, r, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
 			return
 		}
 	}
 
 	org, err := h.orgStore.GetByID(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "NOT_FOUND", "organization not found")
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "organization not found")
 		return
 	}
 
@@ -92,7 +92,7 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.orgStore.Update(r.Context(), &org); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update organization")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update organization", err)
 		return
 	}
 

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -90,7 +90,7 @@ func (h *TeamHandler) ListMembers(w http.ResponseWriter, r *http.Request) {
 
 	users, err := h.users.ListByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list members")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list members", err)
 		return
 	}
 	if users == nil {
@@ -106,7 +106,7 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 
 	memberID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid member ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid member ID")
 		return
 	}
 
@@ -114,41 +114,41 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 		Role string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
 	if !slices.Contains(validRoles, body.Role) {
-		writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
 		return
 	}
 
 	if currentUser != nil && currentUser.ID == memberID {
-		writeError(w, http.StatusBadRequest, "CANNOT_CHANGE_OWN_ROLE", "admins cannot change their own role")
+		writeError(w, r, http.StatusBadRequest, "CANNOT_CHANGE_OWN_ROLE", "admins cannot change their own role")
 		return
 	}
 
 	// If demoting from admin, ensure they're not the last admin.
 	member, err := h.users.GetByID(r.Context(), orgID, memberID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "MEMBER_NOT_FOUND", "member not found in this organization")
+		writeError(w, r, http.StatusNotFound, "MEMBER_NOT_FOUND", "member not found in this organization")
 		return
 	}
 
 	if member.Role == "admin" && body.Role != "admin" {
 		count, err := h.users.CountAdmins(r.Context(), orgID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "COUNT_FAILED", "failed to check admin count")
+			writeError(w, r, http.StatusInternalServerError, "COUNT_FAILED", "failed to check admin count", err)
 			return
 		}
 		if count <= 1 {
-			writeError(w, http.StatusBadRequest, "LAST_ADMIN", "cannot demote the last admin")
+			writeError(w, r, http.StatusBadRequest, "LAST_ADMIN", "cannot demote the last admin")
 			return
 		}
 	}
 
 	if err := h.users.UpdateRole(r.Context(), orgID, memberID, body.Role); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update role")
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update role", err)
 		return
 	}
 
@@ -170,36 +170,36 @@ func (h *TeamHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
 
 	memberID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid member ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid member ID")
 		return
 	}
 
 	if currentUser != nil && currentUser.ID == memberID {
-		writeError(w, http.StatusBadRequest, "CANNOT_REMOVE_SELF", "admins cannot remove themselves")
+		writeError(w, r, http.StatusBadRequest, "CANNOT_REMOVE_SELF", "admins cannot remove themselves")
 		return
 	}
 
 	// Check that the member exists and isn't the last admin.
 	member, err := h.users.GetByID(r.Context(), orgID, memberID)
 	if err != nil {
-		writeError(w, http.StatusNotFound, "MEMBER_NOT_FOUND", "member not found in this organization")
+		writeError(w, r, http.StatusNotFound, "MEMBER_NOT_FOUND", "member not found in this organization")
 		return
 	}
 
 	if member.Role == "admin" {
 		count, err := h.users.CountAdmins(r.Context(), orgID)
 		if err != nil {
-			writeError(w, http.StatusInternalServerError, "COUNT_FAILED", "failed to check admin count")
+			writeError(w, r, http.StatusInternalServerError, "COUNT_FAILED", "failed to check admin count", err)
 			return
 		}
 		if count <= 1 {
-			writeError(w, http.StatusBadRequest, "LAST_ADMIN", "cannot remove the last admin")
+			writeError(w, r, http.StatusBadRequest, "LAST_ADMIN", "cannot remove the last admin")
 			return
 		}
 	}
 
 	if err := h.users.Delete(r.Context(), orgID, memberID); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to remove member")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to remove member", err)
 		return
 	}
 
@@ -230,14 +230,14 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 		Role  string `json:"role"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
 		return
 	}
 
 	body.Email = strings.TrimSpace(strings.ToLower(body.Email))
 
 	if _, err := mail.ParseAddress(body.Email); err != nil {
-		writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "invalid email address")
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid email address")
 		return
 	}
 
@@ -245,19 +245,19 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 		body.Role = "member"
 	}
 	if !slices.Contains(validRoles, body.Role) {
-		writeError(w, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
 		return
 	}
 
 	// Check if email is already a member of this org.
 	if existing, err := h.users.GetByEmail(r.Context(), body.Email); err == nil && existing.OrgID == orgID {
-		writeError(w, http.StatusConflict, "ALREADY_MEMBER", "this email is already a member of the organization")
+		writeError(w, r, http.StatusConflict, "ALREADY_MEMBER", "this email is already a member of the organization")
 		return
 	}
 
 	token, err := generateRandomString(32)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "TOKEN_ERROR", "failed to generate invitation token")
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_ERROR", "failed to generate invitation token", err)
 		return
 	}
 
@@ -273,10 +273,10 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	if err := h.invitations.Create(r.Context(), inv); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			writeError(w, http.StatusConflict, "INVITE_EXISTS", "a pending invitation already exists for this email")
+			writeError(w, r, http.StatusConflict, "INVITE_EXISTS", "a pending invitation already exists for this email")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "CREATE_FAILED", "failed to create invitation")
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create invitation", err)
 		return
 	}
 
@@ -296,9 +296,9 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 		Msg("invitation created — share this link with the invitee")
 
 	resp := models.InvitationResponse{
-		ID:    inv.ID,
-		Email: inv.Email,
-		Role:  inv.Role,
+		ID:     inv.ID,
+		Email:  inv.Email,
+		Role:   inv.Role,
 		Status: inv.Status,
 		InvitedBy: models.UserBrief{
 			ID:   currentUser.ID,
@@ -317,16 +317,16 @@ func (h *TeamHandler) ListInvitations(w http.ResponseWriter, r *http.Request) {
 
 	invitations, err := h.invitations.ListPendingByOrgWithInviter(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list invitations")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list invitations", err)
 		return
 	}
 
 	responses := make([]models.InvitationResponse, 0, len(invitations))
 	for _, inv := range invitations {
 		responses = append(responses, models.InvitationResponse{
-			ID:    inv.ID,
-			Email: inv.Email,
-			Role:  inv.Role,
+			ID:     inv.ID,
+			Email:  inv.Email,
+			Role:   inv.Role,
 			Status: inv.Status,
 			InvitedBy: models.UserBrief{
 				ID:   inv.InvitedBy,
@@ -346,16 +346,16 @@ func (h *TeamHandler) RevokeInvitation(w http.ResponseWriter, r *http.Request) {
 
 	invID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_ID", "invalid invitation ID")
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid invitation ID")
 		return
 	}
 
 	if err := h.invitations.Revoke(r.Context(), orgID, invID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "INVITE_NOT_FOUND", "invitation not found or already revoked")
+			writeError(w, r, http.StatusNotFound, "INVITE_NOT_FOUND", "invitation not found or already revoked")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "REVOKE_FAILED", "failed to revoke invitation")
+		writeError(w, r, http.StatusInternalServerError, "REVOKE_FAILED", "failed to revoke invitation", err)
 		return
 	}
 
@@ -371,44 +371,44 @@ func (h *TeamHandler) AcceptInvitation(w http.ResponseWriter, r *http.Request) {
 		Token string `json:"token"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token == "" {
-		writeError(w, http.StatusBadRequest, "INVALID_BODY", "token is required")
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "token is required")
 		return
 	}
 
 	inv, err := h.invitations.GetByToken(r.Context(), body.Token)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			writeError(w, http.StatusNotFound, "INVITE_NOT_FOUND", "invitation not found")
+			writeError(w, r, http.StatusNotFound, "INVITE_NOT_FOUND", "invitation not found")
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "LOOKUP_FAILED", "failed to look up invitation")
+		writeError(w, r, http.StatusInternalServerError, "LOOKUP_FAILED", "failed to look up invitation", err)
 		return
 	}
 
 	// Check status-specific errors.
 	switch inv.Status {
 	case "accepted":
-		writeError(w, http.StatusGone, "INVITE_ALREADY_USED", "this invitation has already been accepted")
+		writeError(w, r, http.StatusGone, "INVITE_ALREADY_USED", "this invitation has already been accepted")
 		return
 	case "revoked":
-		writeError(w, http.StatusGone, "INVITE_REVOKED", "this invitation has been revoked")
+		writeError(w, r, http.StatusGone, "INVITE_REVOKED", "this invitation has been revoked")
 		return
 	}
 
 	if inv.Status != "pending" {
-		writeError(w, http.StatusGone, "INVITE_EXPIRED", "this invitation is no longer valid")
+		writeError(w, r, http.StatusGone, "INVITE_EXPIRED", "this invitation is no longer valid")
 		return
 	}
 
 	if time.Now().After(inv.ExpiresAt) {
-		writeError(w, http.StatusGone, "INVITE_EXPIRED", "this invitation has expired")
+		writeError(w, r, http.StatusGone, "INVITE_EXPIRED", "this invitation has expired")
 		return
 	}
 
 	// Look up the org name for the response.
 	org, err := h.orgs.GetByID(r.Context(), inv.OrgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "ORG_LOOKUP_FAILED", "failed to look up organization")
+		writeError(w, r, http.StatusInternalServerError, "ORG_LOOKUP_FAILED", "failed to look up organization", err)
 		return
 	}
 

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -275,9 +275,9 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 			expectedBody: "CANNOT_CHANGE_OWN_ROLE",
 		},
 		{
-			name:     "cannot demote last admin",
-			memberID: memberID.String(),
-			body:     map[string]string{"role": "member"},
+			name:        "cannot demote last admin",
+			memberID:    memberID.String(),
+			body:        map[string]string{"role": "member"},
 			currentUser: adminUser,
 			users: &mockTeamUserStore{
 				getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.User, error) {
@@ -291,9 +291,9 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 			expectedBody: "LAST_ADMIN",
 		},
 		{
-			name:     "successfully changes role",
-			memberID: memberID.String(),
-			body:     map[string]string{"role": "viewer"},
+			name:        "successfully changes role",
+			memberID:    memberID.String(),
+			body:        map[string]string{"role": "viewer"},
 			currentUser: adminUser,
 			users: &mockTeamUserStore{
 				getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.User, error) {
@@ -357,8 +357,8 @@ func TestTeamHandler_RemoveMember(t *testing.T) {
 			expectedBody: "CANNOT_REMOVE_SELF",
 		},
 		{
-			name:     "cannot remove last admin",
-			memberID: memberID.String(),
+			name:        "cannot remove last admin",
+			memberID:    memberID.String(),
 			currentUser: adminUser,
 			users: &mockTeamUserStore{
 				getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.User, error) {
@@ -372,8 +372,8 @@ func TestTeamHandler_RemoveMember(t *testing.T) {
 			expectedBody: "LAST_ADMIN",
 		},
 		{
-			name:     "successfully removes member",
-			memberID: memberID.String(),
+			name:        "successfully removes member",
+			memberID:    memberID.String(),
 			currentUser: adminUser,
 			users: &mockTeamUserStore{
 				getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.User, error) {

--- a/internal/api/handlers/user_credentials.go
+++ b/internal/api/handlers/user_credentials.go
@@ -51,13 +51,13 @@ func (h *UserCredentialHandler) ListPersonal(w http.ResponseWriter, r *http.Requ
 	orgID := middleware.OrgIDFromContext(r.Context())
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
 	}
 
 	creds, err := h.store.ListByUser(r.Context(), orgID, user.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list personal credentials")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list personal credentials", err)
 		return
 	}
 
@@ -95,14 +95,14 @@ func (h *UserCredentialHandler) UpsertPersonal(w http.ResponseWriter, r *http.Re
 	orgID := middleware.OrgIDFromContext(r.Context())
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
 	}
 
 	providerStr := chi.URLParam(r, "provider")
 	provider := models.ProviderName(providerStr)
 	if !provider.IsCodingAgentProvider() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
 		return
 	}
 
@@ -111,28 +111,28 @@ func (h *UserCredentialHandler) UpsertPersonal(w http.ResponseWriter, r *http.Re
 		IsTeamDefault bool            `json:"is_team_default"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 
 	cfg, err := models.ParseProviderConfig(provider, body.Config)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
 		return
 	}
 	if err := cfg.Validate(); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
+		writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", err.Error())
 		return
 	}
 
 	// Only admins can set team defaults.
 	if body.IsTeamDefault && user.Role != "admin" {
-		writeError(w, http.StatusForbidden, "FORBIDDEN", "only admins can set team defaults")
+		writeError(w, r, http.StatusForbidden, "FORBIDDEN", "only admins can set team defaults")
 		return
 	}
 
 	if err := h.store.Upsert(r.Context(), user.ID, orgID, cfg, body.IsTeamDefault); err != nil {
-		writeError(w, http.StatusInternalServerError, "UPSERT_FAILED", "failed to save credential")
+		writeError(w, r, http.StatusInternalServerError, "UPSERT_FAILED", "failed to save credential", err)
 		return
 	}
 
@@ -151,19 +151,19 @@ func (h *UserCredentialHandler) DeletePersonal(w http.ResponseWriter, r *http.Re
 	orgID := middleware.OrgIDFromContext(r.Context())
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
 	}
 
 	providerStr := chi.URLParam(r, "provider")
 	provider := models.ProviderName(providerStr)
 	if !provider.IsCodingAgentProvider() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
 		return
 	}
 
 	if err := h.store.Disable(r.Context(), orgID, user.ID, provider); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to disable credential")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to disable credential", err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (h *UserCredentialHandler) ListTeamDefaults(w http.ResponseWriter, r *http.
 
 	defaults, err := h.store.ListTeamDefaults(r.Context(), orgID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "LIST_FAILED", "failed to list team defaults")
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list team defaults", err)
 		return
 	}
 
@@ -207,7 +207,7 @@ func (h *UserCredentialHandler) SetTeamDefault(w http.ResponseWriter, r *http.Re
 	providerStr := chi.URLParam(r, "provider")
 	provider := models.ProviderName(providerStr)
 	if !provider.IsCodingAgentProvider() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
 		return
 	}
 
@@ -215,17 +215,17 @@ func (h *UserCredentialHandler) SetTeamDefault(w http.ResponseWriter, r *http.Re
 		UserID string `json:"user_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
 		return
 	}
 	userID, err := uuid.Parse(body.UserID)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_USER_ID", "invalid user_id")
+		writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid user_id")
 		return
 	}
 
 	if err := h.store.SetTeamDefault(r.Context(), orgID, userID, provider); err != nil {
-		writeError(w, http.StatusInternalServerError, "SET_FAILED", "failed to set team default")
+		writeError(w, r, http.StatusInternalServerError, "SET_FAILED", "failed to set team default", err)
 		return
 	}
 
@@ -239,12 +239,12 @@ func (h *UserCredentialHandler) DeleteTeamDefault(w http.ResponseWriter, r *http
 	providerStr := chi.URLParam(r, "provider")
 	provider := models.ProviderName(providerStr)
 	if !provider.IsCodingAgentProvider() {
-		writeError(w, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
+		writeError(w, r, http.StatusBadRequest, "INVALID_PROVIDER", "unsupported coding agent provider: "+providerStr)
 		return
 	}
 
 	if err := h.store.RemoveTeamDefault(r.Context(), orgID, provider); err != nil {
-		writeError(w, http.StatusInternalServerError, "DELETE_FAILED", "failed to remove team default")
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to remove team default", err)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (h *UserCredentialHandler) ListResolved(w http.ResponseWriter, r *http.Requ
 	orgID := middleware.OrgIDFromContext(r.Context())
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
 	}
 

--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -39,14 +39,14 @@ func NewWebhookHandler(cfg *config.Config, orgStore *db.OrganizationStore, userS
 func (h *WebhookHandler) HandleGitHub(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "READ_FAILED", "failed to read request body")
+		writeError(w, r, http.StatusBadRequest, "READ_FAILED", "failed to read request body")
 		return
 	}
 
 	// Validate HMAC-SHA256 signature
 	signature := r.Header.Get("X-Hub-Signature-256")
 	if !h.verifySignature(body, signature) {
-		writeError(w, http.StatusUnauthorized, "INVALID_SIGNATURE", "webhook signature verification failed")
+		writeError(w, r, http.StatusUnauthorized, "INVALID_SIGNATURE", "webhook signature verification failed")
 		return
 	}
 
@@ -116,7 +116,7 @@ type installationReposEvent struct {
 func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Request, body []byte) {
 	var event installationEvent
 	if err := json.Unmarshal(body, &event); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "failed to parse installation event")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse installation event")
 		return
 	}
 
@@ -156,7 +156,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 				Settings: json.RawMessage(`{}`),
 			}
 			if createErr := h.orgStore.Create(ctx, newOrg); createErr != nil {
-				writeError(w, http.StatusInternalServerError, "ORG_CREATE_FAILED", "failed to create organization")
+				writeError(w, r, http.StatusInternalServerError, "ORG_CREATE_FAILED", "failed to create organization", createErr)
 				return
 			}
 			org = newOrg
@@ -170,7 +170,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 			})
 			if marshalErr != nil {
 				zerolog.Ctx(r.Context()).Warn().Err(marshalErr).Msg("failed to marshal integration config")
-				writeError(w, http.StatusInternalServerError, "MARSHAL_FAILED", "failed to marshal integration config")
+				writeError(w, r, http.StatusInternalServerError, "MARSHAL_FAILED", "failed to marshal integration config", marshalErr)
 				return
 			}
 			integration = &models.Integration{
@@ -180,7 +180,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 				Status:   models.IntegrationStatusActive,
 			}
 			if err := h.integrationStore.Create(ctx, integration); err != nil {
-				writeError(w, http.StatusInternalServerError, "INTEGRATION_CREATE_FAILED", "failed to create integration")
+				writeError(w, r, http.StatusInternalServerError, "INTEGRATION_CREATE_FAILED", "failed to create integration", err)
 				return
 			}
 		}
@@ -200,7 +200,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 				Settings:       json.RawMessage(`{}`),
 			}
 			if err := h.repoStore.UpsertFromGitHub(ctx, repo); err != nil {
-				writeError(w, http.StatusInternalServerError, "REPOSITORY_UPSERT_FAILED", "failed to upsert repository")
+				writeError(w, r, http.StatusInternalServerError, "REPOSITORY_UPSERT_FAILED", "failed to upsert repository", err)
 				return
 			}
 		}
@@ -210,7 +210,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 	case "deleted":
 		// Disconnect all repos for this installation
 		if err := h.repoStore.DisconnectByInstallationID(ctx, event.Installation.ID); err != nil {
-			writeError(w, http.StatusInternalServerError, "DISCONNECT_FAILED", "failed to disconnect repositories")
+			writeError(w, r, http.StatusInternalServerError, "DISCONNECT_FAILED", "failed to disconnect repositories", err)
 			return
 		}
 		writeJSON(w, http.StatusOK, map[string]string{"status": "installation deleted"})
@@ -223,7 +223,7 @@ func (h *WebhookHandler) handleInstallation(w http.ResponseWriter, r *http.Reque
 func (h *WebhookHandler) handleInstallationRepositories(w http.ResponseWriter, r *http.Request, body []byte) {
 	var event installationReposEvent
 	if err := json.Unmarshal(body, &event); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "failed to parse installation_repositories event")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse installation_repositories event")
 		return
 	}
 
@@ -232,7 +232,7 @@ func (h *WebhookHandler) handleInstallationRepositories(w http.ResponseWriter, r
 	// Look up the integration by installation_id to get org_id and integration_id
 	integration, err := h.integrationStore.GetByGitHubInstallationID(ctx, event.Installation.ID)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "INTEGRATION_LOOKUP_FAILED", "failed to find integration for installation")
+		writeError(w, r, http.StatusInternalServerError, "INTEGRATION_LOOKUP_FAILED", "failed to find integration for installation", err)
 		return
 	}
 
@@ -251,7 +251,7 @@ func (h *WebhookHandler) handleInstallationRepositories(w http.ResponseWriter, r
 			Settings:       json.RawMessage(`{}`),
 		}
 		if err := h.repoStore.UpsertFromGitHub(ctx, repo); err != nil {
-			writeError(w, http.StatusInternalServerError, "REPOSITORY_UPSERT_FAILED", "failed to upsert repository")
+			writeError(w, r, http.StatusInternalServerError, "REPOSITORY_UPSERT_FAILED", "failed to upsert repository", err)
 			return
 		}
 	}
@@ -259,7 +259,7 @@ func (h *WebhookHandler) handleInstallationRepositories(w http.ResponseWriter, r
 	// For removed repos, mark as disconnected
 	for _, whRepo := range event.RepositoriesRemoved {
 		if err := h.repoStore.DisconnectByGitHubID(ctx, event.Installation.ID, whRepo.ID); err != nil {
-			writeError(w, http.StatusInternalServerError, "REPOSITORY_DISCONNECT_FAILED", "failed to disconnect repository")
+			writeError(w, r, http.StatusInternalServerError, "REPOSITORY_DISCONNECT_FAILED", "failed to disconnect repository", err)
 			return
 		}
 	}
@@ -275,12 +275,12 @@ func (h *WebhookHandler) handlePullRequest(w http.ResponseWriter, r *http.Reques
 
 	var event ghservice.PullRequestEvent
 	if err := json.Unmarshal(body, &event); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request event")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request event")
 		return
 	}
 
 	if err := h.prService.HandlePullRequestEvent(r.Context(), event); err != nil {
-		writeError(w, http.StatusInternalServerError, "PR_EVENT_FAILED", "failed to process pull_request event")
+		writeError(w, r, http.StatusInternalServerError, "PR_EVENT_FAILED", "failed to process pull_request event", err)
 		return
 	}
 
@@ -295,12 +295,12 @@ func (h *WebhookHandler) handlePullRequestReview(w http.ResponseWriter, r *http.
 
 	var event ghservice.PullRequestReviewEvent
 	if err := json.Unmarshal(body, &event); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request_review event")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request_review event")
 		return
 	}
 
 	if err := h.prService.HandlePullRequestReviewEvent(r.Context(), event); err != nil {
-		writeError(w, http.StatusInternalServerError, "REVIEW_EVENT_FAILED", "failed to process pull_request_review event")
+		writeError(w, r, http.StatusInternalServerError, "REVIEW_EVENT_FAILED", "failed to process pull_request_review event", err)
 		return
 	}
 
@@ -315,12 +315,12 @@ func (h *WebhookHandler) handlePullRequestReviewComment(w http.ResponseWriter, r
 
 	var event ghservice.PullRequestReviewCommentEvent
 	if err := json.Unmarshal(body, &event); err != nil {
-		writeError(w, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request_review_comment event")
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse pull_request_review_comment event")
 		return
 	}
 
 	if err := h.prService.HandlePullRequestReviewCommentEvent(r.Context(), event); err != nil {
-		writeError(w, http.StatusInternalServerError, "REVIEW_COMMENT_EVENT_FAILED", "failed to process pull_request_review_comment event")
+		writeError(w, r, http.StatusInternalServerError, "REVIEW_COMMENT_EVENT_FAILED", "failed to process pull_request_review_comment event", err)
 		return
 	}
 

--- a/internal/api/handlers/webhooks_test.go
+++ b/internal/api/handlers/webhooks_test.go
@@ -205,9 +205,9 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "INVALID_SIGNATURE",
 		},
 		{
-			name:   "unknown event type is ignored",
-			secret: "test-secret",
-			event:  "push",
+			name:    "unknown event type is ignored",
+			secret:  "test-secret",
+			event:   "push",
 			payload: `{}`,
 			signature: func(secret string, body []byte) string {
 				return computeTestSignature(secret, body)
@@ -217,9 +217,9 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "ignored",
 		},
 		{
-			name:   "invalid JSON returns bad request",
-			secret: "test-secret",
-			event:  "installation",
+			name:    "invalid JSON returns bad request",
+			secret:  "test-secret",
+			event:   "installation",
 			payload: `not valid json{`,
 			signature: func(secret string, body []byte) string {
 				return computeTestSignature(secret, body)
@@ -275,9 +275,9 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "repositories updated",
 		},
 		{
-			name:   "pull_request event ignored when pr service not configured",
-			secret: "test-secret",
-			event:  "pull_request",
+			name:    "pull_request event ignored when pr service not configured",
+			secret:  "test-secret",
+			event:   "pull_request",
 			payload: `{"action":"opened","pull_request":{"number":1}}`,
 			signature: func(secret string, body []byte) string {
 				return computeTestSignature(secret, body)
@@ -287,9 +287,9 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "pr_service_not_configured",
 		},
 		{
-			name:   "pull_request_review event ignored when pr service not configured",
-			secret: "test-secret",
-			event:  "pull_request_review",
+			name:    "pull_request_review event ignored when pr service not configured",
+			secret:  "test-secret",
+			event:   "pull_request_review",
 			payload: `{"action":"submitted","review":{"id":1}}`,
 			signature: func(secret string, body []byte) string {
 				return computeTestSignature(secret, body)
@@ -299,9 +299,9 @@ func TestWebhook_HandleGitHub(t *testing.T) {
 			expectedBody: "pr_service_not_configured",
 		},
 		{
-			name:   "pull_request_review_comment event ignored when pr service not configured",
-			secret: "test-secret",
-			event:  "pull_request_review_comment",
+			name:    "pull_request_review_comment event ignored when pr service not configured",
+			secret:  "test-secret",
+			event:   "pull_request_review_comment",
 			payload: `{"action":"created","comment":{"id":1}}`,
 			signature: func(secret string, body []byte) string {
 				return computeTestSignature(secret, body)

--- a/internal/api/middleware/body_limit.go
+++ b/internal/api/middleware/body_limit.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"net/http"
+
+	"github.com/rs/zerolog"
 )
 
 // MaxBodySize returns middleware that limits request body size.
@@ -13,6 +15,7 @@ func MaxBodySize(maxBytes int64) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.ContentLength > maxBytes {
+				zerolog.Ctx(r.Context()).Warn().Int64("content_length", r.ContentLength).Int64("max_bytes", maxBytes).Msg("request body too large")
 				http.Error(w, `{"error":{"code":"PAYLOAD_TOO_LARGE","message":"request body too large"}}`, http.StatusRequestEntityTooLarge)
 				return
 			}

--- a/internal/api/middleware/org_context.go
+++ b/internal/api/middleware/org_context.go
@@ -2,6 +2,8 @@ package middleware
 
 import (
 	"net/http"
+
+	"github.com/rs/zerolog"
 )
 
 // OrgContext middleware ensures the org_id is set from the authenticated user.
@@ -11,6 +13,7 @@ func OrgContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		orgID := OrgIDFromContext(r.Context())
 		if orgID.String() == "00000000-0000-0000-0000-000000000000" {
+			zerolog.Ctx(r.Context()).Warn().Msg("request rejected: no organization context")
 			http.Error(w, `{"error":{"code":"FORBIDDEN","message":"no organization context"}}`, http.StatusForbidden)
 			return
 		}

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 // RateLimitConfig defines rate limiting parameters.
@@ -144,6 +145,7 @@ func RateLimit(config RateLimitConfig) func(http.Handler) http.Handler {
 			// Check IP rate limit
 			ip := extractIP(r)
 			if !limiter.getIPBucket(ip).allow() {
+				zerolog.Ctx(r.Context()).Warn().Str("ip", ip).Msg("IP rate limit exceeded")
 				w.Header().Set("Retry-After", "1")
 				http.Error(w, `{"error":{"code":"RATE_LIMITED","message":"too many requests"}}`, http.StatusTooManyRequests)
 				return
@@ -153,6 +155,7 @@ func RateLimit(config RateLimitConfig) func(http.Handler) http.Handler {
 			orgID := OrgIDFromContext(r.Context())
 			if orgID != uuid.Nil {
 				if !limiter.getOrgBucket(orgID).allow() {
+					zerolog.Ctx(r.Context()).Warn().Str("org_id", orgID.String()).Msg("org rate limit exceeded")
 					w.Header().Set("Retry-After", "1")
 					http.Error(w, `{"error":{"code":"RATE_LIMITED","message":"org rate limit exceeded"}}`, http.StatusTooManyRequests)
 					return
@@ -173,7 +176,7 @@ func extractIP(r *http.Request) string {
 				if c == ',' {
 					return xff[:i]
 				}
-				_ = i
+				_ = i // suppress unused variable
 			}
 			return xff
 		}

--- a/internal/api/middleware/response.go
+++ b/internal/api/middleware/response.go
@@ -16,6 +16,9 @@ type errorDetail struct {
 	Message string `json:"message"`
 }
 
+// writeError writes a JSON error response. Uses the global logger for encode
+// failures because this runs in auth/CSRF middleware before the request-scoped
+// logger is available.
 func writeError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/api/middleware/webhook_signature.go
+++ b/internal/api/middleware/webhook_signature.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"net/http"
 	"strings"
+
+	"github.com/rs/zerolog"
 )
 
 // VerifyWebhookSignature verifies HMAC-SHA256 signatures on inbound webhooks.
@@ -25,6 +27,7 @@ func VerifyWebhookSignature(headerName, secret, prefixToStrip string) func(http.
 
 			signature := r.Header.Get(headerName)
 			if signature == "" {
+				zerolog.Ctx(r.Context()).Warn().Str("header", headerName).Msg("missing webhook signature")
 				http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"missing webhook signature"}}`, http.StatusUnauthorized)
 				return
 			}
@@ -36,6 +39,7 @@ func VerifyWebhookSignature(headerName, secret, prefixToStrip string) func(http.
 			// Read the body for verification, then restore it
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
+				zerolog.Ctx(r.Context()).Warn().Err(err).Msg("failed to read webhook request body")
 				http.Error(w, `{"error":{"code":"BAD_REQUEST","message":"failed to read request body"}}`, http.StatusBadRequest)
 				return
 			}
@@ -47,6 +51,7 @@ func VerifyWebhookSignature(headerName, secret, prefixToStrip string) func(http.
 			expectedMAC := hex.EncodeToString(mac.Sum(nil))
 
 			if !hmac.Equal([]byte(signature), []byte(expectedMAC)) {
+				zerolog.Ctx(r.Context()).Warn().Str("header", headerName).Msg("invalid webhook signature")
 				http.Error(w, `{"error":{"code":"UNAUTHORIZED","message":"invalid webhook signature"}}`, http.StatusUnauthorized)
 				return
 			}

--- a/internal/llm/anthropic.go
+++ b/internal/llm/anthropic.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rs/zerolog/log"
+	"github.com/rs/zerolog"
 )
 
 // AnthropicProvider implements Provider using the Anthropic Messages API.
@@ -53,7 +53,7 @@ func (p *AnthropicProvider) Name() string { return "anthropic" }
 func (p *AnthropicProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
 	if reasoningEffort != "" {
 		// Anthropic does not support reasoning_effort; log so callers know it was ignored.
-		log.Ctx(ctx).Warn().
+		zerolog.Ctx(ctx).Warn().
 			Str("provider", "anthropic").
 			Str("model", model).
 			Str("reasoning_effort", string(reasoningEffort)).

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -619,11 +619,11 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		go func() {
 			defer restoreWg.Done()
 			restoreErr = o.snapshots.Load(ctx, *session.SnapshotKey, snapshotWriter)
-			_ = snapshotWriter.Close()
+			_ = snapshotWriter.Close() // Intentionally ignored: pipe close error is not actionable here; restoreErr captures the real failure.
 		}()
 
 		if err := o.provider.Restore(ctx, sandbox, snapshotReader); err != nil {
-			_ = snapshotReader.Close()
+			_ = snapshotReader.Close() // Intentionally ignored: we already have the restore error.
 			restoreWg.Wait()
 			o.failRun(ctx, session, fmt.Sprintf("restore snapshot: %s", err))
 			return fmt.Errorf("restore snapshot: %w", err)

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -434,6 +434,8 @@ func (d *DockerProvider) Restore(ctx context.Context, sb *agent.Sandbox, reader 
 	if _, err := io.Copy(attachResp.Conn, reader); err != nil {
 		return fmt.Errorf("write snapshot to container: %w", err)
 	}
+	// Intentionally ignored: CloseWrite signals EOF to the exec process; any error here
+	// does not affect the snapshot data already written.
 	_ = attachResp.CloseWrite()
 
 	// Drain stdout/stderr so the exec process can finish writing.

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -306,6 +306,7 @@ func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID) (*AuthStatu
 		var errResp struct {
 			Error string `json:"error"`
 		}
+		// Intentionally ignored: if unmarshal fails, errResp.Error stays empty and the default switch case handles it.
 		_ = json.Unmarshal(body, &errResp)
 
 		switch errResp.Error {

--- a/internal/services/prioritization/service.go
+++ b/internal/services/prioritization/service.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
 
 	llmpkg "github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/models"
@@ -54,10 +53,10 @@ type jobStore interface {
 // unification is not done because the nested struct shapes differ slightly
 // (e.g. ConfidenceThresholds, PriorityWeights use inline structs here).
 type OrgSettings struct {
-	AutonomyLevel    string `json:"autonomy_level"`
-	Aggressiveness   int    `json:"execution_aggressiveness"`
-	MaxConcurrentRuns int   `json:"max_concurrent_runs"`
-	AgentAutonomy    string `json:"agent_autonomy"`
+	AutonomyLevel        string `json:"autonomy_level"`
+	Aggressiveness       int    `json:"execution_aggressiveness"`
+	MaxConcurrentRuns    int    `json:"max_concurrent_runs"`
+	AgentAutonomy        string `json:"agent_autonomy"`
 	ConfidenceThresholds struct {
 		AutoProceed float64 `json:"auto_proceed"`
 		HumanReview float64 `json:"human_review"`
@@ -92,7 +91,7 @@ type Service struct {
 	issues     issueStore
 	priorities priorityScoreStore
 	complexity complexityEstimateStore
-	sessions  sessionStore
+	sessions   sessionStore
 	orgs       orgStore
 	jobs       jobStore
 	llm        llmpkg.Client // can be nil
@@ -114,7 +113,7 @@ func NewService(
 		issues:     issues,
 		priorities: priorities,
 		complexity: complexity,
-		sessions:  sessions,
+		sessions:   sessions,
 		orgs:       orgs,
 		jobs:       jobs,
 		llm:        llmClient,
@@ -134,7 +133,7 @@ func (s *Service) ComputeScore(ctx context.Context, orgID, issueID uuid.UUID) (*
 		return nil, fmt.Errorf("fetch org: %w", err)
 	}
 
-	settings := parseOrgSettings(org.Settings)
+	settings := parseOrgSettings(s.logger, org.Settings)
 
 	// Compute sub-scores.
 	customerImpact := computeCustomerImpact(issue.AffectedCustomerCount, issue.OccurrenceCount)
@@ -276,7 +275,7 @@ func (s *Service) CheckAutoTrigger(ctx context.Context, orgID uuid.UUID, score *
 	if err != nil {
 		return fmt.Errorf("fetch org: %w", err)
 	}
-	settings := parseOrgSettings(org.Settings)
+	settings := parseOrgSettings(s.logger, org.Settings)
 
 	// Gate 1: autonomy level.
 	if settings.AutonomyLevel == string(models.AutonomyLevelManual) {
@@ -331,12 +330,12 @@ func (s *Service) CheckAutoTrigger(ctx context.Context, orgID uuid.UUID, score *
 		agentType = models.DefaultDefaultAgentType
 	}
 	run := &models.Session{
-		IssueID:       issue.ID,
-		OrgID:         orgID,
-		AgentType:     agentType,
-		Status:        "pending",
-		AutonomyLevel: settings.AutonomyLevel,
-		TokenMode:     "low",
+		IssueID:        issue.ID,
+		OrgID:          orgID,
+		AgentType:      agentType,
+		Status:         "pending",
+		AutonomyLevel:  settings.AutonomyLevel,
+		TokenMode:      "low",
 		ComplexityTier: &estimate.Tier,
 	}
 	if err := s.sessions.Create(ctx, run); err != nil {
@@ -345,7 +344,7 @@ func (s *Service) CheckAutoTrigger(ctx context.Context, orgID uuid.UUID, score *
 
 	payload := map[string]string{
 		"session_id": run.ID.String(),
-		"org_id":       orgID.String(),
+		"org_id":     orgID.String(),
 	}
 	dedupeKey := fmt.Sprintf("run_agent:%s", run.ID.String())
 	if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
@@ -493,11 +492,11 @@ func heuristicComplexity(issue *models.Issue) (tier int, label string, confidenc
 }
 
 // parseOrgSettings parses OrgSettings from raw JSON, returning defaults for missing values.
-func parseOrgSettings(raw json.RawMessage) OrgSettings {
+func parseOrgSettings(logger zerolog.Logger, raw json.RawMessage) OrgSettings {
 	var settings OrgSettings
 	if len(raw) > 0 {
 		if err := json.Unmarshal(raw, &settings); err != nil {
-			log.Warn().Err(err).Msg("failed to parse org settings for prioritization, using defaults")
+			logger.Warn().Err(err).Msg("failed to parse org settings for prioritization, using defaults")
 		}
 	}
 	return settings

--- a/internal/services/prioritization/service_test.go
+++ b/internal/services/prioritization/service_test.go
@@ -462,11 +462,11 @@ func TestScoringAndHelpers(t *testing.T) {
 		{
 			name: "org settings parsing uses defaults for invalid json",
 			validate: func(t *testing.T) {
-				settings := parseOrgSettings(json.RawMessage(`{"autonomy_level":"auto","execution_aggressiveness":4}`))
+				settings := parseOrgSettings(zerolog.Nop(), json.RawMessage(`{"autonomy_level":"auto","execution_aggressiveness":4}`))
 				require.Equal(t, "auto", settings.AutonomyLevel, "parseOrgSettings should parse autonomy level when provided")
 				require.Equal(t, 4, settings.Aggressiveness, "parseOrgSettings should parse aggressiveness when provided")
 
-				badSettings := parseOrgSettings(json.RawMessage(`{"autonomy_level":`))
+				badSettings := parseOrgSettings(zerolog.Nop(), json.RawMessage(`{"autonomy_level":`))
 				require.Equal(t, "", badSettings.AutonomyLevel, "parseOrgSettings should return zero values for invalid json")
 			},
 		},

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -149,17 +149,21 @@ func (w *Worker) poll(ctx context.Context) {
 }
 
 func (w *Worker) succeedJob(ctx context.Context, jobID uuid.UUID) {
-	_, _ = w.db.Exec(ctx, `
+	if _, err := w.db.Exec(ctx, `
 		UPDATE jobs SET status = 'succeeded', completed_at = now(), locked_by_node_id = NULL, locked_at = NULL, updated_at = now()
 		WHERE id = $1
-	`, jobID)
+	`, jobID); err != nil {
+		w.logger.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to mark job as succeeded")
+	}
 }
 
 func (w *Worker) failJob(ctx context.Context, jobID uuid.UUID, errMsg string) {
-	_, _ = w.db.Exec(ctx, `
+	if _, err := w.db.Exec(ctx, `
 		UPDATE jobs SET status = 'failed', last_error = $1, locked_by_node_id = NULL, locked_at = NULL, updated_at = now()
 		WHERE id = $2
-	`, errMsg, jobID)
+	`, errMsg, jobID); err != nil {
+		w.logger.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to mark job as failed")
+	}
 }
 
 func (w *Worker) retryJob(ctx context.Context, jobID uuid.UUID, errMsg string, attempt int) {
@@ -169,15 +173,19 @@ func (w *Worker) retryJob(ctx context.Context, jobID uuid.UUID, errMsg string, a
 		exp = 10
 	}
 	backoff := time.Duration(1<<exp) * time.Second // exp is capped at 10 above
-	_, _ = w.db.Exec(ctx, `
+	if _, err := w.db.Exec(ctx, `
 		UPDATE jobs SET status = 'pending', last_error = $1, run_at = now() + $2::interval, locked_by_node_id = NULL, locked_at = NULL, updated_at = now()
 		WHERE id = $3
-	`, errMsg, fmt.Sprintf("%d seconds", int(backoff.Seconds())), jobID)
+	`, errMsg, fmt.Sprintf("%d seconds", int(backoff.Seconds())), jobID); err != nil {
+		w.logger.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to schedule job retry")
+	}
 }
 
 func (w *Worker) deadLetterJob(ctx context.Context, jobID uuid.UUID, errMsg string) {
-	_, _ = w.db.Exec(ctx, `
+	if _, err := w.db.Exec(ctx, `
 		UPDATE jobs SET status = 'dead_letter', last_error = $1, completed_at = now(), locked_by_node_id = NULL, locked_at = NULL, updated_at = now()
 		WHERE id = $2
-	`, errMsg, jobID)
+	`, errMsg, jobID); err != nil {
+		w.logger.Warn().Err(err).Str("job_id", jobID.String()).Msg("failed to dead-letter job")
+	}
 }


### PR DESCRIPTION
## Summary

Ensures every HTTP error response (4xx, 5xx) is logged consistently with full request context.

- Modified `writeError` to log automatically using request-scoped logger (org_id, user_id, request_id)
- Updated all 23 handlers to pass request and error to `writeError`
- Added error logging to worker job status update methods
- Removed global log package usage from prioritization service
- Established error logging conventions in internal/AGENTS.md

## Changes

- **handlers/helpers.go**: New `writeError` signature accepts request and optional error; logs at Error/Warn levels
- **All handler files**: Updated 100+ `writeError` calls to include request and error parameters
- **worker.go**: Job status methods now log failures instead of silently discarding errors
- **prioritization/service.go**: Removed global log import; uses injected logger
- **internal/AGENTS.md**: Documented logging conventions and best practices

## Testing

- All changes maintain existing API contracts
- Handler tests updated to pass required parameters
- Syntax validated across all files