### PR TITLE
Add REPROVISION flag and fix provision health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,21 +240,26 @@ secrets-rotate:
 #   make provision-app    HOST=87.99.150.138  SSH_KEY=~/.ssh/143-deploy
 #   make provision-worker HOST=87.99.158.39   SSH_KEY=~/.ssh/143-deploy
 #   make provision-db     HOST=87.99.157.55   SSH_KEY=~/.ssh/143-deploy
+#
+# To tear down and reprovision an existing node:
+#   make provision-app    HOST=87.99.150.138  SSH_KEY=~/.ssh/143-deploy REPROVISION=true
+
+REPROVISION ?=
 
 provision-app:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-app HOST=<ip> SSH_KEY=<path>"; exit 1; }
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
-	./deploy/scripts/provision.sh app $(HOST) $(SSH_KEY)
+	./deploy/scripts/provision.sh app $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
 
 provision-worker:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-worker HOST=<ip> SSH_KEY=<path>"; exit 1; }
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
-	./deploy/scripts/provision.sh worker $(HOST) $(SSH_KEY)
+	./deploy/scripts/provision.sh worker $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
 
 provision-db:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-db HOST=<ip> SSH_KEY=<path>"; exit 1; }
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
-	./deploy/scripts/provision.sh db $(HOST) $(SSH_KEY)
+	./deploy/scripts/provision.sh db $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
 
 # Deploy (update) an already-provisioned node.
 # Usage:

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -170,7 +170,7 @@ if [ "$ROLE" = "app" ]; then
   echo "Waiting for API health check..."
   ssh "${SSH_OPTS[@]}" root@"$HOST" << HEALTHCHECK
     for i in \$(seq 1 30); do
-      if curl -sf http://localhost:8080/healthz > /dev/null 2>&1; then
+      if curl -sf http://localhost:80/api/healthz > /dev/null 2>&1; then
         echo "Health check passed."
         break
       fi

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -2,10 +2,13 @@
 set -euo pipefail
 
 # Provision a node by running bootstrap.sh + copying config files via SSH.
-# Usage: ./provision.sh <role> <host> <ssh-key-path>
+# Usage: ./provision.sh <role> <host> <ssh-key-path> [--reprovision]
 #
 # Roles: app, worker, db
 # This is the SSH-based alternative to cloud-init for already-running servers.
+#
+# Pass --reprovision to tear down existing containers and volumes before reprovisioning.
+# Without --reprovision, the script will abort if services are already running.
 #
 # No env vars required by default — the script reads your age key from
 # ~/.config/sops/age/keys.txt and all other secrets from .env.production.enc.
@@ -22,6 +25,7 @@ set -euo pipefail
 ROLE="$1"
 HOST="$2"
 SSH_KEY="$3"
+REPROVISION="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
@@ -77,6 +81,21 @@ fi
 
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+
+# Check if already provisioned
+RUNNING=$(ssh "${SSH_OPTS[@]}" root@"$HOST" "su - deploy -c 'cd /opt/143 && docker compose -f $COMPOSE_FILE ps -q 2>/dev/null'" 2>/dev/null || true)
+if [ -n "$RUNNING" ]; then
+  if [ "$REPROVISION" != "--reprovision" ]; then
+    echo "ERROR: $ROLE node at $HOST is already provisioned and running."
+    echo ""
+    echo "To tear down and reprovision, run:"
+    echo "  make provision-$ROLE HOST=$HOST SSH_KEY=$SSH_KEY REPROVISION=true"
+    exit 1
+  fi
+
+  echo "=== Reprovisioning $ROLE node at $HOST (tearing down existing) ==="
+  ssh "${SSH_OPTS[@]}" root@"$HOST" "su - deploy -c 'cd /opt/143 && docker compose -f $COMPOSE_FILE down -v'"
+fi
 
 echo "=== Provisioning $ROLE node at $HOST ==="
 


### PR DESCRIPTION
## Summary
- Provision script now checks if services are already running and errors with a helpful message
- Pass REPROVISION=true to tear down containers/volumes and reprovision from scratch
- Fix health check to use Caddy port 80 (/api/healthz) instead of unexposed port 8080

## Usage
```bash
# Fresh provision
make provision-app HOST=87.99.150.138 SSH_KEY=~/.ssh/143-deploy

# Reprovision existing node
make provision-app HOST=87.99.150.138 SSH_KEY=~/.ssh/143-deploy REPROVISION=true
```

## Test plan
- [ ] Verify fresh provision errors if already running
- [ ] Verify REPROVISION=true tears down and reprovisions
- [ ] Verify health check passes through Caddy