### PR TITLE
Add ToggleGroup component and refactor session sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen } from '@/test/test-utils';
-import { fireEvent } from '@testing-library/react';
+
 import { server } from '@/test/mocks/server';
 import { SessionSidebar } from './session-sidebar';
 
@@ -85,10 +85,8 @@ describe('SessionSidebar', () => {
 
     await screen.findByText('Fixed TypeError by adding null check');
 
-    // Search is collapsed behind an icon button — click to expand
-    fireEvent.click(screen.getByRole('button', { name: 'Search sessions' }));
-
-    expect(await screen.findByPlaceholderText('Search sessions...')).toBeInTheDocument();
+    // Search input is always visible
+    expect(screen.getByPlaceholderText('Search sessions...')).toBeInTheDocument();
   });
 
   it('shows ghost New session entry when on /sessions/new', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { UserFilterParam } from "@/hooks/use-session-user-filter";
 
 interface SessionOwnerToggleProps {
@@ -9,40 +10,24 @@ interface SessionOwnerToggleProps {
   className?: string;
 }
 
-const options = [
-  { label: "Everyone", value: "all" },
-  { label: "Mine", value: "mine" },
-] as const;
-
 export function SessionOwnerToggle({
   currentUserFilter,
   onFilterChange,
   className,
 }: SessionOwnerToggleProps) {
   return (
-    <div
-      className={cn(
-        "inline-flex items-center rounded-md bg-muted/60 p-0.5",
-        className,
-      )}
+    <ToggleGroup
+      type="single"
+      size="sm"
+      value={currentUserFilter}
+      onValueChange={(value: string) => {
+        if (!value) return; // prevent deselecting
+        onFilterChange(value === "all" ? null : "mine");
+      }}
+      className={cn(className)}
     >
-      {options.map((opt) => {
-        const isActive = currentUserFilter === opt.value;
-        return (
-          <button
-            key={opt.value}
-            onClick={() => onFilterChange(opt.value === "all" ? null : "mine")}
-            className={cn(
-              "px-2.5 py-1 text-[11px] font-medium rounded-[5px] transition-all duration-150",
-              isActive
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground/80",
-            )}
-          >
-            {opt.label}
-          </button>
-        );
-      })}
-    </div>
+      <ToggleGroupItem value="all">Everyone</ToggleGroupItem>
+      <ToggleGroupItem value="mine">Mine</ToggleGroupItem>
+    </ToggleGroup>
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { UserFilterParam } from "@/hooks/use-session-user-filter";
 
@@ -24,7 +23,7 @@ export function SessionOwnerToggle({
         if (!value) return; // prevent deselecting
         onFilterChange(value === "all" ? null : "mine");
       }}
-      className={cn(className)}
+      className={className}
     >
       <ToggleGroupItem value="all">Everyone</ToggleGroupItem>
       <ToggleGroupItem value="mine">Mine</ToggleGroupItem>

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -4,7 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
@@ -110,7 +110,7 @@ export function SessionSidebar() {
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
-  const searchInputRef = useRef<HTMLInputElement>(null);
+
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
 
@@ -167,7 +167,6 @@ export function SessionSidebar() {
           <div className="relative flex-1 min-w-0">
             <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
             <input
-              ref={searchInputRef}
               type="text"
               placeholder="Search sessions..."
               value={search}
@@ -175,7 +174,7 @@ export function SessionSidebar() {
               onKeyDown={(e) => {
                 if (e.key === "Escape") {
                   setSearch("");
-                  searchInputRef.current?.blur();
+                  e.currentTarget.blur();
                 }
               }}
               className="w-full h-7 pl-8 pr-2 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Plus, Search, X } from "lucide-react";
+import { Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useRef, useState } from "react";
@@ -110,7 +110,6 @@ export function SessionSidebar() {
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
-  const [searchOpen, setSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
@@ -163,54 +162,30 @@ export function SessionSidebar() {
       {/* Header */}
       <div className="px-4 pt-3 pb-2 space-y-2.5">
 
-        {/* Row 1: Search icon + Owner toggle (or expanded search input) */}
+        {/* Row 1: Search + Owner toggle */}
         <div className="flex items-center gap-2">
-          {searchOpen ? (
-            <div className="relative flex-1">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
-              <input
-                ref={searchInputRef}
-                type="text"
-                placeholder="Search sessions..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                onBlur={() => {
-                  if (!search.trim()) setSearchOpen(false);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    setSearch("");
-                    setSearchOpen(false);
-                  }
-                }}
-                className="w-full h-8 pl-8 pr-8 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
-              />
-              <button
-                onClick={() => { setSearch(""); setSearchOpen(false); }}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          ) : (
-            <>
-              <button
-                aria-label="Search sessions"
-                onClick={() => {
-                  setSearchOpen(true);
-                  requestAnimationFrame(() => searchInputRef.current?.focus());
-                }}
-                className="flex items-center justify-center h-8 w-8 rounded-md border border-border bg-background hover:bg-accent transition-colors shrink-0"
-              >
-                <Search className="h-3.5 w-3.5 text-muted-foreground" />
-              </button>
-              <SessionOwnerToggle
-                currentUserFilter={currentUserFilter}
-                onFilterChange={setUserFilter}
-                className="flex-1"
-              />
-            </>
-          )}
+          <div className="relative flex-1 min-w-0">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              placeholder="Search sessions..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") {
+                  setSearch("");
+                  searchInputRef.current?.blur();
+                }
+              }}
+              className="w-full h-7 pl-8 pr-2 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+          </div>
+          <SessionOwnerToggle
+            currentUserFilter={currentUserFilter}
+            onFilterChange={setUserFilter}
+            className="shrink-0"
+          />
         </div>
 
         {/* New session button */}

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -74,7 +74,7 @@ function ToggleGroupItem({
       data-slot="toggle-group-item"
       className={cn(
         toggleGroupItemVariants({ size }),
-        "text-muted-foreground hover:text-foreground/80 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
+        "text-muted-foreground hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import * as React from "react"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const toggleGroupVariants = cva(
+  "inline-flex items-center rounded-md bg-muted p-0.5",
+  {
+    variants: {
+      size: {
+        default: "h-8",
+        sm: "h-7",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+const toggleGroupItemVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-[5px] font-medium transition-all disabled:pointer-events-none disabled:opacity-50 cursor-pointer",
+  {
+    variants: {
+      size: {
+        default: "px-2.5 py-1 text-xs",
+        sm: "px-2 py-0.5 text-[11px]",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+type ToggleGroupContextValue = VariantProps<typeof toggleGroupItemVariants>
+
+const ToggleGroupContext = React.createContext<ToggleGroupContextValue>({
+  size: "default",
+})
+
+function ToggleGroup({
+  className,
+  size = "default",
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleGroupVariants>) {
+  return (
+    <ToggleGroupContext.Provider value={{ size }}>
+      <ToggleGroupPrimitive.Root
+        data-slot="toggle-group"
+        className={cn(toggleGroupVariants({ size }), className)}
+        {...props}
+      >
+        {children}
+      </ToggleGroupPrimitive.Root>
+    </ToggleGroupContext.Provider>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item>) {
+  const { size } = React.useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      className={cn(
+        toggleGroupItemVariants({ size }),
+        "text-muted-foreground hover:text-foreground/80 data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }


### PR DESCRIPTION
## Summary
This PR introduces a new `ToggleGroup` UI component and refactors the session sidebar to use it, while simplifying the search functionality.

## Key Changes

- **New Component**: Added `ToggleGroup` and `ToggleGroupItem` components in `frontend/src/components/ui/toggle-group.tsx`
  - Built on top of Radix UI's ToggleGroup primitive
  - Supports `default` and `sm` size variants
  - Includes proper styling for active/inactive states, focus rings, and disabled states
  - Uses context to pass size information to child items

- **Refactored SessionOwnerToggle**: Replaced custom button-based implementation with the new `ToggleGroup` component
  - Simplified from 40 lines to 24 lines
  - Now uses Radix UI's native toggle group functionality
  - Maintains the same "Everyone" / "Mine" filter behavior

- **Simplified Session Sidebar Search**: Removed toggle-based search UI
  - Search input is now always visible instead of expanding on click
  - Removed `searchOpen` state and `searchInputRef` ref
  - Cleaned up event handlers (removed focus management, simplified escape key handling)
  - Adjusted input height from `h-8` to `h-7` for consistency with new toggle group size

## Implementation Details

- The `ToggleGroup` component uses CVA (class-variance-authority) for variant management
- Context is used to propagate the `size` prop to child `ToggleGroupItem` components
- The toggle group prevents deselection by ignoring empty value changes
- Search input now uses `min-w-0` to properly handle flex layout with overflow

https://claude.ai/code/session_015HASMLggEBbPMvmwDkVJso