### PR TITLE
Fix deploy health check: use wget instead of missing curl

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -26,7 +26,7 @@ services:
     env_file:
       - .env
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
       interval: 15s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
- Deploy was failing because the docker-compose health checks used `curl`, which is not installed in the server image
- The Dockerfile installs `wget` (and its own HEALTHCHECK uses `wget`), so switched both `docker-compose.app.yml` and `docker-compose.worker.yml` to use `wget -qO-` instead

## Test plan
- [ ] Deploy to app node and verify API container reaches healthy state
- [ ] Deploy to worker node and verify worker container reaches healthy state