### PR TITLE
Fix sessions stuck in pending state indefinitely

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -99,6 +99,11 @@ function formatDuration(startedAt?: string, completedAt?: string): string {
   return `${mins}m ${secs}s`;
 }
 
+/** Returns true if the session has been pending for more than 2 minutes. */
+function isPendingTooLong(createdAt: string): boolean {
+  return Date.now() - new Date(createdAt).getTime() > 2 * 60 * 1000;
+}
+
 
 const validationChecks: { key: string; label: string }[] = [
   { key: "direction_check", label: "Direction check" },
@@ -125,6 +130,14 @@ type DetailTab = "overview" | "changes" | "validation";
 function OverviewTab({ session, members }: { session: Session; members: User[] }) {
   const queryClient = useQueryClient();
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
+
+  // Force re-render every 5s while pending so the elapsed time stays current.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (session.status !== "pending") return;
+    const id = setInterval(() => setTick((t) => t + 1), 5000);
+    return () => clearInterval(id);
+  }, [session.status]);
 
   const isCodexAuthFailure = session.failure_category === FAILURE_CATEGORY_CODEX_AUTH;
 
@@ -276,7 +289,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
           !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
           <span className="inline-flex items-center gap-1.5">
             <Timer className="h-3 w-3" />
-            {formatDuration(session.started_at, session.completed_at)}
+            {session.status === "pending" ? formatDuration(session.created_at) : formatDuration(session.started_at, session.completed_at)}
           </span>
         )}
         <span className="inline-flex items-center gap-1.5">
@@ -302,7 +315,12 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
               <Clock className="h-3 w-3" />
               Started {formatTimeAgo(session.started_at)}
             </>
-          ) : null}
+          ) : (
+            <>
+              <Clock className="h-3 w-3" />
+              Queued {formatTimeAgo(session.created_at)}
+            </>
+          )}
         </span>
       </div>
 
