### PR TITLE
Add org-size-aware context limits and adaptive token budgets

### DIFF
--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -69,6 +69,47 @@ func (r ReasoningEffort) Validate() error {
 	}
 }
 
+// OrgSize classifies an organization by volume of issues and activity.
+// It drives default context limits to ensure the PM agent gets sufficient
+// signal for prioritization without blowing token budgets.
+type OrgSize string
+
+const (
+	OrgSizeSmall      OrgSize = "small"      // <50 open issues, ≤3 concurrent runs
+	OrgSizeMedium     OrgSize = "medium"     // 50–200 open issues, ≤5 concurrent runs
+	OrgSizeLarge      OrgSize = "large"      // 200–1000 open issues, ≤10 concurrent runs
+	OrgSizeEnterprise OrgSize = "enterprise" // 1000+ open issues, ≤20 concurrent runs
+)
+
+// Validate returns an error if the org size is not a recognized value.
+func (s OrgSize) Validate() error {
+	switch s {
+	case "", OrgSizeSmall, OrgSizeMedium, OrgSizeLarge, OrgSizeEnterprise:
+		return nil
+	default:
+		return fmt.Errorf("invalid org size: %q", s)
+	}
+}
+
+// ContextLimits controls how much data is gathered for PM and agent contexts.
+// All fields are configurable per-org; zero values are replaced with
+// size-appropriate defaults in ParseOrgSettings.
+type ContextLimits struct {
+	// PM context gathering limits
+	MaxOpenIssues       int `json:"max_open_issues"`       // max open issues fetched for PM
+	MaxTriagedIssues    int `json:"max_triaged_issues"`    // max triaged issues fetched for PM
+	MaxInFlightRuns     int `json:"max_in_flight_runs"`    // max in-flight sessions shown to PM
+	MaxRecentOutcomes   int `json:"max_recent_outcomes"`   // max recent completed/failed runs
+	MaxRecentPRs        int `json:"max_recent_prs"`        // max recent PRs shown to PM
+	MaxDecisionHistory  int `json:"max_decision_history"`  // max past decisions shown to PM
+	IssueDescriptionMax int `json:"issue_description_max"` // max chars per issue description
+
+	// Token limits for agents
+	PMMaxTokens        int `json:"pm_max_tokens"`         // max tokens for PM agent context
+	AgentLowTokenMax   int `json:"agent_low_token_max"`   // token limit for low-complexity tasks
+	AgentHighTokenMax  int `json:"agent_high_token_max"`  // token limit for high-complexity tasks
+}
+
 // OrgSettings is the strongly-typed representation of organizations.settings JSONB.
 type OrgSettings struct {
 	AutonomyLevel        AutonomyLevel        `json:"autonomy_level"`
@@ -87,6 +128,8 @@ type OrgSettings struct {
 	AgentConfig          AgentEnvConfig       `json:"agent_config,omitempty"`
 	DefaultAgentType     AgentType            `json:"default_agent_type,omitempty"`
 	AuditRetentionDays   int                  `json:"audit_retention_days,omitempty"`
+	OrgSize              OrgSize              `json:"org_size,omitempty"`
+	ContextLimits        ContextLimits        `json:"context_limits,omitempty"`
 }
 
 // Agent autonomy mode constants.
@@ -134,6 +177,7 @@ const (
 	DefaultPMScheduleHours      = 4
 	DefaultPMModel              = PMModelSonnet
 	DefaultAuditRetentionDays   = 90
+	DefaultOrgSize              OrgSize       = OrgSizeMedium
 
 	DefaultWeightCustomerImpact = 0.35
 	DefaultWeightSeverity       = 0.25
@@ -143,6 +187,100 @@ const (
 	DefaultConfidenceAutoProceed = 0.85
 	DefaultConfidenceHumanReview = 0.60
 )
+
+// ContextLimitsForSize returns the default context limits for a given org size.
+// These presets balance signal quality against token costs:
+//   - Small orgs: minimal context, all issues fit easily
+//   - Medium orgs: moderate context (current defaults)
+//   - Large orgs: expanded context, more frequent PM runs, higher token budgets
+//   - Enterprise orgs: maximum context for comprehensive prioritization
+func ContextLimitsForSize(size OrgSize) ContextLimits {
+	switch size {
+	case OrgSizeSmall:
+		return ContextLimits{
+			MaxOpenIssues:       50,
+			MaxTriagedIssues:    50,
+			MaxInFlightRuns:     20,
+			MaxRecentOutcomes:   10,
+			MaxRecentPRs:        10,
+			MaxDecisionHistory:  25,
+			IssueDescriptionMax: 500,
+			PMMaxTokens:         30_000,
+			AgentLowTokenMax:    50_000,
+			AgentHighTokenMax:   200_000,
+		}
+	case OrgSizeLarge:
+		return ContextLimits{
+			MaxOpenIssues:       300,
+			MaxTriagedIssues:    200,
+			MaxInFlightRuns:     100,
+			MaxRecentOutcomes:   50,
+			MaxRecentPRs:        40,
+			MaxDecisionHistory:  100,
+			IssueDescriptionMax: 400,
+			PMMaxTokens:         100_000,
+			AgentLowTokenMax:    50_000,
+			AgentHighTokenMax:   200_000,
+		}
+	case OrgSizeEnterprise:
+		return ContextLimits{
+			MaxOpenIssues:       500,
+			MaxTriagedIssues:    300,
+			MaxInFlightRuns:     150,
+			MaxRecentOutcomes:   75,
+			MaxRecentPRs:        60,
+			MaxDecisionHistory:  150,
+			IssueDescriptionMax: 300,
+			PMMaxTokens:         150_000,
+			AgentLowTokenMax:    75_000,
+			AgentHighTokenMax:   250_000,
+		}
+	default: // medium (current defaults)
+		return ContextLimits{
+			MaxOpenIssues:       100,
+			MaxTriagedIssues:    100,
+			MaxInFlightRuns:     50,
+			MaxRecentOutcomes:   20,
+			MaxRecentPRs:        20,
+			MaxDecisionHistory:  50,
+			IssueDescriptionMax: 500,
+			PMMaxTokens:         50_000,
+			AgentLowTokenMax:    50_000,
+			AgentHighTokenMax:   200_000,
+		}
+	}
+}
+
+// PMScheduleHoursForSize returns the recommended PM schedule interval
+// for a given org size. Larger orgs benefit from more frequent PM runs
+// to keep up with higher issue volume.
+func PMScheduleHoursForSize(size OrgSize) int {
+	switch size {
+	case OrgSizeSmall:
+		return 6
+	case OrgSizeLarge:
+		return 2
+	case OrgSizeEnterprise:
+		return 1
+	default: // medium
+		return 4
+	}
+}
+
+// MaxConcurrentRunsForSize returns the recommended concurrency limit
+// for a given org size.
+func MaxConcurrentRunsForSize(size OrgSize) int {
+	switch size {
+	case OrgSizeSmall:
+		return 3
+	case OrgSizeLarge:
+		return 10
+	case OrgSizeEnterprise:
+		return 20
+	default: // medium
+		return 5
+	}
+}
 
 // ProductContext captures the strategic context for the PM agent.
 type ProductContext struct {
@@ -168,8 +306,14 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 	if s.Aggressiveness == 0 {
 		s.Aggressiveness = DefaultAggressiveness
 	}
+	// Resolve org size early so size-aware defaults can be applied below.
+	effectiveSize := s.OrgSize
+	if effectiveSize == "" {
+		effectiveSize = DefaultOrgSize
+	}
+
 	if s.MaxConcurrentRuns == 0 {
-		s.MaxConcurrentRuns = DefaultMaxConcurrentRuns
+		s.MaxConcurrentRuns = MaxConcurrentRunsForSize(effectiveSize)
 	}
 	if s.AgentAutonomy == "" {
 		s.AgentAutonomy = DefaultAgentAutonomy
@@ -180,7 +324,7 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 		s.MinPriorityThreshold = DefaultMinPriorityThreshold
 	}
 	if s.PMScheduleHours == 0 {
-		s.PMScheduleHours = DefaultPMScheduleHours
+		s.PMScheduleHours = PMScheduleHoursForSize(effectiveSize)
 	}
 	if s.PMModel == "" {
 		s.PMModel = DefaultPMModel
@@ -204,5 +348,43 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 			Direction: s.ProductDirection,
 		}
 	}
+
+	// Apply org-size-aware defaults for context limits.
+	orgSize := s.OrgSize
+	if orgSize == "" {
+		orgSize = DefaultOrgSize
+	}
+	defaults := ContextLimitsForSize(orgSize)
+	if s.ContextLimits.MaxOpenIssues == 0 {
+		s.ContextLimits.MaxOpenIssues = defaults.MaxOpenIssues
+	}
+	if s.ContextLimits.MaxTriagedIssues == 0 {
+		s.ContextLimits.MaxTriagedIssues = defaults.MaxTriagedIssues
+	}
+	if s.ContextLimits.MaxInFlightRuns == 0 {
+		s.ContextLimits.MaxInFlightRuns = defaults.MaxInFlightRuns
+	}
+	if s.ContextLimits.MaxRecentOutcomes == 0 {
+		s.ContextLimits.MaxRecentOutcomes = defaults.MaxRecentOutcomes
+	}
+	if s.ContextLimits.MaxRecentPRs == 0 {
+		s.ContextLimits.MaxRecentPRs = defaults.MaxRecentPRs
+	}
+	if s.ContextLimits.MaxDecisionHistory == 0 {
+		s.ContextLimits.MaxDecisionHistory = defaults.MaxDecisionHistory
+	}
+	if s.ContextLimits.IssueDescriptionMax == 0 {
+		s.ContextLimits.IssueDescriptionMax = defaults.IssueDescriptionMax
+	}
+	if s.ContextLimits.PMMaxTokens == 0 {
+		s.ContextLimits.PMMaxTokens = defaults.PMMaxTokens
+	}
+	if s.ContextLimits.AgentLowTokenMax == 0 {
+		s.ContextLimits.AgentLowTokenMax = defaults.AgentLowTokenMax
+	}
+	if s.ContextLimits.AgentHighTokenMax == 0 {
+		s.ContextLimits.AgentHighTokenMax = defaults.AgentHighTokenMax
+	}
+
 	return s, nil
 }

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -84,7 +84,7 @@ const (
 // Validate returns an error if the org size is not a recognized value.
 func (s OrgSize) Validate() error {
 	switch s {
-	case "", OrgSizeSmall, OrgSizeMedium, OrgSizeLarge, OrgSizeEnterprise:
+	case OrgSizeSmall, OrgSizeMedium, OrgSizeLarge, OrgSizeEnterprise:
 		return nil
 	default:
 		return fmt.Errorf("invalid org size: %q", s)
@@ -108,6 +108,44 @@ type ContextLimits struct {
 	PMMaxTokens        int `json:"pm_max_tokens"`         // max tokens for PM agent context
 	AgentLowTokenMax   int `json:"agent_low_token_max"`   // token limit for low-complexity tasks
 	AgentHighTokenMax  int `json:"agent_high_token_max"`  // token limit for high-complexity tasks
+}
+
+// WithDefaults returns a copy of the ContextLimits with any zero-valued fields
+// filled in from defaults. This is idempotent — calling it on an already-complete
+// ContextLimits returns an identical copy.
+func (c ContextLimits) WithDefaults(defaults ContextLimits) ContextLimits {
+	out := c
+	if out.MaxOpenIssues == 0 {
+		out.MaxOpenIssues = defaults.MaxOpenIssues
+	}
+	if out.MaxTriagedIssues == 0 {
+		out.MaxTriagedIssues = defaults.MaxTriagedIssues
+	}
+	if out.MaxInFlightRuns == 0 {
+		out.MaxInFlightRuns = defaults.MaxInFlightRuns
+	}
+	if out.MaxRecentOutcomes == 0 {
+		out.MaxRecentOutcomes = defaults.MaxRecentOutcomes
+	}
+	if out.MaxRecentPRs == 0 {
+		out.MaxRecentPRs = defaults.MaxRecentPRs
+	}
+	if out.MaxDecisionHistory == 0 {
+		out.MaxDecisionHistory = defaults.MaxDecisionHistory
+	}
+	if out.IssueDescriptionMax == 0 {
+		out.IssueDescriptionMax = defaults.IssueDescriptionMax
+	}
+	if out.PMMaxTokens == 0 {
+		out.PMMaxTokens = defaults.PMMaxTokens
+	}
+	if out.AgentLowTokenMax == 0 {
+		out.AgentLowTokenMax = defaults.AgentLowTokenMax
+	}
+	if out.AgentHighTokenMax == 0 {
+		out.AgentHighTokenMax = defaults.AgentHighTokenMax
+	}
+	return out
 }
 
 // OrgSettings is the strongly-typed representation of organizations.settings JSONB.
@@ -188,14 +226,14 @@ const (
 	DefaultConfidenceHumanReview = 0.60
 )
 
-// ContextLimitsForSize returns the default context limits for a given org size.
+// ContextLimits returns the default context limits for this org size.
 // These presets balance signal quality against token costs:
 //   - Small orgs: minimal context, all issues fit easily
 //   - Medium orgs: moderate context (current defaults)
 //   - Large orgs: expanded context, more frequent PM runs, higher token budgets
 //   - Enterprise orgs: maximum context for comprehensive prioritization
-func ContextLimitsForSize(size OrgSize) ContextLimits {
-	switch size {
+func (s OrgSize) ContextLimits() ContextLimits {
+	switch s {
 	case OrgSizeSmall:
 		return ContextLimits{
 			MaxOpenIssues:       50,
@@ -251,11 +289,10 @@ func ContextLimitsForSize(size OrgSize) ContextLimits {
 	}
 }
 
-// PMScheduleHoursForSize returns the recommended PM schedule interval
-// for a given org size. Larger orgs benefit from more frequent PM runs
-// to keep up with higher issue volume.
-func PMScheduleHoursForSize(size OrgSize) int {
-	switch size {
+// PMScheduleHours returns the recommended PM schedule interval for this org size.
+// Larger orgs benefit from more frequent PM runs to keep up with higher issue volume.
+func (s OrgSize) PMScheduleHours() int {
+	switch s {
 	case OrgSizeSmall:
 		return 6
 	case OrgSizeLarge:
@@ -267,10 +304,9 @@ func PMScheduleHoursForSize(size OrgSize) int {
 	}
 }
 
-// MaxConcurrentRunsForSize returns the recommended concurrency limit
-// for a given org size.
-func MaxConcurrentRunsForSize(size OrgSize) int {
-	switch size {
+// MaxConcurrentRuns returns the recommended concurrency limit for this org size.
+func (s OrgSize) MaxConcurrentRuns() int {
+	switch s {
 	case OrgSizeSmall:
 		return 3
 	case OrgSizeLarge:
@@ -313,7 +349,7 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 	}
 
 	if s.MaxConcurrentRuns == 0 {
-		s.MaxConcurrentRuns = MaxConcurrentRunsForSize(effectiveSize)
+		s.MaxConcurrentRuns = effectiveSize.MaxConcurrentRuns()
 	}
 	if s.AgentAutonomy == "" {
 		s.AgentAutonomy = DefaultAgentAutonomy
@@ -324,7 +360,7 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 		s.MinPriorityThreshold = DefaultMinPriorityThreshold
 	}
 	if s.PMScheduleHours == 0 {
-		s.PMScheduleHours = PMScheduleHoursForSize(effectiveSize)
+		s.PMScheduleHours = effectiveSize.PMScheduleHours()
 	}
 	if s.PMModel == "" {
 		s.PMModel = DefaultPMModel
@@ -350,41 +386,7 @@ func ParseOrgSettings(raw json.RawMessage) (OrgSettings, error) {
 	}
 
 	// Apply org-size-aware defaults for context limits.
-	orgSize := s.OrgSize
-	if orgSize == "" {
-		orgSize = DefaultOrgSize
-	}
-	defaults := ContextLimitsForSize(orgSize)
-	if s.ContextLimits.MaxOpenIssues == 0 {
-		s.ContextLimits.MaxOpenIssues = defaults.MaxOpenIssues
-	}
-	if s.ContextLimits.MaxTriagedIssues == 0 {
-		s.ContextLimits.MaxTriagedIssues = defaults.MaxTriagedIssues
-	}
-	if s.ContextLimits.MaxInFlightRuns == 0 {
-		s.ContextLimits.MaxInFlightRuns = defaults.MaxInFlightRuns
-	}
-	if s.ContextLimits.MaxRecentOutcomes == 0 {
-		s.ContextLimits.MaxRecentOutcomes = defaults.MaxRecentOutcomes
-	}
-	if s.ContextLimits.MaxRecentPRs == 0 {
-		s.ContextLimits.MaxRecentPRs = defaults.MaxRecentPRs
-	}
-	if s.ContextLimits.MaxDecisionHistory == 0 {
-		s.ContextLimits.MaxDecisionHistory = defaults.MaxDecisionHistory
-	}
-	if s.ContextLimits.IssueDescriptionMax == 0 {
-		s.ContextLimits.IssueDescriptionMax = defaults.IssueDescriptionMax
-	}
-	if s.ContextLimits.PMMaxTokens == 0 {
-		s.ContextLimits.PMMaxTokens = defaults.PMMaxTokens
-	}
-	if s.ContextLimits.AgentLowTokenMax == 0 {
-		s.ContextLimits.AgentLowTokenMax = defaults.AgentLowTokenMax
-	}
-	if s.ContextLimits.AgentHighTokenMax == 0 {
-		s.ContextLimits.AgentHighTokenMax = defaults.AgentHighTokenMax
-	}
+	s.ContextLimits = s.ContextLimits.WithDefaults(effectiveSize.ContextLimits())
 
 	return s, nil
 }

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -229,32 +229,32 @@ func TestConfidenceThresholdsForAutonomy(t *testing.T) {
 func TestOrgSize_Validate(t *testing.T) {
 	t.Parallel()
 
-	require.NoError(t, OrgSize("").Validate(), "empty should be valid (defaults to medium)")
 	require.NoError(t, OrgSizeSmall.Validate())
 	require.NoError(t, OrgSizeMedium.Validate())
 	require.NoError(t, OrgSizeLarge.Validate())
 	require.NoError(t, OrgSizeEnterprise.Validate())
+	require.Error(t, OrgSize("").Validate(), "empty string should be invalid")
 	require.Error(t, OrgSize("huge").Validate())
 }
 
-func TestContextLimitsForSize(t *testing.T) {
+func TestOrgSize_ContextLimits(t *testing.T) {
 	t.Parallel()
 
-	small := ContextLimitsForSize(OrgSizeSmall)
+	small := OrgSizeSmall.ContextLimits()
 	require.Equal(t, 50, small.MaxOpenIssues, "small orgs should have lower issue limit")
 	require.Equal(t, 30_000, small.PMMaxTokens, "small orgs should have lower PM token limit")
 
-	medium := ContextLimitsForSize(OrgSizeMedium)
+	medium := OrgSizeMedium.ContextLimits()
 	require.Equal(t, 100, medium.MaxOpenIssues, "medium should match previous defaults")
 	require.Equal(t, 50_000, medium.PMMaxTokens, "medium should match previous PM token default")
 	require.Equal(t, 50_000, medium.AgentLowTokenMax, "medium low token should match previous default")
 	require.Equal(t, 200_000, medium.AgentHighTokenMax, "medium high token should match previous default")
 
-	large := ContextLimitsForSize(OrgSizeLarge)
+	large := OrgSizeLarge.ContextLimits()
 	require.Equal(t, 300, large.MaxOpenIssues, "large orgs should see more issues")
 	require.Equal(t, 100_000, large.PMMaxTokens, "large orgs should have higher PM token limit")
 
-	enterprise := ContextLimitsForSize(OrgSizeEnterprise)
+	enterprise := OrgSizeEnterprise.ContextLimits()
 	require.Equal(t, 500, enterprise.MaxOpenIssues, "enterprise orgs should see most issues")
 	require.Equal(t, 150_000, enterprise.PMMaxTokens, "enterprise orgs should have highest PM token limit")
 	require.Equal(t, 75_000, enterprise.AgentLowTokenMax, "enterprise low tokens should be elevated")
@@ -265,22 +265,55 @@ func TestContextLimitsForSize(t *testing.T) {
 		"larger orgs should have shorter per-issue descriptions to fit more issues in context")
 }
 
-func TestPMScheduleHoursForSize(t *testing.T) {
+func TestOrgSize_PMScheduleHours(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, 6, PMScheduleHoursForSize(OrgSizeSmall), "small orgs run PM less often")
-	require.Equal(t, 4, PMScheduleHoursForSize(OrgSizeMedium), "medium matches previous default")
-	require.Equal(t, 2, PMScheduleHoursForSize(OrgSizeLarge), "large orgs need more frequent PM")
-	require.Equal(t, 1, PMScheduleHoursForSize(OrgSizeEnterprise), "enterprise orgs need hourly PM")
+	require.Equal(t, 6, OrgSizeSmall.PMScheduleHours(), "small orgs run PM less often")
+	require.Equal(t, 4, OrgSizeMedium.PMScheduleHours(), "medium matches previous default")
+	require.Equal(t, 2, OrgSizeLarge.PMScheduleHours(), "large orgs need more frequent PM")
+	require.Equal(t, 1, OrgSizeEnterprise.PMScheduleHours(), "enterprise orgs need hourly PM")
 }
 
-func TestMaxConcurrentRunsForSize(t *testing.T) {
+func TestOrgSize_MaxConcurrentRuns(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, 3, MaxConcurrentRunsForSize(OrgSizeSmall))
-	require.Equal(t, 5, MaxConcurrentRunsForSize(OrgSizeMedium))
-	require.Equal(t, 10, MaxConcurrentRunsForSize(OrgSizeLarge))
-	require.Equal(t, 20, MaxConcurrentRunsForSize(OrgSizeEnterprise))
+	require.Equal(t, 3, OrgSizeSmall.MaxConcurrentRuns())
+	require.Equal(t, 5, OrgSizeMedium.MaxConcurrentRuns())
+	require.Equal(t, 10, OrgSizeLarge.MaxConcurrentRuns())
+	require.Equal(t, 20, OrgSizeEnterprise.MaxConcurrentRuns())
+}
+
+func TestContextLimits_WithDefaults(t *testing.T) {
+	t.Parallel()
+
+	defaults := OrgSizeLarge.ContextLimits()
+
+	t.Run("fills all zero fields", func(t *testing.T) {
+		t.Parallel()
+		empty := ContextLimits{}
+		result := empty.WithDefaults(defaults)
+		require.Equal(t, defaults, result, "all-zero input should produce the defaults")
+	})
+
+	t.Run("preserves explicit values", func(t *testing.T) {
+		t.Parallel()
+		partial := ContextLimits{
+			MaxOpenIssues: 400,
+			PMMaxTokens:   120_000,
+		}
+		result := partial.WithDefaults(defaults)
+		require.Equal(t, 400, result.MaxOpenIssues, "explicit value should be preserved")
+		require.Equal(t, 120_000, result.PMMaxTokens, "explicit value should be preserved")
+		require.Equal(t, defaults.MaxTriagedIssues, result.MaxTriagedIssues, "zero field should get default")
+		require.Equal(t, defaults.AgentHighTokenMax, result.AgentHighTokenMax, "zero field should get default")
+	})
+
+	t.Run("idempotent on complete input", func(t *testing.T) {
+		t.Parallel()
+		complete := OrgSizeEnterprise.ContextLimits()
+		result := complete.WithDefaults(defaults)
+		require.Equal(t, complete, result, "already-complete input should be unchanged")
+	})
 }
 
 func TestParseOrgSettings_OrgSizeDefaults(t *testing.T) {

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -225,3 +225,114 @@ func TestConfidenceThresholdsForAutonomy(t *testing.T) {
 	unknown := ConfidenceThresholdsForAutonomy("unknown")
 	require.Equal(t, balanced, unknown)
 }
+
+func TestOrgSize_Validate(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, OrgSize("").Validate(), "empty should be valid (defaults to medium)")
+	require.NoError(t, OrgSizeSmall.Validate())
+	require.NoError(t, OrgSizeMedium.Validate())
+	require.NoError(t, OrgSizeLarge.Validate())
+	require.NoError(t, OrgSizeEnterprise.Validate())
+	require.Error(t, OrgSize("huge").Validate())
+}
+
+func TestContextLimitsForSize(t *testing.T) {
+	t.Parallel()
+
+	small := ContextLimitsForSize(OrgSizeSmall)
+	require.Equal(t, 50, small.MaxOpenIssues, "small orgs should have lower issue limit")
+	require.Equal(t, 30_000, small.PMMaxTokens, "small orgs should have lower PM token limit")
+
+	medium := ContextLimitsForSize(OrgSizeMedium)
+	require.Equal(t, 100, medium.MaxOpenIssues, "medium should match previous defaults")
+	require.Equal(t, 50_000, medium.PMMaxTokens, "medium should match previous PM token default")
+	require.Equal(t, 50_000, medium.AgentLowTokenMax, "medium low token should match previous default")
+	require.Equal(t, 200_000, medium.AgentHighTokenMax, "medium high token should match previous default")
+
+	large := ContextLimitsForSize(OrgSizeLarge)
+	require.Equal(t, 300, large.MaxOpenIssues, "large orgs should see more issues")
+	require.Equal(t, 100_000, large.PMMaxTokens, "large orgs should have higher PM token limit")
+
+	enterprise := ContextLimitsForSize(OrgSizeEnterprise)
+	require.Equal(t, 500, enterprise.MaxOpenIssues, "enterprise orgs should see most issues")
+	require.Equal(t, 150_000, enterprise.PMMaxTokens, "enterprise orgs should have highest PM token limit")
+	require.Equal(t, 75_000, enterprise.AgentLowTokenMax, "enterprise low tokens should be elevated")
+	require.Equal(t, 250_000, enterprise.AgentHighTokenMax, "enterprise high tokens should be elevated")
+
+	// Verify description truncation decreases for larger orgs (more issues = less per-issue budget)
+	require.Greater(t, small.IssueDescriptionMax, enterprise.IssueDescriptionMax,
+		"larger orgs should have shorter per-issue descriptions to fit more issues in context")
+}
+
+func TestPMScheduleHoursForSize(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 6, PMScheduleHoursForSize(OrgSizeSmall), "small orgs run PM less often")
+	require.Equal(t, 4, PMScheduleHoursForSize(OrgSizeMedium), "medium matches previous default")
+	require.Equal(t, 2, PMScheduleHoursForSize(OrgSizeLarge), "large orgs need more frequent PM")
+	require.Equal(t, 1, PMScheduleHoursForSize(OrgSizeEnterprise), "enterprise orgs need hourly PM")
+}
+
+func TestMaxConcurrentRunsForSize(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, 3, MaxConcurrentRunsForSize(OrgSizeSmall))
+	require.Equal(t, 5, MaxConcurrentRunsForSize(OrgSizeMedium))
+	require.Equal(t, 10, MaxConcurrentRunsForSize(OrgSizeLarge))
+	require.Equal(t, 20, MaxConcurrentRunsForSize(OrgSizeEnterprise))
+}
+
+func TestParseOrgSettings_OrgSizeDefaults(t *testing.T) {
+	t.Parallel()
+
+	// Large org should get size-appropriate defaults
+	raw := json.RawMessage(`{"org_size": "large"}`)
+	s, err := ParseOrgSettings(raw)
+	require.NoError(t, err)
+
+	require.Equal(t, OrgSizeLarge, s.OrgSize)
+	require.Equal(t, 10, s.MaxConcurrentRuns, "large org should default to 10 concurrent runs")
+	require.Equal(t, 2, s.PMScheduleHours, "large org should default to 2-hour PM schedule")
+	require.Equal(t, 300, s.ContextLimits.MaxOpenIssues, "large org should see 300 open issues")
+	require.Equal(t, 100_000, s.ContextLimits.PMMaxTokens, "large org should get 100k PM tokens")
+}
+
+func TestParseOrgSettings_OrgSizeWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	// Explicit overrides should take precedence over size defaults
+	raw := json.RawMessage(`{
+		"org_size": "large",
+		"max_concurrent_runs": 15,
+		"pm_schedule_hours": 3,
+		"context_limits": {
+			"max_open_issues": 400,
+			"pm_max_tokens": 120000
+		}
+	}`)
+	s, err := ParseOrgSettings(raw)
+	require.NoError(t, err)
+
+	require.Equal(t, 15, s.MaxConcurrentRuns, "explicit override should win over size default")
+	require.Equal(t, 3, s.PMScheduleHours, "explicit override should win over size default")
+	require.Equal(t, 400, s.ContextLimits.MaxOpenIssues, "explicit context limit should win")
+	require.Equal(t, 120_000, s.ContextLimits.PMMaxTokens, "explicit token limit should win")
+	// Non-overridden fields should still get size defaults
+	require.Equal(t, 200, s.ContextLimits.MaxTriagedIssues, "non-overridden should use size default")
+}
+
+func TestParseOrgSettings_DefaultOrgSizeIsMedium(t *testing.T) {
+	t.Parallel()
+
+	s, err := ParseOrgSettings(nil)
+	require.NoError(t, err)
+
+	// With no org_size set, defaults should match medium profile (backward compatible)
+	require.Equal(t, 5, s.MaxConcurrentRuns, "default should match medium concurrent runs")
+	require.Equal(t, 4, s.PMScheduleHours, "default should match medium PM schedule")
+	require.Equal(t, 100, s.ContextLimits.MaxOpenIssues, "default should match medium open issues")
+	require.Equal(t, 50_000, s.ContextLimits.PMMaxTokens, "default should match medium PM tokens")
+	require.Equal(t, 50_000, s.ContextLimits.AgentLowTokenMax, "default should match medium low tokens")
+	require.Equal(t, 200_000, s.ContextLimits.AgentHighTokenMax, "default should match medium high tokens")
+}

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -40,6 +40,7 @@ type AgentInput struct {
 	PMContext          *PMTaskContext // PM guidance for coding agents
 	PMContextJSON      string         // serialized PM context for PM agent runs
 	IntegrationSkills  string         // auto-generated CLI skills doc for integration tools
+	ContextLimits      *models.ContextLimits // org-specific token limits (nil = use defaults)
 }
 
 // PMTaskContext carries the PM agent's analysis into the coding agent's prompt.

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -19,9 +19,28 @@ import (
 )
 
 const (
-	lowTokenMax  = 50_000
-	highTokenMax = 200_000
+	defaultLowTokenMax  = 50_000
+	defaultHighTokenMax = 200_000
 )
+
+// resolveTokenLimit returns the appropriate max token limit based on
+// the token mode and optional org-specific context limits.
+func resolveTokenLimit(mode string, limits *models.ContextLimits) int {
+	low := defaultLowTokenMax
+	high := defaultHighTokenMax
+	if limits != nil {
+		if limits.AgentLowTokenMax > 0 {
+			low = limits.AgentLowTokenMax
+		}
+		if limits.AgentHighTokenMax > 0 {
+			high = limits.AgentHighTokenMax
+		}
+	}
+	if mode == "high" {
+		return high
+	}
+	return low
+}
 
 // ClaudeCodeAdapter runs the Claude Code CLI inside a sandbox.
 type ClaudeCodeAdapter struct {
@@ -47,10 +66,7 @@ func (a *ClaudeCodeAdapter) PreparePrompt(ctx context.Context, input *agent.Agen
 		return nil, fmt.Errorf("agent input and issue are required")
 	}
 
-	maxTokens := lowTokenMax
-	if input.TokenMode == "high" {
-		maxTokens = highTokenMax
-	}
+	maxTokens := resolveTokenLimit(input.TokenMode, input.ContextLimits)
 
 	systemPrompt := buildSystemPrompt(input)
 	userPrompt := buildUserPrompt(input)

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -50,7 +50,7 @@ func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
 				Issue:     &models.Issue{Title: "Bug", Source: models.IssueSourceSentry},
 				TokenMode: "low",
 			},
-			wantToken: lowTokenMax,
+			wantToken: defaultLowTokenMax,
 		},
 		{
 			name: "high token mode",
@@ -58,14 +58,14 @@ func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
 				Issue:     &models.Issue{Title: "Bug", Source: models.IssueSourceSentry},
 				TokenMode: "high",
 			},
-			wantToken: highTokenMax,
+			wantToken: defaultHighTokenMax,
 		},
 		{
 			name: "default token mode",
 			input: &agent.AgentInput{
 				Issue: &models.Issue{Title: "Bug"},
 			},
-			wantToken: lowTokenMax,
+			wantToken: defaultLowTokenMax,
 		},
 	}
 
@@ -85,6 +85,45 @@ func TestClaudeCodeAdapter_PreparePrompt(t *testing.T) {
 			require.NotEmpty(t, prompt.UserPrompt)
 		})
 	}
+}
+
+func TestResolveTokenLimit(t *testing.T) {
+	t.Parallel()
+
+	// Without context limits (nil), uses defaults
+	require.Equal(t, defaultLowTokenMax, resolveTokenLimit("low", nil))
+	require.Equal(t, defaultHighTokenMax, resolveTokenLimit("high", nil))
+	require.Equal(t, defaultLowTokenMax, resolveTokenLimit("", nil))
+
+	// With custom context limits
+	custom := &models.ContextLimits{
+		AgentLowTokenMax:  75_000,
+		AgentHighTokenMax: 250_000,
+	}
+	require.Equal(t, 75_000, resolveTokenLimit("low", custom))
+	require.Equal(t, 250_000, resolveTokenLimit("high", custom))
+	require.Equal(t, 75_000, resolveTokenLimit("", custom))
+
+	// Partial override (only low set)
+	partial := &models.ContextLimits{AgentLowTokenMax: 60_000}
+	require.Equal(t, 60_000, resolveTokenLimit("low", partial))
+	require.Equal(t, defaultHighTokenMax, resolveTokenLimit("high", partial))
+}
+
+func TestClaudeCodeAdapter_PreparePrompt_WithContextLimits(t *testing.T) {
+	t.Parallel()
+
+	a := NewClaudeCodeAdapter(zerolog.Nop())
+	input := &agent.AgentInput{
+		Issue:     &models.Issue{Title: "Bug", Source: models.IssueSourceSentry},
+		TokenMode: "high",
+		ContextLimits: &models.ContextLimits{
+			AgentHighTokenMax: 300_000,
+		},
+	}
+	prompt, err := a.PreparePrompt(context.Background(), input)
+	require.NoError(t, err)
+	require.Equal(t, 300_000, prompt.MaxTokens, "should use org-specific high token limit")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -39,10 +39,7 @@ func (a *CodexAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInpu
 		return nil, fmt.Errorf("agent input and issue are required")
 	}
 
-	maxTokens := lowTokenMax
-	if input.TokenMode == "high" {
-		maxTokens = highTokenMax
-	}
+	maxTokens := resolveTokenLimit(input.TokenMode, input.ContextLimits)
 
 	systemPrompt := buildSystemPrompt(input)
 	userPrompt := buildUserPrompt(input)

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -53,7 +53,7 @@ func TestCodexAdapter_PreparePrompt(t *testing.T) {
 				TokenMode: "low",
 			},
 			wantErr:   false,
-			wantToken: lowTokenMax,
+			wantToken: defaultLowTokenMax,
 		},
 		{
 			name: "high token mode",
@@ -66,7 +66,7 @@ func TestCodexAdapter_PreparePrompt(t *testing.T) {
 				TokenMode: "high",
 			},
 			wantErr:   false,
-			wantToken: highTokenMax,
+			wantToken: defaultHighTokenMax,
 		},
 	}
 

--- a/internal/services/agent/adapters/gemini_cli.go
+++ b/internal/services/agent/adapters/gemini_cli.go
@@ -40,10 +40,7 @@ func (a *GeminiCLIAdapter) PreparePrompt(ctx context.Context, input *agent.Agent
 		return nil, fmt.Errorf("agent input and issue are required")
 	}
 
-	maxTokens := lowTokenMax
-	if input.TokenMode == "high" {
-		maxTokens = highTokenMax
-	}
+	maxTokens := resolveTokenLimit(input.TokenMode, input.ContextLimits)
 
 	systemPrompt := buildSystemPrompt(input)
 	userPrompt := buildUserPrompt(input)

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -278,12 +278,23 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		return fmt.Errorf("unknown agent type: %s", run.AgentType)
 	}
 
+	// 5b. Resolve org-specific context limits for adaptive token budgets.
+	var contextLimits *models.ContextLimits
+	if o.orgs != nil {
+		if org, orgErr := o.orgs.GetByID(ctx, run.OrgID); orgErr == nil {
+			if orgSettings, parseErr := models.ParseOrgSettings(org.Settings); parseErr == nil {
+				contextLimits = &orgSettings.ContextLimits
+			}
+		}
+	}
+
 	// 6. Prepare the prompt.
 	input := &AgentInput{
-		Issue:      issue,
-		RepoURL:    repoURL,
-		RepoBranch: branch,
-		TokenMode:  run.TokenMode,
+		Issue:         issue,
+		RepoURL:       repoURL,
+		RepoBranch:    branch,
+		TokenMode:     run.TokenMode,
+		ContextLimits: contextLimits,
 	}
 	if run.ComplexityTier != nil {
 		input.ComplexityEstimate = &ComplexityEstimate{
@@ -1305,12 +1316,25 @@ func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, or
 }
 
 // tokenLimitForMode returns the max token limit based on the session's token mode.
-func tokenLimitForMode(mode string) int {
+// Optional context limits from org settings override the defaults when provided.
+func tokenLimitForMode(mode string, limits ...models.ContextLimits) int {
+	var lowMax, highMax int
+	if len(limits) > 0 && limits[0].AgentLowTokenMax > 0 {
+		lowMax = limits[0].AgentLowTokenMax
+	} else {
+		lowMax = 50000
+	}
+	if len(limits) > 0 && limits[0].AgentHighTokenMax > 0 {
+		highMax = limits[0].AgentHighTokenMax
+	} else {
+		highMax = 200000
+	}
+
 	switch mode {
 	case "high":
-		return 200000
+		return highMax
 	default:
-		return 50000
+		return lowMax
 	}
 }
 

--- a/internal/services/pm/adapter.go
+++ b/internal/services/pm/adapter.go
@@ -14,10 +14,19 @@ type PMAdapter struct {
 	inner          agent.AgentAdapter
 	availableSlots int
 	maxConcurrent  int
+	maxTokens      int
 }
 
 func NewPMAdapter(inner agent.AgentAdapter, availableSlots int, maxConcurrent int) *PMAdapter {
-	return &PMAdapter{inner: inner, availableSlots: availableSlots, maxConcurrent: maxConcurrent}
+	return &PMAdapter{inner: inner, availableSlots: availableSlots, maxConcurrent: maxConcurrent, maxTokens: defaultPMMaxTokens}
+}
+
+// NewPMAdapterWithLimits creates a PM adapter with a custom token limit from org settings.
+func NewPMAdapterWithLimits(inner agent.AgentAdapter, availableSlots int, maxConcurrent int, maxTokens int) *PMAdapter {
+	if maxTokens <= 0 {
+		maxTokens = defaultPMMaxTokens
+	}
+	return &PMAdapter{inner: inner, availableSlots: availableSlots, maxConcurrent: maxConcurrent, maxTokens: maxTokens}
 }
 
 func (a *PMAdapter) Name() models.AgentType { return models.AgentTypePMAgent }
@@ -29,7 +38,7 @@ func (a *PMAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) 
 	return &agent.AgentPrompt{
 		SystemPrompt: buildPMSystemPrompt(a.availableSlots, a.maxConcurrent, 0),
 		UserPrompt:   input.PMContextJSON,
-		MaxTokens:    pmMaxTokens,
+		MaxTokens:    a.maxTokens,
 	}, nil
 }
 

--- a/internal/services/pm/adapter_pm_test.go
+++ b/internal/services/pm/adapter_pm_test.go
@@ -52,7 +52,7 @@ func TestPMAdapterPreparePrompt(t *testing.T) {
 			name:          "builds PM prompt from input context",
 			input:         &agent.AgentInput{PMContextJSON: `{"open_issues":[]}`},
 			expectedUser:  `{"open_issues":[]}`,
-			expectedToken: pmMaxTokens,
+			expectedToken: defaultPMMaxTokens,
 		},
 	}
 
@@ -74,6 +74,22 @@ func TestPMAdapterPreparePrompt(t *testing.T) {
 			require.Contains(t, strings.ToLower(prompt.SystemPrompt), "available agent slots", "PreparePrompt should include available slot guidance in PM system prompt")
 		})
 	}
+}
+
+func TestPMAdapterWithLimits(t *testing.T) {
+	t.Parallel()
+
+	// Custom token limit should be used
+	adapter := NewPMAdapterWithLimits(&pmInnerAdapterMock{}, 3, 7, 100_000)
+	prompt, err := adapter.PreparePrompt(context.Background(), &agent.AgentInput{PMContextJSON: `{}`})
+	require.NoError(t, err)
+	require.Equal(t, 100_000, prompt.MaxTokens, "should use custom PM token limit")
+
+	// Zero/negative falls back to default
+	adapterZero := NewPMAdapterWithLimits(&pmInnerAdapterMock{}, 3, 7, 0)
+	promptZero, err := adapterZero.PreparePrompt(context.Background(), &agent.AgentInput{PMContextJSON: `{}`})
+	require.NoError(t, err)
+	require.Equal(t, defaultPMMaxTokens, promptZero.MaxTokens, "zero should fall back to default")
 }
 
 func TestPMAdapterExecuteAndName(t *testing.T) {

--- a/internal/services/pm/constants.go
+++ b/internal/services/pm/constants.go
@@ -1,3 +1,5 @@
 package pm
 
-const pmMaxTokens = 50_000
+// defaultPMMaxTokens is the fallback PM token limit when org settings are unavailable.
+// Prefer using settings.ContextLimits.PMMaxTokens from the org's parsed settings.
+const defaultPMMaxTokens = 50_000

--- a/internal/services/pm/context.go
+++ b/internal/services/pm/context.go
@@ -49,11 +49,13 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 		settings = models.MergeRepoPMSettings(settings, repoSettings)
 	}
 
-	openIssues, err := s.issues.ListByOrg(ctx, orgID, db.IssueFilters{Status: "open", Limit: 100})
+	limits := settings.ContextLimits
+
+	openIssues, err := s.issues.ListByOrg(ctx, orgID, db.IssueFilters{Status: "open", Limit: limits.MaxOpenIssues})
 	if err != nil {
 		return nil, err
 	}
-	triagedIssues, err := s.issues.ListByOrg(ctx, orgID, db.IssueFilters{Status: "triaged", Limit: 100})
+	triagedIssues, err := s.issues.ListByOrg(ctx, orgID, db.IssueFilters{Status: "triaged", Limit: limits.MaxTriagedIssues})
 	if err != nil {
 		return nil, err
 	}
@@ -63,14 +65,14 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 
 	issueSummaries := make([]IssueSummary, 0, len(allIssues))
 	for _, issue := range allIssues {
-		issueSummaries = append(issueSummaries, summarizeIssue(issue))
+		issueSummaries = append(issueSummaries, summarizeIssue(issue, limits.IssueDescriptionMax))
 	}
 
 	// Fetch pending + running sessions in a single query. Results are ordered by
 	// created_at DESC (interleaved), which is fine since we only summarize them.
 	inFlight, err := s.sessions.ListByOrg(ctx, orgID, db.SessionFilters{
 		Statuses: []models.SessionStatus{models.SessionStatusPending, models.SessionStatusRunning},
-		Limit:    50,
+		Limit:    limits.MaxInFlightRuns,
 	})
 	if err != nil {
 		return nil, err
@@ -86,7 +88,7 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 		})
 	}
 
