### PR TITLE
Add file upload support with S3 and local filesystem storage

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -152,6 +152,11 @@ func main() {
 		reaper := agent.NewSessionReaper(sessionStore, snapshotStore, cfg.SessionMaxIdleAge, cfg.SessionMaxSnapshotAge, cfg.SessionReaperInterval, logger)
 		go reaper.Run(ctx)
 
+		// Upload reaper: clean up old uploaded files (local mode only; use S3 lifecycle rules for S3).
+		uploadStore := storage.NewFileUploadStore(cfg.UploadStorageDir, "")
+		uploadReaper := storage.NewUploadReaper(uploadStore, cfg.UploadMaxAge, cfg.SessionReaperInterval, logger)
+		go uploadReaper.Run(ctx)
+
 		scheduler := cluster.NewScheduler(
 			cluster.NewSchedulerLock(pool),
 			jobStore,

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -17,6 +17,10 @@ import {
   PanelRightOpen,
   PanelRightClose,
   ChevronDown,
+  Paperclip,
+  X,
+  ImagePlus,
+  Loader2,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
@@ -701,7 +705,10 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   const [message, setMessage] = useState("");
   const [selectedModel, setSelectedModel] = useState("");
   const [streamedLogs, setStreamedLogs] = useState<SessionLog[]>([]);
+  const [attachments, setAttachments] = useState<string[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const uploadInputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const seenLogIds = useRef<Set<number>>(new Set());
   const reconnectAttempts = useRef(0);
@@ -848,10 +855,34 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     };
   }, [sessionId, apiBase, isActive, mergeLogs, queryClient]);
 
+  async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
+    const fileList = event.target.files;
+    if (!fileList || fileList.length === 0) return;
+
+    setIsUploading(true);
+    try {
+      const files = Array.from(fileList);
+      const results = await Promise.all(
+        files.map((file) => api.uploads.upload(file))
+      );
+      setAttachments((prev) => [...prev, ...results.map((r) => r.url)]);
+    } catch {
+      // Upload failed — silently ignore (user can retry).
+    } finally {
+      setIsUploading(false);
+      event.target.value = "";
+    }
+  }
+
+  function removeAttachment(url: string) {
+    setAttachments((prev) => prev.filter((a) => a !== url));
+  }
+
   const sendMutation = useMutation({
-    mutationFn: () => api.sessions.sendMessage(sessionId, message, undefined, selectedModel || undefined),
+    mutationFn: () => api.sessions.sendMessage(sessionId, message, attachments.length > 0 ? attachments : undefined, selectedModel || undefined),
     onSuccess: () => {
       setMessage("");
+      setAttachments([]);
       if (textareaRef.current) {
         textareaRef.current.style.height = "auto";
       }
@@ -906,10 +937,12 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     }
   }, [timelineEntries.length]);
 
+  const hasContent = message.trim() || attachments.length > 0;
+
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (message.trim() && canSendMessage && !sendMutation.isPending) {
+      if (hasContent && canSendMessage && !sendMutation.isPending) {
         sendMutation.mutate();
       }
     }
@@ -959,7 +992,67 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
             disabled={!canSendMessage || sendMutation.isPending}
             className="min-h-[44px] max-h-[200px] resize-none border-none bg-transparent shadow-none focus-visible:ring-0"
           />
+
+          {/* Attachment previews */}
+          {attachments.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2 px-3 pb-2">
+              {attachments.map((url) => {
+                const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(url);
+                const fileName = url.split("/").pop() || "file";
+                return (
+                  <div key={url} className="relative group">
+                    {isImage ? (
+                      <img
+                        src={url}
+                        alt={fileName}
+                        className="h-16 w-16 rounded-md object-cover border border-border"
+                      />
+                    ) : (
+                      <div className="h-16 px-3 flex items-center rounded-md border border-border bg-muted text-xs text-muted-foreground">
+                        {fileName}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => removeAttachment(url)}
+                      className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full bg-background border border-border flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                      aria-label={`Remove ${fileName}`}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                );
+              })}
+              {isUploading && (
+                <div className="h-16 w-16 rounded-md border border-border bg-muted flex items-center justify-center">
+                  <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                </div>
+              )}
+            </div>
+          )}
+
           <div className="flex items-center gap-1 px-2 pb-2">
+            {/* File upload button */}
+            <Button
+              type="button"
+              size="icon"
+              variant="ghost"
+              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+              title="Attach files or images"
+              disabled={!canSendMessage || isUploading}
+              onClick={() => uploadInputRef.current?.click()}
+            >
+              {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
+            </Button>
+            <input
+              ref={uploadInputRef}
+              type="file"
+              accept="image/*,.pdf,.txt,.md,.json,.csv"
+              multiple
+              className="hidden"
+              onChange={handleFileUpload}
+            />
+
             {availableModels.length > 0 && (
               <Select value={selectedModel} onValueChange={setSelectedModel}>
                 <SelectTrigger className="h-8 w-auto gap-1.5 border-none bg-transparent px-2 text-[13px] text-muted-foreground shadow-none hover:text-foreground focus:ring-0" aria-label="Model override">
@@ -1005,7 +1098,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
                   variant="default"
                   className="h-8 w-8 shrink-0 rounded-lg"
                   title="Send message"
-                  disabled={!message.trim() || !canSendMessage || sendMutation.isPending}
+                  disabled={!hasContent || !canSendMessage || sendMutation.isPending}
                   onClick={() => sendMutation.mutate()}
                 >
                   <ArrowUp className="h-4 w-4" />

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -855,14 +855,23 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     };
   }, [sessionId, apiBase, isActive, mergeLogs, queryClient]);
 
+  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
   async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const fileList = event.target.files;
     if (!fileList || fileList.length === 0) return;
 
