### PR TITLE
Fix Postgres 18 volume mount path

### DIFF
--- a/docker-compose.db.yml
+++ b/docker-compose.db.yml
@@ -11,7 +11,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_INITDB_ARGS: "--data-checksums"
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
       - ./deploy/postgres/postgresql.conf:/etc/postgresql/conf.d/custom.conf:ro
       - ./deploy/postgres/pg_hba.conf:/etc/postgresql/conf.d/pg_hba.conf:ro
     command: postgres -c config_file=/etc/postgresql/conf.d/custom.conf -c hba_file=/etc/postgresql/conf.d/pg_hba.conf


### PR DESCRIPTION
## Summary
- Postgres 18 changed its data directory layout to use versioned subdirectories under `/var/lib/postgresql`
- Updated `docker-compose.db.yml` to mount the volume at `/var/lib/postgresql` instead of `/var/lib/postgresql/data`
- Without this fix, Postgres 18 containers crash-loop on startup

## Test plan
- [x] Verified fix resolves crash-loop on Hetzner `143-db-1` node
- [ ] Confirm `make provision-db` works end-to-end with fresh volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)