### PR TITLE
Split failed sessions out of Needs attention into own tab

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -38,22 +38,26 @@ const filterTabs = [
   { value: "all", label: "All" },
   { value: "needs_attention", label: "Needs attention" },
   { value: "working", label: "Working" },
+  { value: "failed", label: "Failed" },
   { value: "done", label: "Done" },
 ];
 
-// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / DoneStatuses.
-const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
+// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses.
+const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
 const workingStatuses = ["pending", "running"];
+const failedStatuses = ["failed"];
 const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
 
 const needsAttentionSet = new Set(needsAttentionStatuses);
 const workingSet = new Set(workingStatuses);
+const failedSet = new Set(failedStatuses);
 
 /** Map a filter tab value to the comma-separated status string for the API. */
 function filterToStatusParam(filter: string | null): string | undefined {
   if (!filter || filter === "all") return undefined;
   if (filter === "needs_attention") return needsAttentionStatuses.join(",");
   if (filter === "working") return workingStatuses.join(",");
+  if (filter === "failed") return failedStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
 }
@@ -192,6 +196,7 @@ export function SessionSidebar() {
 
   const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
+  const failedSessions = allSessions.filter((s) => failedSet.has(s.status));
 
   const filteredSessions = useMemo(
     () => {
@@ -259,6 +264,7 @@ export function SessionSidebar() {
               const count =
                 tab.value === "needs_attention" ? needsAttentionSessions.length
                 : tab.value === "working" ? workingSessions.length
+                : tab.value === "failed" ? failedSessions.length
                 : 0;
               return (
                 <TabsTrigger key={tab.value} value={tab.value}>
@@ -267,6 +273,7 @@ export function SessionSidebar() {
                     <span className={cn(
                       "rounded-full text-white text-xs leading-none px-1.5 py-0.5",
                       tab.value === "needs_attention" ? "bg-orange-500"
+                      : tab.value === "failed" ? "bg-destructive"
                       : "bg-primary"
                     )}>{count}</span>
                   )}

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -16,6 +16,12 @@ import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import type { SessionListItem } from "@/lib/types";
+import {
+  needsAttentionSet,
+  workingSet,
+  failedSet,
+  filterToStatusParam,
+} from "@/lib/session-status-groups";
 
 // ---------------------------------------------------------------------------
 // Status config
@@ -42,25 +48,6 @@ const filterTabs = [
   { value: "done", label: "Done" },
 ];
 
-// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses.
-const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
-const workingStatuses = ["pending", "running"];
-const failedStatuses = ["failed"];
-const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
-
-const needsAttentionSet = new Set(needsAttentionStatuses);
-const workingSet = new Set(workingStatuses);
-const failedSet = new Set(failedStatuses);
-
-/** Map a filter tab value to the comma-separated status string for the API. */
-function filterToStatusParam(filter: string | null): string | undefined {
-  if (!filter || filter === "all") return undefined;
-  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
-  if (filter === "working") return workingStatuses.join(",");
-  if (filter === "failed") return failedStatuses.join(",");
-  if (filter === "done") return doneStatuses.join(",");
-  return filter;
-}
 
 // ---------------------------------------------------------------------------
 // Unread indicator logic

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -55,23 +55,27 @@ const filterTabs = [
   { value: "all", label: "All" },
   { value: "needs_attention", label: "Action needed" },
   { value: "working", label: "Working" },
+  { value: "failed", label: "Failed" },
   { value: "done", label: "Done" },
   { value: "decisions", label: "Decisions" },
 ];
 
-// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / DoneStatuses.
-const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance", "failed"];
+// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses.
+const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
 const workingStatuses = ["pending", "running"];
+const failedStatuses = ["failed"];
 const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
 
 const needsAttentionSet = new Set(needsAttentionStatuses);
 const workingSet = new Set(workingStatuses);
+const failedSet = new Set(failedStatuses);
 
 /** Map a filter tab value to the comma-separated status string for the API. */
 function filterToStatusParam(filter: string | null): string | undefined {
   if (!filter || filter === "all" || filter === "decisions") return undefined;
   if (filter === "needs_attention") return needsAttentionStatuses.join(",");
   if (filter === "working") return workingStatuses.join(",");
+  if (filter === "failed") return failedStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
 }
@@ -261,6 +265,7 @@ export function SessionsPageContent() {
 
   const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
+  const failedSessions = allSessions.filter((s) => failedSet.has(s.status));
 
   const filteredSessions = useMemo(
     () => {
@@ -299,6 +304,7 @@ export function SessionsPageContent() {
             const count =
               tab.value === "needs_attention" ? needsAttentionSessions.length
               : tab.value === "working" ? workingSessions.length
+              : tab.value === "failed" ? failedSessions.length
               : 0;
             return (
               <button
@@ -315,6 +321,7 @@ export function SessionsPageContent() {
                   {count > 0 && (
                     <span className={`rounded-full text-white text-xs leading-none px-1.5 py-0.5 font-normal ${
                       tab.value === "needs_attention" ? "bg-orange-500"
+                      : tab.value === "failed" ? "bg-destructive"
                       : "bg-primary"
                     }`}>{count}</span>
                   )}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -33,6 +33,12 @@ import { StatusDot } from "@/components/status-dot";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
 import { SessionOwnerToggle } from "./session-owner-toggle";
 import type { Session, User } from "@/lib/types";
+import {
+  needsAttentionSet,
+  workingSet,
+  failedSet,
+  filterToStatusParam as baseFilterToStatusParam,
+} from "@/lib/session-status-groups";
 
 // ---------------------------------------------------------------------------
 // Status config
@@ -60,24 +66,9 @@ const filterTabs = [
   { value: "decisions", label: "Decisions" },
 ];
 
-// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses.
-const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
-const workingStatuses = ["pending", "running"];
-const failedStatuses = ["failed"];
-const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
-
-const needsAttentionSet = new Set(needsAttentionStatuses);
-const workingSet = new Set(workingStatuses);
-const failedSet = new Set(failedStatuses);
-
-/** Map a filter tab value to the comma-separated status string for the API. */
+/** Wrapper that also passes through "decisions" as a client-only filter. */
 function filterToStatusParam(filter: string | null): string | undefined {
-  if (!filter || filter === "all" || filter === "decisions") return undefined;
-  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
-  if (filter === "working") return workingStatuses.join(",");
-  if (filter === "failed") return failedStatuses.join(",");
-  if (filter === "done") return doneStatuses.join(",");
-  return filter;
+  return baseFilterToStatusParam(filter, ["decisions"]);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/create-session-dialog.test.tsx
+++ b/frontend/src/components/create-session-dialog.test.tsx
@@ -443,37 +443,39 @@ describe("CreateSessionDialog", () => {
       }),
     );
 
-    renderWithProviders(
-      <CreateSessionDialog open onOpenChange={onOpenChange} />,
-    );
+    try {
+      renderWithProviders(
+        <CreateSessionDialog open onOpenChange={onOpenChange} />,
+      );
 
-    // Type a message
-    await user.type(
-      screen.getByPlaceholderText("Tell the agent what to do..."),
-      "Fix the bug",
-    );
+      // Type a message
+      await user.type(
+        screen.getByPlaceholderText("Tell the agent what to do..."),
+        "Fix the bug",
+      );
 
-    // Wait for repo selector and select a repo
-    const repoButton = await screen.findByRole("button", { name: /Repo/ });
-    await user.click(repoButton);
+      // Wait for repo selector and select a repo
+      const repoButton = await screen.findByRole("button", { name: /Repo/ });
+      await user.click(repoButton);
 
-    // Wait for dropdown to fully open and select repo
-    const repoOption = await screen.findByText("acme/api-server");
-    await user.click(repoOption);
+      // Wait for dropdown to fully open and select repo
+      const repoOption = await screen.findByText("acme/api-server");
+      await user.click(repoOption);
 
-    // Wait for dropdown to close, selection to settle, and branch data to load
-    await waitFor(() => {
-      expect(screen.getByText("api-server")).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /Target branch/ })).toBeInTheDocument();
-    });
+      // Wait for dropdown to close, selection to settle, and branch data to load
+      await waitFor(() => {
+        expect(screen.getByText("api-server")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Target branch/ })).toBeInTheDocument();
+      });
 
-    // Submit
-    await user.click(screen.getByRole("button", { name: /Create/ }));
+      // Submit
+      await user.click(screen.getByRole("button", { name: /Create/ }));
 
-    await waitFor(() => {
-      expect(onOpenChange).toHaveBeenCalledWith(false);
-    });
-
-    console.error = origConsoleError;
+      await waitFor(() => {
+        expect(onOpenChange).toHaveBeenCalledWith(false);
+      });
+    } finally {
+      console.error = origConsoleError;
+    }
   });
 });

--- a/frontend/src/lib/session-status-groups.ts
+++ b/frontend/src/lib/session-status-groups.ts
@@ -1,0 +1,22 @@
+// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses
+// in internal/models/session_enums.go.
+
+export const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
+export const workingStatuses = ["pending", "running"];
+export const failedStatuses = ["failed"];
+export const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
+
+export const needsAttentionSet = new Set(needsAttentionStatuses);
+export const workingSet = new Set(workingStatuses);
+export const failedSet = new Set(failedStatuses);
+
+/** Map a filter tab value to the comma-separated status string for the API. */
+export function filterToStatusParam(filter: string | null, extraPassthrough?: string[]): string | undefined {
+  if (!filter || filter === "all") return undefined;
+  if (extraPassthrough?.includes(filter)) return undefined;
+  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
+  if (filter === "working") return workingStatuses.join(",");
+  if (filter === "failed") return failedStatuses.join(",");
+  if (filter === "done") return doneStatuses.join(",");
+  return filter;
+}

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -39,10 +39,12 @@ func (s SessionStatus) Validate() error {
 // Status groups used by the frontend filter tabs. Defined here so the backend
 // is the source of truth; the frontend arrays must stay in sync.
 var (
-	// NeedsAttentionStatuses are statuses where user action is required.
-	NeedsAttentionStatuses = []SessionStatus{SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance, SessionStatusFailed}
+	// NeedsAttentionStatuses are statuses where the agent is blocked waiting on the user.
+	NeedsAttentionStatuses = []SessionStatus{SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance}
 	// WorkingStatuses are statuses where the agent is actively executing.
 	WorkingStatuses = []SessionStatus{SessionStatusPending, SessionStatusRunning}
+	// FailedStatuses are sessions that terminated with an error.
+	FailedStatuses = []SessionStatus{SessionStatusFailed}
 	// DoneStatuses are terminal or parked statuses.
 	DoneStatuses = []SessionStatus{SessionStatusCompleted, SessionStatusPRCreated, SessionStatusCancelled, SessionStatusSkipped, SessionStatusIdle}
 )


### PR DESCRIPTION
## Summary
- Removed `failed` from the "Needs attention" filter so it only shows sessions where the agent is blocked on the user (`awaiting_input`, `needs_human_guidance`)
- Added a dedicated "Failed" tab with a red badge between "Working" and "Done"
- Updated both the sidebar and table view filters, plus the backend status group definitions

## Test plan
- [ ] Verify "Needs attention" tab only shows `awaiting_input` and `needs_human_guidance` sessions
- [ ] Verify "Failed" tab shows failed sessions with red badge count
- [ ] Verify other tabs (All, Working, Done) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)