### PR TITLE
Add About page and link in footer navigation

### DIFF
--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -73,10 +73,11 @@ export default function AboutPage() {
                 features and ship small fixes without waiting on a sprint cycle.
               </p>
               <p>
-                The name comes from a simple idea: 143 means &ldquo;I love
-                you&rdquo;&mdash;one letter, four letters, three letters. We
-                wanted to build something we loved working with every day, and we
-                did.
+                The name comes from the 143 days it took a small team of
+                Lockheed engineers to build the XP-80 Shooting
+                Star&mdash;America&rsquo;s first jet fighter&mdash;in 1943.
+                Proof that a small, focused team with the right tools can do the
+                impossible. That spirit is what we wanted to capture.
               </p>
             </section>
 
@@ -84,14 +85,15 @@ export default function AboutPage() {
               <h2
                 className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
               >
-                Why open source
+                Open source from day one
               </h2>
               <p>
-                After seeing how much 143 changed the way we worked at
-                Assembled, we decided to open source it and give it back to the
-                community. We believe the best developer tools are built in the
-                open, shaped by the people who use them. By sharing 143, we hope
-                to help other teams&mdash;whether they have five engineers or
+                143 was built from the beginning to be open-source software. Our
+                founders have been involved in open source for a long time and
+                always wanted to find a way to contribute back to the community.
+                143 was that opportunity. We believe the best developer tools are
+                built in the open, shaped by the people who use them, and we hope
+                143 helps other teams&mdash;whether they have five engineers or
                 five hundred&mdash;move faster and bring more people into the
                 building process.
               </p>

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -41,7 +41,7 @@ export default function AboutPage() {
                 How it started
               </h2>
               <p>
-                143 began as an internal project at{" "}
+                143 started as an internal project at{" "}
                 <a
                   href="https://www.assembled.com"
                   target="_blank"
@@ -50,11 +50,10 @@ export default function AboutPage() {
                 >
                   Assembled
                 </a>
-                . Our engineering team needed a way to move faster, and we
-                looked everywhere for the right tool. Nothing quite had the
-                combination we were after: agentic thinking, cloud-based coding,
-                and the ability for non-technical teammates to jump in and build
-                product alongside engineers.
+                . We wanted to speed up our engineering team and looked at
+                everything out there. None of the existing tools had what we
+                needed: agentic thinking, cloud-based coding, and a way for
+                non-technical people to build product too.
               </p>
             </section>
 
@@ -65,19 +64,18 @@ export default function AboutPage() {
                 Built for ourselves first
               </h2>
               <p>
-                So we built one. 143 started as the tool we really wanted to
-                use&mdash;an autopilot for coding agents that let anyone on the
-                team spin up cloud sessions, describe what they needed, and watch
-                it come to life. Engineers used it to accelerate day-to-day
-                development. Product managers and designers used it to prototype
-                features and ship small fixes without waiting on a sprint cycle.
+                So we built it ourselves. 143 is an autopilot for coding agents
+                that lets anyone on the team spin up a cloud session, describe
+                what they need, and watch it get built. Engineers use it to move
+                faster day to day. PMs and designers use it to prototype features
+                and ship fixes without waiting on a sprint.
               </p>
               <p>
                 The name comes from the 143 days it took a small team of
-                Lockheed engineers to build the XP-80 Shooting
-                Star&mdash;America&rsquo;s first jet fighter&mdash;in 1943.
-                Proof that a small, focused team with the right tools can do the
-                impossible. That spirit is what we wanted to capture.
+                Lockheed engineers to build the XP-80 Shooting Star, America's
+                first jet fighter, in 1943. A small focused team with the right
+                tools doing the impossible. That's the spirit we wanted to
+                capture.
               </p>
             </section>
 
@@ -88,14 +86,12 @@ export default function AboutPage() {
                 Open source from day one
               </h2>
               <p>
-                143 was built from the beginning to be open-source software. Our
-                founders have been involved in open source for a long time and
-                always wanted to find a way to contribute back to the community.
-                143 was that opportunity. We believe the best developer tools are
-                built in the open, shaped by the people who use them, and we hope
-                143 helps other teams&mdash;whether they have five engineers or
-                five hundred&mdash;move faster and bring more people into the
-                building process.
+                We built 143 as open source from the start. Our founders have
+                been in open source for a long time and always wanted to
+                contribute back to the community. 143 was that chance. We think
+                the best developer tools are built in the open and shaped by the
+                people who use them. We hope it helps other teams move faster and
+                bring more people into the building process.
               </p>
             </section>
 
@@ -106,26 +102,24 @@ export default function AboutPage() {
                 One platform, every model, every agent
               </h2>
               <p>
-                One of our biggest frustrations was that every model provider
-                only supported their own models. We wanted something
-                cross-platform&mdash;a single place where different members of
-                the team could use the coding agents they preferred, whether that
-                was Claude, GPT, Gemini, or anything else, without being locked
-                into one vendor&rsquo;s ecosystem.
+                Every model provider only supports their own models. That
+                frustrated us. We wanted one place where different people on the
+                team could use whatever coding agent they preferred, whether
+                that's Claude, GPT, Gemini, or something else, without getting
+                locked into a single vendor.
               </p>
               <p>
-                But it wasn&rsquo;t just about model choice. We wanted a single
-                experience for the entire team that let you see all coding agent
-                usage in one place, collaborate on projects that spanned multiple
-                PRs and multiple commits, and keep context alive across
-                sessions&mdash;not start from scratch every time.
+                It's not just about model choice though. We wanted a single
+                experience for the whole team where you can see all coding agent
+                usage in one place, collaborate on projects that span multiple
+                PRs and commits, and keep context alive across sessions instead
+                of starting from scratch every time.
               </p>
               <p>
-                Most importantly, we wanted to build a PM agent that truly
-                understood your company&rsquo;s context&mdash;your codebase,
-                your product, your priorities&mdash;and could keep building on
-                top of that knowledge over time. Not a generic assistant, but one
-                that gets smarter the more your team uses it.
+                We also wanted to build a PM agent that actually knows your
+                company's context. Your codebase, your product, your priorities.
+                One that keeps building on that knowledge over time and gets
+                smarter the more your team uses it.
               </p>
             </section>
 
@@ -145,10 +139,9 @@ export default function AboutPage() {
                   Assembled
                 </a>{" "}
                 is a workforce management platform that helps support teams
-                deliver better customer experiences. 143 is our way of sharing a
-                piece of the engineering culture that makes Assembled
-                possible&mdash;a belief that great tools should empower everyone
-                to build.
+                deliver better customer experiences. 143 is a piece of the
+                engineering culture behind Assembled that we wanted to share with
+                everyone.
               </p>
             </section>
           </div>

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -103,6 +103,36 @@ export default function AboutPage() {
               <h2
                 className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
               >
+                One platform, every model, every agent
+              </h2>
+              <p>
+                One of our biggest frustrations was that every model provider
+                only supported their own models. We wanted something
+                cross-platform&mdash;a single place where different members of
+                the team could use the coding agents they preferred, whether that
+                was Claude, GPT, Gemini, or anything else, without being locked
+                into one vendor&rsquo;s ecosystem.
+              </p>
+              <p>
+                But it wasn&rsquo;t just about model choice. We wanted a single
+                experience for the entire team that let you see all coding agent
+                usage in one place, collaborate on projects that spanned multiple
+                PRs and multiple commits, and keep context alive across
+                sessions&mdash;not start from scratch every time.
+              </p>
+              <p>
+                Most importantly, we wanted to build a PM agent that truly
+                understood your company&rsquo;s context&mdash;your codebase,
+                your product, your priorities&mdash;and could keep building on
+                top of that knowledge over time. Not a generic assistant, but one
+                that gets smarter the more your team uses it.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2
+                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+              >
                 About Assembled
               </h2>
               <p>

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { usePrefersDark } from "@/hooks/use-prefers-dark";
+import Link from "next/link";
+import Footer from "@/components/landing/footer";
+
+export default function AboutPage() {
+  const isDark = usePrefersDark();
+
+  return (
+    <div
+      className="min-h-screen flex flex-col"
+      style={{ background: isDark ? "#08080f" : "#d4e6f5" }}
+    >
+      {/* Nav */}
+      <div className="flex items-center justify-between px-6 sm:px-10 pt-6 sm:pt-8">
+        <Link
+          href="/"
+          className={`text-sm font-medium ${isDark ? "text-white/60 hover:text-white" : "text-slate-600 hover:text-slate-900"} transition-colors`}
+        >
+          &larr; 143
+        </Link>
+      </div>
+
+      {/* Content */}
+      <main className="flex-1 px-6 sm:px-10 py-16 sm:py-24">
+        <div className="max-w-2xl mx-auto">
+          <h1
+            className={`text-2xl sm:text-3xl font-light tracking-tight mb-12 ${isDark ? "text-white" : "text-slate-900"}`}
+          >
+            About 143
+          </h1>
+
+          <div
+            className={`space-y-8 text-sm leading-relaxed ${isDark ? "text-white/50" : "text-slate-600"}`}
+          >
+            <section className="space-y-3">
+              <h2
+                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+              >
+                How it started
+              </h2>
+              <p>
+                143 began as an internal project at{" "}
+                <a
+                  href="https://www.assembled.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`underline underline-offset-2 ${isDark ? "hover:text-white/70" : "hover:text-slate-800"} transition-colors`}
+                >
+                  Assembled
+                </a>
+                . Our engineering team needed a way to move faster, and we
+                looked everywhere for the right tool. Nothing quite had the
+                combination we were after: agentic thinking, cloud-based coding,
+                and the ability for non-technical teammates to jump in and build
+                product alongside engineers.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2
+                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+              >
+                Built for ourselves first
+              </h2>
+              <p>
+                So we built one. 143 started as the tool we really wanted to
+                use&mdash;an autopilot for coding agents that let anyone on the
+                team spin up cloud sessions, describe what they needed, and watch
+                it come to life. Engineers used it to accelerate day-to-day
+                development. Product managers and designers used it to prototype
+                features and ship small fixes without waiting on a sprint cycle.
+              </p>
+              <p>
+                The name comes from a simple idea: 143 means &ldquo;I love
+                you&rdquo;&mdash;one letter, four letters, three letters. We
+                wanted to build something we loved working with every day, and we
+                did.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2
+                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+              >
+                Why open source
+              </h2>
+              <p>
+                After seeing how much 143 changed the way we worked at
+                Assembled, we decided to open source it and give it back to the
+                community. We believe the best developer tools are built in the
+                open, shaped by the people who use them. By sharing 143, we hope
+                to help other teams&mdash;whether they have five engineers or
+                five hundred&mdash;move faster and bring more people into the
+                building process.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2
+                className={`text-base font-medium ${isDark ? "text-white/70" : "text-slate-800"}`}
+              >
+                About Assembled
+              </h2>
+              <p>
+                <a
+                  href="https://www.assembled.com"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`underline underline-offset-2 ${isDark ? "hover:text-white/70" : "hover:text-slate-800"} transition-colors`}
+                >
+                  Assembled
+                </a>{" "}
+                is a workforce management platform that helps support teams
+                deliver better customer experiences. 143 is our way of sharing a
+                piece of the engineering culture that makes Assembled
+                possible&mdash;a belief that great tools should empower everyone
+                to build.
+              </p>
+            </section>
+          </div>
+        </div>
+      </main>
+
+      <Footer isDark={isDark} />
+    </div>
+  );
+}

--- a/frontend/src/app/(landing)/about/page.tsx
+++ b/frontend/src/app/(landing)/about/page.tsx
@@ -72,9 +72,9 @@ export default function AboutPage() {
               </p>
               <p>
                 The name comes from the 143 days it took a small team of
-                Lockheed engineers to build the XP-80 Shooting Star, America's
+                Lockheed engineers to build the XP-80 Shooting Star, America&apos;s
                 first jet fighter, in 1943. A small focused team with the right
-                tools doing the impossible. That's the spirit we wanted to
+                tools doing the impossible. That&apos;s the spirit we wanted to
                 capture.
               </p>
             </section>
@@ -105,11 +105,11 @@ export default function AboutPage() {
                 Every model provider only supports their own models. That
                 frustrated us. We wanted one place where different people on the
                 team could use whatever coding agent they preferred, whether
-                that's Claude, GPT, Gemini, or something else, without getting
+                that&apos;s Claude, GPT, Gemini, or something else, without getting
                 locked into a single vendor.
               </p>
               <p>
-                It's not just about model choice though. We wanted a single
+                It&apos;s not just about model choice though. We wanted a single
                 experience for the whole team where you can see all coding agent
                 usage in one place, collaborate on projects that span multiple
                 PRs and commits, and keep context alive across sessions instead
@@ -117,7 +117,7 @@ export default function AboutPage() {
               </p>
               <p>
                 We also wanted to build a PM agent that actually knows your
-                company's context. Your codebase, your product, your priorities.
+                company&apos;s context. Your codebase, your product, your priorities.
                 One that keeps building on that knowledge over time and gets
                 smarter the more your team uses it.
               </p>

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -230,7 +230,7 @@ describe("integration connection cards", () => {
         githubConnected
         onConnectGitHub={vi.fn()}
         onDisconnect={vi.fn()}
-        disconnectingProvider="github"
+        disconnectErrorProvider="github"
         disconnectError="Failed to disconnect."
       />
     );

--- a/frontend/src/components/landing/footer.tsx
+++ b/frontend/src/components/landing/footer.tsx
@@ -47,6 +47,14 @@ export default function Footer({ isDark }: FooterProps) {
               </p>
               <ul className="space-y-2">
                 <li>
+                  <Link
+                    href="/about"
+                    className={`text-xs ${isDark ? "text-white/30 hover:text-white/60" : "text-slate-500 hover:text-slate-700"} transition-colors`}
+                  >
+                    About
+                  </Link>
+                </li>
+                <li>
                   <a
                     href="https://github.com/assembledhq/143"
                     target="_blank"


### PR DESCRIPTION
## Summary
Added a new About page for the 143 project that explains its origins, philosophy, and vision. The page is now linked from the footer navigation.

## Key Changes
- **New About page** (`frontend/src/app/(landing)/about/page.tsx`): Created a comprehensive about page that covers:
  - How 143 started as an internal project at Assembled
  - The philosophy of building for themselves first
  - Open source commitment from day one
  - Multi-model and multi-agent platform vision
  - Information about Assembled
  
- **Footer navigation update** (`frontend/src/components/landing/footer.tsx`): Added an "About" link to the Project section of the footer

## Implementation Details
- The About page uses the `usePrefersDark` hook to support both light and dark themes, matching the existing design system
- Responsive design with proper spacing for mobile and desktop viewports
- Includes styled links to external resources (Assembled website)
- Reuses the existing Footer component for consistency
- Navigation back to home page via the "← 143" link in the header

https://claude.ai/code/session_01EYm2V7HnoXNj4zaY9X3ccR