### PR TITLE
Fix horizontal scroll layout in file diff section

### DIFF
--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -142,13 +142,14 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
     }), [file.newPath, commentsByLine, activeCommentLine, onAddComment, handleAddComment, onSubmitComment, onCancelComment, onUpdateComment, onDeleteComment]);
 
     return (
-      <div ref={ref} className="border border-border rounded-lg overflow-x-auto">
+      <div ref={ref} className="border border-border rounded-lg">
         <FileDiffHeader
           filePath={file.newPath}
           added={file.stats.added}
           removed={file.stats.removed}
           onBrowseFile={onBrowseFile}
         />
+        <div className="overflow-x-auto">
         {file.hunks.map((hunk, i) => {
           const hunkEl =
             viewMode === "split" ? (
@@ -207,6 +208,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
             </div>
           );
         })}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
Restructured the overflow handling in the FileDiffSection component to prevent the header from being included in the horizontal scroll area.

## Key Changes
- Moved `overflow-x-auto` class from the outer container div to a new inner wrapper div that contains only the diff hunks
- The FileDiffHeader now remains fixed and is not affected by horizontal scrolling
- Maintains the border and rounded corners on the outer container while allowing only the diff content to scroll horizontally

## Implementation Details
The change wraps the hunk rendering logic in a new `<div className="overflow-x-auto">` container, ensuring that:
- The file diff header stays visible and doesn't scroll with the content
- Only the actual diff hunks are scrollable when content exceeds the viewport width
- The visual styling (border, rounded corners) remains applied to the entire section

https://claude.ai/code/session_012sNweLbixrXL3HuhYH3sng