### PR TITLE
Add 143-tools binary to sandbox Docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,8 @@ jobs:
       - name: Build sandbox Docker image
         uses: docker/build-push-action@v6
         with:
-          context: ./sandbox
+          context: .
+          file: sandbox/Dockerfile
           push: false
           tags: 143-sandbox:latest
           cache-from: type=gha

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   sandbox:
     image: 143-sandbox:latest
     build:
-      context: ./sandbox
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: sandbox/Dockerfile
     profiles:
       - sandbox
 

--- a/internal/config/sandbox_image_wiring_test.go
+++ b/internal/config/sandbox_image_wiring_test.go
@@ -23,7 +23,7 @@ func TestSandboxImageWiring(t *testing.T) {
 			patterns: []string{
 				"sandbox:",
 				"image: 143-sandbox:latest",
-				"context: ./sandbox",
+				"dockerfile: sandbox/Dockerfile",
 			},
 		},
 		{
@@ -40,7 +40,7 @@ func TestSandboxImageWiring(t *testing.T) {
 			path: ".github/workflows/ci.yml",
 			patterns: []string{
 				"name: Build sandbox Docker image",
-				"context: ./sandbox",
+				"file: sandbox/Dockerfile",
 				"tags: 143-sandbox:latest",
 			},
 		},

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -2,9 +2,21 @@
 # Sandbox image for running coding agents (Claude Code, Codex CLI, Gemini CLI).
 # Tagged as 143-sandbox:latest by default.
 #
-# Build:  docker build -t 143-sandbox:latest sandbox/
+# Build:  docker build -t 143-sandbox:latest -f sandbox/Dockerfile .
 # See also: docs/design/24-design-resolutions.md (Resolution 15)
 
+# Stage 1: Build 143-tools Go binary.
+FROM golang:1.26 AS go-builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 go build -o /bin/143-tools ./cmd/tools
+
+# Stage 2: Runtime
 FROM ubuntu:26.04
 
 # System dependencies for agent CLIs and typical repo operations.
@@ -22,7 +34,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 
 # Install agent CLIs at pinned versions.
 # The npm cache mount avoids re-downloading unchanged packages on rebuilds.
-COPY versions.json /tmp/versions.json
+COPY sandbox/versions.json /tmp/versions.json
 RUN --mount=type=cache,target=/root/.npm \
     CLAUDE_CODE_VERSION=$(jq -r '.claude_code' /tmp/versions.json) && \
     CODEX_CLI_VERSION=$(jq -r '.codex_cli' /tmp/versions.json) && \
@@ -32,6 +44,9 @@ RUN --mount=type=cache,target=/root/.npm \
       "@openai/codex@${CODEX_CLI_VERSION}" \
       "@google/gemini-cli@${GEMINI_CLI_VERSION}" && \
     rm /tmp/versions.json
+
+# Copy 143-tools binary from Go builder.
+COPY --from=go-builder /bin/143-tools /usr/local/bin/143-tools
 
 # Non-root user for sandbox execution.
 RUN useradd -m -s /bin/bash sandbox

--- a/setup.sh
+++ b/setup.sh
@@ -214,7 +214,7 @@ fi
 # ---------------------------------------------------------------------------
 if command -v docker >/dev/null 2>&1; then
   info "Building sandbox image (143-sandbox:latest)..."
-  docker build -t 143-sandbox:latest sandbox
+  docker build -t 143-sandbox:latest -f sandbox/Dockerfile .
 else
   warn "Docker not found — skipping sandbox image build."
   warn "Docker-backed agent runs need 143-sandbox:latest built from sandbox/Dockerfile."


### PR DESCRIPTION
The 143-tools CLI was never compiled or included in the sandbox Docker image, so coding agents couldn't access integration tools inside sessions. This adds a Go builder stage to the sandbox Dockerfile that compiles 143-tools and copies it into the image. All build references (CI, docker-compose, setup.sh) are updated to use the repo root as the build context so the Go source is available during the build.