### PR TITLE
Move review comments submission to dedicated input component

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -48,6 +48,7 @@ import { AGENT_TYPE_OPTIONS } from "@/lib/model-constants";
 import { SSE_EVENT, addSSEListener } from "@/lib/sse";
 import { buildTimeline } from "@/lib/timeline";
 import { parseDiffStats, type DiffFile } from "@/lib/diff-parser";
+import { formatReviewMessage } from "@/lib/format-review-message";
 import type { Session, SessionLog, SessionMessage, SessionReviewComment, User, Validation } from "@/lib/types";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { ResizeHandle } from "@/components/resize-handle";
@@ -518,43 +519,6 @@ function ChangesTab({
 }
 
 // ---------------------------------------------------------------------------
-// Helper: extract diff hunk context around a commented line
-// Returns ~3 lines before and after, formatted as a mini diff snippet.
-// ---------------------------------------------------------------------------
-
-function getDiffHunkContext(
-  files: DiffFile[],
-  filePath: string,
-  lineNumber: number,
-  side: "old" | "new"
-): string | null {
-  const file = files.find((f) => f.newPath === filePath || f.oldPath === filePath);
-  if (!file) return null;
-
-  for (const hunk of file.hunks) {
-    // Find the target line's index within this hunk
-    const targetIdx = hunk.lines.findIndex((line) => {
-      const ln = side === "new" ? line.newLineNumber : line.oldLineNumber;
-      return ln === lineNumber;
-    });
-    if (targetIdx === -1) continue;
-
-    // Extract surrounding lines (up to 3 before, 3 after)
-    const start = Math.max(0, targetIdx - 3);
-    const end = Math.min(hunk.lines.length, targetIdx + 4);
-    const contextLines = hunk.lines.slice(start, end);
-
-    const formatted = contextLines.map((line) => {
-      const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
-      return `${prefix} ${line.content}`;
-    });
-
-    return formatted.join("\n");
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
 // Review comment input bar (shown at bottom during review mode)
 // ---------------------------------------------------------------------------
 
@@ -577,36 +541,8 @@ function ReviewCommentInput({
 
   const sendMutation = useMutation({
     mutationFn: () => {
-      const parts: string[] = [];
-
-      // Section 1: Inline comments (anchored to specific file:line with diff context)
-      if (openComments.length > 0) {
-        parts.push("Please address the following code review comments:\n");
-        openComments.forEach((c, i) => {
-          parts.push(`${i + 1}. **${c.file_path}:${c.line_number}** (${c.diff_side} side)`);
-          const hunk = getDiffHunkContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
-          if (hunk) {
-            parts.push("   ```");
-            hunk.split("\n").forEach((line) => parts.push(`   ${line}`));
-            parts.push("   ```");
-          }
-          const indented = c.body.replace(/\n/g, "\n   ");
-          parts.push(`   Comment: "${indented}"\n`);
-        });
-      }
-
-      // Section 2: General instructions (not tied to a specific line)
-      if (message.trim()) {
-        if (openComments.length > 0) {
-          parts.push("---\n");
-          parts.push("Additional instructions:\n");
-          parts.push(message.trim());
-        } else {
-          parts.push(message.trim());
-        }
-      }
-
-      return api.sessions.sendMessage(sessionId, parts.join("\n").trim());
+      const formatted = formatReviewMessage(openComments, diffFiles, message);
+      return api.sessions.sendMessage(sessionId, formatted);
     },
     onSuccess: () => {
       setMessage("");

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -519,10 +519,11 @@ function ChangesTab({
 }
 
 // ---------------------------------------------------------------------------
-// Helper: extract code context from diff for a given comment
+// Helper: extract diff hunk context around a commented line
+// Returns ~3 lines before and after, formatted as a mini diff snippet.
 // ---------------------------------------------------------------------------
 
-function getLineContext(
+function getDiffHunkContext(
   files: DiffFile[],
   filePath: string,
   lineNumber: number,
@@ -530,13 +531,26 @@ function getLineContext(
 ): string | null {
   const file = files.find((f) => f.newPath === filePath || f.oldPath === filePath);
   if (!file) return null;
+
   for (const hunk of file.hunks) {
-    for (const line of hunk.lines) {
+    // Find the target line's index within this hunk
+    const targetIdx = hunk.lines.findIndex((line) => {
       const ln = side === "new" ? line.newLineNumber : line.oldLineNumber;
-      if (ln === lineNumber) {
-        return line.content;
-      }
-    }
+      return ln === lineNumber;
+    });
+    if (targetIdx === -1) continue;
+
+    // Extract surrounding lines (up to 3 before, 3 after)
+    const start = Math.max(0, targetIdx - 3);
+    const end = Math.min(hunk.lines.length, targetIdx + 4);
+    const contextLines = hunk.lines.slice(start, end);
+
+    const formatted = contextLines.map((line) => {
+      const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
+      return `${prefix} ${line.content}`;
+    });
+
+    return formatted.join("\n");
   }
   return null;
 }
@@ -564,27 +578,36 @@ function ReviewCommentInput({
 
   const sendMutation = useMutation({
     mutationFn: () => {
-      let fullMessage = "";
+      const parts: string[] = [];
+
+      // Section 1: Inline comments (anchored to specific file:line with diff context)
       if (openComments.length > 0) {
-        fullMessage += "Please address the following code review comments:\n\n";
+        parts.push("Please address the following code review comments:\n");
         openComments.forEach((c, i) => {
-          fullMessage += `${i + 1}. ${c.file_path}:${c.line_number}\n`;
-          const ctx = getLineContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
-          if (ctx) {
-            fullMessage += `   Code: \`${ctx.trim()}\`\n`;
+          parts.push(`${i + 1}. **${c.file_path}:${c.line_number}** (${c.diff_side} side)`);
+          const hunk = getDiffHunkContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
+          if (hunk) {
+            parts.push("   ```");
+            hunk.split("\n").forEach((line) => parts.push(`   ${line}`));
+            parts.push("   ```");
           }
           const indented = c.body.replace(/\n/g, "\n   ");
-          fullMessage += `   "${indented}"\n\n`;
+          parts.push(`   Comment: "${indented}"\n`);
         });
       }
+
+      // Section 2: General instructions (not tied to a specific line)
       if (message.trim()) {
         if (openComments.length > 0) {
-          fullMessage += `Additional instructions: ${message.trim()}`;
+          parts.push("---\n");
+          parts.push("Additional instructions:\n");
+          parts.push(message.trim());
         } else {
-          fullMessage = message.trim();
+          parts.push(message.trim());
         }
       }
-      return api.sessions.sendMessage(sessionId, fullMessage.trim());
+
+      return api.sessions.sendMessage(sessionId, parts.join("\n").trim());
     },
     onSuccess: () => {
       setMessage("");

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -423,8 +423,6 @@ function ChangesTab({
   onToggleReviewed,
   comments,
   onCommentClick,
-  onSendToAgent,
-  isSendingComments,
   passes,
   passRange,
   onPassRangeChange,
@@ -439,8 +437,6 @@ function ChangesTab({
   onToggleReviewed: (filePath: string) => void;
   comments: SessionReviewComment[];
   onCommentClick: (filePath: string) => void;
-  onSendToAgent: () => void;
-  isSendingComments: boolean;
   passes: DiffPassEntry[];
   passRange: PassRange | null;
   onPassRangeChange: (range: PassRange | null) => void;
@@ -474,8 +470,6 @@ function ChangesTab({
         <CommentsSummary
           comments={comments}
           onCommentClick={onCommentClick}
-          onSendToAgent={onSendToAgent}
-          isSending={isSendingComments}
         />
       )}
 
@@ -518,6 +512,179 @@ function ChangesTab({
               {emptyStatusText}
             </p>
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helper: extract code context from diff for a given comment
+// ---------------------------------------------------------------------------
+
+function getLineContext(
+  files: DiffFile[],
+  filePath: string,
+  lineNumber: number,
+  side: "old" | "new"
+): string | null {
+  const file = files.find((f) => f.newPath === filePath || f.oldPath === filePath);
+  if (!file) return null;
+  for (const hunk of file.hunks) {
+    for (const line of hunk.lines) {
+      const ln = side === "new" ? line.newLineNumber : line.oldLineNumber;
+      if (ln === lineNumber) {
+        return line.content;
+      }
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Review comment input bar (shown at bottom during review mode)
+// ---------------------------------------------------------------------------
+
+function ReviewCommentInput({
+  sessionId,
+  comments,
+  diffFiles,
+  canSendMessage,
+}: {
+  sessionId: string;
+  comments: SessionReviewComment[];
+  diffFiles: DiffFile[];
+  canSendMessage: boolean;
+}) {
+  const [message, setMessage] = useState("");
+  const queryClient = useQueryClient();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const openComments = useMemo(() => comments.filter((c) => !c.resolved), [comments]);
+
+  const sendMutation = useMutation({
+    mutationFn: () => {
+      let fullMessage = "";
+      if (openComments.length > 0) {
+        fullMessage += "Please address the following code review comments:\n\n";
+        openComments.forEach((c, i) => {
+          fullMessage += `${i + 1}. ${c.file_path}:${c.line_number}\n`;
+          const ctx = getLineContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
+          if (ctx) {
+            fullMessage += `   Code: \`${ctx.trim()}\`\n`;
+          }
+          const indented = c.body.replace(/\n/g, "\n   ");
+          fullMessage += `   "${indented}"\n\n`;
+        });
+      }
+      if (message.trim()) {
+        if (openComments.length > 0) {
+          fullMessage += `Additional instructions: ${message.trim()}`;
+        } else {
+          fullMessage = message.trim();
+        }
+      }
+      return api.sessions.sendMessage(sessionId, fullMessage.trim());
+    },
+    onSuccess: () => {
+      setMessage("");
+      if (textareaRef.current) {
+        textareaRef.current.style.height = "auto";
+      }
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId, "messages"] });
+    },
+  });
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }, [message]);
+
+  const hasContent = message.trim() || openComments.length > 0;
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (hasContent && canSendMessage && !sendMutation.isPending) {
+        sendMutation.mutate();
+      }
+    }
+  }
+
+  return (
+    <div className="border-t border-border p-3 bg-background shrink-0">
+      <div className={cn("rounded-xl border border-border bg-muted/30 focus-within:border-ring focus-within:ring-1 focus-within:ring-ring")}>
+        {/* Open comments as chips */}
+        {openComments.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 px-3 pt-2.5 pb-1">
+            {openComments.map((c) => {
+              const fileName = c.file_path.split("/").pop() ?? c.file_path;
+              return (
+                <div
+                  key={c.id}
+                  className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-[11px]"
+                >
+                  <MessageSquare className="h-3 w-3 text-muted-foreground shrink-0" />
+                  <span className="font-mono text-muted-foreground">
+                    {fileName}:{c.line_number}
+                  </span>
+                  <span className="text-muted-foreground/40">&mdash;</span>
+                  <span className="truncate max-w-[200px]">
+                    {c.body.length > 60 ? `${c.body.slice(0, 60)}...` : c.body}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <Textarea
+          ref={textareaRef}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            openComments.length > 0
+              ? "Add instructions or send comments to agent..."
+              : "Ask to make changes, @mention files..."
+          }
+          disabled={!canSendMessage || sendMutation.isPending}
+          className="min-h-[44px] max-h-[200px] resize-none border-none bg-transparent shadow-none focus-visible:ring-0"
+        />
+
+        <div className="flex items-center gap-1 px-2 pb-2">
+          {openComments.length > 0 && (
+            <span className="text-[11px] text-muted-foreground">
+              {openComments.length} comment{openComments.length > 1 ? "s" : ""} attached
+            </span>
+          )}
+          <div className="ml-auto">
+            <Button
+              size="icon"
+              variant="default"
+              className="h-8 w-8 shrink-0 rounded-lg"
+              title="Send to agent"
+              disabled={!hasContent || !canSendMessage || sendMutation.isPending}
+              onClick={() => sendMutation.mutate()}
+            >
+              {sendMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowUp className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {sendMutation.error && (
+        <div className="flex items-center gap-2 mt-2 text-xs text-destructive">
+          <AlertTriangle className="h-3 w-3 shrink-0" />
+          {sendMutation.error instanceof Error ? sendMutation.error.message : "Failed to send"}
         </div>
       )}
     </div>
@@ -1136,24 +1303,6 @@ export function SessionDetailContent({ id }: { id: string }) {
     setActiveCommentLine(null);
   }, []);
 
-  const sendToAgentMutation = useMutation({
-    mutationFn: async () => {
-      const resp = await api.sessions.sendReviewComments(id);
-      if (!resp.data.sent) {
-        const message = resp.data.message;
-        return api.sessions.sendMessage(id, message);
-      }
-      return resp;
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["session", id] });
-      queryClient.invalidateQueries({ queryKey: ["session", id, "messages"] });
-    },
-    onError: (err: Error) => {
-      console.error("Failed to send review comments to agent:", err.message);
-    },
-  });
-
   const handleCommentClick = useCallback(
     (filePath: string) => {
       const fileIndex = filteredFiles.findIndex((f) => f.newPath === filePath);
@@ -1238,23 +1387,31 @@ export function SessionDetailContent({ id }: { id: string }) {
           </div>
           {/* Review diff view — mounted only when active */}
           {centerMode === "review" && (
-            <div className="h-full animate-in fade-in duration-150">
-              <ReviewDiffView
+            <div className="h-full animate-in fade-in duration-150 flex flex-col">
+              <div className="flex-1 min-h-0">
+                <ReviewDiffView
+                  sessionId={id}
+                  files={filteredFiles}
+                  allFiles={allDiffFiles}
+                  activeFileIndex={activeFileIndex}
+                  onFileChange={setActiveFileIndex}
+                  onBack={exitReview}
+                  commentsByLine={commentsByLine}
+                  activeCommentLine={activeCommentLine}
+                  onAddComment={handleAddComment}
+                  onSubmitComment={handleSubmitComment}
+                  onCancelComment={handleCancelComment}
+                  onUpdateComment={updateComment}
+                  onDeleteComment={deleteComment}
+                  diffSearchQuery={diffSearchQuery}
+                  onDiffSearchChange={setDiffSearchQuery}
+                />
+              </div>
+              <ReviewCommentInput
                 sessionId={id}
-                files={filteredFiles}
-                allFiles={allDiffFiles}
-                activeFileIndex={activeFileIndex}
-                onFileChange={setActiveFileIndex}
-                onBack={exitReview}
-                commentsByLine={commentsByLine}
-                activeCommentLine={activeCommentLine}
-                onAddComment={handleAddComment}
-                onSubmitComment={handleSubmitComment}
-                onCancelComment={handleCancelComment}
-                onUpdateComment={updateComment}
-                onDeleteComment={deleteComment}
-                diffSearchQuery={diffSearchQuery}
-                onDiffSearchChange={setDiffSearchQuery}
+                comments={comments}
+                diffFiles={filteredFiles}
+                canSendMessage={session.status !== "skipped" && session.status !== "pending"}
               />
             </div>
           )}
@@ -1311,8 +1468,6 @@ export function SessionDetailContent({ id }: { id: string }) {
                 onToggleReviewed={toggleReviewed}
                 comments={comments}
                 onCommentClick={handleCommentClick}
-                onSendToAgent={() => sendToAgentMutation.mutate()}
-                isSendingComments={sendToAgentMutation.isPending}
                 passes={passes}
                 passRange={passRange}
                 onPassRangeChange={setPassRange}

--- a/frontend/src/components/code-review/comments-summary.test.tsx
+++ b/frontend/src/components/code-review/comments-summary.test.tsx
@@ -25,7 +25,7 @@ function makeComment(overrides: Partial<SessionReviewComment> = {}): SessionRevi
 describe("CommentsSummary", () => {
   it("returns null when no comments", () => {
     const { container } = render(
-      <CommentsSummary comments={[]} onCommentClick={vi.fn()} onSendToAgent={vi.fn()} isSending={false} />
+      <CommentsSummary comments={[]} onCommentClick={vi.fn()} />
     );
     expect(container.firstChild).toBeNull();
   });
@@ -35,8 +35,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment()]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("1 comment")).toBeInTheDocument();
@@ -48,8 +46,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ id: "c1" }), makeComment({ id: "c2" })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("2 comments")).toBeInTheDocument();
@@ -63,62 +59,9 @@ describe("CommentsSummary", () => {
           makeComment({ id: "c2", resolved: true }),
         ]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("(1 open, 1 resolved)")).toBeInTheDocument();
-  });
-
-  it("shows Send to agent button when there are open comments", () => {
-    render(
-      <CommentsSummary
-        comments={[makeComment()]}
-        onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
-      />
-    );
-    expect(screen.getByText("Send to agent")).toBeInTheDocument();
-  });
-
-  it("shows Sending... when isSending is true", () => {
-    render(
-      <CommentsSummary
-        comments={[makeComment()]}
-        onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={true}
-      />
-    );
-    expect(screen.getByText("Sending...")).toBeInTheDocument();
-  });
-
-  it("does not show Send to agent button when all resolved", () => {
-    render(
-      <CommentsSummary
-        comments={[makeComment({ resolved: true })]}
-        onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
-      />
-    );
-    expect(screen.queryByText("Send to agent")).not.toBeInTheDocument();
-  });
-
-  it("calls onSendToAgent when button clicked", async () => {
-    const onSendToAgent = vi.fn();
-    const user = userEvent.setup();
-    render(
-      <CommentsSummary
-        comments={[makeComment()]}
-        onCommentClick={vi.fn()}
-        onSendToAgent={onSendToAgent}
-        isSending={false}
-      />
-    );
-    await user.click(screen.getByText("Send to agent"));
-    expect(onSendToAgent).toHaveBeenCalled();
   });
 
   it("renders comment body text truncated to 80 chars", () => {
@@ -127,8 +70,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ body: longBody })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("A".repeat(80) + "...")).toBeInTheDocument();
@@ -139,8 +80,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ file_path: "src/components/app.tsx", line_number: 42 })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("app.tsx:42")).toBeInTheDocument();
@@ -153,8 +92,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ file_path: "src/app.ts" })]}
         onCommentClick={onCommentClick}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     await user.click(screen.getByText("app.ts:10"));
@@ -167,8 +104,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ body: "visible body" })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("visible body")).toBeInTheDocument();
@@ -182,8 +117,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ pass_number: 3 })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.getByText("P3")).toBeInTheDocument();
@@ -194,8 +127,6 @@ describe("CommentsSummary", () => {
       <CommentsSummary
         comments={[makeComment({ pass_number: 1 })]}
         onCommentClick={vi.fn()}
-        onSendToAgent={vi.fn()}
-        isSending={false}
       />
     );
     expect(screen.queryByText("P1")).not.toBeInTheDocument();

--- a/frontend/src/components/code-review/comments-summary.tsx
+++ b/frontend/src/components/code-review/comments-summary.tsx
@@ -1,23 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import { ChevronDown, ChevronRight, Check, Send, MessageSquare } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ChevronDown, ChevronRight, Check, MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { SessionReviewComment } from "@/lib/types";
 
 interface CommentsSummaryProps {
   comments: SessionReviewComment[];
   onCommentClick: (filePath: string) => void;
-  onSendToAgent: () => void;
-  isSending: boolean;
 }
 
 export function CommentsSummary({
   comments,
   onCommentClick,
-  onSendToAgent,
-  isSending,
 }: CommentsSummaryProps) {
   const [expanded, setExpanded] = useState(true);
 
@@ -46,21 +41,6 @@ export function CommentsSummary({
             ({openCount} open{resolvedCount > 0 ? `, ${resolvedCount} resolved` : ""})
           </span>
         </div>
-        {openCount > 0 && (
-          <Button
-            size="sm"
-            variant="default"
-            className="h-6 text-[11px] px-2 gap-1"
-            onClick={(e) => {
-              e.stopPropagation();
-              onSendToAgent();
-            }}
-            disabled={isSending}
-          >
-            <Send className="h-3 w-3" />
-            {isSending ? "Sending..." : "Send to agent"}
-          </Button>
-        )}
       </button>
 
       {expanded && (

--- a/frontend/src/lib/diff-parser.test.ts
+++ b/frontend/src/lib/diff-parser.test.ts
@@ -3,6 +3,7 @@ import {
   parseDiff,
   parseDiffStats,
   computeDiffDelta,
+  getDiffHunkContext,
   type DiffFile,
 } from "./diff-parser";
 
@@ -181,5 +182,84 @@ diff --git a/src/utils.ts b/src/utils.ts
     // All files in older are "reverted"
     expect(delta).toHaveLength(2);
     expect(delta.every((f) => f.hunks.length === 0)).toBe(true);
+  });
+});
+
+describe("parseDiff fallback path parsing", () => {
+  it("falls back to first-line path parsing when --- / +++ headers are missing", () => {
+    const minimalDiff = `diff --git a/src/hello.ts b/src/hello.ts
+@@ -1,2 +1,2 @@
+ const greeting = "hello";
+-export default greeting;
++export { greeting };`;
+    const files = parseDiff(minimalDiff);
+    expect(files).toHaveLength(1);
+    expect(files[0].newPath).toBe("src/hello.ts");
+  });
+});
+
+describe("getDiffHunkContext", () => {
+  const files = parseDiff(sampleDiff);
+
+  it("returns surrounding lines around a target line", () => {
+    // Line 2 (new side) is the added "import cors" line
+    const ctx = getDiffHunkContext(files, "src/app.ts", 2, "new");
+    expect(ctx).not.toBeNull();
+    expect(ctx).toContain("import cors");
+    expect(ctx).toContain("import express");
+  });
+
+  it("returns null when file is not found", () => {
+    const ctx = getDiffHunkContext(files, "nonexistent.ts", 1, "new");
+    expect(ctx).toBeNull();
+  });
+
+  it("returns null when line number is not in any hunk", () => {
+    const ctx = getDiffHunkContext(files, "src/app.ts", 999, "new");
+    expect(ctx).toBeNull();
+  });
+
+  it("formats add lines with + prefix", () => {
+    const ctx = getDiffHunkContext(files, "src/app.ts", 2, "new");
+    expect(ctx).toContain("+ import cors");
+  });
+
+  it("formats context lines with space prefix", () => {
+    const ctx = getDiffHunkContext(files, "src/app.ts", 2, "new");
+    expect(ctx).toContain("  import express");
+  });
+
+  it("works with old side line numbers", () => {
+    // src/utils.ts has a removal on old line 11
+    const ctx = getDiffHunkContext(files, "src/utils.ts", 11, "old");
+    expect(ctx).not.toBeNull();
+    expect(ctx).toContain("-   return a + b;");
+  });
+
+  it("limits context to 3 lines before and after", () => {
+    const ctx = getDiffHunkContext(files, "src/app.ts", 2, "new");
+    const lines = ctx!.split("\n");
+    // Hunk has 4 lines total (1 context + 1 add + 2 context), so all fit within ±3
+    expect(lines.length).toBeLessThanOrEqual(7);
+  });
+
+  it("matches file by oldPath when newPath differs", () => {
+    const renamedFiles: DiffFile[] = [{
+      oldPath: "src/old-name.ts",
+      newPath: "src/new-name.ts",
+      hunks: [{
+        oldStart: 1, oldCount: 1, newStart: 1, newCount: 1,
+        header: "@@ -1,1 +1,1 @@",
+        lines: [
+          { type: "remove", content: "old line", oldLineNumber: 1, newLineNumber: null },
+          { type: "add", content: "new line", oldLineNumber: null, newLineNumber: 1 },
+        ],
+      }],
+      stats: { added: 1, removed: 1 },
+      language: "typescript",
+    }];
+    const ctx = getDiffHunkContext(renamedFiles, "src/old-name.ts", 1, "old");
+    expect(ctx).not.toBeNull();
+    expect(ctx).toContain("- old line");
   });
 });

--- a/frontend/src/lib/diff-parser.ts
+++ b/frontend/src/lib/diff-parser.ts
@@ -296,3 +296,37 @@ function parseHunks(lines: string[]): DiffHunk[] {
 
   return hunks;
 }
+
+/**
+ * Extract a diff hunk context (~3 lines before and after) around a specific line.
+ * Used when formatting review comments for the agent.
+ */
+export function getDiffHunkContext(
+  files: DiffFile[],
+  filePath: string,
+  lineNumber: number,
+  side: "old" | "new"
+): string | null {
+  const file = files.find((f) => f.newPath === filePath || f.oldPath === filePath);
+  if (!file) return null;
+
+  for (const hunk of file.hunks) {
+    const targetIdx = hunk.lines.findIndex((line) => {
+      const ln = side === "new" ? line.newLineNumber : line.oldLineNumber;
+      return ln === lineNumber;
+    });
+    if (targetIdx === -1) continue;
+
+    const start = Math.max(0, targetIdx - 3);
+    const end = Math.min(hunk.lines.length, targetIdx + 4);
+    const contextLines = hunk.lines.slice(start, end);
+
+    const formatted = contextLines.map((line) => {
+      const prefix = line.type === "add" ? "+" : line.type === "remove" ? "-" : " ";
+      return `${prefix} ${line.content}`;
+    });
+
+    return formatted.join("\n");
+  }
+  return null;
+}

--- a/frontend/src/lib/format-review-message.test.ts
+++ b/frontend/src/lib/format-review-message.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { formatReviewMessage } from "./format-review-message";
+import type { SessionReviewComment } from "./types";
+import type { DiffFile } from "./diff-parser";
+
+function makeComment(overrides: Partial<SessionReviewComment> = {}): SessionReviewComment {
+  return {
+    id: "c1",
+    session_id: "s1",
+    org_id: "o1",
+    user_id: "u1",
+    file_path: "src/app.ts",
+    line_number: 10,
+    diff_side: "new",
+    body: "Fix this bug",
+    resolved: false,
+    pass_number: 1,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const diffFiles: DiffFile[] = [
+  {
+    oldPath: "src/app.ts",
+    newPath: "src/app.ts",
+    hunks: [
+      {
+        oldStart: 9,
+        oldCount: 3,
+        newStart: 9,
+        newCount: 4,
+        header: "@@ -9,3 +9,4 @@",
+        lines: [
+          { type: "context", content: "const a = 1;", oldLineNumber: 9, newLineNumber: 9 },
+          { type: "add", content: "const b = 2;", oldLineNumber: null, newLineNumber: 10 },
+          { type: "context", content: "const c = 3;", oldLineNumber: 10, newLineNumber: 11 },
+          { type: "context", content: "export default a;", oldLineNumber: 11, newLineNumber: 12 },
+        ],
+      },
+    ],
+    stats: { added: 1, removed: 0 },
+    language: "typescript",
+  },
+];
+
+describe("formatReviewMessage", () => {
+  it("returns general instructions only when no comments", () => {
+    const result = formatReviewMessage([], [], "Add tests please");
+    expect(result).toBe("Add tests please");
+  });
+
+  it("returns empty string when no comments and no instructions", () => {
+    const result = formatReviewMessage([], [], "");
+    expect(result).toBe("");
+  });
+
+  it("formats a single comment with file, line, and body", () => {
+    const result = formatReviewMessage([makeComment()], diffFiles, "");
+    expect(result).toContain("1. **src/app.ts:10** (new side)");
+    expect(result).toContain('Comment: "Fix this bug"');
+  });
+
+  it("includes diff hunk context when available", () => {
+    const result = formatReviewMessage([makeComment()], diffFiles, "");
+    expect(result).toContain("```");
+    expect(result).toContain("+ const b = 2;");
+    expect(result).toContain("  const a = 1;");
+  });
+
+  it("formats multiple comments with numbered list", () => {
+    const comments = [
+      makeComment({ id: "c1", file_path: "src/app.ts", line_number: 10, body: "First comment" }),
+      makeComment({ id: "c2", file_path: "src/utils.ts", line_number: 5, body: "Second comment" }),
+    ];
+    const result = formatReviewMessage(comments, diffFiles, "");
+    expect(result).toContain("1. **src/app.ts:10**");
+    expect(result).toContain("2. **src/utils.ts:5**");
+    expect(result).toContain('"First comment"');
+    expect(result).toContain('"Second comment"');
+  });
+
+  it("separates general instructions with divider when comments present", () => {
+    const result = formatReviewMessage([makeComment()], diffFiles, "Also add tests");
+    expect(result).toContain("---");
+    expect(result).toContain("Additional instructions:");
+    expect(result).toContain("Also add tests");
+  });
+
+  it("does not include divider when only general instructions", () => {
+    const result = formatReviewMessage([], [], "Just do this");
+    expect(result).not.toContain("---");
+    expect(result).not.toContain("Additional instructions:");
+    expect(result).toBe("Just do this");
+  });
+
+  it("handles multi-line comment bodies with indentation", () => {
+    const comment = makeComment({ body: "Line one\nLine two\nLine three" });
+    const result = formatReviewMessage([comment], diffFiles, "");
+    expect(result).toContain('Comment: "Line one\n   Line two\n   Line three"');
+  });
+
+  it("skips diff hunk when file not found in diffFiles", () => {
+    const comment = makeComment({ file_path: "nonexistent.ts" });
+    const result = formatReviewMessage([comment], diffFiles, "");
+    expect(result).toContain("1. **nonexistent.ts:10**");
+    expect(result).not.toContain("```");
+  });
+
+  it("includes diff side in the header", () => {
+    const comment = makeComment({ diff_side: "old" });
+    const result = formatReviewMessage([comment], diffFiles, "");
+    expect(result).toContain("(old side)");
+  });
+
+  it("starts with the standard preamble when comments are present", () => {
+    const result = formatReviewMessage([makeComment()], diffFiles, "");
+    expect(result).toMatch(/^Please address the following code review comments:/);
+  });
+
+  it("trims whitespace from general instructions", () => {
+    const result = formatReviewMessage([], [], "  padded text  ");
+    expect(result).toBe("padded text");
+  });
+});

--- a/frontend/src/lib/format-review-message.ts
+++ b/frontend/src/lib/format-review-message.ts
@@ -1,0 +1,45 @@
+import { getDiffHunkContext, type DiffFile } from "./diff-parser";
+import type { SessionReviewComment } from "./types";
+
+/**
+ * Format review comments and optional general instructions into a structured
+ * message for the coding agent. Inline comments include file path, line number,
+ * diff side, surrounding code context, and the comment body. General instructions
+ * are separated with a divider.
+ */
+export function formatReviewMessage(
+  openComments: SessionReviewComment[],
+  diffFiles: DiffFile[],
+  generalInstructions: string
+): string {
+  const parts: string[] = [];
+
+  // Section 1: Inline comments (anchored to specific file:line with diff context)
+  if (openComments.length > 0) {
+    parts.push("Please address the following code review comments:\n");
+    openComments.forEach((c, i) => {
+      parts.push(`${i + 1}. **${c.file_path}:${c.line_number}** (${c.diff_side} side)`);
+      const hunk = getDiffHunkContext(diffFiles, c.file_path, c.line_number, c.diff_side as "old" | "new");
+      if (hunk) {
+        parts.push("   ```");
+        hunk.split("\n").forEach((line) => parts.push(`   ${line}`));
+        parts.push("   ```");
+      }
+      const indented = c.body.replace(/\n/g, "\n   ");
+      parts.push(`   Comment: "${indented}"\n`);
+    });
+  }
+
+  // Section 2: General instructions (not tied to a specific line)
+  if (generalInstructions.trim()) {
+    if (openComments.length > 0) {
+      parts.push("---\n");
+      parts.push("Additional instructions:\n");
+      parts.push(generalInstructions.trim());
+    } else {
+      parts.push(generalInstructions.trim());
+    }
+  }
+
+  return parts.join("\n").trim();
+}

--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -317,13 +317,14 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 	}
 
 	// Format into a structured directive for the agent.
+	// Each comment includes file path, line number, and diff side for precise location.
 	// Indent multi-line comment bodies so each line stays within the numbered block.
 	var sb strings.Builder
 	sb.WriteString("Please address the following code review comments:\n\n")
 	for i, c := range open {
-		sb.WriteString(fmt.Sprintf("%d. %s:%d\n", i+1, c.FilePath, c.LineNumber))
+		sb.WriteString(fmt.Sprintf("%d. **%s:%d** (%s side)\n", i+1, c.FilePath, c.LineNumber, c.DiffSide))
 		indented := strings.ReplaceAll(c.Body, "\n", "\n   ")
-		sb.WriteString(fmt.Sprintf("   \"%s\"\n\n", indented))
+		sb.WriteString(fmt.Sprintf("   Comment: \"%s\"\n\n", indented))
 	}
 	message := strings.TrimSpace(sb.String())
 


### PR DESCRIPTION
## Summary
Refactored the code review comments workflow by moving the "send to agent" functionality from the `CommentsSummary` component to a new dedicated `ReviewCommentInput` component positioned at the bottom of the review diff view. This improves UX by keeping the submission interface contextually near where comments are being reviewed.

## Key Changes

- **Removed `onSendToAgent` and `isSendingComments` props** from `ChangesTab` and `CommentsSummary` components, simplifying their interfaces
- **Created new `ReviewCommentInput` component** that:
  - Displays open review comments as visual chips at the top
  - Provides a textarea for additional instructions or general changes
  - Intelligently formats the message sent to the agent with:
    - Inline comments anchored to specific file:line with diff context (3 lines before/after)
    - General instructions separated by a divider
  - Supports Shift+Enter for multi-line input and Enter to send
  - Auto-resizes textarea up to 200px max height
  - Shows loading state and error handling
- **Added `getDiffHunkContext` helper function** to extract surrounding diff context (±3 lines) around commented lines for better agent context
- **Updated review mode layout** to use flexbox with the new input component as a fixed footer
- **Removed `sendReviewComments` API call** - now directly constructs and sends the formatted message via `sendMessage`
- **Updated tests** to remove assertions related to the removed "Send to agent" button

## Implementation Details

The new `ReviewCommentInput` component intelligently combines:
1. All open (unresolved) review comments with their diff context
2. Any additional free-form instructions from the user
3. Proper formatting with markdown for readability

The component respects session status (disabled when session is "skipped" or "pending") and provides visual feedback for the number of attached comments.

https://claude.ai/code/session_01P6KTcvNh1YrhGZjK9CXgJS