### PR TITLE
Audit design doc statuses against codebase implementation

### DIFF
--- a/docs/design/40-pr-creation-revamp.md
+++ b/docs/design/40-pr-creation-revamp.md
@@ -1,6 +1,8 @@
 # Design: PR Creation Revamp — User-Authored PRs, Template Support, and Issueless Sessions
 
-> **Status:** Proposal | **Last reviewed:** 2026-03-29
+> **Status:** Partially Implemented | **Last reviewed:** 2026-04-05
+>
+> **Implementation notes:** PR template detection and caching implemented (`pr_templates` store). Missing: user GitHub auth OAuth expansion, user-authored PR creation flow, issueless session support.
 
 **Depends on**: [08-pr-and-ship.md](implemented/08-pr-and-ship.md), [13-repository-onboarding.md](implemented/13-repository-onboarding.md), [34-personal-team-coding-agents.md](implemented/34-personal-team-coding-agents.md)
 

--- a/docs/design/implemented/39-pm-agent-logging-and-issue-cli.md
+++ b/docs/design/implemented/39-pm-agent-logging-and-issue-cli.md
@@ -1,6 +1,8 @@
 # 39 - PM Agent Logging & Issue Creation CLI
 
-> **Status:** Proposed | **Last reviewed:** 2026-03-29
+> **Status:** Partially Implemented | **Last reviewed:** 2026-04-05
+>
+> **Implementation notes:** PM agent logs now stream into `session_logs`. Missing: issue creation CLI tool.
 
 ## Problem
 

--- a/docs/design/implemented/41-pm-project-proposals.md
+++ b/docs/design/implemented/41-pm-project-proposals.md
@@ -1,6 +1,6 @@
 # 41 - PM Agent Project Proposals
 
-> **Status:** Proposed | **Last reviewed:** 2026-03-31
+> **Status:** Implemented | **Last reviewed:** 2026-04-05
 
 ## Why this matters
 

--- a/docs/design/implemented/43-prompt-and-input-versioning.md
+++ b/docs/design/implemented/43-prompt-and-input-versioning.md
@@ -1,6 +1,8 @@
 # 43 - Prompt and Input Versioning
 
-> **Status:** Not Started | **Last reviewed:** 2026-04-01
+> **Status:** Partially Implemented | **Last reviewed:** 2026-04-05
+>
+> **Implementation notes:** PM document versioning fully implemented (insert-only pattern, logical_id, content_hash, set pins). Input manifest struct and DB column exist on sessions table. Deploy SHA via version package. Missing: manifest recording during agent runs, org settings version tracking, memory snapshot recording, sandbox image pinning, integration skills hash, frontend version history UI.
 >
 > **Required by:** [42-eval-task-builder.md](42-eval-task-builder.md) (input freezing for reproducible evals), [16-ai-agent-evals.md](future/16-ai-agent-evals.md) (prompt lifecycle and release gates)
 


### PR DESCRIPTION
## Summary

- Moved **41-pm-project-proposals** to implemented/ — project proposer service, model fields, and API are all fully built.
- Updated **39** (PM Agent Logging), **40** (PR Creation Revamp), and **43** (Prompt & Input Versioning) from Proposed/Not Started to Partially Implemented with implementation notes.
- Audited all 29 non-implemented design docs against the codebase; the remaining 22 active and 6 future docs are correctly categorized.

## Test plan

- [ ] Verify moved file renders correctly in docs/design/implemented/
- [ ] Verify updated status headers are well-formed markdown

Generated with [Claude Code](https://claude.com/claude-code)