### PR TITLE
Add workspace-scoped search to Notion integration

### DIFF
--- a/internal/services/integration/notion.go
+++ b/internal/services/integration/notion.go
@@ -8,9 +8,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 )
+
+// notionUUIDRe matches Notion-style UUIDs (with or without hyphens).
+var notionUUIDRe = regexp.MustCompile(`^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$`)
 
 // NotionDocumentStore implements DocumentStore for the Notion API.
 // It provides search and document retrieval using Notion's REST API,
@@ -67,9 +71,17 @@ func (n *NotionDocumentStore) Name() string { return "notion" }
 // SearchDocuments finds pages in Notion matching the text query.
 // An empty query returns all accessible pages (useful for discovery).
 //
-// TODO: Use filter.Workspace to scope search to a specific database
-// via the Notion search API's filter parameter.
+// When filter.Workspace is set, searches are scoped to a specific database.
+// The value can be a database UUID or a database name (case-insensitive match).
 func (n *NotionDocumentStore) SearchDocuments(ctx context.Context, query string, filter DocFilter) ([]DocSummary, error) {
+	if filter.Workspace != "" {
+		return n.searchInDatabase(ctx, query, filter)
+	}
+	return n.searchGeneric(ctx, query, filter)
+}
+
+// searchGeneric performs an unscoped search across the entire workspace.
+func (n *NotionDocumentStore) searchGeneric(ctx context.Context, query string, filter DocFilter) ([]DocSummary, error) {
 	limit := filter.Limit
 	if limit <= 0 {
 		limit = 10
@@ -97,6 +109,75 @@ func (n *NotionDocumentStore) SearchDocuments(ctx context.Context, query string,
 		summaries = append(summaries, pageToDocSummary(page))
 	}
 	return summaries, nil
+}
+
+// searchInDatabase queries pages within a specific Notion database.
+// It resolves filter.Workspace to a database ID (by UUID or name lookup),
+// then uses the POST /v1/databases/{id}/query endpoint.
+func (n *NotionDocumentStore) searchInDatabase(ctx context.Context, query string, filter DocFilter) ([]DocSummary, error) {
+	dbID, err := n.resolveDatabaseID(ctx, filter.Workspace)
+	if err != nil {
+		return nil, fmt.Errorf("resolve database: %w", err)
+	}
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 10
+	}
+	if limit > notionPageSize {
+		limit = notionPageSize
+	}
+
+	body := notionDatabaseQueryRequest{
+		PageSize: limit,
+	}
+
+	path := "/v1/databases/" + url.PathEscape(dbID) + "/query"
+	var resp notionSearchResponse
+	if err := n.doRequest(ctx, http.MethodPost, path, body, &resp); err != nil {
+		return nil, fmt.Errorf("notion query database: %w", err)
+	}
+
+	// The database query endpoint doesn't support full-text search, so
+	// filter results client-side when a text query is provided.
+	queryLower := strings.ToLower(query)
+	summaries := make([]DocSummary, 0, len(resp.Results))
+	for _, page := range resp.Results {
+		s := pageToDocSummary(page)
+		if query != "" && !strings.Contains(strings.ToLower(s.Title), queryLower) {
+			continue
+		}
+		summaries = append(summaries, s)
+	}
+	return summaries, nil
+}
+
+// resolveDatabaseID resolves a workspace filter value to a Notion database ID.
+// If the value looks like a UUID, it's used directly. Otherwise, the available
+// databases are listed and matched by name (case-insensitive).
+func (n *NotionDocumentStore) resolveDatabaseID(ctx context.Context, workspace string) (string, error) {
+	if notionUUIDRe.MatchString(strings.ToLower(workspace)) {
+		return workspace, nil
+	}
+
+	databases, err := n.ListDatabases(ctx)
+	if err != nil {
+		return "", fmt.Errorf("list databases for name lookup: %w", err)
+	}
+
+	target := strings.ToLower(workspace)
+	for _, db := range databases {
+		if strings.ToLower(db.Title) == target {
+			return db.ID, nil
+		}
+	}
+	return "", fmt.Errorf("no database found matching %q", workspace)
+}
+
+// notionDatabaseQueryRequest is the body for POST /v1/databases/{id}/query.
+type notionDatabaseQueryRequest struct {
+	PageSize    int    `json:"page_size,omitempty"`
+	StartCursor string `json:"start_cursor,omitempty"`
 }
 
 // GetDocument fetches a Notion page's metadata and full block content,

--- a/internal/services/integration/notion_test.go
+++ b/internal/services/integration/notion_test.go
@@ -716,3 +716,140 @@ func TestNotionServerError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "500")
 }
