### PR TITLE
Fix sessions sidebar to match projects sidebar sizing

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -160,7 +160,7 @@ export function SessionSidebar() {
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
       {/* Header */}
-      <div className="px-4 pt-3 pb-3 space-y-2.5">
+      <div className="px-4 pt-3 pb-3 space-y-3">
 
         {/* Row 1: Search + Owner toggle */}
         <div className="flex items-center gap-2">
@@ -177,7 +177,7 @@ export function SessionSidebar() {
                   e.currentTarget.blur();
                 }
               }}
-              className="w-full h-7 pl-8 pr-2 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+              className="w-full h-8 pl-8 pr-3 rounded-md border border-border bg-background text-[13px] placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
             />
           </div>
           <SessionOwnerToggle
@@ -190,9 +190,9 @@ export function SessionSidebar() {
         {/* New session button */}
         <Link
           href="/sessions/new"
-          className="flex items-center justify-center gap-2 w-full h-8 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
+          className="flex items-center justify-center gap-2 w-full h-9 rounded-md border border-border bg-background text-[13px] font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
         >
-          <Plus className="h-3.5 w-3.5" />
+          <Plus className="h-4 w-4" />
           New session
         </Link>
 


### PR DESCRIPTION
## Summary
- Updated the sessions sidebar search input and "New session" button to use the same sizing as the projects sidebar
- Search input: `h-7`→`h-8`, `pr-2`→`pr-3`; button: `h-8`→`h-9`, icon `h-3.5 w-3.5`→`h-4 w-4`; spacing `space-y-2.5`→`space-y-3`

## Test plan
- [ ] Verify sessions and projects sidebars have visually identical search bar and button sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)