### PR TITLE
Reorganize docs: extract development setup to dedicated guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **from issues to validated PRs, on autopilot**
 
-[Getting Started](#getting-started) · [Development Setup](docs/contributing/development-setup.md) · [Architecture](docs/design/overall.md)
+[Getting Started](#getting-started) · [Development Setup](docs/contributing/development-setup.md) · [Architecture](docs/design/overall.md) · [143.dev](https://www.143.dev)
 
 ---
 
@@ -22,6 +22,8 @@ Use whatever coding agent you trust — Claude Code, Codex, Cursor, or your own 
 
 The result: bugs get triaged, planned, fixed, validated, and shipped as PRs — without context-switching your team away from the work that matters.
 
+> **Don't want to self-host?** [143.dev](https://www.143.dev) is the hosted version — connect your repos and start shipping fixes in minutes.
+
 ## How it works
 
 ```
@@ -37,6 +39,26 @@ issues in → PM agent plans → coding agents execute → validate → ship PRs
 5. **Ship** — open GitHub PRs with full context for human review
 6. **Observe** — measure post-deploy impact on error rates and support volume
 7. **Learn** — extract review feedback into conventions, feed back into future runs
+
+## Key Features
+
+**Sandboxed execution with gVisor** — every agent run happens in an isolated container with gVisor syscall-level enforcement, read-only root filesystem, dropped capabilities, and network restricted to LLM APIs and package registries. Graceful fallback to standard Docker in local dev.
+
+**6-stage validation pipeline** — direction check, correctness check, quality check, security scanning (gitleaks + semgrep), regression tests, and CI integration. Fail-fast ordering minimizes wasted tokens.
+
+**Smart routing & complexity estimation** — before spinning up an agent, 143 estimates issue complexity (trivial → very complex) and routes accordingly. An admin-configurable aggressiveness slider controls which tiers the system attempts autonomously.
+
+**Interactive sessions** — create free-form sessions without waiting for a PM cycle. Each agent turn auto-snapshots sandbox state so you can review, send follow-ups, or resume locally via CLI.
+
+**Multi-agent sessions** — run multiple agents in parallel on the same codebase: compare Claude vs Codex output, or split backend and frontend work across independent threads.
+
+**Post-deploy impact measurement** — after a fix ships, 143 measures the actual impact on Sentry error rates, support ticket volume, and custom metrics. Closes the loop from issue to outcome.
+
+**Distributed, no primary node** — symmetric architecture where every node runs the same binary. Leader election via Postgres advisory locks, job distribution via `SELECT ... FOR UPDATE SKIP LOCKED`. No external coordination service needed.
+
+**Dashboard credential management** — all API keys (LLM providers, GitHub, Sentry, Linear) are configured through the UI with per-org isolation and AES-256-GCM encryption at rest. No env vars for secrets in production.
+
+**Prompt overrides & tuning** — customize agent system prompts per repo, issue type, or execution phase. Insert-only versioned config preserves full change history with point-in-time rollback.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,9 @@ issues in → PM agent plans → coding agents execute → validate → ship PRs
 
 ## Built for production
 
-**Sandboxed execution** — every agent runs in a gVisor-isolated container with a read-only root filesystem, dropped capabilities, and network restricted to LLM APIs and package registries. Your code never leaves an environment you control.
+Agents run in gVisor-isolated containers with read-only filesystems and no network access beyond LLM APIs. PRs go through security scanning (gitleaks, semgrep), correctness checks, and your CI before a human sees them. After deploy, 143 measures actual impact on error rates and support volume — so you know if the fix worked, not just if it merged.
 
-**Validated before it ships** — PRs go through direction, correctness, quality, and security checks (gitleaks + semgrep) before a human ever sees them. Fail-fast ordering so bad fixes get caught early and cheaply.
-
-**Measures what matters** — after a fix deploys, 143 tracks the actual impact on error rates and support volume. You see whether the fix worked, not just whether it merged.
-
-**Scales without coordination** — symmetric architecture with no primary node. Postgres-backed job queue and leader election. Add capacity by running more instances of the same binary.
+No primary node. Postgres-backed job queue and leader election. Add capacity by running more copies of the same binary.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ issues in → PM agent plans → coding agents execute → validate → ship PRs
 
 ## Built for production
 
-Agents run in gVisor-isolated containers with read-only filesystems and no network access beyond LLM APIs. PRs go through security scanning (gitleaks, semgrep), correctness checks, and your CI before a human sees them. After deploy, 143 measures actual impact on error rates and support volume — so you know if the fix worked, not just if it merged.
+Every agent runs in a gVisor-isolated container with a read-only filesystem and network access limited to LLM APIs and package registries. PRs go through security scanning (gitleaks, semgrep), correctness checks, and your CI before a human ever sees them. Your code never leaves infrastructure you control.
 
-No primary node. Postgres-backed job queue and leader election. Add capacity by running more copies of the same binary.
+The architecture is symmetric — there's no primary node. A Postgres-backed job queue handles scheduling and leader election, so scaling out means running more copies of the same binary behind a load balancer.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -40,25 +40,15 @@ issues in → PM agent plans → coding agents execute → validate → ship PRs
 6. **Observe** — measure post-deploy impact on error rates and support volume
 7. **Learn** — extract review feedback into conventions, feed back into future runs
 
-## Key Features
+## Built for production
 
-**Sandboxed execution with gVisor** — every agent run happens in an isolated container with gVisor syscall-level enforcement, read-only root filesystem, dropped capabilities, and network restricted to LLM APIs and package registries. Graceful fallback to standard Docker in local dev.
+**Sandboxed execution** — every agent runs in a gVisor-isolated container with a read-only root filesystem, dropped capabilities, and network restricted to LLM APIs and package registries. Your code never leaves an environment you control.
 
-**6-stage validation pipeline** — direction check, correctness check, quality check, security scanning (gitleaks + semgrep), regression tests, and CI integration. Fail-fast ordering minimizes wasted tokens.
+**Validated before it ships** — PRs go through direction, correctness, quality, and security checks (gitleaks + semgrep) before a human ever sees them. Fail-fast ordering so bad fixes get caught early and cheaply.
 
-**Smart routing & complexity estimation** — before spinning up an agent, 143 estimates issue complexity (trivial → very complex) and routes accordingly. An admin-configurable aggressiveness slider controls which tiers the system attempts autonomously.
+**Measures what matters** — after a fix deploys, 143 tracks the actual impact on error rates and support volume. You see whether the fix worked, not just whether it merged.
 
-**Interactive sessions** — create free-form sessions without waiting for a PM cycle. Each agent turn auto-snapshots sandbox state so you can review, send follow-ups, or resume locally via CLI.
-
-**Multi-agent sessions** — run multiple agents in parallel on the same codebase: compare Claude vs Codex output, or split backend and frontend work across independent threads.
-
-**Post-deploy impact measurement** — after a fix ships, 143 measures the actual impact on Sentry error rates, support ticket volume, and custom metrics. Closes the loop from issue to outcome.
-
-**Distributed, no primary node** — symmetric architecture where every node runs the same binary. Leader election via Postgres advisory locks, job distribution via `SELECT ... FOR UPDATE SKIP LOCKED`. No external coordination service needed.
-
-**Dashboard credential management** — all API keys (LLM providers, GitHub, Sentry, Linear) are configured through the UI with per-org isolation and AES-256-GCM encryption at rest. No env vars for secrets in production.
-
-**Prompt overrides & tuning** — customize agent system prompts per repo, issue type, or execution phase. Insert-only versioned config preserves full change history with point-in-time rollback.
+**Scales without coordination** — symmetric architecture with no primary node. Postgres-backed job queue and leader election. Add capacity by running more instances of the same binary.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -2,95 +2,25 @@
 
 **from issues to validated PRs, on autopilot**
 
-[Local Development](docs/local-development.md) · [Architecture](docs/design/overall.md) · [How it works](#how-it-works)
+[Getting Started](#getting-started) · [Development Setup](docs/contributing/development-setup.md) · [Architecture](docs/design/overall.md)
 
 ---
 
-143 ingests production issues from Sentry, Linear, and support tickets. An AI product manager agent analyzes the full issue landscape, clusters related problems, and builds a prioritized plan. Coding agents execute the plan in sandboxed containers — fixing bugs, shipping improvements, and opening validated PRs.
+## Why 143
 
-Every PR review makes the next run smarter. Learned conventions are extracted and fed back into future agent executions, creating a flywheel that compounds over time.
+Most issues in your backlog don't need a sprint planning meeting. They need someone (or something) to analyze the landscape, prioritize what matters, write the fix, validate it, and open the PR.
 
-## Local Development
+143 gives you two things:
 
-### Setup
+### Bring your own coding agent
 
-Requires Go 1.24+, Node.js 18+, and PostgreSQL 17. The setup script installs anything missing via Homebrew (macOS) or apt (Linux).
+Use whatever coding agent you trust — Claude Code, Codex, Cursor, or your own custom agent. 143 orchestrates the work: it ingests issues, plans the approach, spins up sandboxed containers, and hands off execution to the coding agent you configure. You stay in control of how code gets written while 143 handles everything around it.
 
-```bash
-git clone https://github.com/assembledhq/143.git && cd 143 && ./setup.sh
-```
+### An autopilot PM that learns your product
 
-This creates the database, copies `.env.example` to `.env`, installs dependencies, and runs migrations.
+143 includes an AI product manager agent that understands your product roadmap and engineering philosophy. It analyzes your full issue landscape across Sentry errors, Linear tickets, and support requests — clusters related problems, identifies root causes, and builds a prioritized plan. Every PR review teaches it more about your codebase conventions and preferences, creating a flywheel that compounds over time.
 
-### Running
-
-**Option A — with ngrok tunnel** (recommended for GitHub OAuth / webhook testing):
-
-```bash
-make dev-ngrok NGROK_DOMAIN=yourname.ngrok.dev
-```
-
-**Option B — with Docker Compose**:
-
-```bash
-make dev              # starts Postgres, API server, and frontend
-```
-
-**Option C — without Docker** (two terminals):
-
-```bash
-make server-dev       # Go API on localhost:8080
-make frontend-dev     # Next.js on localhost:3000
-```
-
-The frontend proxies `/api/*` to the Go server automatically.
-
-### Common commands
-
-```bash
-make setup            # run setup.sh (install deps, create DB, run migrations)
-make build            # compile server and migrate binaries to bin/
-make test             # run all tests
-make test-race        # run tests with race detector
-make test-coverage    # generate coverage.html
-make migrate-up       # apply pending migrations
-make migrate-down     # roll back last migration
-make lint             # run golangci-lint
-make frontend-lint    # run frontend linter
-make frontend-typecheck  # run TypeScript type checking
-make frontend-check   # typecheck + lint + build (all frontend checks)
-```
-
-### Environment
-
-All config lives in `.env` (created by setup). The defaults work out of the box for local dev.
-
-To enable GitHub OAuth login and repo onboarding, set these in `.env`:
-
-- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` — create an OAuth app
-- `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` / `GITHUB_WEBHOOK_SECRET` — create a GitHub App
-
-See the [local development guide](docs/local-development.md) for step-by-step setup including webhook tunneling, and `.env.example` for the full list of variables.
-
-### Secrets & API Keys
-
-For local dev, just copy `.env.example` into `.env` and edit it directly — it's gitignored. For syncing secrets across machines or environments, we use [SOPS](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age) to encrypt secrets into `.env.enc` (safe to commit). Production secrets are stored in `.env.production.enc`. See the [secrets management guide](docs/secrets/README.md) for full setup.
-
-```bash
-make secrets-setup                   # one-time: generate age keypair
-make secrets-encrypt                 # encrypt .env → .env.enc
-make secrets-decrypt                 # decrypt .env.enc → .env
-make secrets-encrypt ENV=production  # encrypt production secrets
-make secrets-decrypt ENV=production  # decrypt production secrets
-make secrets-edit                    # edit encrypted .env.enc in-place
-make secrets-rotate                  # re-encrypt after adding a team member's key
-```
-
-After running `make secrets-setup`, add this to your shell profile (`~/.bash_profile` or `~/.zshrc`):
-
-```bash
-export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
-```
+The result: bugs get triaged, planned, fixed, validated, and shipped as PRs — without context-switching your team away from the work that matters.
 
 ## How it works
 
@@ -108,39 +38,24 @@ issues in → PM agent plans → coding agents execute → validate → ship PRs
 6. **Observe** — measure post-deploy impact on error rates and support volume
 7. **Learn** — extract review feedback into conventions, feed back into future runs
 
-## Project structure
+## Getting Started
 
+Requires Go 1.24+, Node.js 18+, and PostgreSQL 17. The setup script installs anything missing via Homebrew (macOS) or apt (Linux).
+
+```bash
+git clone https://github.com/assembledhq/143.git && cd 143 && ./setup.sh
+make dev
 ```
-cmd/
-  server/         # API server entrypoint
-  migrate/        # database migration runner
-internal/
-  api/
-    handlers/     # HTTP handlers (auth, repos, webhooks, health, settings)
-    middleware/   # auth, CORS, logging, org context
-    router.go     # chi router + route registration
-  config/         # env-based configuration
-  db/             # data access layer (pgx, named args, store-per-domain)
-  models/         # domain types + API response envelopes
-  services/
-    github/       # GitHub App JWT + installation token management
-  worker/         # background job processor
-  cluster/        # node heartbeat + scheduler leader lock
-  logging/        # zerolog setup
-migrations/       # SQL migration files
-frontend/         # Next.js app (App Router, shadcn/ui, TanStack Query)
-docs/design/      # numbered design docs
-```
+
+See the [development setup guide](docs/contributing/development-setup.md) for detailed instructions, make commands, environment configuration, and secrets management.
+
+## Contributing
+
+Read through the [design docs](docs/design/overall.md) to understand the architecture, then pick an issue and open a PR. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Why "143"
 
 In 1943, Lockheed's Skunk Works team designed and built the XP-80 Shooting Star — America's first operational jet fighter — in just 143 days. A small, autonomous team with full ownership, no bureaucracy, and a bias toward shipping.
-
-Most issues in your backlog don't need a sprint planning meeting. They need someone (or something) to analyze the landscape, prioritize what matters, write the fix, validate it, and open the PR. 143 is that something.
-
-## Contributing
-
-Read through the [design docs](docs/design/overall.md) to understand the architecture, then pick an issue and open a PR.
 
 ## License
 

--- a/docs/contributing/development-setup.md
+++ b/docs/contributing/development-setup.md
@@ -1,0 +1,133 @@
+# Development Setup
+
+This guide covers everything you need to build and run 143 locally.
+
+For the full GitHub App configuration walkthrough, see the [local development guide](../local-development.md).
+
+## Prerequisites
+
+- Go 1.24+
+- Node.js 18+
+- PostgreSQL 17
+
+The setup script installs anything missing via Homebrew (macOS) or apt (Linux).
+
+## Quick Start
+
+```bash
+git clone https://github.com/assembledhq/143.git && cd 143 && ./setup.sh
+```
+
+This creates the database, copies `.env.example` to `.env`, installs dependencies, and runs migrations.
+
+## Running
+
+**Option A — with ngrok tunnel** (recommended for GitHub OAuth / webhook testing):
+
+```bash
+make dev-ngrok NGROK_DOMAIN=yourname.ngrok.dev
+```
+
+**Option B — with Docker Compose**:
+
+```bash
+make dev              # starts Postgres, API server, and frontend
+```
+
+**Option C — without Docker** (two terminals):
+
+```bash
+make server-dev       # Go API on localhost:8080
+make frontend-dev     # Next.js on localhost:3000
+```
+
+The frontend proxies `/api/*` to the Go server automatically.
+
+## Make Commands
+
+### Development
+
+| Command | Description |
+|---------|-------------|
+| `make setup` | Run setup.sh (install deps, create DB, run migrations) |
+| `make dev` | Start everything via Docker Compose |
+| `make dev-ngrok NGROK_DOMAIN=...` | Start with ngrok tunnel for webhook testing |
+| `make server-dev` | Go API server only (localhost:8080) |
+| `make frontend-dev` | Next.js frontend only (localhost:3000) |
+
+### Build & Test
+
+| Command | Description |
+|---------|-------------|
+| `make build` | Compile server and migrate binaries to `bin/` |
+| `make test` | Run all tests |
+| `make test-race` | Run tests with Go race detector |
+| `make test-coverage` | Generate `coverage.html` |
+| `make lint` | Run golangci-lint |
+| `make frontend-lint` | Run frontend linter |
+| `make frontend-typecheck` | Run TypeScript type checking |
+| `make frontend-check` | Typecheck + lint + build (all frontend checks) |
+
+### Database
+
+| Command | Description |
+|---------|-------------|
+| `make migrate-up` | Apply pending migrations |
+| `make migrate-down` | Roll back last migration |
+
+### Secrets Management
+
+143 uses [SOPS](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age) to encrypt secrets into `.env.enc` (safe to commit). Production secrets are stored in `.env.production.enc`.
+
+| Command | Description |
+|---------|-------------|
+| `make secrets-setup` | One-time: generate age keypair |
+| `make secrets-encrypt` | Encrypt `.env` → `.env.enc` |
+| `make secrets-decrypt` | Decrypt `.env.enc` → `.env` |
+| `make secrets-encrypt ENV=production` | Encrypt production secrets |
+| `make secrets-decrypt ENV=production` | Decrypt production secrets |
+| `make secrets-edit` | Edit encrypted `.env.enc` in-place |
+| `make secrets-rotate` | Re-encrypt after adding a team member's key |
+
+After running `make secrets-setup`, add this to your shell profile (`~/.bash_profile` or `~/.zshrc`):
+
+```bash
+export SOPS_AGE_KEY_FILE="$HOME/.config/sops/age/keys.txt"
+```
+
+See the [secrets management guide](../secrets/README.md) for the full walkthrough including production secrets.
+
+## Environment
+
+All config lives in `.env` (created by setup). The defaults work out of the box for local dev.
+
+To enable GitHub OAuth login and repo onboarding, set these in `.env`:
+
+- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` — create an OAuth app
+- `GITHUB_APP_ID` / `GITHUB_APP_PRIVATE_KEY` / `GITHUB_WEBHOOK_SECRET` — create a GitHub App
+
+See the [local development guide](../local-development.md) for step-by-step setup including webhook tunneling, and `.env.example` for the full list of variables.
+
+## Project Structure
+
+```
+cmd/
+  server/         # API server entrypoint
+  migrate/        # database migration runner
+internal/
+  api/
+    handlers/     # HTTP handlers (auth, repos, webhooks, health, settings)
+    middleware/   # auth, CORS, logging, org context
+    router.go     # chi router + route registration
+  config/         # env-based configuration
+  db/             # data access layer (pgx, named args, store-per-domain)
+  models/         # domain types + API response envelopes
+  services/
+    github/       # GitHub App JWT + installation token management
+  worker/         # background job processor
+  cluster/        # node heartbeat + scheduler leader lock
+  logging/        # zerolog setup
+migrations/       # SQL migration files
+frontend/         # Next.js app (App Router, shadcn/ui, TanStack Query)
+docs/design/      # numbered design docs
+```


### PR DESCRIPTION
## Summary

Extracted development setup instructions from README.md into a dedicated `docs/contributing/development-setup.md` guide, and restructured the README to focus on product value and high-level overview rather than setup details.

## Key Changes

- **New file**: `docs/contributing/development-setup.md` — comprehensive development guide covering:
  - Prerequisites and quick start
  - Three options for running locally (ngrok, Docker Compose, manual)
  - Complete make command reference (development, build/test, database, secrets management)
  - Environment configuration and GitHub OAuth/App setup
  - Project structure overview

- **README.md restructured** to:
  - Lead with "Why 143" section explaining product value and use cases
  - Add "Getting Started" section with minimal setup (3 lines) and link to full guide
  - Reorganize "How it works" and add "Built for production" section highlighting security/architecture
  - Move detailed setup, make commands, and secrets management to the new dedicated guide
  - Update navigation links to point to development setup guide
  - Clarify the "Why 143" origin story positioning

## Rationale

This separation improves documentation UX by:
- Keeping README focused on what 143 does and why users should care
- Providing a single source of truth for developers setting up locally
- Making it easier to maintain and update setup instructions independently
- Reducing README cognitive load for new visitors

https://claude.ai/code/session_017zT7cYii5UcwLtZ83CWThL