### PR TITLE
Replace status dots with unread indicators and add PR status badge

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1290,6 +1290,15 @@ export function SessionDetailContent({ id }: { id: string }) {
       throw err;
     }),
   });
+  // Record that the user has viewed this session (for unread tracking).
+  useEffect(() => {
+    if (id) {
+      api.sessions.recordView(id).then(() => {
+        queryClient.invalidateQueries({ queryKey: ["sessions"] });
+      }).catch(() => {});
+    }
+  }, [id, queryClient]);
+
   const hasPR = !!prData?.data;
   const hasDiff = !!session?.diff_stats;
   const canCreatePR = hasDiff && !hasPR && !isRunning;

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -15,6 +15,7 @@ import { SessionOwnerToggle } from "./session-owner-toggle";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
+import type { SessionListItem } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Status config
@@ -55,6 +56,57 @@ function filterToStatusParam(filter: string | null): string | undefined {
   if (filter === "working") return workingStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
+}
+
+// ---------------------------------------------------------------------------
+// Unread indicator logic
+// ---------------------------------------------------------------------------
+
+/** Returns true if the session has activity the current user hasn't seen yet. */
+function isUnread(session: SessionListItem): boolean {
+  // Sessions that are actively working are always "live" — show an animated dot instead.
+  if (workingSet.has(session.status)) return false;
+
+  const lastActivity = session.last_activity_at;
+  if (!lastActivity) return false;
+
+  // Never viewed → unread if there's been any activity.
+  if (!session.last_viewed_at) return true;
+
+  return new Date(lastActivity) > new Date(session.last_viewed_at);
+}
+
+// ---------------------------------------------------------------------------
+// PR status badge for sidebar rows
+// ---------------------------------------------------------------------------
+
+function PRStatusBadge({ prSummary }: { prSummary?: SessionListItem["pr_summary"] }) {
+  if (!prSummary) return null;
+
+  let dotColor: string;
+  let label: string;
+
+  if (prSummary.status === "merged") {
+    dotColor = "bg-violet-500";
+    label = "Merged";
+  } else if (prSummary.ci_status === "success") {
+    dotColor = "bg-emerald-500";
+    label = "CI passed";
+  } else if (prSummary.ci_status === "failure") {
+    dotColor = "bg-destructive";
+    label = "CI failed";
+  } else {
+    // pending / unknown CI status
+    dotColor = "bg-muted-foreground/40";
+    label = "CI pending";
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1 shrink-0 rounded-md border border-border/60 bg-muted/50 px-1.5 py-0.5" title={label}>
+      <span className={cn("inline-flex rounded-full h-1.5 w-1.5", dotColor)} />
+      <span className="text-xs text-muted-foreground">PR</span>
+    </span>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +315,7 @@ export function SessionSidebar() {
           const isSelected = selectedId === session.id;
           const cfg = statusConfig[session.status] || statusConfig.pending;
           const isWorkingSession = workingSet.has(session.status);
+          const hasUnread = isUnread(session);
           const ts = session.completed_at || session.started_at || session.created_at;
 
           return (
@@ -277,19 +330,24 @@ export function SessionSidebar() {
               )}
             >
               <div className="flex items-start gap-2.5 min-w-0">
-                {/* Status dot */}
+                {/* Unread / working indicator */}
                 <div className="mt-1.5 shrink-0">
                   {isWorkingSession ? (
                     <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
+                  ) : hasUnread ? (
+                    <StatusDot color="bg-primary" />
                   ) : (
-                    <StatusDot color={cfg.dot} />
+                    <span className="inline-flex rounded-full h-2 w-2" />
                   )}
                 </div>
 
                 {/* Content */}
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start justify-between gap-2">
-                    <p className="text-[13px] font-medium text-foreground truncate leading-snug">
+                    <p className={cn(
+                      "text-[13px] font-medium truncate leading-snug",
+                      hasUnread || isWorkingSession ? "text-foreground" : "text-muted-foreground"
+                    )}>
                       {sessionTitle(session)}
                     </p>
                   </div>
@@ -307,7 +365,10 @@ export function SessionSidebar() {
                         {formatTimeAgo(ts)}
                       </span>
                     </div>
-                    <SessionDiffBadge diffStats={session.diff_stats} />
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <PRStatusBadge prSummary={session.pr_summary} />
+                      <SessionDiffBadge diffStats={session.diff_stats} />
+                    </div>
                   </div>
                   {session.status === "failed" && (session.failure_explanation || session.error) && (
                     <p className="text-xs text-destructive/70 truncate mt-0.5">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -214,8 +214,9 @@ export const api = {
       if (params?.triggered_by_user_id) searchParams.set('triggered_by_user_id', params.triggered_by_user_id);
       if (params?.search) searchParams.set('search', params.search);
       const qs = searchParams.toString();
-      return get<import('./types').ListResponse<import('./types').Session>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
+      return get<import('./types').ListResponse<import('./types').SessionListItem>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
+    recordView: (sessionId: string) => post<{ status: string }>(`/api/v1/sessions/${sessionId}/view`, {}),
     get: (id: string) => get<import('./types').SingleResponse<import('./types').SessionDetail>>(`/api/v1/sessions/${id}`),
     getLogs: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionLog>>(`/api/v1/sessions/${sessionId}/logs`),
     getValidation: (sessionId: string) => get<import('./types').SingleResponse<import('./types').Validation>>(`/api/v1/sessions/${sessionId}/validation`),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -121,6 +121,18 @@ export interface Session {
   created_at: string;
 }
 
+export interface PRSummary {
+  status: string;
+  ci_status: string;
+  number: number;
+  url: string;
+}
+
+export interface SessionListItem extends Session {
+  last_viewed_at?: string;
+  pr_summary?: PRSummary;
+}
+
 export interface Validation {
   id: string;
   session_id: string;
@@ -223,6 +235,7 @@ export interface PullRequest {
   status: string;
   branch_name: string;
   review_status: string | null;
+  ci_status: string;
   merged_at: string | null;
   closed_at: string | null;
   created_at: string;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -108,6 +108,7 @@ export const mockPR: PullRequest = {
   status: 'open',
   branch_name: 'fix/type-error-null-check',
   review_status: 'pending',
+  ci_status: '',
   merged_at: null,
   closed_at: null,
   created_at: '2026-02-17T07:06:00Z',

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -41,6 +41,7 @@ type SessionHandler struct {
 	jobStore         *db.JobStore
 	messageStore     *db.SessionMessageStore
 	threadStore      *db.SessionThreadStore
+	viewStore        *db.SessionViewStore
 	llmClient        llm.Client // optional, used for generating manual session titles
 	logger           zerolog.Logger
 	audit            *db.AuditEmitter
@@ -55,6 +56,11 @@ func (h *SessionHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 // SetCanceller injects the session canceller for stopping running agent sessions.
 func (h *SessionHandler) SetCanceller(c SessionCanceller) {
 	h.canceller = c
+}
+
+// SetViewStore injects the session view store for tracking unread sessions.
+func (h *SessionHandler) SetViewStore(vs *db.SessionViewStore) {
+	h.viewStore = vs
 }
 
 func NewSessionHandler(
@@ -177,8 +183,48 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		nextCursor = encodeSessionCursor(last.CreatedAt, last.ID)
 	}
 
-	writeJSON(w, http.StatusOK, models.ListResponse[models.Session]{
-		Data: runs,
+	// Enrich sessions with last_viewed_at and PR summaries.
+	items := make([]models.SessionListItem, len(runs))
+	sessionIDs := make([]uuid.UUID, len(runs))
+	for i, s := range runs {
+		items[i] = models.SessionListItem{Session: s}
+		sessionIDs[i] = s.ID
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user != nil && h.viewStore != nil && len(sessionIDs) > 0 {
+		viewTimes, err := h.viewStore.BatchGetLastViewed(r.Context(), user.ID, sessionIDs)
+		if err != nil {
+			h.logger.Warn().Err(err).Msg("failed to fetch session view times")
+		} else {
+			for i, s := range runs {
+				if t, ok := viewTimes[s.ID]; ok {
+					items[i].LastViewedAt = &t
+				}
+			}
+		}
+	}
+
+	if h.pullRequestStore != nil && len(sessionIDs) > 0 {
+		prMap, err := h.pullRequestStore.BatchGetBySessionIDs(r.Context(), orgID, sessionIDs)
+		if err != nil {
+			h.logger.Warn().Err(err).Msg("failed to fetch PR summaries")
+		} else {
+			for i, s := range runs {
+				if pr, ok := prMap[s.ID]; ok {
+					items[i].PRSummary = &models.PRSummary{
+						Status:   pr.Status,
+						CIStatus: pr.CIStatus,
+						Number:   pr.GitHubPRNumber,
+						URL:      pr.GitHubPRURL,
+					}
+				}
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, models.ListResponse[models.SessionListItem]{
+		Data: items,
 		Meta: models.PaginationMeta{NextCursor: nextCursor},
 	})
 }
@@ -212,6 +258,33 @@ func (h *SessionHandler) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.SessionDetail]{Data: detail})
+}
+
+// RecordView records that the current user has viewed a session (for unread tracking).
+func (h *SessionHandler) RecordView(w http.ResponseWriter, r *http.Request) {
+	if h.viewStore == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		return
+	}
+
+	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found in context")
+		return
+	}
+
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	if err := h.viewStore.Upsert(r.Context(), user.ID, sessionID, orgID); err != nil {
+		h.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("failed to record session view")
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // TriggerFix creates a new agent run for an issue and enqueues a run_agent job.

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -917,11 +917,11 @@ func TestSessionHandler_GetPullRequest_Success(t *testing.T) {
 			pgxmock.NewRows([]string{
 				"id", "session_id", "org_id", "github_pr_number", "github_pr_url",
 				"github_repo", "title", "body", "status", "review_status",
-				"authored_by", "merged_at", "created_at", "updated_at",
+				"authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 			}).AddRow(
 				prID, &runID, orgID, 42, "https://github.com/org/repo/pull/42",
 				"org/repo", "Fix bug", nil, "open", "pending",
-				"app", nil, now, now,
+				"app", "", nil, now, now,
 			),
 		)
 
@@ -2544,7 +2544,7 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-			"title", "body", "status", "review_status", "merged_at", "created_at", "updated_at",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 		}))
 
 	// Mock job enqueue.
@@ -2659,10 +2659,10 @@ func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows([]string{
 				"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-				"title", "body", "status", "review_status", "authored_by", "merged_at", "created_at", "updated_at",
+				"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 			}).AddRow(
 				prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-				"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now,
 			),
 		)
 

--- a/internal/api/handlers/webhooks.go
+++ b/internal/api/handlers/webhooks.go
@@ -62,6 +62,8 @@ func (h *WebhookHandler) HandleGitHub(w http.ResponseWriter, r *http.Request) {
 		h.handlePullRequestReview(w, r, body)
 	case "pull_request_review_comment":
 		h.handlePullRequestReviewComment(w, r, body)
+	case "check_suite":
+		h.handleCheckSuite(w, r, body)
 	default:
 		writeJSON(w, http.StatusOK, map[string]string{"status": "ignored", "event": event})
 	}
@@ -321,6 +323,26 @@ func (h *WebhookHandler) handlePullRequestReviewComment(w http.ResponseWriter, r
 
 	if err := h.prService.HandlePullRequestReviewCommentEvent(r.Context(), event); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "REVIEW_COMMENT_EVENT_FAILED", "failed to process pull_request_review_comment event", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "processed"})
+}
+
+func (h *WebhookHandler) handleCheckSuite(w http.ResponseWriter, r *http.Request, body []byte) {
+	if h.prService == nil {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ignored", "reason": "pr_service_not_configured"})
+		return
+	}
+
+	var event ghservice.CheckSuiteEvent
+	if err := json.Unmarshal(body, &event); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "failed to parse check_suite event")
+		return
+	}
+
+	if err := h.prService.HandleCheckSuiteEvent(r.Context(), event); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "CHECK_SUITE_FAILED", "failed to process check_suite event", err)
 		return
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -133,6 +133,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	issueHandler := handlers.NewIssueHandler(issueStore)
 	sessionMessageStore := db.NewSessionMessageStore(pool)
 	sessionThreadStore := db.NewSessionThreadStore(pool)
+	sessionViewStore := db.NewSessionViewStore(pool)
 	sessionHandler := handlers.NewSessionHandler(
 		sessionStore,
 		sessionLogStore,
@@ -148,6 +149,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		llmClient,
 		logger,
 	)
+	sessionHandler.SetViewStore(sessionViewStore)
 	threadSvc := threadservice.NewService(
 		sessionThreadStore,
 		sessionStore,
@@ -433,6 +435,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			// File upload (higher body-size limit for multipart uploads).
 			r.With(middleware.MaxBodySize(11<<20)).Post("/api/v1/uploads", uploadHandler.Upload)
 
+			r.Post("/api/v1/sessions/{id}/view", sessionHandler.RecordView)
 			r.Post("/api/v1/sessions/manual", sessionHandler.CreateManual)
 			r.Post("/api/v1/sessions/{id}/questions/{qid}/answer", sessionHandler.AnswerQuestion)
 			r.Post("/api/v1/sessions/{id}/messages", sessionHandler.SendMessage)

--- a/internal/db/pull_request_store_test.go
+++ b/internal/db/pull_request_store_test.go
@@ -13,13 +13,13 @@ import (
 
 var prColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "merged_at", "created_at", "updated_at",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 }
 
 func newPRRow(id, sessionID, orgID uuid.UUID, now time.Time) []any {
 	return []any{
 		id, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-		"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now,
+		"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now,
 	}
 }
 

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -51,10 +51,12 @@ func (s *PullRequestStore) Create(ctx context.Context, pr *models.PullRequest) e
 	return row.Scan(&pr.ID, &pr.CreatedAt, &pr.UpdatedAt)
 }
 
+const prSelectColumns = `id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
+		       title, body, status, review_status, authored_by, ci_status, merged_at, created_at, updated_at`
+
 func (s *PullRequestStore) GetByID(ctx context.Context, orgID, id uuid.UUID) (models.PullRequest, error) {
 	query := `
-		SELECT id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
-		       title, body, status, review_status, authored_by, merged_at, created_at, updated_at
+		SELECT ` + prSelectColumns + `
 		FROM pull_requests
 		WHERE id = @id AND org_id = @org_id`
 
@@ -70,8 +72,7 @@ func (s *PullRequestStore) GetByID(ctx context.Context, orgID, id uuid.UUID) (mo
 
 func (s *PullRequestStore) GetBySessionID(ctx context.Context, orgID, sessionID uuid.UUID) (models.PullRequest, error) {
 	query := `
-		SELECT id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
-		       title, body, status, review_status, authored_by, merged_at, created_at, updated_at
+		SELECT ` + prSelectColumns + `
 		FROM pull_requests
 		WHERE session_id = @session_id AND org_id = @org_id`
 
@@ -104,8 +105,7 @@ func (s *PullRequestStore) UpdateStatus(ctx context.Context, orgID, id uuid.UUID
 // subsequent org-scoped operations.
 func (s *PullRequestStore) GetByRepoAndNumber(ctx context.Context, repo string, number int) (models.PullRequest, error) {
 	query := `
-		SELECT id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
-		       title, body, status, review_status, authored_by, merged_at, created_at, updated_at
+		SELECT ` + prSelectColumns + `
 		FROM pull_requests
 		WHERE github_repo = @github_repo AND github_pr_number = @github_pr_number`
 
@@ -131,8 +131,7 @@ func (s *PullRequestStore) UpdateReviewStatus(ctx context.Context, orgID, id uui
 
 func (s *PullRequestStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters PullRequestFilters) ([]models.PullRequest, error) {
 	query := `
-		SELECT id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
-		       title, body, status, review_status, authored_by, merged_at, created_at, updated_at
+		SELECT ` + prSelectColumns + `
 		FROM pull_requests
 		WHERE org_id = @org_id`
 
@@ -163,4 +162,46 @@ func (s *PullRequestStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filte
 		return nil, fmt.Errorf("query pull requests: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.PullRequest])
+}
+
+// BatchGetBySessionIDs returns PRs keyed by session_id for the given session IDs.
+func (s *PullRequestStore) BatchGetBySessionIDs(ctx context.Context, orgID uuid.UUID, sessionIDs []uuid.UUID) (map[uuid.UUID]models.PullRequest, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT ` + prSelectColumns + `
+		FROM pull_requests
+		WHERE org_id = @org_id AND session_id = ANY(@session_ids)`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":      orgID,
+		"session_ids": sessionIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("batch query pull requests: %w", err)
+	}
+	prs, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.PullRequest])
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[uuid.UUID]models.PullRequest, len(prs))
+	for _, pr := range prs {
+		if pr.SessionID != nil {
+			result[*pr.SessionID] = pr
+		}
+	}
+	return result, nil
+}
+
+// UpdateCIStatus updates the CI status of a pull request.
+func (s *PullRequestStore) UpdateCIStatus(ctx context.Context, orgID, id uuid.UUID, ciStatus string) error {
+	query := `UPDATE pull_requests SET ci_status = @ci_status, updated_at = now() WHERE id = @id AND org_id = @org_id`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":        id,
+		"org_id":    orgID,
+		"ci_status": ciStatus,
+	})
+	return err
 }

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -23,7 +23,7 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 
 	cols := []string{
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-		"title", "body", "status", "review_status", "authored_by", "merged_at", "created_at", "updated_at",
+		"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 	}
 
 	prID := uuid.New()
@@ -36,7 +36,7 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-					"Fix bug", ptrStr("Description"), "open", "pending", "user1", nil, now, now),
+					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", nil, now, now),
 		)
 
 	pr, err := store.GetByRepoAndNumber(context.Background(), "org/repo", 42)

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -46,6 +46,77 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestPullRequestStore_UpdateCIStatus(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+
+	mock.ExpectExec("UPDATE pull_requests SET ci_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateCIStatus(context.Background(), orgID, prID, "success")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPullRequestStore_BatchGetBySessionIDs_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	cols := []string{
+		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+		"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+	}
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(cols).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
+					"Fix bug", ptrStr("body"), "open", "pending", "app", "success", nil, now, now),
+		)
+
+	result, err := store.BatchGetBySessionIDs(context.Background(), orgID, []uuid.UUID{sessionID})
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	require.Equal(t, prID, result[sessionID].ID)
+	require.Equal(t, "success", result[sessionID].CIStatus)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPullRequestStore_BatchGetBySessionIDs_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	result, err := store.BatchGetBySessionIDs(context.Background(), uuid.New(), []uuid.UUID{})
+	require.NoError(t, err)
+	require.Nil(t, result)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPullRequestStore_UpdateReviewStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_views.go
+++ b/internal/db/session_views.go
@@ -1,0 +1,66 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type SessionViewStore struct {
+	db DBTX
+}
+
+func NewSessionViewStore(db DBTX) *SessionViewStore {
+	return &SessionViewStore{db: db}
+}
+
+// Upsert records (or updates) the time the user last viewed a session.
+func (s *SessionViewStore) Upsert(ctx context.Context, userID, sessionID, orgID uuid.UUID) error {
+	query := `
+		INSERT INTO session_views (user_id, session_id, org_id, last_viewed_at)
+		VALUES (@user_id, @session_id, @org_id, now())
+		ON CONFLICT (user_id, session_id)
+		DO UPDATE SET last_viewed_at = now()`
+
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"user_id":    userID,
+		"session_id": sessionID,
+		"org_id":     orgID,
+	})
+	return err
+}
+
+// BatchGetLastViewed returns a map of session_id → last_viewed_at for the
+// given user and set of session IDs.
+func (s *SessionViewStore) BatchGetLastViewed(ctx context.Context, userID uuid.UUID, sessionIDs []uuid.UUID) (map[uuid.UUID]time.Time, error) {
+	if len(sessionIDs) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT session_id, last_viewed_at
+		FROM session_views
+		WHERE user_id = @user_id AND session_id = ANY(@session_ids)`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"user_id":     userID,
+		"session_ids": sessionIDs,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[uuid.UUID]time.Time)
+	for rows.Next() {
+		var sid uuid.UUID
+		var viewedAt time.Time
+		if err := rows.Scan(&sid, &viewedAt); err != nil {
+			return nil, err
+		}
+		result[sid] = viewedAt
+	}
+	return result, rows.Err()
+}

--- a/internal/db/session_views_test.go
+++ b/internal/db/session_views_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSessionViewStore(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+	require.NotNil(t, store, "should create a non-nil store")
+}
+
+func TestSessionViewStore_Upsert_Success(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+
+	mock.ExpectExec("INSERT INTO session_views").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	err = store.Upsert(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	require.NoError(t, err, "should upsert session view without error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionViewStore_Upsert_Error(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+
+	mock.ExpectExec("INSERT INTO session_views").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("db error"))
+
+	err = store.Upsert(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	require.Error(t, err, "should return an error on database failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionViewStore_BatchGetLastViewed_Success(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+
+	userID := uuid.New()
+	sid1 := uuid.New()
+	sid2 := uuid.New()
+	now := time.Now()
+	earlier := now.Add(-time.Hour)
+
+	mock.ExpectQuery("SELECT session_id, last_viewed_at FROM session_views").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"session_id", "last_viewed_at"}).
+				AddRow(sid1, now).
+				AddRow(sid2, earlier),
+		)
+
+	result, err := store.BatchGetLastViewed(context.Background(), userID, []uuid.UUID{sid1, sid2})
+	require.NoError(t, err, "should retrieve last viewed times without error")
+	require.Len(t, result, 2, "should return entries for both sessions")
+	require.Equal(t, now, result[sid1], "should return correct time for first session")
+	require.Equal(t, earlier, result[sid2], "should return correct time for second session")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionViewStore_BatchGetLastViewed_Empty(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+
+	result, err := store.BatchGetLastViewed(context.Background(), uuid.New(), []uuid.UUID{})
+	require.NoError(t, err, "should return nil without error for empty input")
+	require.Nil(t, result, "should return nil map for empty session IDs")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionViewStore_BatchGetLastViewed_QueryError(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionViewStore(mock)
+
+	mock.ExpectQuery("SELECT session_id, last_viewed_at FROM session_views").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("db error"))
+
+	result, err := store.BatchGetLastViewed(context.Background(), uuid.New(), []uuid.UUID{uuid.New()})
+	require.Error(t, err, "should return an error on query failure")
+	require.Nil(t, result, "should return nil map on error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -207,9 +207,25 @@ type PullRequest struct {
 	Status         string     `db:"status" json:"status"`
 	ReviewStatus   string     `db:"review_status" json:"review_status"`
 	AuthoredBy     string     `db:"authored_by" json:"authored_by"`
+	CIStatus       string     `db:"ci_status" json:"ci_status"`
 	MergedAt       *time.Time `db:"merged_at" json:"merged_at,omitempty"`
 	CreatedAt      time.Time  `db:"created_at" json:"created_at"`
 	UpdatedAt      time.Time  `db:"updated_at" json:"updated_at"`
+}
+
+// PRSummary is a lightweight view of a PR for inclusion in session list responses.
+type PRSummary struct {
+	Status   string `json:"status"`
+	CIStatus string `json:"ci_status"`
+	Number   int    `json:"number"`
+	URL      string `json:"url"`
+}
+
+// SessionListItem wraps a Session with enrichment data for list views.
+type SessionListItem struct {
+	Session
+	LastViewedAt *time.Time `json:"last_viewed_at,omitempty"`
+	PRSummary    *PRSummary `json:"pr_summary,omitempty"`
 }
 
 // SessionLog represents a log line emitted during an agent run.

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1595,3 +1595,46 @@ func parseDiff(diff string) []diffFile {
 	}
 	return result
 }
+
+// CheckSuiteEvent represents a GitHub check_suite webhook payload.
+type CheckSuiteEvent struct {
+	Action     string `json:"action"`
+	CheckSuite struct {
+		Conclusion   *string `json:"conclusion"`
+		HeadBranch   string  `json:"head_branch"`
+		PullRequests []struct {
+			Number int `json:"number"`
+		} `json:"pull_requests"`
+	} `json:"check_suite"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+}
+
+// HandleCheckSuiteEvent processes check_suite webhook events to update PR CI status.
+func (s *PRService) HandleCheckSuiteEvent(ctx context.Context, event CheckSuiteEvent) error {
+	if event.Action != "completed" {
+		return nil
+	}
+
+	for _, prRef := range event.CheckSuite.PullRequests {
+		pr, err := s.pullRequests.GetByRepoAndNumber(ctx, event.Repository.FullName, prRef.Number)
+		if err != nil {
+			continue // Not a 143-managed PR.
+		}
+
+		ciStatus := "failure"
+		if event.CheckSuite.Conclusion != nil {
+			switch *event.CheckSuite.Conclusion {
+			case "success", "neutral", "skipped":
+				ciStatus = "success"
+			}
+		}
+
+		if err := s.pullRequests.UpdateCIStatus(ctx, pr.OrgID, pr.ID, ciStatus); err != nil {
+			s.logger.Warn().Err(err).Str("pr_id", pr.ID.String()).Msg("failed to update CI status")
+		}
+	}
+
+	return nil
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -24,7 +24,7 @@ import (
 // If the store query changes its SELECT list, update this slice to match.
 var handlerPRColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "merged_at", "created_at", "updated_at",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
 }
 
 // sessionColumns matches the SELECT columns from SessionStore queries
@@ -118,7 +118,7 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateStatus to merged.
@@ -218,7 +218,7 @@ func TestHandlePullRequestEvent_MergedWithNilSessionID(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateStatus to merged.
@@ -279,7 +279,7 @@ func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateStatus to closed.
@@ -321,7 +321,7 @@ func TestHandlePullRequestEvent_NonClosedAction(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	event := PullRequestEvent{
@@ -385,7 +385,7 @@ func TestHandlePullRequestReviewEvent_ApprovedFlow(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateReviewStatus.
@@ -444,7 +444,7 @@ func TestHandlePullRequestReviewEvent_ChangesRequestedWithBody(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateReviewStatus.
@@ -510,7 +510,7 @@ func TestHandlePullRequestReviewEvent_ChangesRequestedNoReviewStore(t *testing.T
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateReviewStatus.
@@ -565,7 +565,7 @@ func TestHandlePullRequestReviewEvent_UnknownReviewState(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	event := PullRequestReviewEvent{
@@ -634,7 +634,7 @@ func TestHandlePullRequestReviewCommentEvent_Created(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: Create review comment.
@@ -735,7 +735,7 @@ func TestHandlePullRequestReviewCommentEvent_NilReviewCommentStore(t *testing.T)
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	event := PullRequestReviewCommentEvent{
@@ -997,7 +997,7 @@ func TestHandlePullRequestEvent_MergedWithUpdateStatusError(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(handlerPRColumns).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
-					"Fix bug", (*string)(nil), "open", "pending", "app", (*time.Time)(nil), now, now),
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
 		)
 
 	// Mock: UpdateStatus fails.

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1622,3 +1622,128 @@ func TestGetInstallationToken_DelegatesToTokenProvider(t *testing.T) {
 	require.NoError(t, err, "GetInstallationToken should not return an error")
 	require.Equal(t, "cached-install-token", token, "should return the cached token")
 }
+
+func TestHandleCheckSuiteEvent_NonCompleted(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{logger: zerolog.Nop()}
+
+	event := CheckSuiteEvent{Action: "requested"}
+	err := svc.HandleCheckSuiteEvent(context.Background(), event)
+	require.NoError(t, err, "should ignore non-completed events")
+}
+
+func TestHandleCheckSuiteEvent_Success(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateCIStatus.
+	prMock.ExpectExec("UPDATE pull_requests SET ci_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	conclusion := "success"
+	event := CheckSuiteEvent{Action: "completed"}
+	event.CheckSuite.Conclusion = &conclusion
+	event.CheckSuite.PullRequests = []struct {
+		Number int `json:"number"`
+	}{{Number: 42}}
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandleCheckSuiteEvent(context.Background(), event)
+	require.NoError(t, err, "should process check suite event without error")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestHandleCheckSuiteEvent_Failure(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns a PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
+		)
+
+	// Mock: UpdateCIStatus with failure.
+	prMock.ExpectExec("UPDATE pull_requests SET ci_status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	conclusion := "failure"
+	event := CheckSuiteEvent{Action: "completed"}
+	event.CheckSuite.Conclusion = &conclusion
+	event.CheckSuite.PullRequests = []struct {
+		Number int `json:"number"`
+	}{{Number: 42}}
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandleCheckSuiteEvent(context.Background(), event)
+	require.NoError(t, err, "should process check suite failure event without error")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestHandleCheckSuiteEvent_PRNotFound(t *testing.T) {
+	t.Parallel()
+
+	prMock := newMockPool(t)
+	prStore := db.NewPullRequestStore(prMock)
+
+	svc := &PRService{
+		pullRequests: prStore,
+		logger:       zerolog.Nop(),
+	}
+
+	// Mock: GetByRepoAndNumber returns no rows.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(handlerPRColumns))
+
+	conclusion := "success"
+	event := CheckSuiteEvent{Action: "completed"}
+	event.CheckSuite.Conclusion = &conclusion
+	event.CheckSuite.PullRequests = []struct {
+		Number int `json:"number"`
+	}{{Number: 99}}
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandleCheckSuiteEvent(context.Background(), event)
+	require.NoError(t, err, "should skip unknown PRs without error")
+	require.NoError(t, prMock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/migrations/000060_session_views_and_pr_ci.down.sql
+++ b/migrations/000060_session_views_and_pr_ci.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_pull_requests_session_org;
+ALTER TABLE pull_requests DROP COLUMN IF EXISTS ci_status;
+DROP TABLE IF EXISTS session_views;

--- a/migrations/000060_session_views_and_pr_ci.up.sql
+++ b/migrations/000060_session_views_and_pr_ci.up.sql
@@ -1,0 +1,16 @@
+-- session_views tracks when each user last viewed a session (for unread indicators).
+CREATE TABLE IF NOT EXISTS session_views (
+    user_id    UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    org_id     UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    last_viewed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, session_id)
+);
+
+CREATE INDEX idx_session_views_user_org ON session_views (user_id, org_id);
+
+-- Add CI status tracking to pull requests.
+ALTER TABLE pull_requests ADD COLUMN IF NOT EXISTS ci_status TEXT NOT NULL DEFAULT '';
+
+-- Index for BatchGetBySessionIDs queries (session list enrichment).
+CREATE INDEX IF NOT EXISTS idx_pull_requests_session_org ON pull_requests (org_id, session_id) WHERE session_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Replace multi-colored session status dots in the sidebar with a simple unread indicator (blue dot only when there is new activity since the user's last visit, per-user tracking via new `session_views` table)
- Add a compact PR status badge next to sessions that have a PR: green for CI passed, purple for merged, red for CI failed, gray for pending
- Add `ci_status` column to `pull_requests` table, populated via new `check_suite` GitHub webhook handler
- Enrich the session list API response with `last_viewed_at` and `pr_summary` fields (backward-compatible `SessionListItem` extending `Session`)

## Test plan
- [ ] Verify unread blue dot appears for sessions with activity after page load
- [ ] Verify dot disappears after clicking into a session
- [ ] Verify PR badge shows correct color for merged/passing/failing/pending PRs
- [ ] Run existing session handler tests to confirm no regressions