### PR TITLE
Store error details on PM Analysis sessions for UI visibility

### DIFF
--- a/internal/services/pm/context_gather_test.go
+++ b/internal/services/pm/context_gather_test.go
@@ -76,7 +76,7 @@ func (m *gatherSessionStoreMock) ListRecentByOrg(ctx context.Context, orgID uuid
 	return m.recent, nil
 }
 
-func (m *gatherSessionStoreMock) UpdateStatus(ctx context.Context, orgID, runID uuid.UUID, status string) error {
+func (m *gatherSessionStoreMock) UpdateResult(ctx context.Context, orgID, runID uuid.UUID, status string, result *models.SessionResult) error {
 	return nil
 }
 

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -27,7 +27,7 @@ type issueStore interface {
 type sessionStore interface {
 	CountRunningByOrg(ctx context.Context, orgID uuid.UUID) (int, error)
 	Create(ctx context.Context, run *models.Session) error
-	UpdateStatus(ctx context.Context, orgID, runID uuid.UUID, status string) error
+	UpdateResult(ctx context.Context, orgID, runID uuid.UUID, status string, result *models.SessionResult) error
 	UpdatePMPlanID(ctx context.Context, orgID, runID, planID uuid.UUID) error
 	ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.SessionFilters) ([]models.Session, error)
 	ListRecentByOrg(ctx context.Context, orgID uuid.UUID, statuses []string, limit int) ([]models.Session, error)
@@ -267,19 +267,38 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		pmSession = nil
 	}
 
-	// Helper to mark PM session as failed on early return.
-	failSession := func() {
+	// failSession marks the PM session as failed, capturing the error message on
+	// the session record and writing a session log entry (matching the manual-session
+	// pattern so failures are visible in the UI). It returns a wrapped error for the
+	// caller to return directly, avoiding duplicate format strings at each call site.
+	failSession := func(stage string, cause error) error {
+		errMsg := fmt.Sprintf("%s: %v", stage, cause)
 		if pmSession != nil {
-			if err := s.sessions.UpdateStatus(ctx, orgID, pmSession.ID, "failed"); err != nil {
+			result := &models.SessionResult{
+				Error: strPtr(errMsg),
+			}
+			if err := s.sessions.UpdateResult(ctx, orgID, pmSession.ID, "failed", result); err != nil {
 				s.logger.Error().Err(err).Msg("failed to mark PM session as failed")
 			}
+			// Write an error-level session log so the failure appears in the activity stream.
+			if s.sessionLogs != nil {
+				log := &models.SessionLog{
+					SessionID: pmSession.ID,
+					OrgID:     orgID,
+					Level:     "error",
+					Message:   errMsg,
+				}
+				if err := s.sessionLogs.Create(ctx, log); err != nil {
+					s.logger.Error().Err(err).Msg("failed to write PM failure session log")
+				}
+			}
 		}
+		return fmt.Errorf("%s: %w", stage, cause)
 	}
 
 	ctxBundle, err := s.gatherContext(ctx, orgID, &repo)
 	if err != nil {
-		failSession()
-		return nil, fmt.Errorf("gather context: %w", err)
+		return nil, failSession("gather context", err)
 	}
 
 	sbCfg := pmSandboxConfig()
@@ -302,8 +321,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 
 	sb, err := s.sandbox.Create(ctx, sbCfg)
 	if err != nil {
-		failSession()
-		return nil, fmt.Errorf("create sandbox: %w", err)
+		return nil, failSession("create sandbox", err)
 	}
 	defer func() {
 		if destroyErr := s.sandbox.Destroy(ctx, sb); destroyErr != nil {
@@ -315,14 +333,12 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	if s.github != nil {
 		ghToken, err := s.github.GetInstallationToken(ctx, repo.InstallationID)
 		if err != nil {
-			failSession()
-			return nil, fmt.Errorf("get installation token: %w", err)
+			return nil, failSession("get installation token", err)
 		}
 		token = ghToken
 	}
 	if err := s.sandbox.CloneRepo(ctx, sb, repo.CloneURL, repo.DefaultBranch, token); err != nil {
-		failSession()
-		return nil, fmt.Errorf("clone repo: %w", err)
+		return nil, failSession("clone repo", err)
 	}
 
 	if ctxBundle.productContext != nil {
@@ -339,12 +355,10 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 
 	contextJSON, err := json.Marshal(ctxBundle.pmContext)
 	if err != nil {
-		failSession()
-		return nil, fmt.Errorf("marshal pm context: %w", err)
+		return nil, failSession("marshal pm context", err)
 	}
 	if err := s.sandbox.WriteFile(ctx, sb, "/workspace/.pm-context.json", contextJSON); err != nil {
-		failSession()
-		return nil, fmt.Errorf("write context: %w", err)
+		return nil, failSession("write context to sandbox", err)
 	}
 
 	// Write full Slack thread files to the sandbox for PM drill-down.
@@ -384,13 +398,12 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	close(logCh)
 	logWg.Wait()
 	if err != nil {
-		failSession()
-		return nil, fmt.Errorf("pm agent execution: %w", err)
+		return nil, failSession("pm agent execution", err)
 	}
 
 	plan, err := parsePlan(result.Summary)
 	if err != nil {
-		failSession()
+		failSession("parse plan", err)
 		logOutput := result.Summary
 		if len(logOutput) > 2000 {
 			logOutput = logOutput[:2000] + "...(truncated)"
@@ -425,12 +438,10 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 
 	planModel, err := planToModel(plan, ctxBundle.productContext)
 	if err != nil {
-		failSession()
-		return nil, fmt.Errorf("serialize plan: %w", err)
+		return nil, failSession("serialize plan", err)
 	}
 	if err := s.plans.Create(ctx, planModel); err != nil {
-		failSession()
-		return nil, fmt.Errorf("persist plan: %w", err)
+		return nil, failSession("persist plan", err)
 	}
 	plan.ID = planModel.ID
 	plan.CreatedAt = planModel.CreatedAt
@@ -453,8 +464,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	}
 
 	if err := s.executePlan(ctx, orgID, plan, ctxBundle.settings, ctxBundle.productContext); err != nil {
-		failSession()
-		return nil, fmt.Errorf("execute plan: %w", err)
+		return nil, failSession("execute plan", err)
 	}
 
 	// Execute project plans if projects feature is enabled.
@@ -479,9 +489,12 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		s.logger.Error().Err(err).Msg("failed to persist completed plan status")
 	}
 
-	// Mark PM session as completed.
+	// Mark PM session as completed, persisting token usage on the session record.
 	if pmSession != nil {
-		if err := s.sessions.UpdateStatus(ctx, orgID, pmSession.ID, "completed"); err != nil {
+		sessionResult := &models.SessionResult{
+			TokenUsage: plan.TokenUsage,
+		}
+		if err := s.sessions.UpdateResult(ctx, orgID, pmSession.ID, "completed", sessionResult); err != nil {
 			s.logger.Error().Err(err).Msg("failed to mark PM session as completed")
 		}
 	}

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -403,7 +403,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 
 	plan, err := parsePlan(result.Summary)
 	if err != nil {
-		failSession("parse plan", err)
+		sessionErr := failSession("parse plan", err)
 		logOutput := result.Summary
 		if len(logOutput) > 2000 {
 			logOutput = logOutput[:2000] + "...(truncated)"
@@ -420,7 +420,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		if sessionID != "" {
 			return nil, fmt.Errorf("parse plan [session_id=%s]: %w", sessionID, err)
 		}
-		return nil, fmt.Errorf("parse plan: %w", err)
+		return nil, sessionErr
 	}
 
 	plan.OrgID = orgID

--- a/internal/services/pm/service_test.go
+++ b/internal/services/pm/service_test.go
@@ -30,8 +30,10 @@ func (m *mockIssueStore) UpdateStatus(ctx context.Context, orgID, issueID uuid.U
 }
 
 type mockSessionStore struct {
-	created []*models.Session
-	running int
+	created          []*models.Session
+	running          int
+	lastResult       *models.SessionResult
+	lastResultStatus string
 }
 
 func (m *mockSessionStore) CountRunningByOrg(ctx context.Context, orgID uuid.UUID) (int, error) {
@@ -51,7 +53,9 @@ func (m *mockSessionStore) ListRecentByOrg(ctx context.Context, orgID uuid.UUID,
 	return nil, nil
 }
 
-func (m *mockSessionStore) UpdateStatus(ctx context.Context, orgID, runID uuid.UUID, status string) error {
+func (m *mockSessionStore) UpdateResult(ctx context.Context, orgID, runID uuid.UUID, status string, result *models.SessionResult) error {
+	m.lastResult = result
+	m.lastResultStatus = status
 	return nil
 }
 
@@ -196,4 +200,49 @@ func TestExecutePlan_ManualAutonomySkipsDelegation(t *testing.T) {
 
 	runStore := svc.sessions.(*mockSessionStore)
 	require.Len(t, runStore.created, 0, "should not create agent runs in manual mode")
+}
+
+type mockSessionLogStore struct {
+	logs []*models.SessionLog
+}
+
+func (m *mockSessionLogStore) Create(ctx context.Context, log *models.SessionLog) error {
+	m.logs = append(m.logs, log)
+	return nil
+}
+
+func TestAnalyze_FailSessionRecordsError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	sessions := &mockSessionStore{}
+	logStore := &mockSessionLogStore{}
+
+	svc := &Service{
+		sessions:    sessions,
+		sessionLogs: logStore,
+		orgs:        &failingOrgStore{}, // gatherContext will fail on GetByID
+		repos:       &mockRepoStore{repos: []models.Repository{{ID: repoID, Status: "active"}}},
+		sandbox:     &mockSandbox{},
+		adapter:     &mockAdapter{},
+		logger:      zerolog.Nop(),
+	}
+
+	_, err := svc.Analyze(context.Background(), orgID, models.PMTriggerCron, nil)
+	require.Error(t, err, "Analyze should fail")
+	require.Contains(t, err.Error(), "gather context")
+
+	// Verify session was created, then marked failed with error via UpdateResult.
+	require.Len(t, sessions.created, 1, "PM session should be created")
+	require.Equal(t, "failed", sessions.lastResultStatus, "session should be marked failed")
+	require.NotNil(t, sessions.lastResult, "UpdateResult should have been called")
+	require.NotNil(t, sessions.lastResult.Error, "error message should be set on session")
+	require.Contains(t, *sessions.lastResult.Error, "gather context", "error should describe the failure stage")
+	require.Contains(t, *sessions.lastResult.Error, "org not found", "error should include the underlying cause")
+
+	// Verify an error-level session log was written.
+	require.Len(t, logStore.logs, 1, "should write one session log entry")
+	require.Equal(t, "error", logStore.logs[0].Level, "log should be error level")
+	require.Contains(t, logStore.logs[0].Message, "gather context", "log message should describe failure")
 }


### PR DESCRIPTION
## Summary
- PM Analysis sessions were silently marked as "failed" without recording the error, making failures impossible to diagnose from the UI (showed "No activity yet")
- `failSession` now uses `UpdateResult` (matching the manual session pattern) to persist the error on the session record and writes an error-level session log so failures appear in the activity stream
- Refactored `failSession` to return the wrapped error directly, eliminating duplicate format strings at each call site
- Success path also switched to `UpdateResult` to store token usage on the PM session; removed now-unused `UpdateStatus` from the PM `sessionStore` interface
- Added `TestAnalyze_FailSessionRecordsError` verifying that errors are recorded on both the session and session log

## Test plan
- [x] All PM service tests pass (`go test ./internal/services/pm/...`)
- [x] Full project builds cleanly (`go build ./...`)
- [ ] Deploy and trigger a PM Analysis failure — verify the error message appears in the session detail view and activity stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)