### PR TITLE
Remove unsupported --sandbox flag from Codex CLI commands

### DIFF
--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -70,13 +70,13 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 		msg := shellEscapeDouble(prompt.UserMessage)
 		if prompt.ResumeSessionID != "" {
 			cmd = fmt.Sprintf(
-				"codex exec resume --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access --skip-git-repo-check --json %s \"%s\"",
+				"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json %s \"%s\"",
 				shellEscapeCodex(prompt.ResumeSessionID),
 				msg,
 			)
 		} else {
 			cmd = fmt.Sprintf(
-				"codex exec resume --last --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access --skip-git-repo-check --json \"%s\"",
+				"codex exec resume --last --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json \"%s\"",
 				msg,
 			)
 		}
@@ -88,7 +88,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"codex exec --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access --skip-git-repo-check --json \"$(cat '%s')\"",
+			"codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json \"$(cat '%s')\"",
 			shellEscapeCodex(promptPath),
 		)
 	}

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -774,7 +774,7 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
 	require.NoError(t, err, "continuation should succeed without an explicit session ID")
 	require.NotNil(t, result, "continuation should return a result")
-	require.Contains(t, provider.ExecCalls[0], "codex exec resume --last --dangerously-bypass-approvals-and-sandbox --sandbox danger-full-access", "continuation without a session ID should resume the latest restored Codex session")
+	require.Contains(t, provider.ExecCalls[0], "codex exec resume --last --dangerously-bypass-approvals-and-sandbox", "continuation without a session ID should resume the latest restored Codex session")
 	_, exists := provider.Files["/workspace/.143-prompt.md"]
 	require.False(t, exists, "continuation should not write a fresh prompt file")
 }


### PR DESCRIPTION
## Summary
- Removes the `--sandbox danger-full-access` argument from all Codex CLI invocations in the agent adapter
- The Codex CLI no longer accepts `--sandbox` as a separate flag; `--dangerously-bypass-approvals-and-sandbox` already handles sandbox bypassing
- Updates the corresponding test assertion

## Test plan
- [ ] Verify Codex agent sessions start without the `unexpected argument '--sandbox'` error
- [ ] Verify continuation/resume flows work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)