### PR TITLE
Add session cancellation via SIGINT to coding agents

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -89,7 +89,8 @@ func main() {
 		fileReader = sandbox.NoOpFileReader{}
 	}
 
-	router, err := api.NewRouter(cfg, pool, logger, codexAuthSvc, llmClient, fileReader)
+	cancelRegistry := agent.NewCancelRegistry(logger)
+	router, err := api.NewRouter(cfg, pool, logger, codexAuthSvc, llmClient, fileReader, cancelRegistry)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize API router")
 	}
@@ -150,7 +151,7 @@ func main() {
 				jobStore, orgStore, repoStore, validationStore, pullRequestStore,
 				deployStore, priorityScoreStore, complexityEstimateStore, pmPlanStore, pmDecisionLogStore,
 				projectStore, projectTaskStore, projectCycleStore, pmDocumentStore, integrationStore,
-				sessionMessageStore, snapshotStore)
+				sessionMessageStore, snapshotStore, cancelRegistry)
 		}
 		retentionCfg := worker.DataRetentionConfig{
 			WebhookDays: cfg.DataRetentionWebhookDays,
@@ -249,6 +250,7 @@ func buildServices(
 	integrationStore *db.IntegrationStore,
 	sessionMessageStore *db.SessionMessageStore,
 	snapshotStore storage.SnapshotStore,
+	cancelRegistry *agent.CancelRegistry,
 ) *worker.Services {
 	// GitHub App service (for installation tokens, PR creation).
 	ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
@@ -314,6 +316,7 @@ func buildServices(
 		Credentials:      credentialStore,
 		UserCredentials:  userCredentialStore,
 		Snapshots:        snapshotStore,
+		Cancels:          cancelRegistry,
 		Logger:           logger,
 	})
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -655,7 +655,7 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id={runningSession.id} />);
     await screen.findByText('Agent is working...');
-    expect(screen.getByTitle('Stop session')).toBeInTheDocument();
+    expect(screen.getByTitle('Cancel session')).toBeInTheDocument();
     expect(screen.queryByTitle('Send message')).not.toBeInTheDocument();
   });
 
@@ -677,18 +677,18 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id={idleSession.id} />);
     await screen.findByPlaceholderText('Send a follow-up message...');
     expect(screen.getByTitle('Send message')).toBeInTheDocument();
-    expect(screen.queryByTitle('Stop session')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Cancel session')).not.toBeInTheDocument();
   });
 
   it('shows send button for completed session (not stop)', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
     expect(screen.getByTitle('Send message')).toBeInTheDocument();
-    expect(screen.queryByTitle('Stop session')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Cancel session')).not.toBeInTheDocument();
   });
 
