### PR TITLE
Add LLM-generated session titles with periodic re-generation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/agent/adapters"
 	"github.com/assembledhq/143/internal/services/agent/providers"
+	"github.com/assembledhq/143/internal/services"
 	"github.com/assembledhq/143/internal/services/codexauth"
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/assembledhq/143/internal/services/ingestion"
@@ -142,6 +143,7 @@ func main() {
 			EvalBatches:         db.NewEvalBatchStore(pool),
 			EvalBootstraps:      db.NewEvalBootstrapStore(pool),
 			Repositories:        repoStore,
+			SessionMessages:     sessionMessageStore,
 		}
 
 		// Build Phase 3+ services if runtime dependencies are available.
@@ -373,6 +375,12 @@ func buildServices(
 		slackSummarizer = ingestion.NewSlackSummarizer(llmClient, cfg.SlackSummaryModel, logger)
 	}
 
+	// Session title service (optional — only if LLM client is available).
+	var titleService *services.SessionTitleService
+	if llmClient != nil {
+		titleService = services.NewSessionTitleService(llmClient, sessionStore, sessionMessageStore, logger)
+	}
+
 	return &worker.Services{
 		Orchestrator:    orchestrator,
 		Validation:      validationSvc,
@@ -384,5 +392,6 @@ func buildServices(
 		SlackSummarizer: slackSummarizer,
 		LLM:             llmClient,
 		GitHub:          ghSvc,
+		TitleService:    titleService,
 	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -378,7 +378,7 @@ func buildServices(
 	// Session title service (optional — only if LLM client is available).
 	var titleService *services.SessionTitleService
 	if llmClient != nil {
-		titleService = services.NewSessionTitleService(llmClient, sessionStore, sessionMessageStore, logger)
+		titleService = services.NewSessionTitleService(llmClient, sessionStore, sessionMessageStore)
 	}
 
 	return &worker.Services{

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -224,7 +224,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify the issue exists.
-	_, err = h.issueStore.GetByID(r.Context(), orgID, issueID)
+	issue, err := h.issueStore.GetByID(r.Context(), orgID, issueID)
 	if err != nil {
 		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "issue not found")
 		return
@@ -298,6 +298,21 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	if err := h.runStore.Create(r.Context(), run); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create agent run", err)
 		return
+	}
+
+	// Generate a title from the issue for non-manual sessions.
+	if h.llmClient != nil {
+		titleInput := issue.Title
+		if issue.Description != nil && len(*issue.Description) > 0 {
+			desc := *issue.Description
+			if len(desc) > 500 {
+				desc = desc[:500] + "..."
+			}
+			titleInput += "\n\n" + desc
+		}
+		if err := h.generateSessionTitle(r.Context(), run, orgID, titleInput); err != nil {
+			zerolog.Ctx(r.Context()).Warn().Err(err).Msg("failed to generate title for issue session")
+		}
 	}
 
 	// Enqueue the run_agent job.

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -17,6 +17,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -1166,16 +1167,16 @@ func (h *SessionHandler) generateSessionTitle(parent context.Context, session *m
 	if err != nil {
 		return fmt.Errorf("llm completion: %w", err)
 	}
-	generated = strings.TrimSpace(generated)
-	generated = strings.Trim(generated, "\"'")
-	if len(generated) == 0 || len(generated) > 120 {
+
+	title, ok := services.CleanTitle(generated)
+	if !ok {
 		return nil
 	}
 
-	if err := h.runStore.UpdateTitle(ctx, orgID, session.ID, generated); err != nil {
+	if err := h.runStore.UpdateTitle(ctx, orgID, session.ID, title); err != nil {
 		return fmt.Errorf("update title: %w", err)
 	}
-	session.Title = &generated
+	session.Title = &title
 	return nil
 }
 

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -244,6 +244,18 @@ func ComplexityEstimateUserPrompt(data ComplexityEstimateUserPromptData) string 
 	return render("complexity_estimate_user_prompt.template", data)
 }
 
+// ─── Session Title ────────────────────────────────────────────────────────────
+
+// SessionTitlePromptData holds the dynamic values for the session title prompt.
+type SessionTitlePromptData struct {
+	CurrentTitle string // empty on initial generation
+}
+
+// SessionTitlePrompt renders the system prompt for session title generation.
+func SessionTitlePrompt(data SessionTitlePromptData) string {
+	return render("session_title_prompt.template", data)
+}
+
 // ─── Eval ─────────────────────────────────────────────────────────────────────
 
 // EvalJudgePromptData holds the dynamic values for the eval judge system prompt.

--- a/internal/prompts/templates/session_title_prompt.template
+++ b/internal/prompts/templates/session_title_prompt.template
@@ -1,0 +1,8 @@
+You are generating a concise title for a coding session. Produce a short title (max 80 characters) that captures what was discussed and accomplished.
+
+If the conversation covers multiple topics, focus on the most recent or dominant theme. Use imperative or noun-phrase style (e.g., "Fix auth middleware null pointer", "Add pagination to user list API").
+{{ if .CurrentTitle }}
+The current title is: {{ .CurrentTitle }}
+If it is still accurate, return it unchanged.
+{{ end }}
+Output ONLY the title. No quotes, no trailing punctuation.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -62,6 +62,7 @@ type SessionStore interface {
 	UpdateSandboxState(ctx context.Context, orgID, sessionID uuid.UUID, state string) error
 	UpdateWorkingBranch(ctx context.Context, orgID, sessionID uuid.UUID, branch string) error
 	UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
+	UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error
 	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
 }
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -201,6 +201,10 @@ func (m *mockSessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessi
 	return nil
 }
 
+func (m *mockSessionStore) UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error {
+	return nil
+}
+
 func (m *mockSessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/services/session_title.go
+++ b/internal/services/session_title.go
@@ -1,0 +1,163 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/prompts"
+)
+
+// regenerateEveryN controls how often we regenerate the title (every N turns).
+const regenerateEveryN = 3
+
+// maxMessageChars is the maximum characters per message included in the prompt.
+const maxMessageChars = 200
+
+// maxRecentPairs is how many recent user+assistant message pairs to include.
+const maxRecentPairs = 3
+
+// llmClient is the interface for LLM completion calls.
+type llmClient interface {
+	Complete(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+}
+
+// titleSessionStore defines the session DB operations needed by the title service.
+type titleSessionStore interface {
+	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
+	UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error
+}
+
+// titleMessageStore defines the message DB operations needed by the title service.
+type titleMessageStore interface {
+	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error)
+}
+
+// SessionTitleService generates and updates session titles using an LLM.
+type SessionTitleService struct {
+	llm      llmClient
+	sessions titleSessionStore
+	messages titleMessageStore
+	logger   zerolog.Logger
+}
+
+// NewSessionTitleService creates a new SessionTitleService.
+func NewSessionTitleService(llm llmClient, sessions titleSessionStore, messages titleMessageStore, logger zerolog.Logger) *SessionTitleService {
+	return &SessionTitleService{
+		llm:      llm,
+		sessions: sessions,
+		messages: messages,
+		logger:   logger,
+	}
+}
+
+// MaybeRegenerateTitle regenerates the session title if the current turn is
+// a multiple of regenerateEveryN (3, 6, 9, ...). It is safe to call on every
+// turn — it will no-op when regeneration is not due.
+func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, sessionID uuid.UUID, currentTurn int) error {
+	if currentTurn < regenerateEveryN || currentTurn%regenerateEveryN != 0 {
+		return nil
+	}
+
+	session, err := s.sessions.GetByID(ctx, orgID, sessionID)
+	if err != nil {
+		return fmt.Errorf("fetch session: %w", err)
+	}
+
+	msgs, err := s.messages.ListBySession(ctx, orgID, sessionID)
+	if err != nil {
+		return fmt.Errorf("fetch messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return nil
+	}
+
+	currentTitle := ""
+	if session.Title != nil {
+		currentTitle = *session.Title
+	}
+
+	userPrompt := buildTitleUserPrompt(msgs)
+	systemPrompt := prompts.SessionTitlePrompt(prompts.SessionTitlePromptData{
+		CurrentTitle: currentTitle,
+	})
+
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	generated, err := s.llm.Complete(ctx, systemPrompt, userPrompt)
+	if err != nil {
+		return fmt.Errorf("llm completion: %w", err)
+	}
+
+	generated = strings.TrimSpace(generated)
+	generated = strings.Trim(generated, "\"'")
+	if len(generated) == 0 || len(generated) > 120 {
+		return nil
+	}
+
+	// Skip update if the title hasn't changed.
+	if generated == currentTitle {
+		return nil
+	}
+
+	if err := s.sessions.UpdateTitle(ctx, orgID, sessionID, generated); err != nil {
+		return fmt.Errorf("update title: %w", err)
+	}
+	return nil
+}
+
+// buildTitleUserPrompt constructs a compressed conversation summary for title generation.
+func buildTitleUserPrompt(msgs []models.SessionMessage) string {
+	var b strings.Builder
+
+	// Include the first user message (the original task).
+	for _, m := range msgs {
+		if m.Role == models.MessageRoleUser {
+			b.WriteString("Original task:\n")
+			b.WriteString(truncate(m.Content, maxMessageChars))
+			b.WriteString("\n\n")
+			break
+		}
+	}
+
+	// Include the last N message pairs.
+	recent := recentMessages(msgs, maxRecentPairs*2)
+	if len(recent) > 0 {
+		b.WriteString("Recent conversation:\n")
+		for _, m := range recent {
+			role := "User"
+			if m.Role == models.MessageRoleAssistant {
+				role = "Assistant"
+			}
+			b.WriteString(role)
+			b.WriteString(": ")
+			b.WriteString(truncate(m.Content, maxMessageChars))
+			b.WriteString("\n")
+		}
+	}
+
+	return b.String()
+}
+
+// recentMessages returns the last n messages from the list.
+func recentMessages(msgs []models.SessionMessage, n int) []models.SessionMessage {
+	if len(msgs) <= n {
+		return msgs
+	}
+	return msgs[len(msgs)-n:]
+}
+
+// truncate returns s truncated to maxLen characters with "..." appended if needed.
+func truncate(s string, maxLen int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/internal/services/session_title.go
+++ b/internal/services/session_title.go
@@ -7,33 +7,27 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/prompts"
 )
 
-// regenerateEveryN controls how often we regenerate the title (every N turns).
-const regenerateEveryN = 3
+const (
+	regenerateEveryN = 3
+	maxMessageChars  = 200
+	maxRecentPairs   = 3
+	maxTitleLen      = 120
+)
 
-// maxMessageChars is the maximum characters per message included in the prompt.
-const maxMessageChars = 200
-
-// maxRecentPairs is how many recent user+assistant message pairs to include.
-const maxRecentPairs = 3
-
-// llmClient is the interface for LLM completion calls.
 type llmClient interface {
 	Complete(ctx context.Context, systemPrompt, userPrompt string) (string, error)
 }
 
-// titleSessionStore defines the session DB operations needed by the title service.
 type titleSessionStore interface {
 	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
 	UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error
 }
 
-// titleMessageStore defines the message DB operations needed by the title service.
 type titleMessageStore interface {
 	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error)
 }
@@ -43,30 +37,27 @@ type SessionTitleService struct {
 	llm      llmClient
 	sessions titleSessionStore
 	messages titleMessageStore
-	logger   zerolog.Logger
 }
 
-// NewSessionTitleService creates a new SessionTitleService.
-func NewSessionTitleService(llm llmClient, sessions titleSessionStore, messages titleMessageStore, logger zerolog.Logger) *SessionTitleService {
+func NewSessionTitleService(llm llmClient, sessions titleSessionStore, messages titleMessageStore) *SessionTitleService {
 	return &SessionTitleService{
 		llm:      llm,
 		sessions: sessions,
 		messages: messages,
-		logger:   logger,
 	}
 }
 
 // MaybeRegenerateTitle regenerates the session title if the current turn is
 // a multiple of regenerateEveryN (3, 6, 9, ...). It is safe to call on every
 // turn — it will no-op when regeneration is not due.
-func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, sessionID uuid.UUID, currentTurn int) error {
-	if currentTurn < regenerateEveryN || currentTurn%regenerateEveryN != 0 {
-		return nil
-	}
-
+func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, sessionID uuid.UUID) error {
 	session, err := s.sessions.GetByID(ctx, orgID, sessionID)
 	if err != nil {
 		return fmt.Errorf("fetch session: %w", err)
+	}
+
+	if session.CurrentTurn < regenerateEveryN || session.CurrentTurn%regenerateEveryN != 0 {
+		return nil
 	}
 
 	msgs, err := s.messages.ListBySession(ctx, orgID, sessionID)
@@ -95,21 +86,26 @@ func (s *SessionTitleService) MaybeRegenerateTitle(ctx context.Context, orgID, s
 		return fmt.Errorf("llm completion: %w", err)
 	}
 
-	generated = strings.TrimSpace(generated)
-	generated = strings.Trim(generated, "\"'")
-	if len(generated) == 0 || len(generated) > 120 {
+	title, ok := CleanTitle(generated)
+	if !ok || title == currentTitle {
 		return nil
 	}
 
-	// Skip update if the title hasn't changed.
-	if generated == currentTitle {
-		return nil
-	}
-
-	if err := s.sessions.UpdateTitle(ctx, orgID, sessionID, generated); err != nil {
+	if err := s.sessions.UpdateTitle(ctx, orgID, sessionID, title); err != nil {
 		return fmt.Errorf("update title: %w", err)
 	}
 	return nil
+}
+
+// CleanTitle trims whitespace and surrounding quotes from a generated title,
+// returning false if the result is empty or exceeds maxTitleLen.
+func CleanTitle(s string) (string, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\"'")
+	if len(s) == 0 || len(s) > maxTitleLen {
+		return "", false
+	}
+	return s, true
 }
 
 // buildTitleUserPrompt constructs a compressed conversation summary for title generation.

--- a/internal/services/session_title_test.go
+++ b/internal/services/session_title_test.go
@@ -53,6 +53,7 @@ func (m *mockTitleMessageStore) ListBySession(_ context.Context, _, _ uuid.UUID)
 // --- tests ---
 
 func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
+	t.Parallel()
 	llm := &mockLLM{response: "New Title"}
 	for _, turn := range []int{0, 1, 2, 4, 5} {
 		sessions := &mockTitleSessionStore{
@@ -67,6 +68,7 @@ func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
 }
 
 func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
+	t.Parallel()
 	title := "Old title"
 	llm := &mockLLM{response: "New title from LLM"}
 	sessions := &mockTitleSessionStore{
@@ -91,6 +93,7 @@ func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
 }
 
 func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
+	t.Parallel()
 	title := "Same title"
 	llm := &mockLLM{response: "Same title"}
 	sessions := &mockTitleSessionStore{
@@ -110,6 +113,7 @@ func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
 }
 
 func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
+	t.Parallel()
 	title := "Old"
 	llm := &mockLLM{}
 	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
@@ -135,6 +139,7 @@ func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
 }
 
 func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
+	t.Parallel()
 	title := "Old"
 	llm := &mockLLM{err: errors.New("timeout")}
 	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
@@ -151,6 +156,7 @@ func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
 }
 
 func TestMaybeRegenerateTitle_NoMessages(t *testing.T) {
+	t.Parallel()
 	title := "Old"
 	llm := &mockLLM{response: "New"}
 	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
@@ -163,6 +169,7 @@ func TestMaybeRegenerateTitle_NoMessages(t *testing.T) {
 }
 
 func TestCleanTitle(t *testing.T) {
+	t.Parallel()
 	title, ok := CleanTitle("  \"Fix auth bug\"  ")
 	assert.True(t, ok)
 	assert.Equal(t, "Fix auth bug", title)
@@ -175,6 +182,7 @@ func TestCleanTitle(t *testing.T) {
 }
 
 func TestBuildTitleUserPrompt(t *testing.T) {
+	t.Parallel()
 	msgs := []models.SessionMessage{
 		{Role: models.MessageRoleUser, Content: "Fix the login bug in auth service"},
 		{Role: models.MessageRoleAssistant, Content: "I found the issue in auth.go"},
@@ -191,6 +199,7 @@ func TestBuildTitleUserPrompt(t *testing.T) {
 }
 
 func TestBuildTitleUserPrompt_TruncatesLongMessages(t *testing.T) {
+	t.Parallel()
 	longContent := ""
 	for i := 0; i < 300; i++ {
 		longContent += "a"
@@ -205,6 +214,7 @@ func TestBuildTitleUserPrompt_TruncatesLongMessages(t *testing.T) {
 }
 
 func TestRecentMessages(t *testing.T) {
+	t.Parallel()
 	msgs := make([]models.SessionMessage, 10)
 	for i := range msgs {
 		msgs[i] = models.SessionMessage{TurnNumber: i}
@@ -221,6 +231,7 @@ func TestRecentMessages(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "hello", truncate("hello", 10))
 	assert.Equal(t, "hel...", truncate("hello world", 3))
 	assert.Equal(t, "hello", truncate("  hello  ", 10))

--- a/internal/services/session_title_test.go
+++ b/internal/services/session_title_test.go
@@ -1,0 +1,214 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// --- mocks ---
+
+type mockLLM struct {
+	response string
+	err      error
+	calls    int
+}
+
+func (m *mockLLM) Complete(_ context.Context, _, _ string) (string, error) {
+	m.calls++
+	return m.response, m.err
+}
+
+type mockTitleSessionStore struct {
+	session      models.Session
+	getErr       error
+	updatedTitle string
+	updateErr    error
+}
+
+func (m *mockTitleSessionStore) GetByID(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+	return m.session, m.getErr
+}
+
+func (m *mockTitleSessionStore) UpdateTitle(_ context.Context, _, _ uuid.UUID, title string) error {
+	m.updatedTitle = title
+	return m.updateErr
+}
+
+type mockTitleMessageStore struct {
+	messages []models.SessionMessage
+	err      error
+}
+
+func (m *mockTitleMessageStore) ListBySession(_ context.Context, _, _ uuid.UUID) ([]models.SessionMessage, error) {
+	return m.messages, m.err
+}
+
+// --- tests ---
+
+func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
+	llm := &mockLLM{response: "New Title"}
+	svc := NewSessionTitleService(llm, &mockTitleSessionStore{}, &mockTitleMessageStore{}, zerolog.Nop())
+
+	// Turns 0, 1, 2 should all be skipped.
+	for _, turn := range []int{0, 1, 2, 4, 5} {
+		err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), turn)
+		require.NoError(t, err)
+		assert.Equal(t, 0, llm.calls, "should not call LLM on turn %d", turn)
+	}
+}
+
+func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
+	title := "Old title"
+	llm := &mockLLM{response: "New title from LLM"}
+	sessions := &mockTitleSessionStore{
+		session: models.Session{Title: &title},
+	}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Fix the login bug"},
+			{TurnNumber: 0, Role: models.MessageRoleAssistant, Content: "I'll fix it"},
+			{TurnNumber: 1, Role: models.MessageRoleUser, Content: "Also update tests"},
+			{TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "Done"},
+			{TurnNumber: 2, Role: models.MessageRoleUser, Content: "Now refactor auth"},
+			{TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "Refactored"},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, 1, llm.calls)
+	assert.Equal(t, "New title from LLM", sessions.updatedTitle)
+}
+
+func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
+	title := "Same title"
+	llm := &mockLLM{response: "Same title"}
+	sessions := &mockTitleSessionStore{
+		session: models.Session{Title: &title},
+	}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Do something"},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, 1, llm.calls)
+	assert.Empty(t, sessions.updatedTitle, "should not update when title unchanged")
+}
+
+func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
+	title := "Old"
+	llm := &mockLLM{}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+
+	// Empty response
+	llm.response = "   "
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	require.NoError(t, err)
+	assert.Empty(t, sessions.updatedTitle)
+
+	// Too long response
+	llm.response = string(make([]byte, 121))
+	err = svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 6)
+	require.NoError(t, err)
+	assert.Empty(t, sessions.updatedTitle)
+}
+
+func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
+	title := "Old"
+	llm := &mockLLM{err: errors.New("timeout")}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "llm completion")
+}
+
+func TestMaybeRegenerateTitle_NoMessages(t *testing.T) {
+	title := "Old"
+	llm := &mockLLM{response: "New"}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	messages := &mockTitleMessageStore{messages: nil}
+	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	require.NoError(t, err)
+	assert.Equal(t, 0, llm.calls, "should not call LLM with no messages")
+}
+
+func TestBuildTitleUserPrompt(t *testing.T) {
+	msgs := []models.SessionMessage{
+		{Role: models.MessageRoleUser, Content: "Fix the login bug in auth service"},
+		{Role: models.MessageRoleAssistant, Content: "I found the issue in auth.go"},
+		{Role: models.MessageRoleUser, Content: "Now add tests for it"},
+		{Role: models.MessageRoleAssistant, Content: "Tests added"},
+	}
+
+	result := buildTitleUserPrompt(msgs)
+	assert.Contains(t, result, "Original task:")
+	assert.Contains(t, result, "Fix the login bug")
+	assert.Contains(t, result, "Recent conversation:")
+	assert.Contains(t, result, "User: Now add tests")
+	assert.Contains(t, result, "Assistant: Tests added")
+}
+
+func TestBuildTitleUserPrompt_TruncatesLongMessages(t *testing.T) {
+	longContent := ""
+	for i := 0; i < 300; i++ {
+		longContent += "a"
+	}
+	msgs := []models.SessionMessage{
+		{Role: models.MessageRoleUser, Content: longContent},
+	}
+
+	result := buildTitleUserPrompt(msgs)
+	assert.Contains(t, result, "...")
+	// The truncated message (200 chars + "...") plus prefix should be well under the original 300
+	assert.NotContains(t, result, longContent, "should not contain the full 300-char string")
+}
+
+func TestRecentMessages(t *testing.T) {
+	msgs := make([]models.SessionMessage, 10)
+	for i := range msgs {
+		msgs[i] = models.SessionMessage{TurnNumber: i}
+	}
+
+	recent := recentMessages(msgs, 4)
+	assert.Len(t, recent, 4)
+	assert.Equal(t, 6, recent[0].TurnNumber)
+	assert.Equal(t, 9, recent[3].TurnNumber)
+
+	// Fewer messages than requested
+	small := recentMessages(msgs[:2], 4)
+	assert.Len(t, small, 2)
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "hello", truncate("hello", 10))
+	assert.Equal(t, "hel...", truncate("hello world", 3))
+	assert.Equal(t, "hello", truncate("  hello  ", 10))
+}

