### PR TITLE
Add email delivery for team invitations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,14 @@ AWS_SECRET_ACCESS_KEY=
 # POSTGRES_CONTAINER=143-postgres-1
 # WALG_S3_PREFIX=s3://143-backups/wal-g
 
+# ── Email (SMTP) ─────────────────────────────────────────────────────
+# Optional — when not configured, invitation emails are logged to console.
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM=noreply@example.com
+
 # ── LLM ──────────────────────────────────────────────────────────────
 LLM_MODEL=claude-sonnet-4-5
 # OPENAI_API_TYPE=                  # "chat_completions" or "responses"

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -19,6 +19,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/email"
 )
 
 // teamUserStore is the interface the team handler depends on for user operations.
@@ -58,6 +59,7 @@ type TeamHandler struct {
 	sessions    teamSessionStore
 	invitations teamInvitationStore
 	orgs        teamOrgStore
+	emailSender email.Sender
 	frontendURL string
 	audit       *db.AuditEmitter
 }
@@ -74,12 +76,17 @@ func NewTeamHandler(
 	invitations teamInvitationStore,
 	orgs teamOrgStore,
 	frontendURL string,
+	emailSender email.Sender,
 ) *TeamHandler {
+	if emailSender == nil {
+		emailSender = email.NewNoopSender()
+	}
 	return &TeamHandler{
 		users:       users,
 		sessions:    sessions,
 		invitations: invitations,
 		orgs:        orgs,
+		emailSender: emailSender,
 		frontendURL: frontendURL,
 	}
 }
@@ -287,13 +294,28 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 	emitUserAudit(h.audit, r, models.AuditActionTeamMemberInvited, models.AuditResourceInvitation, &invIDStr, invDetails)
 
-	// Log the invitation link to console (SMTP delivery is future work).
 	acceptURL := h.frontendURL + "/invite/accept?token=" + token
+
+	// Look up org name for the email.
+	orgName := ""
+	if org, orgErr := h.orgs.GetByID(r.Context(), orgID); orgErr == nil {
+		orgName = org.Name
+	}
+
+	// Send invitation email. If delivery fails, log the error but don't fail
+	// the request — the invitation record is valid and the admin can share
+	// the link manually.
+	if err := h.emailSender.SendInvitation(r.Context(), body.Email, currentUser.Name, orgName, acceptURL); err != nil {
+		zerolog.Ctx(r.Context()).Warn().Err(err).
+			Str("email", body.Email).
+			Msg("failed to send invitation email — invitation is still valid")
+	}
+
 	zerolog.Ctx(r.Context()).Info().
 		Str("email", body.Email).
 		Str("role", body.Role).
 		Str("accept_url", acceptURL).
