### PR TITLE
Add Create PR button to session detail view

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -366,6 +366,127 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByText('All changes')).toBeInTheDocument();
   });
 
+  it('shows Create PR button for completed session with diff and no existing PR', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.getByTitle('Create PR')).toBeInTheDocument();
+    expect(screen.getByTitle('Create PR')).not.toBeDisabled();
+  });
+
+  it('does not show Create PR button when PR already exists', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      // Default handler already returns mockPR for GET /sessions/:id/pr
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    // Wait for the PR query to resolve before asserting
+    await waitFor(() => {
+      expect(screen.queryByTitle('Create PR')).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show Create PR button when session has no diff', async () => {
+    // Default mockSessions[0] has no diff_stats
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.queryByTitle('Create PR')).not.toBeInTheDocument();
+  });
+
+  it('does not show Create PR button when session is running', async () => {
+    const runningSession: Session = {
+      ...mockSessions[0],
+      status: 'running',
+      completed_at: undefined,
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      sandbox_state: 'running',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findByText('Agent is working...');
+    expect(screen.queryByTitle('Create PR')).not.toBeInTheDocument();
+  });
+
+  it('calls createPR API when Create PR button is clicked', async () => {
+    let createPRCalled = false;
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        createPRCalled = true;
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    const createPRButton = screen.getByTitle('Create PR');
+    await user.click(createPRButton);
+
+    await waitFor(() => {
+      expect(createPRCalled).toBe(true);
+    });
+  });
+
   it('shows PM context when pm_plan_id is set', async () => {
     const sessionWithPM: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   ArrowUp,
   ExternalLink,
+  GitPullRequest,
   RefreshCw,
   CheckCircle2,
   XCircle,
@@ -847,6 +848,22 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
     },
   });
 
