### PR TITLE
Add theme selection UI with next-themes integration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "geist": "^1.7.0",
         "lucide-react": "^0.574.0",
         "next": "16.1.6",
+        "next-themes": "^0.4.6",
         "nuqs": "^2.8.8",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
@@ -13824,6 +13825,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "geist": "^1.7.0",
     "lucide-react": "^0.574.0",
     "next": "16.1.6",
+    "next-themes": "^0.4.6",
     "nuqs": "^2.8.8",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -21,6 +21,10 @@ vi.mock('@/lib/api', () => ({
   },
 }));
 
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}));
+
 describe('SettingsPage', () => {
   beforeEach(() => {
     settingsGetMock.mockClear();
@@ -63,5 +67,16 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Organization name')).toBeDisabled();
     });
+  });
+
+  it('renders the Appearance section with theme selector', async () => {
+    renderWithProviders(<SettingsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Appearance')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.getByText('Select your preferred color scheme')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
+import { ThemeSelect } from "@/components/theme-select";
 import type { Organization, SingleResponse } from "@/lib/types";
 
 export default function SettingsPage() {
@@ -27,6 +28,23 @@ export default function SettingsPage() {
           filters={{ resource_type: "settings" }}
           title="Settings activity"
         />
+        <section className="space-y-3">
+          <h2 className="text-[13px] font-medium text-foreground">Appearance</h2>
+          <Card>
+            <CardContent>
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label>Theme</Label>
+                  <p className="text-[13px] text-muted-foreground">
+                    Select your preferred color scheme
+                  </p>
+                </div>
+                <ThemeSelect />
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
         <section className="space-y-3">
           <h2 className="text-[13px] font-medium text-foreground">General</h2>
           <Card>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -9,7 +9,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`} suppressHydrationWarning>
       <body className="antialiased">
         <Providers>
           {children}

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { useState, useEffect } from "react";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { ThemeProvider } from "@/components/theme-provider";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
@@ -45,12 +46,14 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <NuqsAdapter>
-      <QueryClientProvider client={queryClient}>
-        <ErrorBoundary>
-          {children}
-        </ErrorBoundary>
-      </QueryClientProvider>
-    </NuqsAdapter>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+      <NuqsAdapter>
+        <QueryClientProvider client={queryClient}>
+          <ErrorBoundary>
+            {children}
+          </ErrorBoundary>
+        </QueryClientProvider>
+      </NuqsAdapter>
+    </ThemeProvider>
   );
 }

--- a/frontend/src/components/theme-provider.tsx
+++ b/frontend/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/frontend/src/components/theme-select.tsx
+++ b/frontend/src/components/theme-select.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTheme } from "next-themes";
 import { Monitor, Moon, Sun } from "lucide-react";
 import {
@@ -18,6 +19,15 @@ const themes = [
 
 export function ThemeSelect() {
   const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return (
+      <div className="h-8 w-[140px] rounded-md border border-input bg-transparent" />
+    );
+  }
 
   return (
     <Select value={theme} onValueChange={setTheme}>

--- a/frontend/src/components/theme-select.tsx
+++ b/frontend/src/components/theme-select.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Monitor, Moon, Sun } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const themes = [
+  { value: "system", label: "Auto", icon: Monitor },
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+] as const;
+
+export function ThemeSelect() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <Select value={theme} onValueChange={setTheme}>
+      <SelectTrigger className="w-[140px]">
+        <SelectValue placeholder="Theme" />
+      </SelectTrigger>
+      <SelectContent>
+        {themes.map(({ value, label, icon: Icon }) => (
+          <SelectItem key={value} value={value}>
+            <Icon className="size-4 text-muted-foreground" />
+            {label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/frontend/src/components/theme-select.tsx
+++ b/frontend/src/components/theme-select.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { useTheme } from "next-themes";
 import { Monitor, Moon, Sun } from "lucide-react";
 import {
@@ -17,11 +17,11 @@ const themes = [
   { value: "dark", label: "Dark", icon: Moon },
 ] as const;
 
+const emptySubscribe = () => () => {};
+
 export function ThemeSelect() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
 
   if (!mounted) {
     return (

--- a/frontend/src/hooks/use-prefers-dark.ts
+++ b/frontend/src/hooks/use-prefers-dark.ts
@@ -1,17 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
 
 export function usePrefersDark() {
-  const [isDark, setIsDark] = useState(true);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(prefers-color-scheme: dark)");
-    const update = () => setIsDark(mq.matches);
-    update();
-    mq.addEventListener("change", update);
-    return () => mq.removeEventListener("change", update);
-  }, []);
-
-  return isDark;
+  const { resolvedTheme } = useTheme();
+  return resolvedTheme === "dark";
 }


### PR DESCRIPTION
## Summary
This PR adds theme selection functionality to the application by integrating the `next-themes` library and creating a new theme selector component in the settings page.

## Key Changes
- **New ThemeSelect component** (`theme-select.tsx`): A client-side dropdown component that allows users to choose between Auto, Light, and Dark themes with appropriate icons
- **New ThemeProvider wrapper** (`theme-provider.tsx`): A wrapper around `next-themes` ThemeProvider for consistent theme management across the app
- **Settings page enhancement**: Added an "Appearance" section with the theme selector in the settings page
- **Updated Providers component**: Wrapped the app with ThemeProvider to enable theme functionality globally
- **Refactored usePrefersDark hook**: Simplified to use `next-themes` instead of manual media query listening
- **HTML root element update**: Added `suppressHydrationWarning` to prevent hydration mismatches with theme detection
- **Test coverage**: Added test case for the new Appearance section in settings page
- **Dependencies**: Added `next-themes` package

## Implementation Details
- The ThemeSelect component uses a mounting check to prevent hydration mismatches
- Theme options include system preference detection via the "Auto" option
- The theme provider is configured with `enableSystem` to respect OS preferences and `disableTransitionOnChange` for smooth theme switching
- The component integrates with existing UI components (Select, Card, Label) for consistent styling

https://claude.ai/code/session_0181oCfPZdR3bcbKWsGE1nYj