### PR TITLE
Separate platform LLM from agent credentials

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -107,10 +107,13 @@ func main() {
 	userCredentialStore := db.NewUserCredentialStore(pool, cryptoSvc)
 	codexAuthSvc := codexauth.NewService(credentialStore, logger)
 
-	// LLM client (shared between router and worker services).
-	llmClient, err := llm.NewClient(cfg.LLMConfig(), logger)
+	// Platform LLM client for internal features (titles, PR descriptions, project
+	// generation, validation, prioritization). Uses the cheap PLATFORM_LLM_MODEL.
+	llmClient, err := llm.NewClient(cfg.PlatformLLMConfig(), logger)
 	if err != nil {
-		logger.Warn().Err(err).Msg("LLM client initialization failed — LLM-dependent features will be unavailable")
+		logger.Warn().Err(err).Msg("Platform LLM client initialization failed — LLM-dependent features will be unavailable")
+	} else {
+		logger.Info().Str("model", cfg.PlatformLLMModel).Msg("Platform LLM client initialized for internal features")
 	}
 
 	// Create file reader for sandbox file browsing (optional — gracefully degrades
@@ -320,10 +323,10 @@ func buildServices(
 		}
 	}
 
-	// LLM client (optional — validation/prioritization degrade gracefully without it).
-	llmClient, err := llm.NewClient(cfg.LLMConfig(), logger)
+	// Platform LLM client for worker internal features (validation, prioritization).
+	llmClient, err := llm.NewClient(cfg.PlatformLLMConfig(), logger)
 	if err != nil {
-		logger.Warn().Err(err).Msg("LLM client initialization failed — LLM-dependent checks will be skipped")
+		logger.Warn().Err(err).Msg("Platform LLM client initialization failed — LLM-dependent checks will be skipped")
 	}
 
 	// Agent adapters.

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -101,7 +101,7 @@ export function ManualSessionCreatePageContent() {
 
   const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
     queryKey: queryKeys.credentials.resolved,
-    queryFn: () => api.credentials.listResolved(),
+    queryFn: () => api.userCredentials.listResolved(),
   });
   const resolvedCredentials = useMemo(() => resolvedCredsResponse?.data ?? [], [resolvedCredsResponse]);
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -30,8 +30,9 @@ import { captureError } from "@/lib/errors";
 import { queryKeys } from "@/lib/query-keys";
 import { AGENT_TYPE_OPTIONS, agentTypeForModel } from "@/lib/model-constants";
 import { NoReposWarning } from "@/components/no-repos-warning";
+import { AgentKeyRequiredBanner } from "@/components/agent-key-required-banner";
 import { useOptimisticSessions } from "@/contexts/optimistic-sessions";
-import type { OrgSettings, Organization, Repository, SingleResponse, ListResponse } from "@/lib/types";
+import type { OrgSettings, Organization, Repository, SingleResponse, ListResponse, ResolvedCredential } from "@/lib/types";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -98,6 +99,17 @@ export function ManualSessionCreatePageContent() {
   });
   const repositories = useMemo(() => reposResponse?.data ?? [], [reposResponse]);
 
+  const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
+    queryKey: queryKeys.credentials.resolved,
+    queryFn: () => api.credentials.listResolved(),
+  });
+  const resolvedCredentials = useMemo(() => resolvedCredsResponse?.data ?? [], [resolvedCredsResponse]);
+
+  const { data: codexAuthResponse } = useQuery({
+    queryKey: queryKeys.codexAuth.status,
+    queryFn: () => api.codexAuth.status(),
+  });
+
   // Auto-select the only repo for single-repo orgs; otherwise use user's choice.
   const selectedRepoId = useMemo(() => {
     if (userSelectedRepoId !== null) return userSelectedRepoId;
@@ -139,6 +151,18 @@ export function ManualSessionCreatePageContent() {
       return AGENT_TYPE_OPTIONS.indexOf(a) - AGENT_TYPE_OPTIONS.indexOf(b);
     });
   }, [defaultAgentType]);