--- a/internal/services/session_title_test.go
+++ b/internal/services/session_title_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -55,11 +54,13 @@ func (m *mockTitleMessageStore) ListBySession(_ context.Context, _, _ uuid.UUID)
 
 func TestMaybeRegenerateTitle_SkipsWhenNotDue(t *testing.T) {
 	llm := &mockLLM{response: "New Title"}
-	svc := NewSessionTitleService(llm, &mockTitleSessionStore{}, &mockTitleMessageStore{}, zerolog.Nop())
-
-	// Turns 0, 1, 2 should all be skipped.
 	for _, turn := range []int{0, 1, 2, 4, 5} {
-		err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), turn)
+		sessions := &mockTitleSessionStore{
+			session: models.Session{CurrentTurn: turn},
+		}
+		svc := NewSessionTitleService(llm, sessions, &mockTitleMessageStore{})
+
+		err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 		require.NoError(t, err)
 		assert.Equal(t, 0, llm.calls, "should not call LLM on turn %d", turn)
 	}
@@ -69,7 +70,7 @@ func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
 	title := "Old title"
 	llm := &mockLLM{response: "New title from LLM"}
 	sessions := &mockTitleSessionStore{
-		session: models.Session{Title: &title},
+		session: models.Session{Title: &title, CurrentTurn: 3},
 	}
 	messages := &mockTitleMessageStore{
 		messages: []models.SessionMessage{
@@ -81,9 +82,9 @@ func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
 			{TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "Refactored"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+	svc := NewSessionTitleService(llm, sessions, messages)
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
 	assert.Equal(t, 1, llm.calls)
 	assert.Equal(t, "New title from LLM", sessions.updatedTitle)
@@ -93,16 +94,16 @@ func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
 	title := "Same title"
 	llm := &mockLLM{response: "Same title"}
 	sessions := &mockTitleSessionStore{
-		session: models.Session{Title: &title},
+		session: models.Session{Title: &title, CurrentTurn: 3},
 	}
 	messages := &mockTitleMessageStore{
 		messages: []models.SessionMessage{
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Do something"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+	svc := NewSessionTitleService(llm, sessions, messages)
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
 	assert.Equal(t, 1, llm.calls)
 	assert.Empty(t, sessions.updatedTitle, "should not update when title unchanged")
@@ -111,23 +112,24 @@ func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
 func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
 	title := "Old"
 	llm := &mockLLM{}
-	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
 	messages := &mockTitleMessageStore{
 		messages: []models.SessionMessage{
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+	svc := NewSessionTitleService(llm, sessions, messages)
 
 	// Empty response
 	llm.response = "   "
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.updatedTitle)
 
-	// Too long response
+	// Too long response — reset for next call
+	sessions.session.CurrentTurn = 6
 	llm.response = string(make([]byte, 121))
-	err = svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 6)
+	err = svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
 	assert.Empty(t, sessions.updatedTitle)
 }
@@ -135,15 +137,15 @@ func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {
 func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
 	title := "Old"
 	llm := &mockLLM{err: errors.New("timeout")}
-	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
 	messages := &mockTitleMessageStore{
 		messages: []models.SessionMessage{
 			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "task"},
 		},
 	}
-	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+	svc := NewSessionTitleService(llm, sessions, messages)
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "llm completion")
 }
@@ -151,13 +153,25 @@ func TestMaybeRegenerateTitle_LLMError(t *testing.T) {
 func TestMaybeRegenerateTitle_NoMessages(t *testing.T) {
 	title := "Old"
 	llm := &mockLLM{response: "New"}
-	sessions := &mockTitleSessionStore{session: models.Session{Title: &title}}
+	sessions := &mockTitleSessionStore{session: models.Session{Title: &title, CurrentTurn: 3}}
 	messages := &mockTitleMessageStore{messages: nil}
-	svc := NewSessionTitleService(llm, sessions, messages, zerolog.Nop())
+	svc := NewSessionTitleService(llm, sessions, messages)
 
-	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New(), 3)
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
 	assert.Equal(t, 0, llm.calls, "should not call LLM with no messages")
+}
+
+func TestCleanTitle(t *testing.T) {
+	title, ok := CleanTitle("  \"Fix auth bug\"  ")
+	assert.True(t, ok)
+	assert.Equal(t, "Fix auth bug", title)
+
+	_, ok = CleanTitle("   ")
+	assert.False(t, ok)
+
+	_, ok = CleanTitle(string(make([]byte, 121)))
+	assert.False(t, ok)
 }
 
 func TestBuildTitleUserPrompt(t *testing.T) {
@@ -187,7 +201,6 @@ func TestBuildTitleUserPrompt_TruncatesLongMessages(t *testing.T) {
 
 	result := buildTitleUserPrompt(msgs)
 	assert.Contains(t, result, "...")
-	// The truncated message (200 chars + "...") plus prefix should be well under the original 300
 	assert.NotContains(t, result, longContent, "should not contain the full 300-char string")
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -19,6 +19,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/prompts"
+	"github.com/assembledhq/143/internal/services"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/feedback"
 	ghservice "github.com/assembledhq/143/internal/services/github"
@@ -107,6 +108,7 @@ type Stores struct {
 	EvalBatches         *db.EvalBatchStore     // nil-safe: eval feature
 	EvalBootstraps      *db.EvalBootstrapStore // nil-safe: eval bootstrap feature
 	Repositories        *db.RepositoryStore    // nil-safe: needed for eval repo lookup
+	SessionMessages     *db.SessionMessageStore // nil-safe: needed for title regeneration
 }
 
 // MemoryReinforcer retrieves and reinforces memories for a repo.
@@ -129,6 +131,7 @@ type Services struct {
 	SlackSummarizer *ingestion.SlackSummarizer // nil-safe: Slack summarization disabled if nil
 	LLM             llmClient        // nil-safe: needed for eval LLM judge grading
 	GitHub          agent.GitHubTokenProvider // nil-safe: needed for eval repo cloning
+	TitleService    *services.SessionTitleService // nil-safe: session title regeneration
 }
 
 // llmClient is the interface for LLM completion calls used by eval graders.
@@ -626,7 +629,20 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			Int("current_turn", session.CurrentTurn).
 			Msg("starting continue_session job")
 
-		return services.Orchestrator.ContinueSession(ctx, &session)
+		if err := services.Orchestrator.ContinueSession(ctx, &session); err != nil {
+			return err
+		}
+
+		// Regenerate title if due (every 3 turns). Non-fatal — log and continue.
+		if services.TitleService != nil {
+			updated, fetchErr := stores.Sessions.GetByID(ctx, orgID, sessionID)
+			if fetchErr == nil {
+				if titleErr := services.TitleService.MaybeRegenerateTitle(ctx, orgID, sessionID, updated.CurrentTurn); titleErr != nil {
+					logger.Warn().Err(titleErr).Str("session_id", sessionID.String()).Msg("failed to regenerate session title")
+				}
+			}
+		}
+		return nil
 	}
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -635,11 +635,8 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 
 		// Regenerate title if due (every 3 turns). Non-fatal — log and continue.
 		if services.TitleService != nil {
-			updated, fetchErr := stores.Sessions.GetByID(ctx, orgID, sessionID)
-			if fetchErr == nil {
-				if titleErr := services.TitleService.MaybeRegenerateTitle(ctx, orgID, sessionID, updated.CurrentTurn); titleErr != nil {
-					logger.Warn().Err(titleErr).Str("session_id", sessionID.String()).Msg("failed to regenerate session title")
-				}
+			if titleErr := services.TitleService.MaybeRegenerateTitle(ctx, orgID, sessionID); titleErr != nil {
+				logger.Warn().Err(titleErr).Str("session_id", sessionID.String()).Msg("failed to regenerate session title")
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary
- Generates titles for issue-based sessions at creation time using issue title/description (previously only manual sessions got titles)
- Adds a `SessionTitleService` that re-generates titles every 3 turns using conversation history, so titles stay current as multi-turn discussions evolve
- Includes prompt template that tells the LLM to keep the current title if still accurate, avoiding unnecessary flickering
- Wired into the `continue_session` worker handler as a non-fatal post-processing step

## Test plan
- [x] Unit tests for throttling logic, prompt building, truncation, edge cases (empty messages, LLM errors, unchanged titles)
- [ ] Create a manual session → verify title is generated from user message (existing behavior preserved)
- [ ] Create an issue-based session → verify title is generated from issue title/description
- [ ] Multi-turn session past turn 3 → verify title updates to reflect conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)