### PR TITLE
Compact autopilot config footer into collapsible pill bar

### DIFF
--- a/frontend/src/components/autopilot/autopilot-config-footer.tsx
+++ b/frontend/src/components/autopilot/autopilot-config-footer.tsx
@@ -145,16 +145,8 @@ export function AutopilotConfigFooter({
         </div>
 
         {/* Expanded detail view */}
-        <CollapsibleContent
-          forceMount
-          className={cn(
-            "overflow-hidden transition-all duration-200",
-            isOpen
-              ? "grid grid-rows-[1fr] opacity-100"
-              : "grid grid-rows-[0fr] opacity-0"
-          )}
-        >
-          <div className="min-h-0">
+        <CollapsibleContent className="overflow-hidden">
+          <div>
             <div className="divide-y divide-border/60">
               <ConfigRow
                 label="Direction"

--- a/frontend/src/components/autopilot/autopilot-config-footer.tsx
+++ b/frontend/src/components/autopilot/autopilot-config-footer.tsx
@@ -65,8 +65,8 @@ export function AutopilotConfigFooter({
   const [isOpen, setIsOpen] = useState(false);
 
   const directionPill = directionSummary
-    ? directionSummary.length > 28
-      ? directionSummary.slice(0, 28) + "\u2026"
+    ? directionSummary.length > 48
+      ? directionSummary.slice(0, 48) + "\u2026"
       : directionSummary
     : "No direction";
 

--- a/frontend/src/components/autopilot/autopilot-config-footer.tsx
+++ b/frontend/src/components/autopilot/autopilot-config-footer.tsx
@@ -1,8 +1,16 @@
 "use client";
 
+import { useState } from "react";
+import { ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
+import {
+  Collapsible,
+  CollapsibleTrigger,
+  CollapsibleContent,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
 
 interface AutopilotConfigFooterProps {
   directionSummary: string;
@@ -54,45 +62,128 @@ export function AutopilotConfigFooter({
   onManageDocuments,
   onOpenSettings,
 }: AutopilotConfigFooterProps) {
-  const focusDisplay = focusAreas.length > 0
-    ? (
+  const [isOpen, setIsOpen] = useState(false);
+
+  const directionPill = directionSummary
+    ? directionSummary.length > 28
+      ? directionSummary.slice(0, 28) + "\u2026"
+      : directionSummary
+    : "No direction";
+
+  const focusPill =
+    focusAreas.length > 0
+      ? `${focusAreas.length} focus area${focusAreas.length !== 1 ? "s" : ""}`
+      : "No focus";
+
+  const docsPill = documentsSummary || "No docs";
+
+  const weightsPill = weightsSummary || "Default weights";
+
+  const focusDisplay =
+    focusAreas.length > 0 ? (
       <span className="inline-flex flex-wrap gap-1.5 align-middle">
         {focusAreas.map((area) => (
-          <Badge key={area} variant="secondary" className="text-xs">{area}</Badge>
+          <Badge key={area} variant="secondary" className="text-xs">
+            {area}
+          </Badge>
         ))}
       </span>
-    )
-    : "Add focus areas to narrow analysis";
+    ) : (
+      "Add focus areas to narrow analysis"
+    );
 
   return (
     <section>
       <Separator />
-      <div className="divide-y divide-border/60">
-        <ConfigRow
-          label="Direction"
-          value={directionSummary || "Set a direction to guide analysis"}
-          actionLabel="Edit"
-          onAction={onEditDirection}
-        />
-        <ConfigRow
-          label="Focus"
-          value={focusDisplay}
-          actionLabel="Edit"
-          onAction={onEditDirection}
-        />
-        <ConfigRow
-          label="Documents"
-          value={documentsSummary}
-          actionLabel="Manage"
-          onAction={onManageDocuments}
-        />
-        <ConfigRow
-          label="Weights & more"
-          value={weightsSummary || "Using defaults"}
-          actionLabel="Settings"
-          onAction={onOpenSettings}
-        />
-      </div>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        {/* Pill bar — always visible */}
+        <div className="flex items-center gap-2 py-2.5">
+          <div className="flex flex-1 flex-wrap items-center gap-1.5 min-w-0">
+            <Badge
+              variant="secondary"
+              className="cursor-pointer text-xs hover:bg-secondary/80"
+              onClick={onEditDirection}
+            >
+              {directionPill}
+            </Badge>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer text-xs hover:bg-secondary/80"
+              onClick={onEditDirection}
+            >
+              {focusPill}
+            </Badge>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer text-xs hover:bg-secondary/80"
+              onClick={onManageDocuments}
+            >
+              {docsPill}
+            </Badge>
+            <Badge
+              variant="secondary"
+              className="cursor-pointer text-xs hover:bg-secondary/80"
+              onClick={onOpenSettings}
+            >
+              {weightsPill}
+            </Badge>
+          </div>
+          <CollapsibleTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="shrink-0 text-muted-foreground"
+            >
+              <ChevronRight
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-200",
+                  isOpen && "rotate-90"
+                )}
+              />
+            </Button>
+          </CollapsibleTrigger>
+        </div>
+
+        {/* Expanded detail view */}
+        <CollapsibleContent
+          forceMount
+          className={cn(
+            "overflow-hidden transition-all duration-200",
+            isOpen
+              ? "grid grid-rows-[1fr] opacity-100"
+              : "grid grid-rows-[0fr] opacity-0"
+          )}
+        >
+          <div className="min-h-0">
+            <div className="divide-y divide-border/60">
+              <ConfigRow
+                label="Direction"
+                value={directionSummary || "Set a direction to guide analysis"}
+                actionLabel="Edit"
+                onAction={onEditDirection}
+              />
+              <ConfigRow
+                label="Focus"
+                value={focusDisplay}
+                actionLabel="Edit"
+                onAction={onEditDirection}
+              />
+              <ConfigRow
+                label="Documents"
+                value={documentsSummary}
+                actionLabel="Manage"
+                onAction={onManageDocuments}
+              />
+              <ConfigRow
+                label="Weights & more"
+                value={weightsSummary || "Using defaults"}
+                actionLabel="Settings"
+                onAction={onOpenSettings}
+              />
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Replaces the 4 full-width config rows (Direction, Focus, Documents, Weights) with a compact collapsible pill bar
- Collapsed state (default) shows a single row of clickable badge pills summarizing each setting
- Chevron toggle expands to the original detail view with full descriptions and action buttons
- Uses existing Collapsible, Badge, and Button components with smooth CSS grid-rows animation

## Test plan
- [ ] Verify pill bar renders with correct summaries for each setting
- [ ] Verify clicking each pill opens the correct editor/sheet
- [ ] Verify chevron expands/collapses the detail view with smooth animation
- [ ] Check responsive behavior on narrow screens (pills should wrap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)