+
+func TestNotionSearchDocuments_WorkspaceFilterByUUID(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/databases/a1b2c3d4-e5f6-7890-abcd-ef1234567890/query", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method, "should POST to database query endpoint")
+
+		resp := notionSearchResponse{
+			Results: []notionPage{
+				{
+					ID:  "page-in-db",
+					URL: "https://notion.so/page-in-db",
+					Properties: map[string]notionProperty{
+						"Name": {Type: "title", Title: []notionRichText{{PlainText: "Task Alpha"}}},
+					},
+				},
+				{
+					ID:  "page-in-db-2",
+					URL: "https://notion.so/page-in-db-2",
+					Properties: map[string]notionProperty{
+						"Name": {Type: "title", Title: []notionRichText{{PlainText: "Unrelated Page"}}},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	store := NewNotionDocumentStore(NotionDocumentStoreConfig{
+		AuthToken: "test-token",
+		APIURL:    srv.URL,
+	})
+
+	// With query filter — should client-side filter by title.
+	results, err := store.SearchDocuments(context.Background(), "Alpha", DocFilter{
+		Workspace: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+		Limit:     10,
+	})
+	require.NoError(t, err, "search with UUID workspace should succeed")
+	require.Len(t, results, 1, "should filter to matching title only")
+	require.Equal(t, "Task Alpha", results[0].Title, "should return the matching page")
+}
+
+func TestNotionSearchDocuments_WorkspaceFilterByName(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+
+	// ListDatabases is called to resolve the name.
+	mux.HandleFunc("/v1/search", func(w http.ResponseWriter, r *http.Request) {
+		var body notionSearchRequest
+		json.NewDecoder(r.Body).Decode(&body)
+		require.Equal(t, "database", body.Filter.Value, "should search for databases")
+
+		resp := notionSearchResponse{
+			Results: []notionPage{
+				{
+					ID:    "resolved-db-id",
+					Title: []notionRichText{{PlainText: "Sprint Board"}},
+				},
+				{
+					ID:    "other-db-id",
+					Title: []notionRichText{{PlainText: "Knowledge Base"}},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	// Database query for the resolved ID.
+	mux.HandleFunc("/v1/databases/resolved-db-id/query", func(w http.ResponseWriter, r *http.Request) {
+		resp := notionSearchResponse{
+			Results: []notionPage{
+				{
+					ID:  "sprint-page",
+					URL: "https://notion.so/sprint-page",
+					Properties: map[string]notionProperty{
+						"Name": {Type: "title", Title: []notionRichText{{PlainText: "Sprint 42"}}},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	store := NewNotionDocumentStore(NotionDocumentStoreConfig{
+		AuthToken: "test-token",
+		APIURL:    srv.URL,
+	})
+
+	// Case-insensitive name match.
+	results, err := store.SearchDocuments(context.Background(), "", DocFilter{
+		Workspace: "sprint board",
+		Limit:     10,
+	})
+	require.NoError(t, err, "search with name workspace should succeed")
+	require.Len(t, results, 1, "should return pages from the resolved database")
+	require.Equal(t, "Sprint 42", results[0].Title, "should return the page from Sprint Board db")
+}
+
+func TestNotionSearchDocuments_WorkspaceNameNotFound(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := notionSearchResponse{
+			Results: []notionPage{
+				{ID: "db-1", Title: []notionRichText{{PlainText: "Other DB"}}},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	store := NewNotionDocumentStore(NotionDocumentStoreConfig{
+		AuthToken: "test-token",
+		APIURL:    srv.URL,
+	})
+
+	_, err := store.SearchDocuments(context.Background(), "test", DocFilter{
+		Workspace: "Nonexistent DB",
+	})
+	require.Error(t, err, "should error when workspace name not found")
+	require.Contains(t, err.Error(), "no database found matching", "error should indicate name not found")
+}


### PR DESCRIPTION
## Summary
- Implement workspace/database scoping for Notion document search
- When `DocFilter.Workspace` is set, use `POST /v1/databases/{id}/query` instead of generic search
- Support both UUID (direct) and name (case-insensitive lookup via ListDatabases) as workspace identifiers
- Apply client-side title filtering since the database query endpoint lacks full-text search

## Test plan
- [x] `TestNotionSearchDocuments_WorkspaceFilterByUUID` -- scoped query with direct UUID + client-side filter
- [x] `TestNotionSearchDocuments_WorkspaceFilterByName` -- name resolution via ListDatabases + query
- [x] `TestNotionSearchDocuments_WorkspaceNameNotFound` -- error when no matching database
- [x] Existing `TestNotionSearchDocuments` tests pass (backward compatible)

Generated with [Claude Code](https://claude.com/claude-code)