-  it('calls end session API when stop button is clicked during running state', async () => {
-    let endSessionCalled = false;
+  it('calls cancel session API when cancel button is clicked during running state', async () => {
+    let cancelSessionCalled = false;
 
     const runningSession: Session = {
       ...mockSessions[0],
@@ -702,9 +702,9 @@ describe('SessionDetailPage', () => {
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
       }),
-      http.post('/api/v1/sessions/:id/end', () => {
-        endSessionCalled = true;
-        return HttpResponse.json({ data: { ...runningSession, status: 'idle' } });
+      http.post('/api/v1/sessions/:id/cancel', () => {
+        cancelSessionCalled = true;
+        return HttpResponse.json({ data: { ...runningSession, status: 'cancelled' } });
       }),
     );
 
@@ -712,11 +712,11 @@ describe('SessionDetailPage', () => {
     await screen.findByText('Agent is working...');
 
     const user = userEvent.setup();
-    const stopButton = screen.getByTitle('Stop session');
-    await user.click(stopButton);
+    const cancelButton = screen.getByTitle('Cancel session');
+    await user.click(cancelButton);
 
     await waitFor(() => {
-      expect(endSessionCalled).toBe(true);
+      expect(cancelSessionCalled).toBe(true);
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -919,6 +919,13 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     },
   });
 
+  const cancelMutation = useMutation({
+    mutationFn: () => api.sessions.cancelSession(sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+
   const { data: prData } = useQuery({
     queryKey: ["session", sessionId, "pr"],
     queryFn: () => api.sessions.getPR(sessionId).catch((err) => {
@@ -1037,7 +1044,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
       {/* Error display */}
       {(() => {
-        const firstError = uploadError || [sendMutation, endMutation, createPRMutation].find(m => m.error)?.error;
+        const firstError = uploadError || [sendMutation, endMutation, cancelMutation, createPRMutation].find(m => m.error)?.error;
         if (!firstError) return null;
         const msg = typeof firstError === "string" ? firstError : (firstError instanceof Error ? firstError.message : "An error occurred");
         return (
@@ -1226,9 +1233,9 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
                   size="icon"
                   variant="outline"
                   className="h-8 w-8 shrink-0 rounded-lg"
-                  title="Stop session"
-                  disabled={endMutation.isPending}
-                  onClick={() => endMutation.mutate()}
+                  title="Cancel session"
+                  disabled={cancelMutation.isPending}
+                  onClick={() => cancelMutation.mutate()}
                 >
                   <Square className="h-3 w-3" />
                 </Button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -235,6 +235,8 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/end`),
     retry: (sessionId: string) =>
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/retry`),
+    cancelSession: (sessionId: string) =>
+      post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/cancel`),
     // Thread endpoints
     listThreads: (sessionId: string) =>
       get<import('./types').ListResponse<import('./types').SessionThread>>(`/api/v1/sessions/${sessionId}/threads`),

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -23,6 +23,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// SessionCanceller can cancel a running agent session. The Orchestrator
+// implements this interface; it is injected after construction via SetCanceller.
+type SessionCanceller interface {
+	CancelSession(sessionID uuid.UUID) bool
+}
+
 type SessionHandler struct {
 	runStore         *db.SessionStore
 	logStore         *db.SessionLogStore
@@ -38,11 +44,17 @@ type SessionHandler struct {
 	llmClient        llm.Client // optional, used for generating manual session titles
 	logger           zerolog.Logger
 	audit            *db.AuditEmitter
+	canceller        SessionCanceller // optional — enables cancelling running sessions
 }
 
 // SetAuditEmitter injects the audit emitter for logging session events.
 func (h *SessionHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 	h.audit = audit
+}
+
+// SetCanceller injects the session canceller for stopping running agent sessions.
+func (h *SessionHandler) SetCanceller(c SessionCanceller) {
+	h.canceller = c
 }
 
 func NewSessionHandler(
@@ -853,6 +865,54 @@ func (h *SessionHandler) EndSession(w http.ResponseWriter, r *http.Request) {
 
 	session.Status = string(models.SessionStatusCompleted)
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Session]{Data: session})
+}
+
+// CancelSession handles POST /sessions/{id}/cancel — cancels a running session
+// by signalling the orchestrator to send SIGINT to the agent process.
+//
+// The response returns the session in its current state (still "running").
+// The orchestrator updates the status asynchronously once the agent exits —
+// typically to "idle" (if snapshot succeeds) or "cancelled" (if not).
+// The frontend should poll for the final status.
+func (h *SessionHandler) CancelSession(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+
+	if session.Status != string(models.SessionStatusRunning) {
+		writeError(w, r, http.StatusConflict, "NOT_RUNNING", "only running sessions can be cancelled")
+		return
+	}
+
+	if h.canceller == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "CANCEL_UNAVAILABLE", "session cancellation is not available")
+		return
+	}
+
+	// Signal the orchestrator to send SIGINT to the agent.
+	// The orchestrator will update the session status asynchronously when the
+	// agent execution terminates (to idle or cancelled).
+	if !h.canceller.CancelSession(sessionID) {
+		// The session is marked as running but isn't tracked in the cancel
+		// registry. This can happen if the session just finished or the worker
+		// is on a different node. Return 202 Accepted — the client should poll.
+		h.logger.Warn().
+			Str("session_id", sessionID.String()).
+			Msg("cancel requested but session not found in local cancel registry")
+	}
+
+	// Return the session as-is (still "running"). The status will be updated
+	// asynchronously by the orchestrator once the agent exits.
+	writeJSON(w, http.StatusAccepted, models.SingleResponse[models.Session]{Data: session})
 }
 
 func isTerminalStatus(status string) bool {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2768,6 +2768,197 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// mockCanceller implements SessionCanceller for testing.
+type mockCanceller struct {
+	called    bool
+	sessionID uuid.UUID
+	result    bool
+}
+
+func (m *mockCanceller) CancelSession(sessionID uuid.UUID) bool {
+	m.called = true
+	m.sessionID = sessionID
+	return m.result
+}
+
+func TestSessionHandler_CancelSession_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	canceller := &mockCanceller{result: true}
+	handler.SetCanceller(canceller)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "running", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil, // triggered_by_user_id
+				nil, 1, &now, "running", nil,
+				nil, nil, nil, nil, nil,
+				nil, // input_manifest
+				nil, // deleted_at
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/cancel", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CancelSession(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "cancel should return 202 Accepted")
+	require.Contains(t, w.Body.String(), `"status":"running"`, "response should still show running status")
+	require.True(t, canceller.called, "canceller should have been called")
+	require.Equal(t, sessionID, canceller.sessionID, "canceller should receive correct session ID")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionHandler_CancelSession_NotRunning(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	canceller := &mockCanceller{result: true}
+	handler.SetCanceller(canceller)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "idle", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil, // triggered_by_user_id
+				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
+				nil, nil, nil, nil, nil,
+				nil, // input_manifest
+				nil, // deleted_at
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/cancel", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CancelSession(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "cancelling non-running session should return 409")
+	require.Contains(t, w.Body.String(), "NOT_RUNNING")
+	require.False(t, canceller.called, "canceller should not be called for non-running sessions")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionHandler_CancelSession_InvalidID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := newSessionHandler(t, mock)
+	canceller := &mockCanceller{result: true}
+	handler.SetCanceller(canceller)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/not-a-uuid/cancel", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CancelSession(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_ID")
+	require.False(t, canceller.called)
+}
+
+func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	// Don't set canceller — leave it nil.
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "running", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil, // triggered_by_user_id
+				nil, 1, &now, "running", nil,
+				nil, nil, nil, nil, nil,
+				nil, // input_manifest
+				nil, // deleted_at
+				now,
+			),
+		)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/cancel", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CancelSession(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+	require.Contains(t, w.Body.String(), "CANCEL_UNAVAILABLE")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -28,7 +28,7 @@ import (
 	threadservice "github.com/assembledhq/143/internal/services/thread"
 )
 
-func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, codexAuthSvc *codexauth.Service, llmClient llm.Client, fileReader sandbox.FileReader) (*chi.Mux, error) {
+func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, codexAuthSvc *codexauth.Service, llmClient llm.Client, fileReader sandbox.FileReader, canceller handlers.SessionCanceller) (*chi.Mux, error) {
 	// Create stores
 	orgStore := db.NewOrganizationStore(pool)
 	userStore := db.NewUserStore(pool)
@@ -201,6 +201,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	// Wire audit emitter into all handlers that perform state changes.
 	authHandler.SetAuditEmitter(auditEmitter)
 	sessionHandler.SetAuditEmitter(auditEmitter)
+	if canceller != nil {
+		sessionHandler.SetCanceller(canceller)
+	}
 	teamHandler.SetAuditEmitter(auditEmitter)
 	settingsHandler.SetAuditEmitter(auditEmitter)
 	credentialHandler.SetAuditEmitter(auditEmitter)
@@ -435,6 +438,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Post("/api/v1/sessions/{id}/messages", sessionHandler.SendMessage)
 			r.Post("/api/v1/sessions/{id}/end", sessionHandler.EndSession)
 			r.Post("/api/v1/sessions/{id}/retry", sessionHandler.RetrySession)
+			r.Post("/api/v1/sessions/{id}/cancel", sessionHandler.CancelSession)
 			r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
 			r.Post("/api/v1/sessions/{id}/threads", sessionThreadHandler.CreateThread)
 			r.Post("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.SendThreadMessage)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -36,7 +36,7 @@ func TestNewRouter_EncryptionKeyValidation(t *testing.T) {
 
 			cfg := &config.Config{EncryptionMasterKey: tt.masterKey}
 			codexSvc := codexauth.NewService(nil, zerolog.Nop())
-			router, err := NewRouter(cfg, nil, zerolog.Nop(), codexSvc, nil, nil)
+			router, err := NewRouter(cfg, nil, zerolog.Nop(), codexSvc, nil, nil, nil)
 			if tt.expectErr {
 				require.Error(t, err, "NewRouter should return an error when encryption key is invalid")
 				require.Nil(t, router, "NewRouter should not construct a router with an invalid encryption key")

--- a/internal/services/agent/cancel.go
+++ b/internal/services/agent/cancel.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// cancelEntry holds everything needed to gracefully cancel a running session.
+type cancelEntry struct {
+	sandbox   *Sandbox
+	provider  SandboxProvider
+	ctxCancel context.CancelFunc
+	once      sync.Once // guards against multiple cancel goroutines
+}
+
+// CancelRegistry tracks cancellable running sessions. The Orchestrator
+// registers entries when starting agent runs, and the API layer calls
+// CancelSession to send SIGINT to the agent process inside the container.
+type CancelRegistry struct {
+	mu        sync.Map // session ID (uuid.UUID) → *cancelEntry
+	cancelled sync.Map // session ID (uuid.UUID) → bool — tracks which sessions had SIGINT sent
+	logger    zerolog.Logger
+}
+
+// NewCancelRegistry creates a new CancelRegistry.
+func NewCancelRegistry(logger zerolog.Logger) *CancelRegistry {
+	return &CancelRegistry{logger: logger}
+}
+
+// Register stores the sandbox and provider for a running session so that
+// CancelSession can send SIGINT to the agent process.
+func (r *CancelRegistry) Register(sessionID uuid.UUID, sandbox *Sandbox, provider SandboxProvider, ctxCancel context.CancelFunc) {
+	r.mu.Store(sessionID, &cancelEntry{
+		sandbox:   sandbox,
+		provider:  provider,
+		ctxCancel: ctxCancel,
+	})
+}
+
+// Deregister removes the cancel entry for the given session.
+func (r *CancelRegistry) Deregister(sessionID uuid.UUID) {
+	r.mu.Delete(sessionID)
+	r.cancelled.Delete(sessionID)
+}
+
+// WasCancelled returns true if CancelSession was called for this session.
+// The orchestrator uses this to decide whether to treat the result as a
+// cancellation rather than normal completion.
+func (r *CancelRegistry) WasCancelled(sessionID uuid.UUID) bool {
+	_, ok := r.cancelled.Load(sessionID)
+	return ok
+}
+
+// CancelSession sends SIGINT to the coding agent running inside the sandbox,
+// giving it a chance to save session state and exit gracefully. If the agent
+// doesn't exit within a timeout, the context is cancelled as a fallback.
+// Returns true if the session was found and the cancel was initiated.
+// Safe to call multiple times — only the first call spawns the cancel goroutine.
+func (r *CancelRegistry) CancelSession(sessionID uuid.UUID) bool {
+	val, ok := r.mu.Load(sessionID)
+	if !ok {
+		return false
+	}
+	entry := val.(*cancelEntry)
+	r.cancelled.Store(sessionID, true)
+
+	// Use sync.Once to ensure only one cancel goroutine runs, even if the
+	// user clicks cancel multiple times rapidly.
+	entry.once.Do(func() {
+		go r.doCancel(sessionID, entry)
+	})
+
+	return true
+}
+
+// doCancel performs the actual SIGINT + fallback timeout logic.
+func (r *CancelRegistry) doCancel(sessionID uuid.UUID, entry *cancelEntry) {
+	killCtx, killCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer killCancel()
+
+	// Send SIGINT to the agent process inside the container.
+	// The agent CLIs (claude, codex, gemini) all handle SIGINT gracefully:
+	// they save conversation state, flush output, and exit cleanly.
+	//
+	// We use -x for exact process name matching (not -f which matches the
+	// full command line and can self-match the pkill command or match file
+	// paths containing these words). Each sandbox runs exactly one agent,
+	// so matching by binary name is precise.
+	cmd := "pkill -INT -x 'claude|codex|gemini' 2>/dev/null; true"
+
+	// The exit code from Exec is intentionally ignored. pkill returns 1
+	// when no matching process is found (agent already exited), which is
+	// fine — the trailing "; true" ensures the shell exits 0 regardless.
+	if _, err := entry.provider.Exec(killCtx, entry.sandbox, cmd, io.Discard, io.Discard); err != nil {
+		r.logger.Warn().Err(err).
+			Str("session_id", sessionID.String()).
+			Msg("failed to send SIGINT to agent process, falling back to context cancel")
+		entry.ctxCancel()
+		return
+	}
+
+	r.logger.Info().
+		Str("session_id", sessionID.String()).
+		Msg("sent SIGINT to agent process in sandbox")
+
+	// Give the agent time to wind down gracefully. If ExecStream hasn't
+	// returned after the timeout, force-cancel the context as a fallback.
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+
+	<-timer.C
+	if _, stillRunning := r.mu.Load(sessionID); stillRunning {
+		r.logger.Warn().
+			Str("session_id", sessionID.String()).
+			Msg("agent did not exit after SIGINT, force-cancelling context")
+		entry.ctxCancel()
+	}
+}

--- a/internal/services/agent/cancel_test.go
+++ b/internal/services/agent/cancel_test.go
@@ -47,9 +47,9 @@ func TestCancelRegistry_CancelSession_SendsSIGINT(t *testing.T) {
 	id := uuid.New()
 
 	provider := testutil.NewMockSandboxProvider()
-	var execCmd string
+	var execCmd atomic.Value
 	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
-		execCmd = cmd
+		execCmd.Store(cmd)
 		return 0, nil
 	}
 
@@ -60,10 +60,11 @@ func TestCancelRegistry_CancelSession_SendsSIGINT(t *testing.T) {
 
 	// Give the goroutine a moment to execute.
 	require.Eventually(t, func() bool {
-		return execCmd != ""
+		v, _ := execCmd.Load().(string)
+		return v != ""
 	}, 2*time.Second, 10*time.Millisecond)
 
-	require.Contains(t, execCmd, "pkill -INT")
+	require.Contains(t, execCmd.Load().(string), "pkill -INT")
 	require.True(t, reg.WasCancelled(id))
 }
 

--- a/internal/services/agent/cancel_test.go
+++ b/internal/services/agent/cancel_test.go
@@ -1,0 +1,122 @@
+package agent_test
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/assembledhq/143/internal/testutil"
+)
+
+func TestCancelRegistry_RegisterDeregister(t *testing.T) {
+	t.Parallel()
+	reg := agent.NewCancelRegistry(zerolog.Nop())
+	id := uuid.New()
+
+	require.False(t, reg.WasCancelled(id), "should not be cancelled before registration")
+
+	provider := testutil.NewMockSandboxProvider()
+	sb := &agent.Sandbox{ID: "sb-1", Provider: "mock", WorkDir: "/workspace"}
+	reg.Register(id, sb, provider, func() {})
+
+	// CancelSession should find it.
+	require.True(t, reg.CancelSession(id))
+	require.True(t, reg.WasCancelled(id))
+
+	// After deregister, WasCancelled should be cleared.
+	reg.Deregister(id)
+	require.False(t, reg.WasCancelled(id))
+}
+
+func TestCancelRegistry_CancelSession_NotFound(t *testing.T) {
+	t.Parallel()
+	reg := agent.NewCancelRegistry(zerolog.Nop())
+	require.False(t, reg.CancelSession(uuid.New()))
+}
+
+func TestCancelRegistry_CancelSession_SendsSIGINT(t *testing.T) {
+	t.Parallel()
+	reg := agent.NewCancelRegistry(zerolog.Nop())
+	id := uuid.New()
+
+	provider := testutil.NewMockSandboxProvider()
+	var execCmd string
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		execCmd = cmd
+		return 0, nil
+	}
+
+	sb := &agent.Sandbox{ID: "sb-1", Provider: "mock", WorkDir: "/workspace"}
+	reg.Register(id, sb, provider, func() {})
+
+	require.True(t, reg.CancelSession(id))
+
+	// Give the goroutine a moment to execute.
+	require.Eventually(t, func() bool {
+		return execCmd != ""
+	}, 2*time.Second, 10*time.Millisecond)
+
+	require.Contains(t, execCmd, "pkill -INT")
+	require.True(t, reg.WasCancelled(id))
+}
+
+func TestCancelRegistry_CancelSession_OnlyOnce(t *testing.T) {
+	t.Parallel()
+	reg := agent.NewCancelRegistry(zerolog.Nop())
+	id := uuid.New()
+
+	var execCount atomic.Int32
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		execCount.Add(1)
+		return 0, nil
+	}
+
+	sb := &agent.Sandbox{ID: "sb-1", Provider: "mock", WorkDir: "/workspace"}
+	reg.Register(id, sb, provider, func() {})
+
+	// Call cancel multiple times rapidly.
+	require.True(t, reg.CancelSession(id))
+	require.True(t, reg.CancelSession(id))
+	require.True(t, reg.CancelSession(id))
+
+	// Wait for goroutine to run.
+	require.Eventually(t, func() bool {
+		return execCount.Load() > 0
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Should only have exec'd once despite 3 cancel calls.
+	time.Sleep(100 * time.Millisecond) // brief pause to ensure no extra goroutines fire
+	require.Equal(t, int32(1), execCount.Load(), "pkill should only be sent once")
+}
+
+func TestCancelRegistry_CancelSession_FallsBackToCtxCancel(t *testing.T) {
+	t.Parallel()
+	reg := agent.NewCancelRegistry(zerolog.Nop())
+	id := uuid.New()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		return 0, context.DeadlineExceeded // simulate exec failure
+	}
+
+	var ctxCancelled atomic.Bool
+	cancelFn := func() { ctxCancelled.Store(true) }
+
+	sb := &agent.Sandbox{ID: "sb-1", Provider: "mock", WorkDir: "/workspace"}
+	reg.Register(id, sb, provider, cancelFn)
+
+	require.True(t, reg.CancelSession(id))
+
+	// Should fall back to context cancel when exec fails.
+	require.Eventually(t, func() bool {
+		return ctxCancelled.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+}

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -154,6 +154,7 @@ type Orchestrator struct {
 	snapshots         storage.SnapshotStore // can be nil — multi-turn disabled if nil
 	logger            zerolog.Logger
 	maxConcurrent     int
+	cancels           *CancelRegistry
 }
 
 // OrchestratorConfig holds the dependencies for creating an Orchestrator.
@@ -176,6 +177,7 @@ type OrchestratorConfig struct {
 	Memory            MemoryService // optional — injects learned memories into agent prompts
 	UserCredentials   UserCredentialProvider // optional — enables personal/team credential resolution
 	Snapshots         storage.SnapshotStore // optional — enables multi-turn snapshot/restore
+	Cancels           *CancelRegistry       // optional — enables session cancellation from API
 	Logger            zerolog.Logger
 	MaxConcurrent     int
 }
@@ -206,6 +208,7 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		memory:            cfg.Memory,
 		userCredentials:   cfg.UserCredentials,
 		snapshots:         cfg.Snapshots,
+		cancels:           cfg.Cancels,
 		logger:            cfg.Logger,
 		maxConcurrent:     maxConcurrent,
 	}
@@ -215,6 +218,14 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 // concurrency check → sandbox creation → repo clone → agent execution →
 // result handling → follow-up job enqueuing → sandbox cleanup.
 func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error {
+	// Create a cancellable context. The cancel registry is populated later
+	// once the sandbox is available, so CancelSession can send SIGINT.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if o.cancels != nil {
+		defer o.cancels.Deregister(run.ID)
+	}
+
 	log := o.logger.With().
 		Str("run_id", run.ID.String()).
 		Str("org_id", run.OrgID.String()).
@@ -378,10 +389,17 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		return fmt.Errorf("create sandbox: %w", err)
 	}
 	defer func() {
-		if destroyErr := o.provider.Destroy(ctx, sandbox); destroyErr != nil {
+		// Use a background context for cleanup since the run context may be cancelled.
+		destroyCtx := context.Background()
+		if destroyErr := o.provider.Destroy(destroyCtx, sandbox); destroyErr != nil {
 			log.Error().Err(destroyErr).Msg("failed to destroy sandbox")
 		}
 	}()
+
+	// Register sandbox with cancel registry so CancelSession can send SIGINT.
+	if o.cancels != nil {
+		o.cancels.Register(run.ID, sandbox, o.provider, cancel)
+	}
 
 	// 8. Clone repo into sandbox. This must happen before auth injection
 	// so that /workspace is empty when git clone runs (git clone fails on
@@ -444,13 +462,30 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, run.CurrentTurn, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 11. Handle result.
+	wasCancelled := o.cancels != nil && o.cancels.WasCancelled(run.ID)
+
 	if err != nil {
+		// If the session was cancelled by the user (context force-cancelled
+		// after SIGINT timeout), snapshot what we have and go to idle.
+		if wasCancelled || ctx.Err() != nil {
+			log.Info().Msg("session cancelled by user")
+			o.handleCancelledSession(run, sandbox, result, run.CurrentTurn+1, log)
+			return fmt.Errorf("session cancelled: %w", ctx.Err())
+		}
 		o.failRun(ctx, run, err.Error())
 		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
 			"session_id": run.ID.String(),
 			"org_id":     run.OrgID.String(),
 		})
 		return fmt.Errorf("execute agent: %w", err)
+	}
+
+	// 11a. If the agent exited after receiving SIGINT (user cancel), snapshot
+	// the workspace and return the session to idle so it can be continued.
+	if wasCancelled {
+		log.Info().Msg("agent exited after cancel, snapshotting and returning to idle")
+		o.handleCancelledSession(run, sandbox, result, run.CurrentTurn+1, log)
+		return nil
 	}
 
 	// 11b. Snapshot workspace for multi-turn support (does not change session status).
@@ -564,6 +599,14 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 // invoking this method. The SendMessage HTTP handler enforces this via org_id
 // scoping and ClaimIdle atomicity.
 func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Session) error {
+	// Create a cancellable context. The cancel registry is populated later
+	// once the sandbox is available, so CancelSession can send SIGINT.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	if o.cancels != nil {
+		defer o.cancels.Deregister(session.ID)
+	}
+
 	log := o.logger.With().
 		Str("session_id", session.ID.String()).
 		Str("org_id", session.OrgID.String()).
@@ -647,10 +690,16 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("create sandbox: %w", err)
 	}
 	defer func() {
-		if destroyErr := o.provider.Destroy(ctx, sandbox); destroyErr != nil {
+		destroyCtx := context.Background()
+		if destroyErr := o.provider.Destroy(destroyCtx, sandbox); destroyErr != nil {
 			log.Error().Err(destroyErr).Msg("failed to destroy sandbox")
 		}
 	}()
+
+	// Register sandbox with cancel registry so CancelSession can send SIGINT.
+	if o.cancels != nil {
+		o.cancels.Register(session.ID, sandbox, o.provider, cancel)
+	}
 
 	// 5. Set up the workspace — either restore snapshot or clone fresh.
 	var prompt *AgentPrompt
@@ -758,9 +807,23 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	// 6b. Retry once on token expiration for Codex agents.
 	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.ID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
 
+	wasCancelled := o.cancels != nil && o.cancels.WasCancelled(session.ID)
+
 	if err != nil {
+		if wasCancelled || ctx.Err() != nil {
+			log.Info().Msg("session cancelled by user during continue")
+			o.handleCancelledSession(session, sandbox, result, turnNumber, log)
+			return fmt.Errorf("session cancelled: %w", ctx.Err())
+		}
 		o.failRun(ctx, session, err.Error())
 		return fmt.Errorf("execute agent on continue: %w", err)
+	}
+
+	// 6c. If cancelled but agent exited gracefully, snapshot and return to idle.
+	if wasCancelled {
+		log.Info().Msg("agent exited after cancel during continue, returning to idle")
+		o.handleCancelledSession(session, sandbox, result, turnNumber, log)
+		return nil
 	}
 
 	// 7. Create assistant message with result summary.
@@ -1354,9 +1417,47 @@ func (o *Orchestrator) BuildIntegrationSkills(ctx context.Context, orgID uuid.UU
 	return mcp.GenerateSkillsDoc(tr)
 }
 
+// handleCancelledSession snapshots the workspace and returns the session to idle
+// (if snapshot succeeds) or marks it as cancelled (if not). This is shared by
+// both RunAgent and ContinueSession to avoid duplication.
+//
+// result may be nil (e.g. when the agent was force-killed and returned an error).
+func (o *Orchestrator) handleCancelledSession(session *models.Session, sandbox *Sandbox, result *AgentResult, turnNumber int, log zerolog.Logger) {
+	bgCtx := context.Background()
+
+	// Attempt to snapshot so the session can be continued later.
+	snapshotKey, snapshotErr := o.snapshotSession(bgCtx, session, sandbox, nil)
+	if snapshotErr != nil {
+		log.Warn().Err(snapshotErr).Msg("failed to snapshot cancelled session")
+	}
+
+	// Resolve the agent session ID — prefer the result if the agent exited
+	// gracefully, otherwise fall back to whatever was on the session.
+	agentSessionID := ""
+	if result != nil && result.AgentSessionID != "" {
+		agentSessionID = result.AgentSessionID
+	} else if session.AgentSessionID != nil {
+		agentSessionID = *session.AgentSessionID
+	}
+
+	// If we got a snapshot, return to idle via UpdateTurnComplete so the user
+	// can continue the conversation. Otherwise, mark as cancelled (terminal).
+	if snapshotKey != "" {
+		if err := o.sessions.UpdateTurnComplete(bgCtx, session.OrgID, session.ID, turnNumber, nil, agentSessionID, snapshotKey); err != nil {
+			log.Warn().Err(err).Msg("failed to return cancelled session to idle")
+			_ = o.sessions.UpdateStatus(bgCtx, session.OrgID, session.ID, string(models.SessionStatusCancelled))
+		} else {
+			log.Info().Int("turn", turnNumber).Msg("cancelled session returned to idle")
+		}
+	} else {
+		_ = o.sessions.UpdateStatus(bgCtx, session.OrgID, session.ID, string(models.SessionStatusCancelled))
+	}
+}
+
 // snapshotSession snapshots the sandbox workspace to object storage for multi-turn support.
 // If snapshots are not configured, this is a no-op. This only saves the snapshot
 // and updates sandbox state — it does NOT change session status or call UpdateTurnComplete.
+// result is unused but kept in the signature for future extensibility (e.g. metadata).
 func (o *Orchestrator) snapshotSession(ctx context.Context, session *models.Session, sandbox *Sandbox, result *AgentResult) (string, error) {
 	if o.snapshots == nil {
 		return "", nil

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1582,3 +1582,54 @@ func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
 }
 
+func TestRunAgent_CancelWithoutSnapshotMarksCancelled(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	agentSessID := "existing-agent-sess"
+	run.AgentSessionID = &agentSessID
+
+	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
+
+	d := defaultDeps()
+	d.cancels = cancelReg
+	// Make snapshot fail so handleCancelledSession hits the "no snapshot" path
+	// and marks the session as cancelled instead of idle.
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return nil, errors.New("snapshot unavailable")
+	}
+	// Make Exec fail so doCancel falls back to immediate context cancel.
+	d.provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		return 1, errors.New("exec not available in test")
+	}
+
+	adapterStarted := make(chan struct{})
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		close(adapterStarted)
+		<-ctx.Done()
+		// Return nil result to exercise the session.AgentSessionID fallback path.
+		return nil, ctx.Err()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- buildOrchestrator(d).RunAgent(context.Background(), run)
+	}()
+
+	<-adapterStarted
+	require.True(t, cancelReg.CancelSession(run.ID))
+
+	err := <-done
+	require.Error(t, err)
+
+	// Without snapshots, session should be marked cancelled (not idle).
+	statuses := d.sessions.getStatusUpdates()
+	require.Contains(t, statuses, "cancelled", "session without snapshot should be marked cancelled")
+
+	// No turn updates since there's no snapshot.
+	turnUpdates := d.sessions.getTurnUpdates()
+	require.Empty(t, turnUpdates, "cancelled session without snapshot should not have turn updates")
+}
+

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -529,6 +529,7 @@ type testDeps struct {
 	codexAuth agent.CodexAuthProvider
 	creds     *mockCredentialProvider
 	snapshots *mockSnapshotStore
+	cancels   *agent.CancelRegistry
 }
 
 func defaultDeps() testDeps {
@@ -569,6 +570,7 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 		CodexAuth:        d.codexAuth,
 		Credentials:      d.creds,
 		Snapshots:        d.snapshots,
+		Cancels:          d.cancels,
 		Logger:           zerolog.Nop(),
 		MaxConcurrent:    3,
 	})
@@ -1522,5 +1524,61 @@ func TestRunAgent_CodexAuthRefreshFallsBackToGetValidToken(t *testing.T) {
 	tokens, ok := authJSON["tokens"].(map[string]interface{})
 	require.True(t, ok, "auth.json should have tokens object")
 	require.Equal(t, "fallback-access-token", tokens["access_token"], "auth.json should contain the fallback token from GetValidToken")
+}
+
+func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
+
+	d := defaultDeps()
+	d.cancels = cancelReg
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("cancel-snapshot"))), nil
+	}
+	// Make Exec fail so doCancel falls back to immediate context cancel
+	// (avoids 30s timer wait in tests).
+	d.provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		return 1, errors.New("exec not available in test")
+	}
+
+	// The adapter blocks until the cancel registry fires, then returns an error
+	// simulating the agent being interrupted.
+	adapterStarted := make(chan struct{})
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		close(adapterStarted)
+		// Wait for the context to be cancelled (by the cancel registry fallback).
+		<-ctx.Done()
+		return &agent.AgentResult{
+			Summary:        "partial work",
+			ExitCode:       1,
+			AgentSessionID: "agent-sess-123",
+		}, ctx.Err()
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- buildOrchestrator(d).RunAgent(context.Background(), run)
+	}()
+
+	// Wait for the adapter to start executing, then trigger cancel.
+	<-adapterStarted
+	require.True(t, cancelReg.CancelSession(run.ID), "cancel should find registered session")
+
+	err := <-done
+	require.Error(t, err, "RunAgent should return an error when cancelled")
+	require.Contains(t, err.Error(), "cancelled")
+
+	// handleCancelledSession should have snapshot'd and returned to idle.
+	turnUpdates := d.sessions.getTurnUpdates()
+	require.Len(t, turnUpdates, 1, "cancelled session should have a turn update (returned to idle)")
+	require.NotEmpty(t, turnUpdates[0].snapshotKey, "cancelled session should have a snapshot key")
+
+	// Sandbox should be destroyed.
+	require.Equal(t, 1, d.provider.GetDestroyCalls())
 }
 


### PR DESCRIPTION
## Summary
- Adds a `POST /api/v1/sessions/{id}/cancel` endpoint that sends SIGINT to the coding agent (claude/codex/gemini) running inside the Docker sandbox, allowing graceful shutdown with conversation state preserved
- Introduces a shared `CancelRegistry` between the API handler and orchestrator, using `sync.Once` to prevent double-cancel goroutine leaks and a 30s fallback to context cancellation
- Cancelled sessions with successful snapshots return to idle (continuable); without snapshots they transition to cancelled (terminal)
- Frontend Stop button now calls the cancel endpoint instead of the end endpoint
- Includes 9 new tests covering CancelRegistry logic and the CancelSession HTTP handler

## Test plan
- [x] CancelRegistry unit tests pass (register/deregister, SIGINT sending, only-once guard, fallback to ctx cancel)
- [x] CancelSession handler tests pass (202 success, 409 not-running, 400 invalid ID, 503 no canceller)
- [ ] Manual test: click Cancel on a running session and verify agent receives SIGINT and session returns to idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)