+    const files = Array.from(fileList);
+    const oversized = files.filter((f) => f.size > MAX_FILE_SIZE);
+    if (oversized.length > 0) {
+      setUploadError(`File${oversized.length > 1 ? "s" : ""} too large (max 10 MB): ${oversized.map((f) => f.name).join(", ")}`);
+      event.target.value = "";
+      return;
+    }
+
     setIsUploading(true);
     setUploadError(null);
     try {
-      const files = Array.from(fileList);
       const results = await Promise.all(
         files.map((file) => api.uploads.upload(file))
       );
@@ -999,8 +1008,9 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
           {(attachments.length > 0 || isUploading) && (
             <div className="flex flex-wrap items-center gap-2 px-3 pb-2">
               {attachments.map((url) => {
-                const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(url);
-                const fileName = url.split("/").pop() || "file";
+                const pathname = url.split("?")[0].split("#")[0];
+                const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
+                const fileName = pathname.split("/").pop() || "file";
                 return (
                   <div key={url} className="relative group">
                     {isImage ? (

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -43,7 +43,7 @@ import { parseDiffStats } from "@/lib/diff-parser";
 import type { Session, SessionLog, SessionMessage, User, Validation } from "@/lib/types";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
-import { cn, sessionTitle } from "@/lib/utils";
+import { cn, sessionTitle, isImageURL, fileNameFromURL } from "@/lib/utils";
 import { DiffStatsBadge, FileTree, ReviewToolbar, DiffPane, SessionFooter, KeyboardHelpOverlay, CommentsSummary, RepoExplorer, type ViewMode, type DiffPaneHandle } from "@/components/code-review";
 import { useDiffKeyboardNav } from "@/hooks/use-diff-keyboard-nav";
 import { useReviewComments } from "@/hooks/use-review-comments";
@@ -698,6 +698,7 @@ function ChangesTab({
 
 const MAX_SSE_RECONNECT_ATTEMPTS = 5;
 const BASE_SSE_RECONNECT_DELAY_MS = 1000;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Session; sessionId: string; isActive: boolean; onDiffClick?: () => void }) {
   const queryClient = useQueryClient();
@@ -855,8 +856,6 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     };
   }, [sessionId, apiBase, isActive, mergeLogs, queryClient]);
 
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-
   async function handleFileUpload(event: React.ChangeEvent<HTMLInputElement>) {
     const fileList = event.target.files;
     if (!fileList || fileList.length === 0) return;
@@ -889,7 +888,10 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   }
 
   const sendMutation = useMutation({
-    mutationFn: () => api.sessions.sendMessage(sessionId, message, attachments.length > 0 ? attachments : undefined, selectedModel || undefined),
+    mutationFn: () => {
+      setUploadError(null);
+      return api.sessions.sendMessage(sessionId, message, attachments.length > 0 ? attachments : undefined, selectedModel || undefined);
+    },
     onSuccess: () => {
       setMessage("");
       setAttachments([]);
@@ -1008,9 +1010,8 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
           {(attachments.length > 0 || isUploading) && (
             <div className="flex flex-wrap items-center gap-2 px-3 pb-2">
               {attachments.map((url) => {
-                const pathname = url.split("?")[0].split("#")[0];
-                const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
-                const fileName = pathname.split("/").pop() || "file";
+                const isImage = isImageURL(url);
+                const fileName = fileNameFromURL(url);
                 return (
                   <div key={url} className="relative group">
                     {isImage ? (

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -19,7 +19,6 @@ import {
   ChevronDown,
   Paperclip,
   X,
-  ImagePlus,
   Loader2,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
@@ -707,6 +706,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   const [streamedLogs, setStreamedLogs] = useState<SessionLog[]>([]);
   const [attachments, setAttachments] = useState<string[]>([]);
   const [isUploading, setIsUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -860,14 +860,15 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     if (!fileList || fileList.length === 0) return;
 
     setIsUploading(true);
+    setUploadError(null);
     try {
       const files = Array.from(fileList);
       const results = await Promise.all(
         files.map((file) => api.uploads.upload(file))
       );
       setAttachments((prev) => [...prev, ...results.map((r) => r.url)]);
-    } catch {
-      // Upload failed — silently ignore (user can retry).
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Upload failed");
     } finally {
       setIsUploading(false);
       event.target.value = "";
@@ -970,12 +971,13 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
       {/* Error display */}
       {(() => {
-        const firstError = [sendMutation, endMutation, createPRMutation].find(m => m.error)?.error;
+        const firstError = uploadError || [sendMutation, endMutation, createPRMutation].find(m => m.error)?.error;
         if (!firstError) return null;
+        const msg = typeof firstError === "string" ? firstError : (firstError instanceof Error ? firstError.message : "An error occurred");
         return (
           <div className="flex items-center gap-2 px-4 py-2 text-xs text-destructive border-t bg-destructive/5">
             <AlertTriangle className="h-3 w-3 shrink-0" />
-            {firstError instanceof Error ? firstError.message : "An error occurred"}
+            {msg}
           </div>
         );
       })()}
@@ -994,7 +996,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
           />
 
           {/* Attachment previews */}
-          {attachments.length > 0 && (
+          {(attachments.length > 0 || isUploading) && (
             <div className="flex flex-wrap items-center gap-2 px-3 pb-2">
               {attachments.map((url) => {
                 const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(url);

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -180,21 +180,31 @@ export function ManualSessionCreatePageContent() {
     resizeMessageInput();
   }, [message]);
 
+  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
   async function onUploadChange(event: React.ChangeEvent<HTMLInputElement>) {
     const fileList = event.target.files;
     if (!fileList || fileList.length === 0) {
       return;
     }
 
+    const files = Array.from(fileList);
+    const oversized = files.filter((f) => f.size > MAX_FILE_SIZE);
+    if (oversized.length > 0) {
+      setCreationError(`File${oversized.length > 1 ? "s" : ""} too large (max 10 MB): ${oversized.map((f) => f.name).join(", ")}`);
+      event.target.value = "";
+      return;
+    }
+
     setIsUploading(true);
+    setCreationError(null);
     try {
-      const files = Array.from(fileList);
       const results = await Promise.all(
         files.map((file) => api.uploads.upload(file))
       );
       setAttachments((previous) => [...previous, ...results.map((r) => r.url)]);
-    } catch {
-      // Upload failed silently — user can retry.
+    } catch (err) {
+      setCreationError(err instanceof Error ? err.message : "Upload failed");
     } finally {
       setIsUploading(false);
       event.target.value = "";
@@ -308,8 +318,9 @@ export function ManualSessionCreatePageContent() {
             {(attachments.length > 0 || isUploading) && (
               <div className="flex flex-wrap items-center gap-2 pb-3">
                 {attachments.map((url) => {
-                  const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(url) || url.startsWith("data:image/");
-                  const fileName = url.startsWith("data:") ? "photo" : (url.split("/").pop() || "file");
+                  const pathname = url.split("?")[0].split("#")[0];
+                  const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname) || url.startsWith("data:image/");
+                  const fileName = url.startsWith("data:") ? "photo" : (pathname.split("/").pop() || "file");
                   return (
                     <div key={url} className="relative group">
                       {isImage ? (

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, Mic, Plus, X, ImagePlus, Paperclip, GitBranch, ChevronDown } from "lucide-react";
+import { ArrowUp, Mic, Plus, X, ImagePlus, Paperclip, GitBranch, ChevronDown, Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -53,15 +53,6 @@ type BrowserSpeechRecognition = {
 
 type SpeechRecognitionCtor = new () => BrowserSpeechRecognition;
 
-function readFileAsDataURL(file: File): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result ?? ""));
-    reader.onerror = () => reject(new Error("file read failed"));
-    reader.readAsDataURL(file);
-  });
-}
-
 export function ManualSessionCreatePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -76,6 +67,7 @@ export function ManualSessionCreatePageContent() {
 
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<string[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
   const [showImageInput, setShowImageInput] = useState(false);
   const [imageURL, setImageURL] = useState("");
   const [isDictating, setIsDictating] = useState(false);
@@ -194,16 +186,19 @@ export function ManualSessionCreatePageContent() {
       return;
     }
 
-    const files = Array.from(fileList);
-    const uploadedAttachments = await Promise.all(files.map(async (file) => {
-      if (file.type.startsWith("image/")) {
-        return readFileAsDataURL(file);
-      }
-      return `attachment:${file.name}`;
-    }));
-
-    setAttachments((previous) => [...previous, ...uploadedAttachments]);
-    event.target.value = "";
+    setIsUploading(true);
+    try {
+      const files = Array.from(fileList);
+      const results = await Promise.all(
+        files.map((file) => api.uploads.upload(file))
+      );
+      setAttachments((previous) => [...previous, ...results.map((r) => r.url)]);
+    } catch {
+      // Upload failed silently — user can retry.
+    } finally {
+      setIsUploading(false);
+      event.target.value = "";
+    }
   }
 
   function addImageURL() {
@@ -310,23 +305,40 @@ export function ManualSessionCreatePageContent() {
               aria-label="Manual session prompt"
             />
 
-            {attachments.length > 0 && (
+            {(attachments.length > 0 || isUploading) && (
               <div className="flex flex-wrap items-center gap-2 pb-3">
-                {attachments.map((attachment) => (
-                  <Badge key={attachment} variant="secondary" className="gap-1 text-xs">
-                    {attachment.startsWith("data:") ? "photo" : attachment}
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-4 w-4 p-0"
-                      onClick={() => removeAttachment(attachment)}
-                      aria-label={`Remove ${attachment}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </Button>
-                  </Badge>
-                ))}
+                {attachments.map((url) => {
+                  const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(url) || url.startsWith("data:image/");
+                  const fileName = url.startsWith("data:") ? "photo" : (url.split("/").pop() || "file");
+                  return (
+                    <div key={url} className="relative group">
+                      {isImage ? (
+                        <img
+                          src={url}
+                          alt={fileName}
+                          className="h-16 w-16 rounded-md object-cover border border-border"
+                        />
+                      ) : (
+                        <Badge variant="secondary" className="gap-1 text-xs h-8">
+                          {fileName}
+                        </Badge>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => removeAttachment(url)}
+                        className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full bg-background border border-border flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                        aria-label={`Remove ${fileName}`}
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </div>
+                  );
+                })}
+                {isUploading && (
+                  <div className="h-16 w-16 rounded-md border border-border bg-muted flex items-center justify-center">
+                    <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -23,12 +23,15 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { api } from "@/lib/api";
+import { isImageURL, fileNameFromURL } from "@/lib/utils";
 import { captureError } from "@/lib/errors";
 import { queryKeys } from "@/lib/query-keys";
 import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
 import { NoReposWarning } from "@/components/no-repos-warning";
 import { useOptimisticSessions } from "@/contexts/optimistic-sessions";
 import type { OrgSettings, Organization, Repository, SingleResponse, ListResponse } from "@/lib/types";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
 type BranchInfo = { name: string; protected: boolean };
 
@@ -180,8 +183,6 @@ export function ManualSessionCreatePageContent() {
     resizeMessageInput();
   }, [message]);
 
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
-
   async function onUploadChange(event: React.ChangeEvent<HTMLInputElement>) {
     const fileList = event.target.files;
     if (!fileList || fileList.length === 0) {
@@ -318,9 +319,8 @@ export function ManualSessionCreatePageContent() {
             {(attachments.length > 0 || isUploading) && (
               <div className="flex flex-wrap items-center gap-2 pb-3">
                 {attachments.map((url) => {
-                  const pathname = url.split("?")[0].split("#")[0];
-                  const isImage = /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname) || url.startsWith("data:image/");
-                  const fileName = url.startsWith("data:") ? "photo" : (pathname.split("/").pop() || "file");
+                  const isImage = isImageURL(url);
+                  const fileName = url.startsWith("data:") ? "photo" : fileNameFromURL(url);
                   return (
                     <div key={url} className="relative group">
                       {isImage ? (

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -132,11 +132,11 @@ describe('ManualSessionCreatePage', () => {
     await user.type(screen.getByPlaceholderText('https://example.com/screenshot.png'), 'https://example.com/test.png');
     await user.click(screen.getByRole('button', { name: 'Add' }));
 
-    expect(screen.getByText('https://example.com/test.png')).toBeInTheDocument();
+    expect(screen.getByAltText('test.png')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Remove https://example.com/test.png' }));
+    await user.click(screen.getByRole('button', { name: 'Remove test.png' }));
 
-    expect(screen.queryByText('https://example.com/test.png')).not.toBeInTheDocument();
+    expect(screen.queryByAltText('test.png')).not.toBeInTheDocument();
   });
 
   it('does not add empty URL', async () => {

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -152,6 +152,54 @@ describe('ManualSessionCreatePage', () => {
     expect(screen.getByPlaceholderText('https://example.com/screenshot.png')).toBeInTheDocument();
   });
 
+  it('uploads a file via the upload endpoint and shows thumbnail', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.post('/api/v1/uploads', () => {
+        return HttpResponse.json({
+          url: '/api/v1/uploads/files/org-1/2026-03/test-uuid.png',
+          file_name: 'photo.png',
+          content_type: 'image/png',
+        });
+      }),
+    );
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    // Trigger upload via hidden file input.
+    const file = new File(['fake-png'], 'photo.png', { type: 'image/png' });
+    await user.click(screen.getByRole('button', { name: 'Add files or photos' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Upload files or photos' }));
+
+    // The hidden file input should exist; simulate a file selection.
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    await user.upload(fileInput, file);
+
+    // Should show the uploaded image thumbnail.
+    await waitFor(() => {
+      expect(screen.getByAltText('test-uuid.png')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error for oversized files', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    // Create a file larger than 10 MB.
+    const bigContent = new Uint8Array(11 * 1024 * 1024);
+    const bigFile = new File([bigContent], 'huge.png', { type: 'image/png' });
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+    await user.upload(fileInput, bigFile);
+
+    await waitFor(() => {
+      expect(screen.getByText(/too large/i)).toBeInTheDocument();
+    });
+  });
+
   it('shows error when session creation fails', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -174,4 +174,91 @@ describe("ChatTimeline", () => {
     );
     expect(screen.getByText("1 file changed")).toBeInTheDocument();
   });
+
+  it("renders image attachments as thumbnails on user messages", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({
+          id: 10,
+          role: "user",
+          content: "See this screenshot",
+          attachments: ["/uploads/org-1/screenshot.png"],
+        }),
+      },
+    ];
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+    expect(screen.getByText("See this screenshot")).toBeInTheDocument();
+    expect(screen.getByAltText("Attached image")).toBeInTheDocument();
+  });
+
+  it("renders non-image attachments as file links", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({
+          id: 11,
+          role: "user",
+          content: "Here is a log",
+          attachments: ["/uploads/org-1/debug.txt"],
+        }),
+      },
+    ];
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+    expect(screen.getByText("debug.txt")).toBeInTheDocument();
+    const link = screen.getByText("debug.txt").closest("a");
+    expect(link).toHaveAttribute("href", "/uploads/org-1/debug.txt");
+  });
+
+  it("opens and closes lightbox when clicking an image attachment", async () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({
+          id: 12,
+          role: "user",
+          content: "",
+          attachments: ["/uploads/org-1/photo.jpg"],
+        }),
+      },
+    ];
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+
+    // Click thumbnail to open lightbox.
+    await userEvent.click(screen.getByAltText("Attached image"));
+    // Lightbox shows a larger image with close button.
+    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+
+    // Close via button.
+    await userEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+  });
+
+  it("renders attachments on assistant messages", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({
+          id: 13,
+          role: "assistant",
+          content: "Generated this image",
+          attachments: ["/uploads/org-1/output.png"],
+        }),
+      },
+    ];
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+    expect(screen.getByAltText("Attached image")).toBeInTheDocument();
+  });
+
+  it("does not render attachment grid when attachments is empty", () => {
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({ id: 14, role: "user", content: "No attachments", attachments: [] }),
+      },
+    ];
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+    expect(screen.getByText("No attachments")).toBeInTheDocument();
+    expect(screen.queryByAltText("Attached image")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -196,7 +196,10 @@ function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClos
 // ---------------------------------------------------------------------------
 
 function isImageURL(url: string): boolean {
-  return /\.(png|jpe?g|gif|webp|svg)$/i.test(url) || url.startsWith("data:image/");
+  if (url.startsWith("data:image/")) return true;
+  // Strip query params and fragment so S3 presigned URLs still match.
+  const pathname = url.split("?")[0].split("#")[0];
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
 }
 
 function AttachmentGrid({ attachments }: { attachments: string[] }) {
@@ -242,7 +245,7 @@ function AttachmentGrid({ attachments }: { attachments: string[] }) {
       {files.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-2">
           {files.map((url) => {
-            const fileName = url.split("/").pop() || "file";
+            const fileName = url.split("?")[0].split("/").pop() || "file";
             return (
               <a
                 key={url}

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
+import { isImageURL, fileNameFromURL } from "@/lib/utils";
 
 function safeDate(dateStr: string): Date | null {
   const d = new Date(dateStr);
@@ -195,13 +196,6 @@ function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClos
 // Attachment thumbnails for messages
 // ---------------------------------------------------------------------------
 
-function isImageURL(url: string): boolean {
-  if (url.startsWith("data:image/")) return true;
-  // Strip query params and fragment so S3 presigned URLs still match.
-  const pathname = url.split("?")[0].split("#")[0];
-  return /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
-}
-
 function AttachmentGrid({ attachments }: { attachments: string[] }) {
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
@@ -245,7 +239,7 @@ function AttachmentGrid({ attachments }: { attachments: string[] }) {
       {files.length > 0 && (
         <div className="flex flex-wrap gap-1.5 mt-2">
           {files.map((url) => {
-            const fileName = url.split("?")[0].split("/").pop() || "file";
+            const fileName = fileNameFromURL(url);
             return (
               <a
                 key={url}

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronRight, AlertTriangle, Wrench, FileCode2 } from "lucide-react";
+import { useState, useCallback, useEffect } from "react";
+import { ChevronRight, AlertTriangle, Wrench, FileCode2, X, FileText } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
 import type { TimelineEntry } from "@/lib/timeline";
@@ -156,6 +156,112 @@ export function formatMessageTime(dateStr: string): string {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Image lightbox overlay
+// ---------------------------------------------------------------------------
+
+function ImageLightbox({ src, alt, onClose }: { src: string; alt: string; onClose: () => void }) {
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 h-8 w-8 rounded-full bg-background/80 flex items-center justify-center hover:bg-background transition-colors"
+        aria-label="Close"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <img
+        src={src}
+        alt={alt}
+        className="max-w-[90vw] max-h-[90vh] rounded-lg shadow-2xl object-contain"
+        onClick={(e) => e.stopPropagation()}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Attachment thumbnails for messages
+// ---------------------------------------------------------------------------
+
+function isImageURL(url: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(url) || url.startsWith("data:image/");
+}
+
+function AttachmentGrid({ attachments }: { attachments: string[] }) {
+  const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
+  const closeLightbox = useCallback(() => setLightboxSrc(null), []);
+
+  if (!attachments || attachments.length === 0) return null;
+
+  const images = attachments.filter(isImageURL);
+  const files = attachments.filter((a) => !isImageURL(a));
+
+  return (
+    <>
+      {lightboxSrc && (
+        <ImageLightbox
+          src={lightboxSrc}
+          alt="Attachment"
+          onClose={closeLightbox}
+        />
+      )}
+
+      {images.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {images.map((url) => (
+            <button
+              key={url}
+              type="button"
+              onClick={() => setLightboxSrc(url)}
+              className="relative group rounded-md overflow-hidden border border-border/50 hover:border-border transition-colors"
+            >
+              <img
+                src={url}
+                alt="Attached image"
+                className="h-24 w-24 object-cover"
+              />
+              <div className="absolute inset-0 bg-black/0 group-hover:bg-black/10 transition-colors" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {files.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {files.map((url) => {
+            const fileName = url.split("/").pop() || "file";
+            return (
+              <a
+                key={url}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded-md border border-border/50 bg-background/50 px-2 py-1 text-xs text-muted-foreground hover:text-foreground hover:border-border transition-colors"
+              >
+                <FileText className="h-3 w-3 shrink-0" />
+                {fileName}
+              </a>
+            );
+          })}
+        </div>
+      )}
+    </>
+  );
+}
+
 function AssistantBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-start">
@@ -171,7 +277,10 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
     return (
       <div className="flex justify-end">
         <div className="max-w-[80%] rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm">
-          <p className="whitespace-pre-wrap">{msg.content}</p>
+          {msg.content && <p className="whitespace-pre-wrap">{msg.content}</p>}
+          {msg.attachments && msg.attachments.length > 0 && (
+            <AttachmentGrid attachments={msg.attachments} />
+          )}
           <p className="text-[10px] mt-1 text-white/70">
             {formatMessageTime(msg.created_at)}
           </p>
@@ -183,6 +292,9 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
   return (
     <AssistantBubble>
       <MarkdownContent content={msg.content} />
+      {msg.attachments && msg.attachments.length > 0 && (
+        <AttachmentGrid attachments={msg.attachments} />
+      )}
       <p className="text-[10px] mt-1 text-muted-foreground">
         {formatMessageTime(msg.created_at)}
       </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -81,7 +81,38 @@ function del<T>(path: string): Promise<T> {
   return request<T>(path, { method: 'DELETE' });
 }
 
+async function uploadFile(file: File): Promise<{ url: string; file_name: string; content_type: string }> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const headers: Record<string, string> = {
+    'X-CSRF-Token': getCSRFToken(),
+  };
+  // Do NOT set Content-Type — the browser sets it with the multipart boundary.
+
+  const res = await fetch(`${API_BASE}/api/v1/uploads`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+    body: formData,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new ApiError(
+      body?.error?.code || 'UNKNOWN',
+      body?.error?.message || res.statusText,
+      body?.error?.details
+    );
+  }
+
+  return res.json();
+}
+
 export const api = {
+  uploads: {
+    upload: uploadFile,
+  },
   auth: {
     providers: () => get<import('./types').SingleResponse<import('./types').AuthProviders>>('/api/v1/auth/providers'),
     me: () => get<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/me'),

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatTimeAgo } from "./utils";
+import { formatTimeAgo, isImageURL, fileNameFromURL } from "./utils";
 
 describe("formatTimeAgo", () => {
   it("returns 'just now' for dates less than a minute ago", () => {
@@ -43,5 +43,58 @@ describe("formatTimeAgo", () => {
   it("returns '23h ago' just under a day", () => {
     const twentyThreeHoursAgo = new Date(Date.now() - 23 * 3_600_000).toISOString();
     expect(formatTimeAgo(twentyThreeHoursAgo)).toBe("23h ago");
+  });
+});
+
+describe("isImageURL", () => {
+  it("matches common image extensions", () => {
+    expect(isImageURL("/uploads/photo.png")).toBe(true);
+    expect(isImageURL("/uploads/photo.jpg")).toBe(true);
+    expect(isImageURL("/uploads/photo.jpeg")).toBe(true);
+    expect(isImageURL("/uploads/photo.gif")).toBe(true);
+    expect(isImageURL("/uploads/photo.webp")).toBe(true);
+    expect(isImageURL("/uploads/photo.svg")).toBe(true);
+  });
+
+  it("matches data: image URLs", () => {
+    expect(isImageURL("data:image/png;base64,abc")).toBe(true);
+  });
+
+  it("rejects non-image URLs", () => {
+    expect(isImageURL("/uploads/doc.pdf")).toBe(false);
+    expect(isImageURL("/uploads/file.txt")).toBe(false);
+    expect(isImageURL("/uploads/data.json")).toBe(false);
+  });
+
+  it("strips query params from S3 presigned URLs", () => {
+    expect(isImageURL("https://bucket.s3.amazonaws.com/uploads/photo.png?X-Amz-Algorithm=AWS4")).toBe(true);
+    expect(isImageURL("https://bucket.s3.amazonaws.com/uploads/doc.pdf?X-Amz-Algorithm=AWS4")).toBe(false);
+  });
+
+  it("strips fragments", () => {
+    expect(isImageURL("/uploads/photo.jpg#section")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isImageURL("/uploads/PHOTO.PNG")).toBe(true);
+    expect(isImageURL("/uploads/photo.JPG")).toBe(true);
+  });
+});
+
+describe("fileNameFromURL", () => {
+  it("extracts filename from simple path", () => {
+    expect(fileNameFromURL("/uploads/org-1/photo.png")).toBe("photo.png");
+  });
+
+  it("strips query params", () => {
+    expect(fileNameFromURL("https://s3.amazonaws.com/uploads/photo.png?token=abc")).toBe("photo.png");
+  });
+
+  it("strips fragments", () => {
+    expect(fileNameFromURL("/uploads/photo.png#section")).toBe("photo.png");
+  });
+
+  it("returns 'file' for empty paths", () => {
+    expect(fileNameFromURL("")).toBe("file");
   });
 });

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -13,6 +13,23 @@ export function sessionTitle(session: Session): string {
   return `Session ${session.id.slice(0, 8)}`;
 }
 
+/**
+ * Check whether a URL points to an image, handling query params/fragments
+ * from S3 presigned URLs.
+ */
+export function isImageURL(url: string): boolean {
+  if (url.startsWith("data:image/")) return true;
+  const pathname = url.split("?")[0].split("#")[0];
+  return /\.(png|jpe?g|gif|webp|svg)$/i.test(pathname);
+}
+
+/**
+ * Extract a clean file name from a URL, stripping query params.
+ */
+export function fileNameFromURL(url: string): string {
+  return url.split("?")[0].split("#")[0].split("/").pop() || "file";
+}
+
 export function formatTimeAgo(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -902,6 +902,27 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Persist the initial user message as a turn-0 record so that attachments
+	// (uploaded images) are displayed alongside the prompt in the chat timeline.
+	if h.messageStore != nil {
+		initMsg := &models.SessionMessage{
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 0,
+			Role:       models.MessageRoleUser,
+			Content:    body.Message,
+		}
+		if user := middleware.UserFromContext(r.Context()); user != nil {
+			initMsg.UserID = &user.ID
+		}
+		if len(body.Images) > 0 {
+			initMsg.Attachments = body.Images
+		}
+		if err := h.messageStore.Create(r.Context(), initMsg); err != nil {
+			zerolog.Ctx(r.Context()).Warn().Err(err).Msg("failed to create initial session message — continuing without it")
+		}
+	}
+
 	// Check concurrency before enqueuing so the user gets immediate feedback.
 	runningCount, err := h.runStore.CountRunningByOrg(r.Context(), orgID)
 	if err != nil {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -578,8 +578,8 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	body.Message = strings.TrimSpace(body.Message)
-	if body.Message == "" {
-		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
+	if body.Message == "" && len(body.Images) == 0 {
+		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message or images are required")
 		return
 	}
 

--- a/internal/api/handlers/uploads.go
+++ b/internal/api/handlers/uploads.go
@@ -118,8 +118,8 @@ func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
 
 	// Extract the file key from the URL path after /api/v1/uploads/files/
 	key := strings.TrimPrefix(r.URL.Path, "/api/v1/uploads/files/")
-	if key == "" {
-		writeError(w, r, http.StatusBadRequest, "MISSING_KEY", "file key is required")
+	if key == "" || strings.Contains(key, "..") {
+		writeError(w, r, http.StatusBadRequest, "INVALID_KEY", "invalid file key")
 		return
 	}
 

--- a/internal/api/handlers/uploads.go
+++ b/internal/api/handlers/uploads.go
@@ -1,0 +1,154 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/services/storage"
+	"github.com/google/uuid"
+)
+
+// maxUploadSize is the maximum allowed file size (10 MB).
+const maxUploadSize = 10 << 20
+
+// allowedImageTypes are the MIME types accepted for upload.
+var allowedUploadTypes = map[string]bool{
+	"image/png":      true,
+	"image/jpeg":     true,
+	"image/gif":      true,
+	"image/webp":     true,
+	"image/svg+xml":  true,
+	"application/pdf": true,
+	"text/plain":      true,
+	"text/markdown":   true,
+	"text/csv":        true,
+	"application/json": true,
+}
+
+// UploadHandler handles file uploads to object storage.
+type UploadHandler struct {
+	store storage.UploadStore
+}
+
+// NewUploadHandler creates an UploadHandler backed by the given store.
+func NewUploadHandler(store storage.UploadStore) *UploadHandler {
+	return &UploadHandler{store: store}
+}
+
+// Upload handles POST /api/v1/uploads — accepts a multipart file upload,
+// stores it, and returns the URL for the uploaded file.
+func (h *UploadHandler) Upload(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		writeError(w, r, http.StatusNotImplemented, "NOT_CONFIGURED", "file uploads not configured")
+		return
+	}
+
+	// Parse multipart form with 10 MB limit.
+	if err := r.ParseMultipartForm(maxUploadSize); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "failed to parse multipart form")
+		return
+	}
+
+	file, header, err := r.FormFile("file")
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "MISSING_FILE", "file field is required")
+		return
+	}
+	defer file.Close()
+
+	if header.Size > maxUploadSize {
+		writeError(w, r, http.StatusRequestEntityTooLarge, "FILE_TOO_LARGE", "file size exceeds 10MB limit")
+		return
+	}
+
+	// Validate content type.
+	contentType := header.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+	// Normalize content type (strip charset params).
+	baseType := strings.Split(contentType, ";")[0]
+	baseType = strings.TrimSpace(baseType)
+
+	if !allowedUploadTypes[baseType] {
+		writeError(w, r, http.StatusBadRequest, "INVALID_FILE_TYPE",
+			fmt.Sprintf("file type %s is not allowed", baseType))
+		return
+	}
+
+	// Build a unique key: orgId/YYYY-MM/uuid.ext
+	orgID := middleware.OrgIDFromContext(r.Context())
+	ext := path.Ext(header.Filename)
+	if ext == "" {
+		ext = extensionFromMIME(baseType)
+	}
+	now := time.Now().UTC()
+	key := fmt.Sprintf("%s/%s/%s%s",
+		orgID.String(),
+		now.Format("2006-01"),
+		uuid.New().String(),
+		ext,
+	)
+
+	url, err := h.store.Save(r.Context(), key, file, baseType)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "UPLOAD_FAILED", "failed to store file", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"url":          url,
+		"file_name":    header.Filename,
+		"content_type": baseType,
+	})
+}
+
+// ServeUpload handles GET /api/v1/uploads/files/* — serves locally-stored uploads.
+// Only functional when using FileUploadStore.
+func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
+	fileStore, ok := h.store.(*storage.FileUploadStore)
+	if !ok {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "file serving not available in S3 mode")
+		return
+	}
+
+	// Extract the file key from the URL path after /api/v1/uploads/files/
+	key := strings.TrimPrefix(r.URL.Path, "/api/v1/uploads/files/")
+	if key == "" {
+		writeError(w, r, http.StatusBadRequest, "MISSING_KEY", "file key is required")
+		return
+	}
+
+	fileStore.ServeFile(w, r, key)
+}
+
+func extensionFromMIME(mime string) string {
+	switch mime {
+	case "image/png":
+		return ".png"
+	case "image/jpeg":
+		return ".jpg"
+	case "image/gif":
+		return ".gif"
+	case "image/webp":
+		return ".webp"
+	case "image/svg+xml":
+		return ".svg"
+	case "application/pdf":
+		return ".pdf"
+	case "text/plain":
+		return ".txt"
+	case "text/markdown":
+		return ".md"
+	case "text/csv":
+		return ".csv"
+	case "application/json":
+		return ".json"
+	default:
+		return ""
+	}
+}

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/textproto"
 	"testing"
 
 	"github.com/google/uuid"
@@ -20,7 +22,12 @@ func newUploadRequest(t *testing.T, fieldName, fileName, contentType string, bod
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
-	part, err := writer.CreateFormFile(fieldName, fileName)
+
+	// Create a part with the correct Content-Type (CreateFormFile always uses application/octet-stream).
+	h := make(textproto.MIMEHeader)
+	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, fieldName, fileName))
+	h.Set("Content-Type", contentType)
+	part, err := writer.CreatePart(h)
 	require.NoError(t, err)
 	_, err = part.Write(body)
 	require.NoError(t, err)

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -1,0 +1,170 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/services/storage"
+)
+
+func newUploadRequest(t *testing.T, fieldName, fileName, contentType string, body []byte) *http.Request {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile(fieldName, fileName)
+	require.NoError(t, err)
+	_, err = part.Write(body)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/uploads", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	// Inject org ID into context (middleware normally does this).
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	return req.WithContext(ctx)
+}
+
+func TestUploadHandler_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	h := NewUploadHandler(nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/uploads", nil)
+	w := httptest.NewRecorder()
+
+	h.Upload(w, req)
+
+	require.Equal(t, http.StatusNotImplemented, w.Code)
+	require.Contains(t, w.Body.String(), "NOT_CONFIGURED")
+}
+
+func TestUploadHandler_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/uploads")
+	h := NewUploadHandler(store)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/uploads", nil)
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.Upload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUploadHandler_InvalidFileType(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/uploads")
+	h := NewUploadHandler(store)
+	req := newUploadRequest(t, "file", "malware.exe", "application/x-executable", []byte("bad"))
+	w := httptest.NewRecorder()
+
+	h.Upload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_FILE_TYPE")
+}
+
+func TestUploadHandler_Success(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+	req := newUploadRequest(t, "file", "screenshot.png", "image/png", []byte("png-data"))
+	w := httptest.NewRecorder()
+
+	h.Upload(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp["url"], "response should contain a url")
+	require.Equal(t, "screenshot.png", resp["file_name"])
+	require.Equal(t, "image/png", resp["content_type"])
+}
+
+func TestUploadHandler_ServeUpload_PathTraversal(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/../../etc/passwd", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_KEY")
+}
+
+func TestUploadHandler_ServeUpload_EmptyKey(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_KEY")
+}
+
+func TestUploadHandler_ServeUpload_S3Mode(t *testing.T) {
+	t.Parallel()
+
+	s3Store := storage.NewS3UploadStore(nil, "bucket", "prefix", "https://example.com")
+	h := NewUploadHandler(s3Store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/some-key.png", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestExtensionFromMIME(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		mime string
+		ext  string
+	}{
+		{"image/png", ".png"},
+		{"image/jpeg", ".jpg"},
+		{"image/gif", ".gif"},
+		{"image/webp", ".webp"},
+		{"image/svg+xml", ".svg"},
+		{"application/pdf", ".pdf"},
+		{"text/plain", ".txt"},
+		{"text/markdown", ".md"},
+		{"text/csv", ".csv"},
+		{"application/json", ".json"},
+		{"application/octet-stream", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.mime, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.ext, extensionFromMIME(tt.mime))
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"context"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/go-chi/chi/v5"
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -180,10 +184,17 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	// Upload store: use S3 if configured, otherwise fall back to local filesystem.
 	var uploadStore storage.UploadStore
 	if cfg.UploadS3Bucket != "" {
-		// S3 upload store requires the S3 client to be configured externally.
-		// For now, use file-based uploads until an S3 client is provided.
-		logger.Warn().Msg("UPLOAD_S3_BUCKET is set but S3 client not yet injected into router — falling back to file uploads")
-		uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
+		awsCfg, awsErr := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion(cfg.UploadS3Region),
+		)
+		if awsErr != nil {
+			logger.Warn().Err(awsErr).Msg("failed to load AWS config for upload S3 — falling back to file uploads")
+			uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
+		} else {
+			s3Client := s3.NewFromConfig(awsCfg)
+			uploadStore = storage.NewS3UploadStore(s3Client, cfg.UploadS3Bucket, cfg.UploadS3Prefix, cfg.UploadS3Endpoint)
+			logger.Info().Str("bucket", cfg.UploadS3Bucket).Str("prefix", cfg.UploadS3Prefix).Msg("upload S3 store configured")
+		}
 	} else {
 		uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
 	}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -14,6 +14,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/services/codexauth"
+	"github.com/assembledhq/143/internal/services/storage"
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/assembledhq/143/internal/services/ingestion"
 	"github.com/assembledhq/143/internal/services/sandbox"
@@ -176,6 +177,18 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	sessionReviewCommentHandler.SetMessageAndJobStores(sessionMessageStore, jobStore)
 	sessionFileHandler := handlers.NewSessionFileHandler(sessionStore, fileReader, logger)
 
+	// Upload store: use S3 if configured, otherwise fall back to local filesystem.
+	var uploadStore storage.UploadStore
+	if cfg.UploadS3Bucket != "" {
+		// S3 upload store requires the S3 client to be configured externally.
+		// For now, use file-based uploads until an S3 client is provided.
+		logger.Warn().Msg("UPLOAD_S3_BUCKET is set but S3 client not yet injected into router — falling back to file uploads")
+		uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
+	} else {
+		uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
+	}
+	uploadHandler := handlers.NewUploadHandler(uploadStore)
+
 	r := chi.NewRouter()
 
 	// Global middleware
@@ -255,6 +268,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.GetThreadMessages)
 			r.Get("/api/v1/sessions/{id}/threads/{tid}/logs", sessionThreadHandler.GetThreadLogs)
 			r.Get("/api/v1/sessions/{id}/review-comments", sessionReviewCommentHandler.List)
+			r.Get("/api/v1/uploads/files/*", uploadHandler.ServeUpload)
 			r.Get("/api/v1/sessions/{id}/files", sessionFileHandler.ListFiles)
 			r.Get("/api/v1/sessions/{id}/files/content", sessionFileHandler.GetFileContent)
 			r.Get("/api/v1/sessions/{id}/files/context", sessionFileHandler.GetFileContext)
@@ -311,6 +325,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Delete("/api/v1/settings/credentials/personal/{provider}", userCredentialHandler.DeletePersonal)
 
 			r.Post("/api/v1/issues/{id}/fix", sessionHandler.TriggerFix)
+			// File upload (higher body-size limit for multipart uploads).
+			r.With(middleware.MaxBodySize(11<<20)).Post("/api/v1/uploads", uploadHandler.Upload)
+
 			r.Post("/api/v1/sessions/manual", sessionHandler.CreateManual)
 			r.Post("/api/v1/sessions/{id}/questions/{qid}/answer", sessionHandler.AnswerQuestion)
 			r.Post("/api/v1/sessions/{id}/messages", sessionHandler.SendMessage)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,10 +87,12 @@ type Config struct {
 	DataRetentionJobsDays    int `env:"DATA_RETENTION_JOBS_DAYS"    envDefault:"30"`
 
 	// Upload storage (images/files attached to session messages)
-	UploadStorageDir string `env:"UPLOAD_STORAGE_DIR" envDefault:".data/uploads"`
-	UploadS3Bucket   string `env:"UPLOAD_S3_BUCKET"`
-	UploadS3Prefix   string `env:"UPLOAD_S3_PREFIX"   envDefault:"uploads"`
-	UploadS3Endpoint string `env:"UPLOAD_S3_ENDPOINT"` // e.g. https://mybucket.s3.amazonaws.com
+	UploadStorageDir      string `env:"UPLOAD_STORAGE_DIR"      envDefault:".data/uploads"`
+	UploadS3Bucket        string `env:"UPLOAD_S3_BUCKET"`
+	UploadS3Prefix        string `env:"UPLOAD_S3_PREFIX"        envDefault:"uploads"`
+	UploadS3Endpoint      string `env:"UPLOAD_S3_ENDPOINT"`      // e.g. https://mybucket.s3.amazonaws.com
+	UploadS3Region        string `env:"UPLOAD_S3_REGION"        envDefault:"us-east-1"`
+	UploadMaxAge          time.Duration `env:"UPLOAD_MAX_AGE"    envDefault:"2160h"` // 90 days
 
 	// Interactive session snapshots
 	SnapshotStorageDir    string        `env:"SNAPSHOT_STORAGE_DIR"    envDefault:".data/snapshots"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,12 @@ type Config struct {
 	DataRetentionLogsDays    int `env:"DATA_RETENTION_LOGS_DAYS"    envDefault:"90"`
 	DataRetentionJobsDays    int `env:"DATA_RETENTION_JOBS_DAYS"    envDefault:"30"`
 
+	// Upload storage (images/files attached to session messages)
+	UploadStorageDir string `env:"UPLOAD_STORAGE_DIR" envDefault:".data/uploads"`
+	UploadS3Bucket   string `env:"UPLOAD_S3_BUCKET"`
+	UploadS3Prefix   string `env:"UPLOAD_S3_PREFIX"   envDefault:"uploads"`
+	UploadS3Endpoint string `env:"UPLOAD_S3_ENDPOINT"` // e.g. https://mybucket.s3.amazonaws.com
+
 	// Interactive session snapshots
 	SnapshotStorageDir    string        `env:"SNAPSHOT_STORAGE_DIR"    envDefault:".data/snapshots"`
 	SessionMaxIdleAge     time.Duration `env:"SESSION_MAX_IDLE_AGE"    envDefault:"2h"`

--- a/internal/services/storage/upload_reaper.go
+++ b/internal/services/storage/upload_reaper.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -119,18 +118,4 @@ func (r *UploadReaper) cleanEmptyDirs(baseDir string) {
 			}
 		}
 	}
-}
-
-// S3LifecycleHint returns a suggested S3 lifecycle configuration XML
-// for the given prefix and max age.
-func S3LifecycleHint(prefix string, maxAge time.Duration) string {
-	days := int(maxAge.Hours() / 24)
-	if days < 1 {
-		days = 1
-	}
-	return fmt.Sprintf(`Suggested S3 lifecycle rule for upload cleanup:
-  Prefix: %s/
-  Expiration: %d days
-Configure this via the S3 console or aws cli:
-  aws s3api put-bucket-lifecycle-configuration --bucket YOUR_BUCKET --lifecycle-configuration ...`, prefix, days)
 }

--- a/internal/services/storage/upload_reaper.go
+++ b/internal/services/storage/upload_reaper.go
@@ -1,0 +1,136 @@
+package storage
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// UploadReaper periodically cleans up old uploaded files that are past their
+// max age. For FileUploadStore it walks the local directory; for S3UploadStore
+// the reaper is a no-op (use S3 lifecycle rules instead).
+type UploadReaper struct {
+	store    UploadStore
+	maxAge   time.Duration
+	interval time.Duration
+	logger   zerolog.Logger
+}
+
+// NewUploadReaper creates a reaper that runs every interval and deletes
+// uploads older than maxAge.
+func NewUploadReaper(store UploadStore, maxAge, interval time.Duration, logger zerolog.Logger) *UploadReaper {
+	return &UploadReaper{
+		store:    store,
+		maxAge:   maxAge,
+		interval: interval,
+		logger:   logger,
+	}
+}
+
+// Run starts the reaper loop. It blocks until ctx is cancelled.
+func (r *UploadReaper) Run(ctx context.Context) {
+	fileStore, ok := r.store.(*FileUploadStore)
+	if !ok {
+		r.logger.Info().Msg("upload reaper: S3 mode — use S3 lifecycle rules for cleanup; reaper disabled")
+		return
+	}
+
+	ticker := time.NewTicker(r.interval)
+	defer ticker.Stop()
+
+	r.logger.Info().
+		Dur("interval", r.interval).
+		Dur("max_age", r.maxAge).
+		Msg("upload reaper started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Info().Msg("upload reaper stopped")
+			return
+		case <-ticker.C:
+			r.reapFiles(ctx, fileStore)
+		}
+	}
+}
+
+func (r *UploadReaper) reapFiles(_ context.Context, store *FileUploadStore) {
+	cutoff := time.Now().Add(-r.maxAge)
+	var deleted, errors int
+
+	err := filepath.Walk(store.baseDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if info.ModTime().Before(cutoff) {
+			if removeErr := os.Remove(path); removeErr != nil {
+				r.logger.Warn().Err(removeErr).Str("path", path).Msg("upload reaper: failed to delete file")
+				errors++
+			} else {
+				deleted++
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		r.logger.Error().Err(err).Msg("upload reaper: failed to walk upload directory")
+		return
+	}
+
+	if deleted > 0 || errors > 0 {
+		r.logger.Info().Int("deleted", deleted).Int("errors", errors).Msg("upload reaper: cleanup complete")
+	}
+
+	// Clean up empty directories left behind after file deletion.
+	r.cleanEmptyDirs(store.baseDir)
+}
+
+// cleanEmptyDirs removes empty directories under baseDir (bottom-up).
+func (r *UploadReaper) cleanEmptyDirs(baseDir string) {
+	// Walk in reverse order (deepest first) to handle nested empties.
+	var dirs []string
+	_ = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && path != baseDir {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+
+	// Remove in reverse (deepest first).
+	for i := len(dirs) - 1; i >= 0; i-- {
+		entries, err := os.ReadDir(dirs[i])
+		if err != nil {
+			continue
+		}
+		if len(entries) == 0 {
+			if err := os.Remove(dirs[i]); err != nil {
+				r.logger.Warn().Err(err).Str("dir", dirs[i]).Msg("upload reaper: failed to remove empty dir")
+			}
+		}
+	}
+}
+
+// S3LifecycleHint returns a suggested S3 lifecycle configuration XML
+// for the given prefix and max age.
+func S3LifecycleHint(prefix string, maxAge time.Duration) string {
+	days := int(maxAge.Hours() / 24)
+	if days < 1 {
+		days = 1
+	}
+	return fmt.Sprintf(`Suggested S3 lifecycle rule for upload cleanup:
+  Prefix: %s/
+  Expiration: %d days
+Configure this via the S3 console or aws cli:
+  aws s3api put-bucket-lifecycle-configuration --bucket YOUR_BUCKET --lifecycle-configuration ...`, prefix, days)
+}

--- a/internal/services/storage/upload_reaper_test.go
+++ b/internal/services/storage/upload_reaper_test.go
@@ -1,0 +1,97 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadReaper_ReapsOldFiles(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store := NewFileUploadStore(baseDir, "/uploads")
+
+	// Create an old file (backdate mod time).
+	oldDir := filepath.Join(baseDir, "org-1", "2025-01")
+	require.NoError(t, os.MkdirAll(oldDir, 0o750))
+	oldFile := filepath.Join(oldDir, "old-file.png")
+	require.NoError(t, os.WriteFile(oldFile, []byte("old"), 0o600))
+	oldTime := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(oldFile, oldTime, oldTime))
+
+	// Create a recent file.
+	newDir := filepath.Join(baseDir, "org-1", "2026-03")
+	require.NoError(t, os.MkdirAll(newDir, 0o750))
+	newFile := filepath.Join(newDir, "new-file.png")
+	require.NoError(t, os.WriteFile(newFile, []byte("new"), 0o600))
+
+	logger := zerolog.Nop()
+	reaper := NewUploadReaper(store, 24*time.Hour, time.Minute, logger)
+
+	// Run reap directly.
+	reaper.reapFiles(context.Background(), store)
+
+	// Old file should be deleted.
+	_, err := os.Stat(oldFile)
+	require.True(t, os.IsNotExist(err), "old file should be deleted")
+
+	// New file should still exist.
+	_, err = os.Stat(newFile)
+	require.NoError(t, err, "new file should still exist")
+}
+
+func TestUploadReaper_CleansEmptyDirs(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store := NewFileUploadStore(baseDir, "/uploads")
+
+	// Create a nested directory structure with an old file.
+	dir := filepath.Join(baseDir, "org-1", "2025-01")
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	f := filepath.Join(dir, "file.png")
+	require.NoError(t, os.WriteFile(f, []byte("x"), 0o600))
+	oldTime := time.Now().Add(-48 * time.Hour)
+	require.NoError(t, os.Chtimes(f, oldTime, oldTime))
+
+	logger := zerolog.Nop()
+	reaper := NewUploadReaper(store, 24*time.Hour, time.Minute, logger)
+
+	reaper.reapFiles(context.Background(), store)
+
+	// Both the file and empty parent dirs should be cleaned up.
+	_, err := os.Stat(dir)
+	require.True(t, os.IsNotExist(err), "empty directory should be cleaned up")
+}
+
+func TestUploadReaper_S3ModeNoop(t *testing.T) {
+	t.Parallel()
+
+	// S3UploadStore should cause the reaper to exit immediately.
+	s3Store := NewS3UploadStore(nil, "bucket", "prefix", "https://example.com")
+	logger := zerolog.Nop()
+	reaper := NewUploadReaper(s3Store, 24*time.Hour, time.Minute, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// Run should return immediately for S3 mode (not block).
+	done := make(chan struct{})
+	go func() {
+		reaper.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Expected: Run exits immediately for S3 mode.
+	case <-time.After(2 * time.Second):
+		t.Fatal("UploadReaper.Run should return immediately in S3 mode")
+	}
+}

--- a/internal/services/storage/uploads.go
+++ b/internal/services/storage/uploads.go
@@ -1,0 +1,116 @@
+// Package storage provides UploadStore for persisting user-uploaded files
+// (images, documents) to an object store for display in session chat.
+package storage
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// UploadStore abstracts persistence for user-uploaded files (images, etc.).
+type UploadStore interface {
+	// Save stores a file and returns the public URL to access it.
+	Save(ctx context.Context, key string, reader io.Reader, contentType string) (url string, err error)
+
+	// URL returns the public URL for a previously-uploaded file.
+	URL(key string) string
+}
+
+// S3UploadStore stores uploads in an S3-compatible bucket.
+type S3UploadStore struct {
+	client   S3Client
+	bucket   string
+	prefix   string
+	endpoint string // base URL for constructing public URLs
+}
+
+// NewS3UploadStore creates an S3UploadStore.
+// endpoint is the base URL for the bucket (e.g. "https://mybucket.s3.amazonaws.com").
+func NewS3UploadStore(client S3Client, bucket, prefix, endpoint string) *S3UploadStore {
+	return &S3UploadStore{
+		client:   client,
+		bucket:   bucket,
+		prefix:   strings.TrimSuffix(prefix, "/"),
+		endpoint: strings.TrimSuffix(endpoint, "/"),
+	}
+}
+
+func (s *S3UploadStore) fullKey(key string) string {
+	if s.prefix == "" {
+		return key
+	}
+	return s.prefix + "/" + key
+}
+
+func (s *S3UploadStore) Save(ctx context.Context, key string, reader io.Reader, contentType string) (string, error) {
+	fullKey := s.fullKey(key)
+	input := &s3.PutObjectInput{
+		Bucket:               aws.String(s.bucket),
+		Key:                  aws.String(fullKey),
+		Body:                 reader,
+		ServerSideEncryption: s3types.ServerSideEncryptionAes256,
+	}
+	if contentType != "" {
+		input.ContentType = aws.String(contentType)
+	}
+	if _, err := s.client.PutObject(ctx, input); err != nil {
+		return "", fmt.Errorf("upload file %s: %w", fullKey, err)
+	}
+	return s.URL(key), nil
+}
+
+func (s *S3UploadStore) URL(key string) string {
+	return s.endpoint + "/" + s.fullKey(key)
+}
+
+// FileUploadStore stores uploads on the local filesystem and serves them
+// via a configurable base URL. Used for development when S3 is not configured.
+type FileUploadStore struct {
+	baseDir string
+	baseURL string // e.g. "/api/v1/uploads/files"
+}
+
+// NewFileUploadStore creates a local filesystem upload store.
+func NewFileUploadStore(baseDir, baseURL string) *FileUploadStore {
+	return &FileUploadStore{
+		baseDir: baseDir,
+		baseURL: strings.TrimSuffix(baseURL, "/"),
+	}
+}
+
+func (f *FileUploadStore) Save(ctx context.Context, key string, reader io.Reader, _ string) (string, error) {
+	path := filepath.Join(f.baseDir, filepath.Clean(key))
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return "", fmt.Errorf("create upload dir: %w", err)
+	}
+
+	file, err := os.Create(path) // #nosec G304 -- path is sanitized
+	if err != nil {
+		return "", fmt.Errorf("create upload file: %w", err)
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, reader); err != nil {
+		return "", fmt.Errorf("write upload file: %w", err)
+	}
+	return f.URL(key), ctx.Err()
+}
+
+func (f *FileUploadStore) URL(key string) string {
+	return f.baseURL + "/" + key
+}
+
+// ServeFile serves a locally-stored upload file. Only used with FileUploadStore.
+func (f *FileUploadStore) ServeFile(w http.ResponseWriter, r *http.Request, key string) {
+	path := filepath.Join(f.baseDir, filepath.Clean(key))
+	http.ServeFile(w, r, path)
+}

--- a/internal/services/storage/uploads_test.go
+++ b/internal/services/storage/uploads_test.go
@@ -1,0 +1,81 @@
+package storage
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileUploadStore_SaveAndURL(t *testing.T) {
+	t.Parallel()
+
+	baseDir := t.TempDir()
+	store := NewFileUploadStore(baseDir, "/api/v1/uploads/files")
+	ctx := context.Background()
+	key := "org-1/2026-03/test-file.png"
+	payload := []byte("fake-image-data")
+
+	url, err := store.Save(ctx, key, bytes.NewReader(payload), "image/png")
+	require.NoError(t, err, "Save should succeed")
+	require.Equal(t, "/api/v1/uploads/files/"+key, url, "Save should return the correct URL")
+
+	// Verify file on disk.
+	data, err := os.ReadFile(filepath.Join(baseDir, key))
+	require.NoError(t, err, "file should exist on disk")
+	require.Equal(t, payload, data, "file content should match")
+}
+
+func TestFileUploadStore_URL(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileUploadStore("/tmp/uploads", "/api/v1/uploads/files")
+	require.Equal(t, "/api/v1/uploads/files/org-1/file.png", store.URL("org-1/file.png"))
+}
+
+func TestFileUploadStore_SaveMkdirFails(t *testing.T) {
+	t.Parallel()
+
+	// Use a file as base dir so MkdirAll fails.
+	tmp := t.TempDir()
+	filePath := filepath.Join(tmp, "not-a-dir")
+	require.NoError(t, os.WriteFile(filePath, []byte("x"), 0o600))
+
+	store := NewFileUploadStore(filePath, "/uploads")
+	_, err := store.Save(context.Background(), "sub/key.png", bytes.NewReader([]byte("data")), "image/png")
+	require.Error(t, err, "Save should fail when MkdirAll fails")
+	require.Contains(t, err.Error(), "create upload dir")
+}
+
+func TestFileUploadStore_TrailingSlashTrimmed(t *testing.T) {
+	t.Parallel()
+
+	store := NewFileUploadStore("/tmp/uploads", "/api/v1/uploads/files/")
+	require.Equal(t, "/api/v1/uploads/files/key.png", store.URL("key.png"),
+		"trailing slash on baseURL should be trimmed")
+}
+
+func TestS3UploadStore_URL(t *testing.T) {
+	t.Parallel()
+
+	store := NewS3UploadStore(nil, "mybucket", "uploads", "https://mybucket.s3.amazonaws.com")
+	require.Equal(t, "https://mybucket.s3.amazonaws.com/uploads/org-1/file.png", store.URL("org-1/file.png"))
+}
+
+func TestS3UploadStore_URL_NoPrefix(t *testing.T) {
+	t.Parallel()
+
+	store := NewS3UploadStore(nil, "mybucket", "", "https://mybucket.s3.amazonaws.com")
+	require.Equal(t, "https://mybucket.s3.amazonaws.com/org-1/file.png", store.URL("org-1/file.png"))
+}
+
+func TestS3UploadStore_EndpointTrailingSlashTrimmed(t *testing.T) {
+	t.Parallel()
+
+	store := NewS3UploadStore(nil, "mybucket", "uploads", "https://mybucket.s3.amazonaws.com/")
+	require.Equal(t, "https://mybucket.s3.amazonaws.com/uploads/file.png", store.URL("file.png"),
+		"trailing slash on endpoint should be trimmed")
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive file upload functionality to the application, allowing users to attach images and documents to session messages. Uploads are persisted to either S3 or local filesystem storage, with automatic cleanup of old files via a background reaper process.

## Key Changes

**Backend Upload Handler & Storage**
- New `UploadHandler` in `internal/api/handlers/uploads.go` that validates and persists uploaded files
  - Enforces 10 MB file size limit
  - Validates MIME types (images, PDFs, text, JSON, CSV)
  - Generates unique keys with org ID and date-based organization
- New `UploadStore` interface with two implementations:
  - `S3UploadStore`: Stores files in S3-compatible buckets with configurable prefix and endpoint
  - `FileUploadStore`: Stores files locally for development, serves via HTTP endpoint
- `UploadReaper` background service that periodically cleans up old uploaded files
  - For local storage: walks directory tree and deletes files older than configured max age
  - For S3: provides guidance to use S3 lifecycle rules instead

**API Integration**
- New `/api/v1/uploads` POST endpoint for file uploads
- New `/api/v1/uploads/files/*` GET endpoint for serving local uploads
- Updated `SendMessage` endpoint to accept `images` field (array of attachment URLs)
- Updated `CreateManual` endpoint to persist initial user message with attachments as turn-0 record

**Frontend Upload UI**
- File upload button in chat input with attachment preview grid
- Image thumbnails with lightbox overlay (click to expand, ESC to close)
- File attachments shown as downloadable links with icons
- Upload progress indicator and error handling
- Attachment removal with hover-activated delete button
- Support for both new server-side uploads and existing data URLs

**Configuration**
- New config options: `UPLOAD_STORAGE_DIR`, `UPLOAD_S3_BUCKET`, `UPLOAD_S3_REGION`, `UPLOAD_S3_PREFIX`, `UPLOAD_S3_ENDPOINT`
- Automatic fallback to local filesystem if S3 config is incomplete
- Configurable upload reaper interval and max age

## Notable Implementation Details
- Multipart form parsing with size validation before full file read
- MIME type normalization (strips charset parameters)
- Automatic file extension inference from MIME type when filename lacks extension
- Org-based storage hierarchy: `{orgId}/{YYYY-MM}/{uuid}.{ext}`
- Path traversal protection via `filepath.Clean()` in file serving
- Graceful degradation: upload handler returns 501 if store is nil
- Session messages now support optional attachments field for display in chat timeline

https://claude.ai/code/session_01FDvTMStX3duXsaGLvEhDyw