### PR TITLE
Fix sidebar scrollbar and standardize font sizes

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -118,7 +118,7 @@ export function ProjectSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-y-hidden">
+          <TabsList size="sm" className="overflow-x-auto overflow-y-hidden">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "active" ? activeCount

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -172,7 +172,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
                 <XCircle className="h-3.5 w-3.5" />
                 Failure details
                 {session.failure_category && (
-                  <Badge variant="secondary" className="bg-destructive/10 text-destructive border-destructive/20 text-xs">
+                  <Badge variant="secondary" className="bg-destructive/10 text-destructive border-destructive/20 text-sm">
                     {session.failure_category}
                   </Badge>
                 )}
@@ -195,7 +195,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             {/* Show next steps only for non-codex-auth failures (codex auth has the reauth button instead) */}
             {!isCodexAuthFailure && session.failure_next_steps && session.failure_next_steps.length > 0 && (
               <div>
-                <p className="text-xs font-medium text-muted-foreground mb-1">Next steps</p>
+                <p className="text-sm font-medium text-muted-foreground mb-1">Next steps</p>
                 <ul className="list-disc list-inside text-sm space-y-1">
                   {session.failure_next_steps.map((step, i) => (
                     <li key={i}>{step}</li>
@@ -236,7 +236,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
       <Card>
         <CardContent className="p-4">
           <div className="flex items-center gap-3 flex-wrap">
-            <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${status.color}`}>
+            <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-sm font-medium ${status.color}`}>
               {isActive && (
                 <span className="relative mr-1.5 flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
@@ -264,7 +264,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
       </Card>
 
       {/* Timestamps — secondary reference data */}
-      <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs text-muted-foreground px-1">
+      <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-sm text-muted-foreground px-1">
         <span className="inline-flex items-center gap-1.5">
           <Timer className="h-3 w-3" />
           {formatDuration(session.started_at, session.completed_at)}
@@ -293,13 +293,13 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
           <CardContent className="space-y-3 text-sm">
             {session.pm_reasoning && (
               <div>
-                <p className="text-xs font-medium text-muted-foreground">Why this was prioritized</p>
+                <p className="text-sm font-medium text-muted-foreground">Why this was prioritized</p>
                 <p>{session.pm_reasoning}</p>
               </div>
             )}
             {session.pm_approach && (
               <div>
-                <p className="text-xs font-medium text-muted-foreground">Suggested approach</p>
+                <p className="text-sm font-medium text-muted-foreground">Suggested approach</p>
                 <p>{session.pm_approach}</p>
               </div>
             )}
@@ -1528,7 +1528,7 @@ export function SessionDetailContent({ id }: { id: string }) {
               </TabsList>
               {hasPR && prData?.data?.github_pr_url ? (
                 <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
-                  <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
+                  <Button variant="outline" size="sm" className="h-7 text-sm gap-1.5">
                     <ExternalLink className="h-3 w-3" />
                     View PR
                   </Button>
@@ -1537,7 +1537,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="h-7 text-xs gap-1.5"
+                  className="h-7 text-sm gap-1.5"
                   disabled={
                     createPRMutation.isPending ||
                     (ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected)

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -254,7 +254,7 @@ export function SessionSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-y-hidden">
+          <TabsList size="sm" className="overflow-x-auto overflow-y-hidden">
             {filterTabs.map((tab) => {
               const count =
                 tab.value === "needs_attention" ? needsAttentionSessions.length

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -67,7 +67,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title }: AuditL
         variant="ghost"
         size="sm"
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 hover:text-muted-foreground transition-all duration-150 h-auto px-1.5 py-0.5 -ml-1.5"
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground/70 hover:text-muted-foreground transition-all duration-150 h-auto px-1.5 py-0.5 -ml-1.5"
       >
         <Clock className="h-3 w-3" />
         <span>

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -35,7 +35,7 @@ const tabsListVariants = cva(
       },
       size: {
         default: "",
-        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 py-0.5 px-0 rounded-none bg-transparent flex w-full flex-nowrap justify-start overflow-x-auto",
+        sm: "group-data-[orientation=horizontal]/tabs:h-auto gap-0.5 py-0.5 px-0 rounded-none bg-transparent flex w-full flex-nowrap justify-start",
       },
     },
     defaultVariants: {
@@ -71,7 +71,7 @@ function TabsTrigger({
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
       className={cn(
-        "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 group-data-[size=sm]/tabs-list:h-auto group-data-[size=sm]/tabs-list:flex-none group-data-[size=sm]/tabs-list:text-xs group-data-[size=sm]/tabs-list:gap-1",
+        "cursor-pointer focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 group-data-[size=sm]/tabs-list:h-auto group-data-[size=sm]/tabs-list:flex-none group-data-[size=sm]/tabs-list:text-sm group-data-[size=sm]/tabs-list:gap-1",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
         "after:absolute after:opacity-0 after:transition-opacity after:bg-[image:var(--gradient-primary)] after:rounded-full group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",


### PR DESCRIPTION
## Summary
- Removes unwanted scrollbar in the session detail sidebar tab header by dropping `overflow-x-auto` from the small TabsList variant
- Standardizes font sizes across the sidebar from a mix of `text-xs` and `text-sm` to consistently use `text-sm`, covering status badges, timestamps, failure details, PM context labels, tab triggers, PR buttons, and the audit log trigger

## Test plan
- [ ] Open a session detail sidebar and verify no scrollbar appears near the Overview/Changes tabs
- [ ] Confirm font sizes look consistent across all sidebar elements (status badge, timestamps, failure card, audit log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)