### PR TITLE
Move repo dropdown from header to bottom of sidebar

### DIFF
--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -147,7 +147,6 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
                 {orgName}
               </span>
             </Link>
-            <RepoContextSwitcher />
           </div>
           <TooltipProvider>
             <div className="flex items-center gap-0.5">
@@ -210,6 +209,11 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           })}
           <SidebarSettingsSection pathname={pathname} userRole={user?.role} />
         </nav>
+
+        {/* Repo context switcher */}
+        <div className="relative px-2 pb-1 border-t border-border/50 pt-2">
+          <RepoContextSwitcher />
+        </div>
 
         {/* User menu */}
         <div className="relative px-2 pb-3 border-t border-border/50 pt-2">

--- a/frontend/src/components/repo-context-switcher.tsx
+++ b/frontend/src/components/repo-context-switcher.tsx
@@ -75,14 +75,15 @@ export function RepoContextSwitcher() {
   return (
     <DropdownMenu onOpenChange={(open) => { if (!open) setSearch(""); }}>
       <DropdownMenuTrigger
-        className="flex items-center gap-1.5 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors px-2 py-1 rounded-md hover:bg-sidebar-accent"
+        className="flex items-center h-8 w-full gap-2 rounded-md px-2.5 text-[13px] font-medium transition-colors duration-150 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
         data-testid="repo-context-switcher"
       >
-        <span>{label}</span>
-        <ChevronDown className="h-3.5 w-3.5 opacity-50" />
+        <GitBranch className="h-4 w-4 shrink-0" />
+        <span className="truncate flex-1 text-left">{label}</span>
         {selectedRepo && <StatusDot status={selectedRepo.latest_session_status} />}
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-64">
+      <DropdownMenuContent align="start" side="top" className="w-64">
         {showSearch && (
           <div className="px-2 pb-1.5">
             <Input


### PR DESCRIPTION
## Summary
- Moves the "All repositories" dropdown from the cramped sidebar header to its own section above the user menu
- Restyles the trigger to match the user menu pattern: full-width button with GitBranch icon, truncating label, and upward-opening dropdown
- Frees up header space so the org name and action icons are no longer squished

## Test plan
- [x] Frontend build passes
- [x] All 7 repo-context-switcher tests pass
- [ ] Visual check: org name no longer truncated, repo switcher visible above user menu

Generated with [Claude Code](https://claude.com/claude-code)