### PR TITLE
Allow sending messages to running sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -214,7 +214,26 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id={runningSession.id} />);
     expect(await screen.findByText('Agent is working...')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Agent is working...')).toBeDisabled();
+    expect(screen.getByPlaceholderText('Send a message to the agent...')).toBeEnabled();
+  });
+
+  it('disables input for pending session', async () => {
+    const pendingSession: Session = {
+      ...mockSessions[0],
+      status: 'pending',
+      completed_at: undefined,
+      current_turn: 0,
+      sandbox_state: 'none',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: pendingSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
+    expect(await screen.findByPlaceholderText('Session is not active')).toBeDisabled();
   });
 
   it('keeps polling logs and reconnects after an SSE error while the session is active', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -692,13 +692,10 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
 
   const isIdle = session.status === "idle";
   const isRunning = session.status === "running";
-  const isCompleted = session.status === "completed";
-  const isPrCreated = session.status === "pr_created";
-  const isFailed = session.status === "failed";
-  const isCancelled = session.status === "cancelled";
-  // "skipped" sessions are intentionally excluded — they were never run,
-  // so there is no workspace state or context to resume from.
-  const canSendMessage = isIdle || isCompleted || isPrCreated || isFailed || isCancelled;
+  // Allow messaging in any state except "skipped" (never ran, no workspace)
+  // and "pending" (agent not started yet). The backend will reject statuses
+  // it cannot handle, so this is safe to be permissive.
+  const canSendMessage = session.status !== "skipped" && session.status !== "pending";
 
   const { data: messagesData } = useQuery({
     queryKey: ["session", sessionId, "messages"],
@@ -899,7 +896,7 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={canSendMessage ? "Send a follow-up message..." : isRunning ? "Agent is working..." : "Session is not active"}
+            placeholder={canSendMessage ? (isRunning ? "Send a message to the agent..." : "Send a follow-up message...") : "Session is not active"}
             disabled={!canSendMessage || sendMutation.isPending}
             className="min-h-[44px] max-h-[200px] resize-none"
           />

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -531,27 +531,27 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Build the user message from the request context.
+	user := middleware.UserFromContext(r.Context())
+	var userID *uuid.UUID
+	if user != nil {
+		userID = &user.ID
+	}
+	msg := &models.SessionMessage{
+		SessionID:  sessionID,
+		OrgID:      orgID,
+		UserID:     userID,
+		TurnNumber: session.CurrentTurn + 1,
+		Role:       models.MessageRoleUser,
+		Content:    body.Message,
+	}
+	if len(body.Images) > 0 {
+		msg.Attachments = body.Images
+	}
+
 	// If the session is already running, just save the message — the coding
 	// agent will buffer it and process inline. No status change or job needed.
 	if session.Status == string(models.SessionStatusRunning) {
-		user := middleware.UserFromContext(r.Context())
-		var userID *uuid.UUID
-		if user != nil {
-			userID = &user.ID
-		}
-
-		msg := &models.SessionMessage{
-			SessionID:  sessionID,
-			OrgID:      orgID,
-			UserID:     userID,
-			TurnNumber: session.CurrentTurn + 1,
-			Role:       models.MessageRoleUser,
-			Content:    body.Message,
-		}
-		if len(body.Images) > 0 {
-			msg.Attachments = body.Images
-		}
-
 		if err := h.messageStore.Create(r.Context(), msg); err != nil {
 			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 			return
@@ -575,25 +575,9 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	} else {
 		revertStatus = string(models.SessionStatusIdle)
 	}
+	// Update turn number from the claimed session (may differ after status transition).
 	session = claimed
-
-	user := middleware.UserFromContext(r.Context())
-	var userID *uuid.UUID
-	if user != nil {
-		userID = &user.ID
-	}
-
-	msg := &models.SessionMessage{
-		SessionID:  sessionID,
-		OrgID:      orgID,
-		UserID:     userID,
-		TurnNumber: session.CurrentTurn + 1,
-		Role:       models.MessageRoleUser,
-		Content:    body.Message,
-	}
-	if len(body.Images) > 0 {
-		msg.Attachments = body.Images
-	}
+	msg.TurnNumber = session.CurrentTurn + 1
 
 	if err := h.messageStore.Create(r.Context(), msg); err != nil {
 		if revertErr := h.runStore.UpdateStatus(r.Context(), orgID, sessionID, revertStatus); revertErr != nil {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -524,26 +524,58 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Look up the session to check its current status.
+	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+
+	// If the session is already running, just save the message — the coding
+	// agent will buffer it and process inline. No status change or job needed.
+	if session.Status == string(models.SessionStatusRunning) {
+		user := middleware.UserFromContext(r.Context())
+		var userID *uuid.UUID
+		if user != nil {
+			userID = &user.ID
+		}
+
+		msg := &models.SessionMessage{
+			SessionID:  sessionID,
+			OrgID:      orgID,
+			UserID:     userID,
+			TurnNumber: session.CurrentTurn + 1,
+			Role:       models.MessageRoleUser,
+			Content:    body.Message,
+		}
+		if len(body.Images) > 0 {
+			msg.Attachments = body.Images
+		}
+
+		if err := h.messageStore.Create(r.Context(), msg); err != nil {
+			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
+		return
+	}
+
 	// Try claiming an idle session first, then fall back to resuming a
 	// terminal session (completed/pr_created/failed/cancelled).
 	var revertStatus string
-	session, err := h.runStore.ClaimIdle(r.Context(), orgID, sessionID)
-	if err != nil {
-		// Look up the session to capture its current status for revert.
-		existing, lookupErr := h.runStore.GetByID(r.Context(), orgID, sessionID)
-		if lookupErr != nil {
-			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+	claimed, claimErr := h.runStore.ClaimIdle(r.Context(), orgID, sessionID)
+	if claimErr != nil {
+		claimed, claimErr = h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
+		if claimErr != nil {
+			writeError(w, r, http.StatusConflict, "NOT_RESUMABLE", "session must be idle, running, or completed to send a message")
 			return
 		}
-		session, err = h.runStore.ClaimForResume(r.Context(), orgID, sessionID)
-		if err != nil {
-			writeError(w, r, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or completed to send a message")
-			return
-		}
-		revertStatus = existing.Status // preserve original status for revert
+		revertStatus = session.Status // preserve original status for revert
 	} else {
 		revertStatus = string(models.SessionStatusIdle)
 	}
+	session = claimed
 
 	user := middleware.UserFromContext(r.Context())
 	var userID *uuid.UUID

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1730,7 +1730,29 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			body: `{"message":"Please add tests"}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
 				now := time.Now()
-				// ClaimIdle.
+				// GetByID — session is idle.
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "idle", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
+							nil, // target_branch
+							nil, // working_branch
+							nil, // repository_id
+							nil, // diff_stats
+							nil, // diff_history
+							now,
+						),
+					)
+				// ClaimIdle succeeds.
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
@@ -1765,6 +1787,41 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			expectedBody: "Please add tests",
 		},
 		{
+			name: "sends message to running session without enqueuing job",
+			body: `{"message":"Quick note while you work"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				now := time.Now()
+				// GetByID — session is running.
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 2, &now, "running", nil,
+							nil, // target_branch
+							nil, // working_branch
+							nil, // repository_id
+							nil, // diff_stats
+							nil, // diff_history
+							now,
+						),
+					)
+				// Create message — no ClaimIdle, no ClaimForResume, no Enqueue.
+				mock.ExpectQuery("INSERT INTO session_messages").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+			},
+			expectedCode: http.StatusCreated,
+			expectedBody: "Quick note while you work",
+		},
+		{
 			name: "rejects empty message",
 			body: `{"message":""}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
@@ -1777,16 +1834,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			body: `{"message":"More work"}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
 				now := time.Now()
-				// ClaimIdle fails (no row returned).
-				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// GetByID lookup (to capture original status for revert).
+				// GetByID — session is pending (not running, not idle, not terminal).
 				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionColumns).AddRow(
-							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
+							sessionID, uuid.New(), orgID, "claude-code", "pending", "semi", "low",
 							nil, nil, nil, nil,
 							nil, &now, nil, nil,
 							nil, nil, nil, nil,
@@ -1803,6 +1856,10 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							now,
 						),
 					)
+				// ClaimIdle fails (no row returned).
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionColumns))
 				// ClaimForResume also fails (no row returned).
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -1816,11 +1873,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			body: `{"message":"Continue working on this"}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
 				now := time.Now()
-				// ClaimIdle fails (no row returned).
-				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// GetByID lookup (to capture original status for revert).
+				// GetByID — session is completed.
 				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
@@ -1842,6 +1895,10 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							now,
 						),
 					)
+				// ClaimIdle fails (no row returned).
+				mock.ExpectQuery("UPDATE sessions SET status").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionColumns))
 				// ClaimForResume succeeds.
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).


### PR DESCRIPTION
## Summary
- Enable the session input field while an agent is actively running, so users can send follow-up messages that the coding agent will buffer and process inline
- Add a backend fast path for running sessions that saves the message without re-claiming status or enqueuing a duplicate `continue_session` job
- Simplify `canSendMessage` to exclude only `skipped` and `pending` statuses, making it resilient to new status additions

## Test plan
- [x] New backend test: "sends message to running session without enqueuing job" — verifies only GetByID + INSERT message (no ClaimIdle, no ClaimForResume, no job enqueue)
- [x] Updated backend tests for idle/completed/pending paths to reflect new GetByID-first flow
- [x] New frontend test: "disables input for pending session" — verifies input shows "Session is not active" and is disabled
- [x] Updated frontend test: running session input is enabled with "Send a message to the agent..." placeholder
- [x] All 21 frontend tests pass, TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)