+
+  // Determine which agent type would be used and whether credentials exist.
+  const effectiveAgentType = selectedModel ? agentTypeForModel(selectedModel) ?? defaultAgentType : defaultAgentType;
+  const AGENT_PROVIDER_MAP: Record<string, string> = {
+    codex: "openai",
+    claude_code: "anthropic",
+    gemini_cli: "gemini",
+  };
+  const requiredProvider = AGENT_PROVIDER_MAP[effectiveAgentType] ?? "";
+  const hasAgentCredentials =
+    resolvedCredentials.some((c) => c.provider === requiredProvider)
+    || (effectiveAgentType === "codex" && codexAuthResponse?.data?.status === "completed");
 
   const createManualSessionMutation = useMutation({
     mutationFn: () =>
@@ -293,6 +317,15 @@ export function ManualSessionCreatePageContent() {
         <div className="shrink-0 px-4">
           <div className="w-full max-w-3xl mx-auto">
             <NoReposWarning />
+          </div>
+        </div>
+      )}
+
+      {/* Agent credentials warning */}
+      {!hasAgentCredentials && (
+        <div className="shrink-0 px-4">
+          <div className="w-full max-w-3xl mx-auto">
+            <AgentKeyRequiredBanner agentType={effectiveAgentType} />
           </div>
         </div>
       )}

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
-import { Check, Eye, EyeOff } from "lucide-react";
+import { AlertTriangle, Check, Eye, EyeOff } from "lucide-react";
 import {
   LLM_MODELS_BY_PROVIDER,
   LLM_PROVIDER_INFO,
@@ -65,11 +65,13 @@ export default function LLMPage() {
   const credentials = useMemo(() => credentialsResp?.data ?? [], [credentialsResp?.data]);
 
   // Fetch platform-level LLM defaults (to show fallback availability)
-  const { data: llmDefaultsResp } = useQuery<{ data: Record<string, string> }>({
+  const { data: llmDefaultsResp } = useQuery<{ data: Record<string, string>; platform_model?: string }>({
     queryKey: ["llm-defaults"],
     queryFn: () => api.settings.getLLMDefaults(),
   });
   const platformProviders = useMemo(() => llmDefaultsResp?.data ?? {}, [llmDefaultsResp?.data]);
+  const platformModel = llmDefaultsResp?.platform_model;
+  const hasPlatformLLM = Object.keys(platformProviders).length > 0;
 
   // Fetch available models from backend (source of truth)
   const { data: llmModelsResp } = useQuery<{ data: Record<string, string[]> }>({
@@ -210,15 +212,59 @@ export default function LLMPage() {
       <div className="space-y-6">
         <PageHeader
           title="LLM"
-          description="Configure the AI model used for validation, prioritization, and general intelligence."
+          description="Configure agent credentials and the AI model for your organization."
         />
 
-        {/* Provider API Keys */}
+        {/* Platform Intelligence (read-only) */}
         <section className="space-y-3">
-          <h2 className="text-[13px] font-medium text-foreground">Provider keys</h2>
+          <h2 className="text-[13px] font-medium text-foreground">Platform intelligence</h2>
+          <Card>
+            <CardContent>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm text-muted-foreground">
+                    These features are powered by the platform and work automatically. No configuration needed.
+                  </p>
+                  {hasPlatformLLM ? (
+                    <Badge variant="success" className="text-xs px-1.5 py-0 shrink-0">
+                      <Check className="mr-0.5 h-3 w-3" />
+                      Active
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary" className="text-xs px-1.5 py-0 shrink-0">
+                      <AlertTriangle className="mr-0.5 h-3 w-3" />
+                      Not configured
+                    </Badge>
+                  )}
+                </div>
+                <ul className="text-xs text-muted-foreground space-y-1 ml-1">
+                  <li>Session titles</li>
+                  <li>PR descriptions</li>
+                  <li>Project generation</li>
+                  <li>Validation checks</li>
+                  <li>Priority scoring</li>
+                </ul>
+                {platformModel && (
+                  <p className="text-xs text-muted-foreground">
+                    Model: <span className="font-mono">{platformModel}</span>
+                  </p>
+                )}
+                {!hasPlatformLLM && (
+                  <p className="text-xs text-amber-600 dark:text-amber-400">
+                    The platform administrator has not configured an LLM provider. These features will be unavailable.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* Agent Credentials */}
+        <section className="space-y-3">
+          <h2 className="text-[13px] font-medium text-foreground">Agent credentials</h2>
           <p className="text-xs text-muted-foreground">
-            Add your own API key for any provider below. If you don&apos;t configure a key, the platform
-            default will be used when available.
+            Add API keys for running coding agent sessions (Claude Code, Codex, Gemini CLI).
+            These keys are separate from the platform&apos;s built-in intelligence.
           </p>
           <div className="space-y-3">
             {LLM_PROVIDERS.map((provider) => {
@@ -238,11 +284,6 @@ export default function LLMPage() {
                               <Badge variant="success" className="text-xs px-1.5 py-0">
                                 <Check className="mr-0.5 h-3 w-3" />
                                 Configured
-                              </Badge>
-                            )}
-                            {!ps?.orgConfigured && ps?.platformAvailable && (
-                              <Badge variant="secondary" className="text-xs px-1.5 py-0">
-                                Platform default
                               </Badge>
                             )}
                           </div>

--- a/frontend/src/components/agent-key-required-banner.tsx
+++ b/frontend/src/components/agent-key-required-banner.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+const AGENT_LABELS: Record<string, string> = {
+  codex: "Codex",
+  claude_code: "Claude Code",
+  gemini_cli: "Gemini CLI",
+};
+
+export function AgentKeyRequiredBanner({ agentType }: { agentType: string }) {
+  const label = AGENT_LABELS[agentType] ?? agentType;
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3">
+      <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] text-amber-700 dark:text-amber-300">
+          No API key configured for {label}. Add your key in Settings to start sessions.
+        </p>
+      </div>
+      <Button size="sm" variant="outline" asChild className="shrink-0">
+        <Link href="/settings/agent">Configure keys</Link>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/components/autopilot/autopilot-helpers.ts
+++ b/frontend/src/components/autopilot/autopilot-helpers.ts
@@ -10,20 +10,16 @@ export const DEFAULT_PRIORITY_WEIGHTS: Required<NonNullable<OrgSettings["priorit
 export function isAgentConnected(
   agentType: NonNullable<OrgSettings["default_agent_type"]>,
   agentConfig: Record<string, Record<string, string>>,
-  agentDefaults: Record<string, Record<string, string>>,
   codexAuthStatus?: CodexAuthStatus | null,
 ): boolean {
   switch (agentType) {
     case "codex":
       return codexAuthStatus?.status === "completed"
-        || Boolean(agentConfig.codex?.OPENAI_API_KEY)
-        || Boolean(agentDefaults.codex?.OPENAI_API_KEY);
+        || Boolean(agentConfig.codex?.OPENAI_API_KEY);
     case "claude_code":
-      return Boolean(agentConfig.claude_code?.ANTHROPIC_API_KEY)
-        || Boolean(agentDefaults.claude_code?.ANTHROPIC_API_KEY);
+      return Boolean(agentConfig.claude_code?.ANTHROPIC_API_KEY);
     case "gemini_cli":
-      return Boolean(agentConfig.gemini_cli?.GEMINI_API_KEY)
-        || Boolean(agentDefaults.gemini_cli?.GEMINI_API_KEY);
+      return Boolean(agentConfig.gemini_cli?.GEMINI_API_KEY);
     default:
       return false;
   }

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -93,14 +93,14 @@ function AgentSelectionSection({ onConnectedChange }: { onConnectedChange?: (con
     {
       value: "claude_code",
       label: "Claude Code",
-      description: "Use your Anthropic API key for Claude-powered fixes.",
+      description: "Your own Anthropic API key is required for agent sessions. Platform keys are used for internal features only.",
       configureLabel: "Configure",
       ctaLabel: "Configure",
     },
     {
       value: "gemini_cli",
       label: "Gemini CLI",
-      description: "Use your Google Gemini API key for Gemini-powered fixes.",
+      description: "Your own Google Gemini API key is required for agent sessions. Platform keys are used for internal features only.",
       configureLabel: "Configure",
       ctaLabel: "Configure",
     },
@@ -120,18 +120,12 @@ function AgentSelectionSection({ onConnectedChange }: { onConnectedChange?: (con
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
-  const { data: agentDefaultsResponse } = useQuery({
-    queryKey: queryKeys.settings.agentDefaults,
-    queryFn: () => api.settings.getAgentDefaults(),
-  });
-
   const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const agentConfig = settings?.agent_config ?? {};
-  const agentDefaults = agentDefaultsResponse?.data ?? {};
 
   const selectedAgentType: AgentType = selectedAgentTypeOverride ?? settings?.default_agent_type ?? "codex";
 
-  const isSelectedAgentConnected = isAgentConnected(selectedAgentType, agentConfig, agentDefaults, codexAuthResponse?.data);
+  const isSelectedAgentConnected = isAgentConnected(selectedAgentType, agentConfig, codexAuthResponse?.data);
 
   const selectedAgent = agentOptions.find((agent) => agent.value === selectedAgentType) ?? agentOptions[0];
 

--- a/frontend/src/hooks/use-setup-status.ts
+++ b/frontend/src/hooks/use-setup-status.ts
@@ -12,11 +12,6 @@ export function useSetupStatus() {
     queryFn: () => api.settings.get(),
   });
 
-  const { data: agentDefaultsResponse, isLoading: agentDefaultsLoading } = useQuery({
-    queryKey: queryKeys.settings.agentDefaults,
-    queryFn: () => api.settings.getAgentDefaults(),
-  });
-
   const { data: codexAuthStatusResponse, isLoading: codexAuthLoading } = useQuery({
     queryKey: queryKeys.codexAuth.status,
     queryFn: () => api.codexAuth.status(),
@@ -35,16 +30,15 @@ export function useSetupStatus() {
   const rawSettings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const defaultAgent = rawSettings?.default_agent_type ?? "codex";
   const agentConfig = rawSettings?.agent_config ?? {};
-  const agentDefaults = agentDefaultsResponse?.data ?? {};
 
-  const agentConnected = isAgentConnected(defaultAgent, agentConfig, agentDefaults, codexAuthStatusResponse?.data);
+  const agentConnected = isAgentConnected(defaultAgent, agentConfig, codexAuthStatusResponse?.data);
 
   const integrations = integrationsResponse?.data ?? [];
   const repositories = repositoriesResponse?.data ?? [];
   const githubReady = integrations.some((i) => i.provider === "github" && i.status === "active")
     && repositories.length > 0;
 
-  const isLoading = settingsLoading || agentDefaultsLoading || codexAuthLoading || integrationsLoading || repositoriesLoading;
+  const isLoading = settingsLoading || codexAuthLoading || integrationsLoading || repositoriesLoading;
   const isSetupComplete = agentConnected && githubReady;
 
   return {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -282,7 +282,7 @@ export const api = {
     get: () => get<import('./types').SingleResponse<import('./types').Organization>>('/api/v1/settings'),
     update: (data: Record<string, unknown>) => patch<import('./types').SingleResponse<import('./types').Organization>>('/api/v1/settings', data),
     getAgentDefaults: () => get<{ data: Record<string, Record<string, string>> }>('/api/v1/settings/agent-defaults'),
-    getLLMDefaults: () => get<{ data: Record<string, string> }>('/api/v1/settings/llm-defaults'),
+    getLLMDefaults: () => get<{ data: Record<string, string>; platform_model?: string }>('/api/v1/settings/llm-defaults'),
     getLLMModels: () => get<{ data: Record<string, string[]> }>('/api/v1/settings/llm-models'),
   },
   credentials: {

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -33,6 +33,10 @@ export const queryKeys = {
     all: ["settings"] as const,
     agentDefaults: ["agent-defaults"] as const,
   },
+  credentials: {
+    all: ["credentials"] as const,
+    resolved: ["credentials", "resolved"] as const,
+  },
   codexAuth: {
     status: ["codex-auth-status"] as const,
   },

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -13,6 +13,7 @@ type SettingsHandler struct {
 	orgStore      *db.OrganizationStore
 	agentDefaults map[string]map[string]string
 	llmDefaults   map[string]string // provider name → masked key (from server env)
+	platformModel string            // cheap model used for internal features (e.g. "gpt-5-nano")
 	audit         *db.AuditEmitter
 }
 
@@ -21,8 +22,8 @@ func (h *SettingsHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 	h.audit = audit
 }
 
-func NewSettingsHandler(orgStore *db.OrganizationStore, agentDefaults map[string]map[string]string, llmDefaults map[string]string) *SettingsHandler {
-	return &SettingsHandler{orgStore: orgStore, agentDefaults: agentDefaults, llmDefaults: llmDefaults}
+func NewSettingsHandler(orgStore *db.OrganizationStore, agentDefaults map[string]map[string]string, llmDefaults map[string]string, platformModel string) *SettingsHandler {
+	return &SettingsHandler{orgStore: orgStore, agentDefaults: agentDefaults, llmDefaults: llmDefaults, platformModel: platformModel}
 }
 
 func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +46,10 @@ func (h *SettingsHandler) GetAgentDefaults(w http.ResponseWriter, r *http.Reques
 // configured, with keys masked. This lets the frontend show whether a platform
 // fallback is available when the org hasn't configured their own key.
 func (h *SettingsHandler) GetLLMDefaults(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]any{"data": h.llmDefaults})
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data":           h.llmDefaults,
+		"platform_model": h.platformModel,
+	})
 }
 
 // GetLLMModels returns the available LLM models grouped by provider.

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -65,7 +65,7 @@ func TestSettingsHandler_Get(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, nil)
+			handler := NewSettingsHandler(store, nil, nil, "gpt-5-nano")
 
 			tt.setupMock(mock, orgID)
 
@@ -88,7 +88,7 @@ func TestSettingsHandler_GetAgentDefaults(t *testing.T) {
 	defaults := map[string]map[string]string{
 		"claude_code": {"ANTHROPIC_API_KEY": "sk-a••••test"},
 	}
-	handler := NewSettingsHandler(nil, defaults, nil)
+	handler := NewSettingsHandler(nil, defaults, nil, "gpt-5-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/agent-defaults", nil)
 	w := httptest.NewRecorder()
@@ -104,7 +104,7 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	defaults := map[string]string{
 		"anthropic": "sk-a••••test",
 	}
-	handler := NewSettingsHandler(nil, nil, defaults)
+	handler := NewSettingsHandler(nil, nil, defaults, "gpt-5-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -113,12 +113,14 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "should return 200 OK")
 	require.Contains(t, w.Body.String(), "anthropic", "response should contain provider name")
 	require.Contains(t, w.Body.String(), "sk-a", "response should contain masked key prefix")
+	require.Contains(t, w.Body.String(), "platform_model", "response should contain platform_model")
+	require.Contains(t, w.Body.String(), "gpt-5-nano", "response should contain platform model name")
 }
 
 func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, nil, map[string]string{})
+	handler := NewSettingsHandler(nil, nil, map[string]string{}, "gpt-5-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -134,7 +136,7 @@ func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 func TestSettingsHandler_GetLLMModels(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, nil, nil)
+	handler := NewSettingsHandler(nil, nil, nil, "gpt-5-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-models", nil)
 	w := httptest.NewRecorder()
@@ -291,7 +293,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, nil)
+			handler := NewSettingsHandler(store, nil, nil, "gpt-5-nano")
 
 			tt.setupMock(mock, orgID)
 

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -128,9 +128,12 @@ func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	handler.GetLLMDefaults(w, req)
 	require.Equal(t, http.StatusOK, w.Code, "should return 200 OK")
 
-	var resp map[string]map[string]string
+	var resp map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-	require.Empty(t, resp["data"], "should return empty map when no providers configured")
+	dataMap, ok := resp["data"].(map[string]any)
+	require.True(t, ok, "data should be a map")
+	require.Empty(t, dataMap, "should return empty map when no providers configured")
+	require.Equal(t, "gpt-5-nano", resp["platform_model"], "should return platform model")
 }
 
 func TestSettingsHandler_GetLLMModels(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -131,7 +131,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	webhookHandler := handlers.NewWebhookHandler(cfg, orgStore, userStore, repoStore, integrationStore, prService)
 	containerUsageStore := db.NewContainerUsageStore(pool)
 	usageHandler := handlers.NewUsageHandler(containerUsageStore)
-	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeAgentEnv(), cfg.SafeLLMEnv())
+	platformModel := cfg.PlatformLLMModel
+	if platformModel == "" {
+		platformModel = "gpt-5-nano"
+	}
+	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeAgentEnv(), cfg.SafeLLMEnv(), platformModel)
 	issueHandler := handlers.NewIssueHandler(issueStore)
 	sessionMessageStore := db.NewSessionMessageStore(pool)
 	sessionThreadStore := db.NewSessionThreadStore(pool)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	// LLM
 	LLMModel           string `env:"LLM_MODEL"`
 	LLMReasoningEffort string `env:"LLM_REASONING_EFFORT"`
+	PlatformLLMModel   string `env:"PLATFORM_LLM_MODEL"    envDefault:"gpt-5-nano"`
 	AnthropicAPIKey    string `env:"ANTHROPIC_API_KEY"`
 	AnthropicBaseURL  string `env:"ANTHROPIC_BASE_URL"`
 	AnthropicModel    string `env:"ANTHROPIC_MODEL"`
@@ -157,6 +158,26 @@ func Load() *Config {
 func (c *Config) LLMConfig() llm.Config {
 	return llm.Config{
 		Model:             llm.ModelName(c.LLMModel),
+		ReasoningEffort:   llm.ReasoningEffort(c.LLMReasoningEffort),
+		AnthropicAPIKey:   c.AnthropicAPIKey,
+		AnthropicBaseURL:  c.AnthropicBaseURL,
+		OpenAIAPIKey:      c.OpenAIAPIKey,
+		OpenAIBaseURL:     c.OpenAIBaseURL,
+		OpenAIAPIType:     c.OpenAIAPIType,
+		OpenRouterAPIKey:  c.OpenRouterAPIKey,
+		OpenRouterBaseURL: c.OpenRouterBaseURL,
+		OpenRouterAppName: c.OpenRouterAppName,
+		OpenRouterSiteURL: c.OpenRouterSiteURL,
+	}
+}
+
+// PlatformLLMConfig returns the llm.Config for platform-internal features
+// (titles, PR descriptions, project generation, validation, prioritization).
+// Uses the cheap PLATFORM_LLM_MODEL (default: gpt-5-nano) regardless of what
+// LLM_MODEL is set to, keeping internal feature costs low.
+func (c *Config) PlatformLLMConfig() llm.Config {
+	return llm.Config{
+		Model:             llm.ModelName(c.PlatformLLMModel),
 		ReasoningEffort:   llm.ReasoningEffort(c.LLMReasoningEffort),
 		AnthropicAPIKey:   c.AnthropicAPIKey,
 		AnthropicBaseURL:  c.AnthropicBaseURL,


### PR DESCRIPTION
## Summary
- Adds `PLATFORM_LLM_MODEL` config (default: `gpt-5-nano`) so internal features (titles, PR descriptions, project generation, validation, prioritization) use a cheap model, separate from org-level model selection
- Fixes `isAgentConnected` bug where platform-level API keys falsely showed agents as "Connected" even though the orchestrator never injects platform keys into sandboxes
- Restructures the LLM settings page into "Platform intelligence" (read-only status) and "Agent credentials" sections to clearly communicate the two-tier system
- Adds `AgentKeyRequiredBanner` warning on the session creation page when no agent credentials are configured
- Updates setup checklist descriptions to clarify that personal keys are required for agent sessions

## Test plan
- [ ] Verify platform intelligence section shows Active/Not configured based on env vars
- [ ] Verify agents show as disconnected when only platform keys exist (no org/user keys)
- [ ] Verify session creation page shows warning banner when agent credentials are missing
- [ ] Verify `settings_test.go` passes with updated `NewSettingsHandler` signature
- [ ] Verify Codex OAuth flow still works independently of API key checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)