### PR TITLE
Remove Confidence from session detail Overview card

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -63,11 +63,10 @@ describe('SessionDetailPage', () => {
     expect(screen.getAllByText(/Claude Code/).length).toBeGreaterThanOrEqual(1);
   });
 
-  it('shows overview tab with status and confidence in detail panel', async () => {
+  it('shows overview tab with status in detail panel', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
     expect(screen.getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('92%')).toBeInTheDocument();
   });
 
   it('shows detail panel tabs for Overview, Changes, Validation', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -73,12 +73,6 @@ function formatTimestamp(dateStr?: string): string {
   return new Date(dateStr).toLocaleString();
 }
 
-function confidenceColor(score: number): string {
-  if (score > 0.8) return "text-emerald-600 dark:text-emerald-400";
-  if (score >= 0.5) return "text-amber-600 dark:text-amber-400";
-  return "text-destructive";
-}
-
 const validationChecks: { key: string; label: string }[] = [
   { key: "direction_check", label: "Direction check" },
   { key: "correctness_check", label: "Correctness check" },
@@ -156,14 +150,6 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
                 )}
               </div>
             </div>
-            {session.confidence_score != null && (
-              <div>
-                <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Confidence</span>
-                <p className={`mt-1 font-medium ${confidenceColor(session.confidence_score)}`}>
-                  {(session.confidence_score * 100).toFixed(0)}%
-                </p>
-              </div>
-            )}
             <div>
               <span className="text-xs font-medium text-muted-foreground/70 tracking-wider">Duration</span>
               <p className="mt-1 font-medium">{formatDuration(session.started_at, session.completed_at)}</p>


### PR DESCRIPTION
## Summary
- Removes the "Confidence" field from the Overview card in the session detail view
- Removes the unused `confidenceColor` helper function

## Test plan
- [ ] Verify the session detail Overview card no longer shows a Confidence score
- [ ] Verify other Overview fields (Triggered by, Duration, Started, Completed) still render correctly

https://claude.ai/code/session_01VMQKFMABerpgWTk4XPXiLi