-	recentRuns, err := s.sessions.ListRecentByOrg(ctx, orgID, []string{"completed", "failed", "needs_human_guidance"}, 20)
+	recentRuns, err := s.sessions.ListRecentByOrg(ctx, orgID, []string{"completed", "failed", "needs_human_guidance"}, limits.MaxRecentOutcomes)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +107,7 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 
 	prSummaries := make([]PRSummary, 0)
 	if s.pullRequests != nil {
-		prs, err := s.pullRequests.ListByOrg(ctx, orgID, db.PullRequestFilters{Limit: 20})
+		prs, err := s.pullRequests.ListByOrg(ctx, orgID, db.PullRequestFilters{Limit: limits.MaxRecentPRs})
 		if err != nil {
 			return nil, err
 		}
@@ -123,7 +125,7 @@ func (s *Service) gatherContext(ctx context.Context, orgID uuid.UUID, repo *mode
 
 	decisionSummaries := make([]DecisionLogEntrySummary, 0)
 	if s.decisionLog != nil {
-		decisions, err := s.decisionLog.ListRecentByOrg(ctx, orgID, 50)
+		decisions, err := s.decisionLog.ListRecentByOrg(ctx, orgID, limits.MaxDecisionHistory)
 		if err != nil {
 			return nil, err
 		}
@@ -245,12 +247,12 @@ func (s *Service) gatherSlackContext(ctx context.Context, orgID uuid.UUID) ([]Sl
 	return summaries, threadData, nil
 }
 
-func summarizeIssue(issue models.Issue) IssueSummary {
+func summarizeIssue(issue models.Issue, descriptionMax int) IssueSummary {
 	description := ""
 	if issue.Description != nil {
 		description = *issue.Description
 	}
-	description = truncate(description, 500)
+	description = truncate(description, descriptionMax)
 
 	summary := IssueSummary{
 		ID:                    issue.ID.String(),

--- a/internal/services/pm/context_helpers_test.go
+++ b/internal/services/pm/context_helpers_test.go
@@ -112,7 +112,7 @@ func TestSummarizeIssue(t *testing.T) {
 		RawData:               json.RawMessage(`{"stacktrace":"line 1"}`),
 	}
 
-	summary := summarizeIssue(issue)
+	summary := summarizeIssue(issue, 500)
 	require.Equal(t, issue.ID.String(), summary.ID, "summary should include issue ID")
 	require.Equal(t, string(issue.Source), summary.Source, "summary should include source")
 	require.Equal(t, issue.Title, summary.Title, "summary should include title")

--- a/internal/services/pm/coverage_boost_test.go
+++ b/internal/services/pm/coverage_boost_test.go
@@ -909,7 +909,7 @@ func TestSummarizeIssue_NilDescription(t *testing.T) {
 		LastSeenAt:  time.Now(),
 	}
 
-	summary := summarizeIssue(issue)
+	summary := summarizeIssue(issue, 500)
 	require.Equal(t, "", summary.Description)
 }
 

--- a/internal/services/pm/project_analyze.go
+++ b/internal/services/pm/project_analyze.go
@@ -92,10 +92,15 @@ func (s *Service) AnalyzeProject(ctx context.Context, orgID, projectID uuid.UUID
 		return fmt.Errorf("write project context: %w", err)
 	}
 
+	pmTokenLimit := settings.ContextLimits.PMMaxTokens
+	if pmTokenLimit <= 0 {
+		pmTokenLimit = defaultPMMaxTokens
+	}
+
 	prompt := &agent.AgentPrompt{
 		SystemPrompt: buildProjectCycleSystemPrompt(&projectSummary),
 		UserPrompt:   string(contextJSON),
-		MaxTokens:    pmMaxTokens,
+		MaxTokens:    pmTokenLimit,
 	}
 
 	logCh := make(chan agent.LogEntry, 100)

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -261,10 +261,15 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		available = 0
 	}
 
+	pmTokenLimit := ctxBundle.settings.ContextLimits.PMMaxTokens
+	if pmTokenLimit <= 0 {
+		pmTokenLimit = defaultPMMaxTokens
+	}
+
 	prompt := &agent.AgentPrompt{
 		SystemPrompt: buildPMSystemPrompt(available, ctxBundle.pmContext.MaxConcurrentRuns, len(ctxBundle.pmContext.ActiveProjects)),
 		UserPrompt:   string(contextJSON),
-		MaxTokens:    pmMaxTokens,
+		MaxTokens:    pmTokenLimit,
 	}
 
 	logCh := make(chan agent.LogEntry, 100)


### PR DESCRIPTION
## Summary

This change introduces organization size classification and adaptive context limits to enable the PM and agent systems to scale appropriately based on repository volume. Organizations can now be classified as Small, Medium, Large, or Enterprise, with each tier receiving size-appropriate defaults for issue context gathering, token budgets, and scheduling intervals.

## Key Changes

- **New `OrgSize` type and constants**: Added `OrgSizeSmall`, `OrgSizeMedium`, `OrgSizeLarge`, and `OrgSizeEnterprise` with validation
- **New `ContextLimits` struct**: Encapsulates all context gathering and token limits (max open issues, triaged issues, in-flight runs, recent outcomes, PRs, decision history, issue description length, and token budgets for PM and agents)
- **Size-aware defaults**: Each org size provides appropriate defaults via `OrgSize.ContextLimits()`, `OrgSize.PMScheduleHours()`, and `OrgSize.MaxConcurrentRuns()`
- **Org settings integration**: Added `OrgSize` and `ContextLimits` fields to `OrgSettings` with automatic defaults applied during parsing
- **Adaptive token budgets**: Agent and PM adapters now accept org-specific context limits to override hardcoded token maximums
- **PM context gathering**: Updated to use org-specific limits for issue fetching, description truncation, and session filtering
- **Backward compatibility**: Default org size is Medium, preserving existing behavior when org size is not specified

## Implementation Details

- `ContextLimits.WithDefaults()` provides idempotent merging of explicit overrides with size-appropriate defaults
- `ParseOrgSettings()` resolves effective org size early to apply size-aware defaults for concurrency and scheduling
- Agent adapters (`ClaudeCodeAdapter`, `CodexAdapter`, `GeminiCLIAdapter`) use a shared `resolveTokenLimit()` helper to support org-specific token limits
- PM service passes org-specific token limits when creating agent prompts
- All context gathering in PM service respects org-specific limits for issue counts, description lengths, and session filtering
- Comprehensive test coverage validates size-specific defaults, override precedence, and backward compatibility

https://claude.ai/code/session_01RoQtecWKds5yWsdzmdqrcY