### PR TITLE
Fix provision health check and pg18 volume

### DIFF
--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -170,7 +170,7 @@ if [ "$ROLE" = "app" ]; then
   echo "Waiting for API health check..."
   ssh "${SSH_OPTS[@]}" root@"$HOST" << HEALTHCHECK
     for i in \$(seq 1 30); do
-      if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+      if curl -sf http://localhost:80/api/healthz > /dev/null 2>&1; then
         echo "Health check passed."
         break
       fi


### PR DESCRIPTION
## Summary
- Fix Postgres 18 volume mount path to use /var/lib/postgresql instead of /var/lib/postgresql/data
- Fix provision script health check to use Caddy port 80 (/api/healthz) instead of localhost:8080

## Test plan
- [x] Verified pg18 starts successfully with new mount path on Hetzner
- [x] Verified app health check passes through Caddy
- [ ] Full clean provision of all three nodes