### PR TITLE
Improve discoverability of diff button and Changes tab

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -379,7 +379,7 @@ describe('SessionDetailPage', () => {
     await screen.findAllByText('Fixed TypeError by adding null check');
 
     const user = userEvent.setup();
-    const changesTab = screen.getByRole('button', { name: 'Changes' });
+    const changesTab = screen.getByRole('button', { name: /^Changes/ });
     await user.click(changesTab);
 
     // Pass selector should be visible with "All changes" label
@@ -505,6 +505,115 @@ describe('SessionDetailPage', () => {
     await waitFor(() => {
       expect(createPRCalled).toBe(true);
     });
+  });
+
+  it('shows file count badge on Changes tab when session has diff', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);\ndiff --git a/src/new.ts b/src/new.ts\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+export const x = 1;',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    // Changes tab should show file count badge
+    const changesTab = screen.getByRole('button', { name: /^Changes/ });
+    expect(changesTab).toHaveTextContent('Changes2');
+  });
+
+  it('does not show file count badge on Changes tab when session has no diff', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const changesTab = screen.getByRole('button', { name: 'Changes' });
+    expect(changesTab).toHaveTextContent('Changes');
+    expect(changesTab).not.toHaveTextContent(/\d/);
+  });
+
+  it('shows diff stats badge with file count in header when session has diff', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    // Header and footer should show clickable diff stats badges with file count
+    const viewChangesButtons = screen.getAllByTitle('View changes');
+    expect(viewChangesButtons.length).toBeGreaterThanOrEqual(1);
+    expect(viewChangesButtons[0]).toHaveTextContent('1 file');
+    expect(viewChangesButtons[0]).toHaveTextContent('+1');
+  });
+
+  it('clicking diff stats badge in header opens Changes tab', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    const viewChangesButtons = screen.getAllByTitle('View changes');
+    await user.click(viewChangesButtons[0]);
+
+    // Should show the diff content in the Changes tab
+    expect(await screen.findByText('src/app.ts')).toBeInTheDocument();
+  });
+
+  it('shows contextual empty state for completed session with no changes', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    const changesTab = screen.getByRole('button', { name: 'Changes' });
+    await user.click(changesTab);
+
+    expect(await screen.findByText('No changes yet')).toBeInTheDocument();
+    expect(screen.getByText('This session did not produce any file changes.')).toBeInTheDocument();
+  });
+
+  it('shows contextual empty state for running session with no changes', async () => {
+    const runningSession: Session = {
+      ...mockSessions[0],
+      status: 'running',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    const changesTab = screen.getByRole('button', { name: 'Changes' });
+    await user.click(changesTab);
+
+    expect(await screen.findByText('No changes yet')).toBeInTheDocument();
+    expect(screen.getByText('Changes will appear here as the agent modifies files.')).toBeInTheDocument();
   });
 
   it('shows PM context when pm_plan_id is set', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   ArrowUp,
   ExternalLink,
+  FileCode2,
   GitPullRequest,
   RefreshCw,
   CheckCircle2,
@@ -672,9 +673,17 @@ function ChangesTab({
         </div>
       ) : (
         <div className="flex-1 flex items-center justify-center py-12">
-          <p className="text-sm text-muted-foreground">
-            No diff available for this session.
-          </p>
+          <div className="text-center space-y-2 max-w-[280px]">
+            <FileCode2 className="h-8 w-8 text-muted-foreground/40 mx-auto" />
+            <p className="text-sm font-medium text-muted-foreground">
+              No changes yet
+            </p>
+            <p className="text-xs text-muted-foreground/60">
+              {session.status === "running" || session.status === "pending"
+                ? "Changes will appear here as the agent modifies files."
+                : "This session did not produce any file changes."}
+            </p>
+          </div>
         </div>
       )}
 
@@ -1067,9 +1076,9 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const status = statusConfig[session.status] || statusConfig.pending;
 
-  const detailTabs: { value: DetailTab; label: string }[] = [
+  const detailTabs: { value: DetailTab; label: string; count?: number }[] = [
     { value: "overview", label: "Overview" },
-    { value: "changes", label: "Changes" },
+    { value: "changes", label: "Changes", count: diffStats?.filesChanged },
     { value: "validation", label: "Validation" },
   ];
 
@@ -1091,6 +1100,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 <DiffStatsBadge
                   added={diffStats.added}
                   removed={diffStats.removed}
+                  filesChanged={diffStats.filesChanged}
                   onClick={openChangesTab}
                 />
               )}
@@ -1158,7 +1168,19 @@ export function SessionDetailContent({ id }: { id: string }) {
                 )}
                 onClick={() => setDetailTab(tab.value)}
               >
