### PR TITLE
Add pagination for GitHub PR inline comments

### DIFF
--- a/internal/services/integration/github_reviews.go
+++ b/internal/services/integration/github_reviews.go
@@ -222,7 +222,7 @@ func doGetPaginated[T any](ctx context.Context, g *GitHubCodeReviewSource, initi
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			if len(all) > 0 {
 				zerolog.Ctx(ctx).Warn().Int("status", resp.StatusCode).Int("pages_fetched", page).Msg("pagination stopped: non-200 status")
 				return all, nil
@@ -232,7 +232,7 @@ func doGetPaginated[T any](ctx context.Context, g *GitHubCodeReviewSource, initi
 
 		var items []T
 		decodeErr := json.NewDecoder(resp.Body).Decode(&items)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 		if decodeErr != nil {
 			if len(all) > 0 {
 				zerolog.Ctx(ctx).Warn().Err(decodeErr).Int("pages_fetched", page).Msg("pagination stopped: decode error")

--- a/internal/services/integration/github_reviews.go
+++ b/internal/services/integration/github_reviews.go
@@ -6,9 +6,20 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/rs/zerolog"
 )
+
+// maxPaginationPages caps how many pages we follow when paginating GitHub
+// API results. 10 pages * 100 per_page = 1000 items max.
+const maxPaginationPages = 10
+
+// linkNextRe extracts the URL from a GitHub Link header rel="next" entry.
+// Example: <https://api.github.com/repos/...?page=2>; rel="next"
+var linkNextRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
 
 // GitHubCodeReviewSource implements CodeReviewSource for GitHub pull requests.
 // It uses the GitHub REST API to list recent PRs and their review comments.
@@ -120,13 +131,12 @@ func (g *GitHubCodeReviewSource) GetPRReviews(ctx context.Context, prNumber int)
 		return nil, fmt.Errorf("get reviews: %w", err)
 	}
 
-	// Fetch inline review comments (capped at 100; pagination not implemented —
-	// PRs with >100 inline comments are rare and the PM agent only needs themes).
+	// Fetch all inline review comments, paginating via Link headers.
 	commentsEndpoint := fmt.Sprintf("%s/repos/%s/%s/pulls/%d/comments?per_page=100",
 		g.baseURL, g.owner, g.repo, prNumber)
 
-	var ghComments []ghReviewComment
-	if err := g.doGet(ctx, commentsEndpoint, &ghComments); err != nil {
+	ghComments, err := doGetPaginated[ghReviewComment](ctx, g, commentsEndpoint)
+	if err != nil {
 		return nil, fmt.Errorf("get review comments: %w", err)
 	}
 
@@ -179,6 +189,81 @@ func (g *GitHubCodeReviewSource) doGet(ctx context.Context, url string, target a
 	}
 
 	return json.NewDecoder(resp.Body).Decode(target)
+}
+
+// doGetPaginated fetches all pages of a GitHub API list endpoint by following
+// Link rel="next" headers. It stops after maxPaginationPages to prevent
+// runaway pagination. On mid-pagination errors it returns whatever was
+// collected so far along with a nil error (logging a warning instead).
+func doGetPaginated[T any](ctx context.Context, g *GitHubCodeReviewSource, initialURL string) ([]T, error) {
+	var all []T
+	nextURL := initialURL
+
+	for page := 0; page < maxPaginationPages; page++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, nextURL, nil)
+		if err != nil {
+			if len(all) > 0 {
+				zerolog.Ctx(ctx).Warn().Err(err).Int("pages_fetched", page).Msg("pagination stopped: failed to create request")
+				return all, nil
+			}
+			return nil, err
+		}
+		req.Header.Set("Authorization", "Bearer "+g.token)
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+		resp, err := g.httpClient.Do(req)
+		if err != nil {
+			if len(all) > 0 {
+				zerolog.Ctx(ctx).Warn().Err(err).Int("pages_fetched", page).Msg("pagination stopped: request failed")
+				return all, nil
+			}
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			if len(all) > 0 {
+				zerolog.Ctx(ctx).Warn().Int("status", resp.StatusCode).Int("pages_fetched", page).Msg("pagination stopped: non-200 status")
+				return all, nil
+			}
+			return nil, fmt.Errorf("GitHub API returned %d", resp.StatusCode)
+		}
+
+		var items []T
+		decodeErr := json.NewDecoder(resp.Body).Decode(&items)
+		resp.Body.Close()
+		if decodeErr != nil {
+			if len(all) > 0 {
+				zerolog.Ctx(ctx).Warn().Err(decodeErr).Int("pages_fetched", page).Msg("pagination stopped: decode error")
+				return all, nil
+			}
+			return nil, decodeErr
+		}
+
+		all = append(all, items...)
+
+		// Check for next page.
+		nextURL = parseLinkNext(resp.Header.Get("Link"))
+		if nextURL == "" {
+			break
+		}
+	}
+
+	return all, nil
+}
+
+// parseLinkNext extracts the URL for rel="next" from a GitHub Link header.
+// Returns "" if no next link is found.
+func parseLinkNext(header string) string {
+	if header == "" {
+		return ""
+	}
+	matches := linkNextRe.FindStringSubmatch(header)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
 }
 
 // reviewDecision returns a simple summary based on review comment count.

--- a/internal/services/integration/github_reviews_test.go
+++ b/internal/services/integration/github_reviews_test.go
@@ -418,6 +418,59 @@ func TestGetPRReviews_PaginationSafetyCap(t *testing.T) {
 	require.Equal(t, maxPaginationPages, pageCount, "should stop at maxPaginationPages")
 }
 
+func TestGetPRReviews_PaginationMidPageError(t *testing.T) {
+	t.Parallel()
+
+	pageCount := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":           int64(100),
+				"user":         map[string]any{"login": "rev"},
+				"state":        "COMMENTED",
+				"body":         "",
+				"submitted_at": "2025-06-15T12:00:00Z",
+			},
+		})
+	})
+
+	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		pageCount++
+		if pageCount == 1 {
+			// Page 1 succeeds with a Link header to page 2.
+			page2URL := fmt.Sprintf("http://%s/repos/o/r/pulls/1/comments?page=2", r.Host)
+			w.Header().Set("Link", `<`+page2URL+`>; rel="next"`)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id": int64(200), "pull_request_review_id": int64(100),
+					"path": "a.go", "line": 1, "body": "page1-comment",
+					"diff_hunk": "@@", "user": map[string]any{"login": "rev"},
+				},
+			})
+		} else {
+			// Page 2 returns a server error.
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		BaseURL: server.URL, Token: "t", Owner: "o", Repo: "r",
+	})
+
+	reviews, err := src.GetPRReviews(context.Background(), 1)
+	require.NoError(t, err, "should succeed with partial results on mid-pagination error")
+	require.Len(t, reviews, 1, "should return the review")
+	require.Len(t, reviews[0].Comments, 1, "should preserve page 1 comments despite page 2 failure")
+	require.Equal(t, "a.go", reviews[0].Comments[0].Path, "should have the page 1 comment")
+}
+
 func TestReviewDecision(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/integration/github_reviews_test.go
+++ b/internal/services/integration/github_reviews_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -272,6 +273,149 @@ func TestGitHubCodeReviewSource_GetPRReviews_APIError(t *testing.T) {
 	_, err := src.GetPRReviews(context.Background(), 1)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "403")
+}
+
+func TestParseLinkNext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{
+			name:     "standard next link",
+			header:   `<https://api.github.com/repos/o/r/pulls/1/comments?per_page=100&page=2>; rel="next", <https://api.github.com/repos/o/r/pulls/1/comments?per_page=100&page=5>; rel="last"`,
+			expected: "https://api.github.com/repos/o/r/pulls/1/comments?per_page=100&page=2",
+		},
+		{
+			name:     "no next link",
+			header:   `<https://api.github.com/repos/o/r/pulls/1/comments?per_page=100&page=1>; rel="first"`,
+			expected: "",
+		},
+		{
+			name:     "empty header",
+			header:   "",
+			expected: "",
+		},
+		{
+			name:     "next only",
+			header:   `<https://example.com/page2>; rel="next"`,
+			expected: "https://example.com/page2",
+		},
+		{
+			name:     "next at end",
+			header:   `<https://example.com/first>; rel="first", <https://example.com/next>; rel="next"`,
+			expected: "https://example.com/next",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := parseLinkNext(tt.header)
+			require.Equal(t, tt.expected, result, "parseLinkNext should extract the correct URL")
+		})
+	}
+}
+
+func TestGetPRReviews_PaginatesComments(t *testing.T) {
+	t.Parallel()
+
+	commentPage := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id":           int64(100),
+				"user":         map[string]any{"login": "rev"},
+				"state":        "COMMENTED",
+				"body":         "",
+				"submitted_at": "2025-06-15T12:00:00Z",
+			},
+		})
+	})
+
+	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		commentPage++
+		if commentPage == 1 {
+			// First page — include Link header pointing to page 2.
+			page2URL := "http://" + r.Host + "/repos/o/r/pulls/1/comments?per_page=100&page=2"
+			w.Header().Set("Link", `<`+page2URL+`>; rel="next"`)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id": int64(200), "pull_request_review_id": int64(100),
+					"path": "a.go", "line": 1, "body": "comment1",
+					"diff_hunk": "@@", "user": map[string]any{"login": "rev"},
+				},
+			})
+		} else {
+			// Second page — no Link header.
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode([]map[string]any{
+				{
+					"id": int64(201), "pull_request_review_id": int64(100),
+					"path": "b.go", "line": 2, "body": "comment2",
+					"diff_hunk": "@@", "user": map[string]any{"login": "rev"},
+				},
+			})
+		}
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		BaseURL: server.URL, Token: "t", Owner: "o", Repo: "r",
+	})
+
+	reviews, err := src.GetPRReviews(context.Background(), 1)
+	require.NoError(t, err, "GetPRReviews should succeed")
+	require.Len(t, reviews, 1, "should return one review")
+	require.Len(t, reviews[0].Comments, 2, "should have paginated comments from both pages")
+	require.Equal(t, "a.go", reviews[0].Comments[0].Path, "first comment from page 1")
+	require.Equal(t, "b.go", reviews[0].Comments[1].Path, "second comment from page 2")
+}
+
+func TestGetPRReviews_PaginationSafetyCap(t *testing.T) {
+	t.Parallel()
+
+	pageCount := 0
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{})
+	})
+
+	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		pageCount++
+		// Always return a next link to simulate infinite pagination.
+		nextURL := fmt.Sprintf("http://%s/repos/o/r/pulls/1/comments?page=%d", r.Host, pageCount+1)
+		w.Header().Set("Link", `<`+nextURL+`>; rel="next"`)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]map[string]any{
+			{
+				"id": int64(pageCount), "pull_request_review_id": int64(0),
+				"path": "f.go", "line": pageCount, "body": "c",
+				"diff_hunk": "@@", "user": map[string]any{"login": "u"},
+			},
+		})
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		BaseURL: server.URL, Token: "t", Owner: "o", Repo: "r",
+	})
+
+	_, err := src.GetPRReviews(context.Background(), 1)
+	require.NoError(t, err, "GetPRReviews should succeed even at safety cap")
+	require.Equal(t, maxPaginationPages, pageCount, "should stop at maxPaginationPages")
 }
 
 func TestReviewDecision(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implement Link header-based pagination for fetching inline review comments via GitHub REST API
- Replace the previous 100-comment hard cap with proper `rel="next"` link following
- Add a generic `doGetPaginated` helper with a safety cap of 10 pages (1000 comments max)
- On mid-pagination errors, gracefully return collected results with a warning log

## Test plan
- [x] `TestParseLinkNext` — table-driven tests for Link header parsing (5 cases)
- [x] `TestGetPRReviews_PaginatesComments` — verifies multi-page comment collection
- [x] `TestGetPRReviews_PaginationSafetyCap` — verifies pagination stops at 10 pages
- [x] Existing `TestGetPRReviews` tests continue to pass (single-page backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)