### PR TITLE
Prevent PM Analysis from rerunning on persistent failures

### DIFF
--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -274,6 +274,8 @@ func (h *PMHandler) Status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Compute next automatic run time from org settings (pm_schedule_hours).
+	// If the last run failed, the scheduler backs off for the full interval from
+	// the failure time, so use the later of (last plan + interval, last failure + interval).
 	if status.LastRunAt != nil && !status.IsRunning {
 		scheduleHours := models.DefaultPMScheduleHours
 		if h.orgStore != nil {
@@ -287,7 +289,11 @@ func (h *PMHandler) Status(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		nextRunAt := status.LastRunAt.Add(time.Duration(scheduleHours) * time.Hour)
+		interval := time.Duration(scheduleHours) * time.Hour
+		nextRunAt := status.LastRunAt.Add(interval)
+		if status.LastFailedAt != nil && status.LastFailedAt.Add(interval).After(nextRunAt) {
+			nextRunAt = status.LastFailedAt.Add(interval)
+		}
 		status.NextRunAt = &nextRunAt
 
 		remaining := time.Until(nextRunAt)

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -310,6 +310,75 @@ func TestPMHandler_StatusWithJobError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPMHandler_StatusNextRunAtAccountsForFailure(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	decisionLogStore := db.NewPMDecisionLogStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
+
+	orgID := uuid.New()
+	now := time.Now()
+	planCreatedAt := now.Add(-5 * time.Hour)  // plan was 5h ago
+	failedAt := now.Add(-30 * time.Minute)    // failure was 30min ago (more recent)
+
+	// Mock GetLatestByOrg — old successful plan.
+	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(pmPlanColumnsWithContext).
+				AddRow(uuid.New(), orgID, nil, "completed", "analysis",
+					json.RawMessage(`[]`), json.RawMessage(`[]`), json.RawMessage(`[]`),
+					5, 0, 0, 0, 0, 0,
+					json.RawMessage(`{}`), json.RawMessage(`{}`), "cron",
+					planCreatedAt, &planCreatedAt,
+				),
+		)
+
+	// Mock GetLatestFailedByType — recent failure.
+	mock.ExpectQuery("SELECT id, last_error, updated_at FROM jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "last_error", "updated_at"}).
+				AddRow(uuid.New(), "create sandbox: Docker daemon unreachable", failedAt),
+		)
+
+	// Mock GetDecisionSummary query.
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"total_delegated", "succeeded", "failed", "still_open"}).
+				AddRow(0, 0, 0, 0),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/status", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.Status(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "should return OK")
+
+	var resp models.SingleResponse[models.PMStatus]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
+	require.NotNil(t, resp.Data.NextRunAt, "should compute next run time")
+
+	// With default 4h schedule: plan-based next run = planCreatedAt + 4h = now - 1h (in the past).
+	// Failure-based next run = failedAt + 4h = now + 3h30m (in the future).
+	// NextRunAt should use the failure-based time since it's later.
+	defaultInterval := time.Duration(models.DefaultPMScheduleHours) * time.Hour
+	expectedNextRun := failedAt.Add(defaultInterval)
+	require.WithinDuration(t, expectedNextRun, *resp.Data.NextRunAt, time.Second,
+		"NextRunAt should be based on failure time, not the older plan time")
+
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 // pmDocColumns matches the column order in db/pm_documents.go scanPMDoc.
 var pmDocTestColumns = []string{
 	"id", "org_id", "title", "content", "doc_type", "sort_order",

--- a/internal/cluster/scheduler.go
+++ b/internal/cluster/scheduler.go
@@ -349,9 +349,9 @@ func (s *Scheduler) shouldRunPM(ctx context.Context, orgID uuid.UUID, now time.T
 	if err != nil {
 		return false, err
 	}
-	// Use half the success interval for failure backoff so transient errors
-	// don't block retries for the full schedule period.
-	failureBackoff := interval / 2
+	// Use the full interval for failure backoff. Persistent failures (e.g. Docker
+	// daemon down) won't resolve in minutes, so retrying sooner just creates noise.
+	failureBackoff := interval
 	if failedJob != nil && failedJob.UpdatedAt.Add(failureBackoff).After(now) {
 		s.logger.Debug().
 			Str("org_id", orgID.String()).

--- a/internal/cluster/scheduler_test.go
+++ b/internal/cluster/scheduler_test.go
@@ -401,7 +401,7 @@ func TestScheduler_ShouldRunPM_RecentFailure(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	failedAt := now.Add(-30 * time.Minute) // failed 30 min ago, within 2h failure backoff (interval/2)
+	failedAt := now.Add(-30 * time.Minute) // failed 30 min ago, within 4h failure backoff
 	s := &Scheduler{
 		lock: &mockSchedulerLock{},
 		jobs: &mockJobs{failedJob: &models.LatestJobError{
@@ -418,14 +418,14 @@ func TestScheduler_ShouldRunPM_RecentFailure(t *testing.T) {
 
 	run, err := s.shouldRunPM(context.Background(), uuid.New(), now, 4*time.Hour)
 	require.NoError(t, err, "shouldRunPM should not error")
-	require.False(t, run, "should not run when a recent failure exists within the failure backoff (interval/2)")
+	require.False(t, run, "should not run when a recent failure exists within the failure backoff")
 }
 
 func TestScheduler_ShouldRunPM_OldFailure(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now()
-	failedAt := now.Add(-3 * time.Hour) // failed 3 hours ago, beyond 2h failure backoff (interval/2)
+	failedAt := now.Add(-5 * time.Hour) // failed 5 hours ago, beyond 4h failure backoff
 	s := &Scheduler{
 		lock: &mockSchedulerLock{},
 		jobs: &mockJobs{failedJob: &models.LatestJobError{
@@ -442,5 +442,5 @@ func TestScheduler_ShouldRunPM_OldFailure(t *testing.T) {
 
 	run, err := s.shouldRunPM(context.Background(), uuid.New(), now, 4*time.Hour)
 	require.NoError(t, err, "shouldRunPM should not error")
-	require.True(t, run, "should run when the failure is older than the failure backoff (interval/2)")
+	require.True(t, run, "should run when the failure is older than the failure backoff")
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -240,7 +240,14 @@ func newPMAnalyzeHandler(stores *Stores, services *Services, logger zerolog.Logg
 
 		logger.Info().Str("org_id", orgID.String()).Str("trigger", string(trigger)).Msg("running pm analyze")
 		_, err = services.PM.Analyze(ctx, orgID, trigger, repoID)
-		return err
+		if err != nil {
+			// Mark all PM analysis errors as fatal (no retries). Analyze() creates a
+			// new session record before doing any real work, so each retry would produce
+			// a duplicate failed session in the UI. The scheduler will retry at the next
+			// configured interval instead.
+			return &FatalError{Err: err}
+		}
+		return nil
 	}
 }
 

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1183,6 +1183,10 @@ func TestPMAnalyzeHandler_ServiceError(t *testing.T) {
 	err := handler(context.Background(), "pm_analyze", payload)
 	require.Error(t, err, "pm_analyze handler should return error when service fails")
 	require.Contains(t, err.Error(), "pm analysis failed", "error should contain service error message")
+
+	// PM analyze errors should be wrapped as FatalError to prevent retries.
+	var fatal *FatalError
+	require.ErrorAs(t, err, &fatal, "pm_analyze errors should be wrapped as FatalError")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -25,6 +25,16 @@ type RetryableError struct {
 func (e *RetryableError) Error() string { return e.Err.Error() }
 func (e *RetryableError) Unwrap() error { return e.Err }
 
+// FatalError wraps an error to indicate that the job should be dead-lettered
+// immediately without retrying. Use this for persistent failures where retrying
+// would produce the same result (e.g. Docker daemon unreachable, missing config).
+type FatalError struct {
+	Err error
+}
+
+func (e *FatalError) Error() string { return e.Err.Error() }
+func (e *FatalError) Unwrap() error { return e.Err }
+
 type jobContextKey string
 
 const jobOrgIDContextKey jobContextKey = "job_org_id"
@@ -147,6 +157,14 @@ func (w *Worker) poll(ctx context.Context) {
 	handlerCtx := withJobOrgID(ctx, orgID)
 	w.logger.Info().Str("job_id", jobID.String()).Str("job_type", jobType).Msg("processing job")
 	if err := handler(handlerCtx, jobType, payload); err != nil {
+		// FatalError means the failure is persistent — dead-letter immediately
+		// without wasting retries (e.g. Docker daemon unreachable).
+		var fatal *FatalError
+		if errors.As(err, &fatal) {
+			w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed (fatal, skipping retries)")
+			w.deadLetterJob(ctx, jobID, err.Error())
+			return
+		}
 		// RetryableError means we should retry without consuming an attempt
 		// (e.g. concurrency limit reached — the job will succeed once a slot opens).
 		var retryable *RetryableError

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -424,6 +424,33 @@ func TestWorker_Poll(t *testing.T) {
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 			},
 		},
+		{
+			name: "fatal error dead-letters immediately without retrying",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+				jobID := uuid.New()
+				orgID := uuid.New()
+				payload := json.RawMessage(`{}`)
+				handlerErr := &FatalError{Err: errors.New("docker daemon unreachable")}
+
+				w.Register("fatal_job", func(ctx context.Context, jobType string, p json.RawMessage) error {
+					return handlerErr
+				})
+
+				mock.ExpectBegin()
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
+					AddRow(jobID, orgID, "fatal_job", payload, 0, 3) // attempt 0 of 3 — should still dead-letter
+				mock.ExpectQuery("SELECT .+ FROM jobs").
+					WillReturnRows(rows)
+				mock.ExpectExec("UPDATE jobs SET status = 'running'").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectCommit()
+				mock.ExpectExec("UPDATE jobs SET status = 'dead_letter'").
+					WithArgs(handlerErr.Error(), jobID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Add FatalError type to the worker so handlers can signal do not retry -- PM analyze jobs now dead-letter immediately instead of retrying 3 times and creating duplicate failed sessions
- Change scheduler failure backoff from interval/2 to the full configured interval, so failed runs are not re-triggered sooner than the schedule setting
- Fix the status endpoint NextRunAt calculation to account for failure backoff, so the UI shows accurate timing instead of soon during persistent failures

## Test plan
- [x] New test: FatalError dead-letters job on first attempt (worker_test.go)
- [x] New test: PM analyze handler wraps errors as FatalError (handlers_test.go)
- [x] Updated tests: scheduler backoff tests use full interval (scheduler_test.go)
- [x] New test: NextRunAt uses failure time when more recent than last plan (pm_test.go)
- [ ] Manual: trigger PM Analysis with Docker stopped, verify only 1 failed session appears and next run respects the full interval