### PR TITLE
Simplify session status filter tabs

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -65,9 +65,8 @@ describe('SessionSidebar', () => {
     await screen.findByText('Fixed TypeError by adding null check');
 
     expect(screen.getByRole('tab', { name: 'All' })).toBeInTheDocument();
-    expect(screen.getAllByText('Needs attention').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Working').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('Done').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Active').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Archived').length).toBeGreaterThanOrEqual(1);
   });
 
   it('uses a left-aligned horizontal-only tab scroller', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -17,9 +17,8 @@ import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimi
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import type { SessionListItem } from "@/lib/types";
 import {
-  needsAttentionSet,
+  activeSet,
   workingSet,
-  failedSet,
   filterToStatusParam,
 } from "@/lib/session-status-groups";
 
@@ -42,10 +41,7 @@ const statusConfig: Record<string, { dot: string; label: string }> = {
 
 const filterTabs = [
   { value: "all", label: "All" },
-  { value: "needs_attention", label: "Needs attention" },
-  { value: "working", label: "Working" },
-  { value: "failed", label: "Failed" },
-  { value: "done", label: "Done" },
+  { value: "active", label: "Active" },
   { value: "archived", label: "Archived" },
 ];
 
@@ -206,9 +202,7 @@ export function SessionSidebar() {
 
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);
 
-  const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
-  const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
-  const failedSessions = allSessions.filter((s) => failedSet.has(s.status));
+  const activeSessions = allSessions.filter((s) => activeSet.has(s.status));
 
   // Archived sessions: backend returns only archived sessions via only_archived filter.
   const archivedSessions = useMemo(
@@ -281,20 +275,13 @@ export function SessionSidebar() {
           <TabsList size="sm" className="overflow-x-auto overflow-y-hidden">
             {filterTabs.map((tab) => {
               const count =
-                tab.value === "needs_attention" ? needsAttentionSessions.length
-                : tab.value === "working" ? workingSessions.length
-                : tab.value === "failed" ? failedSessions.length
+                tab.value === "active" ? activeSessions.length
                 : 0;
               return (
                 <TabsTrigger key={tab.value} value={tab.value}>
                   {tab.label}
                   {count > 0 && (
-                    <span className={cn(
-                      "rounded-full text-white text-xs leading-none px-1.5 py-0.5",
-                      tab.value === "needs_attention" ? "bg-orange-500"
-                      : tab.value === "failed" ? "bg-destructive"
-                      : "bg-primary"
-                    )}>{count}</span>
+                    <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 bg-primary">{count}</span>
                   )}
                 </TabsTrigger>
               );
@@ -320,7 +307,7 @@ export function SessionSidebar() {
           </Link>
         )}
 
-        {(currentFilter === "all" || currentFilter === "working") &&
+        {(currentFilter === "all" || currentFilter === "active") &&
           optimisticSessions.map((os) => (
             <OptimisticSessionRow key={os.id} session={os} />
           ))}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -34,9 +34,8 @@ import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
 import { SessionOwnerToggle } from "./session-owner-toggle";
 import type { Session, User } from "@/lib/types";
 import {
-  needsAttentionSet,
+  activeSet,
   workingSet,
-  failedSet,
   filterToStatusParam as baseFilterToStatusParam,
 } from "@/lib/session-status-groups";
 
@@ -59,10 +58,7 @@ const statusConfig: Record<string, { dot: string; text: string; bg: string; labe
 
 const filterTabs = [
   { value: "all", label: "All" },
-  { value: "needs_attention", label: "Action needed" },
-  { value: "working", label: "Working" },
-  { value: "failed", label: "Failed" },
-  { value: "done", label: "Done" },
+  { value: "active", label: "Active" },
   { value: "decisions", label: "Decisions" },
 ];
 
@@ -254,9 +250,8 @@ export function SessionsPageContent() {
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);
   const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);
 
-  const needsAttentionSessions = allSessions.filter((s) => needsAttentionSet.has(s.status));
+  const activeSessions = allSessions.filter((s) => activeSet.has(s.status));
   const workingSessions = allSessions.filter((s) => workingSet.has(s.status));
-  const failedSessions = allSessions.filter((s) => failedSet.has(s.status));
 
   const filteredSessions = useMemo(
     () => {
@@ -293,9 +288,7 @@ export function SessionsPageContent() {
           {filterTabs.map((tab) => {
             const isSelected = currentFilter === tab.value;
             const count =
-              tab.value === "needs_attention" ? needsAttentionSessions.length
-              : tab.value === "working" ? workingSessions.length
-              : tab.value === "failed" ? failedSessions.length
+              tab.value === "active" ? activeSessions.length
               : 0;
             return (
               <button
@@ -310,11 +303,7 @@ export function SessionsPageContent() {
                 <span className="flex items-center gap-1.5">
                   {tab.label}
                   {count > 0 && (
-                    <span className={`rounded-full text-white text-xs leading-none px-1.5 py-0.5 font-normal ${
-                      tab.value === "needs_attention" ? "bg-orange-500"
-                      : tab.value === "failed" ? "bg-destructive"
-                      : "bg-primary"
-                    }`}>{count}</span>
+                    <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 font-normal bg-primary">{count}</span>
                   )}
                 </span>
                 {isSelected && (

--- a/frontend/src/lib/session-status-groups.ts
+++ b/frontend/src/lib/session-status-groups.ts
@@ -1,22 +1,17 @@
-// Status groups — keep in sync with models.NeedsAttentionStatuses / WorkingStatuses / FailedStatuses / DoneStatuses
+// Status groups — keep in sync with models.ActiveStatuses / DoneStatuses
 // in internal/models/session_enums.go.
 
-export const needsAttentionStatuses = ["awaiting_input", "needs_human_guidance"];
-export const workingStatuses = ["pending", "running"];
-export const failedStatuses = ["failed"];
-export const doneStatuses = ["completed", "pr_created", "cancelled", "skipped", "idle"];
+export const activeStatuses = ["pending", "running", "idle", "awaiting_input", "needs_human_guidance"];
+export const doneStatuses = ["completed", "pr_created", "failed", "cancelled", "skipped"];
 
-export const needsAttentionSet = new Set(needsAttentionStatuses);
-export const workingSet = new Set(workingStatuses);
-export const failedSet = new Set(failedStatuses);
+export const activeSet = new Set(activeStatuses);
+export const workingSet = new Set(["pending", "running"]);
 
 /** Map a filter tab value to the comma-separated status string for the API. */
 export function filterToStatusParam(filter: string | null, extraPassthrough?: string[]): string | undefined {
   if (!filter || filter === "all") return undefined;
   if (extraPassthrough?.includes(filter)) return undefined;
-  if (filter === "needs_attention") return needsAttentionStatuses.join(",");
-  if (filter === "working") return workingStatuses.join(",");
-  if (filter === "failed") return failedStatuses.join(",");
+  if (filter === "active") return activeStatuses.join(",");
   if (filter === "done") return doneStatuses.join(",");
   return filter;
 }

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -39,14 +39,10 @@ func (s SessionStatus) Validate() error {
 // Status groups used by the frontend filter tabs. Defined here so the backend
 // is the source of truth; the frontend arrays must stay in sync.
 var (
-	// NeedsAttentionStatuses are statuses where the agent is blocked waiting on the user.
-	NeedsAttentionStatuses = []SessionStatus{SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance}
-	// WorkingStatuses are statuses where the agent is actively executing.
-	WorkingStatuses = []SessionStatus{SessionStatusPending, SessionStatusRunning}
-	// FailedStatuses are sessions that terminated with an error.
-	FailedStatuses = []SessionStatus{SessionStatusFailed}
-	// DoneStatuses are terminal or parked statuses.
-	DoneStatuses = []SessionStatus{SessionStatusCompleted, SessionStatusPRCreated, SessionStatusCancelled, SessionStatusSkipped, SessionStatusIdle}
+	// ActiveStatuses are sessions that are in-progress or need attention.
+	ActiveStatuses = []SessionStatus{SessionStatusPending, SessionStatusRunning, SessionStatusIdle, SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance}
+	// DoneStatuses are terminal statuses.
+	DoneStatuses = []SessionStatus{SessionStatusCompleted, SessionStatusPRCreated, SessionStatusFailed, SessionStatusCancelled, SessionStatusSkipped}
 )
 
 // SandboxState tracks the lifecycle of a session's sandbox.


### PR DESCRIPTION
## Summary
- Consolidates 6 filter tabs (All, Needs attention, Working, Failed, Done, Archived/Decisions) into 2-3: **All**, **Active**, and **Archived** (sidebar) / **Decisions** (main page).
- "Active" combines all non-terminal statuses (pending, running, idle, awaiting_input, needs_human_guidance) into a single tab with a badge count.
- Individual per-session status labels (Running, Awaiting input, etc.) remain unchanged — only the filter tabs are simplified.
- Backend status groups updated to match: `ActiveStatuses` and `DoneStatuses` replace the previous four groups.

## Test plan
- [ ] Verify sidebar shows All / Active / Archived tabs
- [ ] Verify main sessions page shows All / Active / Decisions tabs
- [ ] Verify Active badge count reflects non-terminal sessions
- [ ] Verify archived sessions still hidden from All, visible in Archived tab
- [ ] Verify individual session status dots and labels unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)