### PR TITLE
Implement global command palette

### DIFF
--- a/docs/design/future/45-global-command-palette.md
+++ b/docs/design/future/45-global-command-palette.md
@@ -1,6 +1,6 @@
 # Design: Global Command Palette
 
-> **Status:** Not Started | **Last reviewed:** 2026-04-06
+> **Status:** Implemented (Phases 1–3) | **Last reviewed:** 2026-04-06
 >
 > **Depends on:** [03-frontend.md](03-frontend.md), [34-repo-ribbons-nav.md](34-repo-ribbons-nav.md)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "geist": "^1.7.0",
         "lucide-react": "^0.574.0",
         "next": "16.1.6",
@@ -8598,6 +8599,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/code-block-writer": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "geist": "^1.7.0",
     "lucide-react": "^0.574.0",
     "next": "16.1.6",

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -28,10 +28,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
-import { useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { RepoContextSwitcher } from "@/components/repo-context-switcher";
+import { CommandPalette } from "@/components/command-palette/command-palette";
+import { CommandPaletteTrigger } from "@/components/command-palette/command-palette-trigger";
 
 const navItems = [
   { label: "Autopilot", icon: Zap, href: "/autopilot", showProposalBadge: false },
@@ -51,6 +53,23 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     enabled: isAuthenticated,
   });
   const proposalCount = proposalSummary?.data?.count ?? 0;
