### PR TITLE
Sync compose files to remote servers on every deploy

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -77,6 +77,9 @@ else
   echo "Skipping secret refresh (no SOPS key or .env.production.enc not found)."
 fi
 
+# Sync compose file so the remote always runs the latest version
+scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
+
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \
   bash << 'REMOTE'


### PR DESCRIPTION
## Summary
- Deploy was failing because compose files on remote servers were stale (placed during initial cloud-init provisioning and never updated since)
- The stale compose files still used `curl` for health checks, but the Docker image only has `wget` installed — causing worker health checks to fail with `curl: not found`
- Adds an `scp` step to sync the compose file to the remote before running `docker compose` commands

## Test plan
- [ ] Deploy to a worker node and verify health check passes
- [ ] Deploy to all roles (app, worker, db) via `deploy-fleet.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)