### PR TITLE
Render session result summary as markdown

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -17,6 +17,7 @@ import {
   PanelRightClose,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { MarkdownContent } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
@@ -186,7 +187,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             <CardTitle className="text-sm">Result</CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm">{session.result_summary}</p>
+            <MarkdownContent content={session.result_summary} className="text-sm" />
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
## Summary
Updated the session detail view to render the result summary as markdown content instead of plain text, enabling support for formatted text, links, and other markdown features.

## Changes
- Imported the `MarkdownContent` component from the markdown utilities
- Replaced plain text paragraph rendering with `MarkdownContent` component for the session result summary
- Preserved the `text-sm` styling by passing it as a className prop to the new component

## Details
The result summary in the session overview tab now supports markdown formatting, allowing for richer content presentation while maintaining the existing visual styling.

https://claude.ai/code/session_01Qy9WTPpzP8sLgeTvMhdVH9