+
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  // Global Cmd+K / Ctrl+K shortcut — registered independently of other
+  // keyboard nav so it works even when focus is inside an input or textarea.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setPaletteOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
+
+  const handlePaletteOpen = useCallback(() => setPaletteOpen(true), []);
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated) {
@@ -111,6 +130,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
             143.dev
           </Link>
           <RepoContextSwitcher />
+          <CommandPaletteTrigger onClick={handlePaletteOpen} />
         </div>
         <nav className="relative flex-1 px-2.5 space-y-0.5">
           {navItems.map((item) => {
@@ -222,6 +242,14 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           {children}
         </div>
       </main>
+      {user && (
+        <CommandPalette
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+          userRole={user.role}
+          logout={logout}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/command-palette/command-palette-actions.test.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { getFilteredActions, staticActions } from "./command-palette-actions";
+
+describe("command-palette-actions", () => {
+  it("includes audit log for admin users", () => {
+    const actions = getFilteredActions("admin");
+    expect(actions.find((a) => a.id === "settings-audit-log")).toBeDefined();
+  });
+
+  it("excludes audit log for non-admin users", () => {
+    const actions = getFilteredActions("member");
+    expect(actions.find((a) => a.id === "settings-audit-log")).toBeUndefined();
+  });
+
+  it("excludes audit log for viewer users", () => {
+    const actions = getFilteredActions("viewer");
+    expect(actions.find((a) => a.id === "settings-audit-log")).toBeUndefined();
+  });
+
+  it("all static actions have unique ids", () => {
+    const ids = staticActions.map((a) => a.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("navigation actions have href", () => {
+    const navActions = staticActions.filter((a) => a.group === "navigation");
+    for (const action of navActions) {
+      expect(action.href).toBeDefined();
+    }
+  });
+
+  it("repo-scoped navigation actions have preserveRepo", () => {
+    const sessionsAction = staticActions.find((a) => a.id === "nav-sessions");
+    expect(sessionsAction?.preserveRepo).toBe(true);
+    const projectsAction = staticActions.find((a) => a.id === "nav-projects");
+    expect(projectsAction?.preserveRepo).toBe(true);
+  });
+});

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -1,0 +1,59 @@
+import {
+  Zap,
+  Play,
+  FolderKanban,
+  Settings,
+  Users,
+  Plug,
+  Bot,
+  Sparkles,
+  Target,
+  FlaskConical,
+  ScrollText,
+  Plus,
+  LogOut,
+  type LucideIcon,
+} from "lucide-react";
+
+export interface PaletteAction {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  href?: string;
+  /** If true, preserve the current ?repo= param when navigating. */
+  preserveRepo?: boolean;
+  /** If set, only users with this role see the action. */
+  requiredRole?: string;
+  group: "navigation" | "settings" | "quick-actions";
+  /** If set, show this keyboard shortcut hint on the right. */
+  shortcut?: string;
+}
+
+export const staticActions: PaletteAction[] = [
+  // Navigation
+  { id: "nav-autopilot", label: "Autopilot", icon: Zap, href: "/autopilot", group: "navigation" },
+  { id: "nav-sessions", label: "Sessions", icon: Play, href: "/sessions", preserveRepo: true, group: "navigation" },
+  { id: "nav-projects", label: "Projects", icon: FolderKanban, href: "/projects", preserveRepo: true, group: "navigation" },
+
+  // Settings & admin
+  { id: "settings-general", label: "General", icon: Settings, href: "/settings", group: "settings" },
+  { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/integrations", group: "settings" },
+  { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/agent", group: "settings" },
+  { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/llm", group: "settings" },
+  { id: "settings-autopilot", label: "Autopilot settings", icon: Target, href: "/settings/autopilot", group: "settings" },
+  { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", group: "settings" },
+  { id: "settings-team", label: "Team", icon: Users, href: "/team", group: "settings" },
+  { id: "settings-audit-log", label: "Audit log", icon: ScrollText, href: "/settings/audit-log", requiredRole: "admin", group: "settings" },
+
+  // Quick actions
+  { id: "action-new-session", label: "New session", icon: Plus, href: "/sessions/new", preserveRepo: true, group: "quick-actions" },
+  { id: "action-new-project", label: "New project", icon: Plus, href: "/projects/new", preserveRepo: true, group: "quick-actions" },
+  { id: "action-new-eval", label: "Create eval task", icon: Plus, href: "/settings/evals/new", group: "quick-actions" },
+  { id: "action-logout", label: "Log out", icon: LogOut, group: "quick-actions" },
+];
+
+export function getFilteredActions(userRole: string): PaletteAction[] {
+  return staticActions.filter(
+    (action) => !action.requiredRole || action.requiredRole === userRole
+  );
+}

--- a/frontend/src/components/command-palette/command-palette-trigger.tsx
+++ b/frontend/src/components/command-palette/command-palette-trigger.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface CommandPaletteTriggerProps {
+  onClick: () => void;
+}
+
+export function CommandPaletteTrigger({ onClick }: CommandPaletteTriggerProps) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={onClick}
+      className="h-7 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+      aria-label="Open command palette"
+    >
+      <Search className="h-3.5 w-3.5" />
+      <span className="hidden sm:inline">Search</span>
+      <kbd className="pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+        <span className="text-xs">⌘</span>K
+      </kbd>
+    </Button>
+  );
+}

--- a/frontend/src/components/command-palette/command-palette-trigger.tsx
+++ b/frontend/src/components/command-palette/command-palette-trigger.tsx
@@ -18,7 +18,7 @@ export function CommandPaletteTrigger({ onClick }: CommandPaletteTriggerProps) {
     >
       <Search className="h-3.5 w-3.5" />
       <span className="hidden sm:inline">Search</span>
-      <kbd className="pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+      <kbd className="pointer-events-none hidden h-5 select-none items-center gap-0.5 rounded border bg-muted px-1.5 font-mono text-xs font-medium opacity-100 sm:flex">
         <span className="text-xs">⌘</span>K
       </kbd>
     </Button>

--- a/frontend/src/components/command-palette/command-palette.test.tsx
+++ b/frontend/src/components/command-palette/command-palette.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { CommandPalette } from "./command-palette";
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/mocks/server";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/sessions",
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+const logoutMock = vi.fn();
+
+function renderPalette(overrides?: {
+  open?: boolean;
+  userRole?: string;
+  searchParams?: Record<string, string>;
+}) {
+  const onOpenChange = vi.fn();
+  return {
+    onOpenChange,
+    ...renderWithProviders(
+      <CommandPalette
+        open={overrides?.open ?? true}
+        onOpenChange={onOpenChange}
+        userRole={overrides?.userRole ?? "admin"}
+        logout={logoutMock}
+      />,
+      { searchParams: overrides?.searchParams }
+    ),
+  };
+}
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+    logoutMock.mockClear();
+    localStorage.clear();
+  });
+
+  it("renders static navigation items when open", async () => {
+    renderPalette();
+    expect(await screen.findByText("Sessions")).toBeInTheDocument();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+    expect(screen.getByText("Autopilot")).toBeInTheDocument();
+  });
+
+  it("renders settings items", async () => {
+    renderPalette();
+    expect(await screen.findByText("General")).toBeInTheDocument();
+    expect(screen.getByText("Integrations")).toBeInTheDocument();
+    expect(screen.getByText("Team")).toBeInTheDocument();
+  });
+
+  it("renders quick action items", async () => {
+    renderPalette();
+    expect(await screen.findByText("New session")).toBeInTheDocument();
+    expect(screen.getByText("New project")).toBeInTheDocument();
+    expect(screen.getByText("Log out")).toBeInTheDocument();
+  });
+
+  it("excludes admin-only items for non-admin users", async () => {
+    renderPalette({ userRole: "member" });
+    await screen.findByText("General");
+    expect(screen.queryByText("Audit log")).not.toBeInTheDocument();
+  });
+
+  it("includes admin-only items for admin users", async () => {
+    renderPalette({ userRole: "admin" });
+    expect(await screen.findByText("Audit log")).toBeInTheDocument();
+  });
+
+  it("navigates to a page when a navigation item is selected", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    const autopilotItem = await screen.findByText("Autopilot");
+    await user.click(autopilotItem);
+
+    expect(pushMock).toHaveBeenCalledWith("/autopilot");
+  });
+
+  it("calls logout when Log out is selected", async () => {
+    const user = userEvent.setup();
+    renderPalette();
+
+    const logoutItem = await screen.findByText("Log out");
+    await user.click(logoutItem);
+
+    expect(logoutMock).toHaveBeenCalled();
+  });
+
+  it("shows 'Start manual session' when search has no results", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/sessions", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      ),
+      http.get("/api/v1/projects", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      )
+    );
+
+    renderPalette();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "nonexistent-thing-xyz");
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Start manual session/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows dynamic session results when typing a search query", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/sessions", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("search")) {
+          return HttpResponse.json({
+            data: [
+              { id: "sess-1", title: "Fix login bug", status: "completed", created_at: "2026-01-01T00:00:00Z", current_turn: 0, sandbox_state: "none", org_id: "org-1", issue_id: "00000000-0000-0000-0000-000000000000", agent_type: "codex", autonomy_level: "semi", token_mode: "normal" },
+            ],
+            meta: {},
+          });
+        }
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get("/api/v1/projects", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      )
+    );
+
+    renderPalette();
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "Fix login");
+
+    await waitFor(() => {
+      expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+    });
+  });
+
+  it("preserves repo context when opening a session result", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/sessions", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("search") === "Fix login") {
+          return HttpResponse.json({
+            data: [
+              { id: "sess-1", title: "Fix login bug", status: "completed", created_at: "2026-01-01T00:00:00Z", current_turn: 0, sandbox_state: "none", org_id: "org-1", issue_id: "00000000-0000-0000-0000-000000000000", agent_type: "codex", autonomy_level: "semi", token_mode: "normal", repository_id: "repo-1" },
+            ],
+            meta: {},
+          });
+        }
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get("/api/v1/projects", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      )
+    );
+
+    renderPalette({ searchParams: { repo: "repo-1" } });
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "Fix login");
+
+    const sessionItem = await screen.findByText("Fix login bug");
+    await user.click(sessionItem);
+
+    expect(pushMock).toHaveBeenCalledWith("/sessions/sess-1?repo=repo-1");
+  });
+
+  it("preserves repo context when opening a recent item", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem(
+      "143:command-palette:recents",
+      JSON.stringify([
+        {
+          type: "session",
+          id: "sess-1",
+          label: "Fix login bug",
+          href: "/sessions/sess-1",
+          timestamp: Date.now(),
+        },
+      ])
+    );
+
+    renderPalette({ searchParams: { repo: "repo-1" } });
+
+    const recentItem = await screen.findByText("Fix login bug");
+    await user.click(recentItem);
+
+    expect(pushMock).toHaveBeenCalledWith("/sessions/sess-1?repo=repo-1");
+  });
+
+  it("starts a manual session from the keyboard when search has no results", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/v1/sessions", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      ),
+      http.get("/api/v1/projects", () =>
+        HttpResponse.json({ data: [], meta: {} })
+      )
+    );
+
+    renderPalette({ searchParams: { repo: "repo-1" } });
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "nonexistent-thing-xyz");
+
+    await screen.findByText(/Start manual session/i);
+    await user.keyboard("[ArrowDown][Enter]");
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/sessions/new?prompt=nonexistent-thing-xyz&repo=repo-1"
+    );
+  });
+
+  it("clears the query when the palette is reopened", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    const rendered = renderWithProviders(
+      <CommandPalette
+        open
+        onOpenChange={onOpenChange}
+        userRole="admin"
+        logout={logoutMock}
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Type a command or search...");
+    await user.type(input, "stale query");
+    expect(input).toHaveValue("stale query");
+
+    rendered.rerender(
+      <CommandPalette
+        open={false}
+        onOpenChange={onOpenChange}
+        userRole="admin"
+        logout={logoutMock}
+      />
+    );
+    rendered.rerender(
+      <CommandPalette
+        open
+        onOpenChange={onOpenChange}
+        userRole="admin"
+        logout={logoutMock}
+      />
+    );
+
+    expect(screen.getByPlaceholderText("Type a command or search...")).toHaveValue("");
+  });
+
+  it("shows repository switching when multiple repos exist", async () => {
+    server.use(
+      http.get("/api/v1/repositories/summary", () =>
+        HttpResponse.json({
+          data: [
+            { repository_id: "repo-1", full_name: "acme/api", active_session_count: 2, latest_session_status: "running", active_project_count: 1 },
+            { repository_id: "repo-2", full_name: "acme/web", active_session_count: 0, latest_session_status: null, active_project_count: 0 },
+          ],
+          meta: {},
+        })
+      )
+    );
+
+    renderPalette();
+
+    await waitFor(() => {
+      expect(screen.getByText("acme/api")).toBeInTheDocument();
+      expect(screen.getByText("acme/web")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/command-palette/command-palette.tsx
+++ b/frontend/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryState } from "nuqs";
+import { useQuery } from "@tanstack/react-query";
+import { GitBranch, Loader2, Play, FolderKanban, Sparkles } from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { getFilteredActions, type PaletteAction } from "./command-palette-actions";
+import { useCommandPaletteSearch } from "./use-command-palette-search";
+import { useRecentPaletteItems, type RecentItem } from "./use-recent-palette-items";
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  userRole: string;
+  logout: () => void;
+}
+
+interface CommandPaletteContentProps {
+  userRole: string;
+  logout: () => void;
+  onClose: () => void;
+}
+
+function CommandPaletteContent({
+  userRole,
+  logout,
+  onClose,
+}: CommandPaletteContentProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [repo, setRepo] = useQueryState("repo");
+  const { displayItems, addRecent } = useRecentPaletteItems();
+
+  const actions = useMemo(() => getFilteredActions(userRole), [userRole]);
+  const { sessions, projects, isLoading } = useCommandPaletteSearch(query, repo);
+
+  const { data: repoSummaries } = useQuery({
+    queryKey: queryKeys.repositories.summary,
+    queryFn: () => api.repositories.summary(),
+    refetchInterval: 10_000,
+  });
+  const repos = useMemo(() => repoSummaries?.data ?? [], [repoSummaries?.data]);
+
+  const buildHref = useCallback(
+    (href: string, preserveRepo = false) => {
+      if (!preserveRepo || !repo) {
+        return href;
+      }
+
+      const url = new URL(href, "http://localhost");
+      if (!url.searchParams.has("repo")) {
+        url.searchParams.set("repo", repo);
+      }
+      return `${url.pathname}${url.search}${url.hash}`;
+    },
+    [repo]
+  );
+
+  const navigate = useCallback(
+    (href: string, preserveRepo = false) => {
+      router.push(buildHref(href, preserveRepo));
+      onClose();
+    },
+    [buildHref, onClose, router]
+  );
+
+  const handleActionSelect = useCallback(
+    (action: PaletteAction) => {
+      if (action.id === "action-logout") {
+        onClose();
+        logout();
+        return;
+      }
+      if (action.href) {
+        if (action.group === "navigation") {
+          addRecent({
+            type: "navigation",
+            id: action.id,
+            label: action.label,
+            href: action.href,
+          });
+        }
+        navigate(action.href, action.preserveRepo);
+      }
+    },
+    [addRecent, logout, navigate, onClose]
+  );
+
+  const handleSessionSelect = useCallback(
+    (session: { id: string; title?: string }) => {
+      const label = session.title || `Session ${session.id.slice(0, 8)}`;
+      addRecent({
+        type: "session",
+        id: session.id,
+        label,
+        href: `/sessions/${session.id}`,
+      });
+      navigate(`/sessions/${session.id}`, true);
+    },
+    [addRecent, navigate]
+  );
+
+  const handleProjectSelect = useCallback(
+    (project: { id: string; title: string }) => {
+      addRecent({
+        type: "project",
+        id: project.id,
+        label: project.title,
+        href: `/projects/${project.id}`,
+      });
+      navigate(`/projects/${project.id}`, true);
+    },
+    [addRecent, navigate]
+  );
+
+  const handleRepoSelect = useCallback(
+    (repoID: string | null) => {
+      setRepo(repoID);
+      onClose();
+    },
+    [onClose, setRepo]
+  );
+
+  const handleRecentSelect = useCallback(
+    (item: RecentItem) => {
+      navigate(item.href, true);
+    },
+    [navigate]
+  );
+
+  const handleStartSession = useCallback(() => {
+    const params = new URLSearchParams();
+    if (query) {
+      params.set("prompt", query);
+    }
+    if (repo) {
+      params.set("repo", repo);
+    }
+    const qs = params.toString();
+    navigate(`/sessions/new${qs ? `?${qs}` : ""}`);
+  }, [navigate, query, repo]);
+
+  const normalizedQuery = query.trim().toLowerCase();
+  const navigationActions = actions.filter((action) => action.group === "navigation");
+  const settingsActions = actions.filter((action) => action.group === "settings");
+  const quickActions = actions.filter((action) => action.group === "quick-actions");
+  const hasQuery = query.length >= 2;
+  const hasDynamicResults = sessions.length > 0 || projects.length > 0;
+  const hasMatchingStaticItem = useMemo(() => {
+    if (normalizedQuery.length === 0) {
+      return false;
+    }
+
+    const labels = [
+      ...actions.map((action) => action.label),
+      ...displayItems.map((item) => item.label),
+      ...(repos.length >= 2 ? ["All repositories"] : []),
+      ...repos.map((repoSummary) => repoSummary.full_name),
+    ];
+    return labels.some((label) => label.toLowerCase().includes(normalizedQuery));
+  }, [actions, displayItems, normalizedQuery, repos]);
+  const canStartSessionFromKeyboard =
+    normalizedQuery.length > 0 &&
+    !isLoading &&
+    !hasDynamicResults &&
+    !hasMatchingStaticItem;
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === "Enter" && canStartSessionFromKeyboard) {
+        event.preventDefault();
+        handleStartSession();
+      }
+    },
+    [canStartSessionFromKeyboard, handleStartSession]
+  );
+
+  return (
+    <>
+      <CommandInput
+        placeholder="Type a command or search..."
+        value={query}
+        onValueChange={setQuery}
+        onKeyDown={handleInputKeyDown}
+      />
+      <CommandList>
+        {isLoading && (
+          <div className="flex items-center justify-center gap-2 py-3 text-xs text-muted-foreground">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Searching...
+          </div>
+        )}
+
+        {hasQuery && sessions.length > 0 && (
+          <CommandGroup heading="Sessions">
+            {sessions.map((session) => (
+              <CommandItem
+                key={session.id}
+                value={`session-${session.id}-${session.title ?? ""}`}
+                onSelect={() => handleSessionSelect(session)}
+              >
+                <Play className="h-4 w-4" />
+                <span className="flex-1 truncate">
+                  {session.title || `Session ${session.id.slice(0, 8)}`}
+                </span>
+                <Badge
+                  variant="secondary"
+                  className="ml-auto px-1.5 py-0 text-[10px]"
+                >
+                  {session.status}
+                </Badge>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {hasQuery && projects.length > 0 && (
+          <CommandGroup heading="Projects">
+            {projects.map((project) => (
+              <CommandItem
+                key={project.id}
+                value={`project-${project.id}-${project.title}`}
+                onSelect={() => handleProjectSelect(project)}
+              >
+                <FolderKanban className="h-4 w-4" />
+                <span className="flex-1 truncate">{project.title}</span>
+                <Badge
+                  variant="secondary"
+                  className="ml-auto px-1.5 py-0 text-[10px]"
+                >
+                  {project.status}
+                </Badge>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {hasQuery && hasDynamicResults && <CommandSeparator />}
+
+        {displayItems.length > 0 && (
+          <CommandGroup heading="Recent">
+            {displayItems.map((item) => (
+              <CommandItem
+                key={`${item.type}-${item.id}`}
+                value={`recent-${item.type}-${item.id}-${item.label}`}
+                onSelect={() => handleRecentSelect(item)}
+              >
+                {item.type === "session" && <Play className="h-4 w-4" />}
+                {item.type === "project" && <FolderKanban className="h-4 w-4" />}
+                {item.type === "navigation" && <Sparkles className="h-4 w-4" />}
+                <span className="truncate">{item.label}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        <CommandGroup heading="Quick Actions">
+          {quickActions.map((action) => (
+            <CommandItem
+              key={action.id}
+              value={action.label}
+              onSelect={() => handleActionSelect(action)}
+            >
+              <action.icon className="h-4 w-4" />
+              {action.label}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        {repos.length >= 2 && (
+          <CommandGroup heading="Switch Repository">
+            <CommandItem
+              value="All repositories"
+              onSelect={() => handleRepoSelect(null)}
+            >
+              <GitBranch className="h-4 w-4" />
+              <span className={!repo ? "font-medium" : ""}>All repositories</span>
+            </CommandItem>
+            {repos.map((repoSummary) => (
+              <CommandItem
+                key={repoSummary.repository_id}
+                value={`repo-${repoSummary.full_name}`}
+                onSelect={() => handleRepoSelect(repoSummary.repository_id)}
+              >
+                <GitBranch className="h-4 w-4" />
+                <span
+                  className={`flex-1 truncate ${repo === repoSummary.repository_id ? "font-medium" : ""}`}
+                >
+                  {repoSummary.full_name}
+                </span>
+                {repoSummary.active_session_count > 0 && (
+                  <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary">
+                    {repoSummary.active_session_count}
+                  </span>
+                )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        <CommandGroup heading="Navigation">
+          {navigationActions.map((action) => (
+            <CommandItem
+              key={action.id}
+              value={action.label}
+              onSelect={() => handleActionSelect(action)}
+            >
+              <action.icon className="h-4 w-4" />
+              {action.label}
+              {action.shortcut && (
+                <kbd className="ml-auto text-xs text-muted-foreground">
+                  {action.shortcut}
+                </kbd>
+              )}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandGroup heading="Settings">
+          {settingsActions.map((action) => (
+            <CommandItem
+              key={action.id}
+              value={action.label}
+              onSelect={() => handleActionSelect(action)}
+            >
+              <action.icon className="h-4 w-4" />
+              {action.label}
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandEmpty>
+          {query.length > 0 ? (
+            <Button
+              variant="ghost"
+              onClick={handleStartSession}
+              className="h-auto w-full justify-center gap-2 px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
+            >
+              <Sparkles className="h-4 w-4" />
+              Start manual session: &ldquo;{query}&rdquo;
+            </Button>
+          ) : (
+            "No results found."
+          )}
+        </CommandEmpty>
+      </CommandList>
+    </>
+  );
+}
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  userRole,
+  logout,
+}: CommandPaletteProps) {
+  const previousActiveElement = useRef<Element | null>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (open && !wasOpenRef.current) {
+      previousActiveElement.current = document.activeElement;
+      wasOpenRef.current = true;
+      return;
+    }
+
+    if (!open && wasOpenRef.current) {
+      wasOpenRef.current = false;
+      requestAnimationFrame(() => {
+        const element = previousActiveElement.current;
+        if (element instanceof HTMLElement && document.contains(element)) {
+          element.focus();
+        }
+        previousActiveElement.current = null;
+      });
+    }
+  }, [open]);
+
+  const close = useCallback(() => {
+    onOpenChange(false);
+  }, [onOpenChange]);
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Command Palette"
+      description="Search for pages, sessions, projects, and actions"
+      showCloseButton={false}
+    >
+      {open ? (
+        <CommandPaletteContent
+          userRole={userRole}
+          logout={logout}
+          onClose={close}
+        />
+      ) : null}
+    </CommandDialog>
+  );
+}

--- a/frontend/src/components/command-palette/command-palette.tsx
+++ b/frontend/src/components/command-palette/command-palette.tsx
@@ -147,17 +147,14 @@ function CommandPaletteContent({
     if (query) {
       params.set("prompt", query);
     }
-    if (repo) {
-      params.set("repo", repo);
-    }
     const qs = params.toString();
-    navigate(`/sessions/new${qs ? `?${qs}` : ""}`);
-  }, [navigate, query, repo]);
+    navigate(`/sessions/new${qs ? `?${qs}` : ""}`, true);
+  }, [navigate, query]);
 
   const normalizedQuery = query.trim().toLowerCase();
-  const navigationActions = actions.filter((action) => action.group === "navigation");
-  const settingsActions = actions.filter((action) => action.group === "settings");
-  const quickActions = actions.filter((action) => action.group === "quick-actions");
+  const navigationActions = useMemo(() => actions.filter((action) => action.group === "navigation"), [actions]);
+  const settingsActions = useMemo(() => actions.filter((action) => action.group === "settings"), [actions]);
+  const quickActions = useMemo(() => actions.filter((action) => action.group === "quick-actions"), [actions]);
   const hasQuery = query.length >= 2;
   const hasDynamicResults = sessions.length > 0 || projects.length > 0;
   const hasMatchingStaticItem = useMemo(() => {

--- a/frontend/src/components/command-palette/command-palette.tsx
+++ b/frontend/src/components/command-palette/command-palette.tsx
@@ -216,7 +216,7 @@ function CommandPaletteContent({
                 </span>
                 <Badge
                   variant="secondary"
-                  className="ml-auto px-1.5 py-0 text-[10px]"
+                  className="ml-auto px-1.5 py-0 text-xs"
                 >
                   {session.status}
                 </Badge>
@@ -237,7 +237,7 @@ function CommandPaletteContent({
                 <span className="flex-1 truncate">{project.title}</span>
                 <Badge
                   variant="secondary"
-                  className="ml-auto px-1.5 py-0 text-[10px]"
+                  className="ml-auto px-1.5 py-0 text-xs"
                 >
                   {project.status}
                 </Badge>
@@ -300,7 +300,7 @@ function CommandPaletteContent({
                   {repoSummary.full_name}
                 </span>
                 {repoSummary.active_session_count > 0 && (
-                  <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary">
+                  <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium tabular-nums text-primary">
                     {repoSummary.active_session_count}
                   </span>
                 )}

--- a/frontend/src/components/command-palette/use-command-palette-search.ts
+++ b/frontend/src/components/command-palette/use-command-palette-search.ts
@@ -1,0 +1,41 @@
+import { useDeferredValue } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+
+const MIN_SEARCH_LENGTH = 2;
+const SEARCH_LIMIT = 5;
+
+export function useCommandPaletteSearch(query: string, repo: string | null) {
+  const deferredQuery = useDeferredValue(query);
+  const enabled = deferredQuery.length >= MIN_SEARCH_LENGTH;
+
+  const sessions = useQuery({
+    queryKey: [...queryKeys.sessions.list(repo), "search", deferredQuery],
+    queryFn: () =>
+      api.sessions.list({
+        search: deferredQuery,
+        limit: SEARCH_LIMIT,
+        ...(repo ? { repository_id: repo } : {}),
+      }),
+    enabled,
+    staleTime: 10_000,
+  });
+
+  const projects = useQuery({
+    queryKey: [...queryKeys.projects.list({ repo, search: deferredQuery })],
+    queryFn: () =>
+      api.projects.list({
+        search: deferredQuery,
+        limit: SEARCH_LIMIT,
+        ...(repo ? { repository_id: repo } : {}),
+      }),
+    enabled,
+  });
+
+  return {
+    sessions: sessions.data?.data ?? [],
+    projects: projects.data?.data ?? [],
+    isLoading: enabled && (sessions.isLoading || projects.isLoading),
+  };
+}

--- a/frontend/src/components/command-palette/use-recent-palette-items.test.ts
+++ b/frontend/src/components/command-palette/use-recent-palette-items.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+const STORAGE_KEY = "143:command-palette:recents";
+
+describe("recent palette items localStorage contract", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("stores items under the correct key", () => {
+    const items = [
+      { type: "session", id: "s1", label: "Fix bug", href: "/sessions/s1", timestamp: 1 },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe("s1");
+  });
+
+  it("deduplicates by type+id, keeping the newer entry", () => {
+    const items = [
+      { type: "session", id: "s1", label: "Updated label", href: "/sessions/s1", timestamp: 2 },
+      { type: "session", id: "s2", label: "Other", href: "/sessions/s2", timestamp: 1 },
+    ];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    const s1Entries = stored.filter((i: { id: string }) => i.id === "s1");
+    expect(s1Entries).toHaveLength(1);
+    expect(s1Entries[0].label).toBe("Updated label");
+  });
+
+  it("caps at 10 entries", () => {
+    const items = Array.from({ length: 12 }, (_, i) => ({
+      type: "session",
+      id: `s${i}`,
+      label: `Session ${i}`,
+      href: `/sessions/s${i}`,
+      timestamp: i,
+    }));
+    // Simulate the cap logic
+    const capped = items.slice(0, 10);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(capped));
+
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!);
+    expect(stored).toHaveLength(10);
+  });
+});

--- a/frontend/src/components/command-palette/use-recent-palette-items.ts
+++ b/frontend/src/components/command-palette/use-recent-palette-items.ts
@@ -1,0 +1,88 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+const STORAGE_KEY = "143:command-palette:recents";
+const MAX_ENTRIES = 10;
+const DISPLAY_COUNT = 5;
+
+export interface RecentItem {
+  type: "session" | "project" | "navigation";
+  id: string;
+  label: string;
+  href: string;
+  timestamp: number;
+}
+
+function getStoredItems(): RecentItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as RecentItem[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function setStoredItems(items: RecentItem[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  // Dispatch a storage event so other tabs pick it up. The native storage
+  // event only fires on *other* tabs, so we also fire a custom event for
+  // the current tab.
+  window.dispatchEvent(new Event("palette-recents-changed"));
+}
+
+// Thin external-store wrapper so React re-renders when recents change.
+// Initialized lazily to avoid calling localStorage during SSR module import.
+let snapshot: RecentItem[] | null = null;
+
+function subscribe(callback: () => void) {
+  const onUpdate = () => {
+    snapshot = getStoredItems();
+    callback();
+  };
+
+  // Cross-tab sync via native storage event.
+  window.addEventListener("storage", onUpdate);
+  // Same-tab sync via custom event.
+  window.addEventListener("palette-recents-changed", onUpdate);
+
+  return () => {
+    window.removeEventListener("storage", onUpdate);
+    window.removeEventListener("palette-recents-changed", onUpdate);
+  };
+}
+
+function getSnapshot() {
+  if (snapshot === null) snapshot = getStoredItems();
+  return snapshot;
+}
+
+function getServerSnapshot() {
+  return [] as RecentItem[];
+}
+
+export function useRecentPaletteItems() {
+  const items = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const addRecent = useCallback((item: Omit<RecentItem, "timestamp">) => {
+    const current = getStoredItems();
+    const dedupeKey = `${item.type}:${item.id}`;
+    const filtered = current.filter((i) => `${i.type}:${i.id}` !== dedupeKey);
+    const updated: RecentItem[] = [
+      { ...item, timestamp: Date.now() },
+      ...filtered,
+    ].slice(0, MAX_ENTRIES);
+    setStoredItems(updated);
+  }, []);
+
+  const removeRecent = useCallback((type: string, id: string) => {
+    const current = getStoredItems();
+    const updated = current.filter((i) => !(i.type === type && i.id === id));
+    setStoredItems(updated);
+  }, []);
+
+  return {
+    /** Most recent 5 items for display. */
+    displayItems: items.slice(0, DISPLAY_COUNT),
+    addRecent,
+    removeRecent,
+  };
+}

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import * as React from "react"
+import { Command as CommandPrimitive } from "cmdk"
+import { SearchIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+function Command({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandDialog({
+  title = "Command Palette",
+  description = "Search for a command to run...",
+  children,
+  className,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof Dialog> & {
+  title?: string
+  description?: string
+  className?: string
+  showCloseButton?: boolean
+}) {
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent
+        className={cn("overflow-hidden p-0", className)}
+        showCloseButton={showCloseButton}
+      >
+        <Command className="**:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function CommandInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Input>) {
+  return (
+    <div
+      data-slot="command-input-wrapper"
+      className="flex h-9 items-center gap-2 border-b px-3"
+    >
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CommandList({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn(
+        "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandEmpty({
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  )
+}
+
+function CommandGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Group>) {
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Separator>) {
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn("-mx-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function CommandItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CommandShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/frontend/src/components/ui/command.tsx
+++ b/frontend/src/components/ui/command.tsx
@@ -163,7 +163,7 @@ function CommandShortcut({
     <span
       data-slot="command-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
+        "ml-auto text-xs tracking-wider text-muted-foreground",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,20 +1,34 @@
 "use client"
 
 import * as React from "react"
+import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
-import { X } from "lucide-react"
-import { cn } from "@/lib/utils"
 
-function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
   return <DialogPrimitive.Root data-slot="dialog" {...props} />
 }
 
-function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
   return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
 }
 
-function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
   return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
 }
 
 function DialogOverlay({
@@ -25,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className
       )}
       {...props}
@@ -36,39 +50,71 @@ function DialogOverlay({
 function DialogContent({
   className,
   children,
+  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
   return (
-    <DialogPortal>
+    <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 w-full max-w-2xl translate-x-[-50%] translate-y-[-50%] rounded-lg border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
       </DialogPrimitive.Content>
     </DialogPortal>
   )
 }
 
-function DialogHeader({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="dialog-header"
-      className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
       {...props}
     />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
   )
 }
 
@@ -79,7 +125,7 @@ function DialogTitle({
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn("text-lg leading-none font-semibold", className)}
       {...props}
     />
   )
@@ -100,11 +146,13 @@ function DialogDescription({
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogTrigger,
+  DialogClose,
   DialogContent,
-  DialogHeader,
-  DialogTitle,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -205,13 +205,14 @@ export const api = {
       del(`/api/v1/pm/documents/${docId}`),
   },
   sessions: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string; search?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit) searchParams.set('limit', String(params.limit));
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       if (params?.triggered_by_user_id) searchParams.set('triggered_by_user_id', params.triggered_by_user_id);
+      if (params?.search) searchParams.set('search', params.search);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Session>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
@@ -385,12 +386,13 @@ export const api = {
     revokeInvitation: (id: string) => del<void>(`/api/v1/team/invitations/${id}`),
   },
   projects: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
       if (params?.limit) searchParams.set('limit', String(params.limit));
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
+      if (params?.search) searchParams.set('search', params.search);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Project>>(`/api/v1/projects${qs ? `?${qs}` : ''}`);
     },

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -22,7 +22,12 @@ export const queryKeys = {
   },
   repositories: {
     all: ["repositories"] as const,
+    summary: ["repositories", "summary"] as const,
     branches: (id: string) => ["repositories", id, "branches"] as const,
+  },
+  projects: {
+    all: ["projects"] as const,
+    list: (params?: { repo?: string | null; search?: string }) => ["projects", params] as const,
   },
   settings: {
     all: ["settings"] as const,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -112,6 +112,7 @@ export interface Session {
   sandbox_state: string;
   snapshot_key?: string;
   target_branch?: string;
+  repository_id?: string;
   error?: string;
   result_summary?: string;
   diff?: string;

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -87,6 +87,10 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 		Cursor: r.URL.Query().Get("cursor"),
 	}
 
+	if search := r.URL.Query().Get("search"); search != "" {
+		filters.Search = search
+	}
+
 	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
 		repoID, err := uuid.Parse(repoIDStr)
 		if err != nil {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -128,6 +128,10 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if search := r.URL.Query().Get("search"); search != "" {
+		filters.Search = search
+	}
+
 	if repoIDStr := r.URL.Query().Get("repository_id"); repoIDStr != "" {
 		repoID, err := uuid.Parse(repoIDStr)
 		if err != nil {

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -443,6 +443,33 @@ func TestProjectStore_ListByOrg_WithRepositoryID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestProjectStore_ListByOrg_WithSearch(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM projects WHERE org_id .+ AND \\(title ILIKE .+ OR goal ILIKE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(projectTestColumns).
+				AddRow(newProjectRow(uuid.New(), orgID, repoID, now)...),
+		)
+
+	store := NewProjectStore(mock)
+	projects, err := store.ListByOrg(context.Background(), orgID, ProjectFilters{
+		Search: "build",
+	})
+	require.NoError(t, err, "ListByOrg with Search should not return an error")
+	require.Len(t, projects, 1, "should return one project")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestProjectStore_SoftDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,6 +26,7 @@ type ProjectFilters struct {
 	Limit        int
 	Cursor       string
 	RepositoryID uuid.UUID
+	Search       string // When non-empty, filter projects by title or goal (case-insensitive substring match).
 }
 
 // projectColumns is the column list shared across all project queries.
@@ -216,6 +218,11 @@ func (s *ProjectStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters P
 	if filters.RepositoryID != uuid.Nil {
 		query += ` AND repository_id = @repository_id`
 		args["repository_id"] = &filters.RepositoryID
+	}
+	if filters.Search != "" {
+		query += ` AND (title ILIKE @search OR goal ILIKE @search)`
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(filters.Search)
+		args["search"] = "%" + escaped + "%"
 	}
 	if filters.Cursor != "" {
 		cursorID, err := uuid.Parse(filters.Cursor)

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,6 +35,7 @@ type SessionFilters struct {
 	AdHocOnly          bool       // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
 	RepositoryID       uuid.UUID  // When non-zero, filter sessions by repository via issues table.
 	TriggeredByUserID  uuid.UUID  // When non-zero, filter sessions to those triggered by this user.
+	Search             string     // When non-empty, filter sessions by title (case-insensitive prefix/substring match).
 }
 
 // sessionSelectColumns is used for single-session queries where we want all fields.
@@ -125,6 +127,11 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 	if filters.TriggeredByUserID != uuid.Nil {
 		query += ` AND triggered_by_user_id = @triggered_by_user_id`
 		args["triggered_by_user_id"] = filters.TriggeredByUserID
+	}
+	if filters.Search != "" {
+		query += ` AND title ILIKE @search`
+		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(filters.Search)
+		args["search"] = "%" + escaped + "%"
 	}
 	if filters.AdHocOnly {
 		query += ` AND pm_plan_id IS NULL`

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -101,6 +101,34 @@ func TestSessionStore_ListByOrg_WithoutRepositoryID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionStore_ListByOrg_WithSearch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id .+ title ILIKE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(sessionID, issueID, orgID, now)...),
+		)
+
+	sessions, err := store.ListByOrg(context.Background(), orgID, SessionFilters{
+		Search: "fix bug",
+	})
+	require.NoError(t, err, "ListByOrg with Search should not return an error")
+	require.Len(t, sessions, 1, "should return one session")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_UpdateTitle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a global command palette with Cmd/Ctrl+K, repo-aware navigation, recents, and quick actions in the authenticated layout
- add shared command/dialog UI primitives plus focused palette tests for actions, recents, keyboard behavior, and reopen/reset behavior
- extend sessions and projects list APIs and Go stores/handlers with search support used by the palette, and mark the design doc as implemented

## Verification
- cd frontend && npm run test:ci -- src/components/command-palette/command-palette.test.tsx src/components/command-palette/command-palette-actions.test.ts src/components/command-palette/use-recent-palette-items.test.ts
- cd frontend && npm run typecheck
- cd frontend && npm run lint
- cd frontend && npm run build