### PR TITLE
Allow ngrok.dev origins in Next.js development configuration

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,7 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 const apiTarget = process.env.API_PROXY_TARGET || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
-  allowedDevOrigins: ["*.ngrok.dev"],
+  allowedDevOrigins: ["*.ngrok.dev", "localhost", "127.0.0.1"],
   async rewrites() {
     return [
       {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 const apiTarget = process.env.API_PROXY_TARGET || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ["*.ngrok.dev"],
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
Added support for ngrok.dev origins in the Next.js development configuration to enable local development with ngrok tunneling.

## Changes
- Added `allowedDevOrigins` configuration to `next.config.ts` with support for `*.ngrok.dev` domains
- This allows developers to use ngrok for exposing their local development server to external networks while maintaining proper origin validation

## Implementation Details
The `allowedDevOrigins` setting permits any subdomain under `ngrok.dev` (e.g., `abc123.ngrok.dev`) to be recognized as valid development origins, which is useful for testing webhooks, external integrations, and sharing development environments with team members.

https://claude.ai/code/session_012gWWLYQbzSR8KPgyq3EnS6