### PR TITLE
Fix LLM settings page UI inconsistencies

### DIFF
--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -237,7 +237,7 @@ export default function LLMPage() {
                     </Badge>
                   )}
                 </div>
-                <ul className="text-xs text-muted-foreground space-y-1 ml-1">
+                <ul className="text-xs text-muted-foreground space-y-1">
                   <li>Session titles</li>
                   <li>PR descriptions</li>
                   <li>Project generation</li>
@@ -287,7 +287,6 @@ export default function LLMPage() {
                               </Badge>
                             )}
                           </div>
-                          <p className="text-xs text-muted-foreground mt-0.5">{info.description}</p>
                         </div>
                         {ps?.orgConfigured && (
                           <Button
@@ -317,7 +316,7 @@ export default function LLMPage() {
                             onChange={(e) =>
                               setApiKeys((prev) => ({ ...prev, [provider]: e.target.value }))
                             }
-                            className="pr-9 font-mono text-xs"
+                            className="h-8 pr-9 font-mono text-xs"
                           />
                           <button
                             type="button"
@@ -334,13 +333,13 @@ export default function LLMPage() {
                           </button>
                         </div>
                         <Button
-                          size="sm"
                           onClick={() => handleSaveKey(provider)}
                           disabled={!apiKeys[provider]?.trim() || status === "saving"}
                         >
                           {status === "saving" ? "Saving..." : "Save key"}
                         </Button>
                       </div>
+                      <p className="text-xs text-muted-foreground">{info.description}</p>
                       {status === "success" && (
                         <p className="text-xs text-emerald-600 dark:text-emerald-400">Key saved successfully.</p>
                       )}

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -91,6 +91,6 @@ export const OPENAI_API_TYPE_CHAT = "chat";
 
 export const LLM_PROVIDER_INFO: Record<string, { name: string; description: string; keyPlaceholder: string }> = {
   anthropic: { name: "Anthropic", description: "Claude models (Opus, Sonnet, Haiku)", keyPlaceholder: "sk-ant-..." },
-  openai: { name: "OpenAI", description: "GPT-4o and O3 models", keyPlaceholder: "sk-..." },
+  openai: { name: "OpenAI", description: "OpenAI models (GPT series)", keyPlaceholder: "sk-..." },
   openrouter: { name: "OpenRouter", description: "Access all models with a single key", keyPlaceholder: "sk-or-..." },
 };


### PR DESCRIPTION
## Summary
- Fix input/button size mismatch in agent credentials: input now uses h-8 to match button and select heights
- Remove extra indentation from platform intelligence feature list
- Move provider helper text below inputs for consistency with model section
- Update OpenAI description from "GPT-4o and O3 models" to "OpenAI models (GPT series)"

## Test plan
- [ ] Verify credential inputs and save buttons are the same height
- [ ] Verify platform intelligence list has no extra left indentation
- [ ] Verify helper text appears below inputs consistently across all sections
- [ ] Verify OpenAI provider description reads "OpenAI models (GPT series)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)