-                {tab.label}
+                <span className="inline-flex items-center gap-1.5">
+                  {tab.label}
+                  {tab.count != null && tab.count > 0 && (
+                    <span className={cn(
+                      "inline-flex items-center justify-center min-w-[18px] h-[18px] rounded-full px-1 text-[10px] font-semibold leading-none",
+                      detailTab === tab.value
+                        ? "bg-primary/15 text-primary"
+                        : "bg-muted text-muted-foreground"
+                    )}>
+                      {tab.count}
+                    </span>
+                  )}
+                </span>
                 {detailTab === tab.value && (
                   <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-[image:var(--gradient-primary)] rounded-full" />
                 )}

--- a/frontend/src/components/code-review/diff-stats-badge.tsx
+++ b/frontend/src/components/code-review/diff-stats-badge.tsx
@@ -1,17 +1,23 @@
+import { FileCode2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 interface DiffStatsBadgeProps {
   added: number;
   removed: number;
+  filesChanged?: number;
   onClick?: () => void;
   className?: string;
 }
 
-export function DiffStatsBadge({ added, removed, onClick, className }: DiffStatsBadgeProps) {
+export function DiffStatsBadge({ added, removed, filesChanged, onClick, className }: DiffStatsBadgeProps) {
   if (added === 0 && removed === 0) return null;
 
   const content = (
-    <span className={cn("inline-flex items-center gap-1 text-[11px] font-mono", className)}>
+    <span className={cn("inline-flex items-center gap-1.5 text-[11px] font-mono", className)}>
+      <FileCode2 className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+      {filesChanged != null && filesChanged > 0 && (
+        <span className="text-muted-foreground">{filesChanged} file{filesChanged !== 1 ? "s" : ""}</span>
+      )}
       <span className="text-green-600 dark:text-green-400">+{added}</span>
       <span className="text-muted-foreground/40">/</span>
       <span className="text-red-600 dark:text-red-400">-{removed}</span>
@@ -22,7 +28,12 @@ export function DiffStatsBadge({ added, removed, onClick, className }: DiffStats
     return (
       <button
         onClick={onClick}
-        className="hover:bg-muted/50 rounded px-1.5 py-0.5 transition-colors"
+        className={cn(
+          "inline-flex items-center rounded-md border border-border px-2 py-1 transition-colors",
+          "hover:bg-muted/60 hover:border-muted-foreground/30",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        )}
+        title="View changes"
       >
         {content}
       </button>

--- a/frontend/src/components/code-review/session-footer.tsx
+++ b/frontend/src/components/code-review/session-footer.tsx
@@ -73,6 +73,7 @@ export function SessionFooter({
         <DiffStatsBadge
           added={diffStats.added}
           removed={diffStats.removed}
+          filesChanged={diffStats.filesChanged}
           onClick={onDiffClick}
         />
       )}


### PR DESCRIPTION
## Summary
- **DiffStatsBadge redesigned**: Added a `FileCode2` icon, visible border, file count label ("3 files"), hover/focus states, and a tooltip — transforms it from invisible monospace text into an obvious clickable button
- **Changes tab gets a count badge**: Shows a pill with the number of changed files (e.g. "Changes (3)") so users can tell at a glance whether there are changes without clicking the tab
- **Better empty state**: Replaced the terse "No diff available for this session." with a contextual message and icon — "Changes will appear here as the agent modifies files" for active sessions, or "This session did not produce any file changes" for completed ones

## Context
The diff button in the session header and footer was a tiny `+X / -Y` string with no icon, border, or visual affordance suggesting it was clickable. The Changes tab label was static regardless of whether changes existed. Together, these made the diff review functionality nearly invisible.

## Test plan
- [ ] Open a completed session that has file changes — verify the header shows a bordered badge with file icon, file count, and +/- stats
- [ ] Click the badge — verify it opens the Changes tab
- [ ] Verify the Changes tab label shows a count pill (e.g. "3") when changes exist
- [ ] Open a session with no changes — verify the empty state shows the contextual message with icon
- [ ] Open a running session with no changes yet — verify it says "Changes will appear here as the agent modifies files"
- [ ] Check the footer bar also shows the updated badge with file count

https://claude.ai/code/session_01Ho8VsJesdfMCMLcdN78o8n