### PR TITLE
Fix header-to-scroll spacing in sidebars to prevent content overlap

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -58,6 +58,8 @@ The base font size is `text-[13px]` (set globally). Use these specific sizes:
 | Form field groups (label → input → hint) | `space-y-2` |
 | Filter tabs gap | `gap-1` |
 | Button groups | `gap-3` |
+| Sidebar/panel header padding | `px-4 pt-3 pb-3` — minimum `pb-3` (12px) bottom padding to prevent scrollable content from overlapping with the last header element (e.g., filter tabs, buttons) |
+| Gap between fixed header and scrollable list | Always ensure at least 12px (`pb-3`) of bottom padding on the fixed header container so interactive elements (tabs, buttons) are fully visible and not clipped by the scroll area |
 
 ### Border Radius
 
@@ -426,3 +428,4 @@ Use the `tags` parameter to add searchable context (feature name, endpoint, comp
 8. **Missing dark mode** — Banners/alerts using hardcoded Tailwind colors (e.g., `bg-blue-50`, `border-green-200`) need `dark:` variant classes. Semantic tokens (`bg-destructive/10`, `bg-primary/10`) adapt automatically.
 9. **Flat cards** — Cards should always have `shadow-sm` (provided by the Card component). Don't override with `shadow-none`.
 10. **Missing transitions** — Interactive elements (radio cards, buttons, rows) need `transition-all duration-150`.
+11. **Insufficient header-to-scroll-area spacing** — Fixed header sections above scrollable content must have at least `pb-3` (12px) bottom padding. Using `pb-2` or less causes the scroll area to overlap with the last header element (e.g., filter tabs, buttons), clipping their bottom border or active indicator.

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -79,7 +79,7 @@ export function ProjectSidebar() {
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
       {/* Header */}
-      <div className="px-4 pt-3 pb-2 space-y-3">
+      <div className="px-4 pt-3 pb-3 space-y-3">
 
         {/* Search */}
         <div className="relative">

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -161,7 +161,7 @@ export function SessionSidebar() {
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
       {/* Header */}
-      <div className="px-4 pt-3 pb-2 space-y-2.5">
+      <div className="px-4 pt-3 pb-3 space-y-2.5">
 
         {/* Row 1: Search icon + Owner toggle (or expanded search input) */}
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
Updated sidebar header bottom padding from `pb-2` to `pb-3` to ensure proper spacing between fixed header sections and scrollable content, preventing interactive elements from being clipped by the scroll area.

## Changes
- **project-sidebar.tsx**: Changed header padding from `pb-2` to `pb-3` (12px bottom padding)
- **session-sidebar.tsx**: Changed header padding from `pb-2` to `pb-3` (12px bottom padding)
- **AGENTS.md**: Added documentation clarifying the spacing requirement and common pitfall to avoid

## Details
The minimum `pb-3` (12px) bottom padding on fixed header containers ensures that scrollable content below doesn't overlap with interactive elements like filter tabs or buttons. Using `pb-2` or less causes the scroll area to clip the bottom borders or active indicators of these elements, creating a visual defect.

This aligns with the established spacing guidelines for sidebar/panel headers documented in the design system.

https://claude.ai/code/session_01VwheNST4NfhFQgheHkfZHS