### PR TITLE
Update PageContainer wide size to max-w-7xl for data-heavy pages

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -84,14 +84,14 @@ Use `PageContainer` (`src/components/page-container.tsx`) for ALL dashboard page
 </PageContainer>
 ```
 
-**All pages MUST use the same `size="default"` (max-w-5xl)** to ensure consistent margins across the app. This is critical — using different sizes creates jarring layout shifts when navigating between pages.
+Available sizes:
 
 - `narrow` (max-w-3xl): Only for focused single-column forms/modals
-- `default` (max-w-5xl): **Standard for all dashboard pages** — use this
-- `wide` (max-w-5xl): Alias for default (kept for backwards compat)
+- `default` (max-w-5xl): **Standard for most dashboard pages** — use this
+- `wide` (max-w-7xl): For data-heavy pages (tables, logs) that benefit from extra horizontal space
 - `full` (max-w-none): Only for true full-bleed layouts
 
-**NEVER use `size="wide"` or `size="narrow"` for regular dashboard pages.** The outer `<div className="space-y-6">` is mandatory for consistent vertical rhythm.
+Use `size="default"` for most pages. Use `size="wide"` for pages dominated by data tables or tabular content. The outer `<div className="space-y-6">` is mandatory for consistent vertical rhythm.
 
 ### Page Header
 
@@ -423,7 +423,7 @@ Use the `tags` parameter to add searchable context (feature name, endpoint, comp
 3. **Ad-hoc page headers** — Never use `<h1>` directly. Use `PageHeader` component.
 4. **Non-responsive grids** — Never `grid grid-cols-2` without `md:` breakpoint.
 5. **Missing PageContainer** — Every dashboard page must be wrapped in `PageContainer`.
-6. **Inconsistent container sizes** — All dashboard pages MUST use `size="default"`. Never use `size="wide"` or `size="narrow"` for regular pages — this creates different margins between pages.
+6. **Inconsistent container sizes** — Use `size="default"` for most pages and `size="wide"` for data-table-heavy pages. Never use `size="narrow"` for regular dashboard pages.
 7. **Inconsistent row padding** — Always `py-3.5 px-4` for list rows.
 8. **Missing dark mode** — Banners/alerts using hardcoded Tailwind colors (e.g., `bg-blue-50`, `border-green-200`) need `dark:` variant classes. Semantic tokens (`bg-destructive/10`, `bg-primary/10`) adapt automatically.
 9. **Flat cards** — Cards should always have `shadow-sm` (provided by the Card component). Don't override with `shadow-none`.

--- a/frontend/src/components/page-container.test.tsx
+++ b/frontend/src/components/page-container.test.tsx
@@ -11,7 +11,7 @@ describe("PageContainer", () => {
     expect(container).toHaveClass("mx-auto");
   });
 
-  it("applies narrow width for narrow size and same default for wide", () => {
+  it("applies narrow width for narrow size and wider max for wide", () => {
     const { rerender } = render(<PageContainer size="narrow">Sized container</PageContainer>);
 
     let container = screen.getByText("Sized container");
@@ -19,6 +19,6 @@ describe("PageContainer", () => {
 
     rerender(<PageContainer size="wide">Sized container</PageContainer>);
     container = screen.getByText("Sized container");
-    expect(container).toHaveClass("max-w-5xl");
+    expect(container).toHaveClass("max-w-7xl");
   });
 });

--- a/frontend/src/components/page-container.tsx
+++ b/frontend/src/components/page-container.tsx
@@ -6,7 +6,7 @@ type PageContainerSize = "narrow" | "default" | "wide" | "full";
 const sizeClassMap: Record<PageContainerSize, string> = {
   narrow: "max-w-3xl",
   default: "max-w-5xl",
-  wide: "max-w-5xl",
+  wide: "max-w-7xl",
   full: "max-w-none",
 };
 


### PR DESCRIPTION
## Summary
Updated the `PageContainer` component to differentiate between `default` and `wide` sizes, allowing data-heavy pages with tables and tabular content to use additional horizontal space while maintaining consistency for standard dashboard pages.

## Changes
- **PageContainer component**: Changed `wide` size from `max-w-5xl` to `max-w-7xl` to provide extra horizontal space for data-intensive layouts
- **Documentation (AGENTS.md)**: 
  - Clarified that `wide` is no longer an alias for `default`, but a distinct size for data-table-heavy pages
  - Updated guidance to recommend `size="default"` for most pages and `size="wide"` for pages dominated by tables or tabular content
  - Removed overly strict requirement that all pages must use `size="default"`
  - Updated common mistakes section to reflect the new flexibility
- **Tests**: Updated test expectations to verify `wide` now applies `max-w-7xl` instead of `max-w-5xl`

## Implementation Details
The change maintains backward compatibility while providing a clearer semantic distinction:
- `narrow` (max-w-3xl): Focused single-column forms/modals
- `default` (max-w-5xl): Standard for most dashboard pages
- `wide` (max-w-7xl): Data-heavy pages that benefit from extra horizontal space
- `full` (max-w-none): True full-bleed layouts

This allows developers to optimize layout width based on content type without compromising consistency across the application.

https://claude.ai/code/session_01Pzhr92NMSF1VwqymfGr5HQ