### PR TITLE
Hide vertical scrollbars in detail panel tabs

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1562,11 +1562,11 @@ export function SessionDetailContent({ id }: { id: string }) {
                 }
               />
             </TabsContent>
-            <TabsContent value="overview" className="flex-1 overflow-y-auto p-4">
+            <TabsContent value="overview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
               <OverviewTab session={session} members={members} />
             </TabsContent>
             {showValidationTab && (
-              <TabsContent value="validation" className="flex-1 overflow-y-auto p-4">
+              <TabsContent value="validation" className="flex-1 overflow-y-auto scrollbar-hide p-4">
                 <ValidationTab sessionId={id} />
               </TabsContent>
             )}

--- a/frontend/src/components/code-review/file-tree.tsx
+++ b/frontend/src/components/code-review/file-tree.tsx
@@ -257,7 +257,7 @@ export function FileTree({
           />
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto px-3 pb-2">
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-3 pb-2">
         <TreeDirectory
           node={tree}
           activeFileIndex={sortedActiveIndex}


### PR DESCRIPTION
## Summary
- Adds `scrollbar-hide` class to the Overview, Validation, and Changes file tree containers in the session detail panel to remove visible vertical scrollbars while preserving scroll functionality.

## Test plan
- [ ] Open a session detail panel and switch between Overview and Changes tabs
- [ ] Verify no vertical scrollbar is visible in any tab
- [ ] Verify content is still scrollable when it overflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)