### PR TITLE
Show re-auth dialog when Codex ChatGPT auth fails

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -59,6 +59,8 @@ import { useDiffViewState } from "@/hooks/use-diff-view-state";
 import { useReviewedFiles } from "@/hooks/use-reviewed-files";
 import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 
+const FAILURE_CATEGORY_CODEX_AUTH = "codex_auth_expired";
+
 const statusConfig: Record<string, { color: string; label: string }> = {
   pending: { color: "bg-muted text-muted-foreground", label: "Pending" },
   running: { color: "bg-primary/10 text-primary", label: "Running" },
@@ -190,7 +192,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
                 </ul>
               </div>
             )}
-            {session.failure_category === "codex_auth_expired" && (
+            {session.failure_category === FAILURE_CATEGORY_CODEX_AUTH && (
               <Button
                 size="sm"
                 variant="outline"
@@ -209,6 +211,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
           onConnected={() => {
             setShowDeviceCodeModal(false);
             queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+            queryClient.invalidateQueries({ queryKey: ["session", session.id] });
           }}
         />
       )}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -57,6 +57,7 @@ import { DiffStatsBadge, FileTree, SessionFooter, CommentsSummary, ReviewDiffVie
 import { useReviewComments } from "@/hooks/use-review-comments";
 import { useDiffViewState } from "@/hooks/use-diff-view-state";
 import { useReviewedFiles } from "@/hooks/use-reviewed-files";
+import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 
 const statusConfig: Record<string, { color: string; label: string }> = {
   pending: { color: "bg-muted text-muted-foreground", label: "Pending" },
@@ -115,6 +116,7 @@ type DetailTab = "overview" | "changes" | "validation";
 
 function OverviewTab({ session, members }: { session: Session; members: User[] }) {
   const queryClient = useQueryClient();
+  const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
   const retryMutation = useMutation({
     mutationFn: () => api.issues.triggerFix(session.issue_id),
     onSuccess: () => {
@@ -188,8 +190,27 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
                 </ul>
               </div>
             )}
+            {session.failure_category === "codex_auth_expired" && (
+              <Button
+                size="sm"
+                variant="outline"
+                className="mt-1"
+                onClick={() => setShowDeviceCodeModal(true)}
+              >
+                Re-authenticate with ChatGPT
+              </Button>
+            )}
           </CardContent>
         </Card>
+      )}
+      {showDeviceCodeModal && (
+        <CodexDeviceCodeModal
+          onClose={() => setShowDeviceCodeModal(false)}
+          onConnected={() => {
+            setShowDeviceCodeModal(false);
+            queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+          }}
+        />
       )}
 
       {/* Session vitals — primary info row */}

--- a/internal/services/agent/failure.go
+++ b/internal/services/agent/failure.go
@@ -11,6 +11,15 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
+// Well-known failure categories.
+const (
+	FailureCategoryTooling    = "tooling"
+	FailureCategoryContext    = "context"
+	FailureCategoryValidation = "validation"
+	FailureCategoryComplexity = "complexity"
+	FailureCategoryCodexAuth  = "codex_auth_expired"
+)
+
 // FailureSummary holds a human-readable explanation of why an agent run failed,
 // along with classification metadata and actionable next steps.
 type FailureSummary struct {
@@ -81,7 +90,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if containsAny(errorMsg, "timeout", "deadline exceeded") {
 		return &FailureSummary{
 			Explanation:  "The agent ran out of time before completing the fix. This usually means the issue requires more analysis than the allocated time window allows.",
-			Category:     "tooling",
+			Category:     FailureCategoryTooling,
 			SubType:      "timeout",
 			NextSteps:    []string{"Retry with a higher complexity tier to allow more time", "Break the issue into smaller, more focused sub-tasks", "Provide additional context about the root cause to speed up analysis"},
 			RetryAdvised: true,
@@ -92,7 +101,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if containsAny(errorMsg, "oom", "killed", "signal", "crash", "out of memory") {
 		return &FailureSummary{
 			Explanation:  "The agent's sandbox environment crashed, likely due to running out of memory or being terminated by the system. This is an infrastructure issue, not a problem with the fix approach.",
-			Category:     "tooling",
+			Category:     FailureCategoryTooling,
 			SubType:      "sandbox_crash",
 			NextSteps:    []string{"Retry the run — sandbox crashes are usually transient", "If this keeps happening, the repository may need more resources to build", "Contact support if crashes persist across multiple retries"},
 			RetryAdvised: true,
@@ -103,7 +112,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if containsAny(errorMsg, "rate limit", "429", "503", "api error") {
 		return &FailureSummary{
 			Explanation:  "The agent encountered an API error, likely due to rate limiting or a temporary service outage. This is not related to the quality of the fix.",
-			Category:     "tooling",
+			Category:     FailureCategoryTooling,
 			SubType:      "api_error",
 			NextSteps:    []string{"Wait a few minutes and retry", "Check the status page for any ongoing service incidents", "If rate limiting persists, consider reducing concurrent agent runs"},
 			RetryAdvised: true,
@@ -114,7 +123,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if containsAny(errorMsg, "build failed", "compilation error", "syntax error") {
 		return &FailureSummary{
 			Explanation:  "The agent's changes caused a build failure. The generated code had compilation or syntax errors that prevented a successful build.",
-			Category:     "tooling",
+			Category:     FailureCategoryTooling,
 			SubType:      "build_failure",
 			NextSteps:    []string{"Review the build logs for specific errors", "Ensure the repository's build toolchain is properly configured", "Retry — the agent may produce a different, valid fix on a second attempt"},
 			RetryAdvised: true,
@@ -125,7 +134,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if diff == "" && errorMsg == "" {
 		return &FailureSummary{
 			Explanation:  "The agent was unable to produce a code change. It could not identify the right files to modify or determine a clear fix for this issue.",
-			Category:     "context",
+			Category:     FailureCategoryContext,
 			SubType:      "missing_context",
 			NextSteps:    []string{"Add more detail to the issue description, especially which files or functions are involved", "Link related issues or stack traces to provide more context", "Consider manually pointing the agent to the relevant code area"},
 			RetryAdvised: false,
@@ -137,7 +146,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		containsAny(resultSummary, "test failed", "test regression", "tests failed") {
 		return &FailureSummary{
 			Explanation:  "The agent produced a fix, but it caused existing tests to fail. The change was rejected to protect against regressions.",
-			Category:     "validation",
+			Category:     FailureCategoryValidation,
 			SubType:      "test_regression",
 			NextSteps:    []string{"Review which tests failed to understand the regression", "The fix may be partially correct — consider refining the approach manually", "Retry with more context about the expected test behavior"},
 			RetryAdvised: true,
@@ -149,7 +158,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 		containsAny(resultSummary, "security violation", "security scan", "vulnerability") {
 		return &FailureSummary{
 			Explanation:  "The agent's fix was rejected because it introduced a security concern. The security scan flagged potential vulnerabilities in the generated code.",
-			Category:     "validation",
+			Category:     FailureCategoryValidation,
 			SubType:      "security_violation",
 			NextSteps:    []string{"Review the security scan results to understand the specific concern", "A human developer should address this issue with security best practices in mind", "Consider adding security-related context or constraints to the issue description"},
 			RetryAdvised: false,
@@ -160,7 +169,7 @@ func (s *FailureService) classifyFailure(run *models.Session) *FailureSummary {
 	if diff != "" && countLines(diff) > 500 {
 		return &FailureSummary{
 			Explanation:  "The agent produced a very large change spanning many lines. Changes of this size are often unreliable and may indicate the issue requires a more targeted approach.",
-			Category:     "complexity",
+			Category:     FailureCategoryComplexity,
 			SubType:      "multi_file_scope",
 			NextSteps:    []string{"Break the issue into smaller, more focused sub-tasks", "Identify the core change needed and create a narrower issue", "Consider having a human developer handle this architectural change"},
 			RetryAdvised: false,

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -61,6 +61,7 @@ type SessionStore interface {
 	UpdateSnapshotInfo(ctx context.Context, orgID, sessionID uuid.UUID, agentSessionID, snapshotKey string) error
 	UpdateSandboxState(ctx context.Context, orgID, sessionID uuid.UUID, state string) error
 	UpdateWorkingBranch(ctx context.Context, orgID, sessionID uuid.UUID, branch string) error
+	UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
 	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
 }
 
@@ -417,11 +418,21 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if run.AgentType == models.AgentTypeCodex {
 		injected, err := o.injectCodexAuth(ctx, run.OrgID, sandbox)
 		if err != nil {
-			o.failRun(ctx, run, fmt.Sprintf("codex auth injection failed: %s", err))
+			o.failRunWithCategory(ctx, run,
+				fmt.Sprintf("codex auth injection failed: %s", err),
+				"codex_auth_expired",
+				"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
+				[]string{"Click 'Re-authenticate with ChatGPT' below to sign in again"},
+			)
 			return fmt.Errorf("codex auth injection: %w", err)
 		}
 		if !injected {
-			o.failRun(ctx, run, "no credentials configured for codex: connect ChatGPT from the Overview page")
+			o.failRunWithCategory(ctx, run,
+				"no credentials configured for codex: connect ChatGPT from the Overview page",
+				"codex_auth_expired",
+				"No ChatGPT credentials are configured. Please connect your ChatGPT account to use Codex.",
+				[]string{"Click 'Re-authenticate with ChatGPT' below to sign in"},
+			)
 			return fmt.Errorf("no credentials for codex agent")
 		}
 	}
@@ -687,11 +698,21 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if session.AgentType == models.AgentTypeCodex {
 			injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
 			if err != nil {
-				o.failRun(ctx, session, fmt.Sprintf("codex auth injection failed: %s", err))
+				o.failRunWithCategory(ctx, session,
+					fmt.Sprintf("codex auth injection failed: %s", err),
+					"codex_auth_expired",
+					"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
+					[]string{"Click 'Re-authenticate with ChatGPT' below to sign in again"},
+				)
 				return fmt.Errorf("codex auth injection: %w", err)
 			}
 			if !injected {
-				o.failRun(ctx, session, "no credentials configured for codex: connect ChatGPT from the Overview page")
+				o.failRunWithCategory(ctx, session,
+					"no credentials configured for codex: connect ChatGPT from the Overview page",
+					"codex_auth_expired",
+					"No ChatGPT credentials are configured. Please connect your ChatGPT account to use Codex.",
+					[]string{"Click 'Re-authenticate with ChatGPT' below to sign in"},
+				)
 				return fmt.Errorf("no credentials for codex agent")
 			}
 		}
@@ -1019,6 +1040,16 @@ func (o *Orchestrator) failRun(ctx context.Context, run *models.Session, errMsg 
 		if err := o.projectTasks.OnSessionComplete(ctx, run, "failed"); err != nil {
 			o.logger.Warn().Err(err).Str("run_id", run.ID.String()).Msg("failed to update project task on run failure")
 		}
+	}
+}
+
+// failRunWithCategory marks a run as failed with a structured failure category,
+// explanation, and next steps. Used for well-known failure modes (e.g. auth expiry)
+// where we can provide actionable guidance in the UI.
+func (o *Orchestrator) failRunWithCategory(ctx context.Context, run *models.Session, errMsg, category, explanation string, nextSteps []string) {
+	o.failRun(ctx, run, errMsg)
+	if err := o.sessions.UpdateFailure(ctx, run.OrgID, run.ID, explanation, category, nextSteps, true); err != nil {
+		o.logger.Error().Err(err).Str("run_id", run.ID.String()).Msg("failed to update run failure details")
 	}
 }
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -416,24 +416,8 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	//    auth.json is the primary auth mechanism (uses ChatGPT backend).
 	//    Done after clone so the workspace is available.
 	if run.AgentType == models.AgentTypeCodex {
-		injected, err := o.injectCodexAuth(ctx, run.OrgID, sandbox)
-		if err != nil {
-			o.failRunWithCategory(ctx, run,
-				fmt.Sprintf("codex auth injection failed: %s", err),
-				"codex_auth_expired",
-				"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
-				[]string{"Click 'Re-authenticate with ChatGPT' below to sign in again"},
-			)
-			return fmt.Errorf("codex auth injection: %w", err)
-		}
-		if !injected {
-			o.failRunWithCategory(ctx, run,
-				"no credentials configured for codex: connect ChatGPT from the Overview page",
-				"codex_auth_expired",
-				"No ChatGPT credentials are configured. Please connect your ChatGPT account to use Codex.",
-				[]string{"Click 'Re-authenticate with ChatGPT' below to sign in"},
-			)
-			return fmt.Errorf("no credentials for codex agent")
+		if err := o.ensureCodexAuth(ctx, run, sandbox); err != nil {
+			return err
 		}
 	}
 
@@ -696,24 +680,8 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 
 		// Re-inject Codex auth.json if needed.
 		if session.AgentType == models.AgentTypeCodex {
-			injected, err := o.injectCodexAuth(ctx, session.OrgID, sandbox)
-			if err != nil {
-				o.failRunWithCategory(ctx, session,
-					fmt.Sprintf("codex auth injection failed: %s", err),
-					"codex_auth_expired",
-					"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
-					[]string{"Click 'Re-authenticate with ChatGPT' below to sign in again"},
-				)
-				return fmt.Errorf("codex auth injection: %w", err)
-			}
-			if !injected {
-				o.failRunWithCategory(ctx, session,
-					"no credentials configured for codex: connect ChatGPT from the Overview page",
-					"codex_auth_expired",
-					"No ChatGPT credentials are configured. Please connect your ChatGPT account to use Codex.",
-					[]string{"Click 'Re-authenticate with ChatGPT' below to sign in"},
-				)
-				return fmt.Errorf("no credentials for codex agent")
+			if err := o.ensureCodexAuth(ctx, session, sandbox); err != nil {
+				return err
 			}
 		}
 
@@ -1051,6 +1019,31 @@ func (o *Orchestrator) failRunWithCategory(ctx context.Context, run *models.Sess
 	if err := o.sessions.UpdateFailure(ctx, run.OrgID, run.ID, explanation, category, nextSteps, true); err != nil {
 		o.logger.Error().Err(err).Str("run_id", run.ID.String()).Msg("failed to update run failure details")
 	}
+}
+
+// ensureCodexAuth injects Codex auth credentials into the sandbox, failing the
+// run with a codex_auth_expired category if injection fails or no creds exist.
+func (o *Orchestrator) ensureCodexAuth(ctx context.Context, run *models.Session, sandbox *Sandbox) error {
+	injected, err := o.injectCodexAuth(ctx, run.OrgID, sandbox)
+	if err != nil {
+		o.failRunWithCategory(ctx, run,
+			fmt.Sprintf("codex auth injection failed: %s", err),
+			FailureCategoryCodexAuth,
+			"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
+			[]string{"Re-authenticate with ChatGPT from the session page to sign in again"},
+		)
+		return fmt.Errorf("codex auth injection: %w", err)
+	}
+	if !injected {
+		o.failRunWithCategory(ctx, run,
+			"no credentials configured for codex: connect ChatGPT from the Overview page",
+			FailureCategoryCodexAuth,
+			"No ChatGPT credentials are configured. Please connect your ChatGPT account to use Codex.",
+			[]string{"Re-authenticate with ChatGPT from the session page to sign in"},
+		)
+		return fmt.Errorf("no credentials for codex agent")
+	}
+	return nil
 }
 
 // buildRunResult converts an AgentResult into the DB update struct.

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -134,7 +134,15 @@ type mockSessionStore struct {
 	statusUpdates   []string
 	resultUpdates   []resultUpdate
 	turnUpdates     []turnUpdate
+	failureUpdates  []failureUpdate
 	countRunningErr error
+}
+
+type failureUpdate struct {
+	explanation  string
+	category     string
+	nextSteps    []string
+	retryAdvised bool
 }
 
 type resultUpdate struct {
@@ -194,6 +202,14 @@ func (m *mockSessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessi
 }
 
 func (m *mockSessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failureUpdates = append(m.failureUpdates, failureUpdate{
+		explanation:  explanation,
+		category:     category,
+		nextSteps:    nextSteps,
+		retryAdvised: retryAdvised,
+	})
 	return nil
 }
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -193,6 +193,10 @@ func (m *mockSessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessi
 	return nil
 }
 
+func (m *mockSessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error {
+	return nil
+}
+
 func (m *mockSessionStore) GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	return models.Session{}, nil
 }


### PR DESCRIPTION
## Summary
- When Codex auth injection fails (token expired/revoked/missing), the backend now sets `failure_category: "codex_auth_expired"` with a user-friendly explanation and next steps
- The session detail failure card detects this category and shows a "Re-authenticate with ChatGPT" button
- Clicking the button opens the existing device code OAuth modal so users can re-auth without navigating away

## Test plan
- [ ] Trigger a Codex session with an expired/revoked ChatGPT token
- [ ] Verify the failure card shows the re-auth button
- [ ] Click the button and complete the OAuth flow
- [ ] Retry the session after re-authenticating

🤖 Generated with [Claude Code](https://claude.com/claude-code)