### PR TITLE
Add server-side filtering for PM decisions

### DIFF
--- a/frontend/src/components/pm/decisions-view.tsx
+++ b/frontend/src/components/pm/decisions-view.tsx
@@ -132,9 +132,13 @@ export function DecisionsView() {
   const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ["pm", "decisions"],
-    // TODO: add server-side filter params to avoid fetching all decisions client-side
-    queryFn: () => api.pm.decisions({ limit: 200 }),
+    queryKey: ["pm", "decisions", decisionFilter, outcomeFilter],
+    queryFn: () =>
+      api.pm.decisions({
+        limit: 200,
+        decision_type: decisionFilter !== "all" ? decisionFilter : undefined,
+        outcome: outcomeFilter !== "all" ? outcomeFilter : undefined,
+      }),
     refetchInterval: 30000,
   });
 
@@ -171,14 +175,8 @@ export function DecisionsView() {
     );
   }
 
-  // Apply filters
-  const decisions = allDecisions.filter((d) => {
-    if (decisionFilter !== "all" && d.decision !== decisionFilter) return false;
-    if (outcomeFilter === "succeeded" && d.outcome !== "succeeded") return false;
-    if (outcomeFilter === "failed" && d.outcome !== "failed") return false;
-    if (outcomeFilter === "still_open" && d.outcome && d.outcome !== "still_open") return false;
-    return true;
-  });
+  // Server-side filtering is applied via query params; use results directly.
+  const decisions = allDecisions;
 
   const filterButtons: { value: DecisionFilter; label: string }[] = [
     { value: "all", label: "All" },
@@ -232,7 +230,7 @@ export function DecisionsView() {
         </div>
         {(decisionFilter !== "all" || outcomeFilter !== "all") && (
           <span className="text-[11px] text-muted-foreground self-center">
-            {decisions.length} of {allDecisions.length} decisions
+            {decisions.length} decisions
           </span>
         )}
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -182,10 +182,12 @@ export const api = {
     },
     latest: () => get<import('./types').SingleResponse<import('./types').PMPlan>>('/api/v1/pm/plans/latest'),
     get: (id: string) => get<import('./types').SingleResponse<import('./types').PMPlan>>(`/api/v1/pm/plans/${id}`),
-    decisions: (params?: { cursor?: string; limit?: number }) => {
+    decisions: (params?: { cursor?: string; limit?: number; decision_type?: string; outcome?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit != null) searchParams.set('limit', String(params.limit));
+      if (params?.decision_type) searchParams.set('decision_type', params.decision_type);
+      if (params?.outcome) searchParams.set('outcome', params.outcome);
       const qs = searchParams.toString();
       return get<import('./types').PMDecisionsResponse>(`/api/v1/pm/decisions${qs ? `?${qs}` : ''}`);
     },

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -176,16 +176,20 @@ func (h *PMHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 
 	limit := queryInt(r, "limit", 50)
 
-	decisionType := r.URL.Query().Get("decision_type")
-	if decisionType != "" && decisionType != "delegate" && decisionType != "skip" && decisionType != "cluster" {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid decision_type: must be delegate, skip, or cluster")
-		return
+	decisionType := models.PMDecisionType(r.URL.Query().Get("decision_type"))
+	if decisionType != "" {
+		if err := decisionType.Validate(); err != nil {
+			writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid decision_type: must be delegate, skip, or cluster")
+			return
+		}
 	}
 
-	outcome := r.URL.Query().Get("outcome")
-	if outcome != "" && outcome != "succeeded" && outcome != "failed" && outcome != "still_open" {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid outcome: must be succeeded, failed, or still_open")
-		return
+	outcome := models.PMDecisionOutcome(r.URL.Query().Get("outcome"))
+	if outcome != "" {
+		if err := outcome.Validate(); err != nil {
+			writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid outcome: must be succeeded, failed, or still_open")
+			return
+		}
 	}
 
 	filters := db.PMDecisionFilters{

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -176,27 +176,27 @@ func (h *PMHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 
 	limit := queryInt(r, "limit", 50)
 
-	decisionType := models.PMDecisionType(r.URL.Query().Get("decision_type"))
-	if decisionType != "" {
+	filters := db.PMDecisionFilters{
+		Limit:  limit,
+		Cursor: r.URL.Query().Get("cursor"),
+	}
+
+	if dt := r.URL.Query().Get("decision_type"); dt != "" {
+		decisionType := models.PMDecisionType(dt)
 		if err := decisionType.Validate(); err != nil {
 			writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid decision_type: must be delegate, skip, or cluster")
 			return
 		}
+		filters.DecisionType = &decisionType
 	}
 
-	outcome := models.PMDecisionOutcome(r.URL.Query().Get("outcome"))
-	if outcome != "" {
+	if o := r.URL.Query().Get("outcome"); o != "" {
+		outcome := models.PMDecisionOutcome(o)
 		if err := outcome.Validate(); err != nil {
 			writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid outcome: must be succeeded, failed, or still_open")
 			return
 		}
-	}
-
-	filters := db.PMDecisionFilters{
-		Limit:        limit,
-		Cursor:       r.URL.Query().Get("cursor"),
-		DecisionType: decisionType,
-		Outcome:      outcome,
+		filters.Outcome = &outcome
 	}
 
 	decisions, err := h.decisionLogStore.ListDecisionViews(r.Context(), orgID, filters)

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -175,9 +175,24 @@ func (h *PMHandler) Decisions(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	limit := queryInt(r, "limit", 50)
+
+	decisionType := r.URL.Query().Get("decision_type")
+	if decisionType != "" && decisionType != "delegate" && decisionType != "skip" && decisionType != "cluster" {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid decision_type: must be delegate, skip, or cluster")
+		return
+	}
+
+	outcome := r.URL.Query().Get("outcome")
+	if outcome != "" && outcome != "succeeded" && outcome != "failed" && outcome != "still_open" {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid outcome: must be succeeded, failed, or still_open")
+		return
+	}
+
 	filters := db.PMDecisionFilters{
-		Limit:  limit,
-		Cursor: r.URL.Query().Get("cursor"),
+		Limit:        limit,
+		Cursor:       r.URL.Query().Get("cursor"),
+		DecisionType: decisionType,
+		Outcome:      outcome,
 	}
 
 	decisions, err := h.decisionLogStore.ListDecisionViews(r.Context(), orgID, filters)

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -152,6 +152,44 @@ func TestPMHandler_Decisions(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPMHandler_Decisions_InvalidDecisionType(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	handler := NewPMHandler(db.NewPMPlanStore(mock), db.NewPMDecisionLogStore(mock), db.NewJobStore(mock), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/decisions?decision_type=invalid", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.Decisions(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "should reject invalid decision_type")
+	require.Contains(t, rr.Body.String(), "VALIDATION_ERROR", "should return validation error code")
+}
+
+func TestPMHandler_Decisions_InvalidOutcome(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	handler := NewPMHandler(db.NewPMPlanStore(mock), db.NewPMDecisionLogStore(mock), db.NewJobStore(mock), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/decisions?outcome=bogus", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.Decisions(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "should reject invalid outcome")
+	require.Contains(t, rr.Body.String(), "VALIDATION_ERROR", "should return validation error code")
+}
+
 func TestPMHandler_Status(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/pm_decision_log.go
+++ b/internal/db/pm_decision_log.go
@@ -55,8 +55,8 @@ func (s *PMDecisionLogStore) ListRecentByOrg(ctx context.Context, orgID uuid.UUI
 type PMDecisionFilters struct {
 	Limit        int
 	Cursor       string
-	DecisionType string // "delegate", "skip", "cluster" — empty means all
-	Outcome      string // "succeeded", "failed", "still_open" — empty means all
+	DecisionType models.PMDecisionType    // empty means all
+	Outcome      models.PMDecisionOutcome // empty means all
 }
 
 // ListDecisionViews returns enriched decisions joined with issue and project data.
@@ -80,7 +80,7 @@ func (s *PMDecisionLogStore) ListDecisionViews(ctx context.Context, orgID uuid.U
 	}
 
 	if filters.Outcome != "" {
-		if filters.Outcome == "still_open" {
+		if filters.Outcome == models.PMDecisionOutcomeStillOpen {
 			query += ` AND (d.outcome = 'still_open' OR d.outcome IS NULL OR d.outcome = '')`
 		} else {
 			query += ` AND d.outcome = @outcome`

--- a/internal/db/pm_decision_log.go
+++ b/internal/db/pm_decision_log.go
@@ -53,8 +53,10 @@ func (s *PMDecisionLogStore) ListRecentByOrg(ctx context.Context, orgID uuid.UUI
 }
 
 type PMDecisionFilters struct {
-	Limit  int
-	Cursor string
+	Limit        int
+	Cursor       string
+	DecisionType string // "delegate", "skip", "cluster" — empty means all
+	Outcome      string // "succeeded", "failed", "still_open" — empty means all
 }
 
 // ListDecisionViews returns enriched decisions joined with issue and project data.
@@ -71,6 +73,20 @@ func (s *PMDecisionLogStore) ListDecisionViews(ctx context.Context, orgID uuid.U
 		WHERE d.org_id = @org_id`
 
 	args := pgx.NamedArgs{"org_id": orgID}
+
+	if filters.DecisionType != "" {
+		query += ` AND d.decision = @decision_type`
+		args["decision_type"] = filters.DecisionType
+	}
+
+	if filters.Outcome != "" {
+		if filters.Outcome == "still_open" {
+			query += ` AND (d.outcome = 'still_open' OR d.outcome IS NULL OR d.outcome = '')`
+		} else {
+			query += ` AND d.outcome = @outcome`
+			args["outcome"] = filters.Outcome
+		}
+	}
 
 	if filters.Cursor != "" {
 		cursorID, err := uuid.Parse(filters.Cursor)

--- a/internal/db/pm_decision_log.go
+++ b/internal/db/pm_decision_log.go
@@ -55,8 +55,8 @@ func (s *PMDecisionLogStore) ListRecentByOrg(ctx context.Context, orgID uuid.UUI
 type PMDecisionFilters struct {
 	Limit        int
 	Cursor       string
-	DecisionType models.PMDecisionType    // empty means all
-	Outcome      models.PMDecisionOutcome // empty means all
+	DecisionType *models.PMDecisionType
+	Outcome      *models.PMDecisionOutcome
 }
 
 // ListDecisionViews returns enriched decisions joined with issue and project data.
@@ -74,17 +74,17 @@ func (s *PMDecisionLogStore) ListDecisionViews(ctx context.Context, orgID uuid.U
 
 	args := pgx.NamedArgs{"org_id": orgID}
 
-	if filters.DecisionType != "" {
+	if filters.DecisionType != nil {
 		query += ` AND d.decision = @decision_type`
-		args["decision_type"] = filters.DecisionType
+		args["decision_type"] = *filters.DecisionType
 	}
 
-	if filters.Outcome != "" {
-		if filters.Outcome == models.PMDecisionOutcomeStillOpen {
+	if filters.Outcome != nil {
+		if *filters.Outcome == models.PMDecisionOutcomeStillOpen {
 			query += ` AND (d.outcome = 'still_open' OR d.outcome IS NULL OR d.outcome = '')`
 		} else {
 			query += ` AND d.outcome = @outcome`
-			args["outcome"] = filters.Outcome
+			args["outcome"] = *filters.Outcome
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add `decision_type` and `outcome` query parameters to `GET /api/v1/pm/decisions`
- Backend applies filters in SQL (parameterized queries) with validation against known enums
- Frontend passes active filter state as query params, includes in React Query key for auto-refetch
- Remove client-side filtering since server handles it now

## Test plan
- [x] `go vet` passes
- [x] Backend validates invalid decision_type/outcome values with 400
- [x] SQL filters use named params (no injection risk)
- [x] Existing pagination/cursor behavior preserved
- [x] Frontend filter UI unchanged, now triggers server-side filtering

Generated with [Claude Code](https://claude.com/claude-code)