### PR TITLE
Add user-based session filtering with Mine/Everyone toggle

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -10,6 +10,7 @@ import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
+import { useAuth } from "@/hooks/use-auth";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
@@ -101,9 +102,11 @@ function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
 export function SessionSidebar() {
   const params = useParams();
   const pathname = usePathname();
+  const { user } = useAuth();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
+  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
   const [repo] = useQueryState("repo");
 
   const { optimisticSessions } = useOptimisticSessions();
@@ -111,19 +114,23 @@ export function SessionSidebar() {
   const currentFilter = activeFilter ?? "all";
   const statusParam = filterToStatusParam(currentFilter);
 
+  // User filter: default to "mine" when not set, "all" shows everyone
+  const currentUserFilter = userFilter ?? "mine";
+  const triggeredByUserId = currentUserFilter === "mine" && user ? user.id : undefined;
+
   // Fetch all sessions (for tab badge counts and the "all" view).
   // Also fetches a filtered query when a tab is active — see sessions-page-content
   // for the rationale on the double-fetch tradeoff.
   const { data: allData, isLoading } = useQuery({
-    queryKey: queryKeys.sessions.list(repo),
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
+    queryKey: [...queryKeys.sessions.list(repo), triggeredByUserId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId }),
     refetchInterval: 10000,
   });
 
   // Fetch filtered sessions from the backend when a specific tab is selected.
   const { data: filteredData } = useQuery({
-    queryKey: [...queryKeys.sessions.list(repo), statusParam],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam }),
+    queryKey: [...queryKeys.sessions.list(repo), statusParam, triggeredByUserId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId }),
     refetchInterval: 10000,
     enabled: !!statusParam,
   });
@@ -174,6 +181,32 @@ export function SessionSidebar() {
           <Plus className="h-4 w-4" />
           New session
         </Link>
+
+        {/* User filter toggle */}
+        <div className="flex items-center gap-0.5 rounded-md border border-border bg-muted/50 p-0.5">
+          <button
+            className={cn(
+              "flex-1 px-2.5 py-1 text-[12px] font-medium rounded transition-colors text-center",
+              currentUserFilter === "mine"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground/80"
+            )}
+            onClick={() => setUserFilter(null)}
+          >
+            Mine
+          </button>
+          <button
+            className={cn(
+              "flex-1 px-2.5 py-1 text-[12px] font-medium rounded transition-colors text-center",
+              currentUserFilter === "all"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground/80"
+            )}
+            onClick={() => setUserFilter("all")}
+          >
+            Everyone
+          </button>
+        </div>
 
         {/* Filter tabs */}
         <Tabs

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Plus, Search } from "lucide-react";
+import { ChevronDown, Plus, Search, Users } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -9,6 +9,14 @@ import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api";
 import { useAuth } from "@/hooks/use-auth";
 import { queryKeys } from "@/lib/query-keys";
@@ -114,9 +122,13 @@ export function SessionSidebar() {
   const currentFilter = activeFilter ?? "all";
   const statusParam = filterToStatusParam(currentFilter);
 
-  // User filter: default to "mine" when not set, "all" shows everyone
+  // User filter: "mine" (default), "all" (everyone), or a specific user ID
   const currentUserFilter = userFilter ?? "mine";
-  const triggeredByUserId = currentUserFilter === "mine" && user ? user.id : undefined;
+  const triggeredByUserId = currentUserFilter === "all"
+    ? undefined
+    : currentUserFilter === "mine" && user
+      ? user.id
+      : currentUserFilter !== "mine" ? currentUserFilter : undefined;
 
   // Fetch all sessions (for tab badge counts and the "all" view).
   // Also fetches a filtered query when a tab is active — see sessions-page-content
@@ -135,7 +147,13 @@ export function SessionSidebar() {
     enabled: !!statusParam,
   });
 
+  const { data: membersData } = useQuery({
+    queryKey: ["team", "members"],
+    queryFn: () => api.team.listMembers(),
+  });
+
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);
+  const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);
 
   const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
