### PR TITLE
Add session archiving with user tracking and audit logging

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { Plus, Search } from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Archive, ArchiveRestore, Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -46,6 +46,7 @@ const filterTabs = [
   { value: "working", label: "Working" },
   { value: "failed", label: "Failed" },
   { value: "done", label: "Done" },
+  { value: "archived", label: "Archived" },
 ];
 
 
@@ -150,6 +151,7 @@ function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
 export function SessionSidebar() {
   const params = useParams();
   const pathname = usePathname();
+  const queryClient = useQueryClient();
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
@@ -160,6 +162,7 @@ export function SessionSidebar() {
   const { optimisticSessions } = useOptimisticSessions();
 
   const currentFilter = activeFilter ?? "all";
+  const isArchivedView = currentFilter === "archived";
   const statusParam = filterToStatusParam(currentFilter);
 
   // Fetch all sessions (for tab badge counts and the "all" view).
@@ -179,18 +182,47 @@ export function SessionSidebar() {
     enabled: !!statusParam,
   });
 
+  // Fetch archived sessions when the archived tab is active.
+  const { data: archivedData, isLoading: isArchivedLoading } = useQuery({
+    queryKey: [...queryKeys.sessions.list(repo), "archived", triggeredByUserId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId, only_archived: true }),
+    refetchInterval: 10000,
+    enabled: isArchivedView,
+  });
+
+  const invalidateSessions = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
+  };
+
+  const archiveMutation = useMutation({
+    mutationFn: (sessionId: string) => api.sessions.archive(sessionId),
+    onSuccess: invalidateSessions,
+  });
+
+  const unarchiveMutation = useMutation({
+    mutationFn: (sessionId: string) => api.sessions.unarchive(sessionId),
+    onSuccess: invalidateSessions,
+  });
+
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);
 
   const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
   const failedSessions = allSessions.filter((s) => failedSet.has(s.status));
 
+  // Archived sessions: backend returns only archived sessions via only_archived filter.
+  const archivedSessions = useMemo(
+    () => archivedData?.data ?? [],
+    [archivedData?.data],
+  );
+
   const filteredSessions = useMemo(
     () => {
+      if (isArchivedView) return archivedSessions;
       if (statusParam && filteredData) return filteredData.data;
       return allSessions;
     },
-    [allSessions, filteredData, statusParam],
+    [allSessions, filteredData, statusParam, isArchivedView, archivedSessions],
   );
 
   const displayedSessions = useMemo(() => {
@@ -293,13 +325,13 @@ export function SessionSidebar() {
             <OptimisticSessionRow key={os.id} session={os} />
           ))}
 
