### PR TITLE
Fix clipped top border on selected session in sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -278,7 +278,7 @@ export function SessionSidebar() {
       </div>
 
       {/* Session list */}
-      <div className="flex-1 overflow-y-auto px-2 pb-2">
+      <div className="flex-1 overflow-y-auto px-2 pt-1 pb-2">
         {/* Ghost "New session" entry when creating */}
         {isNewSession && (
           <Link


### PR DESCRIPTION
The session list scroll container had horizontal and bottom padding but no top padding, so the first session item's selection border was clipped by the container edge. Adds `pt-1` to ensure the border and shadow are fully visible.