### PR TITLE
Improve chat input box design

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -507,6 +507,88 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('shows stop button instead of send button when session is running', async () => {
+    const runningSession: Session = {
+      ...mockSessions[0],
+      status: 'running',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'running',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={runningSession.id} />);
+    await screen.findByText('Agent is working...');
+    expect(screen.getByTitle('Stop session')).toBeInTheDocument();
+    expect(screen.queryByTitle('Send message')).not.toBeInTheDocument();
+  });
+
+  it('shows send button instead of stop button when session is idle', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={idleSession.id} />);
+    await screen.findByPlaceholderText('Send a follow-up message...');
+    expect(screen.getByTitle('Send message')).toBeInTheDocument();
+    expect(screen.queryByTitle('Stop session')).not.toBeInTheDocument();
+  });
+
+  it('shows send button for completed session (not stop)', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    expect(screen.getByTitle('Send message')).toBeInTheDocument();
+    expect(screen.queryByTitle('Stop session')).not.toBeInTheDocument();
+  });
+
+  it('calls end session API when stop button is clicked during running state', async () => {
+    let endSessionCalled = false;
+
+    const runningSession: Session = {
+      ...mockSessions[0],
+      status: 'running',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'running',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
+      }),
+      http.post('/api/v1/sessions/:id/end', () => {
+        endSessionCalled = true;
+        return HttpResponse.json({ data: { ...runningSession, status: 'idle' } });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={runningSession.id} />);
+    await screen.findByText('Agent is working...');
+
+    const user = userEvent.setup();
+    const stopButton = screen.getByTitle('Stop session');
+    await user.click(stopButton);
+
+    await waitFor(() => {
+      expect(endSessionCalled).toBe(true);
+    });
+  });
+
   it('shows PM context when pm_plan_id is set', async () => {
     const sessionWithPM: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -938,7 +938,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
       {/* Input bar */}
       <div className="border-t border-border p-3 bg-background">
-        <div className="flex items-end gap-2">
+        <div className="relative flex items-end rounded-xl border border-border bg-muted/30 focus-within:border-ring focus-within:ring-1 focus-within:ring-ring">
           <Textarea
             ref={textareaRef}
             value={message}
@@ -946,40 +946,41 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
             onKeyDown={handleKeyDown}
             placeholder={canSendMessage ? (isRunning ? "Send a message to the agent..." : "Send a follow-up message...") : "Session is not active"}
             disabled={!canSendMessage || sendMutation.isPending}
-            className="min-h-[44px] max-h-[200px] resize-none"
+            className="min-h-[44px] max-h-[200px] resize-none border-none bg-transparent shadow-none focus-visible:ring-0 pr-20"
           />
-          <div className="flex flex-col gap-1">
-            <Button
-              size="icon"
-              variant="default"
-              className="h-8 w-8 shrink-0"
-              disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
-              onClick={() => sendMutation.mutate()}
-            >
-              <ArrowUp className="h-4 w-4" />
-            </Button>
-            {isIdle && (
-              <Button
-                size="icon"
-                variant="outline"
-                className="h-8 w-8 shrink-0"
-                title="End session"
-                disabled={endMutation.isPending}
-                onClick={() => endMutation.mutate()}
-              >
-                <Square className="h-3 w-3" />
-              </Button>
-            )}
+          <div className="absolute right-2 bottom-2 flex items-center gap-1">
             {canCreatePR && (
               <Button
                 size="icon"
-                variant="outline"
-                className="h-8 w-8 shrink-0"
+                variant="ghost"
+                className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
                 title="Create PR"
                 disabled={createPRMutation.isPending}
                 onClick={() => createPRMutation.mutate()}
               >
                 <GitPullRequest className="h-3.5 w-3.5" />
+              </Button>
+            )}
+            {isRunning ? (
+              <Button
+                size="icon"
+                variant="outline"
+                className="h-8 w-8 shrink-0 rounded-lg"
+                title="Stop session"
+                disabled={endMutation.isPending}
+                onClick={() => endMutation.mutate()}
+              >
+                <Square className="h-3 w-3" />
+              </Button>
+            ) : (
+              <Button
+                size="icon"
+                variant="default"
+                className="h-8 w-8 shrink-0 rounded-lg"
+                disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
+                onClick={() => sendMutation.mutate()}
+              >
+                <ArrowUp className="h-4 w-4" />
               </Button>
             )}
           </div>

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -977,6 +977,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
                 size="icon"
                 variant="default"
                 className="h-8 w-8 shrink-0 rounded-lg"
+                title="Send message"
                 disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
                 onClick={() => sendMutation.mutate()}
               >


### PR DESCRIPTION
## Summary
- Moved send/stop/PR buttons inside the textarea container (bottom-right), matching the Codex-style unified input design
- Send and stop buttons now swap instead of stacking: show stop when running, send when idle
- Styled the input as a unified rounded container with focus ring for a cleaner look

## Test plan
- [ ] Verify the input box renders with buttons inside the textarea container
- [ ] Verify the stop button appears (replacing send) when a session is running
- [ ] Verify the send button appears when the session is idle
- [ ] Verify the Create PR button still appears inline when applicable
- [ ] Test keyboard submit (Enter) still works

https://claude.ai/code/session_01NTbZTYczsmY2eu1dVc7zWW