@@ -182,31 +200,52 @@ export function SessionSidebar() {
           New session
         </Link>
 
-        {/* User filter toggle */}
-        <div className="flex items-center gap-0.5 rounded-md border border-border bg-muted/50 p-0.5">
-          <button
-            className={cn(
-              "flex-1 px-2.5 py-1 text-[12px] font-medium rounded transition-colors text-center",
-              currentUserFilter === "mine"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground/80"
+        {/* User filter dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center justify-between w-full px-2.5 py-1.5 text-[12px] font-medium rounded-md border border-border bg-muted/50 hover:bg-muted transition-colors text-foreground">
+              <span className="flex items-center gap-1.5">
+                <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                {currentUserFilter === "mine" ? "Mine" : currentUserFilter === "all" ? "Everyone" : members.find(m => m.id === currentUserFilter)?.name.split(" ")[0] ?? "User"}
+              </span>
+              <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-48">
+            <DropdownMenuItem
+              className={cn("text-[12px]", currentUserFilter === "mine" && "font-semibold")}
+              onClick={() => setUserFilter(null)}
+            >
+              Mine
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={cn("text-[12px]", currentUserFilter === "all" && "font-semibold")}
+              onClick={() => setUserFilter("all")}
+            >
+              Everyone
+            </DropdownMenuItem>
+            {members.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
+                  Team members
+                </DropdownMenuLabel>
+                {members.map((member) => (
+                  <DropdownMenuItem
+                    key={member.id}
+                    className={cn("text-[12px]", currentUserFilter === member.id && "font-semibold")}
+                    onClick={() => setUserFilter(member.id === user?.id ? null : member.id)}
+                  >
+                    {member.name}
+                    {member.id === user?.id && (
+                      <span className="text-[10px] text-muted-foreground ml-1">(you)</span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </>
             )}
-            onClick={() => setUserFilter(null)}
-          >
-            Mine
-          </button>
-          <button
-            className={cn(
-              "flex-1 px-2.5 py-1 text-[12px] font-medium rounded transition-colors text-center",
-              currentUserFilter === "all"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground/80"
-            )}
-            onClick={() => setUserFilter("all")}
-          >
-            Everyone
-          </button>
-        </div>
+          </DropdownMenuContent>
+        </DropdownMenu>
 
         {/* Filter tabs */}
         <Tabs

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { ChevronDown, Plus, Search, Users } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -9,16 +9,9 @@ import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { api } from "@/lib/api";
-import { useAuth } from "@/hooks/use-auth";
+import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
+import { SessionUserFilterDropdown } from "./session-user-filter-dropdown";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
@@ -110,25 +103,16 @@ function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
 export function SessionSidebar() {
   const params = useParams();
   const pathname = usePathname();
-  const { user } = useAuth();
+  const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
-  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
   const [repo] = useQueryState("repo");
 
   const { optimisticSessions } = useOptimisticSessions();
 
   const currentFilter = activeFilter ?? "all";
   const statusParam = filterToStatusParam(currentFilter);
-
-  // User filter: "mine" (default), "all" (everyone), or a specific user ID
-  const currentUserFilter = userFilter ?? "mine";
-  const triggeredByUserId = currentUserFilter === "all"
-    ? undefined
-    : currentUserFilter === "mine" && user
-      ? user.id
-      : currentUserFilter !== "mine" ? currentUserFilter : undefined;
 
   // Fetch all sessions (for tab badge counts and the "all" view).
   // Also fetches a filtered query when a tab is active — see sessions-page-content
@@ -201,51 +185,14 @@ export function SessionSidebar() {
         </Link>
 
         {/* User filter dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="flex items-center justify-between w-full px-2.5 py-1.5 text-[12px] font-medium rounded-md border border-border bg-muted/50 hover:bg-muted transition-colors text-foreground">
-              <span className="flex items-center gap-1.5">
-                <Users className="h-3.5 w-3.5 text-muted-foreground" />
-                {currentUserFilter === "mine" ? "Mine" : currentUserFilter === "all" ? "Everyone" : members.find(m => m.id === currentUserFilter)?.name.split(" ")[0] ?? "User"}
-              </span>
-              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className="w-48">
-            <DropdownMenuItem
-              className={cn("text-[12px]", currentUserFilter === "mine" && "font-semibold")}
-              onClick={() => setUserFilter(null)}
-            >
-              Mine
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className={cn("text-[12px]", currentUserFilter === "all" && "font-semibold")}
-              onClick={() => setUserFilter("all")}
-            >
-              Everyone
-            </DropdownMenuItem>
-            {members.length > 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
-                  Team members
-                </DropdownMenuLabel>
-                {members.map((member) => (
-                  <DropdownMenuItem
-                    key={member.id}
-                    className={cn("text-[12px]", currentUserFilter === member.id && "font-semibold")}
-                    onClick={() => setUserFilter(member.id === user?.id ? null : member.id)}
-                  >
-                    {member.name}
-                    {member.id === user?.id && (
-                      <span className="text-[10px] text-muted-foreground ml-1">(you)</span>
-                    )}
-                  </DropdownMenuItem>
-                ))}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <SessionUserFilterDropdown
+          currentUserFilter={currentUserFilter}
+          members={members}
+          currentUser={user}
+          onFilterChange={setUserFilter}
+          align="start"
+          className="w-full justify-between"
+        />
 
         {/* Filter tabs */}
         <Tabs

--- a/frontend/src/app/(dashboard)/sessions/session-user-filter-dropdown.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-user-filter-dropdown.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { ChevronDown, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  userFilterLabel,
+  userFilterParamForMember,
+  type UserFilterParam,
+} from "@/hooks/use-session-user-filter";
+import type { User } from "@/lib/types";
+
+interface SessionUserFilterDropdownProps {
+  currentUserFilter: string;
+  members: User[];
+  currentUser: User | null;
+  onFilterChange: (value: UserFilterParam) => void;
+  /** Dropdown content alignment. */
+  align?: "start" | "end";
+  /** Additional class names for the trigger button. */
+  className?: string;
+}
+
+export function SessionUserFilterDropdown({
+  currentUserFilter,
+  members,
+  currentUser,
+  onFilterChange,
+  align = "end",
+  className,
+}: SessionUserFilterDropdownProps) {
+  const label = userFilterLabel(currentUserFilter, members);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className={cn(
+            "flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium rounded-md border border-border bg-muted/50 hover:bg-muted transition-colors text-foreground",
+            className,
+          )}
+        >
+          <Users className="h-3.5 w-3.5 text-muted-foreground" />
+          {label}
+          <ChevronDown className="h-3 w-3 text-muted-foreground" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={align} className="w-48">
+        <DropdownMenuItem
+          className={cn("text-[12px]", currentUserFilter === "mine" && "font-semibold")}
+          onClick={() => onFilterChange(null)}
+        >
+          Mine
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className={cn("text-[12px]", currentUserFilter === "all" && "font-semibold")}
+          onClick={() => onFilterChange("all")}
+        >
+          Everyone
+        </DropdownMenuItem>
+        {members.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
+              Team members
+            </DropdownMenuLabel>
+            {members.map((member) => (
+              <DropdownMenuItem
+                key={member.id}
+                className={cn("text-[12px]", currentUserFilter === member.id && "font-semibold")}
+                onClick={() => onFilterChange(userFilterParamForMember(member.id, currentUser?.id))}
+              >
+                {member.name}
+                {member.id === currentUser?.id && (
+                  <span className="text-[10px] text-muted-foreground ml-1">(you)</span>
+                )}
+              </DropdownMenuItem>
+            ))}
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -30,6 +30,7 @@ import {
 import { api } from "@/lib/api";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { useAuth } from "@/hooks/use-auth";
 import type { Session, User } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -206,13 +207,19 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
 
 export function SessionsPageContent() {
   const router = useRouter();
+  const { user } = useAuth();
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
+  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const currentFilter = activeFilter ?? "all";
   const showDecisions = currentFilter === "decisions";
   const statusParam = filterToStatusParam(currentFilter);
+
+  // User filter: default to "mine" when not set, "all" shows everyone
+  const currentUserFilter = userFilter ?? "mine";
+  const triggeredByUserId = currentUserFilter === "mine" && user ? user.id : undefined;
 
   // Fetch all sessions (for tab badge counts and the "all" view).
   // We also fetch a filtered query below when a tab is active. The two queries
@@ -222,15 +229,15 @@ export function SessionsPageContent() {
   // the limit. If polling cost becomes a concern, consider a dedicated
   // /sessions/counts endpoint.
   const { data: allData, isLoading, error } = useQuery({
-    queryKey: ["sessions", repo],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined }),
+    queryKey: ["sessions", repo, triggeredByUserId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId }),
     refetchInterval: 10000,
   });
 
   // Fetch filtered sessions from the backend when a specific tab is selected.
   const { data: filteredData } = useQuery({
-    queryKey: ["sessions", repo, statusParam],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam }),
+    queryKey: ["sessions", repo, statusParam, triggeredByUserId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId }),
     refetchInterval: 10000,
     enabled: !!statusParam,
   });
@@ -276,38 +283,64 @@ export function SessionsPageContent() {
       <PMStatusBanner hasActivePlanSession={workingSessions.length > 0} />
 
       {/* ── Tab filters ────────────────────────────────────────────── */}
-      <div className="flex items-center gap-0 border-b border-border">
-        {filterTabs.map((tab) => {
-          const isSelected = currentFilter === tab.value;
-          const count =
-            tab.value === "needs_attention" ? needsAttentionSessions.length
-            : tab.value === "working" ? workingSessions.length
-            : 0;
-          return (
-            <button
-              key={tab.value}
-              className={`relative px-3 py-2.5 text-[13px] font-medium transition-colors duration-150 ${
-                isSelected
-                  ? "text-foreground"
-                  : "text-muted-foreground hover:text-foreground/80"
-              }`}
-              onClick={() => setActiveFilter(tab.value === "all" ? null : tab.value)}
-            >
-              <span className="flex items-center gap-1.5">
-                {tab.label}
-                {count > 0 && (
-                  <span className={`rounded-full text-white text-[10px] leading-none px-1.5 py-0.5 font-normal ${
-                    tab.value === "needs_attention" ? "bg-orange-500"
-                    : "bg-primary"
-                  }`}>{count}</span>
+      <div className="flex items-center justify-between border-b border-border">
+        <div className="flex items-center gap-0">
+          {filterTabs.map((tab) => {
+            const isSelected = currentFilter === tab.value;
+            const count =
+              tab.value === "needs_attention" ? needsAttentionSessions.length
+              : tab.value === "working" ? workingSessions.length
+              : 0;
+            return (
+              <button
+                key={tab.value}
+                className={`relative px-3 py-2.5 text-[13px] font-medium transition-colors duration-150 ${
+                  isSelected
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground/80"
+                }`}
+                onClick={() => setActiveFilter(tab.value === "all" ? null : tab.value)}
+              >
+                <span className="flex items-center gap-1.5">
+                  {tab.label}
+                  {count > 0 && (
+                    <span className={`rounded-full text-white text-[10px] leading-none px-1.5 py-0.5 font-normal ${
+                      tab.value === "needs_attention" ? "bg-orange-500"
+                      : "bg-primary"
+                    }`}>{count}</span>
+                  )}
+                </span>
+                {isSelected && (
+                  <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-[image:var(--gradient-primary)] rounded-full" />
                 )}
-              </span>
-              {isSelected && (
-                <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-[image:var(--gradient-primary)] rounded-full" />
-              )}
-            </button>
-          );
-        })}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* User filter toggle */}
+        <div className="flex items-center gap-0.5 mr-2 rounded-md border border-border bg-muted/50 p-0.5">
+          <button
+            className={`px-2.5 py-1 text-[12px] font-medium rounded transition-colors ${
+              currentUserFilter === "mine"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground/80"
+            }`}
+            onClick={() => setUserFilter(null)}
+          >
+            Mine
+          </button>
+          <button
+            className={`px-2.5 py-1 text-[12px] font-medium rounded transition-colors ${
+              currentUserFilter === "all"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground/80"
+            }`}
+            onClick={() => setUserFilter("all")}
+          >
+            Everyone
+          </button>
+        </div>
       </div>
 
       {/* ── Decisions tab ──────────────────────────────────────────── */}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -9,7 +9,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
-import { ArrowUpDown, CalendarClock, ChevronDown, Plus, Users } from "lucide-react";
+import { ArrowUpDown, CalendarClock, Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -19,14 +19,6 @@ import { PMStatusBanner } from "@/components/pm/pm-status-banner";
 import { DecisionsView } from "@/components/pm/decisions-view";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -38,7 +30,8 @@ import {
 import { api } from "@/lib/api";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
-import { useAuth } from "@/hooks/use-auth";
+import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
+import { SessionUserFilterDropdown } from "./session-user-filter-dropdown";
 import type { Session, User } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -215,23 +208,14 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
 
 export function SessionsPageContent() {
   const router = useRouter();
-  const { user } = useAuth();
+  const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
-  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const currentFilter = activeFilter ?? "all";
   const showDecisions = currentFilter === "decisions";
   const statusParam = filterToStatusParam(currentFilter);
-
-  // User filter: "mine" (default), "all" (everyone), or a specific user ID
-  const currentUserFilter = userFilter ?? "mine";
-  const triggeredByUserId = currentUserFilter === "all"
-    ? undefined
-    : currentUserFilter === "mine" && user
-      ? user.id
-      : currentUserFilter !== "mine" ? currentUserFilter : undefined;
 
   // Fetch all sessions (for tab badge counts and the "all" view).
   // We also fetch a filtered query below when a tab is active. The two queries
@@ -331,49 +315,14 @@ export function SessionsPageContent() {
         </div>
 
         {/* User filter dropdown */}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button className="flex items-center gap-1.5 mr-2 px-2.5 py-1.5 text-[12px] font-medium rounded-md border border-border bg-muted/50 hover:bg-muted transition-colors text-foreground">
-              <Users className="h-3.5 w-3.5 text-muted-foreground" />
-              {currentUserFilter === "mine" ? "Mine" : currentUserFilter === "all" ? "Everyone" : members.find(m => m.id === currentUserFilter)?.name.split(" ")[0] ?? "User"}
-              <ChevronDown className="h-3 w-3 text-muted-foreground" />
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48">
-            <DropdownMenuItem
-              className={`text-[12px] ${currentUserFilter === "mine" ? "font-semibold" : ""}`}
-              onClick={() => setUserFilter(null)}
-            >
-              Mine
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className={`text-[12px] ${currentUserFilter === "all" ? "font-semibold" : ""}`}
-              onClick={() => setUserFilter("all")}
-            >
-              Everyone
-            </DropdownMenuItem>
-            {members.length > 0 && (
-              <>
-                <DropdownMenuSeparator />
-                <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
-                  Team members
-                </DropdownMenuLabel>
-                {members.map((member) => (
-                  <DropdownMenuItem
-                    key={member.id}
-                    className={`text-[12px] ${currentUserFilter === member.id ? "font-semibold" : ""}`}
-                    onClick={() => setUserFilter(member.id === user?.id ? null : member.id)}
-                  >
-                    {member.name}
-                    {member.id === user?.id && (
-                      <span className="text-[10px] text-muted-foreground ml-1">(you)</span>
-                    )}
-                  </DropdownMenuItem>
-                ))}
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+        <SessionUserFilterDropdown
+          currentUserFilter={currentUserFilter}
+          members={members}
+          currentUser={user}
+          onFilterChange={setUserFilter}
+          align="end"
+          className="mr-2"
+        />
       </div>
 
       {/* ── Decisions tab ──────────────────────────────────────────── */}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -9,7 +9,7 @@ import {
   type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table";
-import { ArrowUpDown, CalendarClock, Plus } from "lucide-react";
+import { ArrowUpDown, CalendarClock, ChevronDown, Plus, Users } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -19,6 +19,14 @@ import { PMStatusBanner } from "@/components/pm/pm-status-banner";
 import { DecisionsView } from "@/components/pm/decisions-view";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -217,9 +225,13 @@ export function SessionsPageContent() {
   const showDecisions = currentFilter === "decisions";
   const statusParam = filterToStatusParam(currentFilter);
 
-  // User filter: default to "mine" when not set, "all" shows everyone
+  // User filter: "mine" (default), "all" (everyone), or a specific user ID
   const currentUserFilter = userFilter ?? "mine";
-  const triggeredByUserId = currentUserFilter === "mine" && user ? user.id : undefined;
+  const triggeredByUserId = currentUserFilter === "all"
+    ? undefined
+    : currentUserFilter === "mine" && user
+      ? user.id
+      : currentUserFilter !== "mine" ? currentUserFilter : undefined;
 
   // Fetch all sessions (for tab badge counts and the "all" view).
   // We also fetch a filtered query below when a tab is active. The two queries
@@ -318,29 +330,50 @@ export function SessionsPageContent() {
           })}
         </div>
 
-        {/* User filter toggle */}
-        <div className="flex items-center gap-0.5 mr-2 rounded-md border border-border bg-muted/50 p-0.5">
-          <button
-            className={`px-2.5 py-1 text-[12px] font-medium rounded transition-colors ${
-              currentUserFilter === "mine"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground/80"
-            }`}
-            onClick={() => setUserFilter(null)}
-          >
-            Mine
-          </button>
-          <button
-            className={`px-2.5 py-1 text-[12px] font-medium rounded transition-colors ${
-              currentUserFilter === "all"
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground/80"
-            }`}
-            onClick={() => setUserFilter("all")}
-          >
-            Everyone
-          </button>
-        </div>
+        {/* User filter dropdown */}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center gap-1.5 mr-2 px-2.5 py-1.5 text-[12px] font-medium rounded-md border border-border bg-muted/50 hover:bg-muted transition-colors text-foreground">
+              <Users className="h-3.5 w-3.5 text-muted-foreground" />
+              {currentUserFilter === "mine" ? "Mine" : currentUserFilter === "all" ? "Everyone" : members.find(m => m.id === currentUserFilter)?.name.split(" ")[0] ?? "User"}
+              <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem
+              className={`text-[12px] ${currentUserFilter === "mine" ? "font-semibold" : ""}`}
+              onClick={() => setUserFilter(null)}
+            >
+              Mine
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className={`text-[12px] ${currentUserFilter === "all" ? "font-semibold" : ""}`}
+              onClick={() => setUserFilter("all")}
+            >
+              Everyone
+            </DropdownMenuItem>
+            {members.length > 0 && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-[11px] text-muted-foreground font-normal">
+                  Team members
+                </DropdownMenuLabel>
+                {members.map((member) => (
+                  <DropdownMenuItem
+                    key={member.id}
+                    className={`text-[12px] ${currentUserFilter === member.id ? "font-semibold" : ""}`}
+                    onClick={() => setUserFilter(member.id === user?.id ? null : member.id)}
+                  >
+                    {member.name}
+                    {member.id === user?.id && (
+                      <span className="text-[10px] text-muted-foreground ml-1">(you)</span>
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* ── Decisions tab ──────────────────────────────────────────── */}

--- a/frontend/src/hooks/use-session-user-filter.ts
+++ b/frontend/src/hooks/use-session-user-filter.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useQueryState, parseAsString } from "nuqs";
+import { useAuth } from "@/hooks/use-auth";
+import type { User } from "@/lib/types";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Well-known user filter presets. Any other string value is a specific user ID. */
+export type UserFilterPreset = "mine" | "all";
+
+/** The resolved value stored in the URL query param. `null` means "mine" (default). */
+export type UserFilterParam = string | null;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the URL-level filter value to the effective filter key.
+ * `null` (no param) → "mine".
+ */
+export function resolveUserFilter(param: string | null): UserFilterPreset | string {
+  return param ?? "mine";
+}
+
+/**
+ * Derive the `triggered_by_user_id` API param from the resolved filter and
+ * the current user.
+ *
+ * - `"all"`          → `undefined` (no server filter)
+ * - `"mine"`         → current user's ID (or `undefined` if not yet loaded)
+ * - specific user ID → that ID
+ */
+export function deriveTriggeredByUserId(
+  filter: UserFilterPreset | string,
+  currentUser: User | null,
+): string | undefined {
+  if (filter === "all") return undefined;
+  if (filter === "mine") return currentUser?.id;
+  return filter; // specific user ID
+}
+
+/**
+ * Compute the display label for the user filter trigger button.
+ */
+export function userFilterLabel(
+  filter: UserFilterPreset | string,
+  members: User[],
+): string {
+  if (filter === "mine") return "Mine";
+  if (filter === "all") return "Everyone";
+  const member = members.find((m) => m.id === filter);
+  return member ? member.name.split(" ")[0] : "User";
+}
+
+/**
+ * Determine the URL param value to set for a given member selection.
+ * Selecting yourself maps to `null` ("mine") for a clean URL.
+ */
+export function userFilterParamForMember(
+  memberId: string,
+  currentUserId: string | undefined,
+): UserFilterParam {
+  return memberId === currentUserId ? null : memberId;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSessionUserFilter() {
+  const { user } = useAuth();
+  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
+
+  const currentUserFilter = resolveUserFilter(userFilter);
+  const triggeredByUserId = deriveTriggeredByUserId(currentUserFilter, user);
+
+  return {
+    /** The resolved filter value: "mine", "all", or a user ID. */
+    currentUserFilter,
+    /** The user ID to pass to the API, or undefined for no filter. */
+    triggeredByUserId,
+    /** The current authenticated user. */
+    user,
+    /** Set the user filter. Pass `null` for "mine", `"all"` for everyone, or a user ID. */
+    setUserFilter,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -172,12 +172,13 @@ export const api = {
       del(`/api/v1/pm/documents/${docId}`),
   },
   sessions: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit) searchParams.set('limit', String(params.limit));
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
+      if (params?.triggered_by_user_id) searchParams.set('triggered_by_user_id', params.triggered_by_user_id);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Session>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -109,6 +109,15 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		filters.RepositoryID = repoID
 	}
 
+	if userIDStr := r.URL.Query().Get("triggered_by_user_id"); userIDStr != "" {
+		userID, err := uuid.Parse(userIDStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid triggered_by_user_id")
+			return
+		}
+		filters.TriggeredByUserID = userID
+	}
+
 	runs, err := h.runStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list runs", err)

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -27,11 +27,12 @@ func NewSessionStore(db DBTX) *SessionStore {
 }
 
 type SessionFilters struct {
-	Statuses     []models.SessionStatus // When non-empty, filter to sessions matching any of these statuses.
-	Limit        int
-	Cursor       string
-	AdHocOnly    bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
-	RepositoryID uuid.UUID // When non-zero, filter sessions by repository via issues table.
+	Statuses           []models.SessionStatus // When non-empty, filter to sessions matching any of these statuses.
+	Limit              int
+	Cursor             string
+	AdHocOnly          bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
+	RepositoryID       uuid.UUID // When non-zero, filter sessions by repository via issues table.
+	TriggeredByUserID  uuid.UUID // When non-zero, filter sessions to those triggered by this user.
 }
 
 // sessionSelectColumns is used for single-session queries where we want all fields.
@@ -119,6 +120,10 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 		}
 		query += ` AND status = ANY(@statuses)`
 		args["statuses"] = statusStrings
+	}
+	if filters.TriggeredByUserID != uuid.Nil {
+		query += ` AND triggered_by_user_id = @triggered_by_user_id`
+		args["triggered_by_user_id"] = filters.TriggeredByUserID
 	}
 	if filters.AdHocOnly {
 		query += ` AND pm_plan_id IS NULL`


### PR DESCRIPTION
## Summary

- Sessions now default to showing only the current user's sessions ("Mine"), making it easy to focus on your own work
- Added a "Mine / Everyone" toggle on both the sessions page and sidebar to quickly switch between viewing your sessions and all team sessions
- Filtering is done server-side via a new `triggered_by_user_id` query parameter on the sessions list API for accurate results
- Filter state is persisted in the URL (`?user=all`) so filtered views are shareable

## Changes

**Backend:**
- Added `TriggeredByUserID` field to `SessionFilters` struct
- Added `triggered_by_user_id` SQL filter in `ListByOrg` query
- Added `triggered_by_user_id` query parameter parsing in the sessions list handler

**Frontend:**
- Added `triggered_by_user_id` parameter to the `api.sessions.list()` client
- Added Mine/Everyone toggle to sessions page (right-aligned next to status tabs)
- Added Mine/Everyone toggle to session sidebar (above status filter tabs)
- Default is "Mine" (no URL param needed); "Everyone" sets `?user=all`

## Test plan

- [ ] Verify sessions page defaults to showing only your own sessions
- [ ] Click "Everyone" toggle and verify all team sessions appear
- [ ] Click "Mine" to return to filtered view
- [ ] Verify status tab filters (Needs attention, Working, Done) work correctly with both user filter states
- [ ] Verify the sidebar toggle stays in sync with the page toggle (shared URL state)
- [ ] Verify URL reflects filter state (`?user=all` when Everyone is selected, no param for Mine)
- [ ] Verify badge counts on status tabs reflect the active user filter

https://claude.ai/code/session_01KcdDTZHKvGByUDwyppHzKm