### PR TITLE
Fix code diff background colors cutting off on horizontal scroll

### DIFF
--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -150,6 +150,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
           onBrowseFile={onBrowseFile}
         />
         <div className="overflow-x-auto">
+        <div className="min-w-fit">
         {file.hunks.map((hunk, i) => {
           const hunkEl =
             viewMode === "split" ? (
@@ -208,6 +209,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
             </div>
           );
         })}
+        </div>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- Adds a `min-w-fit` wrapper inside the `overflow-x-auto` scroll container in `FileDiffSection`
- This ensures line background colors (green/red for add/remove, syntax highlighting) extend to the full scrollable width instead of stopping at the viewport edge when scrolling horizontally

## Test plan
- [ ] Open a code review with long lines that require horizontal scrolling
- [ ] Verify background colors (add/remove highlighting) extend fully when scrolling right
- [ ] Test both unified and split diff views

🤖 Generated with [Claude Code](https://claude.com/claude-code)