### PR TITLE
Fix token refresh serialization and expiry handling for Codex agents

### DIFF
--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -932,6 +932,12 @@ func TestIsRefreshTokenError(t *testing.T) {
 		{"command not found", false},
 		{`"error": { "type": "invalid_request_error" }`, false},
 		{"", false},
+		// token_expired errors must NOT be filtered here — they need to reach
+		// result.Error so the orchestrator's retryOnTokenExpired can detect and
+		// retry them. If these are accidentally caught, the retry path breaks.
+		{"auth error code: token_expired", false},
+		{"Provided authentication token is expired. Please try signing in again.", false},
+		{"token is expired", false},
 	}
 	for _, tt := range tests {
 		require.Equal(t, tt.want, isRefreshTokenError(tt.msg), "isRefreshTokenError(%q)", tt.msg)

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -446,29 +446,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Wait()
 
 	// 10b. Retry once on token expiration for Codex agents.
-	// When the Codex CLI gets a 401 token_expired from ChatGPT's backend,
-	// force-refresh the token, re-inject auth.json, and retry execution.
-	if run.AgentType == models.AgentTypeCodex && result != nil && isTokenExpiredError(result.Error) {
-		log.Warn().Msg("codex CLI hit token_expired, refreshing token and retrying")
-
-		if reinjected, reinjectErr := o.injectCodexAuth(ctx, run.OrgID, sandbox); reinjectErr == nil && reinjected {
-			retryLogCh := make(chan LogEntry, 100)
-			var retryLogWg sync.WaitGroup
-			retryLogWg.Add(1)
-			go func() {
-				defer retryLogWg.Done()
-				o.streamLogs(ctx, run.ID, run.OrgID, run.CurrentTurn, retryLogCh)
-			}()
-
-			result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
-			close(retryLogCh)
-			retryLogWg.Wait()
-
-			log.Info().Msg("codex CLI retry after token refresh completed")
-		} else if reinjectErr != nil {
-			log.Warn().Err(reinjectErr).Msg("failed to re-inject codex auth for retry")
-		}
-	}
+	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, run.CurrentTurn, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 11. Handle result.
 	if err != nil {
@@ -789,27 +767,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	logWg.Wait()
 
 	// 6b. Retry once on token expiration for Codex agents.
-	if session.AgentType == models.AgentTypeCodex && result != nil && isTokenExpiredError(result.Error) {
-		log.Warn().Msg("codex CLI hit token_expired on continue, refreshing token and retrying")
-
-		if reinjected, reinjectErr := o.injectCodexAuth(ctx, session.OrgID, sandbox); reinjectErr == nil && reinjected {
-			retryLogCh := make(chan LogEntry, 100)
-			var retryLogWg sync.WaitGroup
-			retryLogWg.Add(1)
-			go func() {
-				defer retryLogWg.Done()
-				o.streamLogs(ctx, session.ID, session.OrgID, turnNumber, retryLogCh)
-			}()
-
-			result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
-			close(retryLogCh)
-			retryLogWg.Wait()
-
-			log.Info().Msg("codex CLI retry after token refresh completed")
-		} else if reinjectErr != nil {
-			log.Warn().Err(reinjectErr).Msg("failed to re-inject codex auth for retry on continue")
-		}
-	}
+	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.ID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	if err != nil {
 		o.failRun(ctx, session, err.Error())
@@ -1500,6 +1458,10 @@ func shellEscapeSingleQuote(s string) string {
 // isTokenExpiredError returns true if the error string indicates the Codex CLI
 // received a 401 token_expired response from ChatGPT's backend API. This is
 // used to trigger a single retry with a refreshed token.
+//
+// Note: these strings are intentionally NOT covered by isRefreshTokenError
+// in the Codex adapter (which filters refresh_token_reused, invalid_grant, etc.).
+// token_expired errors must flow through to result.Error so this retry can fire.
 func isTokenExpiredError(errMsg string) bool {
 	if errMsg == "" {
 		return false
@@ -1507,4 +1469,52 @@ func isTokenExpiredError(errMsg string) bool {
 	return strings.Contains(errMsg, "token_expired") ||
 		strings.Contains(errMsg, "token is expired") ||
 		strings.Contains(errMsg, "Provided authentication token is expired")
+}
+
+// retryOnTokenExpired checks whether the Codex CLI failed with a token_expired
+// error and, if so, refreshes the token, re-injects auth.json, and retries
+// execution once. Returns the (possibly updated) result and error.
+func (o *Orchestrator) retryOnTokenExpired(
+	ctx context.Context,
+	agentType models.AgentType,
+	orgID uuid.UUID,
+	sessionID uuid.UUID,
+	turnNumber int,
+	sandbox *Sandbox,
+	adapter AgentAdapter,
+	execCtx context.Context,
+	prompt *AgentPrompt,
+	result *AgentResult,
+	err error,
+	log zerolog.Logger,
+) (*AgentResult, error) {
+	if agentType != models.AgentTypeCodex || result == nil || !isTokenExpiredError(result.Error) {
+		return result, err
+	}
+
+	log.Warn().Msg("codex CLI hit token_expired, refreshing token and retrying")
+
+	reinjected, reinjectErr := o.injectCodexAuth(ctx, orgID, sandbox)
+	if reinjectErr != nil {
+		log.Warn().Err(reinjectErr).Msg("failed to re-inject codex auth for retry")
+		return result, err
+	}
+	if !reinjected {
+		return result, err
+	}
+
+	retryLogCh := make(chan LogEntry, 100)
+	var retryLogWg sync.WaitGroup
+	retryLogWg.Add(1)
+	go func() {
+		defer retryLogWg.Done()
+		o.streamLogs(ctx, sessionID, orgID, turnNumber, retryLogCh)
+	}()
+
+	result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
+	close(retryLogCh)
+	retryLogWg.Wait()
+
+	log.Info().Msg("codex CLI retry after token refresh completed")
+	return result, err
 }

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -445,6 +445,31 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	close(logCh)
 	logWg.Wait()
 
+	// 10b. Retry once on token expiration for Codex agents.
+	// When the Codex CLI gets a 401 token_expired from ChatGPT's backend,
+	// force-refresh the token, re-inject auth.json, and retry execution.
+	if run.AgentType == models.AgentTypeCodex && result != nil && isTokenExpiredError(result.Error) {
+		log.Warn().Msg("codex CLI hit token_expired, refreshing token and retrying")
+
+		if reinjected, reinjectErr := o.injectCodexAuth(ctx, run.OrgID, sandbox); reinjectErr == nil && reinjected {
+			retryLogCh := make(chan LogEntry, 100)
+			var retryLogWg sync.WaitGroup
+			retryLogWg.Add(1)
+			go func() {
+				defer retryLogWg.Done()
+				o.streamLogs(ctx, run.ID, run.OrgID, run.CurrentTurn, retryLogCh)
+			}()
+
+			result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
+			close(retryLogCh)
+			retryLogWg.Wait()
+
+			log.Info().Msg("codex CLI retry after token refresh completed")
+		} else if reinjectErr != nil {
+			log.Warn().Err(reinjectErr).Msg("failed to re-inject codex auth for retry")
+		}
+	}
+
 	// 11. Handle result.
 	if err != nil {
 		o.failRun(ctx, run, err.Error())
@@ -762,6 +787,29 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	result, err := adapter.Execute(execCtx, sandbox, prompt, logCh)
 	close(logCh)
 	logWg.Wait()
+
+	// 6b. Retry once on token expiration for Codex agents.
+	if session.AgentType == models.AgentTypeCodex && result != nil && isTokenExpiredError(result.Error) {
+		log.Warn().Msg("codex CLI hit token_expired on continue, refreshing token and retrying")
+
+		if reinjected, reinjectErr := o.injectCodexAuth(ctx, session.OrgID, sandbox); reinjectErr == nil && reinjected {
+			retryLogCh := make(chan LogEntry, 100)
+			var retryLogWg sync.WaitGroup
+			retryLogWg.Add(1)
+			go func() {
+				defer retryLogWg.Done()
+				o.streamLogs(ctx, session.ID, session.OrgID, turnNumber, retryLogCh)
+			}()
+
+			result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)
+			close(retryLogCh)
+			retryLogWg.Wait()
+
+			log.Info().Msg("codex CLI retry after token refresh completed")
+		} else if reinjectErr != nil {
+			log.Warn().Err(reinjectErr).Msg("failed to re-inject codex auth for retry on continue")
+		}
+	}
 
 	if err != nil {
 		o.failRun(ctx, session, err.Error())
@@ -1447,4 +1495,16 @@ func formatWorkingBranch(run *models.Session, issue *models.Issue) string {
 // shellEscapeSingleQuote escapes single quotes for safe use in shell commands.
 func shellEscapeSingleQuote(s string) string {
 	return strings.ReplaceAll(s, "'", "'\\''")
+}
+
+// isTokenExpiredError returns true if the error string indicates the Codex CLI
+// received a 401 token_expired response from ChatGPT's backend API. This is
+// used to trigger a single retry with a refreshed token.
+func isTokenExpiredError(errMsg string) bool {
+	if errMsg == "" {
+		return false
+	}
+	return strings.Contains(errMsg, "token_expired") ||
+		strings.Contains(errMsg, "token is expired") ||
+		strings.Contains(errMsg, "Provided authentication token is expired")
 }

--- a/internal/services/agent/token_expired_test.go
+++ b/internal/services/agent/token_expired_test.go
@@ -1,0 +1,30 @@
+package agent
+
+import "testing"
+
+func TestIsTokenExpiredError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected bool
+	}{
+		{"empty string", "", false},
+		{"unrelated error", "codex CLI exited with code 1: syntax error", false},
+		{"token_expired keyword", "codex CLI exited with code 1: auth error code: token_expired", true},
+		{"token is expired", "Provided authentication token is expired. Please try signing in again.", true},
+		{"full error message", "failed to refresh available models: unexpected status 401 Unauthorized: Provided authentication token is expired", true},
+		{"partial match", "something token_expired something", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isTokenExpiredError(tc.errMsg)
+			if got != tc.expected {
+				t.Errorf("isTokenExpiredError(%q) = %v, want %v", tc.errMsg, got, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -85,6 +85,7 @@ type Service struct {
 	issuer      string
 	clientID    string
 	pending     sync.Map // orgID string -> *PendingAuth
+	refreshMu   sync.Map // orgID string -> *sync.Mutex (per-org refresh lock)
 }
 
 // NewService creates a new Device Code Auth service.
@@ -456,8 +457,31 @@ func parsePollInterval(raw any) (int, error) {
 	}
 }
 
+// orgRefreshMu returns a per-org mutex for serializing token refreshes.
+// This prevents concurrent requests from both consuming the same refresh
+// token at OpenAI, which would cause refresh_token_reused errors.
+func (s *Service) orgRefreshMu(orgID uuid.UUID) *sync.Mutex {
+	val, _ := s.refreshMu.LoadOrStore(orgID.String(), &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
+
 // RefreshToken refreshes an expired access token using the refresh token.
+// It serializes refreshes per-org to prevent concurrent calls from consuming
+// the same refresh token at OpenAI (which causes refresh_token_reused errors).
 func (s *Service) RefreshToken(ctx context.Context, orgID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
+	mu := s.orgRefreshMu(orgID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// After acquiring the lock, check if another goroutine already refreshed
+	// the token while we were waiting. If the token is fresh (not within the
+	// refresh window), return it directly without hitting OpenAI.
+	if cred, err := s.credentials.Get(ctx, orgID, models.ProviderOpenAIChatGPT); err == nil {
+		if cfg, ok := cred.Config.(models.OpenAIChatGPTConfig); ok && !cfg.NeedsRefresh(refreshWindow) && cfg.AccessToken != "" {
+			return &cfg, nil
+		}
+	}
+
 	cred, err := s.credentials.Get(ctx, orgID, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		return nil, fmt.Errorf("get credential: %w", err)
@@ -593,15 +617,10 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 		refreshed, err := s.RefreshToken(ctx, orgID)
 		if err != nil {
 			s.logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("token refresh failed")
-			// If refresh token was already consumed by another client
-			// (e.g. user's local Codex CLI), return the existing config
-			// regardless of expiry. The access token may still work, and
-			// even if it doesn't, Codex CLI can handle 401s at runtime.
-			// This is better than blocking session creation entirely.
-			if strings.Contains(err.Error(), "refresh token already used by another client") {
-				return &cfg, nil
-			}
-			// For other refresh failures, use the token if not expired.
+			// For any refresh failure, use the cached token only if it
+			// hasn't actually expired yet. Previously we returned expired
+			// tokens on refresh_token_reused errors, which caused 401s
+			// downstream. Now we consistently check expiry for all error types.
 			if !cfg.IsExpired() {
 				return &cfg, nil
 			}

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -84,8 +84,8 @@ type Service struct {
 	logger      zerolog.Logger
 	issuer      string
 	clientID    string
-	pending     sync.Map // orgID string -> *PendingAuth
-	refreshMu   sync.Map // orgID string -> *sync.Mutex (per-org refresh lock)
+	pending   sync.Map // orgID string -> *PendingAuth
+	refreshMu sync.Map // orgID string -> *sync.Mutex (per-org refresh lock; entries are tiny and bounded by org count)
 }
 
 // NewService creates a new Device Code Auth service.
@@ -635,6 +635,7 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 // Disconnect removes the ChatGPT OAuth credential for the given org.
 func (s *Service) Disconnect(ctx context.Context, orgID uuid.UUID) error {
 	s.pending.Delete(orgID.String())
+	s.refreshMu.Delete(orgID.String())
 	if s.credentials == nil {
 		return nil
 	}

--- a/internal/services/codexauth/service_test.go
+++ b/internal/services/codexauth/service_test.go
@@ -985,3 +985,128 @@ func TestIsNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+func TestRefreshToken_ConcurrentRefreshesAreSerialized(t *testing.T) {
+	t.Parallel()
+
+	refreshCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshCount++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token":  fmt.Sprintf("cha_refreshed_%d", refreshCount),
+			"refresh_token": fmt.Sprintf("chr_new_%d", refreshCount),
+			"expires_in":    3600,
+		})
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+		AccessToken:  "cha_old",
+		RefreshToken: "chr_old",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute), // Expired.
+	})
+
+	// Fire two concurrent refreshes.
+	done := make(chan *models.OpenAIChatGPTConfig, 2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			cfg, _ := svc.RefreshToken(context.Background(), orgID)
+			done <- cfg
+		}()
+	}
+
+	cfg1 := <-done
+	cfg2 := <-done
+
+	// The mutex should cause the second goroutine to see the already-refreshed
+	// token (within the refresh window check) and skip the HTTP call.
+	// Only 1 HTTP call should have been made.
+	if refreshCount != 1 {
+		t.Errorf("expected exactly 1 HTTP refresh call (serialized), got %d", refreshCount)
+	}
+
+	// Both should return a valid token.
+	if cfg1 == nil || cfg2 == nil {
+		t.Fatal("expected both goroutines to return a valid config")
+	}
+}
+
+func TestGetValidToken_RefreshTokenReused_ExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	// Simulate refresh_token_reused error from OpenAI.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "refresh_token_reused"}`))
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	// Store a credential that is ALREADY EXPIRED and needs refresh.
+	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+		AccessToken:  "cha_expired",
+		RefreshToken: "chr_reused",
+		ExpiresAt:    time.Now().Add(-10 * time.Minute), // Already expired.
+		AccountType:  "plus",
+	})
+
+	// GetValidToken should NOT return the expired token.
+	// Previously this was a bug: it returned the expired token on
+	// refresh_token_reused errors regardless of expiry.
+	cfg, err := svc.GetValidToken(context.Background(), orgID)
+	if err == nil {
+		t.Fatal("expected error when token is expired and refresh fails with refresh_token_reused")
+	}
+	if cfg != nil {
+		t.Errorf("expected nil config for expired token, got access_token=%s", cfg.AccessToken)
+	}
+}
+
+func TestGetValidToken_RefreshTokenReused_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	// Simulate refresh_token_reused error from OpenAI.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "refresh_token_reused"}`))
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	// Store a credential within the refresh window but NOT yet expired.
+	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+		AccessToken:  "cha_still_valid",
+		RefreshToken: "chr_reused",
+		ExpiresAt:    time.Now().Add(3 * time.Minute), // Within 5-min window but still valid.
+		AccountType:  "plus",
+	})
+
+	// GetValidToken should return the still-valid token even though refresh failed.
+	cfg, err := svc.GetValidToken(context.Background(), orgID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config when token still valid despite refresh_token_reused")
+	}
+	if cfg.AccessToken != "cha_still_valid" {
+		t.Errorf("expected original token, got %s", cfg.AccessToken)
+	}
+}

--- a/internal/services/codexauth/service_test.go
+++ b/internal/services/codexauth/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -989,13 +990,13 @@ func TestIsNotFoundError(t *testing.T) {
 func TestRefreshToken_ConcurrentRefreshesAreSerialized(t *testing.T) {
 	t.Parallel()
 
-	refreshCount := 0
+	var refreshCount atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		refreshCount++
+		n := refreshCount.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token":  fmt.Sprintf("cha_refreshed_%d", refreshCount),
-			"refresh_token": fmt.Sprintf("chr_new_%d", refreshCount),
+			"access_token":  fmt.Sprintf("cha_refreshed_%d", n),
+			"refresh_token": fmt.Sprintf("chr_new_%d", n),
 			"expires_in":    3600,
 		})
 	}))
@@ -1028,8 +1029,8 @@ func TestRefreshToken_ConcurrentRefreshesAreSerialized(t *testing.T) {
 	// The mutex should cause the second goroutine to see the already-refreshed
 	// token (within the refresh window check) and skip the HTTP call.
 	// Only 1 HTTP call should have been made.
-	if refreshCount != 1 {
-		t.Errorf("expected exactly 1 HTTP refresh call (serialized), got %d", refreshCount)
+	if got := refreshCount.Load(); got != 1 {
+		t.Errorf("expected exactly 1 HTTP refresh call (serialized), got %d", got)
 	}
 
 	// Both should return a valid token.


### PR DESCRIPTION
## Summary
This PR fixes two critical issues with OpenAI ChatGPT token management:
1. **Concurrent refresh serialization**: Prevents multiple goroutines from simultaneously consuming the same refresh token, which causes `refresh_token_reused` errors
2. **Token expiry consistency**: Ensures expired tokens are never returned, even when refresh fails with `refresh_token_reused` errors
3. **Codex agent retry logic**: Adds automatic retry with token refresh when Codex CLI encounters `token_expired` errors

## Key Changes

### Token Refresh Serialization (`codexauth/service.go`)
- Added per-organization mutex (`refreshMu`) to serialize token refresh operations
- `RefreshToken()` now acquires a lock before refreshing and checks if another goroutine already refreshed the token while waiting
- Prevents concurrent requests from both consuming the same refresh token at OpenAI
- Cleanup of refresh mutex on `Disconnect()`

### Token Expiry Handling (`codexauth/service.go`)
- Fixed `GetValidToken()` to consistently check token expiry for all refresh failure types
- Previously returned expired tokens on `refresh_token_reused` errors; now only returns cached tokens if they haven't actually expired
- Improved error handling logic to be more explicit about when expired tokens are acceptable

### Codex Agent Retry Logic (`agent/orchestrator.go`)
- Added `retryOnTokenExpired()` method that detects `token_expired` errors from Codex CLI
- On detection, refreshes the token, re-injects auth.json, and retries execution once
- Integrated into both `RunAgent()` and `ContinueSession()` execution paths
- Added `isTokenExpiredError()` helper to detect various token expiration error messages

### Test Coverage
- `TestRefreshToken_ConcurrentRefreshesAreSerialized`: Verifies only one HTTP refresh call is made for concurrent requests
- `TestGetValidToken_RefreshTokenReused_ExpiredToken`: Ensures expired tokens are not returned on refresh failures
- `TestGetValidToken_RefreshTokenReused_ValidToken`: Ensures valid tokens are returned even when refresh fails
- `TestIsTokenExpiredError`: Unit tests for token expiration error detection
- Updated `TestIsRefreshTokenError` to document that `token_expired` errors must NOT be filtered (they need to reach the retry logic)

## Implementation Details
- Per-org mutexes are stored in a `sync.Map` and are tiny/bounded by organization count
- Token refresh window check (5 minutes) is used to determine if a token needs refresh
- Retry logic only applies to Codex agent type; other agent types are unaffected
- Error detection uses substring matching to handle various OpenAI error message formats

https://claude.ai/code/session_01AkencQF4NqQcgtuyhUgpr5