### PR TITLE
Separate personal and organization settings into distinct pages

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -1,0 +1,295 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen, waitFor, userEvent } from '@/test/test-utils';
+import { server } from '@/test/mocks/server';
+import AccountPage from './page';
+import type { UserCredentialSummary, ResolvedCredential, ListResponse } from '@/lib/types';
+
+const { useAuthMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}));
+
+const mockPersonalCreds: UserCredentialSummary[] = [
+  {
+    provider: 'anthropic',
+    configured: true,
+    is_team_default: false,
+    masked_key: 'sk-ant-...abc',
+    status: 'active',
+  },
+];
+
+const mockResolved: ResolvedCredential[] = [
+  { provider: 'anthropic', source: 'personal', masked_key: 'sk-ant-...abc' },
+  { provider: 'openai', source: 'team_default', masked_key: 'sk-...def' },
+  { provider: 'gemini', source: 'none' },
+];
+
+function setupHandlers({
+  personal = mockPersonalCreds,
+  resolved = mockResolved,
+}: {
+  personal?: UserCredentialSummary[];
+  resolved?: ResolvedCredential[];
+} = {}) {
+  server.use(
+    http.get('/api/v1/settings/credentials/personal', () => {
+      return HttpResponse.json({ data: personal, meta: {} } satisfies ListResponse<UserCredentialSummary>);
+    }),
+    http.get('/api/v1/settings/credentials/resolved', () => {
+      return HttpResponse.json({ data: resolved, meta: {} } satisfies ListResponse<ResolvedCredential>);
+    }),
+    http.get('/api/v1/github/status', () => {
+      return HttpResponse.json({ connected: false, has_repo_scope: false });
+    }),
+    http.get('/api/v1/settings/codex-auth/status', () => {
+      return HttpResponse.json({ data: { status: 'none' } });
+    }),
+  );
+}
+
+describe('AccountPage', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: { id: 'user-1', name: 'Alice Smith', email: 'alice@example.com', role: 'admin' },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+    setupHandlers();
+  });
+
+  it('renders page header', async () => {
+    renderWithProviders(<AccountPage />);
+    expect(screen.getByText('Account')).toBeInTheDocument();
+    expect(screen.getByText('Your personal preferences and credentials.')).toBeInTheDocument();
+  });
+
+  it('renders the Appearance section with theme selector', async () => {
+    renderWithProviders(<AccountPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Appearance')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Theme')).toBeInTheDocument();
+    expect(screen.getByText('Select your preferred color scheme')).toBeInTheDocument();
+  });
+
+  it('renders the GitHub PR connection section', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('GitHub connection for PRs')).toBeInTheDocument();
+    expect(screen.getByText('Connect GitHub')).toBeInTheDocument();
+  });
+
+  it('renders the coding agent credentials section', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Coding agent credentials')).toBeInTheDocument();
+    expect(screen.getByText('Your personal API keys. Personal keys are used first, falling back to organization defaults.')).toBeInTheDocument();
+  });
+
+  it('shows 3 agent type radio cards', async () => {
+    renderWithProviders(<AccountPage />);
+
+    const claudeLabels = await screen.findAllByText('Claude Code');
+    expect(claudeLabels.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Codex')).toBeInTheDocument();
+    expect(screen.getByText('Gemini CLI')).toBeInTheDocument();
+  });
+
+  it('shows Configured badge for providers with keys', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Configured')).toBeInTheDocument();
+  });
+
+  it('shows masked key for configured providers', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Key: sk-ant-...abc')).toBeInTheDocument();
+  });
+
+  it('shows resolution source badges', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Your key')).toBeInTheDocument();
+  });
+
+  it('saves a new API key', async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.put('/api/v1/settings/credentials/personal/:provider', async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ data: mockPersonalCreds[0] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AccountPage />);
+
+    await screen.findByText('Key: sk-ant-...abc');
+
+    const input = screen.getByPlaceholderText('Replace existing key...');
+    await user.type(input, 'sk-ant-newkey123');
+
+    const saveButton = screen.getByText('Save key');
+    await user.click(saveButton);
+
+    await waitFor(() => {
+      expect(capturedBody).toBeDefined();
+    });
+  });
+
+  it('disables Save key button when input is empty', async () => {
+    renderWithProviders(<AccountPage />);
+
+    const saveButton = await screen.findByText('Save key');
+    expect(saveButton).toBeDisabled();
+  });
+
+  it('shows Remove button for configured providers', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Remove')).toBeInTheDocument();
+  });
+
+  it('shows remove confirmation dialog', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AccountPage />);
+
+    await user.click(await screen.findByText('Remove'));
+
+    expect(await screen.findByText('Remove API key')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('shows Set as team default button for admin with configured key', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Set as team default')).toBeInTheDocument();
+  });
+
+  it('shows success message after saving key', async () => {
+    server.use(
+      http.put('/api/v1/settings/credentials/personal/:provider', () => {
+        return HttpResponse.json({ data: mockPersonalCreds[0] });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AccountPage />);
+
+    await screen.findByText('Key: sk-ant-...abc');
+
+    const input = screen.getByPlaceholderText('Replace existing key...');
+    await user.type(input, 'sk-ant-newkey');
+
+    const saveButton = screen.getByText('Save key');
+    await user.click(saveButton);
+
+    expect(await screen.findByText('Key saved successfully.')).toBeInTheDocument();
+  });
+
+  it('shows error message when save fails', async () => {
+    server.use(
+      http.put('/api/v1/settings/credentials/personal/:provider', () => {
+        return HttpResponse.json(
+          { error: { code: 'INTERNAL', message: 'Server error' } },
+          { status: 500 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AccountPage />);
+
+    await screen.findByText('Key: sk-ant-...abc');
+
+    const input = screen.getByPlaceholderText('Replace existing key...');
+    await user.type(input, 'sk-ant-badkey');
+
+    const saveButton = screen.getByText('Save key');
+    await user.click(saveButton);
+
+    expect(await screen.findByText('Failed to save key.')).toBeInTheDocument();
+  });
+
+  it('switches agent credential card when selecting a different radio', async () => {
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Key: sk-ant-...abc')).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Codex'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Key: sk-ant-...abc')).not.toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
+  });
+
+  it('auto-defaults to the first configured provider', async () => {
+    setupHandlers({
+      personal: [
+        { provider: 'openai', configured: true, is_team_default: false, masked_key: 'sk-...xyz', status: 'active' },
+      ],
+      resolved: [
+        { provider: 'openai', source: 'personal', masked_key: 'sk-...xyz' },
+      ],
+    });
+
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Key: sk-...xyz')).toBeInTheDocument();
+  });
+
+  it('defaults to Codex when no provider has a configured key', async () => {
+    setupHandlers({ personal: [], resolved: [] });
+
+    renderWithProviders(<AccountPage />);
+
+    expect(await screen.findByText('Credential method')).toBeInTheDocument();
+    expect(screen.getByLabelText('Use API key')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sign in with ChatGPT')).toBeInTheDocument();
+  });
+
+  it('hides API key input when ChatGPT method is selected for Codex', async () => {
+    setupHandlers({ personal: [], resolved: [] });
+
+    renderWithProviders(<AccountPage />);
+
+    const apiKeyInput = await screen.findByPlaceholderText('sk-...');
+    expect(apiKeyInput).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByLabelText('Sign in with ChatGPT'));
+
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText('sk-...')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('API key fields are hidden while ChatGPT sign-in is selected.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
+  });
+
+  it('hides Set as team default for non-admin users', async () => {
+    useAuthMock.mockReturnValue({
+      user: { id: 'user-2', name: 'Bob', email: 'bob@example.com', role: 'member' },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    renderWithProviders(<AccountPage />);
+
+    await screen.findByText('Key: sk-ant-...abc');
+    expect(screen.queryByText('Set as team default')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -1,0 +1,524 @@
+"use client";
+
+import { type ReactNode, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2, KeyRound, Sparkles, Check, Eye, EyeOff, Shield } from "lucide-react";
+import { api } from "@/lib/api";
+import { captureError } from "@/lib/errors";
+import { useAuth } from "@/hooks/use-auth";
+import { AGENT_TYPES, KEY_PLACEHOLDERS, sourceLabel, sourceBadgeVariant, providerDisplayName } from "@/lib/agent-constants";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { RadioGroup } from "@/components/ui/radio-group";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/page-header";
+import { PageContainer } from "@/components/page-container";
+import { RadioCard } from "@/components/radio-card";
+import { ThemeSelect } from "@/components/theme-select";
+import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
+import type {
+  UserCredentialSummary,
+  ResolvedCredential,
+  ListResponse,
+} from "@/lib/types";
+
+/* ------------------------------------------------------------------ */
+/*  GitHub PR Connection                                              */
+/* ------------------------------------------------------------------ */
+
+function GitHubPRConnection() {
+  const queryClient = useQueryClient();
+  const { data: ghStatus, isLoading } = useQuery({
+    queryKey: ["github-status"],
+    queryFn: () => api.githubStatus.get(),
+  });
+  const disconnectMutation = useMutation({
+    mutationFn: () => api.githubStatus.disconnect(),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["github-status"] }),
+  });
+
+  if (isLoading) return null;
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-[13px] font-medium text-foreground">Pull requests</h2>
+      <Card>
+        <CardContent>
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label>GitHub connection for PRs</Label>
+              <p className="text-[13px] text-muted-foreground">
+                {ghStatus?.connected && ghStatus?.has_repo_scope
+                  ? `Connected as @${ghStatus.github_login} — PRs will be authored by you`
+                  : ghStatus?.connected && !ghStatus?.has_repo_scope
+                    ? `Connected as @${ghStatus.github_login} — missing repo access, reconnect to author PRs`
+                    : "Connect your GitHub account to create PRs under your name"}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              {ghStatus?.connected ? (
+                <>
+                  {!ghStatus.has_repo_scope && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => api.githubStatus.connect()}
+                    >
+                      Reconnect
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => disconnectMutation.mutate()}
+                    disabled={disconnectMutation.isPending}
+                  >
+                    Disconnect
+                  </Button>
+                </>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => api.githubStatus.connect()}
+                >
+                  Connect GitHub
+                </Button>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Page                                                              */
+/* ------------------------------------------------------------------ */
+
+export default function AccountPage() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
+  /* ---------- Personal credentials queries ---------- */
+
+  const { data: personalResp, isSuccess: personalCredsLoaded } = useQuery<ListResponse<UserCredentialSummary>>({
+    queryKey: ["user-credentials", "personal"],
+    queryFn: () => api.userCredentials.listPersonal(),
+  });
+  const personalCreds = useMemo(() => personalResp?.data ?? [], [personalResp?.data]);
+
+  const { data: resolvedResp } = useQuery<ListResponse<ResolvedCredential>>({
+    queryKey: ["user-credentials", "resolved"],
+    queryFn: () => api.userCredentials.listResolved(),
+  });
+  const resolved = useMemo(() => resolvedResp?.data ?? [], [resolvedResp?.data]);
+
+  /* ---------- Personal credentials state ---------- */
+
+  const initialPersonalAgent = useMemo(() => {
+    if (!personalCredsLoaded) return null;
+    const configured = AGENT_TYPES.find((a) =>
+      personalCreds.some((c) => c.provider === a.providerKey && c.configured),
+    );
+    return configured?.key ?? "codex";
+  }, [personalCreds, personalCredsLoaded]);
+
+  const [personalAgentType, setPersonalAgentType] = useState<string | null>(null);
+  const effectivePersonalAgentType = personalAgentType ?? initialPersonalAgent ?? "codex";
+  const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
+  const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
+  const [keySaveStatus, setKeySaveStatus] = useState<Record<string, "idle" | "saving" | "success" | "error">>({});
+  const [removingProvider, setRemovingProvider] = useState<string | null>(null);
+  const [personalCodexMethodOverride, setPersonalCodexMethodOverride] = useState<"chatgpt" | "api_key" | null>(null);
+  const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
+
+  const upsertMutation = useMutation({
+    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
+      api.userCredentials.upsertPersonal(provider, { api_key: apiKey }),
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
+      setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "success" }));
+      setApiKeys((prev) => ({ ...prev, [variables.provider]: "" }));
+      setTimeout(() => setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" })), 2000);
+    },
+    onError: (err, variables) => {
+      captureError(err, { feature: "agent-key-save" });
+      setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "error" }));
+      setTimeout(() => setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" })), 3000);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (provider: string) => api.userCredentials.deletePersonal(provider),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
+      setRemovingProvider(null);
+    },
+    onError: (error) => {
+      captureError(error, { feature: "agent-key-delete" });
+    },
+  });
+
+  const setTeamDefaultMutation = useMutation({
+    mutationFn: ({ provider, userId }: { provider: string; userId: string }) =>
+      api.userCredentials.setTeamDefault(provider, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
+    },
+  });
+
+  const { data: codexAuthStatusResp } = useQuery({
+    queryKey: ["codex-auth-status"],
+    queryFn: () => api.codexAuth.status(),
+    refetchInterval: false,
+  });
+  const codexAuthStatus = codexAuthStatusResp?.data;
+
+  const hasCodexChatGPTConnection = codexAuthStatus?.status === "completed";
+  const inferredPersonalCodexMethod: "chatgpt" | "api_key" =
+    hasCodexChatGPTConnection ? "chatgpt" : "api_key";
+  const personalCodexMethod = personalCodexMethodOverride ?? inferredPersonalCodexMethod;
+
+  const disconnectMutation = useMutation({
+    mutationFn: () => api.codexAuth.disconnect(),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+    },
+  });
+
+  function handleSavePersonalKey(provider: string) {
+    const key = apiKeys[provider]?.trim();
+    if (!key) return;
+    setKeySaveStatus((prev) => ({ ...prev, [provider]: "saving" }));
+    upsertMutation.mutate({ provider, apiKey: key });
+  }
+
+  /* ---------- Render helpers ---------- */
+
+  function renderChatGPTAuthStatus(): ReactNode {
+    return (
+      <div className="flex items-center gap-2">
+        {codexAuthStatus?.status === "completed" ? (
+          <>
+            <Badge variant="outline" className="border-green-600 text-green-600">
+              <CheckCircle2 className="mr-1 h-3.5 w-3.5" />
+              Connected
+            </Badge>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => disconnectMutation.mutate()}
+              disabled={disconnectMutation.isPending}
+            >
+              {disconnectMutation.isPending ? "Disconnecting..." : "Disconnect"}
+            </Button>
+          </>
+        ) : (
+          <Button size="sm" onClick={() => setShowDeviceCodeModal(true)}>
+            Sign in with ChatGPT
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  function renderAgentConfigHeader({
+    title,
+    badges,
+    action,
+  }: {
+    title: string;
+    badges: ReactNode;
+    action?: ReactNode;
+  }): ReactNode {
+    return (
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">{title}</span>
+          {badges}
+        </div>
+        {action}
+      </div>
+    );
+  }
+
+  function renderCodexCredentialToggle({
+    method,
+    onMethodChange,
+  }: {
+    method: "chatgpt" | "api_key";
+    onMethodChange: (value: "chatgpt" | "api_key") => void;
+  }): ReactNode {
+    return (
+      <div className="space-y-3">
+        <Label className="text-xs text-muted-foreground">Credential method</Label>
+        <RadioGroup
+          value={method}
+          onValueChange={(value) => onMethodChange(value as "chatgpt" | "api_key")}
+          className="grid gap-3 md:grid-cols-2"
+        >
+          <RadioCard
+            value="chatgpt"
+            label="Sign in with ChatGPT"
+            description="Best for gpt-5.3-codex model access."
+            selected={method === "chatgpt"}
+            icon={<Sparkles className="h-4 w-4 text-primary" />}
+            ariaLabel="Sign in with ChatGPT"
+          />
+          <RadioCard
+            value="api_key"
+            label="Use API key"
+            description="Pay-as-you-go credentials with configurable model/base URL."
+            selected={method === "api_key"}
+            icon={<KeyRound className="h-4 w-4 text-muted-foreground" />}
+            ariaLabel="Use API key"
+          />
+        </RadioGroup>
+
+        {method === "chatgpt" && renderChatGPTAuthStatus()}
+      </div>
+    );
+  }
+
+  function renderPersonalCredentialCard(): ReactNode {
+    const agent = AGENT_TYPES.find((a) => a.key === effectivePersonalAgentType) ?? AGENT_TYPES[0];
+    const providerKey = agent.providerKey;
+    const cred = personalCreds.find((c) => c.provider === providerKey);
+    const status = keySaveStatus[providerKey] ?? "idle";
+    const r = resolved.find((c) => c.provider === providerKey);
+    const source = r?.source ?? "none";
+    const isCodex = agent.key === "codex";
+    const hideApiKey = isCodex && personalCodexMethod === "chatgpt";
+
+    return (
+      <div className="space-y-3 border-t pt-3 mt-1">
+        {renderAgentConfigHeader({
+          title: agent.label,
+          badges: (
+            <>
+              {cred?.configured && (
+                <Badge variant="success" className="text-xs px-1.5 py-0">
+                  <Check className="mr-0.5 h-3 w-3" />
+                  Configured
+                </Badge>
+              )}
+              <Badge variant={sourceBadgeVariant(source)} className="text-xs px-1.5 py-0">
+                {sourceLabel(source)}
+              </Badge>
+            </>
+          ),
+          action: cred?.configured ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-xs text-muted-foreground"
+              onClick={() => setRemovingProvider(providerKey)}
+              disabled={deleteMutation.isPending}
+            >
+              Remove
+            </Button>
+          ) : undefined,
+        })}
+
+        {isCodex && renderCodexCredentialToggle({
+          method: personalCodexMethod,
+          onMethodChange: setPersonalCodexMethodOverride,
+        })}
+
+        {cred?.configured && cred.masked_key && !hideApiKey && (
+          <p className="text-xs text-muted-foreground font-mono">
+            Key: {cred.masked_key}
+          </p>
+        )}
+
+        {!hideApiKey && (
+          <div className="flex gap-2">
+            <div className="relative flex-1">
+              <Input
+                type={showKeys[providerKey] ? "text" : "password"}
+                placeholder={cred?.configured ? "Replace existing key..." : KEY_PLACEHOLDERS[providerKey] ?? "API key"}
+                value={apiKeys[providerKey] ?? ""}
+                onChange={(e) =>
+                  setApiKeys((prev) => ({ ...prev, [providerKey]: e.target.value }))
+                }
+                className="pr-9 font-mono text-xs"
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  setShowKeys((prev) => ({ ...prev, [providerKey]: !prev[providerKey] }))
+                }
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+              >
+                {showKeys[providerKey] ? (
+                  <EyeOff className="h-3.5 w-3.5" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5" />
+                )}
+              </button>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => handleSavePersonalKey(providerKey)}
+              disabled={!apiKeys[providerKey]?.trim() || status === "saving"}
+            >
+              {status === "saving" ? "Saving..." : "Save key"}
+            </Button>
+          </div>
+        )}
+
+        {hideApiKey && (
+          <p className="text-xs text-muted-foreground">
+            API key fields are hidden while ChatGPT sign-in is selected.
+          </p>
+        )}
+
+        {status === "success" && (
+          <p className="text-xs text-emerald-600 dark:text-emerald-400">Key saved successfully.</p>
+        )}
+        {status === "error" && (
+          <p className="text-xs text-destructive">Failed to save key.</p>
+        )}
+
+        {isAdmin && cred?.configured && !cred.is_team_default && user && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="text-xs"
+            onClick={() => setTeamDefaultMutation.mutate({ provider: providerKey, userId: user.id })}
+            disabled={setTeamDefaultMutation.isPending}
+          >
+            <Shield className="mr-1 h-3 w-3" />
+            Set as team default
+          </Button>
+        )}
+        {cred?.is_team_default && (
+          <Badge variant="secondary" className="text-xs px-1.5 py-0">
+            <Shield className="mr-0.5 h-3 w-3" />
+            Team default
+          </Badge>
+        )}
+      </div>
+    );
+  }
+
+  /* ---------- Render ---------- */
+
+  return (
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title="Account"
+          description="Your personal preferences and credentials."
+        />
+
+        <section className="space-y-3">
+          <h2 className="text-[13px] font-medium text-foreground">Appearance</h2>
+          <Card>
+            <CardContent>
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <Label>Theme</Label>
+                  <p className="text-[13px] text-muted-foreground">
+                    Select your preferred color scheme
+                  </p>
+                </div>
+                <ThemeSelect />
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <GitHubPRConnection />
+
+        <section className="space-y-3">
+          <div>
+            <h2 className="text-[13px] font-medium text-foreground">
+              Coding agent credentials
+            </h2>
+            <p className="text-xs text-muted-foreground mt-1">
+              Your personal API keys. Personal keys are used first, falling back to organization defaults.
+            </p>
+          </div>
+
+          <Card>
+            <CardContent>
+              <div className="space-y-3">
+                <RadioGroup
+                  value={effectivePersonalAgentType}
+                  onValueChange={setPersonalAgentType}
+                  className="grid grid-cols-3 gap-3"
+                >
+                  {AGENT_TYPES.map((agent) => {
+                    const cred = personalCreds.find((c) => c.provider === agent.providerKey);
+                    return (
+                      <RadioCard
+                        key={agent.key}
+                        value={agent.key}
+                        label={agent.label}
+                        selected={effectivePersonalAgentType === agent.key}
+                        icon={cred?.configured ? <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" /> : undefined}
+                      />
+                    );
+                  })}
+                </RadioGroup>
+
+                {personalCredsLoaded && renderPersonalCredentialCard()}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+
+      {/* Remove Personal Key Dialog */}
+      <AlertDialog open={!!removingProvider} onOpenChange={(open) => !open && setRemovingProvider(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove API key</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove your {providerDisplayName(removingProvider ?? "")} API key?
+              Sessions will fall back to the team default or organization key.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (removingProvider) deleteMutation.mutate(removingProvider);
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Codex Device Code Modal */}
+      {showDeviceCodeModal && (
+        <CodexDeviceCodeModal
+          onClose={() => setShowDeviceCodeModal(false)}
+          onConnected={() => {
+            queryClient.invalidateQueries({ queryKey: ["codex-auth-status"] });
+            setShowDeviceCodeModal(false);
+          }}
+        />
+      )}
+    </PageContainer>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -13,16 +13,6 @@ vi.mock('@/hooks/use-auth', () => ({
   useAuth: useAuthMock,
 }));
 
-const mockPersonalCreds: UserCredentialSummary[] = [
-  {
-    provider: 'anthropic',
-    configured: true,
-    is_team_default: false,
-    masked_key: 'sk-ant-...abc',
-    status: 'active',
-  },
-];
-
 const mockTeamDefaults: UserCredentialSummary[] = [
   {
     provider: 'anthropic',
@@ -56,18 +46,13 @@ const mockOrgSettings: SingleResponse<Organization> = {
 };
 
 function setupHandlers({
-  personal = mockPersonalCreds,
   team = mockTeamDefaults,
   resolved = mockResolved,
 }: {
-  personal?: UserCredentialSummary[];
   team?: UserCredentialSummary[];
   resolved?: ResolvedCredential[];
 } = {}) {
   server.use(
-    http.get('/api/v1/settings/credentials/personal', () => {
-      return HttpResponse.json({ data: personal, meta: {} } satisfies ListResponse<UserCredentialSummary>);
-    }),
     http.get('/api/v1/settings/credentials/team', () => {
       return HttpResponse.json({ data: team, meta: {} } satisfies ListResponse<UserCredentialSummary>);
     }),
@@ -101,139 +86,6 @@ describe('AgentPage', () => {
     expect(screen.getByText('Coding agents')).toBeInTheDocument();
   });
 
-  it('shows 3 agent type radio cards in My coding agents section', async () => {
-    renderWithProviders(<AgentPage />);
-
-    // Both personal and org sections use the same 3 agent types
-    const claudeLabels = await screen.findAllByText('Claude Code');
-    expect(claudeLabels.length).toBeGreaterThanOrEqual(1);
-    const codexLabels = screen.getAllByText('Codex');
-    expect(codexLabels.length).toBeGreaterThanOrEqual(1);
-    const geminiLabels = screen.getAllByText('Gemini CLI');
-    expect(geminiLabels.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it('shows Configured badge for providers with keys', async () => {
-    renderWithProviders(<AgentPage />);
-
-    expect(await screen.findByText('Configured')).toBeInTheDocument();
-  });
-
-  it('shows masked key for configured providers', async () => {
-    renderWithProviders(<AgentPage />);
-
-    expect(await screen.findByText('Key: sk-ant-...abc')).toBeInTheDocument();
-  });
-
-  it('shows resolution source badges', async () => {
-    renderWithProviders(<AgentPage />);
-
-    expect(await screen.findByText('Your key')).toBeInTheDocument();
-  });
-
-  it('saves a new API key', async () => {
-    let capturedBody: unknown;
-    server.use(
-      http.put('/api/v1/settings/credentials/personal/:provider', async ({ request }) => {
-        capturedBody = await request.json();
-        return HttpResponse.json({ data: mockPersonalCreds[0] });
-      }),
-    );
-
-    const user = userEvent.setup();
-    renderWithProviders(<AgentPage />);
-
-    // Wait for personal creds to load
-    await screen.findByText('Key: sk-ant-...abc');
-
-    const input = screen.getByPlaceholderText('Replace existing key...');
-    await user.type(input, 'sk-ant-newkey123');
-
-    const saveButton = screen.getByText('Save key');
-    await user.click(saveButton);
-
-    await waitFor(() => {
-      expect(capturedBody).toBeDefined();
-    });
-  });
-
-  it('disables Save key button when input is empty', async () => {
-    renderWithProviders(<AgentPage />);
-
-    // Wait for credential card to appear (gated on query loading)
-    const saveButton = await screen.findByText('Save key');
-    expect(saveButton).toBeDisabled();
-  });
-
-  it('shows Remove button for configured providers', async () => {
-    renderWithProviders(<AgentPage />);
-
-    expect(await screen.findByText('Remove')).toBeInTheDocument();
-  });
-
-  it('shows remove confirmation dialog', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<AgentPage />);
-
-    await user.click(await screen.findByText('Remove'));
-
-    expect(await screen.findByText('Remove API key')).toBeInTheDocument();
-    expect(screen.getByText('Cancel')).toBeInTheDocument();
-  });
-
-  it('shows Set as team default button for admin with configured key', async () => {
-    renderWithProviders(<AgentPage />);
-
-    expect(await screen.findByText('Set as team default')).toBeInTheDocument();
-  });
-
-  it('shows success message after saving key', async () => {
-    server.use(
-      http.put('/api/v1/settings/credentials/personal/:provider', () => {
-        return HttpResponse.json({ data: mockPersonalCreds[0] });
-      }),
-    );
-
-    const user = userEvent.setup();
-    renderWithProviders(<AgentPage />);
-
-    // Wait for personal creds to load
-    await screen.findByText('Key: sk-ant-...abc');
-
-    const input = screen.getByPlaceholderText('Replace existing key...');
-    await user.type(input, 'sk-ant-newkey');
-
-    const saveButton = screen.getByText('Save key');
-    await user.click(saveButton);
-
-    expect(await screen.findByText('Key saved successfully.')).toBeInTheDocument();
-  });
-
-  it('shows error message when save fails', async () => {
-    server.use(
-      http.put('/api/v1/settings/credentials/personal/:provider', () => {
-        return HttpResponse.json(
-          { error: { code: 'INTERNAL', message: 'Server error' } },
-          { status: 500 },
-        );
-      }),
-    );
-
-    const user = userEvent.setup();
-    renderWithProviders(<AgentPage />);
-
-    // Wait for personal creds to load
-    await screen.findByText('Key: sk-ant-...abc');
-
-    const input = screen.getByPlaceholderText('Replace existing key...');
-    await user.type(input, 'sk-ant-badkey');
-
-    const saveButton = screen.getByText('Save key');
-    await user.click(saveButton);
-
-    expect(await screen.findByText('Failed to save key.')).toBeInTheDocument();
-  });
-
   it('shows Organization coding agents section for admins', async () => {
     renderWithProviders(<AgentPage />);
 
@@ -253,13 +105,10 @@ describe('AgentPage', () => {
 
     renderWithProviders(<AgentPage />);
 
-    // Org config card should show "Not configured" badge when no team credential exists
     const orgSection = await screen.findByText('Organization coding agents');
     expect(orgSection).toBeInTheDocument();
 
-    // The org config card shows "Not configured" for the selected agent
     const notConfiguredBadges = await screen.findAllByText('Not configured');
-    // At least one should be in the org section
     expect(notConfiguredBadges.length).toBeGreaterThanOrEqual(1);
   });
 
@@ -280,7 +129,10 @@ describe('AgentPage', () => {
 
     renderWithProviders(<AgentPage />);
 
-    await screen.findAllByText('Claude Code');
+    // Wait for page to render
+    await waitFor(() => {
+      expect(screen.getByText('Coding agents')).toBeInTheDocument();
+    });
     expect(screen.queryByText('Organization coding agents')).not.toBeInTheDocument();
     expect(screen.queryByText('Autonomy level')).not.toBeInTheDocument();
     expect(screen.queryByText('Execution aggressiveness')).not.toBeInTheDocument();
@@ -293,108 +145,8 @@ describe('AgentPage', () => {
     expect(screen.getByText('Save organization settings')).toBeInTheDocument();
   });
 
-  it('shows empty state for unconfigured providers', async () => {
-    setupHandlers({ personal: [], team: [], resolved: [] });
-
-    renderWithProviders(<AgentPage />);
-
-    // Wait for credential card to appear (gated on query loading)
-    const saveButton = await screen.findByText('Save key');
-    expect(saveButton).toBeDisabled();
-  });
-
-  it('switches personal agent credential card when selecting a different radio', async () => {
-    renderWithProviders(<AgentPage />);
-
-    // Default shows Claude Code credential card (auto-selected because anthropic key is configured)
-    expect(await screen.findByText('Key: sk-ant-...abc')).toBeInTheDocument();
-
-    // Click on Codex radio card
-    const user = userEvent.setup();
-    const codexLabels = screen.getAllByText('Codex');
-    // The first Codex label is in the personal RadioGroup
-    await user.click(codexLabels[0]);
-
-    // Should now show Codex placeholder, not Claude Code key
-    await waitFor(() => {
-      expect(screen.queryByText('Key: sk-ant-...abc')).not.toBeInTheDocument();
-    });
-    expect(screen.getByPlaceholderText('sk-...')).toBeInTheDocument();
-  });
-
-  it('auto-defaults personal agent to the first configured provider', async () => {
-    // Only openai is configured — should auto-select Codex
-    setupHandlers({
-      personal: [
-        { provider: 'openai', configured: true, is_team_default: false, masked_key: 'sk-...xyz', status: 'active' },
-      ],
-      team: [],
-      resolved: [
-        { provider: 'openai', source: 'personal', masked_key: 'sk-...xyz' },
-      ],
-    });
-
-    renderWithProviders(<AgentPage />);
-
-    // Should show the openai masked key in the credential card (Codex auto-selected)
-    expect(await screen.findByText('Key: sk-...xyz')).toBeInTheDocument();
-  });
-
-  it('defaults to Codex when no provider has a configured key', async () => {
-    setupHandlers({ personal: [], team: [], resolved: [] });
-
-    renderWithProviders(<AgentPage />);
-
-    // Codex is the default agent; its credential method toggle should appear
-    expect(await screen.findByText('Credential method')).toBeInTheDocument();
-    expect(screen.getByLabelText('Use API key')).toBeInTheDocument();
-    expect(screen.getByLabelText('Sign in with ChatGPT')).toBeInTheDocument();
-  });
-
-  it('shows ChatGPT credential method toggle when Codex is selected in personal section', async () => {
-    renderWithProviders(<AgentPage />);
-
-    // Default auto-selects Claude Code because the anthropic key is configured
-    expect(await screen.findByText('Key: sk-ant-...abc')).toBeInTheDocument();
-
-    // Switch to Codex
-    const user = userEvent.setup();
-    const codexLabels = screen.getAllByText('Codex');
-    await user.click(codexLabels[0]);
-
-    // Should show credential method toggle for Codex
-    await waitFor(() => {
-      expect(screen.getByText('Credential method')).toBeInTheDocument();
-    });
-    expect(screen.getByLabelText('Sign in with ChatGPT')).toBeInTheDocument();
-    expect(screen.getByLabelText('Use API key')).toBeInTheDocument();
-  });
-
-  it('hides API key input when ChatGPT method is selected for personal Codex', async () => {
-    // No configured keys — defaults to Codex
-    setupHandlers({ personal: [], team: [], resolved: [] });
-
-    renderWithProviders(<AgentPage />);
-
-    // Default is api_key since no ChatGPT connection exists
-    const apiKeyInput = await screen.findByPlaceholderText('sk-...');
-    expect(apiKeyInput).toBeInTheDocument();
-
-    // Switch to ChatGPT method
-    const user = userEvent.setup();
-    await user.click(screen.getByLabelText('Sign in with ChatGPT'));
-
-    // API key input should be hidden
-    await waitFor(() => {
-      expect(screen.queryByPlaceholderText('sk-...')).not.toBeInTheDocument();
-    });
-    expect(screen.getByText('API key fields are hidden while ChatGPT sign-in is selected.')).toBeInTheDocument();
-    // Sign in button should appear
-    expect(screen.getByRole('button', { name: 'Sign in with ChatGPT' })).toBeInTheDocument();
-  });
-
   it('shows Connected badge when ChatGPT auth is completed', async () => {
-    setupHandlers({ personal: [], team: [], resolved: [] });
+    setupHandlers({ team: [], resolved: [] });
     server.use(
       http.get('/api/v1/settings/codex-auth/status', () => {
         return HttpResponse.json({ data: { status: 'completed' } });
@@ -403,7 +155,6 @@ describe('AgentPage', () => {
 
     renderWithProviders(<AgentPage />);
 
-    // With completed auth, ChatGPT method is auto-selected and shows Connected
     expect(await screen.findByText('Connected')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Disconnect' })).toBeInTheDocument();
   });
@@ -426,7 +177,6 @@ describe('AgentPage', () => {
     await waitFor(() => {
       expect(capturedBody).toBeDefined();
       const body = capturedBody as Record<string, Record<string, unknown>>;
-      // Should contain both agent config and execution settings in one payload
       expect(body.settings).toHaveProperty('default_agent_type');
       expect(body.settings).toHaveProperty('autonomy_level');
       expect(body.settings).toHaveProperty('execution_aggressiveness');

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -151,6 +151,14 @@ describe('AgentPage', () => {
       http.get('/api/v1/settings/codex-auth/status', () => {
         return HttpResponse.json({ data: { status: 'completed' } });
       }),
+      http.get('/api/v1/settings', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockOrgSettings.data,
+            settings: { ...mockOrgSettings.data.settings, default_agent_type: 'codex' },
+          },
+        });
+      }),
     );
 
     renderWithProviders(<AgentPage />);

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -2,16 +2,17 @@
 
 import { type ReactNode, useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, KeyRound, Sparkles, Check, Eye, EyeOff, Shield } from "lucide-react";
+import { CheckCircle2, KeyRound, Sparkles, Shield } from "lucide-react";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
 import { useAuth } from "@/hooks/use-auth";
+import { AGENT_TYPES, sourceLabel, sourceBadgeVariant, providerDisplayName } from "@/lib/agent-constants";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { RadioGroup } from "@/components/ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -31,8 +32,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
+import { RadioCard } from "@/components/radio-card";
 import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
-import { AVAILABLE_CLAUDE_CODE_MODELS, AVAILABLE_CODEX_MODELS, AVAILABLE_GEMINI_CLI_MODELS } from "@/lib/model-constants";
 import type {
   UserCredentialSummary,
   ResolvedCredential,
@@ -41,61 +42,6 @@ import type {
   OrgSettings,
   SingleResponse,
 } from "@/lib/types";
-
-/* ------------------------------------------------------------------ */
-/*  Constants                                                         */
-/* ------------------------------------------------------------------ */
-
-/** Key placeholder strings keyed by provider. */
-const KEY_PLACEHOLDERS: Record<string, string> = {
-  anthropic: "sk-ant-...",
-  openai: "sk-...",
-  gemini: "AIza...",
-};
-
-interface AgentEnvVar {
-  name: string;
-  label: string;
-  sensitive?: boolean;
-  placeholder?: string;
-  options?: string[];
-  advanced?: boolean;
-}
-
-const ORG_AGENT_TYPES: { key: string; label: string; description: string; providerKey: string; envVars: AgentEnvVar[] }[] = [
-  {
-    key: "codex",
-    label: "Codex",
-    description: "OpenAI Codex (GPT-5 models)",
-    providerKey: "openai",
-    envVars: [
-      { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
-      { name: "OPENAI_MODEL", label: "Default model", options: [...AVAILABLE_CODEX_MODELS] },
-      { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)", advanced: true },
-    ],
-  },
-  {
-    key: "claude_code",
-    label: "Claude Code",
-    description: "Anthropic Claude (Opus, Sonnet, Haiku)",
-    providerKey: "anthropic",
-    envVars: [
-      { name: "ANTHROPIC_API_KEY", label: "API Key", sensitive: true },
-      { name: "ANTHROPIC_MODEL", label: "Default model", options: [...AVAILABLE_CLAUDE_CODE_MODELS] },
-      { name: "ANTHROPIC_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)", advanced: true },
-    ],
-  },
-  {
-    key: "gemini_cli",
-    label: "Gemini CLI",
-    description: "Google Gemini (Pro, Flash)",
-    providerKey: "gemini",
-    envVars: [
-      { name: "GEMINI_API_KEY", label: "API Key", sensitive: true },
-      { name: "GEMINI_MODEL", label: "Default model", options: [...AVAILABLE_GEMINI_CLI_MODELS] },
-    ],
-  },
-];
 
 const DEFAULT_EXECUTION_SETTINGS: Pick<
   Required<OrgSettings>,
@@ -107,76 +53,6 @@ const DEFAULT_EXECUTION_SETTINGS: Pick<
 };
 
 /* ------------------------------------------------------------------ */
-/*  Shared RadioCard component                                        */
-/* ------------------------------------------------------------------ */
-
-function RadioCard({
-  value,
-  label,
-  description,
-  selected,
-  icon,
-  ariaLabel,
-}: {
-  value: string;
-  label: string;
-  description?: string;
-  selected: boolean;
-  icon?: ReactNode;
-  ariaLabel?: string;
-}) {
-  const indent = icon ? "pl-10" : "pl-6";
-  return (
-    <label
-      className={`relative flex cursor-pointer flex-col rounded-lg border p-3 shadow-sm transition-all duration-150 ${
-        selected
-          ? "border-primary bg-primary/5 ring-1 ring-primary/20 dark:shadow-[var(--glow-primary-sm)]"
-          : "border-input hover:bg-muted/40 hover:border-border"
-      }`}
-    >
-      <div className="flex items-center gap-2">
-        <RadioGroupItem value={value} {...(ariaLabel ? { "aria-label": ariaLabel } : {})} />
-        {icon}
-        <span className="text-[13px] font-medium">{label}</span>
-      </div>
-      {description && (
-        <span className={`mt-1 ${indent} text-xs text-muted-foreground`}>
-          {description}
-        </span>
-      )}
-    </label>
-  );
-}
-
-/* ------------------------------------------------------------------ */
-/*  Helpers                                                           */
-/* ------------------------------------------------------------------ */
-
-function sourceLabel(source: string): string {
-  switch (source) {
-    case "personal": return "Your key";
-    case "team_default": return "Team default";
-    case "org": return "Organization";
-    default: return "Not configured";
-  }
-}
-
-function sourceBadgeVariant(source: string): "success" | "secondary" | "outline" | "destructive" {
-  switch (source) {
-    case "personal": return "success";
-    case "team_default":
-    case "org": return "secondary";
-    default: return "outline";
-  }
-}
-
-/** Resolve a provider key to a display name. */
-function providerDisplayName(providerKey: string): string {
-  const agent = ORG_AGENT_TYPES.find((a) => a.providerKey === providerKey);
-  return agent?.label ?? providerKey;
-}
-
-/* ------------------------------------------------------------------ */
 /*  Page                                                              */
 /* ------------------------------------------------------------------ */
 
@@ -185,13 +61,7 @@ export default function AgentPage() {
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
 
-  /* ---------- Personal credentials queries ---------- */
-
-  const { data: personalResp, isSuccess: personalCredsLoaded } = useQuery<ListResponse<UserCredentialSummary>>({
-    queryKey: ["user-credentials", "personal"],
-    queryFn: () => api.userCredentials.listPersonal(),
-  });
-  const personalCreds = useMemo(() => personalResp?.data ?? [], [personalResp?.data]);
+  /* ---------- Credentials queries ---------- */
 
   const { data: resolvedResp } = useQuery<ListResponse<ResolvedCredential>>({
     queryKey: ["user-credentials", "resolved"],
@@ -206,53 +76,7 @@ export default function AgentPage() {
   });
   const teamDefaults = useMemo(() => teamResp?.data ?? [], [teamResp?.data]);
 
-  /* ---------- Personal credentials state ---------- */
-
-  // Default to the first agent that already has a configured key, or claude_code.
-  // Returns null until credentials have loaded to avoid a flash of the wrong agent.
-  const initialPersonalAgent = useMemo(() => {
-    if (!personalCredsLoaded) return null;
-    const configured = ORG_AGENT_TYPES.find((a) =>
-      personalCreds.some((c) => c.provider === a.providerKey && c.configured),
-    );
-    return configured?.key ?? "codex";
-  }, [personalCreds, personalCredsLoaded]);
-
-  const [personalAgentType, setPersonalAgentType] = useState<string | null>(null);
-  const effectivePersonalAgentType = personalAgentType ?? initialPersonalAgent ?? "codex";
-  const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
-  const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
-  const [keySaveStatus, setKeySaveStatus] = useState<Record<string, "idle" | "saving" | "success" | "error">>({});
-  const [removingProvider, setRemovingProvider] = useState<string | null>(null);
   const [removingTeamProvider, setRemovingTeamProvider] = useState<string | null>(null);
-  const [personalCodexMethodOverride, setPersonalCodexMethodOverride] = useState<"chatgpt" | "api_key" | null>(null);
-
-  const upsertMutation = useMutation({
-    mutationFn: ({ provider, apiKey }: { provider: string; apiKey: string }) =>
-      api.userCredentials.upsertPersonal(provider, { api_key: apiKey }),
-    onSuccess: (_data, variables) => {
-      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
-      setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "success" }));
-      setApiKeys((prev) => ({ ...prev, [variables.provider]: "" }));
-      setTimeout(() => setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" })), 2000);
-    },
-    onError: (err, variables) => {
-      captureError(err, { feature: "agent-key-save" });
-      setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "error" }));
-      setTimeout(() => setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" })), 3000);
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: (provider: string) => api.userCredentials.deletePersonal(provider),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
-      setRemovingProvider(null);
-    },
-    onError: (error) => {
-      captureError(error, { feature: "agent-key-delete" });
-    },
-  });
 
   const removeTeamMutation = useMutation({
     mutationFn: (provider: string) => api.userCredentials.removeTeamDefault(provider),
@@ -265,32 +89,12 @@ export default function AgentPage() {
     },
   });
 
-  const setTeamDefaultMutation = useMutation({
-    mutationFn: ({ provider, userId }: { provider: string; userId: string }) =>
-      api.userCredentials.setTeamDefault(provider, userId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
-    },
-  });
-
   const { data: codexAuthStatusResp } = useQuery({
     queryKey: ["codex-auth-status"],
     queryFn: () => api.codexAuth.status(),
     refetchInterval: false,
   });
   const codexAuthStatus = codexAuthStatusResp?.data;
-
-  const hasCodexChatGPTConnection = codexAuthStatus?.status === "completed";
-  const inferredPersonalCodexMethod: "chatgpt" | "api_key" =
-    hasCodexChatGPTConnection ? "chatgpt" : "api_key";
-  const personalCodexMethod = personalCodexMethodOverride ?? inferredPersonalCodexMethod;
-
-  function handleSavePersonalKey(provider: string) {
-    const key = apiKeys[provider]?.trim();
-    if (!key) return;
-    setKeySaveStatus((prev) => ({ ...prev, [provider]: "saving" }));
-    upsertMutation.mutate({ provider, apiKey: key });
-  }
 
   /* ---------- Org settings queries (admin-gated) ---------- */
 
@@ -479,130 +283,8 @@ export default function AgentPage() {
     );
   }
 
-  function renderPersonalCredentialCard(): ReactNode {
-    const agent = ORG_AGENT_TYPES.find((a) => a.key === effectivePersonalAgentType) ?? ORG_AGENT_TYPES[0];
-    const providerKey = agent.providerKey;
-    const cred = personalCreds.find((c) => c.provider === providerKey);
-    const status = keySaveStatus[providerKey] ?? "idle";
-    const r = resolved.find((c) => c.provider === providerKey);
-    const source = r?.source ?? "none";
-    const isCodex = agent.key === "codex";
-    const hideApiKey = isCodex && personalCodexMethod === "chatgpt";
-
-    return (
-      <div className="space-y-3 border-t pt-3 mt-1">
-        {renderAgentConfigHeader({
-          title: agent.label,
-          badges: (
-            <>
-              {cred?.configured && (
-                <Badge variant="success" className="text-xs px-1.5 py-0">
-                  <Check className="mr-0.5 h-3 w-3" />
-                  Configured
-                </Badge>
-              )}
-              <Badge variant={sourceBadgeVariant(source)} className="text-xs px-1.5 py-0">
-                {sourceLabel(source)}
-              </Badge>
-            </>
-          ),
-          action: cred?.configured ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="text-xs text-muted-foreground"
-              onClick={() => setRemovingProvider(providerKey)}
-              disabled={deleteMutation.isPending}
-            >
-              Remove
-            </Button>
-          ) : undefined,
-        })}
-
-        {isCodex && renderCodexCredentialToggle({
-          method: personalCodexMethod,
-          onMethodChange: setPersonalCodexMethodOverride,
-        })}
-
-        {cred?.configured && cred.masked_key && !hideApiKey && (
-          <p className="text-xs text-muted-foreground font-mono">
-            Key: {cred.masked_key}
-          </p>
-        )}
-
-        {!hideApiKey && (
-          <div className="flex gap-2">
-            <div className="relative flex-1">
-              <Input
-                type={showKeys[providerKey] ? "text" : "password"}
-                placeholder={cred?.configured ? "Replace existing key..." : KEY_PLACEHOLDERS[providerKey] ?? "API key"}
-                value={apiKeys[providerKey] ?? ""}
-                onChange={(e) =>
-                  setApiKeys((prev) => ({ ...prev, [providerKey]: e.target.value }))
-                }
-                className="pr-9 font-mono text-xs"
-              />
-              <button
-                type="button"
-                onClick={() =>
-                  setShowKeys((prev) => ({ ...prev, [providerKey]: !prev[providerKey] }))
-                }
-                className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-              >
-                {showKeys[providerKey] ? (
-                  <EyeOff className="h-3.5 w-3.5" />
-                ) : (
-                  <Eye className="h-3.5 w-3.5" />
-                )}
-              </button>
-            </div>
-            <Button
-              size="sm"
-              onClick={() => handleSavePersonalKey(providerKey)}
-              disabled={!apiKeys[providerKey]?.trim() || status === "saving"}
-            >
-              {status === "saving" ? "Saving..." : "Save key"}
-            </Button>
-          </div>
-        )}
-
-        {hideApiKey && (
-          <p className="text-xs text-muted-foreground">
-            API key fields are hidden while ChatGPT sign-in is selected.
-          </p>
-        )}
-
-        {status === "success" && (
-          <p className="text-xs text-emerald-600 dark:text-emerald-400">Key saved successfully.</p>
-        )}
-        {status === "error" && (
-          <p className="text-xs text-destructive">Failed to save key.</p>
-        )}
-
-        {isAdmin && cred?.configured && !cred.is_team_default && user && (
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-xs"
-            onClick={() => setTeamDefaultMutation.mutate({ provider: providerKey, userId: user.id })}
-            disabled={setTeamDefaultMutation.isPending}
-          >
-            <Shield className="mr-1 h-3 w-3" />
-            Set as team default
-          </Button>
-        )}
-        {cred?.is_team_default && (
-          <Badge variant="secondary" className="text-xs px-1.5 py-0">
-            <Shield className="mr-0.5 h-3 w-3" />
-            Team default
-          </Badge>
-        )}
-      </div>
-    );
-  }
-
   function renderOrgAgentConfigCard(): ReactNode {
-    const agent = ORG_AGENT_TYPES.find((a) => a.key === defaultAgentType) ?? ORG_AGENT_TYPES[0];
+    const agent = AGENT_TYPES.find((a) => a.key === defaultAgentType) ?? AGENT_TYPES[0];
     const serverVars = (agentDefaultsResponse?.data ?? {})[agent.key] ?? {};
     const teamCred = teamDefaults.find((c) => c.provider === agent.providerKey);
     const r = resolved.find((c) => c.provider === agent.providerKey);
@@ -748,53 +430,11 @@ export default function AgentPage() {
       <div className="space-y-8">
         <PageHeader
           title="Coding agents"
-          description="Configure coding agent credentials and execution behavior."
+          description="Configure organization agent defaults and execution behavior."
         />
 
         {/* ============================================================ */}
-        {/*  SECTION 1 — My coding agents (personal credentials)        */}
-        {/* ============================================================ */}
-        <section className="space-y-3">
-          <div>
-            <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-              My coding agents
-            </h2>
-            <p className="text-xs text-muted-foreground mt-1">
-              Your personal API keys. Personal keys are used first, falling back to organization defaults.
-            </p>
-          </div>
-
-          <Card>
-            <CardContent>
-              <div className="space-y-3">
-                <RadioGroup
-                  value={effectivePersonalAgentType}
-                  onValueChange={setPersonalAgentType}
-                  className="grid grid-cols-3 gap-3"
-                >
-                  {ORG_AGENT_TYPES.map((agent) => {
-                    const cred = personalCreds.find((c) => c.provider === agent.providerKey);
-                    return (
-                      <RadioCard
-                        key={agent.key}
-                        value={agent.key}
-                        label={agent.label}
-                        selected={effectivePersonalAgentType === agent.key}
-                        icon={cred?.configured ? <Check className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" /> : undefined}
-                      />
-                    );
-                  })}
-                </RadioGroup>
-
-                {/* Credential details for the selected personal agent */}
-                {personalCredsLoaded && renderPersonalCredentialCard()}
-              </div>
-            </CardContent>
-          </Card>
-        </section>
-
-        {/* ============================================================ */}
-        {/*  SECTION 2 — Organization coding agents (admin only)        */}
+        {/*  SECTION 1 — Organization coding agents (admin only)        */}
         {/* ============================================================ */}
         {isAdmin && (
           <section className="space-y-3">
@@ -816,7 +456,7 @@ export default function AgentPage() {
                     onValueChange={(value) => setDefaultAgentTypeOverride(value as OrgSettings["default_agent_type"])}
                     className="grid grid-cols-3 gap-3"
                   >
-                    {ORG_AGENT_TYPES.map((agent) => (
+                    {AGENT_TYPES.map((agent) => (
                       <RadioCard
                         key={agent.key}
                         value={agent.key}
@@ -933,30 +573,6 @@ export default function AgentPage() {
           </div>
         </div>
       )}
-
-      {/* Remove Personal Key Dialog */}
-      <AlertDialog open={!!removingProvider} onOpenChange={(open) => !open && setRemovingProvider(null)}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Remove API key</AlertDialogTitle>
-            <AlertDialogDescription>
-              Are you sure you want to remove your {providerDisplayName(removingProvider ?? "")} API key?
-              Sessions will fall back to the team default or organization key.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                if (removingProvider) deleteMutation.mutate(removingProvider);
-              }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Remove
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
 
       {/* Remove Team Default Dialog */}
       <AlertDialog open={!!removingTeamProvider} onOpenChange={(open) => !open && setRemovingTeamProvider(null)}>

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -4,18 +4,12 @@ import SettingsPage from './page';
 
 const {
   settingsGetMock,
-  githubStatusGetMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
       name: 'Test Org',
       settings: {},
     },
-  }),
-  githubStatusGetMock: vi.fn().mockResolvedValue({
-    connected: false,
-    has_repo_scope: false,
-    pr_authorship_mode: 'user_preferred',
   }),
 }));
 
@@ -24,16 +18,7 @@ vi.mock('@/lib/api', () => ({
     settings: {
       get: settingsGetMock,
     },
-    githubStatus: {
-      get: githubStatusGetMock,
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-    },
   },
-}));
-
-vi.mock('next-themes', () => ({
-  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
 }));
 
 describe('SettingsPage', () => {
@@ -47,11 +32,11 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('renders the General section with organization name', async () => {
+  it('renders the Organization section with organization name', async () => {
     renderWithProviders(<SettingsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('General')).toBeInTheDocument();
+      expect(screen.getByText('Organization')).toBeInTheDocument();
     });
 
     expect(screen.getByLabelText('Organization name')).toBeInTheDocument();
@@ -78,16 +63,5 @@ describe('SettingsPage', () => {
     await waitFor(() => {
       expect(screen.getByLabelText('Organization name')).toBeDisabled();
     });
-  });
-
-  it('renders the Appearance section with theme selector', async () => {
-    renderWithProviders(<SettingsPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText('Appearance')).toBeInTheDocument();
-    });
-
-    expect(screen.getByText('Theme')).toBeInTheDocument();
-    expect(screen.getByText('Select your preferred color scheme')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -2,83 +2,14 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
-import { ThemeSelect } from "@/components/theme-select";
 import { useAuth } from "@/hooks/use-auth";
 import type { Organization, OrgSettings, SingleResponse } from "@/lib/types";
-
-function GitHubPRConnection() {
-  const queryClient = useQueryClient();
-  const { data: ghStatus, isLoading } = useQuery({
-    queryKey: ["github-status"],
-    queryFn: () => api.githubStatus.get(),
-  });
-  const disconnectMutation = useMutation({
-    mutationFn: () => api.githubStatus.disconnect(),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["github-status"] }),
-  });
-
-  if (isLoading) return null;
-
-  return (
-    <section className="space-y-3">
-      <h2 className="text-[13px] font-medium text-foreground">Pull requests</h2>
-      <Card>
-        <CardContent>
-          <div className="flex items-center justify-between">
-            <div className="space-y-0.5">
-              <Label>GitHub connection for PRs</Label>
-              <p className="text-[13px] text-muted-foreground">
-                {ghStatus?.connected && ghStatus?.has_repo_scope
-                  ? `Connected as @${ghStatus.github_login} — PRs will be authored by you`
-                  : ghStatus?.connected && !ghStatus?.has_repo_scope
-                    ? `Connected as @${ghStatus.github_login} — missing repo access, reconnect to author PRs`
-                    : "Connect your GitHub account to create PRs under your name"}
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              {ghStatus?.connected ? (
-                <>
-                  {!ghStatus.has_repo_scope && (
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => api.githubStatus.connect()}
-                    >
-                      Reconnect
-                    </Button>
-                  )}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => disconnectMutation.mutate()}
-                    disabled={disconnectMutation.isPending}
-                  >
-                    Disconnect
-                  </Button>
-                </>
-              ) : (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => api.githubStatus.connect()}
-                >
-                  Connect GitHub
-                </Button>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </section>
-  );
-}
 
 const PR_AUTHORSHIP_OPTIONS = [
   { value: "user_preferred", label: "User preferred", description: "Use the user's GitHub token when available, fall back to the 143 app" },
@@ -173,28 +104,9 @@ export default function SettingsPage() {
           filters={{ resource_type: "settings" }}
           title="Settings activity"
         />
-        <section className="space-y-3">
-          <h2 className="text-[13px] font-medium text-foreground">Appearance</h2>
-          <Card>
-            <CardContent>
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <Label>Theme</Label>
-                  <p className="text-[13px] text-muted-foreground">
-                    Select your preferred color scheme
-                  </p>
-                </div>
-                <ThemeSelect />
-              </div>
-            </CardContent>
-          </Card>
-        </section>
-
-        <GitHubPRConnection />
-        {user?.role === "admin" && <PRAuthorshipSettings />}
 
         <section className="space-y-3">
-          <h2 className="text-[13px] font-medium text-foreground">General</h2>
+          <h2 className="text-[13px] font-medium text-foreground">Organization</h2>
           <Card>
             <CardContent>
               <div className="max-w-[560px] space-y-2">
@@ -209,6 +121,8 @@ export default function SettingsPage() {
             </CardContent>
           </Card>
         </section>
+
+        {user?.role === "admin" && <PRAuthorshipSettings />}
       </div>
     </PageContainer>
   );

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -91,6 +91,7 @@ describe("AuthenticatedLayout", () => {
     // Expand the settings section
     await user.click(screen.getByRole("button", { name: /Settings/ }));
 
+    expect(screen.getByRole("link", { name: "Account" })).toHaveAttribute("href", "/settings/account");
     expect(screen.getByRole("link", { name: "General" })).toHaveAttribute("href", "/settings");
     expect(screen.getByRole("link", { name: "Integrations" })).toHaveAttribute("href", "/settings/integrations");
     expect(screen.getByRole("link", { name: "Coding agents" })).toHaveAttribute("href", "/settings/agent");

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -3,6 +3,7 @@ import {
   Play,
   FolderKanban,
   Settings,
+  CircleUser,
   Users,
   Plug,
   Bot,
@@ -36,9 +37,10 @@ export const staticActions: PaletteAction[] = [
   { id: "nav-projects", label: "Projects", icon: FolderKanban, href: "/projects", preserveRepo: true, group: "navigation" },
 
   // Settings & admin
+  { id: "settings-account", label: "Account", icon: CircleUser, href: "/settings/account", group: "settings" },
   { id: "settings-general", label: "General", icon: Settings, href: "/settings", group: "settings" },
   { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/settings/integrations", group: "settings" },
-  { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", group: "settings" },
+  { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", requiredRole: "admin", group: "settings" },
   { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/settings/llm", group: "settings" },
   { id: "settings-autopilot", label: "Autopilot settings", icon: Target, href: "/settings/autopilot", group: "settings" },
   { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", group: "settings" },

--- a/frontend/src/components/radio-card.tsx
+++ b/frontend/src/components/radio-card.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { RadioGroupItem } from "@/components/ui/radio-group";
+
+export function RadioCard({
+  value,
+  label,
+  description,
+  selected,
+  icon,
+  ariaLabel,
+}: {
+  value: string;
+  label: string;
+  description?: string;
+  selected: boolean;
+  icon?: ReactNode;
+  ariaLabel?: string;
+}) {
+  const indent = icon ? "pl-10" : "pl-6";
+  return (
+    <label
+      className={`relative flex cursor-pointer flex-col rounded-lg border p-3 shadow-sm transition-all duration-150 ${
+        selected
+          ? "border-primary bg-primary/5 ring-1 ring-primary/20 dark:shadow-[var(--glow-primary-sm)]"
+          : "border-input hover:bg-muted/40 hover:border-border"
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <RadioGroupItem value={value} {...(ariaLabel ? { "aria-label": ariaLabel } : {})} />
+        {icon}
+        <span className="text-[13px] font-medium">{label}</span>
+      </div>
+      {description && (
+        <span className={`mt-1 ${indent} text-xs text-muted-foreground`}>
+          {description}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import {
   Settings,
+  CircleUser,
   Plug,
   Bot,
   Sparkles,
@@ -35,16 +36,16 @@ interface SettingsGroup {
 
 const settingsGroups: SettingsGroup[] = [
   {
-    label: null,
+    label: "PERSONAL",
     items: [
-      { label: "General", icon: Settings, href: "/settings" },
+      { label: "Account", icon: CircleUser, href: "/settings/account" },
     ],
   },
   {
     label: "PLATFORM",
     items: [
       { label: "Integrations", icon: Plug, href: "/settings/integrations" },
-      { label: "Coding agents", icon: Bot, href: "/settings/agent" },
+      { label: "Coding agents", icon: Bot, href: "/settings/agent", adminOnly: true },
       { label: "LLM", icon: Sparkles, href: "/settings/llm" },
       { label: "Autopilot settings", icon: Target, href: "/settings/autopilot" },
       { label: "Evals", icon: FlaskConical, href: "/settings/evals" },
@@ -53,6 +54,7 @@ const settingsGroups: SettingsGroup[] = [
   {
     label: "ORGANIZATION",
     items: [
+      { label: "General", icon: Settings, href: "/settings" },
       { label: "Team", icon: Users, href: "/settings/team" },
       { label: "Audit log", icon: ScrollText, href: "/settings/audit-log", adminOnly: true },
     ],

--- a/frontend/src/lib/agent-constants.ts
+++ b/frontend/src/lib/agent-constants.ts
@@ -1,0 +1,82 @@
+import { AVAILABLE_CLAUDE_CODE_MODELS, AVAILABLE_CODEX_MODELS, AVAILABLE_GEMINI_CLI_MODELS } from "@/lib/model-constants";
+
+export interface AgentEnvVar {
+  name: string;
+  label: string;
+  sensitive?: boolean;
+  placeholder?: string;
+  options?: string[];
+  advanced?: boolean;
+}
+
+export interface AgentType {
+  key: string;
+  label: string;
+  description: string;
+  providerKey: string;
+  envVars: AgentEnvVar[];
+}
+
+export const AGENT_TYPES: AgentType[] = [
+  {
+    key: "codex",
+    label: "Codex",
+    description: "OpenAI Codex (GPT-5 models)",
+    providerKey: "openai",
+    envVars: [
+      { name: "OPENAI_API_KEY", label: "API Key", sensitive: true },
+      { name: "OPENAI_MODEL", label: "Default model", options: [...AVAILABLE_CODEX_MODELS] },
+      { name: "OPENAI_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)", advanced: true },
+    ],
+  },
+  {
+    key: "claude_code",
+    label: "Claude Code",
+    description: "Anthropic Claude (Opus, Sonnet, Haiku)",
+    providerKey: "anthropic",
+    envVars: [
+      { name: "ANTHROPIC_API_KEY", label: "API Key", sensitive: true },
+      { name: "ANTHROPIC_MODEL", label: "Default model", options: [...AVAILABLE_CLAUDE_CODE_MODELS] },
+      { name: "ANTHROPIC_BASE_URL", label: "Base URL", placeholder: "Custom API endpoint (optional)", advanced: true },
+    ],
+  },
+  {
+    key: "gemini_cli",
+    label: "Gemini CLI",
+    description: "Google Gemini (Pro, Flash)",
+    providerKey: "gemini",
+    envVars: [
+      { name: "GEMINI_API_KEY", label: "API Key", sensitive: true },
+      { name: "GEMINI_MODEL", label: "Default model", options: [...AVAILABLE_GEMINI_CLI_MODELS] },
+    ],
+  },
+];
+
+export const KEY_PLACEHOLDERS: Record<string, string> = {
+  anthropic: "sk-ant-...",
+  openai: "sk-...",
+  gemini: "AIza...",
+};
+
+export function sourceLabel(source: string): string {
+  switch (source) {
+    case "personal": return "Your key";
+    case "team_default": return "Team default";
+    case "org": return "Organization";
+    default: return "Not configured";
+  }
+}
+
+export function sourceBadgeVariant(source: string): "success" | "secondary" | "outline" | "destructive" {
+  switch (source) {
+    case "personal": return "success";
+    case "team_default":
+    case "org": return "secondary";
+    default: return "outline";
+  }
+}
+
+export function providerDisplayName(providerKey: string): string {
+  const agent = AGENT_TYPES.find((a) => a.providerKey === providerKey);
+  return agent?.label ?? providerKey;
+}


### PR DESCRIPTION
## Summary
- Adds a new **Account** page (`/settings/account`) under a PERSONAL nav group for user-specific settings: theme, GitHub PR connection, and personal agent API keys
- Moves **General settings** into the ORGANIZATION nav group (keeping org name + PR defaults) and removes personal settings from it
- Removes the personal credentials section from the **Coding Agents** page, making it admin-only (org agent config + execution settings)
- Extracts shared constants (`AGENT_TYPES`, helpers) into `lib/agent-constants.ts` and `RadioCard` into its own component to eliminate duplication
- Updates sidebar navigation, command palette, and all related tests

## Test plan
- [ ] Verify Account page renders theme selector, GitHub connection, and personal agent credentials
- [ ] Verify General settings page shows only org name and PR defaults
- [ ] Verify Coding agents page is hidden from non-admin users in sidebar
- [ ] Verify sidebar shows PERSONAL / PLATFORM / ORGANIZATION grouping

🤖 Generated with [Claude Code](https://claude.com/claude-code)