### PR TITLE
Fix silent archive errors and add error toasts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,6 +25,7 @@
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
         "shiki": "^4.0.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.1"
       },
       "devDependencies": {
@@ -16076,6 +16077,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "shiki": "^4.0.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.1"
   },
   "devDependencies": {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { Archive, ArchiveRestore, Plus, Search } from "lucide-react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
@@ -193,11 +194,17 @@ export function SessionSidebar() {
   const archiveMutation = useMutation({
     mutationFn: (sessionId: string) => api.sessions.archive(sessionId),
     onSuccess: invalidateSessions,
+    onError: () => {
+      toast.error("Failed to archive session");
+    },
   });
 
   const unarchiveMutation = useMutation({
     mutationFn: (sessionId: string) => api.sessions.unarchive(sessionId),
     onSuccess: invalidateSessions,
+    onError: () => {
+      toast.error("Failed to unarchive session");
+    },
   });
 
   const allSessions = useMemo(() => allData?.data ?? [], [allData?.data]);

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+import { Toaster } from "sonner";
 import { Providers } from "@/components/providers";
 import "./globals.css";
 
@@ -13,6 +14,7 @@ export default function RootLayout({
       <body className="antialiased">
         <Providers>
           {children}
+          <Toaster position="bottom-right" />
         </Providers>
       </body>
     </html>

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1314,7 +1314,7 @@ func (h *SessionHandler) ArchiveSession(w http.ResponseWriter, r *http.Request) 
 		if errors.Is(err, db.ErrSessionAlreadyArchived) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or already archived")
 		} else {
-			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to archive session")
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to archive session", err)
 		}
 		return
 	}
@@ -1338,7 +1338,7 @@ func (h *SessionHandler) UnarchiveSession(w http.ResponseWriter, r *http.Request
 		if errors.Is(err, db.ErrSessionNotArchived) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or not archived")
 		} else {
-			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to unarchive session")
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to unarchive session", err)
 		}
 		return
 	}


### PR DESCRIPTION
## Summary
- The archive/unarchive session handlers were not passing the underlying DB error to `writeError`, so 500s were logged without the actual cause — making the error impossible to diagnose from logs.
- Added `sonner` toast library and `onError` handlers to the archive/unarchive mutations so users see a toast when archiving fails instead of silent failure.

## Test plan
- [ ] Trigger an archive failure and verify the real DB error now appears in server logs
- [ ] Verify the error toast appears in the UI when archive/unarchive fails
- [ ] Verify successful archive/unarchive still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)