### PR TITLE
Increase concurrency limits and handle limit errors gracefully

### DIFF
--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -787,17 +787,18 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		targetBranch = &b
 	}
 
+	org, err := h.orgStore.GetByID(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings", err)
+		return
+	}
+	orgSettings, parseErr := models.ParseOrgSettings(org.Settings)
+	if parseErr != nil {
+		zerolog.Ctx(r.Context()).Warn().Err(parseErr).Msg("failed to parse org settings, using defaults")
+	}
+
 	agentType := models.AgentType(body.AgentType)
 	if agentType == "" {
-		org, err := h.orgStore.GetByID(r.Context(), orgID)
-		if err != nil {
-			writeError(w, r, http.StatusInternalServerError, "DEFAULT_AGENT_LOOKUP_FAILED", "failed to load organization settings", err)
-			return
-		}
-		orgSettings, parseErr := models.ParseOrgSettings(org.Settings)
-		if parseErr != nil {
-			zerolog.Ctx(r.Context()).Warn().Err(parseErr).Msg("failed to parse org settings, using defaults")
-		}
 		agentType = orgSettings.DefaultAgentType
 		if agentType == "" {
 			agentType = models.DefaultDefaultAgentType
@@ -889,6 +890,22 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.runStore.Create(r.Context(), session); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session", err)
+		return
+	}
+
+	// Check concurrency before enqueuing so the user gets immediate feedback.
+	runningCount, err := h.runStore.CountRunningByOrg(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CONCURRENCY_CHECK_FAILED", "failed to check running sessions", err)
+		return
+	}
+	maxConcurrent := orgSettings.MaxConcurrentRuns
+	if maxConcurrent <= 0 {
+		maxConcurrent = models.DefaultMaxConcurrentRuns
+	}
+	if runningCount >= maxConcurrent {
+		writeError(w, r, http.StatusTooManyRequests, "CONCURRENCY_LIMIT",
+			fmt.Sprintf("Too many sessions running (%d/%d). Please wait for a session to finish before starting a new one.", runningCount, maxConcurrent))
 		return
 	}
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1261,6 +1261,12 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 				runID := uuid.New()
 				jobID := uuid.New()
 
+				// Mock org settings lookup
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+						AddRow(orgID, "test-org", nil, now, now))
+
 				// Mock issue upsert (16 named args)
 				mock.ExpectQuery("INSERT INTO issues").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -1277,6 +1283,11 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
+
+				// Mock concurrency check
+				mock.ExpectQuery("SELECT count").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
 
 				// Mock job enqueue (6 named args)
 				mock.ExpectQuery("INSERT INTO jobs").
