### PR TITLE
Fix image attachments not displaying in chat

### DIFF
--- a/internal/api/handlers/uploads.go
+++ b/internal/api/handlers/uploads.go
@@ -107,15 +107,9 @@ func (h *UploadHandler) Upload(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// ServeUpload handles GET /api/v1/uploads/files/* — serves locally-stored uploads.
-// Only functional when using FileUploadStore.
+// ServeUpload handles GET /api/v1/uploads/files/* — serves uploaded files.
+// Works with both local filesystem and S3 storage backends.
 func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
-	fileStore, ok := h.store.(*storage.FileUploadStore)
-	if !ok {
-		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "file serving not available in S3 mode")
-		return
-	}
-
 	// Extract the file key from the URL path after /api/v1/uploads/files/
 	key := strings.TrimPrefix(r.URL.Path, "/api/v1/uploads/files/")
 	if key == "" || strings.Contains(key, "..") {
@@ -130,7 +124,7 @@ func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileStore.ServeFile(w, r, key)
+	h.store.Serve(w, r, key)
 }
 
 func extensionFromMIME(mime string) string {

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -162,14 +162,19 @@ func TestUploadHandler_ServeUpload_CrossOrgDenied(t *testing.T) {
 func TestUploadHandler_ServeUpload_S3Mode(t *testing.T) {
 	t.Parallel()
 
-	s3Store := storage.NewS3UploadStore(nil, "bucket", "prefix", "https://example.com")
+	s3Store := storage.NewS3UploadStore(nil, "bucket", "prefix")
 	h := NewUploadHandler(s3Store)
 
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/some-key.png", nil)
+	// The key must be prefixed by the requesting org's ID.
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+orgID.String()+"/file.png", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
 	h.ServeUpload(w, req)
 
+	// S3 client is nil, so GetObject will fail — handler returns 404.
 	require.Equal(t, http.StatusNotFound, w.Code)
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -253,11 +252,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
 		} else {
 			s3Client := s3.NewFromConfig(awsCfg)
-			endpoint := cfg.UploadS3Endpoint
-			if endpoint == "" {
-				endpoint = fmt.Sprintf("https://%s.s3.%s.amazonaws.com", cfg.UploadS3Bucket, cfg.UploadS3Region)
-			}
-			uploadStore = storage.NewS3UploadStore(s3Client, cfg.UploadS3Bucket, cfg.UploadS3Prefix, endpoint)
+			uploadStore = storage.NewS3UploadStore(s3Client, cfg.UploadS3Bucket, cfg.UploadS3Prefix)
 			logger.Info().Str("bucket", cfg.UploadS3Bucket).Str("prefix", cfg.UploadS3Prefix).Msg("upload S3 store configured")
 		}
 	} else {

--- a/internal/services/storage/upload_reaper_test.go
+++ b/internal/services/storage/upload_reaper_test.go
@@ -74,7 +74,7 @@ func TestUploadReaper_S3ModeNoop(t *testing.T) {
 	t.Parallel()
 
 	// S3UploadStore should cause the reaper to exit immediately.
-	s3Store := NewS3UploadStore(nil, "bucket", "prefix", "https://example.com")
+	s3Store := NewS3UploadStore(nil, "bucket", "prefix")
 	logger := zerolog.Nop()
 	reaper := NewUploadReaper(s3Store, 24*time.Hour, time.Minute, logger)
 

--- a/internal/services/storage/uploads.go
+++ b/internal/services/storage/uploads.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -23,24 +25,27 @@ type UploadStore interface {
 
 	// URL returns the public URL for a previously-uploaded file.
 	URL(key string) string
+
+	// Serve writes the file contents to the response. Implementations may
+	// serve directly (local filesystem) or proxy from object storage (S3).
+	Serve(w http.ResponseWriter, r *http.Request, key string)
 }
 
 // S3UploadStore stores uploads in an S3-compatible bucket.
 type S3UploadStore struct {
-	client   S3Client
-	bucket   string
-	prefix   string
-	endpoint string // base URL for constructing public URLs
+	client  S3Client
+	bucket  string
+	prefix  string
+	baseURL string // backend URL prefix for proxied file serving
 }
 
 // NewS3UploadStore creates an S3UploadStore.
-// endpoint is the base URL for the bucket (e.g. "https://mybucket.s3.amazonaws.com").
-func NewS3UploadStore(client S3Client, bucket, prefix, endpoint string) *S3UploadStore {
+func NewS3UploadStore(client S3Client, bucket, prefix string) *S3UploadStore {
 	return &S3UploadStore{
-		client:   client,
-		bucket:   bucket,
-		prefix:   strings.TrimSuffix(prefix, "/"),
-		endpoint: strings.TrimSuffix(endpoint, "/"),
+		client:  client,
+		bucket:  bucket,
+		prefix:  strings.TrimSuffix(prefix, "/"),
+		baseURL: "/api/v1/uploads/files",
 	}
 }
 
@@ -69,7 +74,42 @@ func (s *S3UploadStore) Save(ctx context.Context, key string, reader io.Reader, 
 }
 
 func (s *S3UploadStore) URL(key string) string {
-	return s.endpoint + "/" + s.fullKey(key)
+	return s.baseURL + "/" + key
+}
+
+// Serve fetches the file from S3 and streams it to the HTTP response.
+func (s *S3UploadStore) Serve(w http.ResponseWriter, r *http.Request, key string) {
+	if s.client == nil {
+		http.Error(w, "storage not configured", http.StatusNotFound)
+		return
+	}
+	out, err := s.client.GetObject(r.Context(), &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(s.fullKey(key)),
+	})
+	if err != nil {
+		http.Error(w, "file not found", http.StatusNotFound)
+		return
+	}
+	defer out.Body.Close()
+
+	if out.ContentType != nil {
+		w.Header().Set("Content-Type", *out.ContentType)
+	}
+	if out.ContentLength != nil {
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", *out.ContentLength))
+	}
+	// Images display inline; other file types download as attachments.
+	fileName := path.Base(key)
+	if out.ContentType != nil && strings.HasPrefix(*out.ContentType, "image/") {
+		w.Header().Set("Content-Disposition", "inline")
+	} else {
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", fileName))
+	}
+	w.Header().Set("Cache-Control", "private, max-age=86400")
+	if _, err := io.Copy(w, out.Body); err != nil {
+		log.Printf("upload serve: streaming %s: %v", key, err)
+	}
 }
 
 // FileUploadStore stores uploads on the local filesystem and serves them
@@ -109,8 +149,9 @@ func (f *FileUploadStore) URL(key string) string {
 	return f.baseURL + "/" + key
 }
 
-// ServeFile serves a locally-stored upload file. Only used with FileUploadStore.
-func (f *FileUploadStore) ServeFile(w http.ResponseWriter, r *http.Request, key string) {
+// Serve serves a locally-stored upload file.
+func (f *FileUploadStore) Serve(w http.ResponseWriter, r *http.Request, key string) {
 	path := filepath.Join(f.baseDir, filepath.Clean(key))
 	http.ServeFile(w, r, path)
 }
+

--- a/internal/services/storage/uploads_test.go
+++ b/internal/services/storage/uploads_test.go
@@ -3,12 +3,48 @@ package storage
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/stretchr/testify/require"
 )
+
+// mockS3Client implements S3Client for testing.
+type mockS3Client struct {
+	getObjectFunc    func(ctx context.Context, input *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	putObjectFunc    func(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	deleteObjectFunc func(ctx context.Context, input *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+func (m *mockS3Client) GetObject(ctx context.Context, input *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	if m.getObjectFunc != nil {
+		return m.getObjectFunc(ctx, input, optFns...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockS3Client) PutObject(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	if m.putObjectFunc != nil {
+		return m.putObjectFunc(ctx, input, optFns...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *mockS3Client) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	if m.deleteObjectFunc != nil {
+		return m.deleteObjectFunc(ctx, input, optFns...)
+	}
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Compile-time check that mockS3Client implements S3Client.
+var _ S3Client = (*mockS3Client)(nil)
 
 func TestFileUploadStore_SaveAndURL(t *testing.T) {
 	t.Parallel()
@@ -61,21 +97,93 @@ func TestFileUploadStore_TrailingSlashTrimmed(t *testing.T) {
 func TestS3UploadStore_URL(t *testing.T) {
 	t.Parallel()
 
-	store := NewS3UploadStore(nil, "mybucket", "uploads", "https://mybucket.s3.amazonaws.com")
-	require.Equal(t, "https://mybucket.s3.amazonaws.com/uploads/org-1/file.png", store.URL("org-1/file.png"))
+	store := NewS3UploadStore(nil, "mybucket", "uploads")
+	require.Equal(t, "/api/v1/uploads/files/org-1/file.png", store.URL("org-1/file.png"),
+		"S3 URLs should be proxied through the backend")
 }
 
 func TestS3UploadStore_URL_NoPrefix(t *testing.T) {
 	t.Parallel()
 
-	store := NewS3UploadStore(nil, "mybucket", "", "https://mybucket.s3.amazonaws.com")
-	require.Equal(t, "https://mybucket.s3.amazonaws.com/org-1/file.png", store.URL("org-1/file.png"))
+	store := NewS3UploadStore(nil, "mybucket", "")
+	require.Equal(t, "/api/v1/uploads/files/org-1/file.png", store.URL("org-1/file.png"),
+		"S3 URLs should be proxied through the backend regardless of prefix")
 }
 
-func TestS3UploadStore_EndpointTrailingSlashTrimmed(t *testing.T) {
+func TestS3UploadStore_Serve(t *testing.T) {
 	t.Parallel()
 
-	store := NewS3UploadStore(nil, "mybucket", "uploads", "https://mybucket.s3.amazonaws.com/")
-	require.Equal(t, "https://mybucket.s3.amazonaws.com/uploads/file.png", store.URL("file.png"),
-		"trailing slash on endpoint should be trimmed")
+	body := []byte("fake-image-data")
+	contentType := "image/png"
+	contentLength := int64(len(body))
+
+	mock := &mockS3Client{
+		getObjectFunc: func(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			require.Equal(t, "mybucket", *input.Bucket)
+			require.Equal(t, "uploads/org-1/2026-01/abc.png", *input.Key)
+			return &s3.GetObjectOutput{
+				Body:          io.NopCloser(bytes.NewReader(body)),
+				ContentType:   &contentType,
+				ContentLength: &contentLength,
+			}, nil
+		},
+	}
+
+	store := NewS3UploadStore(mock, "mybucket", "uploads")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/org-1/2026-01/abc.png", nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, "org-1/2026-01/abc.png")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "image/png", w.Header().Get("Content-Type"))
+	require.Equal(t, fmt.Sprintf("%d", contentLength), w.Header().Get("Content-Length"))
+	require.Equal(t, "inline", w.Header().Get("Content-Disposition"))
+	require.Equal(t, "private, max-age=86400", w.Header().Get("Cache-Control"))
+	require.Equal(t, body, w.Body.Bytes())
+}
+
+func TestS3UploadStore_Serve_NonImageAttachment(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"key": "value"}`)
+	contentType := "application/json"
+	contentLength := int64(len(body))
+
+	mock := &mockS3Client{
+		getObjectFunc: func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{
+				Body:          io.NopCloser(bytes.NewReader(body)),
+				ContentType:   &contentType,
+				ContentLength: &contentLength,
+			}, nil
+		},
+	}
+
+	store := NewS3UploadStore(mock, "mybucket", "uploads")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/org-1/2026-01/data.json", nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, "org-1/2026-01/data.json")
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, `attachment; filename="data.json"`, w.Header().Get("Content-Disposition"))
+}
+
+func TestS3UploadStore_Serve_GetObjectError(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockS3Client{
+		getObjectFunc: func(_ context.Context, _ *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return nil, fmt.Errorf("NoSuchKey: the specified key does not exist")
+		},
+	}
+
+	store := NewS3UploadStore(mock, "mybucket", "uploads")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/org-1/missing.png", nil)
+	w := httptest.NewRecorder()
+
+	store.Serve(w, req, "org-1/missing.png")
+
+	require.Equal(t, http.StatusNotFound, w.Code)
 }


### PR DESCRIPTION
## Summary
- Image attachments were not rendering in the chat composer or sent messages because `S3UploadStore.URL()` returned direct S3 URLs to private objects, causing 403 Forbidden errors in the browser
- Both storage backends now return proxy URLs (`/api/v1/uploads/files/{key}`) and `ServeUpload` fetches from S3 and streams the response, with proper `Content-Type`, `Content-Disposition`, and `Cache-Control` headers
- Removed the unused `endpoint` parameter from `NewS3UploadStore` and added comprehensive tests for the S3 serve path (happy path, non-image attachments, GetObject errors)

## Test plan
- [ ] Upload an image attachment in a chat session and verify it displays in the composer preview
- [ ] Send the message and verify the image renders in the sent message bubble
- [ ] Upload a non-image file (PDF, JSON) and verify it downloads as an attachment when clicked
- [ ] Verify existing local file uploads still work in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)