### PR TITLE
Prevent messaging to sessions with expired sandbox snapshots

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -676,10 +676,11 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   const isClaudeCode = session.agent_type === "claude_code";
 
   const isRunning = session.status === "running";
-  // Allow messaging in any state except "skipped" (never ran, no workspace)
-  // and "pending" (agent not started yet). The backend will reject statuses
-  // it cannot handle, so this is safe to be permissive.
-  const canSendMessage = session.status !== "skipped" && session.status !== "pending";
+  const isSnapshotExpired = session.sandbox_state === "destroyed";
+  // Allow messaging in any state except "skipped" (never ran, no workspace),
+  // "pending" (agent not started yet), and sessions whose sandbox snapshot has
+  // expired (sandbox_state === "destroyed") — the environment no longer exists.
+  const canSendMessage = session.status !== "skipped" && session.status !== "pending" && !isSnapshotExpired;
 
   const availableModels = useMemo(() => {
     const agentType = AGENT_TYPE_OPTIONS.find((a) => a.key === session.agent_type);
@@ -990,6 +991,16 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
         );
       })()}
 
+      {/* Snapshot expired banner */}
+      {isSnapshotExpired && (
+        <div className="flex items-center gap-2 px-4 py-2.5 text-xs border-t bg-amber-50 dark:bg-amber-950/20 border-amber-200 dark:border-amber-800/40 text-amber-800 dark:text-amber-300">
+          <Clock className="h-3.5 w-3.5 shrink-0" />
+          <span>
+            This session&apos;s environment has expired. Sessions can be continued for up to 30 days after their last activity. To make further changes, please start a new session.
+          </span>
+        </div>
+      )}
+
       {/* Input bar — hidden for PM agent sessions (PM agent doesn't accept interactive input) */}
       {session.agent_type !== "pm_agent" && <div className="border-t border-border p-3 bg-background">
         {/* Plan mode indicator */}
@@ -1016,7 +1027,9 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={
-              !canSendMessage
+              isSnapshotExpired
+                ? "Session environment has expired and can no longer be continued"
+                : !canSendMessage
                 ? "Session is not active"
                 : planMode
                 ? "Describe what you want to plan..."
@@ -1390,7 +1403,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 sessionId={id}
                 comments={comments}
                 diffFiles={filteredFiles}
-                canSendMessage={session.status !== "skipped" && session.status !== "pending"}
+                canSendMessage={session.status !== "skipped" && session.status !== "pending" && session.sandbox_state !== "destroyed"}
               />
             </div>
           )}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -597,6 +597,13 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Reject early if the session's sandbox snapshot has been destroyed
