### PR TITLE
Show loading indicator when session is pending

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -259,6 +259,8 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id={pendingSession.id} />);
     expect(await screen.findByPlaceholderText('Session is not active')).toBeDisabled();
+    expect(screen.getByText('Setting up environment')).toBeInTheDocument();
+    expect(screen.getByText('Preparing the container and getting the agent ready to run.')).toBeInTheDocument();
   });
 
   it('keeps polling logs and reconnects after an SSE error while the session is active', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1034,7 +1034,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     <div className="flex flex-col h-full">
       {/* Unified timeline */}
       <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto space-y-2 p-4">
-        {timelineEntries.length === 0 && !isRunning && (
+        {timelineEntries.length === 0 && !isRunning && session.status !== "pending" && (
           <div className="flex items-center justify-center py-12">
             <div className="text-center space-y-2 max-w-[280px]">
               <MessageSquare className="h-8 w-8 text-muted-foreground/40 mx-auto" />
@@ -1051,6 +1051,15 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
           onApprovePlan={canSendMessage ? handleApprovePlan : undefined}
           onAdjustPlan={canSendMessage ? handleAdjustPlan : undefined}
         />
+        {session.status === "pending" && (
+          <div className="flex items-center justify-center py-12">
+            <div className="text-center space-y-2 max-w-[280px]">
+              <Loader2 className="h-8 w-8 text-muted-foreground/40 mx-auto animate-spin" />
+              <p className="text-xs font-medium text-muted-foreground">Setting up environment</p>
+              <p className="text-xs text-muted-foreground/60">Preparing the container and getting the agent ready to run.</p>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* PR queued indicator */}


### PR DESCRIPTION
## Summary
- Adds a spinning loader with "Setting up environment" message in the chat panel when a session is in `pending` status, so users see clear feedback that the container is being prepared instead of an empty view.
- Excludes pending sessions from the generic "No activity yet" empty state since they now have their own dedicated message.
- Adds test assertions for the new loading state.

## Test plan
- [x] Existing tests pass (38/38)
- [ ] Verify visually that pending sessions show the spinner and message
- [ ] Verify that non-pending empty sessions still show "No activity yet"

🤖 Generated with [Claude Code](https://claude.com/claude-code)