### PR TITLE
Fix autodeploy health check failures and add diagnostic logging

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -81,11 +81,21 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \
   bash << 'REMOTE'
   cd /opt/143
+
+  dump_diagnostics() {
+    echo "--- Last 50 lines of $HEALTH_SERVICE logs ---"
+    docker compose -f "$COMPOSE_FILE" logs --tail=50 "$HEALTH_SERVICE" 2>&1 || true
+    echo "--- Docker health check log ---"
+    docker inspect --format '{{range .State.Health.Log}}--- {{.Start}} ---
+{{.Output}}
+{{end}}' "$CONTAINER_ID" 2>&1 || true
+  }
+
   docker compose -f "$COMPOSE_FILE" pull
   docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
 
   echo "Waiting for $HEALTH_SERVICE health check..."
-  for i in $(seq 1 30); do
+  for i in $(seq 1 60); do
     CONTAINER_ID="$(docker compose -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE")"
     if [ -z "$CONTAINER_ID" ]; then
       echo "ERROR: could not find container for service $HEALTH_SERVICE"
@@ -100,11 +110,13 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 
     if [ "$HEALTH_STATUS" = "unhealthy" ] || [ "$HEALTH_STATUS" = "exited" ] || [ "$HEALTH_STATUS" = "dead" ]; then
       echo "ERROR: $HEALTH_SERVICE entered terminal state: $HEALTH_STATUS"
+      dump_diagnostics
       exit 1
     fi
 
-    if [ "$i" -eq 30 ]; then
-      echo "ERROR: Health check timed out after 60s for $HEALTH_SERVICE (last status: $HEALTH_STATUS)"
+    if [ "$i" -eq 60 ]; then
+      echo "ERROR: Health check timed out after 120s for $HEALTH_SERVICE (last status: $HEALTH_STATUS)"
+      dump_diagnostics
       exit 1
     fi
     sleep 2

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -30,6 +30,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+      start_period: 60s
     restart: unless-stopped
     deploy:
       resources:

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -20,6 +20,7 @@ services:
       interval: 15s
       timeout: 5s
       retries: 3
+      start_period: 60s
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
Add `start_period: 60s` to the Docker healthchecks for the app and worker compose files so that startup failures are not counted toward the retry limit. Previously, the API container would be marked `unhealthy` before it finished booting, causing the deploy to fail immediately.

The deploy script wait loop is extended from 60s to 120s to accommodate the start period. On failure, it now dumps the last 50 lines of container logs and the Docker health check log with timestamps via an extracted `dump_diagnostics` helper.