### PR TITLE
Add missing MSW handlers to silence test warnings

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen, userEvent, waitFor } from '@/test/test-utils';
 import { server } from '@/test/mocks/server';
-import { mockSessions, mockMembers } from '@/test/mocks/handlers';
+import { mockSessions, mockMembers, mockIssues } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
 import type { Session, SessionLog, SessionMessage, User, SingleResponse, ListResponse } from '@/lib/types';
 
@@ -202,6 +202,17 @@ describe('SessionDetailPage', () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+      // Return issue without description so no synthetic message is added to timeline
+      http.get('/api/v1/issues/:id', ({ params }) => {
+        const issue = mockIssues.find((i) => i.id === params.id);
+        if (!issue) {
+          return HttpResponse.json(
+            { error: { code: 'NOT_FOUND', message: 'Issue not found' } },
+            { status: 404 },
+          );
+        }
+        return HttpResponse.json({ data: { ...issue, description: '' } } satisfies SingleResponse<typeof issue>);
       }),
     );
 

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -215,6 +215,33 @@ export const mockMembers: User[] = [
 ];
 
 export const handlers = [
+  http.get('/api/v1/auth/me', () => {
+    return HttpResponse.json({
+      data: mockMembers[0],
+    } satisfies SingleResponse<User>);
+  }),
+
+  http.post('/api/v1/sessions/:id/view', () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  http.get('/api/v1/users/me/github-status', () => {
+    return HttpResponse.json({
+      data: { connected: true, username: 'alice' },
+    });
+  }),
+
+  http.get('/api/v1/issues/:id', ({ params }) => {
+    const issue = mockIssues.find((i) => i.id === params.id);
+    if (!issue) {
+      return HttpResponse.json(
+        { error: { code: 'NOT_FOUND', message: 'Issue not found' } },
+        { status: 404 },
+      );
+    }
+    return HttpResponse.json({ data: issue } satisfies SingleResponse<Issue>);
+  }),
+
   http.get('/api/v1/issues', () => {
     return HttpResponse.json({
       data: mockIssues,


### PR DESCRIPTION
## Summary
- Adds four missing MSW request handlers (`GET /api/v1/auth/me`, `POST /api/v1/sessions/:id/view`, `GET /api/v1/users/me/github-status`, `GET /api/v1/issues/:id`) to the shared test mock handlers.
- These endpoints were being called by the session detail page tests but had no matching handlers, causing noisy `[MSW] Error` warnings in stderr on every test run.

## Test plan
- [ ] Run `npm test` in `frontend/` and verify no more MSW unhandled request warnings for these endpoints