### PR TITLE
Limit query retries and SSE reconnect attempts

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -712,7 +712,7 @@ function ReviewCommentInput({
 // Main chat panel
 // ---------------------------------------------------------------------------
 
-const MAX_SSE_RECONNECT_ATTEMPTS = 5;
+const MAX_SSE_RECONNECT_ATTEMPTS = 3;
 const BASE_SSE_RECONNECT_DELAY_MS = 1000;
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const SCROLL_NEAR_BOTTOM_THRESHOLD = 100;

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -431,7 +431,7 @@ function BootstrapDetailSheet({
     });
   }, []);
 
-  const MAX_SSE_RECONNECT_ATTEMPTS = 5;
+  const MAX_SSE_RECONNECT_ATTEMPTS = 3;
 
   useEffect(() => {
     const sessionId = bootstrap.session_id;

--- a/frontend/src/components/providers.tsx
+++ b/frontend/src/components/providers.tsx
@@ -7,7 +7,19 @@ import { ErrorBoundary } from "@/components/error-boundary";
 import { ThemeProvider } from "@/components/theme-provider";
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            retry: 2,
+          },
+          mutations: {
+            retry: 0,
+          },
+        },
+      })
+  );
 
   useEffect(() => {
     // ── P-80 Shooting Star easter egg ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Set global React Query defaults to `retry: 2` for queries and `retry: 0` for mutations (previously used the library default of 3 retries)
- Reduce SSE reconnect attempts from 5 to 3 in session detail and evals pages

This prevents excessive retries when sessions fail to load, reducing unnecessary network requests and improving the user experience on error.

## Test plan
- [ ] Verify session pages stop retrying after 2 failed query attempts
- [ ] Verify SSE streaming reconnects at most 3 times on connection loss
- [ ] Confirm polling intervals for active sessions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)