-        {isLoading && (
+        {(isLoading || (isArchivedView && isArchivedLoading)) && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
             Loading...
           </div>
         )}
 
-        {!isLoading && displayedSessions.length === 0 && (
+        {!isLoading && !(isArchivedView && isArchivedLoading) && displayedSessions.length === 0 && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
             {allSessions.length === 0 ? "No sessions yet" : "No sessions match this filter."}
           </div>
@@ -311,29 +343,30 @@ export function SessionSidebar() {
           const isWorkingSession = workingSet.has(session.status);
           const hasUnread = isUnread(session);
           const ts = session.completed_at || session.started_at || session.created_at;
+          const isArchived = !!session.archived_at;
 
           return (
-            <Link
-              key={session.id}
-              href={`/sessions/${session.id}`}
-              className={cn(
-                "block rounded-lg px-3 py-2.5 mb-0.5 transition-all duration-150",
-                isSelected
-                  ? "bg-background shadow-sm border border-border/50"
-                  : "hover:bg-background/60"
-              )}
-            >
-              <div className="flex items-start gap-2.5 min-w-0">
-                {/* Unread / working indicator */}
-                <div className="mt-1.5 shrink-0">
-                  {isWorkingSession ? (
-                    <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
-                  ) : hasUnread ? (
-                    <StatusDot color="bg-primary" />
-                  ) : (
-                    <span className="inline-flex rounded-full h-2 w-2" />
-                  )}
-                </div>
+            <div key={session.id} className="group relative">
+              <Link
+                href={`/sessions/${session.id}`}
+                className={cn(
+                  "block rounded-lg px-3 py-2.5 mb-0.5 transition-all duration-150",
+                  isSelected
+                    ? "bg-background shadow-sm border border-border/50"
+                    : "hover:bg-background/60"
+                )}
+              >
+                <div className="flex items-start gap-2.5 min-w-0">
+                  {/* Unread / working indicator */}
+                  <div className="mt-1.5 shrink-0">
+                    {isWorkingSession ? (
+                      <StatusDot animate color="bg-primary" pingColor="bg-primary/60" />
+                    ) : hasUnread ? (
+                      <StatusDot color="bg-primary" />
+                    ) : (
+                      <span className="inline-flex rounded-full h-2 w-2" />
+                    )}
+                  </div>
 
                 {/* Content */}
                 <div className="min-w-0 flex-1">
@@ -371,7 +404,24 @@ export function SessionSidebar() {
                   )}
                 </div>
               </div>
-            </Link>
+              </Link>
+              {/* Archive / Unarchive button — visible on hover */}
+              <button
+                className="absolute top-2 right-2 hidden group-hover:flex group-focus-within:flex items-center justify-center h-6 w-6 rounded-md bg-background border border-border/60 text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shadow-sm"
+                title={isArchived ? "Unarchive session" : "Archive session"}
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  if (isArchived) {
+                    unarchiveMutation.mutate(session.id);
+                  } else {
+                    archiveMutation.mutate(session.id);
+                  }
+                }}
+              >
+                {isArchived ? <ArchiveRestore className="h-3 w-3" /> : <Archive className="h-3 w-3" />}
+              </button>
+            </div>
           );
         })}
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -205,7 +205,7 @@ export const api = {
       del(`/api/v1/pm/documents/${docId}`),
   },
   sessions: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string; search?: string }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string; search?: string; include_archived?: boolean; only_archived?: boolean }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
@@ -213,6 +213,8 @@ export const api = {
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       if (params?.triggered_by_user_id) searchParams.set('triggered_by_user_id', params.triggered_by_user_id);
       if (params?.search) searchParams.set('search', params.search);
+      if (params?.only_archived) searchParams.set('only_archived', 'true');
+      else if (params?.include_archived) searchParams.set('include_archived', 'true');
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').SessionListItem>>(`/api/v1/sessions${qs ? `?${qs}` : ''}`);
     },
@@ -238,6 +240,10 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/retry`),
     cancelSession: (sessionId: string) =>
       post<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${sessionId}/cancel`),
+    archive: (sessionId: string) =>
+      post<{ status: string }>(`/api/v1/sessions/${sessionId}/archive`, {}),
+    unarchive: (sessionId: string) =>
+      post<{ status: string }>(`/api/v1/sessions/${sessionId}/unarchive`, {}),
     // Thread endpoints
     listThreads: (sessionId: string) =>
       get<import('./types').ListResponse<import('./types').SessionThread>>(`/api/v1/sessions/${sessionId}/threads`),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -118,6 +118,8 @@ export interface Session {
   diff?: string;
   diff_stats?: { added: number; removed: number; files_changed: number };
   diff_history?: Array<{ pass: number; diff: string; diff_stats: { added: number; removed: number; files_changed: number }; created_at: string }>;
+  archived_at?: string;
+  archived_by_user_id?: string;
   created_at: string;
 }
 

--- a/internal/api/handlers/session_files_test.go
+++ b/internal/api/handlers/session_files_test.go
@@ -78,7 +78,7 @@ var sessionColumnsForFiles = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "deleted_at", "created_at",
 }
 
 func setupSessionMock(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, containerID *string) {
@@ -99,6 +99,7 @@ func setupSessionMock(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, con
 				nil, nil, nil,                      // target_branch, working_branch, repository_id
 				nil, nil,                           // diff_stats, diff_history
 				nil,                                // input_manifest
+				nil, nil,                           // archived_at, archived_by_user_id
 				nil,                                // deleted_at
 				now,                                // created_at
 			),

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -132,6 +132,12 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		filters.CursorID = &id
 	}
 
