### PR TITLE
Add build version information to server binary

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -2,7 +2,7 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
-  cmd = "go build -o ./tmp/server ./cmd/server"
+  cmd = "go build -ldflags \"-X github.com/assembledhq/143/internal/version.BuildSHA=$(git rev-parse HEAD 2>/dev/null || echo dev)\" -o ./tmp/server ./cmd/server"
   bin = "./tmp/server"
   delay = 1000
   include_ext = ["go"]

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ frontend-check:
 	cd frontend && npm run typecheck && npm run lint && npm run build
 
 server-dev:
-	go run cmd/server/main.go
+	go run -ldflags "$(LDFLAGS)" cmd/server/main.go
 
 lint:
 	@$(MAKE) lint-bootstrap


### PR DESCRIPTION
## Summary
This PR adds build-time version information to the server binary by injecting the Git commit SHA during compilation.

## Key Changes
- **air.toml**: Updated the build command to include `-ldflags` that injects the current Git commit SHA into `github.com/assembledhq/143/internal/version.BuildSHA` at build time. Falls back to "dev" if Git is unavailable.
- **Makefile**: Modified the `server-dev` target to use `-ldflags` with the `LDFLAGS` variable, enabling consistent version injection during local development.

## Implementation Details
- The Git commit SHA is captured using `git rev-parse HEAD` with a fallback to "dev" for environments where Git may not be available
- The version information is injected into the `internal/version` package, allowing the application to report its build version at runtime
- Both development (via Makefile) and hot-reload (via air) build processes now include version information

https://claude.ai/code/session_01RfgMpMFnJxRWxNMHM8E6p8