@@ -1321,6 +1332,11 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
+				// Mock concurrency check
+				mock.ExpectQuery("SELECT count").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
+
 				// Mock job enqueue
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -1345,23 +1361,41 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 			expectedBody: "INVALID_BODY",
 		},
 		{
-			name:         "returns bad request for invalid agent type",
-			body:         `{"message":"Fix bug","agent_type":"invalid"}`,
-			setupMock:    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {},
+			name: "returns bad request for invalid agent type",
+			body: `{"message":"Fix bug","agent_type":"invalid"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+						AddRow(orgID, "test-org", nil, now, now))
+			},
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "INVALID_AGENT_TYPE",
 		},
 		{
-			name:         "returns bad request for invalid autonomy level",
-			body:         `{"message":"Fix bug","agent_type":"claude_code","autonomy_level":"chaos"}`,
-			setupMock:    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {},
+			name: "returns bad request for invalid autonomy level",
+			body: `{"message":"Fix bug","agent_type":"claude_code","autonomy_level":"chaos"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+						AddRow(orgID, "test-org", nil, now, now))
+			},
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "INVALID_AUTONOMY_LEVEL",
 		},
 		{
-			name:         "returns bad request for invalid token mode",
-			body:         `{"message":"Fix bug","agent_type":"claude_code","token_mode":"extreme"}`,
-			setupMock:    func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {},
+			name: "returns bad request for invalid token mode",
+			body: `{"message":"Fix bug","agent_type":"claude_code","token_mode":"extreme"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+						AddRow(orgID, "test-org", nil, now, now))
+			},
 			expectedCode: http.StatusBadRequest,
 			expectedBody: "INVALID_TOKEN_MODE",
 		},
@@ -2064,6 +2098,12 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 	runID := uuid.New()
 	jobID := uuid.New()
 
+	// Mock org settings lookup
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "test-org", nil, now, now))
+
 	// Mock issue upsert
 	mock.ExpectQuery("INSERT INTO issues").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -2080,6 +2120,11 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
+
+	// Mock concurrency check
+	mock.ExpectQuery("SELECT count").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
 
 	// Mock job enqueue
 	mock.ExpectQuery("INSERT INTO jobs").
@@ -2145,6 +2190,12 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 	runID := uuid.New()
 	jobID := uuid.New()
 
+	// Mock org settings lookup
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "test-org", nil, now, now))
+
 	// Mock issue upsert
 	mock.ExpectQuery("INSERT INTO issues").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -2161,6 +2212,11 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
+
+	// Mock concurrency check
+	mock.ExpectQuery("SELECT count").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"count"}).AddRow(0))
 
 	// Mock job enqueue
 	mock.ExpectQuery("INSERT INTO jobs").

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -209,7 +209,7 @@ type PriorityWeights struct {
 const (
 	DefaultAutonomyLevel        AutonomyLevel = AutonomyLevelAutoSimple
 	DefaultAggressiveness                     = 5
-	DefaultMaxConcurrentRuns                  = 5
+	DefaultMaxConcurrentRuns                  = 10
 	DefaultAgentAutonomy                      = AgentAutonomyAggressive
 	DefaultMinPriorityThreshold               = 30.0
 	DefaultDefaultAgentType     AgentType     = AgentTypeCodex
@@ -310,13 +310,13 @@ func (s OrgSize) PMScheduleHours() int {
 func (s OrgSize) MaxConcurrentRuns() int {
 	switch s {
 	case OrgSizeSmall:
-		return 3
-	case OrgSizeLarge:
-		return 10
-	case OrgSizeEnterprise:
-		return 20
-	default: // medium
 		return 5
+	case OrgSizeLarge:
+		return 15
+	case OrgSizeEnterprise:
+		return 25
+	default: // medium
+		return 10
 	}
 }
 

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -277,10 +277,10 @@ func TestOrgSize_PMScheduleHours(t *testing.T) {
 func TestOrgSize_MaxConcurrentRuns(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, 3, OrgSizeSmall.MaxConcurrentRuns())
-	require.Equal(t, 5, OrgSizeMedium.MaxConcurrentRuns())
-	require.Equal(t, 10, OrgSizeLarge.MaxConcurrentRuns())
-	require.Equal(t, 20, OrgSizeEnterprise.MaxConcurrentRuns())
+	require.Equal(t, 5, OrgSizeSmall.MaxConcurrentRuns())
+	require.Equal(t, 10, OrgSizeMedium.MaxConcurrentRuns())
+	require.Equal(t, 15, OrgSizeLarge.MaxConcurrentRuns())
+	require.Equal(t, 25, OrgSizeEnterprise.MaxConcurrentRuns())
 }
 
 func TestContextLimits_WithDefaults(t *testing.T) {
@@ -325,7 +325,7 @@ func TestParseOrgSettings_OrgSizeDefaults(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, OrgSizeLarge, s.OrgSize)
-	require.Equal(t, 10, s.MaxConcurrentRuns, "large org should default to 10 concurrent runs")
+	require.Equal(t, 15, s.MaxConcurrentRuns, "large org should default to 15 concurrent runs")
 	require.Equal(t, 2, s.PMScheduleHours, "large org should default to 2-hour PM schedule")
 	require.Equal(t, 300, s.ContextLimits.MaxOpenIssues, "large org should see 300 open issues")
 	require.Equal(t, 100_000, s.ContextLimits.PMMaxTokens, "large org should get 100k PM tokens")
@@ -362,7 +362,7 @@ func TestParseOrgSettings_DefaultOrgSizeIsMedium(t *testing.T) {
 	require.NoError(t, err)
 
 	// With no org_size set, defaults should match medium profile (backward compatible)
-	require.Equal(t, 5, s.MaxConcurrentRuns, "default should match medium concurrent runs")
+	require.Equal(t, 10, s.MaxConcurrentRuns, "default should match medium concurrent runs")
 	require.Equal(t, 4, s.PMScheduleHours, "default should match medium PM schedule")
 	require.Equal(t, 100, s.ContextLimits.MaxOpenIssues, "default should match medium open issues")
 	require.Equal(t, 50_000, s.ContextLimits.PMMaxTokens, "default should match medium PM tokens")

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -22,8 +22,13 @@ import (
 )
 
 const (
-	defaultMaxConcurrent = 3
+	defaultMaxConcurrent = 10
 )
+
+// ErrConcurrencyLimit is returned when an org has reached its maximum
+// number of concurrent agent runs. Callers can check for this with
+// errors.Is to handle it as a transient/retryable condition.
+var ErrConcurrencyLimit = fmt.Errorf("concurrency limit reached")
 
 // GitHubTokenProvider abstracts retrieving a GitHub App installation token.
 type GitHubTokenProvider interface {
@@ -905,7 +910,7 @@ func (o *Orchestrator) checkConcurrency(ctx context.Context, orgID uuid.UUID) er
 		return fmt.Errorf("count running runs: %w", err)
 	}
 	if count >= o.maxConcurrent {
-		return fmt.Errorf("concurrency limit reached: %d/%d runs active", count, o.maxConcurrent)
+		return fmt.Errorf("%w: %d/%d runs active", ErrConcurrencyLimit, count, o.maxConcurrent)
 	}
 	return nil
 }

--- a/internal/services/prioritization/service.go
+++ b/internal/services/prioritization/service.go
@@ -78,7 +78,7 @@ const (
 	defaultWeightSeverity       = 0.25
 	defaultWeightRecency        = 0.20
 	defaultWeightRevenueRisk    = 0.20
-	defaultMaxConcurrentRuns    = 3
+	defaultMaxConcurrentRuns    = 10
 	defaultMinPriorityThreshold = 30.0
 
 	// recencyHalfLifeHours is the half-life in hours for recency decay (1 week).

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -562,7 +562,13 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 			Str("org_id", orgID.String()).
 			Msg("starting run_agent job")
 
-		return services.Orchestrator.RunAgent(ctx, &run)
+		if err := services.Orchestrator.RunAgent(ctx, &run); err != nil {
+			if errors.Is(err, agent.ErrConcurrencyLimit) {
+				return &RetryableError{Err: err}
+			}
+			return err
+		}
+		return nil
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -13,6 +14,16 @@ import (
 )
 
 type JobHandler func(ctx context.Context, jobType string, payload json.RawMessage) error
+
+// RetryableError wraps an error to indicate that the job should be retried
+// without consuming an attempt. This is useful for transient conditions like
+// concurrency limits where the job will succeed once capacity is available.
+type RetryableError struct {
+	Err error
+}
+
+func (e *RetryableError) Error() string { return e.Err.Error() }
+func (e *RetryableError) Unwrap() error { return e.Err }
 
 type jobContextKey string
 
@@ -136,6 +147,14 @@ func (w *Worker) poll(ctx context.Context) {
 	handlerCtx := withJobOrgID(ctx, orgID)
 	w.logger.Info().Str("job_id", jobID.String()).Str("job_type", jobType).Msg("processing job")
 	if err := handler(handlerCtx, jobType, payload); err != nil {
+		// RetryableError means we should retry without consuming an attempt
+		// (e.g. concurrency limit reached — the job will succeed once a slot opens).
+		var retryable *RetryableError
+		if errors.As(err, &retryable) {
+			w.logger.Info().Err(err).Str("job_id", jobID.String()).Msg("job deferred (retryable)")
+			w.retryJob(ctx, jobID, err.Error(), attempts) // don't increment attempt count
+			return
+		}
 		w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed")
 		if attempts+1 >= maxAttempts {
 			w.deadLetterJob(ctx, jobID, err.Error())


### PR DESCRIPTION
## Changes

- **Increased default concurrency limits** across all org sizes:
  - Small: 3 → 5
  - Medium: 5 → 10
  - Large: 10 → 15
  - Enterprise: 20 → 25
  - Default: 5 → 10

- **Added pre-flight concurrency check** in session creation handler to return `429 Too Many Requests` with user-friendly message when limit is reached

- **Implemented graceful retry handling** for transient concurrency limit errors:
  - New `RetryableError` wrapper type allows jobs to be retried without consuming attempt count
  - Worker defers jobs that hit concurrency limits instead of failing them
  - Agent orchestrator returns dedicated `ErrConcurrencyLimit` error

- **Refactored org settings lookup** to occur once at start of session creation instead of conditionally within agent type selection logic

- **Updated tests** to mock org settings and concurrency check queries

## Impact

Users now get immediate feedback when session limits are reached, and transient concurrency errors are automatically retried without affecting job attempt counts.