### PR TITLE
Implement dependency graph execution mode for project tasks

### DIFF
--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -73,6 +73,7 @@ func (s *Service) executeProjectPlan(ctx context.Context, orgID uuid.UUID, pp *P
 
 	// Create new tasks from the PM's plan.
 	tasksCreated := 0
+	titleToID := make(map[string]uuid.UUID) // maps task title → UUID for dependency resolution
 	for i, spec := range pp.NewTasks {
 		task := &models.ProjectTask{
 			ProjectID:   pp.ProjectID,
@@ -103,7 +104,13 @@ func (s *Service) executeProjectPlan(ctx context.Context, orgID uuid.UUID, pp *P
 			s.logger.Error().Err(err).Str("task_title", spec.Title).Msg("failed to create project task")
 			continue
 		}
+		titleToID[spec.Title] = task.ID
 		tasksCreated++
+	}
+
+	// Resolve title-based depends_on references to UUIDs for dependency_graph mode.
+	if project.ExecutionMode == models.ProjectExecModeDependencyGraph && tasksCreated > 0 {
+		s.resolveDependsOnTitles(ctx, orgID, pp, titleToID)
 	}
 
 	// Dispatch eligible pending tasks based on execution mode.
@@ -147,6 +154,21 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 		agentType = models.DefaultDefaultAgentType
 	}
 
+	// For dependency_graph mode, build a status lookup of all project tasks so
+	// we can check whether each task's dependencies have been satisfied.
+	var taskStatusByID map[uuid.UUID]models.ProjectTaskStatus
+	if project.ExecutionMode == models.ProjectExecModeDependencyGraph {
+		allTasks, err := s.projectTasks.ListByProject(ctx, orgID, project.ID, db.ProjectTaskFilters{})
+		if err != nil {
+			s.logger.Error().Err(err).Msg("failed to list all project tasks for dependency check")
+			return 0
+		}
+		taskStatusByID = make(map[uuid.UUID]models.ProjectTaskStatus, len(allTasks))
+		for _, t := range allTasks {
+			taskStatusByID[t.ID] = t.Status
+		}
+	}
+
 	dispatched := 0
 	for i := range pending {
 		if dispatched >= slotsAvailable {
@@ -158,6 +180,24 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 		// Skip low-confidence tasks unless autonomy is auto_all.
 		if task.Confidence != nil && *task.Confidence == "low" && settings.AutonomyLevel != models.AutonomyLevelAutoAll {
 			continue
+		}
+
+		// In dependency_graph mode, only dispatch tasks whose dependencies are all completed.
+		if project.ExecutionMode == models.ProjectExecModeDependencyGraph && len(task.DependsOn) > 0 {
+			depStatus := checkDependenciesStatus(task.DependsOn, taskStatusByID)
+			if depStatus == depStatusBlocked {
+				// At least one dependency failed — mark this task as blocked.
+				task.Status = models.ProjectTaskStatusBlocked
+				if err := s.projectTasks.Update(ctx, task); err != nil {
+					s.logger.Warn().Err(err).Str("task_id", task.ID.String()).Msg("failed to mark task as blocked")
+				}
+				continue
+			}
+			if depStatus == depStatusWaiting {
+				// Dependencies still in progress — skip for now.
+				continue
+			}
+			// depStatusReady: all dependencies completed, proceed with dispatch.
 		}
 
 		branchName := generateProjectBranchName(project.ID, task.BatchNumber, task.SortOrder, task.Title)
@@ -249,8 +289,20 @@ func (s *Service) canDispatchForProject(ctx context.Context, orgID uuid.UUID, pr
 			return 0
 		}
 		return remaining
+	case models.ProjectExecModeDependencyGraph:
+		// Dependency graph mode: allow parallel execution up to max_concurrent,
+		// but actual eligibility is filtered in dispatchProjectTasks based on
+		// whether each task's dependencies are satisfied.
+		maxConcurrent := project.MaxConcurrent
+		if maxConcurrent <= 0 {
+			maxConcurrent = 1
+		}
+		remaining := maxConcurrent - activeCount
+		if remaining < 0 {
+			return 0
+		}
+		return remaining
 	default:
-		// dependency_graph not implemented yet; treat as sequential.
 		if activeCount > 0 {
 			return 0
 		}
@@ -343,6 +395,89 @@ func placeholderIssueID(task *models.ProjectTask) uuid.UUID {
 		return *task.IssueID
 	}
 	return uuid.Nil
+}
+
+// depStatus represents the aggregate state of a task's dependencies.
+type depStatus int
+
+const (
+	depStatusReady   depStatus = iota // all deps completed
+	depStatusWaiting                  // some deps still pending/running
+	depStatusBlocked                  // at least one dep failed/cancelled
+)
+
+// checkDependenciesStatus evaluates whether a task's dependencies allow dispatch.
+func checkDependenciesStatus(dependsOn []uuid.UUID, statusByID map[uuid.UUID]models.ProjectTaskStatus) depStatus {
+	for _, depID := range dependsOn {
+		status, ok := statusByID[depID]
+		if !ok {
+			// Unknown dependency — treat as waiting (may not be created yet).
+			return depStatusWaiting
+		}
+		switch status {
+		case models.ProjectTaskStatusCompleted:
+			continue
+		case models.ProjectTaskStatusFailed, models.ProjectTaskStatusCancelled, models.ProjectTaskStatusSkipped:
+			return depStatusBlocked
+		default:
+			return depStatusWaiting
+		}
+	}
+	return depStatusReady
+}
+
+// resolveDependsOnTitles converts title-based dependency references in new tasks
+// to UUID-based references. The PM agent specifies dependencies by title since
+// IDs don't exist at plan time. After creating the tasks, we resolve titles to
+// the actual task UUIDs. Also looks up existing tasks in the project for
+// cross-batch references.
+func (s *Service) resolveDependsOnTitles(ctx context.Context, orgID uuid.UUID, pp *ProjectPlan, titleToID map[string]uuid.UUID) {
+	// Build a broader title→ID map from all existing tasks in the project.
+	existing, err := s.projectTasks.ListByProject(ctx, orgID, pp.ProjectID, db.ProjectTaskFilters{})
+	if err != nil {
+		s.logger.Warn().Err(err).Msg("failed to list existing tasks for dependency resolution")
+		return
+	}
+	allTitleToID := make(map[string]uuid.UUID, len(existing))
+	for _, t := range existing {
+		allTitleToID[t.Title] = t.ID
+	}
+	// Overlay the newly created tasks (which take precedence).
+	for title, id := range titleToID {
+		allTitleToID[title] = id
+	}
+
+	// Resolve each new task's depends_on titles to UUIDs.
+	for _, spec := range pp.NewTasks {
+		if len(spec.DependsOn) == 0 {
+			continue
+		}
+		taskID, ok := titleToID[spec.Title]
+		if !ok {
+			continue
+		}
+
+		var resolved []uuid.UUID
+		for _, depTitle := range spec.DependsOn {
+			if depID, found := allTitleToID[depTitle]; found {
+				resolved = append(resolved, depID)
+			} else {
+				s.logger.Warn().Str("task", spec.Title).Str("missing_dep", depTitle).Msg("dependency title not found — skipping")
+			}
+		}
+
+		if len(resolved) > 0 {
+			task, err := s.projectTasks.GetByID(ctx, orgID, taskID)
+			if err != nil {
+				s.logger.Warn().Err(err).Str("task_id", taskID.String()).Msg("failed to fetch task for dependency update")
+				continue
+			}
+			task.DependsOn = resolved
+			if err := s.projectTasks.Update(ctx, &task); err != nil {
+				s.logger.Warn().Err(err).Str("task_id", taskID.String()).Msg("failed to update task dependencies")
+			}
+		}
+	}
 }
 
 // tokenModeFromTaskComplexity maps a task's complexity string to a token mode.

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -279,20 +279,11 @@ func (s *Service) canDispatchForProject(ctx context.Context, orgID uuid.UUID, pr
 			return 0
 		}
 		return 1
-	case models.ProjectExecModeParallel:
-		maxConcurrent := project.MaxConcurrent
-		if maxConcurrent <= 0 {
-			maxConcurrent = 1
-		}
-		remaining := maxConcurrent - activeCount
-		if remaining < 0 {
-			return 0
-		}
-		return remaining
-	case models.ProjectExecModeDependencyGraph:
-		// Dependency graph mode: allow parallel execution up to max_concurrent,
-		// but actual eligibility is filtered in dispatchProjectTasks based on
-		// whether each task's dependencies are satisfied.
+	case models.ProjectExecModeParallel, models.ProjectExecModeDependencyGraph:
+		// Both modes allow parallel execution up to max_concurrent. For
+		// dependency_graph mode, actual eligibility is further filtered in
+		// dispatchProjectTasks based on whether each task's dependencies
+		// are satisfied.
 		maxConcurrent := project.MaxConcurrent
 		if maxConcurrent <= 0 {
 			maxConcurrent = 1
@@ -417,7 +408,7 @@ func checkDependenciesStatus(dependsOn []uuid.UUID, statusByID map[uuid.UUID]mod
 		switch status {
 		case models.ProjectTaskStatusCompleted:
 			continue
-		case models.ProjectTaskStatusFailed, models.ProjectTaskStatusCancelled, models.ProjectTaskStatusSkipped:
+		case models.ProjectTaskStatusFailed, models.ProjectTaskStatusCancelled, models.ProjectTaskStatusSkipped, models.ProjectTaskStatusBlocked:
 			return depStatusBlocked
 		default:
 			return depStatusWaiting

--- a/internal/services/pm/project_execute_test.go
+++ b/internal/services/pm/project_execute_test.go
@@ -609,6 +609,14 @@ func TestCheckDependenciesStatus(t *testing.T) {
 			want: depStatusBlocked,
 		},
 		{
+			name:      "blocked dep propagates blocked (transitive)",
+			dependsOn: []uuid.UUID{depA},
+			statuses: map[uuid.UUID]models.ProjectTaskStatus{
+				depA: models.ProjectTaskStatusBlocked,
+			},
+			want: depStatusBlocked,
+		},
+		{
 			name:      "unknown dep is waiting",
 			dependsOn: []uuid.UUID{depC},
 			statuses:  map[uuid.UUID]models.ProjectTaskStatus{},

--- a/internal/services/pm/project_execute_test.go
+++ b/internal/services/pm/project_execute_test.go
@@ -685,7 +685,7 @@ func TestDispatchProjectTasks_DependencyGraph(t *testing.T) {
 		OrgID:     orgID,
 		Title:     "Deploy",
 		Status:    models.ProjectTaskStatusPending,
-		DependsOn: []uuid.UUID{uuid.New()}, // depends on non-existent task
+		DependsOn: []uuid.UUID{uuid.New()}, // depends on unknown task — treated as waiting
 	}
 
 	pts := &mockProjectTaskStore{
@@ -719,4 +719,58 @@ func TestDispatchProjectTasks_DependencyGraph(t *testing.T) {
 	}
 	require.NotNil(t, found, "ready task should still be in store")
 	require.Equal(t, models.ProjectTaskStatusDelegated, found.Status, "ready task should be delegated")
+}
+
+func TestDispatchProjectTasks_DependencyGraph_BlockedPath(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	failedDep := &models.ProjectTask{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		OrgID:     orgID,
+		Title:     "Broken Step",
+		Status:    models.ProjectTaskStatusFailed,
+	}
+
+	blockedTask := &models.ProjectTask{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		OrgID:     orgID,
+		Title:     "Depends on Broken",
+		Status:    models.ProjectTaskStatusPending,
+		DependsOn: []uuid.UUID{failedDep.ID},
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{failedDep, blockedTask},
+		countByStatus: map[string]int{},
+	}
+	svc := newTestProjectService(nil, pts, &mockProjectCycleStore{})
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeDependencyGraph,
+		MaxConcurrent: 5,
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "codex",
+	}, uuid.New())
+
+	require.Equal(t, 0, dispatched, "should not dispatch any tasks when dependency failed")
+
+	// The task with a failed dependency should be marked as blocked.
+	var found *models.ProjectTask
+	for _, task := range pts.tasks {
+		if task.ID == blockedTask.ID {
+			found = task
+			break
+		}
+	}
+	require.NotNil(t, found, "blocked task should still be in store")
+	require.Equal(t, models.ProjectTaskStatusBlocked, found.Status, "task with failed dependency should be marked blocked")
 }

--- a/internal/services/pm/project_execute_test.go
+++ b/internal/services/pm/project_execute_test.go
@@ -553,3 +553,170 @@ func TestDispatchProjectTasks_SkipsLowConfidenceUnlessAutoAll(t *testing.T) {
 	}, uuid.New())
 	require.Equal(t, 1, dispatched)
 }
+
+func TestCheckDependenciesStatus(t *testing.T) {
+	t.Parallel()
+
+	depA := uuid.New()
+	depB := uuid.New()
+	depC := uuid.New()
+
+	tests := []struct {
+		name      string
+		dependsOn []uuid.UUID
+		statuses  map[uuid.UUID]models.ProjectTaskStatus
+		want      depStatus
+	}{
+		{
+			name:      "no dependencies is ready",
+			dependsOn: nil,
+			statuses:  nil,
+			want:      depStatusReady,
+		},
+		{
+			name:      "all completed is ready",
+			dependsOn: []uuid.UUID{depA, depB},
+			statuses: map[uuid.UUID]models.ProjectTaskStatus{
+				depA: models.ProjectTaskStatusCompleted,
+				depB: models.ProjectTaskStatusCompleted,
+			},
+			want: depStatusReady,
+		},
+		{
+			name:      "one pending is waiting",
+			dependsOn: []uuid.UUID{depA, depB},
+			statuses: map[uuid.UUID]models.ProjectTaskStatus{
+				depA: models.ProjectTaskStatusCompleted,
+				depB: models.ProjectTaskStatusRunning,
+			},
+			want: depStatusWaiting,
+		},
+		{
+			name:      "one failed is blocked",
+			dependsOn: []uuid.UUID{depA, depB},
+			statuses: map[uuid.UUID]models.ProjectTaskStatus{
+				depA: models.ProjectTaskStatusCompleted,
+				depB: models.ProjectTaskStatusFailed,
+			},
+			want: depStatusBlocked,
+		},
+		{
+			name:      "cancelled dep is blocked",
+			dependsOn: []uuid.UUID{depA},
+			statuses: map[uuid.UUID]models.ProjectTaskStatus{
+				depA: models.ProjectTaskStatusCancelled,
+			},
+			want: depStatusBlocked,
+		},
+		{
+			name:      "unknown dep is waiting",
+			dependsOn: []uuid.UUID{depC},
+			statuses:  map[uuid.UUID]models.ProjectTaskStatus{},
+			want:      depStatusWaiting,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := checkDependenciesStatus(tt.dependsOn, tt.statuses)
+			require.Equal(t, tt.want, got, "checkDependenciesStatus should return expected status")
+		})
+	}
+}
+
+func TestCanDispatchForProject_DependencyGraph(t *testing.T) {
+	t.Parallel()
+
+	pts := &mockProjectTaskStore{countByStatus: map[string]int{}}
+	svc := newTestProjectService(nil, pts, nil)
+
+	project := &models.Project{
+		ID:            uuid.New(),
+		ExecutionMode: models.ProjectExecModeDependencyGraph,
+		MaxConcurrent: 3,
+	}
+
+	t.Run("no active tasks returns max concurrent", func(t *testing.T) { //nolint:paralleltest
+		pts.countByStatus = map[string]int{}
+		got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+		require.Equal(t, 3, got, "should allow max_concurrent when no active tasks")
+	})
+
+	t.Run("some active returns remaining", func(t *testing.T) { //nolint:paralleltest
+		pts.countByStatus = map[string]int{string(models.ProjectTaskStatusRunning): 2}
+		got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+		require.Equal(t, 1, got, "should return remaining slots")
+	})
+
+	t.Run("all slots used returns 0", func(t *testing.T) { //nolint:paralleltest
+		pts.countByStatus = map[string]int{string(models.ProjectTaskStatusRunning): 3}
+		got := svc.canDispatchForProject(context.Background(), uuid.New(), project)
+		require.Equal(t, 0, got, "should return 0 when all slots are used")
+	})
+}
+
+func TestDispatchProjectTasks_DependencyGraph(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	projectID := uuid.New()
+
+	depTask := &models.ProjectTask{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		OrgID:     orgID,
+		Title:     "Setup DB",
+		Status:    models.ProjectTaskStatusCompleted,
+	}
+
+	readyTask := &models.ProjectTask{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		OrgID:     orgID,
+		Title:     "Build API",
+		Status:    models.ProjectTaskStatusPending,
+		DependsOn: []uuid.UUID{depTask.ID},
+	}
+
+	blockedTask := &models.ProjectTask{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		OrgID:     orgID,
+		Title:     "Deploy",
+		Status:    models.ProjectTaskStatusPending,
+		DependsOn: []uuid.UUID{uuid.New()}, // depends on non-existent task
+	}
+
+	pts := &mockProjectTaskStore{
+		tasks:         []*models.ProjectTask{depTask, readyTask, blockedTask},
+		countByStatus: map[string]int{},
+	}
+	svc := newTestProjectService(nil, pts, &mockProjectCycleStore{})
+
+	project := &models.Project{
+		ID:            projectID,
+		ExecutionMode: models.ProjectExecModeDependencyGraph,
+		MaxConcurrent: 5,
+	}
+
+	dispatched := svc.dispatchProjectTasks(context.Background(), orgID, project, models.OrgSettings{
+		AutonomyLevel:    "auto_all",
+		DefaultAgentType: "codex",
+	}, uuid.New())
+
+	require.Equal(t, 1, dispatched, "should only dispatch the task with satisfied dependencies")
+
+	// Look up the task via the mock store — dispatchProjectTasks works on
+	// copies returned by ListByProject, so the original readyTask pointer
+	// isn't mutated; the mock's Update replaces the entry in pts.tasks.
+	var found *models.ProjectTask
+	for _, task := range pts.tasks {
+		if task.ID == readyTask.ID {
+			found = task
+			break
+		}
+	}
+	require.NotNil(t, found, "ready task should still be in store")
+	require.Equal(t, models.ProjectTaskStatusDelegated, found.Status, "ready task should be delegated")
+}


### PR DESCRIPTION
## Summary
- Implements the dependency_graph execution mode for project tasks, replacing the previous TODO stub
- Tasks are only dispatched when all upstream dependencies (specified by UUID) have completed; tasks with failed/cancelled deps are marked blocked
- Adds resolveDependsOnTitles() to convert the PM agent title-based depends_on references into UUID-based references after task creation
- canDispatchForProject treats dependency_graph like parallel mode (respects max_concurrent) while dispatchProjectTasks adds dependency filtering

## Test plan
- [x] TestCheckDependenciesStatus - 6 table-driven cases covering ready, waiting, blocked states
- [x] TestCanDispatchForProject_DependencyGraph - 3 subtests for slot allocation
- [x] TestDispatchProjectTasks_DependencyGraph - integration test verifying only dependency-satisfied tasks are dispatched
- [x] Full ./internal/services/pm/... test suite passes
- [x] go vet passes

Generated with [Claude Code](https://claude.com/claude-code)