### PR TITLE
Fix session filter tabs wrapping with scrollable tab bar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -12,7 +12,7 @@ import {
 import { ArrowUpDown, CalendarClock, Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { PageHeader } from "@/components/page-header";
 import { PMStatusBanner } from "@/components/pm/pm-status-banner";
@@ -53,7 +53,7 @@ const statusConfig: Record<string, { dot: string; text: string; bg: string; labe
 
 const filterTabs = [
   { value: "all", label: "All" },
-  { value: "needs_attention", label: "Needs attention" },
+  { value: "needs_attention", label: "Action needed" },
   { value: "working", label: "Working" },
   { value: "done", label: "Done" },
   { value: "decisions", label: "Decisions" },
@@ -212,6 +212,19 @@ export function SessionsPageContent() {
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
+  const tabsRef = useRef<HTMLDivElement>(null);
+  const [tabsOverflow, setTabsOverflow] = useState(false);
+
+  const checkOverflow = useCallback(() => {
+    const el = tabsRef.current;
+    if (el) setTabsOverflow(el.scrollWidth > el.clientWidth);
+  }, []);
+
+  useEffect(() => {
+    checkOverflow();
+    window.addEventListener("resize", checkOverflow);
+    return () => window.removeEventListener("resize", checkOverflow);
+  }, [checkOverflow]);
 
   const currentFilter = activeFilter ?? "all";
   const showDecisions = currentFilter === "decisions";
@@ -279,8 +292,8 @@ export function SessionsPageContent() {
       <PMStatusBanner hasActivePlanSession={workingSessions.length > 0} />
 
       {/* ── Tab filters ────────────────────────────────────────────── */}
-      <div className="flex items-center justify-between border-b border-border">
-        <div className="flex items-center gap-0">
+      <div className="relative flex items-center border-b border-border">
+        <div ref={tabsRef} className={`flex flex-nowrap items-center overflow-x-auto scrollbar-hide min-w-0 ${tabsOverflow ? "mask-fade-r" : ""}`}>
           {filterTabs.map((tab) => {
             const isSelected = currentFilter === tab.value;
             const count =
@@ -290,7 +303,7 @@ export function SessionsPageContent() {
             return (
               <button
                 key={tab.value}
-                className={`relative px-3 py-2.5 text-[13px] font-medium transition-colors duration-150 ${
+                className={`relative shrink-0 px-2.5 py-2.5 text-[13px] font-medium transition-colors duration-150 ${
                   isSelected
                     ? "text-foreground"
                     : "text-muted-foreground hover:text-foreground/80"
@@ -307,7 +320,7 @@ export function SessionsPageContent() {
                   )}
                 </span>
                 {isSelected && (
-                  <span className="absolute bottom-0 left-3 right-3 h-0.5 bg-[image:var(--gradient-primary)] rounded-full" />
+                  <span className="absolute bottom-0 left-2.5 right-2.5 h-0.5 bg-[image:var(--gradient-primary)] rounded-full" />
                 )}
               </button>
             );
@@ -318,7 +331,7 @@ export function SessionsPageContent() {
         <SessionOwnerToggle
           currentUserFilter={currentUserFilter}
           onFilterChange={setUserFilter}
-          className="mr-2"
+          className="ml-auto shrink-0 mr-2"
         />
       </div>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -123,6 +123,19 @@
   --glow-primary-sm: 0 0 10px oklch(0.6 0.18 270 / 15%);
 }
 
+@utility scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+@utility mask-fade-r {
+  mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
## Summary
- Prevents filter tabs from wrapping to a second line at narrow widths by making the tab container horizontally scrollable with hidden scrollbars
- Adds a conditional right-edge fade mask that only appears when tabs overflow, hinting at off-screen content
- Adds explicit `flex-nowrap` and `shrink-0` for clarity and robustness
- Renames "Needs attention" tab label to "Action needed" for a clearer call-to-action

## Test plan
- [ ] Resize the sessions panel to a narrow width and verify tabs scroll horizontally instead of wrapping
- [ ] Confirm the right-edge fade appears only when tabs overflow
- [ ] Verify the "Action needed" tab still filters correctly with its orange badge count

🤖 Generated with [Claude Code](https://claude.com/claude-code)