### PR TITLE
Show status-appropriate time labels for failed/cancelled sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -82,6 +82,11 @@ const agentTypeLabels: Record<string, string> = {
   custom: "Custom",
 };
 
+function hasMeaningfulDuration(startedAt?: string, completedAt?: string): boolean {
+  if (!startedAt || !completedAt) return false;
+  return new Date(completedAt).getTime() - new Date(startedAt).getTime() >= 1000;
+}
+
 function formatDuration(startedAt?: string, completedAt?: string): string {
   if (!startedAt) return "-";
   const start = new Date(startedAt);
@@ -266,16 +271,32 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
 
       {/* Timestamps — secondary reference data */}
       <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs text-muted-foreground px-1">
-        <span className="inline-flex items-center gap-1.5">
-          <Timer className="h-3 w-3" />
-          {formatDuration(session.started_at, session.completed_at)}
-        </span>
+        {/* Hide duration for failed/cancelled sessions with no meaningful runtime */}
+        {!((session.status === "failed" || session.status === "cancelled") &&
+          !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
+          <span className="inline-flex items-center gap-1.5">
+            <Timer className="h-3 w-3" />
+            {formatDuration(session.started_at, session.completed_at)}
+          </span>
+        )}
         <span className="inline-flex items-center gap-1.5">
           {session.completed_at ? (
-            <>
-              <CheckCircle2 className="h-3 w-3" />
-              Completed {formatTimeAgo(session.completed_at)}
-            </>
+            session.status === "failed" ? (
+              <>
+                <XCircle className="h-3 w-3" />
+                Failed {formatTimeAgo(session.completed_at)}
+              </>
+            ) : session.status === "cancelled" ? (
+              <>
+                <MinusCircle className="h-3 w-3" />
+                Cancelled {formatTimeAgo(session.completed_at)}
+              </>
+            ) : (
+              <>
+                <CheckCircle2 className="h-3 w-3" />
+                Completed {formatTimeAgo(session.completed_at)}
+              </>
+            )
           ) : session.started_at ? (
             <>
               <Clock className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- Hide meaningless duration (the `- ` dash) for failed/cancelled sessions that had no real runtime (<1s or never started)
- Show "Failed X ago" with XCircle icon instead of "Completed X ago" for failed sessions
- Show "Cancelled X ago" with MinusCircle icon for cancelled sessions
- Extract `hasMeaningfulDuration` helper for clean conditional logic

## Test plan
- [ ] View a failed session that crashed instantly (e.g. sandbox creation failure) — should show only "Failed X ago", no duration
- [ ] View a failed session that ran for a while before failing — should show both duration and "Failed X ago"
- [ ] View a cancelled session — same behavior as failed
- [ ] View a completed session — unchanged, still shows duration and "Completed X ago"

🤖 Generated with [Claude Code](https://claude.com/claude-code)