### PR TITLE
Add plan mode support for coding agent sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -6,6 +6,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   ArrowUp,
+  ClipboardList,
   ExternalLink,
   FileCode2,
   GitPullRequest,
@@ -690,6 +691,7 @@ const BASE_SSE_RECONNECT_DELAY_MS = 1000;
 function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Session; sessionId: string; isActive: boolean; onDiffClick?: () => void }) {
   const queryClient = useQueryClient();
   const [message, setMessage] = useState("");
+  const [planMode, setPlanMode] = useState(false);
   const [streamedLogs, setStreamedLogs] = useState<SessionLog[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -697,6 +699,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   const reconnectAttempts = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+  const isClaudeCode = session.agent_type === "claude_code";
 
   const isIdle = session.status === "idle";
   const isRunning = session.status === "running";
@@ -834,9 +837,14 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   }, [sessionId, apiBase, isActive, mergeLogs, queryClient]);
 
   const sendMutation = useMutation({
-    mutationFn: () => api.sessions.sendMessage(sessionId, message),
+    mutationFn: (opts?: { planMode?: boolean; overrideMessage?: string }) => {
+      const msg = opts?.overrideMessage ?? message;
+      const isPlan = opts?.planMode ?? planMode;
+      return api.sessions.sendMessage(sessionId, msg, undefined, isPlan);
+    },
     onSuccess: () => {
       setMessage("");
+      setPlanMode(false);
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
@@ -891,12 +899,29 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     }
   }, [timelineEntries.length]);
 
+  // Plan mode callbacks for the timeline approve/adjust buttons.
+  const handleApprovePlan = useCallback((_turnNumber: number) => {
+    if (!canSendMessage || sendMutation.isPending) return;
+    sendMutation.mutate({ planMode: false, overrideMessage: "The plan looks good. Please proceed with executing the implementation plan above. Make all the changes as described." });
+  }, [canSendMessage, sendMutation]);
+
+  const handleAdjustPlan = useCallback((_turnNumber: number) => {
+    setMessage("Please adjust the plan: ");
+    setPlanMode(false);
+    textareaRef.current?.focus();
+  }, []);
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       if (message.trim() && canSendMessage && !sendMutation.isPending) {
         sendMutation.mutate();
       }
+    }
+    // Shift+Tab toggles plan mode for Claude Code sessions.
+    if (e.key === "Tab" && e.shiftKey && isClaudeCode && canSendMessage) {
+      e.preventDefault();
+      setPlanMode((prev) => !prev);
     }
   }
 
@@ -909,7 +934,14 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
             No activity yet. The session is processing its initial turn.
           </div>
         )}
-        <ChatTimeline entries={timelineEntries} isRunning={isRunning} diffStats={session.diff_stats} onDiffClick={onDiffClick} />
+        <ChatTimeline
+          entries={timelineEntries}
+          isRunning={isRunning}
+          diffStats={session.diff_stats}
+          onDiffClick={onDiffClick}
+          onApprovePlan={canSendMessage ? handleApprovePlan : undefined}
+          onAdjustPlan={canSendMessage ? handleAdjustPlan : undefined}
+        />
       </div>
 
       {/* PR queued indicator */}
@@ -934,25 +966,65 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
       {/* Input bar */}
       <div className="border-t border-border p-3 bg-background">
+        {/* Plan mode indicator */}
+        {planMode && (
+          <div className="flex items-center gap-2 mb-2 px-1">
+            <div className="flex items-center gap-1.5 rounded-full bg-amber-500/10 border border-amber-200 dark:border-amber-800/50 px-2.5 py-1">
+              <ClipboardList className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+              <span className="text-[11px] font-medium text-amber-700 dark:text-amber-400">Plan Mode</span>
+              <button
+                onClick={() => setPlanMode(false)}
+                className="ml-1 text-amber-600/60 hover:text-amber-600 dark:text-amber-400/60 dark:hover:text-amber-400 text-xs"
+                title="Exit plan mode"
+              >
+                &times;
+              </button>
+            </div>
+            <span className="text-[11px] text-muted-foreground">Agent will create a plan for review before making changes</span>
+          </div>
+        )}
         <div className="flex items-end gap-2">
