### PR TITLE
Simplify onboarding help text to plain paragraph

### DIFF
--- a/frontend/src/components/onboarding/onboarding-page-content.tsx
+++ b/frontend/src/components/onboarding/onboarding-page-content.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
-import { Card, CardContent } from "@/components/ui/card";
+
 import { SetupChecklist } from "@/components/setup-checklist";
 import { useSetupStatus } from "@/hooks/use-setup-status";
 
@@ -44,18 +44,10 @@ export function OnboardingPageContent() {
           description="Set up your connections to get started with Autopilot."
         />
 
-        <Card className="border-border/70 shadow-sm">
-          <CardContent className="space-y-4 py-8">
-            <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">
-                Autopilot needs a few connections before it can start analyzing.
-              </p>
-              <p className="max-w-3xl text-lg leading-8 text-foreground">
-                Connect a coding agent and GitHub repositories, then run the first analysis.
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+        <p className="text-sm text-muted-foreground">
+          Autopilot needs a few connections before it can start analyzing.
+          Connect a coding agent and GitHub repositories, then run the first analysis.
+        </p>
 
         <SetupChecklist />
       </div>


### PR DESCRIPTION
Replaces the Card-wrapped help text on the onboarding page with a plain paragraph. Both lines now use consistent `text-sm text-muted-foreground` styling instead of mixed `text-sm` / `text-lg` inside a card. Removes unused Card/CardContent import.