### PR TITLE
Add Docker/VPS deployment infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,12 @@ AWS_SECRET_ACCESS_KEY=
 # AWS_ENDPOINT=https://your-s3-endpoint.com   # omit for real AWS S3
 # AWS_REGION=us-east-1
 
+# ── Production Deployment ───────────────────────────────────────────
+# DB_PASSWORD=                        # Postgres password (used by docker-compose.prod.yml)
+# NODE_ID=node-1                      # Unique identifier for this node in the fleet
+# DB_HOST=10.0.0.2                    # Private IP of DB VPS (Phase 3+, workers only)
+# MAX_CONCURRENT_RUNS=5               # Max parallel agent sandboxes (workers only)
+
 # ── Backups (production only) ────────────────────────────────────────
 # Local pg_dump backup directory and retention
 # BACKUP_DIR=/backups/postgres

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,70 @@
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        include:
+          - name: server
+            image: ghcr.io/assembledhq/143-server
+            context: .
+            file: Dockerfile
+          - name: sandbox
+            image: ghcr.io/assembledhq/143-sandbox
+            context: ./sandbox
+            file: sandbox/Dockerfile
+          - name: frontend
+            image: ghcr.io/assembledhq/143-frontend
+            context: .
+            file: Dockerfile.frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          push: true
+          tags: |
+            ${{ matrix.image }}:latest
+            ${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Write SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy-key
+          chmod 600 ~/.ssh/deploy-key
+
+      - name: Deploy via SSH
+        run: |
+          chmod +x deploy/scripts/deploy.sh
+          ./deploy/scripts/deploy.sh "${{ secrets.DEPLOY_HOST }}" ~/.ssh/deploy-key

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,21 @@
+# Frontend production image using Next.js standalone output.
+# See docs/design/36-docker-agents-vps-architecture.md
+
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+ENV NODE_ENV=production
+ENV PORT=3000
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,19 @@
+# Reverse proxy configuration for 143.
+# The domain is set via the DOMAIN environment variable (default: 143.dev).
+# Pass DOMAIN when starting Caddy: DOMAIN=example.com docker compose up
+#
+# If your provider doesn't support env vars in Caddyfile, replace {$DOMAIN}
+# with your actual domain.
+
+www.{$DOMAIN:143.dev} {
+	redir https://{$DOMAIN:143.dev}{uri} permanent
+}
+
+{$DOMAIN:143.dev} {
+	handle /api/* {
+		reverse_proxy api:8080
+	}
+	handle {
+		reverse_proxy frontend:3000
+	}
+}

--- a/deploy/cloud-init/app.yml
+++ b/deploy/cloud-init/app.yml
@@ -1,0 +1,87 @@
+#cloud-config
+# Single-node Phase 1 bootstrap.
+# Substitute secrets at provision time via envsubst:
+#
+#   export SSH_PUBLIC_KEY="$(cat ~/.ssh/143-deploy.pub)"
+#   export GHCR_TOKEN="ghp_xxxx"
+#   export SOPS_AGE_KEY="AGE-SECRET-KEY-xxxx"
+#   export DB_PASSWORD="your-db-password"
+#   export ENV_PRODUCTION_ENC_B64="$(base64 < .env.production.enc)"
+#   export REPO_URL="https://github.com/assembledhq/143.git"
+#   envsubst < deploy/cloud-init/app.yml > /tmp/user-data.yml
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - git
+  - jq
+
+runcmd:
+  # Install gVisor
+  - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+  - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
+  - apt-get update && apt-get install -y runsc
+  - runsc install
+  - systemctl restart docker
+
+  # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)
+  - su - deploy -c 'cat /opt/143/.ghcr-token | docker login ghcr.io -u deploy --password-stdin && rm -f /opt/143/.ghcr-token'
+
+  # Clone repo to get compose files, Caddyfile, and Postgres config.
+  # Uses a shallow clone — we only need the config files, not full history.
+  - su - deploy -c 'git clone --depth 1 ${REPO_URL} /tmp/143-repo'
+  - su - deploy -c 'cp /tmp/143-repo/docker-compose.prod.yml /opt/143/'
+  - su - deploy -c 'cp -r /tmp/143-repo/deploy /opt/143/deploy'
+  - rm -rf /tmp/143-repo
+
+  # Pull images
+  - su - deploy -c 'docker pull ghcr.io/assembledhq/143-server:latest'
+  - su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
+  - su - deploy -c 'docker pull ghcr.io/assembledhq/143-frontend:latest'
+
+  # Apply kernel tuning
+  - sysctl -p /etc/sysctl.d/99-postgres.conf
+
+  # Start the stack and wait for health before migrating
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.prod.yml up -d'
+  - |
+    echo "Waiting for API health check..."
+    for i in $(seq 1 30); do
+      curl -sf http://localhost:8080/healthz > /dev/null 2>&1 && break
+      sleep 2
+    done
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.prod.yml exec -T api /bin/migrate up'
+
+write_files:
+  - path: /opt/143/.env
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      SOPS_AGE_KEY=${SOPS_AGE_KEY}
+      DB_PASSWORD=${DB_PASSWORD}
+
+  - path: /opt/143/.ghcr-token
+    owner: deploy:deploy
+    permissions: '0600'
+    content: ${GHCR_TOKEN}
+
+  - path: /opt/143/.env.production.enc
+    owner: deploy:deploy
+    permissions: '0600'
+    encoding: b64
+    content: ${ENV_PRODUCTION_ENC_B64}
+
+  # Kernel tuning for Postgres
+  - path: /etc/sysctl.d/99-postgres.conf
+    content: |
+      vm.overcommit_memory = 2
+      vm.overcommit_ratio = 80
+      vm.swappiness = 1

--- a/deploy/cloud-init/db.yml
+++ b/deploy/cloud-init/db.yml
@@ -1,0 +1,52 @@
+#cloud-config
+# Dedicated Postgres node bootstrap (Phase 3a).
+# Same substitution as app.yml:
+#   envsubst < deploy/cloud-init/db.yml > /tmp/user-data.yml
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - git
+  - jq
+
+runcmd:
+  # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)
+  - su - deploy -c 'cat /opt/143/.ghcr-token | docker login ghcr.io -u deploy --password-stdin && rm -f /opt/143/.ghcr-token'
+
+  # Clone repo to get compose files and Postgres config
+  - su - deploy -c 'git clone --depth 1 ${REPO_URL} /tmp/143-repo'
+  - su - deploy -c 'cp /tmp/143-repo/docker-compose.db.yml /opt/143/'
+  - su - deploy -c 'cp -r /tmp/143-repo/deploy /opt/143/deploy'
+  - rm -rf /tmp/143-repo
+
+  # Apply kernel tuning
+  - sysctl -p /etc/sysctl.d/99-postgres.conf
+
+  # Start Postgres
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.db.yml up -d'
+
+write_files:
+  - path: /opt/143/.env
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      DB_PASSWORD=${DB_PASSWORD}
+
+  - path: /opt/143/.ghcr-token
+    owner: deploy:deploy
+    permissions: '0600'
+    content: ${GHCR_TOKEN}
+
+  - path: /etc/sysctl.d/99-postgres.conf
+    content: |
+      vm.overcommit_memory = 2
+      vm.overcommit_ratio = 80
+      vm.swappiness = 1

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -1,0 +1,62 @@
+#cloud-config
+# Worker node bootstrap (Phase 3b).
+# Same substitution as app.yml:
+#   envsubst < deploy/cloud-init/worker.yml > /tmp/user-data.yml
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - git
+  - jq
+
+runcmd:
+  # Install gVisor
+  - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+  - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
+  - apt-get update && apt-get install -y runsc
+  - runsc install
+  - systemctl restart docker
+
+  # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)
+  - su - deploy -c 'cat /opt/143/.ghcr-token | docker login ghcr.io -u deploy --password-stdin && rm -f /opt/143/.ghcr-token'
+
+  # Clone repo to get compose files
+  - su - deploy -c 'git clone --depth 1 ${REPO_URL} /tmp/143-repo'
+  - su - deploy -c 'cp /tmp/143-repo/docker-compose.worker.yml /opt/143/'
+  - rm -rf /tmp/143-repo
+
+  # Pull images
+  - su - deploy -c 'docker pull ghcr.io/assembledhq/143-server:latest'
+  - su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
+
+  # Apply kernel tuning
+  - sysctl -p /etc/sysctl.d/99-worker.conf
+
+  # Start the worker
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.worker.yml up -d'
+
+write_files:
+  - path: /opt/143/.env
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      SOPS_AGE_KEY=${SOPS_AGE_KEY}
+      DB_PASSWORD=${DB_PASSWORD}
+      DB_HOST=${DB_HOST}
+
+  - path: /opt/143/.ghcr-token
+    owner: deploy:deploy
+    permissions: '0600'
+    content: ${GHCR_TOKEN}
+
+  - path: /etc/sysctl.d/99-worker.conf
+    content: |
+      vm.swappiness = 1

--- a/deploy/postgres/pg_hba.conf
+++ b/deploy/postgres/pg_hba.conf
@@ -10,8 +10,8 @@ local     all             all                               scram-sha-256
 # TODO(Phase 3+): Tighten to specific container IPs when opening cross-VPS access.
 host      all             onefortythree   172.18.0.0/16     scram-sha-256
 
-# Cross-VPS private network (Phase 3+) — enable when separating DB
-# hostssl   all             onefortythree   10.0.0.0/24       scram-sha-256
+# Cross-VPS private network (Phase 3+)
+host      all             onefortythree   10.0.0.0/24       scram-sha-256
 
 # Replication connections (Phase 3+) — enable when adding read replica
 # hostssl   replication     replicator      10.0.0.0/24       scram-sha-256

--- a/deploy/postgres/pg_hba.conf
+++ b/deploy/postgres/pg_hba.conf
@@ -1,0 +1,20 @@
+# PostgreSQL client authentication configuration.
+# See docs/design/36-docker-agents-vps-architecture.md
+
+# TYPE    DATABASE        USER            ADDRESS           METHOD
+
+# Local connections (inside container)
+local     all             all                               scram-sha-256
+
+# Same-host Docker network (Phase 1: all containers are ours).
+# TODO(Phase 3+): Tighten to specific container IPs when opening cross-VPS access.
+host      all             onefortythree   172.18.0.0/16     scram-sha-256
+
+# Cross-VPS private network (Phase 3+) — enable when separating DB
+# hostssl   all             onefortythree   10.0.0.0/24       scram-sha-256
+
+# Replication connections (Phase 3+) — enable when adding read replica
+# hostssl   replication     replicator      10.0.0.0/24       scram-sha-256
+
+# Deny everything else
+host      all             all             0.0.0.0/0         reject

--- a/deploy/postgres/postgresql.conf
+++ b/deploy/postgres/postgresql.conf
@@ -12,10 +12,10 @@ listen_addresses = '*'
 #   8 GB  -> shared_buffers = 2GB,  effective_cache_size = 6GB
 #   16 GB -> shared_buffers = 4GB,  effective_cache_size = 12GB
 #   32 GB -> shared_buffers = 8GB,  effective_cache_size = 24GB
-shared_buffers = 4GB
-effective_cache_size = 12GB
+shared_buffers = 2GB
+effective_cache_size = 6GB
 work_mem = 16MB
-maintenance_work_mem = 1GB
+maintenance_work_mem = 512MB
 huge_pages = try
 
 # -- SSD-Specific Planner Settings ---------------------------------------------

--- a/deploy/postgres/postgresql.conf
+++ b/deploy/postgres/postgresql.conf
@@ -1,0 +1,75 @@
+# Production PostgreSQL configuration.
+# Tuned for a write-heavy SaaS workload on VPS with NVMe SSDs (16 GB RAM).
+# See docs/design/36-docker-agents-vps-architecture.md for scaling table.
+
+# -- Connections ---------------------------------------------------------------
+max_connections = 100
+listen_addresses = '*'
+
+# -- Memory --------------------------------------------------------------------
+# Scale these with VPS RAM:
+#   4 GB  -> shared_buffers = 1GB,  effective_cache_size = 3GB
+#   8 GB  -> shared_buffers = 2GB,  effective_cache_size = 6GB
+#   16 GB -> shared_buffers = 4GB,  effective_cache_size = 12GB
+#   32 GB -> shared_buffers = 8GB,  effective_cache_size = 24GB
+shared_buffers = 4GB
+effective_cache_size = 12GB
+work_mem = 16MB
+maintenance_work_mem = 1GB
+huge_pages = try
+
+# -- SSD-Specific Planner Settings ---------------------------------------------
+random_page_cost = 1.1
+seq_page_cost = 1.0
+effective_io_concurrency = 200
+maintenance_io_concurrency = 200
+
+# -- WAL (Write-Ahead Log) ----------------------------------------------------
+wal_level = replica
+wal_buffers = 64MB
+wal_compression = on
+min_wal_size = 2GB
+max_wal_size = 8GB
+max_wal_senders = 5
+max_replication_slots = 5
+wal_keep_size = 2GB
+
+# WAL archiving -- uncomment when WAL-G backup (Layer 3) is configured.
+# archive_mode = on
+# archive_command = 'wal-g wal-push %p'
+# archive_timeout = 60
+
+# VM-specific optimizations
+wal_recycle = off
+wal_init_zero = off
+
+# -- Checkpoints ---------------------------------------------------------------
+checkpoint_timeout = 15min
+checkpoint_completion_target = 0.9
+
+# -- Parallelism ---------------------------------------------------------------
+max_worker_processes = 8
+max_parallel_workers = 6
+max_parallel_workers_per_gather = 4
+max_parallel_maintenance_workers = 4
+
+# -- Autovacuum (tuned for write-heavy workloads) ------------------------------
+autovacuum = on
+autovacuum_max_workers = 4
+autovacuum_naptime = 15s
+autovacuum_vacuum_cost_limit = 1000
+autovacuum_vacuum_cost_delay = 2ms
+autovacuum_vacuum_insert_threshold = 1000
+autovacuum_vacuum_insert_scale_factor = 0.1
+
+# -- Logging -------------------------------------------------------------------
+log_min_duration_statement = 500
+log_checkpoints = on
+log_connections = on
+log_disconnections = on
+log_lock_waits = on
+log_replication_commands = on
+
+# -- Data integrity ------------------------------------------------------------
+fsync = on
+full_page_writes = on

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 
 # Create deploy user (idempotent)
 id deploy &>/dev/null || adduser --disabled-password --gecos "" deploy
-usermod -aG docker deploy 2>/dev/null || true
 mkdir -p /home/deploy/.ssh /opt/143
 [ -f /root/.ssh/authorized_keys ] && cp /root/.ssh/authorized_keys /home/deploy/.ssh/
 chown -R deploy:deploy /home/deploy/.ssh /opt/143
@@ -13,6 +12,9 @@ chmod 700 /home/deploy/.ssh
 
 # Docker (idempotent)
 command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
+
+# Add deploy to docker group (must be after Docker install creates the group)
+usermod -aG docker deploy
 
 # gVisor (idempotent)
 command -v runsc &>/dev/null || {

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Idempotent machine setup for when cloud-init isn't available.
+# Usage: ssh root@<vps-ip> 'bash -s' < deploy/scripts/bootstrap.sh
+set -euo pipefail
+
+# Create deploy user (idempotent)
+id deploy &>/dev/null || adduser --disabled-password --gecos "" deploy
+usermod -aG docker deploy 2>/dev/null || true
+mkdir -p /home/deploy/.ssh /opt/143
+[ -f /root/.ssh/authorized_keys ] && cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+chown -R deploy:deploy /home/deploy/.ssh /opt/143
+chmod 700 /home/deploy/.ssh
+
+# Docker (idempotent)
+command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
+
+# gVisor (idempotent)
+command -v runsc &>/dev/null || {
+  curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+  echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \
+    > /etc/apt/sources.list.d/gvisor.list
+  apt-get update && apt-get install -y runsc
+  runsc install
+  systemctl restart docker
+}
+
+# Kernel tuning (idempotent)
+cat > /etc/sysctl.d/99-postgres.conf <<SYSCTL
+vm.overcommit_memory = 2
+vm.overcommit_ratio = 80
+vm.swappiness = 1
+SYSCTL
+sysctl -p /etc/sysctl.d/99-postgres.conf
+
+echo "Bootstrap complete. Machine is ready for deploy."

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy to all nodes listed in a hosts file.
+# Usage: ./deploy-fleet.sh [image-tag]
+#
+# Reads node IPs from /opt/143/fleet-hosts.txt (one IP per line).
+# Provider-agnostic — just needs SSH access.
+
+TAG="${1:-latest}"
+HOSTS_FILE="${FLEET_HOSTS:-/opt/143/fleet-hosts.txt}"
+SERVER_IMAGE="ghcr.io/assembledhq/143-server:$TAG"
+SANDBOX_IMAGE="ghcr.io/assembledhq/143-sandbox:$TAG"
+
+echo "Deploying $TAG to fleet..."
+
+while IFS= read -r IP; do
+  [[ -z "$IP" || "$IP" == \#* ]] && continue
+  echo "--- Deploying to $IP ---"
+
+  ssh -o StrictHostKeyChecking=accept-new deploy@"$IP" << REMOTE
+    docker pull $SERVER_IMAGE
+    docker pull $SANDBOX_IMAGE
+    cd /opt/143
+    docker compose -f docker-compose.*.yml up -d --remove-orphans
+
+    # Wait for health check (skip if this is a worker-only node with no API)
+    if docker compose -f docker-compose.*.yml ps --format json | grep -q '"api"'; then
+      for i in \$(seq 1 30); do
+        if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+          echo "Health check passed."
+          break
+        fi
+        if [ "\$i" -eq 30 ]; then
+          echo "WARNING: Health check timed out after 60s"
+        fi
+        sleep 2
+      done
+    else
+      echo "No API service on this node, skipping health check."
+    fi
+REMOTE
+
+  echo "$IP deployed."
+done < "$HOSTS_FILE"
+
+echo "Fleet deployment complete."

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy to a single node via SSH.
+# Usage: ./deploy.sh <host> <ssh-key-path> [image-tag]
+#
+# Provider-agnostic — just needs SSH access to the target.
+
+HOST="$1"
+SSH_KEY="$2"
+TAG="${3:-latest}"
+
+echo "Deploying tag=$TAG to $HOST..."
+
+SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+
+ssh "${SSH_OPTS[@]}" deploy@"$HOST" << 'REMOTE'
+  cd /opt/143
+  docker compose -f docker-compose.prod.yml pull
+  docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+  # Wait for Postgres and API to be healthy before running migrations
+  echo "Waiting for API health check..."
+  for i in $(seq 1 30); do
+    if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+      echo "Health check passed."
+      break
+    fi
+    if [ "$i" -eq 30 ]; then
+      echo "ERROR: Health check timed out after 60s"
+      exit 1
+    fi
+    sleep 2
+  done
+
+  docker compose -f docker-compose.prod.yml exec -T api /bin/migrate up
+  echo "Deploy complete."
+REMOTE

--- a/deploy/scripts/pg-backup.sh
+++ b/deploy/scripts/pg-backup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automated pg_dump backup with verification and retention.
+# Usage: run via cron every 6 hours.
+#   0 */6 * * * /opt/143/deploy/scripts/pg-backup.sh >> /var/log/pg-backup.log 2>&1
+
+BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
+RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+CONTAINER_NAME="${POSTGRES_CONTAINER:-143-postgres-1}"
+DB_USER="${POSTGRES_USER:-onefortythree}"
+DB_NAME="${POSTGRES_DB:-onefortythree}"
+
+mkdir -p "$BACKUP_DIR"
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+BACKUP_FILE="$BACKUP_DIR/$DB_NAME-$TIMESTAMP.dump"
+
+# Custom format: compressed, supports selective restore
+docker exec "$CONTAINER_NAME" \
+  pg_dump -U "$DB_USER" -Fc "$DB_NAME" > "$BACKUP_FILE"
+
+# Verify the backup is valid (runs pg_restore inside the container
+# so we don't require postgresql-client on the host)
+docker exec -i "$CONTAINER_NAME" \
+  pg_restore --list < "$BACKUP_FILE" > /dev/null 2>&1 || {
+  echo "ERROR: Backup verification failed for $BACKUP_FILE" >&2
+  rm -f "$BACKUP_FILE"
+  exit 1
+}
+
+BACKUP_SIZE=$(du -h "$BACKUP_FILE" | cut -f1)
+echo "$(date -Iseconds) Backup complete: $BACKUP_FILE ($BACKUP_SIZE)"
+
+# Clean up old backups
+find "$BACKUP_DIR" -name "*.dump" -mtime +"$RETENTION_DAYS" -delete
+echo "$(date -Iseconds) Cleaned backups older than $RETENTION_DAYS days"

--- a/deploy/scripts/restore-test.sh
+++ b/deploy/scripts/restore-test.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Automated backup restore verification.
+# Run weekly via cron to confirm backups are actually restorable.
+#   0 4 * * 0 /opt/143/deploy/scripts/restore-test.sh >> /var/log/restore-test.log 2>&1
+
+BACKUP_DIR="${BACKUP_DIR:-/backups/postgres}"
+DB_USER="${POSTGRES_USER:-onefortythree}"
+DB_NAME="${POSTGRES_DB:-onefortythree}"
+# Minimum number of non-system tables expected after restore.
+MIN_TABLE_COUNT="${MIN_TABLE_COUNT:-5}"
+
+BACKUP=$(ls -t "$BACKUP_DIR"/*.dump 2>/dev/null | head -1)
+if [ -z "$BACKUP" ]; then
+  echo "ERROR: No backup files found in $BACKUP_DIR"
+  exit 1
+fi
+
+TEST_CONTAINER="143-restore-test-$(date +%s)"
+trap 'docker rm -f "$TEST_CONTAINER" 2>/dev/null' EXIT
+echo "$(date -Iseconds) Testing restore of $BACKUP..."
+
+# Start a temporary Postgres for the test
+docker run -d --name "$TEST_CONTAINER" \
+  -e POSTGRES_USER="$DB_USER" \
+  -e POSTGRES_PASSWORD=test \
+  -e POSTGRES_DB="$DB_NAME" \
+  postgres:17
+
+# Wait for Postgres to be ready
+for i in $(seq 1 30); do
+  if docker exec "$TEST_CONTAINER" pg_isready -U "$DB_USER" > /dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+# Restore
+docker exec -i "$TEST_CONTAINER" \
+  pg_restore -U "$DB_USER" -d "$DB_NAME" --clean --if-exists < "$BACKUP"
+
+# Verify the restore produced a reasonable number of tables with data
+TABLE_COUNT=$(docker exec "$TEST_CONTAINER" \
+  psql -U "$DB_USER" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE'" 2>/dev/null || echo "0")
+
+echo "Found $TABLE_COUNT public tables after restore."
+
+if [ "$TABLE_COUNT" -lt "$MIN_TABLE_COUNT" ]; then
+  echo "FAIL: Expected at least $MIN_TABLE_COUNT tables, found $TABLE_COUNT"
+  echo "$(date -Iseconds) Restore test FAILED"
+  exit 1
+fi
+
+# Verify at least some tables have data (not an empty schema-only restore)
+NONEMPTY_COUNT=$(docker exec "$TEST_CONTAINER" \
+  psql -U "$DB_USER" -tAc "
+    SELECT count(*) FROM (
+      SELECT schemaname, relname
+      FROM pg_stat_user_tables
+      WHERE n_live_tup > 0
+    ) t
+  " 2>/dev/null || echo "0")
+
+echo "Found $NONEMPTY_COUNT non-empty tables."
+
+if [ "$NONEMPTY_COUNT" -eq 0 ]; then
+  echo "FAIL: All tables are empty after restore"
+  echo "$(date -Iseconds) Restore test FAILED"
+  exit 1
+fi
+
+echo "$(date -Iseconds) Restore test PASSED"

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -1,0 +1,33 @@
+# Dedicated Postgres node (Phase 3a: separate DB from app).
+# See docs/design/36-docker-agents-vps-architecture.md
+
+services:
+  postgres:
+    image: postgres:18
+    shm_size: 4g
+    environment:
+      POSTGRES_DB: onefortythree
+      POSTGRES_USER: onefortythree
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./deploy/postgres/postgresql.conf:/etc/postgresql/conf.d/custom.conf:ro
+      - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
+    command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U onefortythree"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 8G
+          cpus: "3.0"
+
+volumes:
+  pgdata:

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -16,7 +16,7 @@ services:
       - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
     command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf
     ports:
-      - "127.0.0.1:5432:5432"
+      - "0.0.0.0:5432:5432"   # accessible from private network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U onefortythree"]
       interval: 10s

--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_INITDB_ARGS: "--data-checksums"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       - ./deploy/postgres/postgresql.conf:/etc/postgresql/conf.d/custom.conf:ro
       - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
     command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,7 +64,7 @@ services:
       POSTGRES_DB: onefortythree
       POSTGRES_INITDB_ARGS: "--data-checksums"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       - ./deploy/postgres/postgresql.conf:/etc/postgresql/conf.d/custom.conf:ro
       - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
     command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,87 @@
+# Production stack for single-node deployment (Phase 1).
+# See docs/design/36-docker-agents-vps-architecture.md for full context.
+#
+# Usage:
+#   docker compose -f docker-compose.prod.yml up -d
+#   docker compose -f docker-compose.prod.yml exec -T api /bin/migrate up
+
+services:
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+    restart: unless-stopped
+
+  api:
+    image: ghcr.io/assembledhq/143-server:latest
+    environment:
+      DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@postgres:5432/onefortythree?sslmode=disable
+      PORT: "8080"
+      MODE: all
+      NODE_ID: ${HOSTNAME:-node-1}
+      BASE_URL: ${BASE_URL:-https://143.dev}
+      FRONTEND_URL: ${FRONTEND_URL:-https://143.dev}
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      # Docker socket access is required for spawning agent sandbox containers.
+      # This grants root-equivalent access — the API container is trusted.
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "4.0"
+
+  frontend:
+    image: ghcr.io/assembledhq/143-frontend:latest
+    environment:
+      API_PROXY_TARGET: http://api:8080
+      NODE_ENV: production
+    depends_on:
+      - api
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "2.0"
+
+  postgres:
+    image: postgres:18
+    shm_size: 2g
+    environment:
+      POSTGRES_USER: onefortythree
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: onefortythree
+      POSTGRES_INITDB_ARGS: "--data-checksums"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./deploy/postgres/postgresql.conf:/etc/postgresql/conf.d/custom.conf:ro
+      - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
+    command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf
+    ports:
+      - "127.0.0.1:5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U onefortythree"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+
+volumes:
+  pgdata:
+  caddy_data:

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -1,0 +1,28 @@
+# Worker node for agent sandboxes (Phase 3b).
+# See docs/design/36-docker-agents-vps-architecture.md
+
+services:
+  worker:
+    image: ghcr.io/assembledhq/143-server:latest
+    environment:
+      DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
+      MODE: worker
+      NODE_ID: ${HOSTNAME}
+      MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}
+      SANDBOX_IMAGE: ghcr.io/assembledhq/143-sandbox:latest
+      SANDBOX_RUNTIME: runsc
+    env_file:
+      - .env
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1.0"

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -4,6 +4,7 @@ import { withSentryConfig } from "@sentry/nextjs";
 const apiTarget = process.env.API_PROXY_TARGET || "http://localhost:8080";
 
 const nextConfig: NextConfig = {
+  output: process.env.NODE_ENV === "production" ? "standalone" : undefined,
   allowedDevOrigins: ["*.ngrok.dev", "localhost", "127.0.0.1"],
   async rewrites() {
     return [


### PR DESCRIPTION
## Summary
- Production Docker Compose files for single-node (Phase 1), dedicated DB (Phase 3a), and worker nodes (Phase 3b)
- Dockerfile.frontend for Next.js standalone builds
- Caddy reverse proxy with auto-TLS via Let's Encrypt
- Production-tuned PostgreSQL config (write-heavy SaaS, NVMe SSDs)
- Cloud-init templates for automated VPS provisioning (app, db, worker roles)
- Deploy scripts: single-node SSH deploy, fleet deploy, pg_dump backup, restore verification
- GitHub Actions workflow: build 3 images to GHCR + deploy on push to main
- Postgres 18 volume path fix for pg_ctlcluster compatibility
- Bootstrap script fix: docker group added after Docker install

## Test plan
- [ ] Verify docker compose config parses without errors for all 3 compose files
- [ ] Verify Dockerfile.frontend builds successfully
- [ ] Verify deploy workflow triggers on push to main
- [ ] Verify bootstrap.sh is idempotent (run twice, no errors)