-          <Textarea
-            ref={textareaRef}
-            value={message}
-            onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={canSendMessage ? (isRunning ? "Send a message to the agent..." : "Send a follow-up message...") : "Session is not active"}
-            disabled={!canSendMessage || sendMutation.isPending}
-            className="min-h-[44px] max-h-[200px] resize-none"
-          />
+          <div className="flex-1 flex flex-col gap-1">
+            <Textarea
+              ref={textareaRef}
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={
+                !canSendMessage
+                  ? "Session is not active"
+                  : planMode
+                  ? "Describe what you want to plan..."
+                  : isRunning
+                  ? "Send a message to the agent..."
+                  : "Send a follow-up message..."
+              }
+              disabled={!canSendMessage || sendMutation.isPending}
+              className="min-h-[44px] max-h-[200px] resize-none"
+            />
+            {isClaudeCode && canSendMessage && !planMode && (
+              <div className="flex items-center gap-1 px-1">
+                <button
+                  onClick={() => setPlanMode(true)}
+                  className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors py-0.5"
+                  title="Switch to plan mode (Shift+Tab)"
+                >
+                  <ClipboardList className="h-3 w-3" />
+                  <span>Plan mode</span>
+                </button>
+              </div>
+            )}
+          </div>
           <div className="flex flex-col gap-1">
             <Button
               size="icon"
-              variant="default"
-              className="h-8 w-8 shrink-0"
+              variant={planMode ? "outline" : "default"}
+              className={cn("h-8 w-8 shrink-0", planMode && "border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-950/30")}
               disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
               onClick={() => sendMutation.mutate()}
+              title={planMode ? "Send plan request" : "Send message"}
             >
