### PR TITLE
Add curl to cloud-init packages for deploy health checks

### DIFF
--- a/deploy/cloud-init/app.yml
+++ b/deploy/cloud-init/app.yml
@@ -28,6 +28,7 @@ packages:
   - docker-compose-plugin
   - git
   - jq
+  - curl
 
 runcmd:
   # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -26,6 +26,7 @@ packages:
   - docker-compose-plugin
   - git
   - jq
+  - curl
 
 runcmd:
   # Install gVisor


### PR DESCRIPTION
Cloud-init scripts for both app and worker nodes use curl (app.yml for the health check loop, worker.yml for gVisor installation), but curl was missing from the packages list. This caused failures on minimal Ubuntu cloud images where curl is not pre-installed.