### PR TITLE
Fix fleet autodeploy: add FLEET_HOSTS and handle grep failure

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -31,13 +31,14 @@ AWS_SECRET_ACCESS_KEY=ENC[AES256_GCM,data:H0LCeQTN/vGeqMLL6/p1qVvSkT7qElqsYK1ZOv
 DB_PASSWORD=ENC[AES256_GCM,data:4uAdUTHVbTeRnm4ZHMJihP+G/becWQr0tRHtqYnLu7N0YW6wxBf0pReqdOQ=,iv:yxdVt93IOY089HymOfscRGqNCdPnHYR8txykLYoNPPU=,tag:wzbx3/H+Mt8G5WOMdXsH5w==,type:str]
 DB_HOST=ENC[AES256_GCM,data:N4o3L5UqnE0=,iv:kbVv+a/onFxRA/292N9REjYa8nodnp9v7dgRFedqdVg=,tag:9WZDuWUq8icThV0IjEzzUg==,type:str]
 GHCR_TOKEN=ENC[AES256_GCM,data:vhSaR8Vbr/yqziTtn5Xj6ZlOHfW+rMBrMidOF56CVsyO5AqvzMnwdA==,iv:05pmXoqk/tgyrVKBpkfTkjT1TW3Cb/60roBU9rMw/Ao=,tag:C/qkU5ZNhQea/zTNJTDBdQ==,type:str]
+FLEET_HOSTS=ENC[AES256_GCM,data:xn/FnkcZwhrOL9brKvAXNuWbWc9ZMXOfXMLCnnBWLr4aWF0NuJdedQ/6Hx7iymgxyw7ZDwM=,iv:AzCEoDm9cQMclIj0y3x5UEIOKslz+RWkhlLusAfAra4=,tag:jitUb6Drs1XrX4kC6339XA==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwRVlNOEU0YUwzZ3ByQ3Qv\nUjdnbVhNN1ZzeWJHK2hYcGhyY01NenlMZ1dVClhYL3IzcWRpZU43dklJL3l4ZDVK\nUnZLNjJ2OWFpTlpVS2xONFA0TXkxcWMKLS0tIFltaUNOQW5LUG9OcVU0Y2RrTy83\naVhzM1I2TlhpTThDNU93TXk2dGxOVUEKeW+oZNn1lOtsKMnsqzCHm7Ob842xYbtY\nuXNOLcRQc70SxVD1DKHnzYt//hDWNiF6P5DEfZDuAFJ44fn1U7fXlw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1xyvl6ral4fq757tpnz30cuzefrpngnuv6zutjsg7wtnmza4uyqlshc2ucl
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNMGR2ZWtiVTNLMjVBMC9p\nbk9XUnpMMWMvZzhsM2dPcmc3QU9VNUpOV0NRCldaWmIzWWZuNlp2em9PVU14ek1m\nOUhnRW1ZVS9oM3VubThobjQxbGtMQmsKLS0tIHZqWlpDRjNsL2MyL1hWeHFvb2tj\nVmpXRDRMQmxYaythdTFUUFQ2cUVCTWsKvzGFG7rpanzjg6/yCWWvlHOnufRItdcH\nnAscSVItc051kzQRW2lvVTlZ+Dzc7pGvdHRKXOAA1cF62ZO3l4HrUg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-12T06:33:33Z
-sops_mac=ENC[AES256_GCM,data:Sh/Q4SkGrEAUt6Nk2E5QNTVxxJvv2tpL2tLaDDv5uQiUCB+JUrzzsdvmQPdu1bUkWDH/qxXC3iCNFdPp0H1RzWdOIXcboeHMQruCdFW/UB3xLAY14fnP01j3ly3AsyNOLV14EwgXk7XlBtIuYg8anaS9GwRll+fqW1h2zK8KYAE=,iv:nc32NkGdiobZxUjwP9nf0UiflelJGgGfAZNk2miyiPA=,tag:WjBunWvzn0adRTC5gi22fw==,type:str]
+sops_lastmodified=2026-04-14T05:57:46Z
+sops_mac=ENC[AES256_GCM,data:sIMYmdZJ8Aod3kCaqYabaTtv19qnIhHEu+fin59Ko7E7BOBfmjMH5MSULtVA2pC2lkP96/uwEtotNbzEzrxe3+bUJmIqAlOvSwq9i6lVFKAxNXa3doy81MwsOrQdZRP0aa8VKcOMmZcyXq/xgdYXF7tQUJTLKUrlV092qS9eb8M=,iv:4+GsoUeooKdVy7FeIfJYmbx1bU716ZD6S129kyAbxKA=,tag:AvdJWZX2rJrbjE+46PM+zg==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -33,7 +33,7 @@ else
     if [ -f "$ENC_FILE" ]; then
       echo "Decrypting fleet hosts from .env.production.enc..."
       FLEET_HOSTS="$(sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE" \
-        | grep '^FLEET_HOSTS=' | cut -d= -f2-)"
+        | grep '^FLEET_HOSTS=' | cut -d= -f2- || true)"
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Added encrypted `FLEET_HOSTS` (public IPs for app, db, worker nodes) to `.env.production.enc` so the deploy script can find fleet targets
- Fixed `deploy-fleet.sh` pipeline crash: `grep` returning no match with `set -euo pipefail` caused a silent exit before the friendly error message — added `|| true` to let it fall through gracefully

## Test plan
- [ ] Merge and verify the deploy workflow succeeds on the next push to main
- [ ] Confirm fleet hosts are correctly decrypted and each node is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)