+	// (expired after 30 days). The session can no longer be resumed.
+	if session.SandboxState == string(models.SandboxStateDestroyed) {
+		writeError(w, r, http.StatusGone, "SNAPSHOT_EXPIRED", "this session's environment has expired and can no longer be continued")
+		return
+	}
+
 	// Build the user message from the request context.
 	user := middleware.UserFromContext(r.Context())
 	var userID *uuid.UUID

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1962,6 +1962,58 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 			expectedBody: "NOT_RESUMABLE",
 		},
 		{
+			name: "rejects message to completed session with destroyed sandbox snapshot",
+			body: `{"message":"Continue please"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "completed", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 3, &now, "destroyed", nil,
+							nil, nil, nil, nil, nil,
+							now,
+						),
+					)
+			},
+			expectedCode: http.StatusGone,
+			expectedBody: "SNAPSHOT_EXPIRED",
+		},
+		{
+			name: "rejects message to idle session with destroyed sandbox snapshot",
+			body: `{"message":"Continue please"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionColumns).AddRow(
+							sessionID, uuid.New(), orgID, "claude-code", "idle", "semi", "low",
+							nil, nil, nil, nil,
+							nil, &now, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil, nil, nil, nil,
+							nil, nil, nil, nil,
+							nil, nil,
+							nil, // triggered_by_user_id
+							nil, 2, &now, "destroyed", nil,
+							nil, nil, nil, nil, nil,
+							now,
+						),
+					)
+			},
+			expectedCode: http.StatusGone,
+			expectedBody: "SNAPSHOT_EXPIRED",
+		},
+		{
 			name: "sends message to completed session via ClaimForResume",
 			body: `{"message":"Continue working on this"}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -273,11 +273,13 @@ func (s *SessionStore) UpdateResult(ctx context.Context, orgID, runID uuid.UUID,
 // ClaimIdle atomically transitions an idle session to running and returns the
 // claimed session row. Used when a user sends a follow-up message so only one
 // continuation can be queued at a time.
+// Sessions whose sandbox snapshot has been destroyed cannot be claimed.
 func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
 		SET status = 'running'
 		WHERE id = @id AND org_id = @org_id AND status = 'idle'
+		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
@@ -293,11 +295,13 @@ func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID
 // ClaimForResume atomically transitions a terminal session to running so it
 // can be resumed with a follow-up message. Used when a user sends a message
 // to a completed/failed/cancelled/pr_created session.
+// Sessions whose sandbox snapshot has been destroyed cannot be resumed.
 func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
 		SET status = 'running', completed_at = NULL
 		WHERE id = @id AND org_id = @org_id AND status IN ('completed', 'pr_created', 'failed', 'cancelled')
+		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -210,4 +210,130 @@ func TestSessionStore_UpdateResult(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionStore_ClaimIdle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupMock func(mock pgxmock.PgxPoolIface)
+		wantErr   bool
+	}{
+		{
+			name: "claims idle session successfully",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionTestColumns).AddRow(
+							newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...,
+						),
+					)
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns error when no matching row",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			store := NewSessionStore(mock)
+			tt.setupMock(mock)
+
+			_, err = store.ClaimIdle(context.Background(), uuid.New(), uuid.New())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSessionStore_ClaimForResume(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupMock func(mock pgxmock.PgxPoolIface)
+		wantErr   bool
+	}{
+		{
+			name: "resumes completed session successfully",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(sessionTestColumns).AddRow(
+							newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...,
+						),
+					)
+			},
+			wantErr: false,
+		},
+		{
+			name: "returns error when no matching row",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			store := NewSessionStore(mock)
+			tt.setupMock(mock)
+
+			_, err = store.ClaimForResume(context.Background(), uuid.New(), uuid.New())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestSessionStore_UpdatePMPlanID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+
+	mock.ExpectExec("UPDATE sessions SET pm_plan_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdatePMPlanID(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func stringPtr(s string) *string { return &s }


### PR DESCRIPTION
## Summary
This PR adds validation to prevent users from sending messages to sessions whose sandbox snapshots have expired (destroyed after 30 days of inactivity). The backend now rejects such requests early, and the frontend disables messaging and displays an informative banner to users.

## Key Changes

- **Backend validation**: Added early rejection in `SendMessage` handler when `sandbox_state == "destroyed"`, returning HTTP 410 Gone with `SNAPSHOT_EXPIRED` error code
- **Database constraints**: Updated `ClaimIdle` and `ClaimForResume` queries to exclude sessions with destroyed sandbox snapshots, preventing resumption attempts
- **Frontend UI updates**:
  - Modified `canSendMessage` logic to check `sandbox_state === "destroyed"` in addition to status checks
  - Added amber warning banner explaining that the session environment has expired and can be continued for up to 30 days
  - Updated message input placeholder to indicate the session environment has expired
  - Updated `DiffPanel` component's `canSendMessage` prop to include sandbox state check
- **Test coverage**: Added two new test cases covering rejection of messages to both completed and idle sessions with destroyed sandbox snapshots

## Implementation Details

The changes ensure that:
1. Sessions with expired snapshots cannot be resumed or continued via the API
2. Users receive clear feedback about why they cannot continue a session
3. The frontend prevents users from attempting to send messages to expired sessions
4. Both the database layer and API handler enforce this constraint for defense-in-depth

https://claude.ai/code/session_013JNZ5kigjnircruUoGAdWa