+  const { data: prData } = useQuery({
+    queryKey: ["session", sessionId, "pr"],
+    queryFn: () => api.sessions.getPR(sessionId),
+  });
+  const hasPR = !!prData?.data;
+  const hasDiff = !!session.diff_stats;
+  const canCreatePR = hasDiff && !hasPR && !isRunning;
+
+  const createPRMutation = useMutation({
+    mutationFn: () => api.sessions.createPR(sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId, "pr"] });
+    },
+  });
+
   // Auto-resize textarea
   useEffect(() => {
     const el = textareaRef.current;
@@ -884,10 +901,10 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
       </div>
 
       {/* Error display */}
-      {(sendMutation.error || endMutation.error) && (
+      {(sendMutation.error || endMutation.error || createPRMutation.error) && (
         <div className="flex items-center gap-2 px-4 py-2 text-xs text-destructive border-t bg-destructive/5">
           <AlertTriangle className="h-3 w-3 shrink-0" />
-          {sendMutation.error instanceof Error ? sendMutation.error.message : endMutation.error instanceof Error ? endMutation.error.message : "An error occurred"}
+          {sendMutation.error instanceof Error ? sendMutation.error.message : endMutation.error instanceof Error ? endMutation.error.message : createPRMutation.error instanceof Error ? createPRMutation.error.message : "An error occurred"}
         </div>
       )}
 
@@ -923,6 +940,18 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
                 onClick={() => endMutation.mutate()}
               >
                 <Square className="h-3 w-3" />
+              </Button>
+            )}
+            {canCreatePR && (
+              <Button
+                size="icon"
+                variant="outline"
+                className="h-8 w-8 shrink-0"
+                title="Create PR"
+                disabled={createPRMutation.isPending}
+                onClick={() => createPRMutation.mutate()}
+              >
+                <GitPullRequest className="h-3.5 w-3.5" />
               </Button>
             )}
           </div>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -850,15 +850,23 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
 
   const { data: prData } = useQuery({
     queryKey: ["session", sessionId, "pr"],
-    queryFn: () => api.sessions.getPR(sessionId),
+    queryFn: () => api.sessions.getPR(sessionId).catch((err) => {
+      // 404 means no PR exists yet — treat as empty data, not an error.
+      if (err?.code === "NOT_FOUND") return { data: null };
+      throw err;
+    }),
   });
   const hasPR = !!prData?.data;
   const hasDiff = !!session.diff_stats;
   const canCreatePR = hasDiff && !hasPR && !isRunning;
 
+  const [prQueued, setPRQueued] = useState(false);
   const createPRMutation = useMutation({
     mutationFn: () => api.sessions.createPR(sessionId),
     onSuccess: () => {
+      setPRQueued(true);
+      // Clear the queued banner after 30s if the PR hasn't appeared yet.
+      setTimeout(() => setPRQueued(false), 30_000);
       queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
       queryClient.invalidateQueries({ queryKey: ["session", sessionId, "pr"] });
     },
@@ -900,13 +908,25 @@ function ChatPanel({ session, sessionId, isActive }: { session: Session; session
         <ChatTimeline entries={timelineEntries} isRunning={isRunning} />
       </div>
 
-      {/* Error display */}
-      {(sendMutation.error || endMutation.error || createPRMutation.error) && (
-        <div className="flex items-center gap-2 px-4 py-2 text-xs text-destructive border-t bg-destructive/5">
-          <AlertTriangle className="h-3 w-3 shrink-0" />
-          {sendMutation.error instanceof Error ? sendMutation.error.message : endMutation.error instanceof Error ? endMutation.error.message : createPRMutation.error instanceof Error ? createPRMutation.error.message : "An error occurred"}
+      {/* PR queued indicator */}
+      {prQueued && !hasPR && (
+        <div className="flex items-center gap-2 px-4 py-2 text-xs text-muted-foreground border-t bg-muted/30">
+          <GitPullRequest className="h-3 w-3 shrink-0" />
+          PR creation queued — it will appear shortly.
         </div>
       )}
+
+      {/* Error display */}
+      {(() => {
+        const firstError = [sendMutation, endMutation, createPRMutation].find(m => m.error)?.error;
+        if (!firstError) return null;
+        return (
+          <div className="flex items-center gap-2 px-4 py-2 text-xs text-destructive border-t bg-destructive/5">
+            <AlertTriangle className="h-3 w-3 shrink-0" />
+            {firstError instanceof Error ? firstError.message : "An error occurred"}
+          </div>
+        );
+      })()}
 
       {/* Input bar */}
       <div className="border-t border-border p-3 bg-background">

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -718,6 +718,36 @@ describe('api client', () => {
     });
   });
 
+  describe('sessions - createPR', () => {
+    it('creates PR and returns queued status', async () => {
+      let capturedUrl: string | undefined;
+
+      server.use(
+        http.post('/api/v1/sessions/:id/pr', ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ status: 'queued' }, { status: 202 });
+        }),
+      );
+
+      const result = await api.sessions.createPR('session-abc');
+      expect(result.status).toBe('queued');
+      expect(capturedUrl).toContain('/api/v1/sessions/session-abc/pr');
+    });
+
+    it('throws on conflict when PR already exists', async () => {
+      server.use(
+        http.post('/api/v1/sessions/:id/pr', () => {
+          return HttpResponse.json(
+            { error: { code: 'PR_EXISTS', message: 'a pull request already exists for this session' } },
+            { status: 409 },
+          );
+        }),
+      );
+
+      await expect(api.sessions.createPR('session-abc')).rejects.toThrow('a pull request already exists for this session');
+    });
+  });
+
   describe('issues - triggerFix', () => {
     it('triggers fix for an issue', async () => {
       let capturedBody: unknown;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -183,6 +183,7 @@ export const api = {
     getLogs: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionLog>>(`/api/v1/sessions/${sessionId}/logs`),
     getValidation: (sessionId: string) => get<import('./types').SingleResponse<import('./types').Validation>>(`/api/v1/sessions/${sessionId}/validation`),
     getPR: (sessionId: string) => get<import('./types').SingleResponse<import('./types').PullRequest>>(`/api/v1/sessions/${sessionId}/pr`),
+    createPR: (sessionId: string) => post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr`),
     getQuestions: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions`),
     answerQuestion: (sessionId: string, questionId: string, answer: string) =>
       post<import('./types').SingleResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions/${questionId}/answer`, { answer }),

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -282,6 +282,10 @@ export const handlers = [
     } satisfies SingleResponse<Session>);
   }),
 
+  http.post('/api/v1/sessions/:id/pr', () => {
+    return HttpResponse.json({ status: 'queued' }, { status: 202 });
+  }),
+
   http.get('/api/v1/sessions/:id/review-comments', () => {
     return HttpResponse.json({
       data: [] as SessionReviewComment[],

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -17,6 +18,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 )
 
@@ -448,8 +450,13 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check whether a PR already exists for this session.
-	if _, prErr := h.pullRequestStore.GetBySessionID(r.Context(), orgID, sessionID); prErr == nil {
+	_, prErr := h.pullRequestStore.GetBySessionID(r.Context(), orgID, sessionID)
+	if prErr == nil {
 		writeError(w, r, http.StatusConflict, "PR_EXISTS", "a pull request already exists for this session")
+		return
+	}
+	if !errors.Is(prErr, pgx.ErrNoRows) {
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to check for existing PR", prErr)
 		return
 	}
 
@@ -464,7 +471,7 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sessionIDStr := sessionID.String()
-	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionStatusChanged, models.AuditResourceSession, &sessionIDStr, &session.ID, nil, nil)
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionPRRequested, models.AuditResourceSession, &sessionIDStr, &session.ID, nil, nil)
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
 }
 

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -425,6 +425,49 @@ func (h *SessionHandler) GetPullRequest(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PullRequest]{Data: pr})
 }
 
+// CreatePR handles POST /sessions/{id}/pr — enqueues a job to create a GitHub
+// PR from the session's diff. The session must have a non-empty diff and must
+// not already have an associated PR.
+func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+
+	if session.Diff == nil || *session.Diff == "" {
+		writeError(w, r, http.StatusBadRequest, "NO_DIFF", "session has no diff to create a PR from")
+		return
+	}
+
+	// Check whether a PR already exists for this session.
+	if _, prErr := h.pullRequestStore.GetBySessionID(r.Context(), orgID, sessionID); prErr == nil {
+		writeError(w, r, http.StatusConflict, "PR_EXISTS", "a pull request already exists for this session")
+		return
+	}
+
+	payload := map[string]string{
+		"session_id": sessionID.String(),
+		"org_id":     orgID.String(),
+	}
+	dedupeKey := fmt.Sprintf("open_pr:%s", sessionID)
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "open_pr", payload, 5, &dedupeKey); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue PR creation job", err)
+		return
+	}
+
+	sessionIDStr := sessionID.String()
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionStatusChanged, models.AuditResourceSession, &sessionIDStr, &session.ID, nil, nil)
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
+}
+
 // ListQuestions returns the questions for an agent run.
 func (h *SessionHandler) ListQuestions(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2338,6 +2338,60 @@ func TestSessionHandler_CreatePR_SessionNotFound(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"
+
+	// Mock session lookup — session has a diff.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, &diff,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, nil, "none", nil,
+				nil, nil, nil, nil, nil,
+				now,
+			),
+		)
+
+	// Mock PR lookup — returns a database error.
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "should return 500 on PR lookup DB error")
+	require.Contains(t, w.Body.String(), "INTERNAL_ERROR", "error code should indicate internal error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2130,6 +2130,214 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionHandler_CreatePR_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	jobID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"
+
+	// Mock session lookup — session has a diff.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, &diff,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,                      // triggered_by_user_id
+				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
+				nil, // target_branch
+				nil, // working_branch
+				nil, // repository_id
+				nil, // diff_stats
+				nil, // diff_history
+				now,
+			),
+		)
+
+	// Mock PR lookup — no existing PR (returns empty result).
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "merged_at", "created_at", "updated_at",
+		}))
+
+	// Mock job enqueue.
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "should return 202 Accepted")
+	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should indicate job was queued")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_NoDiff(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	// Mock session lookup — session has no diff.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, nil, // diff is nil
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, nil, "none", nil,
+				nil, nil, nil, nil, nil,
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "should return 400 when session has no diff")
+	require.Contains(t, w.Body.String(), "NO_DIFF", "error code should indicate missing diff")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	prID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"
+
+	// Mock session lookup — session has a diff.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, nil,
+				nil, nil, nil, nil, &diff,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, nil, "none", nil,
+				nil, nil, nil, nil, nil,
+				now,
+			),
+		)
+
+	// Mock PR lookup — PR already exists.
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+				"title", "body", "status", "review_status", "merged_at", "created_at", "updated_at",
+			}).AddRow(
+				prID, sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
+				"Fix bug", (*string)(nil), "open", "pending", (*time.Time)(nil), now, now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "should return 409 when PR already exists")
+	require.Contains(t, w.Body.String(), "PR_EXISTS", "error code should indicate PR already exists")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_SessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	// Mock session lookup — not found.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "should return 404 when session not found")
+	require.Contains(t, w.Body.String(), "NOT_FOUND", "error code should indicate session not found")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -308,6 +308,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Post("/api/v1/sessions/{id}/questions/{qid}/answer", sessionHandler.AnswerQuestion)
 			r.Post("/api/v1/sessions/{id}/messages", sessionHandler.SendMessage)
 			r.Post("/api/v1/sessions/{id}/end", sessionHandler.EndSession)
+			r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
 			r.Post("/api/v1/sessions/{id}/threads", sessionThreadHandler.CreateThread)
 			r.Post("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.SendThreadMessage)
 			r.Post("/api/v1/sessions/{id}/threads/{tid}/end", sessionThreadHandler.EndThread)

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -39,6 +39,7 @@ const (
 	AuditActionSessionReviewCommentCreated AuditAction = "session.review_comment.created"
 	AuditActionSessionReviewCommentUpdated AuditAction = "session.review_comment.updated"
 	AuditActionSessionReviewCommentDeleted AuditAction = "session.review_comment.deleted"
+	AuditActionSessionPRRequested          AuditAction = "session.pr_requested"
 
 	// Project actions
 	AuditActionProjectCreated        AuditAction = "project.created"
@@ -92,6 +93,7 @@ func (a AuditAction) Validate() error {
 		AuditActionSessionFailed, AuditActionSessionCancelled, AuditActionSessionStatusChanged,
 		AuditActionSessionQuestionCreated, AuditActionSessionQuestionAnswered, AuditActionSessionResumedLocally,
 		AuditActionSessionReviewCommentCreated, AuditActionSessionReviewCommentUpdated, AuditActionSessionReviewCommentDeleted,
+		AuditActionSessionPRRequested,
 		AuditActionProjectCreated, AuditActionProjectUpdated, AuditActionProjectDeleted,
 		AuditActionProjectStarted, AuditActionProjectPaused, AuditActionProjectResumed,
 		AuditActionProjectApproved, AuditActionProjectCompleted, AuditActionProjectDismissed, AuditActionProjectRunTriggered,


### PR DESCRIPTION
## Summary
- Adds `POST /sessions/{id}/pr` endpoint that validates the session has a diff and no existing PR, then enqueues an `open_pr` job with deduplication
- Surfaces a GitPullRequest icon button in the chat panel when the session has a diff, no existing PR, and is not actively running
- Includes backend handler tests (success, no-diff, already-exists, not-found) and frontend tests

## Test plan
- [ ] Verify the Create PR button appears on completed sessions with diffs
- [ ] Verify the button is hidden when a PR already exists or session is running
- [ ] Verify clicking the button enqueues the job and the button disables during pending state
- [ ] Verify error states display correctly in the error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)