-		Msg("invitation created — share this link with the invitee")
+		Msg("invitation created")
 
 	resp := models.InvitationResponse{
 		ID:     inv.ID,

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -146,7 +146,7 @@ func newTeamHandler(users *mockTeamUserStore, sessions *mockTeamSessionStore, in
 	if orgs == nil {
 		orgs = &mockTeamOrgStore{}
 	}
-	return NewTeamHandler(users, sessions, invitations, orgs, "http://localhost:3000")
+	return NewTeamHandler(users, sessions, invitations, orgs, "http://localhost:3000", nil)
 }
 
 func teamCtx(orgID uuid.UUID, user *models.User) context.Context {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -19,6 +19,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/services/codexauth"
+	"github.com/assembledhq/143/internal/services/email"
 	"github.com/assembledhq/143/internal/services/storage"
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/assembledhq/143/internal/services/ingestion"
@@ -160,7 +161,18 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	credentialHandler := handlers.NewCredentialHandler(credentialStore)
 	memoryHandler := handlers.NewMemoryHandler(memoryStore, reviewCommentStore)
 	userCredentialHandler := handlers.NewUserCredentialHandler(userCredentialStore, credentialStore, userStore)
-	teamHandler := handlers.NewTeamHandler(userStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL)
+	var emailSender email.Sender
+	if cfg.SMTPHost != "" && cfg.SMTPFrom != "" {
+		emailSender = email.NewSMTPSender(email.SMTPConfig{
+			Host:     cfg.SMTPHost,
+			Port:     cfg.SMTPPort,
+			Username: cfg.SMTPUsername,
+			Password: cfg.SMTPPassword,
+			From:     cfg.SMTPFrom,
+		})
+		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
+	}
+	teamHandler := handlers.NewTeamHandler(userStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
 
 	projectHandler := handlers.NewProjectHandler(projectStore, projectTaskStore, projectCycleStore, projectAttachmentStore, projectSpecStore)
 	projectHandler.SetJobStore(jobStore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,13 @@ type Config struct {
 	GeminiAPIKey string `env:"GEMINI_API_KEY"`
 	GeminiModel  string `env:"GEMINI_MODEL"`
 
+	// SMTP (optional — invitation emails are logged to console when not configured)
+	SMTPHost     string `env:"SMTP_HOST"`
+	SMTPPort     string `env:"SMTP_PORT"     envDefault:"587"`
+	SMTPUsername string `env:"SMTP_USERNAME"`
+	SMTPPassword string `env:"SMTP_PASSWORD"`
+	SMTPFrom     string `env:"SMTP_FROM"`
+
 	// Sandbox
 	SandboxRuntime     string `env:"SANDBOX_RUNTIME" envDefault:"runc"`
 	SandboxRequireGVisor bool   `env:"SANDBOX_REQUIRE_GVISOR" envDefault:"false"`

--- a/internal/services/email/sender.go
+++ b/internal/services/email/sender.go
@@ -1,0 +1,114 @@
+package email
+
+import (
+	"context"
+	"fmt"
+	"net/smtp"
+	"strings"
+
+	"github.com/rs/zerolog"
+)
+
+// Sender sends transactional emails.
+type Sender interface {
+	SendInvitation(ctx context.Context, to, inviterName, orgName, acceptURL string) error
+}
+
+// SMTPConfig holds SMTP connection details.
+type SMTPConfig struct {
+	Host     string // SMTP server host
+	Port     string // SMTP server port (e.g. "587")
+	Username string // SMTP auth username
+	Password string // SMTP auth password
+	From     string // From address (e.g. "noreply@example.com")
+}
+
+// SMTPSender sends emails via an SMTP server.
+type SMTPSender struct {
+	cfg SMTPConfig
+}
+
+// NewSMTPSender creates an SMTP-backed email sender.
+func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
+	return &SMTPSender{cfg: cfg}
+}
+
+// SendInvitation sends an HTML invitation email.
+func (s *SMTPSender) SendInvitation(ctx context.Context, to, inviterName, orgName, acceptURL string) error {
+	subject := fmt.Sprintf("You've been invited to join %s", orgName)
+
+	html := invitationHTML(inviterName, orgName, acceptURL)
+
+	msg := strings.Join([]string{
+		"From: " + s.cfg.From,
+		"To: " + to,
+		"Subject: " + subject,
+		"MIME-Version: 1.0",
+		"Content-Type: text/html; charset=UTF-8",
+		"",
+		html,
+	}, "\r\n")
+
+	addr := s.cfg.Host + ":" + s.cfg.Port
+	auth := smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host)
+
+	if err := smtp.SendMail(addr, auth, s.cfg.From, []string{to}, []byte(msg)); err != nil {
+		return fmt.Errorf("send invitation email to %s: %w", to, err)
+	}
+	return nil
+}
+
+// NoopSender logs invitation details without sending an email.
+// Used when SMTP is not configured.
+type NoopSender struct{}
+
+// NewNoopSender creates a no-op email sender that only logs.
+func NewNoopSender() *NoopSender {
+	return &NoopSender{}
+}
+
+// SendInvitation logs the invitation instead of sending an email.
+func (n *NoopSender) SendInvitation(ctx context.Context, to, inviterName, orgName, acceptURL string) error {
+	zerolog.Ctx(ctx).Info().
+		Str("to", to).
+		Str("inviter", inviterName).
+		Str("org", orgName).
+		Str("accept_url", acceptURL).
+		Msg("email sending skipped (SMTP not configured)")
+	return nil
+}
+
+// invitationHTML returns the HTML body for an invitation email.
+func invitationHTML(inviterName, orgName, acceptURL string) string {
+	inviterText := "Someone"
+	if inviterName != "" {
+		inviterText = inviterName
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"></head>
+<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
+    <tr><td align="center">
+      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
+        <tr><td style="padding:32px 32px 24px;text-align:center;">
+          <h1 style="margin:0 0 8px;font-size:20px;font-weight:600;color:#18181b;">
+            Join %s
+          </h1>
+          <p style="margin:0 0 24px;font-size:14px;color:#71717a;line-height:1.5;">
+            %s has invited you to join <strong>%s</strong>.
+          </p>
+          <a href="%s" style="display:inline-block;padding:10px 24px;background-color:#18181b;color:#ffffff;text-decoration:none;border-radius:6px;font-size:14px;font-weight:500;">
+            Accept Invitation
+          </a>
+          <p style="margin:24px 0 0;font-size:12px;color:#a1a1aa;line-height:1.5;">
+            This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>`, orgName, inviterText, orgName, acceptURL)
+}

--- a/internal/services/email/sender.go
+++ b/internal/services/email/sender.go
@@ -3,6 +3,7 @@ package email
 import (
 	"context"
 	"fmt"
+	"html"
 	"net/smtp"
 	"strings"
 
@@ -79,11 +80,14 @@ func (n *NoopSender) SendInvitation(ctx context.Context, to, inviterName, orgNam
 }
 
 // invitationHTML returns the HTML body for an invitation email.
+// All dynamic values are HTML-escaped to prevent injection.
 func invitationHTML(inviterName, orgName, acceptURL string) string {
 	inviterText := "Someone"
 	if inviterName != "" {
-		inviterText = inviterName
+		inviterText = html.EscapeString(inviterName)
 	}
+	safeOrg := html.EscapeString(orgName)
+	safeURL := html.EscapeString(acceptURL)
 
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html>
@@ -110,5 +114,5 @@ func invitationHTML(inviterName, orgName, acceptURL string) string {
     </td></tr>
   </table>
 </body>
-</html>`, orgName, inviterText, orgName, acceptURL)
+</html>`, safeOrg, inviterText, safeOrg, safeURL)
 }

--- a/internal/services/email/sender_test.go
+++ b/internal/services/email/sender_test.go
@@ -1,0 +1,77 @@
+package email
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoopSender_SendInvitation(t *testing.T) {
+	t.Parallel()
+
+	sender := NewNoopSender()
+	err := sender.SendInvitation(context.Background(), "user@example.com", "Alice", "Acme Corp", "https://example.com/accept?token=abc")
+	require.NoError(t, err, "NoopSender should never return an error")
+}
+
+func TestInvitationHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		inviter     string
+		org         string
+		url         string
+		mustContain []string
+	}{
+		{
+			name:    "with inviter name",
+			inviter: "Alice",
+			org:     "Acme Corp",
+			url:     "https://example.com/accept?token=abc",
+			mustContain: []string{
+				"Acme Corp",
+				"Alice",
+				"https://example.com/accept?token=abc",
+				"Accept Invitation",
+			},
+		},
+		{
+			name:    "empty inviter falls back to Someone",
+			inviter: "",
+			org:     "TestOrg",
+			url:     "https://example.com/invite",
+			mustContain: []string{
+				"Someone",
+				"TestOrg",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			html := invitationHTML(tt.inviter, tt.org, tt.url)
+			for _, s := range tt.mustContain {
+				require.Contains(t, html, s, "invitation HTML should contain %q", s)
+			}
+		})
+	}
+}
+
+func TestNewSMTPSender(t *testing.T) {
+	t.Parallel()
+
+	cfg := SMTPConfig{
+		Host:     "smtp.example.com",
+		Port:     "587",
+		Username: "user",
+		Password: "pass",
+		From:     "noreply@example.com",
+	}
+	sender := NewSMTPSender(cfg)
+	require.NotNil(t, sender, "NewSMTPSender should return a non-nil sender")
+	require.Equal(t, "smtp.example.com", sender.cfg.Host, "should store config")
+}

--- a/internal/services/email/sender_test.go
+++ b/internal/services/email/sender_test.go
@@ -47,6 +47,17 @@ func TestInvitationHTML(t *testing.T) {
 				"TestOrg",
 			},
 		},
+		{
+			name:    "HTML special characters are escaped",
+			inviter: "<script>alert('xss')</script>",
+			org:     "Org & Co <Ltd>",
+			url:     "https://example.com/invite?a=1&b=2",
+			mustContain: []string{
+				"&lt;script&gt;",
+				"Org &amp; Co &lt;Ltd&gt;",
+				"a=1&amp;b=2",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Introduce `email.Sender` interface with SMTP and no-op implementations
- When SMTP env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`) are set, send HTML invitation emails
- When not configured, no-op sender logs invitation details (preserving current behavior)
- Email failures are logged at Warn level without failing the invitation creation
- Professional HTML email template with org name, inviter name, and accept button

## Test plan
- [x] `TestNoopSender_SendInvitation` — no-op sender returns nil
- [x] `TestInvitationHTML` — template contains expected content (table-driven)
- [x] `TestNewSMTPSender` — constructor stores config
- [x] Existing team handler tests pass with nil email sender (backward compat)
- [x] `go vet` passes for all changed packages

Generated with [Claude Code](https://claude.com/claude-code)