-              <ArrowUp className="h-4 w-4" />
+              {planMode ? <ClipboardList className="h-4 w-4" /> : <ArrowUp className="h-4 w-4" />}
             </Button>
             {isIdle && (
               <Button

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronRight, AlertTriangle, Wrench, FileCode2 } from "lucide-react";
+import { ChevronRight, AlertTriangle, Wrench, FileCode2, ClipboardList, Check, PenLine } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { MarkdownContent } from "@/components/markdown";
+import { PLAN_MODE_PREFIX } from "@/lib/timeline";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
 
@@ -167,11 +169,23 @@ function AssistantBubble({ children }: { children: React.ReactNode }) {
 }
 
 function MessageBubble({ msg }: { msg: SessionMessage }) {
+  // Strip plan mode prefix from user messages for display.
+  const isPlanModeUser = msg.role === "user" && msg.content.startsWith(PLAN_MODE_PREFIX);
+  const displayContent = isPlanModeUser
+    ? msg.content.slice(PLAN_MODE_PREFIX.length)
+    : msg.content;
+
   if (msg.role === "user") {
     return (
       <div className="flex justify-end">
         <div className="max-w-[80%] rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm">
-          <p className="whitespace-pre-wrap">{msg.content}</p>
+          {isPlanModeUser && (
+            <div className="flex items-center gap-1.5 mb-1.5">
+              <ClipboardList className="h-3 w-3 text-white/80" />
+              <span className="text-[10px] font-medium text-white/80 uppercase tracking-wide">Plan Mode</span>
+            </div>
+          )}
+          <p className="whitespace-pre-wrap">{displayContent}</p>
           <p className="text-[10px] mt-1 text-white/70">
             {formatMessageTime(msg.created_at)}
           </p>
@@ -187,6 +201,56 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
         {formatMessageTime(msg.created_at)}
       </p>
     </AssistantBubble>
+  );
+}
+
+function PlanOutputBubble({
+  children,
+  onApprove,
+  onAdjust,
+  isRunning,
+}: {
+  children: React.ReactNode;
+  onApprove?: () => void;
+  onAdjust?: () => void;
+  isRunning: boolean;
+}) {
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-[80%] rounded-lg text-sm bg-muted border border-amber-200 dark:border-amber-800/50">
+        <div className="flex items-center gap-1.5 px-3 pt-2 pb-1">
+          <ClipboardList className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
+          <span className="text-xs font-medium text-amber-700 dark:text-amber-400">Implementation Plan</span>
+        </div>
+        <div className="px-3 py-2">{children}</div>
+        {(onApprove || onAdjust) && !isRunning && (
+          <div className="flex items-center gap-2 px-3 pb-2.5 pt-1 border-t border-amber-200/50 dark:border-amber-800/30">
+            {onApprove && (
+              <Button
+                size="sm"
+                variant="default"
+                className="h-7 text-xs gap-1.5"
+                onClick={onApprove}
+              >
+                <Check className="h-3 w-3" />
+                Approve Plan
+              </Button>
+            )}
+            {onAdjust && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-xs gap-1.5"
+                onClick={onAdjust}
+              >
+                <PenLine className="h-3 w-3" />
+                Adjust Plan
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -227,9 +291,11 @@ interface ChatTimelineProps {
   isRunning: boolean;
   diffStats?: { added: number; removed: number; files_changed: number } | null;
   onDiffClick?: () => void;
+  onApprovePlan?: (turnNumber: number) => void;
+  onAdjustPlan?: (turnNumber: number) => void;
 }
 
-export function ChatTimeline({ entries, isRunning, diffStats, onDiffClick }: ChatTimelineProps) {
+export function ChatTimeline({ entries, isRunning, diffStats, onDiffClick, onApprovePlan, onAdjustPlan }: ChatTimelineProps) {
   // Separate visible entries (messages, tool groups, errors) from hidden logs.
   // Group consecutive hidden logs together so they share a single "Show more" toggle.
   const rendered: React.ReactNode[] = [];
@@ -261,6 +327,33 @@ export function ChatTimeline({ entries, isRunning, diffStats, onDiffClick }: Cha
           <AssistantBubble key={`aout-${entry.data.id}`}>
             <MarkdownContent content={entry.data.message} />
           </AssistantBubble>
+        );
+        break;
+      case "plan_output":
+        rendered.push(
+          <PlanOutputBubble
+            key={`plan-${entry.data.id}`}
+            onApprove={onApprovePlan ? () => onApprovePlan(entry.turnNumber) : undefined}
+            onAdjust={onAdjustPlan ? () => onAdjustPlan(entry.turnNumber) : undefined}
+            isRunning={isRunning}
+          >
+            <MarkdownContent content={entry.data.message} />
+          </PlanOutputBubble>
+        );
+        break;
+      case "plan_message":
+        rendered.push(
+          <PlanOutputBubble
+            key={`planmsg-${entry.data.id}`}
+            onApprove={onApprovePlan ? () => onApprovePlan(entry.turnNumber) : undefined}
+            onAdjust={onAdjustPlan ? () => onAdjustPlan(entry.turnNumber) : undefined}
+            isRunning={isRunning}
+          >
+            <MarkdownContent content={entry.data.content} />
+            <p className="text-[10px] mt-1 text-muted-foreground">
+              {formatMessageTime(entry.data.created_at)}
+            </p>
+          </PlanOutputBubble>
         );
         break;
       case "tool_group":

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -194,8 +194,8 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').Session>>('/api/v1/sessions/manual', body),
     getMessages: (sessionId: string) =>
       get<import('./types').ListResponse<import('./types').SessionMessage>>(`/api/v1/sessions/${sessionId}/messages`),
-    sendMessage: (sessionId: string, message: string, images?: string[]) =>
-      post<import('./types').SingleResponse<import('./types').SessionMessage>>(`/api/v1/sessions/${sessionId}/messages`, { message, images }),
+    sendMessage: (sessionId: string, message: string, images?: string[], planMode?: boolean) =>
+      post<import('./types').SingleResponse<import('./types').SessionMessage>>(`/api/v1/sessions/${sessionId}/messages`, { message, images, plan_mode: planMode || undefined }),
     endSession: (sessionId: string) =>
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/end`),
     // Thread endpoints

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -1,11 +1,16 @@
 import type { SessionMessage, SessionLog } from "./types";
 
+/** Prefix added by the backend when a message is sent in plan mode. */
+export const PLAN_MODE_PREFIX = "[PLAN_MODE]\n";
+
 export type TimelineEntry =
   | { kind: "message"; data: SessionMessage }
   | { kind: "assistant_output"; data: SessionLog }
   | { kind: "tool_group"; toolUse: SessionLog; toolResult?: SessionLog }
   | { kind: "error"; data: SessionLog }
-  | { kind: "log"; data: SessionLog };
+  | { kind: "log"; data: SessionLog }
+  | { kind: "plan_output"; data: SessionLog; turnNumber: number }
+  | { kind: "plan_message"; data: SessionMessage; turnNumber: number };
 
 /**
  * Merges SessionMessage and SessionLog arrays into a unified timeline
@@ -36,6 +41,15 @@ export function buildTimeline(
     return true;
   });
 
+  // Detect which turn numbers are plan mode turns by checking user messages
+  // for the plan mode prefix.
+  const planModeTurns = new Set<number>();
+  for (const msg of messages) {
+    if (msg.role === "user" && msg.content.startsWith(PLAN_MODE_PREFIX)) {
+      planModeTurns.add(msg.turn_number);
+    }
+  }
+
   // Tag and merge into a single sortable list.
   type Tagged =
     | { source: "message"; ts: string; data: SessionMessage }
@@ -59,7 +73,14 @@ export function buildTimeline(
     const item = items[i];
 
     if (item.source === "message") {
-      entries.push({ kind: "message", data: item.data });
+      const msg = item.data;
+      // If this is an assistant message responding to a plan mode turn,
+      // mark it as a plan_message so the UI can show approve/adjust buttons.
+      if (msg.role === "assistant" && planModeTurns.has(msg.turn_number)) {
+        entries.push({ kind: "plan_message", data: msg, turnNumber: msg.turn_number });
+      } else {
+        entries.push({ kind: "message", data: msg });
+      }
       i++;
       continue;
     }
@@ -96,7 +117,12 @@ export function buildTimeline(
     // output-level logs without metadata type are assistant text responses
     // (e.g. agent_message from Codex CLI). Show them as visible output.
     if (log.level === "output" && (!log.metadata || !log.metadata.type)) {
-      entries.push({ kind: "assistant_output", data: log });
+      // If this output belongs to a plan mode turn, mark it as plan output.
+      if (planModeTurns.has(log.turn_number)) {
+        entries.push({ kind: "plan_output", data: log, turnNumber: log.turn_number });
+      } else {
+        entries.push({ kind: "assistant_output", data: log });
+      }
       i++;
       continue;
     }

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -570,8 +570,9 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Message string   `json:"message"`
-		Images  []string `json:"images"`
+		Message  string   `json:"message"`
+		Images   []string `json:"images"`
+		PlanMode bool     `json:"plan_mode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
@@ -581,6 +582,12 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	if body.Message == "" {
 		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
 		return
+	}
+
+	// When plan mode is requested, prefix the message so the orchestrator
+	// can detect it and instruct the coding agent to plan instead of execute.
+	if body.PlanMode {
+		body.Message = "[PLAN_MODE]\n" + body.Message
 	}
 
 	// Look up the session to check its current status.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -600,6 +600,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 
 	var userMessage string
+	var planMode bool
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == models.MessageRoleUser {
 			userMessage = messages[i].Content
@@ -610,6 +611,22 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		o.failRun(ctx, session, "no user message found for continue_session")
 		return fmt.Errorf("no user message found")
 	}
+
+	// Detect plan mode prefix and strip it, wrapping with plan instructions.
+	const planModePrefix = "[PLAN_MODE]\n"
+	if strings.HasPrefix(userMessage, planModePrefix) {
+		planMode = true
+		originalMessage := strings.TrimPrefix(userMessage, planModePrefix)
+		userMessage = "You are in PLAN MODE. Instead of making changes directly, create a detailed implementation plan for the following request. Describe:\n" +
+			"1. What files need to be changed and why\n" +
+			"2. What specific changes are needed in each file\n" +
+			"3. The order of operations\n" +
+			"4. Any potential risks or considerations\n\n" +
+			"Do NOT make any file changes or use any tools that modify files. Only output the plan as a structured markdown response. " +
+			"The user will review the plan and either approve it or request adjustments before you proceed.\n\n" +
+			"User's request:\n" + originalMessage
+	}
+	_ = planMode // used by adapters that support explicit plan mode
 
 	// 4. Create sandbox.
 	sandboxCfg := DefaultSandboxConfig()


### PR DESCRIPTION
## Summary

- Adds a **plan mode toggle** to the session input bar for Claude Code sessions, allowing users to request an implementation plan before the agent makes changes
- Backend accepts `plan_mode` flag, prefixes the message, and the orchestrator wraps it with structured planning instructions so the agent creates a plan without modifying files
- Plan outputs are displayed in amber-styled bubbles with **Approve Plan** and **Adjust Plan** buttons, enabling interactive plan review workflow

## Details

### Frontend
- **Input bar**: Plan mode toggle button (visible for `claude_code` sessions) with `Shift+Tab` keyboard shortcut
- **Plan mode indicator**: Amber pill badge showing "Plan Mode" with dismiss button and helper text
- **Timeline**: Detects plan mode turns via `[PLAN_MODE]` content prefix; renders `plan_output` and `plan_message` entries with `PlanOutputBubble` component
- **Approve**: Sends "proceed with executing the plan" follow-up message
- **Adjust**: Pre-fills input with "Please adjust the plan: " for the user to type modifications
- **API client**: `sendMessage` now accepts optional `planMode` parameter

### Backend
- **Handler** (`sessions.go`): Accepts `plan_mode` boolean in SendMessage body; prefixes stored content with `[PLAN_MODE]\n`
- **Orchestrator** (`orchestrator.go`): Detects prefix, strips it, and wraps user message with structured planning instructions telling the agent to plan without making file changes

## Test plan

- [ ] Open a Claude Code session and verify the "Plan mode" link appears below the input
- [ ] Click "Plan mode" and verify the amber indicator appears with dismiss button
- [ ] Send a message in plan mode and verify it shows a "Plan Mode" badge on the user bubble
- [ ] Verify agent responds with a plan displayed in an amber-bordered bubble
- [ ] Click "Approve Plan" and verify it sends an execution message
- [ ] Click "Adjust Plan" and verify input is pre-filled with adjustment prompt
- [ ] Test `Shift+Tab` keyboard shortcut toggles plan mode on/off
- [ ] Verify plan mode toggle is NOT shown for non-Claude Code sessions (e.g. Codex)
- [ ] Verify approve/adjust buttons are hidden while the agent is running

https://claude.ai/code/session_01E2ADUHPL3eyNHU6wCCCHp4