### PR TITLE
Fix sidebar tab strip clipping

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -64,6 +64,16 @@ describe('ProjectSidebar', () => {
     expect(screen.getByRole('tab', { name: /Paused/ })).toBeInTheDocument();
   });
 
+  it('uses a left-aligned horizontal-only tab scroller', async () => {
+    renderWithProviders(<ProjectSidebar />);
+    await screen.findByText('Test Project');
+
+    const tabList = screen.getByRole('tablist');
+    expect(tabList.className).toContain('justify-start');
+    expect(tabList.className).toContain('overflow-x-auto');
+    expect(tabList.className).toContain('overflow-y-hidden');
+  });
+
   it('has search input', () => {
     renderWithProviders(<ProjectSidebar />);
     expect(screen.getByPlaceholderText('Search projects...')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -118,7 +118,7 @@ export function ProjectSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm">
+          <TabsList size="sm" className="overflow-y-hidden">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "active" ? activeCount

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -84,6 +84,14 @@ describe('SessionDetailPage', () => {
     expect(screen.getByRole('tab', { name: 'Validation' })).toBeInTheDocument();
   });
 
+  it('does not hide vertical overflow on the detail tablist', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const tabList = screen.getByRole('tablist');
+    expect(tabList.className).not.toContain('overflow-y-hidden');
+  });
+
   it('renders failed session with failure details', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -70,6 +70,17 @@ describe('SessionSidebar', () => {
     expect(screen.getAllByText('Done').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('uses a left-aligned horizontal-only tab scroller', async () => {
+    renderWithProviders(<SessionSidebar />);
+
+    await screen.findByText('Fixed TypeError by adding null check');
+
+    const tabList = screen.getByRole('tablist');
+    expect(tabList.className).toContain('justify-start');
+    expect(tabList.className).toContain('overflow-x-auto');
+    expect(tabList.className).toContain('overflow-y-hidden');
+  });
+
   it('shows status indicators for sessions', async () => {
     renderWithProviders(<SessionSidebar />);
 

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -202,7 +202,7 @@ export function SessionSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm">
+          <TabsList size="sm" className="overflow-y-hidden">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "needs_attention" ? needsAttentionSessions.length

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -293,7 +293,7 @@ export function SessionsPageContent() {
 
       {/* ── Tab filters ────────────────────────────────────────────── */}
       <div className="relative flex items-center border-b border-border">
-        <div ref={tabsRef} className={`flex flex-nowrap items-center overflow-x-auto scrollbar-hide min-w-0 ${tabsOverflow ? "mask-fade-r" : ""}`}>
+        <div ref={tabsRef} className={`flex flex-nowrap items-center overflow-x-auto overflow-y-hidden scrollbar-hide min-w-0 ${tabsOverflow ? "mask-fade-r" : ""}`}>
           {filterTabs.map((tab) => {
             const isSelected = currentFilter === tab.value;
             const count =

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -35,7 +35,7 @@ const tabsListVariants = cva(
       },
       size: {
         default: "",
-        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 py-0.5 px-0 rounded-none bg-transparent flex w-full flex-nowrap overflow-x-auto",
+        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 py-0.5 px-0 rounded-none bg-transparent flex w-full flex-nowrap justify-start overflow-x-auto",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
This keeps the sessions and projects sidebar tab rows left-aligned so the first tab is visible by default. It restricts vertical overflow hiding to the sidebar tab strips and the sessions page filter row, which preserves the session detail underline styling. It also adds regression tests for the sidebar tab scrollers and for the session detail tablist overflow behavior. Verification: targeted Vitest specs passed, along with frontend typecheck, lint, and build.