+	if r.URL.Query().Get("only_archived") == "true" {
+		filters.OnlyArchived = true
+	} else if r.URL.Query().Get("include_archived") == "true" {
+		filters.IncludeArchived = true
+	}
+
 	if statusParam := r.URL.Query().Get("status"); statusParam != "" {
 		for _, s := range strings.Split(statusParam, ",") {
 			s = strings.TrimSpace(s)
@@ -1288,6 +1294,59 @@ func manualSessionTitle(message string) string {
 	}
 
 	return strings.TrimSpace(trimmed[:120]) + "..."
+}
+
+// ArchiveSession marks a session as archived, hiding it from default list views.
+func (h *SessionHandler) ArchiveSession(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not authenticated")
+		return
+	}
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	if err := h.runStore.Archive(r.Context(), orgID, sessionID, user.ID); err != nil {
+		if errors.Is(err, db.ErrSessionAlreadyArchived) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or already archived")
+		} else {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to archive session")
+		}
+		return
+	}
+
+	sessionIDStr := sessionID.String()
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionArchived, models.AuditResourceSession, &sessionIDStr, &sessionID, nil, nil)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// UnarchiveSession removes the archived flag from a session.
+func (h *SessionHandler) UnarchiveSession(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	if err := h.runStore.Unarchive(r.Context(), orgID, sessionID); err != nil {
+		if errors.Is(err, db.ErrSessionNotArchived) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or not archived")
+		} else {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to unarchive session")
+		}
+		return
+	}
+
+	sessionIDStr := sessionID.String()
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionUnarchived, models.AuditResourceSession, &sessionIDStr, &sessionID, nil, nil)
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 // gitRefPattern validates git ref names. Allows alphanumeric, dots, hyphens,

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -52,7 +52,7 @@ var sessionColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "deleted_at", "created_at",
 }
 
 func TestSessionHandler_List(t *testing.T) {
@@ -90,6 +90,7 @@ func TestSessionHandler_List(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -173,6 +174,7 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -267,6 +269,7 @@ func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -426,6 +429,7 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -1140,6 +1144,7 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1228,6 +1233,7 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1289,6 +1295,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1314,6 +1321,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1608,6 +1616,7 @@ func TestSessionHandler_EndSession_EnqueuesValidation(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1668,6 +1677,7 @@ func TestSessionHandler_EndSession_ManualSkipsValidation(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -1849,6 +1859,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -1889,6 +1900,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -1971,6 +1983,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -1995,6 +2008,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2036,6 +2050,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2081,6 +2096,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2117,6 +2133,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, 3, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2145,6 +2162,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, 2, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2178,6 +2196,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2206,6 +2225,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // diff_stats
 							nil, // diff_history
 							nil, // input_manifest
+							nil, nil, // archived_at, archived_by_user_id
 							nil, // deleted_at
 							now,
 						),
@@ -2534,6 +2554,7 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 				nil, // diff_stats
 				nil, // diff_history
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2596,6 +2617,7 @@ func TestSessionHandler_CreatePR_NoDiff(t *testing.T) {
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2648,6 +2670,7 @@ func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2743,6 +2766,7 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2811,6 +2835,7 @@ func TestSessionHandler_CancelSession_Success(t *testing.T) {
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2863,6 +2888,7 @@ func TestSessionHandler_CancelSession_NotRunning(t *testing.T) {
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),
@@ -2939,6 +2965,7 @@ func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
 				nil, // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
 				nil, // deleted_at
 				now,
 			),

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2986,6 +2986,173 @@ func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionHandler_ArchiveSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("archives session successfully", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+
+		mock.ExpectExec("UPDATE sessions SET archived_at").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/archive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", sessionID.String())
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, orgID)
+		ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.ArchiveSession(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "archive should return 200")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns 401 when user is not authenticated", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+		sessionID := uuid.New()
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/archive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", sessionID.String())
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, uuid.New())
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.ArchiveSession(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("returns 404 when session not found", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+
+		mock.ExpectExec("UPDATE sessions SET archived_at").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/archive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", sessionID.String())
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, orgID)
+		ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.ArchiveSession(w, req)
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSessionHandler_UnarchiveSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unarchives session successfully", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+		orgID := uuid.New()
+		sessionID := uuid.New()
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/unarchive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", sessionID.String())
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, orgID)
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.UnarchiveSession(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "unarchive should return 200")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns 404 when session not found or not archived", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+		orgID := uuid.New()
+		sessionID := uuid.New()
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/unarchive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", sessionID.String())
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, orgID)
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.UnarchiveSession(w, req)
+
+		require.Equal(t, http.StatusNotFound, w.Code)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns 400 for invalid session ID", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		handler := newSessionHandler(t, mock)
+
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/not-a-uuid/unarchive", nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("id", "not-a-uuid")
+		ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+		ctx = middleware.WithOrgID(ctx, uuid.New())
+		req = req.WithContext(ctx)
+		w := httptest.NewRecorder()
+
+		handler.UnarchiveSession(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -353,7 +353,7 @@ func TestSessionHandler_List_WithCursor(t *testing.T) {
 				nil, nil, nil, nil,
 				nil, nil, nil,
 				nil, 0, nil, "none", nil,
-				nil, nil, nil, nil, nil, nil, nil, now,
+				nil, nil, nil, nil, nil, nil, nil, nil, nil, now,
 			),
 		)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -445,6 +445,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Post("/api/v1/sessions/{id}/end", sessionHandler.EndSession)
 			r.Post("/api/v1/sessions/{id}/retry", sessionHandler.RetrySession)
 			r.Post("/api/v1/sessions/{id}/cancel", sessionHandler.CancelSession)
+			r.Post("/api/v1/sessions/{id}/archive", sessionHandler.ArchiveSession)
+			r.Post("/api/v1/sessions/{id}/unarchive", sessionHandler.UnarchiveSession)
 			r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
 			r.Post("/api/v1/sessions/{id}/threads", sessionThreadHandler.CreateThread)
 			r.Post("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.SendThreadMessage)

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -25,7 +25,7 @@ var sessionColumns = []string{
 	"agent_session_id", "current_turn", "last_activity_at",
 	"sandbox_state", "snapshot_key", "target_branch", "working_branch",
 	"repository_id", "diff_stats", "diff_history", "input_manifest",
-	"deleted_at", "created_at",
+	"archived_at", "archived_by_user_id", "deleted_at", "created_at",
 }
 
 func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
@@ -50,6 +50,7 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil,    // diff_stats
 		nil,    // diff_history
 		nil,    // input_manifest
+		nil, nil, // archived_at, archived_by_user_id
 		nil,    // deleted_at
 		now,
 	}

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -36,6 +36,8 @@ type SessionFilters struct {
 	RepositoryID       uuid.UUID  // When non-zero, filter sessions by repository via issues table.
 	TriggeredByUserID  uuid.UUID  // When non-zero, filter sessions to those triggered by this user.
 	Search             string     // When non-empty, filter sessions by title (case-insensitive prefix/substring match).
+	IncludeArchived    bool       // When true, include archived sessions in the results.
+	OnlyArchived       bool       // When true, return only archived sessions.
 }
 
 // sessionSelectColumns is used for single-session queries where we want all fields.
@@ -47,7 +49,7 @@ const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-00
 	parent_session_id, revision_context, error, result_summary, diff,
 	pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 	model_override, triggered_by_user_id, agent_session_id, current_turn, last_activity_at,
-	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, diff_history, input_manifest, deleted_at, created_at`
+	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, deleted_at, created_at`
 
 // sessionListColumns excludes large JSONB blobs (diff_history) from list queries
 // to avoid returning multi-megabyte payloads when listing many sessions.
@@ -59,7 +61,7 @@ const sessionListColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-0000
 	parent_session_id, revision_context, error, result_summary, diff,
 	pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 	model_override, triggered_by_user_id, agent_session_id, current_turn, last_activity_at,
-	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, deleted_at, created_at`
+	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, deleted_at, created_at`
 
 // maxDiffHistoryEntries caps the number of entries kept in diff_history.
 // Older entries beyond this limit are pruned when a new entry is appended.
@@ -107,6 +109,12 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 		SELECT ` + sessionListColumns + `
 		FROM sessions
 		WHERE org_id = @org_id AND deleted_at IS NULL`
+
+	if filters.OnlyArchived {
+		query += ` AND archived_at IS NOT NULL`
+	} else if !filters.IncludeArchived {
+		query += ` AND archived_at IS NULL`
+	}
 
 	if filters.RepositoryID != uuid.Nil {
 		query += ` AND repository_id = @repository_id`
@@ -347,6 +355,10 @@ var (
 	ErrSessionNotFound = fmt.Errorf("session not found")
 	// ErrSessionNotFailed is returned when trying to retry a session that is not in failed status.
 	ErrSessionNotFailed = fmt.Errorf("session is not in failed status")
+	// ErrSessionAlreadyArchived is returned when trying to archive an already-archived session.
+	ErrSessionAlreadyArchived = fmt.Errorf("session not found or already archived")
+	// ErrSessionNotArchived is returned when trying to unarchive a session that is not archived.
+	ErrSessionNotArchived = fmt.Errorf("session not found or not archived")
 )
 
 // ResetForRetry resets a failed session back to pending so it can be re-run.
@@ -606,6 +618,39 @@ func (s *SessionStore) ListExpiredSnapshots(ctx context.Context, olderThan time.
 		return nil, fmt.Errorf("query expired snapshots: %w", err)
 	}
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
+}
+
+// Archive marks a session as archived, hiding it from default list views.
+func (s *SessionStore) Archive(ctx context.Context, orgID, sessionID, userID uuid.UUID) error {
+	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = @user_id, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
+	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":      sessionID,
+		"org_id":  orgID,
+		"user_id": userID,
+	})
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSessionAlreadyArchived
+	}
+	return nil
+}
+
+// Unarchive removes the archived flag from a session, restoring it to default views.
+func (s *SessionStore) Unarchive(ctx context.Context, orgID, sessionID uuid.UUID) error {
+	query := `UPDATE sessions SET archived_at = NULL, archived_by_user_id = NULL, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NOT NULL`
+	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	})
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSessionNotArchived
+	}
+	return nil
 }
 
 // SoftDelete marks a session as deleted without removing the row.

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -549,3 +549,82 @@ func TestSessionStore_ListExpiredSnapshots(t *testing.T) {
 	require.Len(t, sessions, 0)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestSessionStore_Archive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("archives session successfully", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+
+		mock.ExpectExec("UPDATE sessions SET archived_at").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		err = store.Archive(context.Background(), orgID, sessionID, userID)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns error when session not found or already archived", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+
+		mock.ExpectExec("UPDATE sessions SET archived_at").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+		err = store.Archive(context.Background(), uuid.New(), uuid.New(), uuid.New())
+		require.ErrorIs(t, err, ErrSessionAlreadyArchived)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSessionStore_Unarchive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unarchives session successfully", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = NULL, archived_by_user_id = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		err = store.Unarchive(context.Background(), uuid.New(), uuid.New())
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns error when session not found or not archived", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+		err = store.Unarchive(context.Background(), uuid.New(), uuid.New())
+		require.ErrorIs(t, err, ErrSessionNotArchived)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -21,7 +21,7 @@ var sessionTestColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "deleted_at", "created_at",
 }
 
 func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []interface{} {
@@ -40,6 +40,7 @@ func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []in
 		nil, // diff_stats
 		nil, // diff_history
 		nil, // input_manifest
+		nil, nil, // archived_at, archived_by_user_id
 		nil, // deleted_at
 		now,
 	}

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -41,6 +41,8 @@ const (
 	AuditActionSessionReviewCommentDeleted AuditAction = "session.review_comment.deleted"
 	AuditActionSessionPRRequested          AuditAction = "session.pr_requested"
 	AuditActionSessionRetried              AuditAction = "session.retried"
+	AuditActionSessionArchived             AuditAction = "session.archived"
+	AuditActionSessionUnarchived           AuditAction = "session.unarchived"
 
 	// Project actions
 	AuditActionProjectCreated        AuditAction = "project.created"
@@ -110,6 +112,7 @@ func (a AuditAction) Validate() error {
 		AuditActionSessionQuestionCreated, AuditActionSessionQuestionAnswered, AuditActionSessionResumedLocally,
 		AuditActionSessionReviewCommentCreated, AuditActionSessionReviewCommentUpdated, AuditActionSessionReviewCommentDeleted,
 		AuditActionSessionPRRequested, AuditActionSessionRetried,
+		AuditActionSessionArchived, AuditActionSessionUnarchived,
 		AuditActionProjectCreated, AuditActionProjectUpdated, AuditActionProjectDeleted,
 		AuditActionProjectStarted, AuditActionProjectPaused, AuditActionProjectResumed,
 		AuditActionProjectApproved, AuditActionProjectCompleted, AuditActionProjectDismissed, AuditActionProjectRunTriggered,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -151,7 +151,9 @@ type Session struct {
 	// field being non-nil unless the session was fetched individually.
 	DiffHistory   json.RawMessage `db:"diff_history" json:"diff_history,omitempty"`
 	InputManifest json.RawMessage `db:"input_manifest" json:"input_manifest,omitempty"`
-	DeletedAt     *time.Time      `db:"deleted_at" json:"-"`
+	ArchivedAt       *time.Time  `db:"archived_at" json:"archived_at,omitempty"`
+	ArchivedByUserID *uuid.UUID  `db:"archived_by_user_id" json:"archived_by_user_id,omitempty"`
+	DeletedAt        *time.Time  `db:"deleted_at" json:"-"`
 	CreatedAt     time.Time       `db:"created_at" json:"created_at"`
 }
 

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -40,7 +40,7 @@ var sessionColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning", "project_task_id",
 	"model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "deleted_at", "created_at",
 }
 
 // newMockPool creates a pgxmock pool and returns it with a cleanup.
@@ -146,6 +146,7 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 					nil, // diff_stats
 					nil, // diff_history
 					nil, // input_manifest
+					nil, nil, // archived_at, archived_by_user_id
 					nil, // deleted_at
 					now),
 		)

--- a/migrations/000062_session_archived_at.down.sql
+++ b/migrations/000062_session_archived_at.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_sessions_not_archived;
+ALTER TABLE sessions DROP COLUMN IF EXISTS archived_by_user_id;
+ALTER TABLE sessions DROP COLUMN IF EXISTS archived_at;

--- a/migrations/000062_session_archived_at.up.sql
+++ b/migrations/000062_session_archived_at.up.sql
@@ -1,0 +1,10 @@
+-- Add archived_at column to sessions for hiding sessions from default views.
+-- Unlike deleted_at (soft-delete), archived sessions are still accessible
+-- but hidden from the default session list to reduce clutter.
+ALTER TABLE sessions ADD COLUMN archived_at timestamptz;
+ALTER TABLE sessions ADD COLUMN archived_by_user_id uuid REFERENCES users(id);
+
+-- Partial index for listing non-archived sessions efficiently.
+CREATE INDEX idx_sessions_not_archived
+  ON sessions (org_id, created_at DESC, id DESC)
+  WHERE archived_at IS NULL AND deleted_at IS NULL;


### PR DESCRIPTION
## Summary
- Adds `archived_at` and `archived_by_user_id` columns to the sessions table (migration 000062) so sessions can be hidden from the default list view without being deleted.
- Backend: `Archive`/`Unarchive` store methods, API endpoints (`POST /sessions/{id}/archive` and `/unarchive`), `include_archived` list filter, and `session.archived`/`session.unarchived` audit events tracking the acting user.
- Frontend: "Archived" filter tab in the session sidebar, hover-to-reveal archive/unarchive button on each session row, with optimistic cache invalidation.

## Test plan
- [ ] Run migration 000062 up and down, verify columns and index created/dropped
- [ ] Archive a session via the sidebar hover button, confirm it disappears from the default list
- [ ] Switch to "Archived" tab, confirm archived sessions appear with unarchive button
- [ ] Unarchive a session, confirm it returns to the default list
- [ ] Verify `archived_by_user_id` is set correctly in the database
- [ ] Verify audit_logs entries are created for archive/unarchive actions with correct user_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)