### PR TITLE
Refactor session user filter UI with collapsible search and toggle

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen } from '@/test/test-utils';
+import { fireEvent } from '@testing-library/react';
 import { server } from '@/test/mocks/server';
 import { SessionSidebar } from './session-sidebar';
 
@@ -85,9 +86,9 @@ describe('SessionSidebar', () => {
     await screen.findByText('Fixed TypeError by adding null check');
 
     // Search is collapsed behind an icon button — click to expand
-    screen.getByRole('button', { name: 'Search sessions' }).click();
+    fireEvent.click(screen.getByRole('button', { name: 'Search sessions' }));
 
-    expect(screen.getByPlaceholderText('Search sessions...')).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText('Search sessions...')).toBeInTheDocument();
   });
 
   it('shows ghost New session entry when on /sessions/new', async () => {

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -84,6 +84,14 @@ describe('SessionSidebar', () => {
 
     await screen.findByText('Fixed TypeError by adding null check');
 
+    // Search is collapsed behind an icon button — click to expand
+    const buttons = screen.getAllByRole('button');
+    const searchToggle = buttons.find(
+      (btn) => btn.querySelector('svg.lucide-search'),
+    );
+    expect(searchToggle).toBeTruthy();
+    searchToggle!.click();
+
     expect(screen.getByPlaceholderText('Search sessions...')).toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -85,12 +85,7 @@ describe('SessionSidebar', () => {
     await screen.findByText('Fixed TypeError by adding null check');
 
     // Search is collapsed behind an icon button — click to expand
-    const buttons = screen.getAllByRole('button');
-    const searchToggle = buttons.find(
-      (btn) => btn.querySelector('svg.lucide-search'),
-    );
-    expect(searchToggle).toBeTruthy();
-    searchToggle!.click();
+    screen.getByRole('button', { name: 'Search sessions' }).click();
 
     expect(screen.getByPlaceholderText('Search sessions...')).toBeInTheDocument();
   });

--- a/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { UserFilterParam } from "@/hooks/use-session-user-filter";
+
+interface SessionOwnerToggleProps {
+  currentUserFilter: string;
+  onFilterChange: (value: UserFilterParam) => void;
+  className?: string;
+}
+
+const options = [
+  { label: "Everyone", value: "all" },
+  { label: "Mine", value: "mine" },
+] as const;
+
+export function SessionOwnerToggle({
+  currentUserFilter,
+  onFilterChange,
+  className,
+}: SessionOwnerToggleProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-md bg-muted/60 p-0.5",
+        className,
+      )}
+    >
+      {options.map((opt) => {
+        const isActive = currentUserFilter === opt.value;
+        return (
+          <button
+            key={opt.value}
+            onClick={() => onFilterChange(opt.value === "all" ? null : "mine")}
+            className={cn(
+              "px-2.5 py-1 text-[11px] font-medium rounded-[5px] transition-all duration-150",
+              isActive
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground/80",
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -195,6 +195,7 @@ export function SessionSidebar() {
           ) : (
             <>
               <button
+                aria-label="Search sessions"
                 onClick={() => {
                   setSearchOpen(true);
                   requestAnimationFrame(() => searchInputRef.current?.focus());

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Plus, Search } from "lucide-react";
+import { Plus, Search, X } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
-import { SessionUserFilterDropdown } from "./session-user-filter-dropdown";
+import { SessionOwnerToggle } from "./session-owner-toggle";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
@@ -110,6 +110,8 @@ export function SessionSidebar() {
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
 
@@ -135,13 +137,7 @@ export function SessionSidebar() {
     enabled: !!statusParam,
   });
 
-  const { data: membersData } = useQuery({
-    queryKey: ["team", "members"],
-    queryFn: () => api.team.listMembers(),
-  });
-
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);
-  const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);
 
   const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
@@ -165,38 +161,65 @@ export function SessionSidebar() {
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
       {/* Header */}
-      <div className="px-4 pt-3 pb-2 space-y-3">
+      <div className="px-4 pt-3 pb-2 space-y-2.5">
 
-        {/* Search */}
-        <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
-          <input
-            type="text"
-            placeholder="Search sessions..."
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            className="w-full h-8 pl-8 pr-3 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-          />
+        {/* Row 1: Search icon + Owner toggle (or expanded search input) */}
+        <div className="flex items-center gap-2">
+          {searchOpen ? (
+            <div className="relative flex-1">
+              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
+              <input
+                ref={searchInputRef}
+                type="text"
+                placeholder="Search sessions..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onBlur={() => {
+                  if (!search.trim()) setSearchOpen(false);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    setSearch("");
+                    setSearchOpen(false);
+                  }
+                }}
+                className="w-full h-8 pl-8 pr-8 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+              />
+              <button
+                onClick={() => { setSearch(""); setSearchOpen(false); }}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          ) : (
+            <>
+              <button
+                onClick={() => {
+                  setSearchOpen(true);
+                  requestAnimationFrame(() => searchInputRef.current?.focus());
+                }}
+                className="flex items-center justify-center h-8 w-8 rounded-md border border-border bg-background hover:bg-accent transition-colors shrink-0"
+              >
+                <Search className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+              <SessionOwnerToggle
+                currentUserFilter={currentUserFilter}
+                onFilterChange={setUserFilter}
+                className="flex-1"
+              />
+            </>
+          )}
         </div>
 
         {/* New session button */}
         <Link
           href="/sessions/new"
-          className="flex items-center justify-center gap-2 w-full h-9 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
+          className="flex items-center justify-center gap-2 w-full h-8 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
         >
-          <Plus className="h-4 w-4" />
+          <Plus className="h-3.5 w-3.5" />
           New session
         </Link>
-
-        {/* User filter dropdown */}
-        <SessionUserFilterDropdown
-          currentUserFilter={currentUserFilter}
-          members={members}
-          currentUser={user}
-          onFilterChange={setUserFilter}
-          align="start"
-          className="w-full justify-between"
-        />
 
         {/* Filter tabs */}
         <Tabs

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -31,7 +31,7 @@ import { api } from "@/lib/api";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
-import { SessionUserFilterDropdown } from "./session-user-filter-dropdown";
+import { SessionOwnerToggle } from "./session-owner-toggle";
 import type { Session, User } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
@@ -314,13 +314,10 @@ export function SessionsPageContent() {
           })}
         </div>
 
-        {/* User filter dropdown */}
-        <SessionUserFilterDropdown
+        {/* User filter toggle */}
+        <SessionOwnerToggle
           currentUserFilter={currentUserFilter}
-          members={members}
-          currentUser={user}
           onFilterChange={setUserFilter}
-          align="end"
           className="mr-2"
         />
       </div>

--- a/frontend/src/hooks/use-session-user-filter.ts
+++ b/frontend/src/hooks/use-session-user-filter.ts
@@ -11,7 +11,7 @@ import type { User } from "@/lib/types";
 /** Well-known user filter presets. Any other string value is a specific user ID. */
 export type UserFilterPreset = "mine" | "all";
 
-/** The resolved value stored in the URL query param. `null` means "mine" (default). */
+/** The resolved value stored in the URL query param. `null` means "all" (default). */
 export type UserFilterParam = string | null;
 
 // ---------------------------------------------------------------------------
@@ -20,10 +20,10 @@ export type UserFilterParam = string | null;
 
 /**
  * Resolve the URL-level filter value to the effective filter key.
- * `null` (no param) → "mine".
+ * `null` (no param) → "all".
  */
 export function resolveUserFilter(param: string | null): UserFilterPreset | string {
-  return param ?? "mine";
+  return param ?? "all";
 }
 
 /**
@@ -85,7 +85,7 @@ export function useSessionUserFilter() {
     triggeredByUserId,
     /** The current authenticated user. */
     user,
-    /** Set the user filter. Pass `null` for "mine", `"all"` for everyone, or a user ID. */
+    /** Set the user filter. Pass `null` for "all" (default), `"mine"` for own sessions, or a user ID. */
     setUserFilter,
   };
 }


### PR DESCRIPTION
## Summary
Redesigned the session sidebar header to use a collapsible search input and replaced the dropdown-based user filter with a simple toggle between "Everyone" and "Mine" views. This simplifies the UI and improves the layout efficiency of the sidebar header.

## Key Changes
- **New `SessionOwnerToggle` component**: Replaces `SessionUserFilterDropdown` with a compact toggle button group offering "Everyone" and "Mine" filter options
- **Collapsible search input**: Search icon becomes a clickable button that expands into a full search input when activated, with support for Escape key and blur-to-close behavior
- **Removed team members query**: Eliminated the `useQuery` call for fetching team members since the new toggle doesn't need the full member list
- **Updated default filter behavior**: Changed the default filter from "mine" to "all" (when no URL param is present)
- **Simplified header layout**: Reorganized the sidebar header to display search button + owner toggle on one row, followed by the "New session" button
- **Updated both sidebar and main page**: Applied the new `SessionOwnerToggle` component to both the session sidebar and sessions page content areas
- **Minor styling adjustments**: Reduced button heights (9px → 8px) and icon sizes for better visual consistency

## Implementation Details
- Search input uses `useRef` to manage focus when expanding
- Search state persists while open but clears when closing via Escape or the X button
- The toggle component is responsive and can fill available space with the `className` prop
- Updated hook documentation to reflect the new default filter behavior

https://claude.ai/code/session_01N6wLasV8mKdnea5Gcr4r3r