### PR TITLE
Fix bottom margin gap on sessions page layout

### DIFF
--- a/frontend/src/components/sidebar-layout.tsx
+++ b/frontend/src/components/sidebar-layout.tsx
@@ -20,7 +20,7 @@ export function SidebarLayout({ sidebar, children }: SidebarLayoutProps) {
   }, []);
 
   return (
-    <div className="flex h-full -mx-8 -my-6 lg:-mx-10 overflow-hidden">
+    <div className="absolute inset-0 flex overflow-hidden">
       <div style={{ width: sidebarWidth }} className="shrink-0">
         {sidebar}
       </div>


### PR DESCRIPTION
## Summary
- Replace negative-margin hack (`h-full -my-6 -mx-8 lg:-mx-10`) with `absolute inset-0` in `SidebarLayout`
- The previous approach left a visible gap at the bottom because `h-full` resolves to the parent's content-box height (excluding padding), so the element couldn't fill the parent's padding area
- `absolute inset-0` fills the parent's entire padding box since the parent already has `position: relative`

## Test plan
- [ ] Verify sessions page has no extra whitespace at the bottom
- [ ] Verify session detail view fills the full height
- [ ] Verify sidebar resizing still works correctly
- [ ] Check other pages using `SidebarLayout` (if any) render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)