@@ -1036,10 +1054,33 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
       <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto space-y-2 p-4">
         {timelineEntries.length === 0 && !isRunning && session.status !== "pending" && (
           <div className="flex items-center justify-center py-12">
-            <div className="text-center space-y-2 max-w-[280px]">
-              <MessageSquare className="h-8 w-8 text-muted-foreground/40 mx-auto" />
-              <p className="text-xs font-medium text-muted-foreground">No activity yet</p>
-              <p className="text-xs text-muted-foreground/60">The session is processing its initial turn.</p>
+            <div className="text-center space-y-2 max-w-[320px]">
+              {session.status === "pending" ? (
+                <>
+                  <Loader2 className="h-8 w-8 text-muted-foreground/40 mx-auto animate-spin" />
+                  <p className="text-xs font-medium text-muted-foreground">Waiting to start</p>
+                  <p className="text-xs text-muted-foreground/60">
+                    This session is queued and waiting for an available slot. Queued {formatTimeAgo(session.created_at)}.
+                  </p>
+                  {isPendingTooLong(session.created_at) && (
+                    <div className="mt-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-3 py-2 text-left">
+                      <p className="text-xs font-medium text-amber-700 dark:text-amber-400 flex items-center gap-1.5">
+                        <AlertTriangle className="h-3 w-3 shrink-0" />
+                        Taking longer than expected
+                      </p>
+                      <p className="text-xs text-amber-600 dark:text-amber-500 mt-1">
+                        This session has been waiting for over 2 minutes. It may be blocked by other running sessions or an internal issue. Try cancelling and retrying if it doesn&apos;t start soon.
+                      </p>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  <MessageSquare className="h-8 w-8 text-muted-foreground/40 mx-auto" />
+                  <p className="text-xs font-medium text-muted-foreground">No activity yet</p>
+                  <p className="text-xs text-muted-foreground/60">The session is processing its initial turn.</p>
+                </>
+              )}
             </div>
           </div>
         )}

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -86,6 +86,18 @@ describe("AuthenticatedLayout", () => {
     expect(contentWrapper).toHaveClass("py-6");
   });
 
+  it("content wrapper supports full-height children via flex-1 and min-h-0", () => {
+    const { container } = renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    const contentWrapper = container.querySelector("main > div:last-child");
+    expect(contentWrapper).toHaveClass("flex-1");
+    expect(contentWrapper).toHaveClass("min-h-0");
+  });
+
   it("shows settings entries in the collapsible sidebar section", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -252,7 +252,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
         </div>
       </aside>
       <main className="flex-1 overflow-auto bg-background relative flex flex-col">
-        <div className="relative max-w-none px-8 py-6 lg:px-10">
+        <div className="relative max-w-none px-8 py-6 lg:px-10 flex-1 min-h-0">
           {children}
         </div>
       </main>

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -575,6 +575,28 @@ func (s *SessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessionID
 	return err
 }
 
+// ListStalePendingSessions returns pending sessions created before the given
+// cutoff. These sessions have been stuck in pending for too long and should be
+// failed with an explanatory error.
+func (s *SessionStore) ListStalePendingSessions(ctx context.Context, createdBefore time.Time) ([]models.Session, error) {
+	query := `
+		SELECT ` + sessionListColumns + `
+		FROM sessions s
+		WHERE s.status = 'pending'
+		  AND s.deleted_at IS NULL
+		  AND s.created_at < @created_before
+		ORDER BY s.created_at ASC
+		LIMIT 100`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"created_before": createdBefore,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query stale pending sessions: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
+}
+
 // ListStaleIdleSessions returns idle sessions that have been inactive longer
 // than the idle timeout. These sessions should be transitioned to completed
 // but their snapshots are preserved for later resumption.

--- a/internal/db/tenancy_test.go
+++ b/internal/db/tenancy_test.go
@@ -60,7 +60,8 @@ func TestMultiTenancyAudit(t *testing.T) {
 	exemptions := []exemption{
 		{"sessions", "where token"},
 		{"sessions", "where user_id"},
-		{"sessions", "where status = 'idle'"},   // ListStaleIdleSessions: system-wide cleanup across all orgs
+		{"sessions", "where status = 'idle'"},    // ListStaleIdleSessions: system-wide cleanup across all orgs
+		{"sessions", "where s.status = 'pending'"}, // ListStalePendingSessions: system-wide cleanup across all orgs
 		{"sessions", "where sandbox_state"},      // ListExpiredSnapshots: system-wide snapshot cleanup across all orgs
 		{"sessions", "diff_history"},             // UpdateResult/UpdateTurnComplete: org_id is in a concatenated string fragment
 		{"repositories", "installation_id"},

--- a/internal/services/agent/reaper.go
+++ b/internal/services/agent/reaper.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -25,7 +26,8 @@ type UsageRoller interface {
 }
 
 // SessionReaper periodically cleans up stale sessions and expired snapshots
-// in four phases:
+// in five phases:
+//   - Phase 0: Fail sessions stuck in pending for longer than maxPendingAge
 //   - Phase 1: Transition idle sessions to completed (keep snapshots)
 //   - Phase 2: Delete snapshots that have exceeded the max snapshot age
 //   - Phase 3: Close orphaned container usage events for billing accuracy
@@ -36,6 +38,7 @@ type SessionReaper struct {
 	orphanCloser     OrphanCloser // nil-safe — billing orphan cleanup disabled if nil
 	usageRoller      UsageRoller  // nil-safe — usage rollup disabled if nil
 	maxIdleAge       time.Duration
+	maxPendingAge    time.Duration
 	maxSnapshotAge   time.Duration
 	interval         time.Duration
 	logger           zerolog.Logger
@@ -46,8 +49,11 @@ type SessionReaper struct {
 // StaleSessionLister is the subset of the session store used by the reaper.
 type StaleSessionLister interface {
 	ListStaleIdleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error)
+	ListStalePendingSessions(ctx context.Context, createdBefore time.Time) ([]models.Session, error)
 	ListExpiredSnapshots(ctx context.Context, olderThan time.Time) ([]models.Session, error)
 	UpdateStatus(ctx context.Context, orgID, sessionID uuid.UUID, status string) error
+	UpdateResult(ctx context.Context, orgID, runID uuid.UUID, status string, result *models.SessionResult) error
+	UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
 	UpdateSandboxState(ctx context.Context, orgID, sessionID uuid.UUID, state string) error
 }
 
@@ -66,11 +72,16 @@ func WithUsageRoller(ur UsageRoller) SessionReaperOption {
 
 // NewSessionReaper creates a reaper that runs every interval, cleaning up
 // sessions idle for longer than maxIdleAge and snapshots older than maxSnapshotAge.
+// defaultMaxPendingAge is the maximum time a session can stay in "pending"
+// before the reaper considers it stuck and marks it as failed.
+const defaultMaxPendingAge = 10 * time.Minute
+
 func NewSessionReaper(sessions StaleSessionLister, snapshotStore storage.SnapshotStore, maxIdleAge, maxSnapshotAge, interval time.Duration, logger zerolog.Logger, opts ...SessionReaperOption) *SessionReaper {
 	r := &SessionReaper{
 		sessions:       sessions,
 		snapshotStore:  snapshotStore,
 		maxIdleAge:     maxIdleAge,
+		maxPendingAge:  defaultMaxPendingAge,
 		maxSnapshotAge: maxSnapshotAge,
 		interval:       interval,
 		logger:         logger,
@@ -88,9 +99,10 @@ func (r *SessionReaper) Run(ctx context.Context) {
 
 	r.logger.Info().
 		Dur("interval", r.interval).
+		Dur("max_pending", r.maxPendingAge).
 		Dur("max_idle", r.maxIdleAge).
 		Dur("max_snapshot_age", r.maxSnapshotAge).
-		Msg("snapshot reaper started")
+		Msg("session reaper started")
 
 	for {
 		select {
@@ -103,7 +115,42 @@ func (r *SessionReaper) Run(ctx context.Context) {
 	}
 }
 
+// FailureCategoryStuckPending is the failure category for sessions that timed
+// out in the pending state without ever starting.
+const FailureCategoryStuckPending = "stuck_pending"
+
 func (r *SessionReaper) reap(ctx context.Context) {
+	// Phase 0: Fail sessions stuck in pending with no active job.
+	pendingCutoff := time.Now().Add(-r.maxPendingAge)
+	stalePending, err := r.sessions.ListStalePendingSessions(ctx, pendingCutoff)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("reaper: failed to list stale pending sessions")
+	} else {
+		for _, s := range stalePending {
+			errMsg := fmt.Sprintf("session timed out after %s in pending state without starting", r.maxPendingAge)
+			result := &models.SessionResult{
+				Error: strPtr(errMsg),
+			}
+			if err := r.sessions.UpdateResult(ctx, s.OrgID, s.ID, string(models.SessionStatusFailed), result); err != nil {
+				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to mark stale pending session as failed")
+				continue
+			}
+			explanation := "This session was unable to start within the expected time. This can happen when the system is under heavy load or if there was an internal error processing the request."
+			nextSteps := []string{
+				"Try running the session again",
+				"Check if you have other sessions currently running that may be consuming capacity",
+			}
+			if err := r.sessions.UpdateFailure(ctx, s.OrgID, s.ID, explanation, FailureCategoryStuckPending, nextSteps, true); err != nil {
+				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to update failure details for stale pending session")
+			}
+			r.logger.Warn().
+				Str("session_id", s.ID.String()).
+				Str("org_id", s.OrgID.String()).
+				Time("created_at", s.CreatedAt).
+				Msg("reaper: failed stale pending session")
+		}
+	}
+
 	// Phase 1: Transition stale idle sessions to completed (keep snapshots).
 	idleCutoff := time.Now().Add(-r.maxIdleAge)
 	staleSessions, err := r.sessions.ListStaleIdleSessions(ctx, idleCutoff)

--- a/internal/services/agent/reaper_test.go
+++ b/internal/services/agent/reaper_test.go
@@ -18,14 +18,20 @@ import (
 
 // reaperMockSessionLister implements StaleSessionLister for testing.
 type reaperMockSessionLister struct {
-	staleIdleSessions []models.Session
-	expiredSnapshots  []models.Session
-	listIdleErr       error
-	listExpiredErr    error
-	updateStatusErr   error
-	updateSandboxErr  error
+	staleIdleSessions    []models.Session
+	stalePendingSessions []models.Session
+	expiredSnapshots     []models.Session
+	listIdleErr          error
+	listPendingErr       error
+	listExpiredErr       error
+	updateStatusErr      error
+	updateResultErr      error
+	updateFailureErr     error
+	updateSandboxErr     error
 
 	updatedStatuses  []statusUpdate
+	updatedResults   []resultUpdate
+	updatedFailures  []failureUpdate
 	updatedSandboxes []sandboxUpdate
 }
 
@@ -33,6 +39,21 @@ type statusUpdate struct {
 	orgID     uuid.UUID
 	sessionID uuid.UUID
 	status    string
+}
+
+type resultUpdate struct {
+	orgID     uuid.UUID
+	sessionID uuid.UUID
+	status    string
+	result    *models.SessionResult
+}
+
+type failureUpdate struct {
+	orgID       uuid.UUID
+	sessionID   uuid.UUID
+	explanation string
+	category    string
+	nextSteps   []string
 }
 
 type sandboxUpdate struct {
@@ -45,6 +66,10 @@ func (m *reaperMockSessionLister) ListStaleIdleSessions(_ context.Context, _ tim
 	return m.staleIdleSessions, m.listIdleErr
 }
 
+func (m *reaperMockSessionLister) ListStalePendingSessions(_ context.Context, _ time.Time) ([]models.Session, error) {
+	return m.stalePendingSessions, m.listPendingErr
+}
+
 func (m *reaperMockSessionLister) ListExpiredSnapshots(_ context.Context, _ time.Time) ([]models.Session, error) {
 	return m.expiredSnapshots, m.listExpiredErr
 }
@@ -52,6 +77,16 @@ func (m *reaperMockSessionLister) ListExpiredSnapshots(_ context.Context, _ time
 func (m *reaperMockSessionLister) UpdateStatus(_ context.Context, orgID, sessionID uuid.UUID, status string) error {
 	m.updatedStatuses = append(m.updatedStatuses, statusUpdate{orgID: orgID, sessionID: sessionID, status: status})
 	return m.updateStatusErr
+}
+
+func (m *reaperMockSessionLister) UpdateResult(_ context.Context, orgID, sessionID uuid.UUID, status string, result *models.SessionResult) error {
+	m.updatedResults = append(m.updatedResults, resultUpdate{orgID: orgID, sessionID: sessionID, status: status, result: result})
+	return m.updateResultErr
+}
+
+func (m *reaperMockSessionLister) UpdateFailure(_ context.Context, orgID, sessionID uuid.UUID, explanation, category string, nextSteps []string, _ bool) error {
+	m.updatedFailures = append(m.updatedFailures, failureUpdate{orgID: orgID, sessionID: sessionID, explanation: explanation, category: category, nextSteps: nextSteps})
+	return m.updateFailureErr
 }
 
 func (m *reaperMockSessionLister) UpdateSandboxState(_ context.Context, orgID, sessionID uuid.UUID, state string) error {
@@ -71,6 +106,59 @@ func (m *reaperMockSnapshotStore) Load(_ context.Context, _ string, _ io.Writer)
 func (m *reaperMockSnapshotStore) Delete(_ context.Context, key string) error {
 	m.deletedKeys = append(m.deletedKeys, key)
 	return m.deleteErr
+}
+
+func TestReapPhase0_FailsStalePendingSessions(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID1 := uuid.New()
+	sessionID2 := uuid.New()
+
+	mock := &reaperMockSessionLister{
+		stalePendingSessions: []models.Session{
+			{ID: sessionID1, OrgID: orgID, Status: string(models.SessionStatusPending)},
+			{ID: sessionID2, OrgID: orgID, Status: string(models.SessionStatusPending)},
+		},
+	}
+	snapStore := &reaperMockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 0 should mark both sessions as failed via UpdateResult.
+	require.Len(t, mock.updatedResults, 2)
+	assert.Equal(t, string(models.SessionStatusFailed), mock.updatedResults[0].status)
+	assert.Equal(t, sessionID1, mock.updatedResults[0].sessionID)
+	assert.Equal(t, string(models.SessionStatusFailed), mock.updatedResults[1].status)
+	assert.Equal(t, sessionID2, mock.updatedResults[1].sessionID)
+
+	// Phase 0 should also set failure details.
+	require.Len(t, mock.updatedFailures, 2)
+	assert.Equal(t, FailureCategoryStuckPending, mock.updatedFailures[0].category)
+	assert.Equal(t, FailureCategoryStuckPending, mock.updatedFailures[1].category)
+}
+
+func TestReapPhase0Error_StillRunsPhase1(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock := &reaperMockSessionLister{
+		listPendingErr: errors.New("db error"),
+		staleIdleSessions: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusIdle)},
+		},
+	}
+	snapStore := &reaperMockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	reaper.reap(context.Background())
+
+	// Phase 0 failed, but phase 1 should still run.
+	require.Len(t, mock.updatedStatuses, 1)
+	assert.Equal(t, string(models.SessionStatusCompleted), mock.updatedStatuses[0].status)
 }
 
 func TestReapPhase1_TransitionsIdleSessionsToCompleted(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -597,6 +597,31 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 
 		if err := services.Orchestrator.RunAgent(ctx, &run); err != nil {
 			if errors.Is(err, agent.ErrConcurrencyLimit) {
+				// If the session has been pending for too long, fail it
+				// instead of retrying indefinitely.
+				if time.Since(run.CreatedAt) > 8*time.Minute {
+					logger.Warn().
+						Str("session_id", runID.String()).
+						Dur("age", time.Since(run.CreatedAt)).
+						Msg("concurrency limit: session pending too long, failing")
+					errMsg := "Session could not start: all agent slots are in use. Please try again when capacity is available."
+					failErr := stores.Sessions.UpdateResult(ctx, orgID, runID, "failed", &models.SessionResult{
+						Error: &errMsg,
+					})
+					if failErr != nil {
+						logger.Error().Err(failErr).Str("session_id", runID.String()).Msg("failed to mark timed-out session as failed")
+					}
+					_ = stores.Sessions.UpdateFailure(ctx, orgID, runID,
+						"This session was unable to start because all available agent slots were in use for an extended period.",
+						"concurrency_timeout",
+						[]string{
+							"Wait for other running sessions to complete, then retry",
+							"Cancel sessions that are no longer needed to free up capacity",
+						},
+						true,
+					)
+					return &FatalError{Err: fmt.Errorf("session timed out waiting for concurrency slot: %w", err)}
+				}
 				return &RetryableError{Err: err}
 			}
 			return err

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -55,6 +55,11 @@ type WorkerDB interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
+// maxRetryableDuration is the maximum wall-clock time a retryable job is
+// allowed to keep retrying before being dead-lettered. This prevents jobs
+// from retrying indefinitely (e.g. when stuck behind a concurrency limit).
+const maxRetryableDuration = 8 * time.Minute
+
 type Worker struct {
 	db           WorkerDB
 	logger       zerolog.Logger
@@ -110,15 +115,16 @@ func (w *Worker) poll(ctx context.Context) {
 	var jobType string
 	var payload json.RawMessage
 	var attempts, maxAttempts int
+	var jobCreatedAt time.Time
 
 	err = tx.QueryRow(ctx, `
-		SELECT id, org_id, job_type, payload, attempts, max_attempts
+		SELECT id, org_id, job_type, payload, attempts, max_attempts, created_at
 		FROM jobs
 		WHERE status = 'pending' AND run_at <= now()
 		ORDER BY priority DESC, created_at ASC
 		FOR UPDATE SKIP LOCKED
 		LIMIT 1
-	`).Scan(&jobID, &orgID, &jobType, &payload, &attempts, &maxAttempts)
+	`).Scan(&jobID, &orgID, &jobType, &payload, &attempts, &maxAttempts, &jobCreatedAt)
 
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -167,8 +173,18 @@ func (w *Worker) poll(ctx context.Context) {
 		}
 		// RetryableError means we should retry without consuming an attempt
 		// (e.g. concurrency limit reached — the job will succeed once a slot opens).
+		// However, cap retryable retries at maxRetryableDuration to prevent
+		// jobs from retrying indefinitely.
 		var retryable *RetryableError
 		if errors.As(err, &retryable) {
+			if time.Since(jobCreatedAt) > maxRetryableDuration {
+				w.logger.Error().Err(err).
+					Str("job_id", jobID.String()).
+					Dur("age", time.Since(jobCreatedAt)).
+					Msg("retryable job exceeded max duration, dead-lettering")
+				w.deadLetterJob(ctx, jobID, fmt.Sprintf("retryable job timed out after %s: %s", maxRetryableDuration, err.Error()))
+				return
+			}
 			w.logger.Info().Err(err).Str("job_id", jobID.String()).Msg("job deferred (retryable)")
 			w.retryJob(ctx, jobID, err.Error(), attempts) // don't increment attempt count
 			return

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -230,8 +230,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "test_job", payload, 0, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "test_job", payload, 0, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -257,8 +257,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "retry_job", payload, 0, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "retry_job", payload, 0, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -285,8 +285,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "dead_job", payload, 2, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "dead_job", payload, 2, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -307,8 +307,8 @@ func TestWorker_Poll(t *testing.T) {
 				payload := json.RawMessage(`{}`)
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "unknown_job", payload, 0, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "unknown_job", payload, 0, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -339,8 +339,8 @@ func TestWorker_Poll(t *testing.T) {
 				payload := json.RawMessage(`{}`)
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "some_job", payload, 0, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "some_job", payload, 0, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -358,8 +358,8 @@ func TestWorker_Poll(t *testing.T) {
 				payload := json.RawMessage(`{}`)
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "some_job", payload, 0, 3)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "some_job", payload, 0, 3, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -383,8 +383,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "boundary_job", payload, 1, 2)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "boundary_job", payload, 1, 2, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -410,8 +410,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "retry_boundary_job", payload, 0, 2)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "retry_boundary_job", payload, 0, 2, time.Now())
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").
@@ -421,6 +421,63 @@ func TestWorker_Poll(t *testing.T) {
 				// retryJob with attempt=1 => backoff = 2^1 = 2 seconds
 				mock.ExpectExec("UPDATE jobs SET status = 'pending'").
 					WithArgs(handlerErr.Error(), "2 seconds", jobID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
+		{
+			name: "retryable error within time limit is retried",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+				jobID := uuid.New()
+				orgID := uuid.New()
+				payload := json.RawMessage(`{}`)
+				handlerErr := &RetryableError{Err: errors.New("concurrency limit")}
+
+				w.Register("retryable_job", func(ctx context.Context, jobType string, p json.RawMessage) error {
+					return handlerErr
+				})
+
+				mock.ExpectBegin()
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "retryable_job", payload, 0, 3, time.Now()) // recently created — should retry
+				mock.ExpectQuery("SELECT .+ FROM jobs").
+					WillReturnRows(rows)
+				mock.ExpectExec("UPDATE jobs SET status = 'running'").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectCommit()
+				// Should retry (not dead-letter) since job is young
+				mock.ExpectExec("UPDATE jobs SET status = 'pending'").
+					WithArgs(handlerErr.Error(), pgxmock.AnyArg(), jobID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
+		{
+			name: "retryable error exceeding max duration is dead-lettered",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+				jobID := uuid.New()
+				orgID := uuid.New()
+				payload := json.RawMessage(`{}`)
+				handlerErr := &RetryableError{Err: errors.New("concurrency limit")}
+
+				w.Register("old_retryable_job", func(ctx context.Context, jobType string, p json.RawMessage) error {
+					return handlerErr
+				})
+
+				mock.ExpectBegin()
+				// Job created 10 minutes ago — exceeds maxRetryableDuration (8 min)
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "old_retryable_job", payload, 0, 3, time.Now().Add(-10*time.Minute))
+				mock.ExpectQuery("SELECT .+ FROM jobs").
+					WillReturnRows(rows)
+				mock.ExpectExec("UPDATE jobs SET status = 'running'").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectCommit()
+				// Should dead-letter since job exceeded max retryable duration
+				mock.ExpectExec("UPDATE jobs SET status = 'dead_letter'").
+					WithArgs(pgxmock.AnyArg(), jobID).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 			},
 		},
@@ -438,8 +495,8 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				mock.ExpectBegin()
-				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts"}).
-					AddRow(jobID, orgID, "fatal_job", payload, 0, 3) // attempt 0 of 3 — should still dead-letter
+				rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+					AddRow(jobID, orgID, "fatal_job", payload, 0, 3, time.Now()) // attempt 0 of 3 — should still dead-letter
 				mock.ExpectQuery("SELECT .+ FROM jobs").
 					WillReturnRows(rows)
 				mock.ExpectExec("UPDATE jobs SET status = 'running'").


### PR DESCRIPTION
## Summary

- Sessions could get stuck in pending forever when concurrency limits caused unbounded retries or jobs were dead-lettered without updating session status
- Adds three layers of defense: the `run_agent` handler fails sessions after 8 min of concurrency stalls, the worker caps retryable job lifetime at 8 min, and the reaper sweeps stale pending sessions after 10 min
- Frontend now shows elapsed queue time with a live timer, warns after 2 minutes, and displays actionable failure details when the session is eventually failed

## Test plan
- [x] Added reaper tests for Phase 0 (stale pending cleanup) and error isolation
- [x] Added worker tests for retryable timeout (young job retries, old job dead-letters)
- [x] Updated all existing worker mock rows with `created_at` column
- [ ] Manual: verify pending session shows "Waiting to start" with spinner, elapsed time, and warning after 2 min
- [ ] Manual: verify session transitions to failed with retry button after 10 min stuck in pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)