### PR TITLE
Refresh secrets on deploy and fix dotenv parsing

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -11,6 +11,8 @@ ROLE="$1"
 HOST="$2"
 SSH_KEY="$3"
 TAG="${4:-latest}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 case "$ROLE" in
   app)
@@ -31,6 +33,49 @@ esac
 echo "Deploying role=$ROLE tag=$TAG to $HOST..."
 
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+
+# --- Refresh secrets from .env.production.enc ---
+if [ -z "${SOPS_AGE_KEY:-}" ]; then
+  AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+  if [ -f "$AGE_KEY_FILE" ]; then
+    SOPS_AGE_KEY=$(grep "^AGE-SECRET-KEY-" "$AGE_KEY_FILE" | head -1)
+    export SOPS_AGE_KEY
+  else
+    echo "WARNING: No SOPS_AGE_KEY set and no keyfile at $AGE_KEY_FILE — skipping secret refresh"
+  fi
+fi
+
+ENC_FILE="$PROJECT_DIR/.env.production.enc"
+if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
+  echo "Refreshing secrets from .env.production.enc..."
+  DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
+
+  while IFS= read -r line; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    if [ -z "${!key+x}" ]; then
+      export "$key=$value"
+    fi
+  done <<< "$DECRYPTED"
+
+  if [ "$ROLE" = "db" ]; then
+    printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+  elif [ "$ROLE" = "worker" ]; then
+    printf 'DB_PASSWORD=%s\nDB_HOST=%s\n' "$DB_PASSWORD" "$DB_HOST" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+  else
+    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+    scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"
+  fi
+  echo "Secrets refreshed."
+else
+  echo "Skipping secret refresh (no SOPS key or .env.production.enc not found)."
+fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -59,9 +59,11 @@ if [ -f "$ENC_FILE" ]; then
   DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
 
   # Source decrypted values, but don't overwrite existing env vars
-  while IFS='=' read -r key value; do
+  while IFS= read -r line; do
     # Skip empty lines and comments
-    [[ -z "$key" || "$key" == \#* ]] && continue
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
     # Only set if not already in environment
     if [ -z "${!key+x}" ]; then
       export "$key=$value"


### PR DESCRIPTION
## Summary
- **deploy.sh now refreshes secrets** from .env.production.enc on every deploy, not just on initial provision. Previously, changing a secret required a full reprovision to update worker/app nodes.
- **Fixes dotenv parsing** in both deploy.sh and provision.sh. The old IFS-based approach would strip trailing = from values (e.g. base64 passwords), causing DB auth failures on worker nodes.

## Test plan
- [ ] Run make deploy-worker and verify /opt/143/.env on the target has the correct password (including any trailing =)
- [ ] Run make deploy-app and verify secrets + .env.production.enc are refreshed
- [ ] Run deploy without a SOPS key available and verify it warns but does not fail