### PR TITLE
Fix negative time stamp error in performance.measure

### DIFF
--- a/frontend/sentry.client.config.ts
+++ b/frontend/sentry.client.config.ts
@@ -1,5 +1,24 @@
 import * as Sentry from "@sentry/nextjs";
 
+// Patch performance.measure to suppress "negative time stamp" errors thrown by
+// Sentry's BrowserTracing integration when it instruments React component renders.
+if (typeof window !== "undefined" && window.performance?.measure) {
+  const originalMeasure = window.performance.measure.bind(window.performance);
+  window.performance.measure = (...args: Parameters<Performance["measure"]>) => {
+    try {
+      return originalMeasure(...args);
+    } catch (e) {
+      if (
+        e instanceof DOMException &&
+        e.message.includes("negative time stamp")
+      ) {
+        return undefined as unknown as PerformanceMeasure;
+      }
+      throw e;
+    }
+  };
+}
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   enabled: !!process.env.NEXT_PUBLIC_SENTRY_DSN,


### PR DESCRIPTION
## Summary
- Patches performance.measure in the Sentry client config to catch and suppress DOMException errors with negative time stamp messages
- Sentry BrowserTracing integration (auto-enabled by tracesSampleRate) instruments React component renders via performance.measure(), which can throw when timestamps go negative during hydration or when tabs are backgrounded
- Only suppresses this specific error; all other exceptions are re-thrown

## Test plan
- [ ] Load the sessions page and verify the negative time stamp console error no longer appears
- [ ] Verify Sentry error reporting still works for real errors