### PR TITLE
Add branch selector dropdown for session creation

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -30,6 +30,8 @@ import { NoReposWarning } from "@/components/no-repos-warning";
 import { useOptimisticSessions } from "@/contexts/optimistic-sessions";
 import type { OrgSettings, Organization, Repository, SingleResponse, ListResponse } from "@/lib/types";
 
+type BranchInfo = { name: string; protected: boolean };
+
 type DictationResult = {
   transcript: string;
 };
@@ -107,6 +109,14 @@ export function ManualSessionCreatePageContent() {
   }, [userSelectedRepoId, repositories]);
 
   const selectedRepo = repositories.find((r) => r.id === selectedRepoId);
+
+  const { data: branchesResponse, isLoading: branchesLoading, isError: branchesFailed } = useQuery<ListResponse<BranchInfo>>({
+    queryKey: queryKeys.repositories.branches(selectedRepoId),
+    queryFn: () => api.repositories.branches(selectedRepoId),
+    enabled: !!selectedRepoId,
+    staleTime: 5 * 60 * 1000,
+  });
+  const branches = useMemo(() => branchesResponse?.data ?? [], [branchesResponse]);
 
   // Derive branch: use user override if set, otherwise the repo's default.
   const selectedBranch = useMemo(() => {
@@ -396,16 +406,51 @@ export function ManualSessionCreatePageContent() {
               )}
 
               {selectedRepo && (
-                <div className="flex items-center gap-1">
-                  <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-                  <Input
-                    value={selectedBranch}
-                    onChange={(e) => setSelectedBranch(e.target.value)}
-                    placeholder={selectedRepo.default_branch || "main"}
-                    className="h-7 w-36 text-[13px] px-2"
-                    aria-label="Target branch"
-                  />
-                </div>
+                branchesFailed ? (
+                  <div className="flex items-center gap-1">
+                    <GitBranch className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                    <Input
+                      value={selectedBranch}
+                      onChange={(e) => setSelectedBranch(e.target.value)}
+                      placeholder={selectedRepo.default_branch || "main"}
+                      className="h-7 w-36 text-[13px] px-2"
+                      aria-label="Target branch"
+                    />
+                  </div>
+                ) : (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-8 gap-1.5 rounded-full px-3 text-[13px] text-muted-foreground hover:text-foreground"
+                        aria-label="Target branch"
+                      >
+                        <GitBranch className="h-3.5 w-3.5" />
+                        <span>{selectedBranch || selectedRepo.default_branch || "main"}</span>
+                        <ChevronDown className="h-3 w-3 opacity-50" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-64 max-h-72 overflow-y-auto">
+                      {branchesLoading && (
+                        <DropdownMenuItem disabled>Loading branches…</DropdownMenuItem>
+                      )}
+                      {!branchesLoading && branches.length === 0 && (
+                        <DropdownMenuItem disabled>No branches found</DropdownMenuItem>
+                      )}
+                      {branches.map((branch) => (
+                        <DropdownMenuItem
+                          key={branch.name}
+                          onClick={() => setSelectedBranch(branch.name)}
+                          className={selectedBranch === branch.name ? "font-medium" : ""}
+                        >
+                          <GitBranch className="mr-2 h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                          <span className="truncate">{branch.name}</span>
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )
               )}
 
               <Select value={selectedModel} onValueChange={setSelectedModel}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -120,6 +120,7 @@ export const api = {
       patch<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}`, data),
     delete: (id: string) => del(`/api/v1/repositories/${id}`),
     summary: () => get<import('./types').ListResponse<import('./types').RepoSummary>>('/api/v1/repositories/summary'),
+    branches: (id: string) => get<import('./types').ListResponse<{ name: string; protected: boolean }>>(`/api/v1/repositories/${id}/branches`),
   },
   issues: {
     list: (params?: { status?: string; source?: string; severity?: string; sort?: string; cursor?: string; limit?: number }) => {

--- a/frontend/src/lib/query-keys.test.ts
+++ b/frontend/src/lib/query-keys.test.ts
@@ -52,6 +52,16 @@ describe("queryKeys", () => {
     });
   });
 
+  describe("repositories", () => {
+    it("all returns static key", () => {
+      expect(queryKeys.repositories.all).toEqual(["repositories"]);
+    });
+
+    it("branches includes repository id", () => {
+      expect(queryKeys.repositories.branches("repo-1")).toEqual(["repositories", "repo-1", "branches"]);
+    });
+  });
+
   describe("settings", () => {
     it("all returns static key", () => {
       expect(queryKeys.settings.all).toEqual(["settings"]);

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -22,6 +22,7 @@ export const queryKeys = {
   },
   repositories: {
     all: ["repositories"] as const,
+    branches: (id: string) => ["repositories", id, "branches"] as const,
   },
   settings: {
     all: ["settings"] as const,

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -3,20 +3,27 @@ package handlers
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 )
 
 type RepositoryHandler struct {
 	repoStore *db.RepositoryStore
+	prService *ghservice.PRService
 }
 
 func NewRepositoryHandler(repoStore *db.RepositoryStore) *RepositoryHandler {
 	return &RepositoryHandler{repoStore: repoStore}
+}
+
+func (h *RepositoryHandler) SetPRService(svc *ghservice.PRService) {
+	h.prService = svc
 }
 
 func (h *RepositoryHandler) List(w http.ResponseWriter, r *http.Request) {
@@ -130,4 +137,53 @@ func (h *RepositoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+type branchResponse struct {
+	Name      string `json:"name"`
+	Protected bool   `json:"protected"`
+}
+
+func (h *RepositoryHandler) ListBranches(w http.ResponseWriter, r *http.Request) {
+	if h.prService == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_NOT_CONFIGURED", "GitHub App is not configured")
+		return
+	}
+
+	orgID := middleware.OrgIDFromContext(r.Context())
+	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
+		return
+	}
+
+	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "repository not found")
+		return
+	}
+
+	parts := strings.SplitN(repo.FullName, "/", 2)
+	if len(parts) != 2 {
+		writeError(w, r, http.StatusInternalServerError, "INVALID_REPO", "invalid repository full name")
+		return
+	}
+
+	token, err := h.prService.GetInstallationToken(r.Context(), repo.InstallationID)
+	if err != nil {
+		writeError(w, r, http.StatusBadGateway, "GITHUB_TOKEN_FAILED", "failed to get GitHub token")
+		return
+	}
+
+	ghBranches, err := h.prService.ListBranches(r.Context(), token, parts[0], parts[1])
+	if err != nil {
+		writeError(w, r, http.StatusBadGateway, "GITHUB_API_FAILED", "failed to list branches from GitHub")
+		return
+	}
+
+	branches := make([]branchResponse, len(ghBranches))
+	for i, b := range ghBranches {
+		branches[i] = branchResponse{Name: b.Name, Protected: b.Protected}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[branchResponse]{Data: branches})
 }

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
@@ -328,6 +330,88 @@ func TestRepositoryHandler_Summary(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestRepositoryHandler_ListBranches_NoPRService(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store) // no SetPRService call
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+repoID.String()+"/branches", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListBranches(w, req)
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "should return 503 when prService is nil")
+	require.Contains(t, w.Body.String(), "GITHUB_NOT_CONFIGURED", "error code should indicate GitHub is not configured")
+}
+
+func TestRepositoryHandler_ListBranches_InvalidID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+	// Set a non-nil prService so we get past the nil check.
+	handler.prService = &ghservice.PRService{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/not-a-uuid/branches", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListBranches(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "should return 400 for invalid UUID")
+	require.Contains(t, w.Body.String(), "INVALID_ID", "error code should indicate invalid ID")
+}
+
+func TestRepositoryHandler_ListBranches_RepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+	handler.prService = &ghservice.PRService{}
+
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("no rows"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+repoID.String()+"/branches", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListBranches(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code, "should return 404 when repo is not found")
+	require.Contains(t, w.Body.String(), "NOT_FOUND", "error code should indicate not found")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestRepositoryHandler_Delete_Success(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -88,6 +88,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	healthHandler := handlers.NewHealthHandler(pool)
 	authHandler := handlers.NewAuthHandler(cfg, orgStore, userStore, authSessionStore, invitationStore)
 	repoHandler := handlers.NewRepositoryHandler(repoStore)
+	if prService != nil {
+		repoHandler.SetPRService(prService)
+	}
 	integrationOpts := []handlers.IntegrationHandlerOption{
 		handlers.WithSentryOAuth(cfg.SentryOAuthClientID, cfg.SentryOAuthClientSecret),
 		handlers.WithGitHubIntegrationOAuth(cfg.GitHubOAuthClientID, cfg.GitHubOAuthClientSecret),
@@ -228,6 +231,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/repositories", repoHandler.List)
 			r.Get("/api/v1/repositories/summary", repoHandler.Summary)
 			r.Get("/api/v1/repositories/{id}", repoHandler.Get)
+			r.Get("/api/v1/repositories/{id}/branches", repoHandler.ListBranches)
 			r.Get("/api/v1/integrations", integrationHandler.ListIntegrations)
 			r.Get("/api/v1/issues", issueHandler.List)
 			r.Get("/api/v1/issues/{id}", issueHandler.Get)

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -617,6 +617,40 @@ func (s *PRService) doGitHubRequest(ctx context.Context, token, method, path str
 	return respBody, nil
 }
 
+// GetInstallationToken returns a GitHub installation token for the given installation ID.
+func (s *PRService) GetInstallationToken(ctx context.Context, installationID int64) (string, error) {
+	return s.tokenProvider.GetInstallationToken(ctx, installationID)
+}
+
+// GitHubBranch represents a branch returned by the GitHub API.
+type GitHubBranch struct {
+	Name      string `json:"name"`
+	Protected bool   `json:"protected"`
+}
+
+// ListBranches returns the branches for a repository from the GitHub API.
+func (s *PRService) ListBranches(ctx context.Context, token, owner, repo string) ([]GitHubBranch, error) {
+	var all []GitHubBranch
+	page := 1
+	for {
+		path := fmt.Sprintf("/repos/%s/%s/branches?per_page=100&page=%d", owner, repo, page)
+		body, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)
+		if err != nil {
+			return nil, fmt.Errorf("list branches: %w", err)
+		}
+		var branches []GitHubBranch
+		if err := json.Unmarshal(body, &branches); err != nil {
+			return nil, fmt.Errorf("decode branches: %w", err)
+		}
+		all = append(all, branches...)
+		if len(branches) < 100 || page >= 10 {
+			break
+		}
+		page++
+	}
+	return all, nil
+}
+
 func (s *PRService) getRef(ctx context.Context, token, owner, repo, ref string) (string, error) {
 	path := fmt.Sprintf("/repos/%s/%s/git/ref/%s", owner, repo, strings.TrimPrefix(ref, "refs/"))
 	body, err := s.doGitHubRequest(ctx, token, http.MethodGet, path, nil)

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1433,3 +1433,114 @@ func TestPushRevision_WithParentSessionID(t *testing.T) {
 	require.NoError(t, err, "PushRevision should not return an error with parent session ID")
 	require.Contains(t, capturedCommitMsg, parentID.String(), "commit message should reference parent session ID")
 }
+
+func TestListBranches_Success(t *testing.T) {
+	t.Parallel()
+
+	branches := []GitHubBranch{
+		{Name: "main", Protected: true},
+		{Name: "develop", Protected: false},
+		{Name: "feature/foo", Protected: false},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method, "ListBranches should use GET")
+		require.Contains(t, r.URL.Path, "/repos/owner/repo/branches", "request path should target branches endpoint")
+		require.Equal(t, "token test-token", r.Header.Get("Authorization"), "should send authorization header")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(branches)
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
+	require.NoError(t, err, "ListBranches should not return an error")
+	require.Len(t, result, 3, "should return all branches")
+	require.Equal(t, "main", result[0].Name, "first branch should be main")
+	require.True(t, result[0].Protected, "main branch should be protected")
+	require.Equal(t, "feature/foo", result[2].Name, "third branch should be feature/foo")
+}
+
+func TestListBranches_Pagination(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		if callCount == 1 {
+			// Return exactly 100 branches to trigger pagination.
+			branches := make([]GitHubBranch, 100)
+			for i := range branches {
+				branches[i] = GitHubBranch{Name: fmt.Sprintf("branch-%d", i)}
+			}
+			json.NewEncoder(w).Encode(branches)
+		} else {
+			// Second page returns fewer than 100.
+			branches := []GitHubBranch{{Name: "last-branch"}}
+			json.NewEncoder(w).Encode(branches)
+		}
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
+	require.NoError(t, err, "ListBranches should not return an error")
+	require.Len(t, result, 101, "should return all branches across pages")
+	require.Equal(t, 2, callCount, "should make exactly 2 API calls")
+	require.Equal(t, "last-branch", result[100].Name, "last branch should be from second page")
+}
+
+func TestListBranches_APIError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message":"internal error"}`))
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	result, err := svc.ListBranches(context.Background(), "test-token", "owner", "repo")
+	require.Error(t, err, "ListBranches should return an error on API failure")
+	require.Nil(t, result, "result should be nil on error")
+	require.Contains(t, err.Error(), "list branches", "error should include context")
+}
+
+func TestGetInstallationToken_DelegatesToTokenProvider(t *testing.T) {
+	t.Parallel()
+
+	tokenSvc := &Service{
+		cache: make(map[int64]*cachedToken),
+	}
+	tokenSvc.cache[42] = &cachedToken{
+		Token:     "cached-install-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		logger:        zerolog.Nop(),
+	}
+
+	token, err := svc.GetInstallationToken(context.Background(), 42)
+	require.NoError(t, err, "GetInstallationToken should not return an error")
+	require.Equal(t, "cached-install-token", token, "should return the cached token")
+}


### PR DESCRIPTION
## Summary
- Replaces the free-text branch input on the manual session creation page with a dropdown that fetches branches from the GitHub API
- Adds `GET /api/v1/repositories/{id}/branches` endpoint backed by `PRService.ListBranches` with pagination support (up to 1000 branches)
- Falls back to text input when the GitHub API is unavailable (e.g., GitHub App not configured)
- Adds backend tests for the handler (nil PRService, invalid ID, repo not found) and service (success, pagination, API error, token delegation)
- Adds frontend tests for the new `repositories.branches` query key

## Test plan
- [ ] Verify branch dropdown populates when selecting a repo with GitHub App configured
- [ ] Verify fallback to text input when GitHub App is not configured
- [ ] Verify pagination works for repos with >100 branches
- [ ] Run `go test ./internal/api/handlers/ -run TestRepositoryHandler_ListBranches`
- [ ] Run `go test ./internal/services/github/ -run "TestListBranches|TestGetInstallationToken_Delegates"`
- [ ] Run `npx vitest run src/lib/query-keys.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)