### PR TITLE
Fix sm tabs to single-line with horizontal scroll and visible focus

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -118,7 +118,7 @@ export function ProjectSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-x-auto">
+          <TabsList size="sm">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "active" ? activeCount

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -202,7 +202,7 @@ export function SessionSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-x-auto">
+          <TabsList size="sm">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "needs_attention" ? needsAttentionSessions.length

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -35,7 +35,7 @@ const tabsListVariants = cva(
       },
       size: {
         default: "",
-        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 p-0 rounded-none bg-transparent flex w-full flex-wrap",
+        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 py-0.5 px-0 rounded-none bg-transparent flex w-full flex-nowrap overflow-x-auto",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary
- Fix the `sm` TabsList variant to use `flex-nowrap` + `overflow-x-auto` instead of `flex-wrap`, so filter tabs stay on a single line and scroll horizontally when they overflow.
- Add `py-0.5` padding so the active/focus button highlight is fully visible (previously clipped at the bottom by `p-0`).
- Remove now-redundant `overflow-x-auto` className overrides from session and project sidebar TabsList usages.

## Test plan
- [ ] Verify session sidebar filter tabs render on a single line and scroll horizontally
- [ ] Verify project sidebar filter tabs render on a single line and scroll horizontally
- [ ] Verify focused tab button shows complete highlight (no clipping at bottom)
- [ ] Resize sidebar narrower to confirm horizontal scroll appears when tabs overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)