### PR TITLE
Implement centralized logging with VictoriaLogs and Vector

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -31,15 +31,17 @@ AWS_SECRET_ACCESS_KEY=ENC[AES256_GCM,data:H0LCeQTN/vGeqMLL6/p1qVvSkT7qElqsYK1ZOv
 DB_PASSWORD=ENC[AES256_GCM,data:4uAdUTHVbTeRnm4ZHMJihP+G/becWQr0tRHtqYnLu7N0YW6wxBf0pReqdOQ=,iv:yxdVt93IOY089HymOfscRGqNCdPnHYR8txykLYoNPPU=,tag:wzbx3/H+Mt8G5WOMdXsH5w==,type:str]
 DB_HOST=ENC[AES256_GCM,data:N4o3L5UqnE0=,iv:kbVv+a/onFxRA/292N9REjYa8nodnp9v7dgRFedqdVg=,tag:9WZDuWUq8icThV0IjEzzUg==,type:str]
 GHCR_TOKEN=ENC[AES256_GCM,data:vhSaR8Vbr/yqziTtn5Xj6ZlOHfW+rMBrMidOF56CVsyO5AqvzMnwdA==,iv:05pmXoqk/tgyrVKBpkfTkjT1TW3Cb/60roBU9rMw/Ao=,tag:C/qkU5ZNhQea/zTNJTDBdQ==,type:str]
-FLEET_HOSTS=ENC[AES256_GCM,data:xn/FnkcZwhrOL9brKvAXNuWbWc9ZMXOfXMLCnnBWLr4aWF0NuJdedQ/6Hx7iymgxyw7ZDwM=,iv:AzCEoDm9cQMclIj0y3x5UEIOKslz+RWkhlLusAfAra4=,tag:jitUb6Drs1XrX4kC6339XA==,type:str]
+FLEET_HOSTS=ENC[AES256_GCM,data:cVON+Bd+WuuCaaZSMcloJ3ynSj+QhiDZd0Q74eZpVtX6rccfLuB9iXrqxIGbDfjJE3N3CCstEyeUA8FmNJOB/yZxfrwJ6IrGHIjn,iv:K8n3Z7TFf1mDMv2xpBygnp0KtpzBaj0dHxp9/LjzdFw=,tag:J59FF+9f1gv3zr0TuOcaRQ==,type:str]
 OPENAI_API_KEY=ENC[AES256_GCM,data:+2nrofAW1Flz5Xh2MO+jYkbdAoRgyFba3rP064e/BHfsAB8HcOjx5wEmT+HgvM/UBnKMHvPoekO0tG0Zprh5S3L2FUGCJoZe7RG3mCd9Wxmd35mRKuWC1W1r9tgwttKvNQQ9iHna2mZZM5c61Ajyf7rnToXF7GiSTOsaaGN2qgID5OO2kHfLMDLFOSrVtHWzTUOVEx+IV2xpdLraZTnJaa0Lor2k2l4=,iv:g+06NdD4AuXseqjxVI+dxk8nORFbbHCP5FSeio1HmZA=,tag:qE8ogT1i0uI12Ritv1h5Qw==,type:str]
+GRAFANA_ADMIN_PASSWORD=ENC[AES256_GCM,data:ZIJvOUHvc/FI3enYrilH+qmDoMeN2sluNdWc8KU8xuk=,iv:FsYZzgXi6tNJ5z/Nl5++Hq406bgr88h9Q4xS0sIC0ZQ=,tag:qvaoezVKTOACNe/4dkW5zA==,type:str]
+VICTORIALOGS_HOST=ENC[AES256_GCM,data:kkLo2cSW28s=,iv:F+ghGcp0NG9Xj/NtkEBmulkThzJwsie4Lsy6lNabud4=,tag:BE0G/xhmKeT3euZatKWZQg==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwRVlNOEU0YUwzZ3ByQ3Qv\nUjdnbVhNN1ZzeWJHK2hYcGhyY01NenlMZ1dVClhYL3IzcWRpZU43dklJL3l4ZDVK\nUnZLNjJ2OWFpTlpVS2xONFA0TXkxcWMKLS0tIFltaUNOQW5LUG9OcVU0Y2RrTy83\naVhzM1I2TlhpTThDNU93TXk2dGxOVUEKeW+oZNn1lOtsKMnsqzCHm7Ob842xYbtY\nuXNOLcRQc70SxVD1DKHnzYt//hDWNiF6P5DEfZDuAFJ44fn1U7fXlw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1xyvl6ral4fq757tpnz30cuzefrpngnuv6zutjsg7wtnmza4uyqlshc2ucl
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNMGR2ZWtiVTNLMjVBMC9p\nbk9XUnpMMWMvZzhsM2dPcmc3QU9VNUpOV0NRCldaWmIzWWZuNlp2em9PVU14ek1m\nOUhnRW1ZVS9oM3VubThobjQxbGtMQmsKLS0tIHZqWlpDRjNsL2MyL1hWeHFvb2tj\nVmpXRDRMQmxYaythdTFUUFQ2cUVCTWsKvzGFG7rpanzjg6/yCWWvlHOnufRItdcH\nnAscSVItc051kzQRW2lvVTlZ+Dzc7pGvdHRKXOAA1cF62ZO3l4HrUg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-14T23:11:26Z
-sops_mac=ENC[AES256_GCM,data:gpTtXW+bsxVm7D4jaTlPi1UynGQFOgal4K9frQBp2wmPhu6qbFqcT0Ralu+w0Fb/Aauv6s3VProY/uN+n4dGB5ZnPhco/gsu+ZtPDBGFhilZWXOQ0bXkP9CqVfH7GSO4SOxXDZn6IFOVoTnmcJDXyu0w5ONYSRUZWBUpLARN4vE=,iv:K+wjD3NK8WDAaSb0xAJu9063pJDHyXnsB2qN/ztp93g=,tag:NGX+RznQJ4s+JCrETPzNYg==,type:str]
+sops_lastmodified=2026-04-15T03:51:29Z
+sops_mac=ENC[AES256_GCM,data:qc7ZVBPbY37mfEpW+yjjQjGNbSe+6j+skodZ8ulv+bKsTPM3lSMgKbXH/DN/W/fRZJZoih7jcxPaQqIXykSRSgzJtozbymgRwGoJbTYH6B3X1mva7EiyCN8oOFDjUuI6JjvFp8BFo2ZXcqAj9IofUXpu92cv3GSf7SaYYsTbupM=,iv:yAweSqQenYwo8nX42NJAKPne7P6welQ85Q1heYet500=,tag:hmICZ9CId39Ypf2SDaAA+Q==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db deploy-app deploy-worker deploy-db deploy-fleet
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy-app deploy-worker deploy-db deploy-logging deploy-fleet
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -261,6 +261,11 @@ provision-db:
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
 	./deploy/scripts/provision.sh db $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
 
+provision-logging:
+	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-logging HOST=<ip> SSH_KEY=<path>"; exit 1; }
+	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
+	./deploy/scripts/provision.sh logging $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
+
 # Deploy (update) an already-provisioned node.
 # Usage:
 #   make deploy-app    HOST=87.99.150.138  SSH_KEY=~/.ssh/143-deploy
@@ -281,6 +286,11 @@ deploy-db:
 	@test -n "$(HOST)" || { echo "HOST is required."; exit 1; }
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
 	./deploy/scripts/deploy.sh db $(HOST) $(SSH_KEY)
+
+deploy-logging:
+	@test -n "$(HOST)" || { echo "HOST is required."; exit 1; }
+	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
+	./deploy/scripts/deploy.sh logging $(HOST) $(SSH_KEY)
 
 # Deploy all nodes in the fleet.
 # Requires FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -42,7 +42,7 @@ import (
 
 func main() {
 	cfg := config.Load()
-	logger := logging.NewLogger(cfg.LogLevel)
+	logger := logging.NewLogger(cfg.LogLevel, cfg.Env)
 	cfg.LogStatus(logger)
 
 	if version.IsDev() {

--- a/deploy/Caddyfile.logging
+++ b/deploy/Caddyfile.logging
@@ -1,0 +1,9 @@
+# Reverse proxy for Grafana on the logging node.
+# Caddy handles TLS automatically via Let's Encrypt.
+#
+# GRAFANA_DOMAIN defaults to logs.143.dev — override via .env:
+#   GRAFANA_DOMAIN=logs.example.com
+
+{$GRAFANA_DOMAIN:logs.143.dev} {
+	reverse_proxy grafana:3000
+}

--- a/deploy/cloud-init/logging.yml
+++ b/deploy/cloud-init/logging.yml
@@ -1,0 +1,60 @@
+#cloud-config
+# Logging node bootstrap (VictoriaLogs + Grafana).
+# Receives logs from Vector collectors on app/worker nodes via Hetzner private network.
+#
+# Provision from your local machine:
+#   make provision-logging HOST=10.0.0.5 SSH_KEY=~/.ssh/143-deploy
+#
+# Or manually substitute and pass as user-data:
+#   export SSH_PUBLIC_KEY="$(cat ~/.ssh/143-deploy.pub)"
+#   export GRAFANA_ADMIN_PASSWORD="your-grafana-password"
+#   export PRIVATE_IP="10.0.0.5"
+#   envsubst < deploy/cloud-init/logging.yml > /tmp/user-data.yml
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+  - git
+  - jq
+
+write_files:
+  - path: /opt/143/.env
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      PRIVATE_IP=${PRIVATE_IP}
+
+runcmd:
+  # Clone repo to get compose files and configs.
+  # No GHCR login needed — VictoriaLogs and Grafana are public images.
+  - su - deploy -c 'git clone --depth 1 https://github.com/assembledhq/143.git /tmp/143-repo'
+  - su - deploy -c 'cp /tmp/143-repo/docker-compose.logging.yml /opt/143/'
+  - su - deploy -c 'cp -r /tmp/143-repo/deploy /opt/143/deploy'
+  - rm -rf /tmp/143-repo
+
+  # Start the stack and wait for Grafana health
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.logging.yml up -d --remove-orphans'
+  - |
+    echo "Waiting for Grafana health check..."
+    HEALTHY=false
+    for i in $(seq 1 30); do
+      if wget -qO- http://localhost:3000/api/health > /dev/null 2>&1; then
+        echo "Health check passed."
+        HEALTHY=true
+        break
+      fi
+      sleep 2
+    done
+    if [ "$HEALTHY" != "true" ]; then
+      echo "ERROR: Grafana health check timed out after 60s."
+      exit 1
+    fi

--- a/deploy/cloud-init/logging.yml
+++ b/deploy/cloud-init/logging.yml
@@ -8,7 +8,7 @@
 # Or manually substitute and pass as user-data:
 #   export SSH_PUBLIC_KEY="$(cat ~/.ssh/143-deploy.pub)"
 #   export GRAFANA_ADMIN_PASSWORD="your-grafana-password"
-#   export PRIVATE_IP="10.0.0.5"
+#   export VICTORIALOGS_HOST="10.0.0.5"
 #   envsubst < deploy/cloud-init/logging.yml > /tmp/user-data.yml
 
 users:
@@ -31,7 +31,7 @@ write_files:
     permissions: '0600'
     content: |
       GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
-      PRIVATE_IP=${PRIVATE_IP}
+      VICTORIALOGS_HOST=${VICTORIALOGS_HOST}
 
 runcmd:
   # Clone repo to get compose files and configs.

--- a/deploy/grafana/provisioning/datasources/victorialogs.yml
+++ b/deploy/grafana/provisioning/datasources/victorialogs.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: VictoriaLogs
+    type: victoriametrics-logs-datasource
+    access: proxy
+    url: http://victorialogs:9428
+    isDefault: true

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Idempotent machine setup for app and worker nodes.
 # Usage: ssh root@<vps-ip> 'bash -s -- <role>' < deploy/scripts/bootstrap.sh
-#        role: app | worker (default: worker)
+#        role: app | worker | logging (default: worker)
 set -euo pipefail
 
 ROLE="${1:-worker}"

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Deploy to a node via SSH.
 # Usage: ./deploy.sh <role> <host> <ssh-key-path> [image-tag]
 #
-# Roles: app, worker, db
+# Roles: app, worker, db, logging
 # Provider-agnostic — just needs SSH access to the target.
 
 ROLE="$1"
@@ -27,7 +27,11 @@ case "$ROLE" in
     COMPOSE_FILE="docker-compose.db.yml"
     HEALTH_SERVICE="postgres"
     ;;
-  *)      echo "Unknown role: $ROLE (expected: app, worker, db)"; exit 1 ;;
+  logging)
+    COMPOSE_FILE="docker-compose.logging.yml"
+    HEALTH_SERVICE="grafana"
+    ;;
+  *)      echo "Unknown role: $ROLE (expected: app, worker, db, logging)"; exit 1 ;;
 esac
 
 echo "Deploying role=$ROLE tag=$TAG to $HOST..."
@@ -60,13 +64,19 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     fi
   done <<< "$DECRYPTED"
 
-  if [ "$ROLE" = "db" ]; then
+  if [ "$ROLE" = "logging" ]; then
+    printf 'GRAFANA_ADMIN_PASSWORD=%s\nPRIVATE_IP=%s\n' "${GRAFANA_ADMIN_PASSWORD:-}" "${PRIVATE_IP:-}" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+  elif [ "$ROLE" = "db" ]; then
     printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+  elif [ "$ROLE" = "worker" ]; then
+    printf 'DB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$DB_PASSWORD" "$DB_HOST" "${VICTORIALOGS_HOST:-}" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   else
     # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
     # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
-    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" \
+    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "${VICTORIALOGS_HOST:-}" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
     ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"
@@ -78,6 +88,10 @@ fi
 
 # Sync compose file so the remote always runs the latest version
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" deploy@"$HOST":/opt/143/
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
+fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -65,18 +65,27 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
   done <<< "$DECRYPTED"
 
   if [ "$ROLE" = "logging" ]; then
-    printf 'GRAFANA_ADMIN_PASSWORD=%s\nPRIVATE_IP=%s\n' "${GRAFANA_ADMIN_PASSWORD:-}" "${PRIVATE_IP:-}" \
+    : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
+    : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for logging role (set it or add to .env.production.enc)}"
+    printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\n' "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   elif [ "$ROLE" = "db" ]; then
+    : "${DB_PASSWORD:?DB_PASSWORD is required for db role (set it or add to .env.production.enc)}"
     printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   elif [ "$ROLE" = "worker" ]; then
-    printf 'DB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$DB_PASSWORD" "$DB_HOST" "${VICTORIALOGS_HOST:-}" "$ROLE" \
+    : "${DB_PASSWORD:?DB_PASSWORD is required for worker role (set it or add to .env.production.enc)}"
+    : "${DB_HOST:?DB_HOST is required for worker role (set it or add to .env.production.enc)}"
+    : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for worker role (set it or add to .env.production.enc)}"
+    printf 'DB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   else
     # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
     # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
-    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "${VICTORIALOGS_HOST:-}" "$ROLE" \
+    : "${DB_PASSWORD:?DB_PASSWORD is required for app role (set it or add to .env.production.enc)}"
+    : "${DB_HOST:?DB_HOST is required for app role (set it or add to .env.production.enc)}"
+    : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for app role (set it or add to .env.production.enc)}"
+    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
     ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -38,45 +38,43 @@ case "$ROLE" in
   *)       echo "Unknown role: $ROLE (expected: app, worker, db, logging)"; exit 1 ;;
 esac
 
-# Logging nodes use only public images and don't need SOPS secrets.
-# Skip SOPS decryption entirely for the logging role.
-if [ "$ROLE" != "logging" ]; then
-  # Read SOPS_AGE_KEY from the default age keyfile if not already set
-  if [ -z "${SOPS_AGE_KEY:-}" ]; then
-    AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
-    if [ -f "$AGE_KEY_FILE" ]; then
-      SOPS_AGE_KEY=$(grep "^AGE-SECRET-KEY-" "$AGE_KEY_FILE" | head -1)
-      export SOPS_AGE_KEY
-      echo "Read SOPS_AGE_KEY from $AGE_KEY_FILE"
-    else
-      echo "ERROR: No SOPS_AGE_KEY set and no keyfile at $AGE_KEY_FILE"
-      echo "Run 'make secrets-setup' first, or export SOPS_AGE_KEY."
-      exit 1
-    fi
-  fi
-
-  # Decrypt .env.production.enc to extract secrets locally.
-  # Values set as env vars already will take precedence (eval won't overwrite).
-  ENC_FILE="$PROJECT_DIR/.env.production.enc"
-  if [ -f "$ENC_FILE" ]; then
-    echo "Reading secrets from .env.production.enc..."
-    DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
-
-    # Source decrypted values, but don't overwrite existing env vars
-    while IFS= read -r line; do
-      # Skip empty lines and comments
-      [[ -z "$line" || "$line" == \#* ]] && continue
-      key="${line%%=*}"
-      value="${line#*=}"
-      # Only set if not already in environment
-      if [ -z "${!key+x}" ]; then
-        export "$key=$value"
-      fi
-    done <<< "$DECRYPTED"
+# Logging nodes use only public runtime images, but they still rely on values
+# that commonly live in the encrypted production env.
+# Read SOPS_AGE_KEY from the default age keyfile if not already set
+if [ -z "${SOPS_AGE_KEY:-}" ]; then
+  AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+  if [ -f "$AGE_KEY_FILE" ]; then
+    SOPS_AGE_KEY=$(grep "^AGE-SECRET-KEY-" "$AGE_KEY_FILE" | head -1)
+    export SOPS_AGE_KEY
+    echo "Read SOPS_AGE_KEY from $AGE_KEY_FILE"
   else
-    echo "WARNING: .env.production.enc not found at $ENC_FILE"
-    echo "Falling back to environment variables."
+    echo "ERROR: No SOPS_AGE_KEY set and no keyfile at $AGE_KEY_FILE"
+    echo "Run 'make secrets-setup' first, or export SOPS_AGE_KEY."
+    exit 1
   fi
+fi
+
+# Decrypt .env.production.enc to extract secrets locally.
+# Values set as env vars already will take precedence (eval won't overwrite).
+ENC_FILE="$PROJECT_DIR/.env.production.enc"
+if [ -f "$ENC_FILE" ]; then
+  echo "Reading secrets from .env.production.enc..."
+  DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
+
+  # Source decrypted values, but don't overwrite existing env vars
+  while IFS= read -r line; do
+    # Skip empty lines and comments
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    # Only set if not already in environment
+    if [ -z "${!key+x}" ]; then
+      export "$key=$value"
+    fi
+  done <<< "$DECRYPTED"
+else
+  echo "WARNING: .env.production.enc not found at $ENC_FILE"
+  echo "Falling back to environment variables."
 fi
 
 # Validate required secrets are available (from env or .env.production.enc)
@@ -89,9 +87,8 @@ if [ "$ROLE" != "db" ] && [ "$ROLE" != "logging" ]; then
 fi
 if [ "$ROLE" = "logging" ]; then
   : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
-  : "${PRIVATE_IP:?PRIVATE_IP is required for logging role (set it or add to .env.production.enc)}"
 fi
-if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+if [ "$ROLE" != "db" ]; then
   : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for $ROLE role (logging server private IP)}"
 fi
 
@@ -168,7 +165,7 @@ ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143"
 echo "--- Step 3/5: Writing secrets ---"
 if [ "$ROLE" = "logging" ]; then
   # Logging nodes need the Grafana admin password and the private IP for binding VictoriaLogs
-  printf 'GRAFANA_ADMIN_PASSWORD=%s\nPRIVATE_IP=%s\n' "$GRAFANA_ADMIN_PASSWORD" "$PRIVATE_IP" \
+  printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\n' "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 elif [ "$ROLE" = "db" ]; then
   printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Provision a node by running bootstrap.sh + copying config files via SSH.
 # Usage: ./provision.sh <role> <host> <ssh-key-path> [--reprovision]
 #
-# Roles: app, worker, db
+# Roles: app, worker, db, logging
 # This is the SSH-based alternative to cloud-init for already-running servers.
 #
 # Pass --reprovision to tear down existing containers and volumes before reprovisioning.
@@ -31,54 +31,68 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Validate role
 case "$ROLE" in
-  app)    COMPOSE_FILE="docker-compose.app.yml" ;;
-  worker) COMPOSE_FILE="docker-compose.worker.yml" ;;
-  db)     COMPOSE_FILE="docker-compose.db.yml" ;;
-  *)      echo "Unknown role: $ROLE (expected: app, worker, db)"; exit 1 ;;
+  app)     COMPOSE_FILE="docker-compose.app.yml" ;;
+  worker)  COMPOSE_FILE="docker-compose.worker.yml" ;;
+  db)      COMPOSE_FILE="docker-compose.db.yml" ;;
+  logging) COMPOSE_FILE="docker-compose.logging.yml" ;;
+  *)       echo "Unknown role: $ROLE (expected: app, worker, db, logging)"; exit 1 ;;
 esac
 
-# Read SOPS_AGE_KEY from the default age keyfile if not already set
-if [ -z "${SOPS_AGE_KEY:-}" ]; then
-  AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
-  if [ -f "$AGE_KEY_FILE" ]; then
-    SOPS_AGE_KEY=$(grep "^AGE-SECRET-KEY-" "$AGE_KEY_FILE" | head -1)
-    export SOPS_AGE_KEY
-    echo "Read SOPS_AGE_KEY from $AGE_KEY_FILE"
+# Logging nodes use only public images and don't need SOPS secrets.
+# Skip SOPS decryption entirely for the logging role.
+if [ "$ROLE" != "logging" ]; then
+  # Read SOPS_AGE_KEY from the default age keyfile if not already set
+  if [ -z "${SOPS_AGE_KEY:-}" ]; then
+    AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+    if [ -f "$AGE_KEY_FILE" ]; then
+      SOPS_AGE_KEY=$(grep "^AGE-SECRET-KEY-" "$AGE_KEY_FILE" | head -1)
+      export SOPS_AGE_KEY
+      echo "Read SOPS_AGE_KEY from $AGE_KEY_FILE"
+    else
+      echo "ERROR: No SOPS_AGE_KEY set and no keyfile at $AGE_KEY_FILE"
+      echo "Run 'make secrets-setup' first, or export SOPS_AGE_KEY."
+      exit 1
+    fi
+  fi
+
+  # Decrypt .env.production.enc to extract secrets locally.
+  # Values set as env vars already will take precedence (eval won't overwrite).
+  ENC_FILE="$PROJECT_DIR/.env.production.enc"
+  if [ -f "$ENC_FILE" ]; then
+    echo "Reading secrets from .env.production.enc..."
+    DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
+
+    # Source decrypted values, but don't overwrite existing env vars
+    while IFS= read -r line; do
+      # Skip empty lines and comments
+      [[ -z "$line" || "$line" == \#* ]] && continue
+      key="${line%%=*}"
+      value="${line#*=}"
+      # Only set if not already in environment
+      if [ -z "${!key+x}" ]; then
+        export "$key=$value"
+      fi
+    done <<< "$DECRYPTED"
   else
-    echo "ERROR: No SOPS_AGE_KEY set and no keyfile at $AGE_KEY_FILE"
-    echo "Run 'make secrets-setup' first, or export SOPS_AGE_KEY."
-    exit 1
+    echo "WARNING: .env.production.enc not found at $ENC_FILE"
+    echo "Falling back to environment variables."
   fi
 fi
 
-# Decrypt .env.production.enc to extract secrets locally.
-# Values set as env vars already will take precedence (eval won't overwrite).
-ENC_FILE="$PROJECT_DIR/.env.production.enc"
-if [ -f "$ENC_FILE" ]; then
-  echo "Reading secrets from .env.production.enc..."
-  DECRYPTED=$(SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt --input-type dotenv --output-type dotenv "$ENC_FILE")
-
-  # Source decrypted values, but don't overwrite existing env vars
-  while IFS= read -r line; do
-    # Skip empty lines and comments
-    [[ -z "$line" || "$line" == \#* ]] && continue
-    key="${line%%=*}"
-    value="${line#*=}"
-    # Only set if not already in environment
-    if [ -z "${!key+x}" ]; then
-      export "$key=$value"
-    fi
-  done <<< "$DECRYPTED"
-else
-  echo "WARNING: .env.production.enc not found at $ENC_FILE"
-  echo "Falling back to environment variables."
-fi
-
 # Validate required secrets are available (from env or .env.production.enc)
-: "${DB_PASSWORD:?DB_PASSWORD is required (set it or add to .env.production.enc)}"
-: "${GHCR_TOKEN:?GHCR_TOKEN is required (set it or add to .env.production.enc)}"
-if [ "$ROLE" != "db" ]; then
+if [ "$ROLE" != "logging" ]; then
+  : "${DB_PASSWORD:?DB_PASSWORD is required (set it or add to .env.production.enc)}"
+  : "${GHCR_TOKEN:?GHCR_TOKEN is required (set it or add to .env.production.enc)}"
+fi
+if [ "$ROLE" != "db" ] && [ "$ROLE" != "logging" ]; then
   : "${DB_HOST:?DB_HOST is required for $ROLE role (set it or add to .env.production.enc)}"
+fi
+if [ "$ROLE" = "logging" ]; then
+  : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
+  : "${PRIVATE_IP:?PRIVATE_IP is required for logging role (set it or add to .env.production.enc)}"
+fi
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+  : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for $ROLE role (logging server private IP)}"
 fi
 
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
@@ -122,6 +136,19 @@ SYSCTL
     sysctl -p /etc/sysctl.d/99-postgres.conf
     echo "Bootstrap complete (db)."
 BOOTSTRAP_DB
+elif [ "$ROLE" = "logging" ]; then
+  # Logging nodes just need Docker — no gVisor, no special kernel tuning
+  ssh "${SSH_OPTS[@]}" root@"$HOST" << 'BOOTSTRAP_LOGGING'
+    set -euo pipefail
+    id deploy &>/dev/null || adduser --disabled-password --gecos "" deploy
+    mkdir -p /home/deploy/.ssh /opt/143
+    [ -f /root/.ssh/authorized_keys ] && cp /root/.ssh/authorized_keys /home/deploy/.ssh/
+    chown -R deploy:deploy /home/deploy/.ssh /opt/143
+    chmod 700 /home/deploy/.ssh
+    command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
+    usermod -aG docker deploy
+    echo "Bootstrap complete (logging)."
+BOOTSTRAP_LOGGING
 else
   ssh "${SSH_OPTS[@]}" root@"$HOST" 'bash -s -- '"$ROLE" < "$SCRIPT_DIR/bootstrap.sh"
 fi
@@ -129,23 +156,31 @@ fi
 # Step 2: Copy compose file and deploy configs
 echo "--- Step 2/5: Copying config files ---"
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" root@"$HOST":/opt/143/
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+  # Vector collector is included from the main compose file
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" root@"$HOST":/opt/143/
+fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
 ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143"
 
 # Step 3: Write .env with secrets
 # Uses printf + pipe to avoid nested heredoc quoting issues with special chars.
 echo "--- Step 3/5: Writing secrets ---"
-if [ "$ROLE" = "db" ]; then
+if [ "$ROLE" = "logging" ]; then
+  # Logging nodes need the Grafana admin password and the private IP for binding VictoriaLogs
+  printf 'GRAFANA_ADMIN_PASSWORD=%s\nPRIVATE_IP=%s\n' "$GRAFANA_ADMIN_PASSWORD" "$PRIVATE_IP" \
+    | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
+elif [ "$ROLE" = "db" ]; then
   printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 elif [ "$ROLE" = "worker" ]; then
   # Workers only get the secrets they need — no age key or encrypted bundle.
   # A worker compromise cannot decrypt the full production secret set.
-  printf 'DB_PASSWORD=%s\nDB_HOST=%s\n' "$DB_PASSWORD" "$DB_HOST" \
+  printf 'DB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 else
   # App nodes get the full secret set for SOPS decryption
-  printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" \
+  printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
   # Copy encrypted production env (baked into the Docker image too, but
   # having it on disk lets you re-decrypt without rebuilding)
@@ -157,9 +192,16 @@ fi
 
 # Step 4: GHCR login + pull images
 echo "--- Step 4/5: Pulling images ---"
-ssh "${SSH_OPTS[@]}" root@"$HOST" << PULL
-  su - deploy -c 'echo "${GHCR_TOKEN}" | docker login ghcr.io -u deploy --password-stdin'
+case "$ROLE" in
+  db|logging)
+    # Public images (postgres, victorialogs, grafana) are pulled automatically by compose
+    ;;
+  *)
+    ssh "${SSH_OPTS[@]}" root@"$HOST" << PULL
+      su - deploy -c 'echo "${GHCR_TOKEN}" | docker login ghcr.io -u deploy --password-stdin'
 PULL
+    ;;
+esac
 
 case "$ROLE" in
   app)
@@ -174,8 +216,8 @@ PULL_APP
       su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
 PULL_WORKER
     ;;
-  db)
-    # Postgres image is pulled automatically by compose
+  db|logging)
+    # Public images are pulled automatically by compose
     ;;
 esac
 

--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -1,0 +1,62 @@
+sources:
+  docker_logs:
+    type: docker_logs
+
+transforms:
+  enrich:
+    type: remap
+    inputs: ["docker_logs"]
+    source: |
+      # Extract Docker Compose service name
+      .service = .label."com.docker.compose.service" ?? "unknown"
+
+      # Parse structured JSON logs from our Go services (zerolog output).
+      # Selectively extract known zerolog fields rather than merging the entire parsed
+      # object into root, which would clobber Vector metadata (source_type, container_name, etc.).
+      parsed, err = parse_json(.message)
+      if err == null {
+        .message = string(parsed.message) ?? .message
+        .timestamp = string(parsed.time) ?? .timestamp
+        .level = string(parsed.level) ?? .level
+        .error = parsed.error
+        .caller = parsed.caller
+        .org_id = parsed.org_id
+        .agent_run_id = parsed.agent_run_id
+        .trace_id = parsed.trace_id
+        .request_id = parsed.request_id
+        .path = parsed.path
+        .response_time_ms = parsed.response_time_ms
+      }
+
+      # Add server identity
+      .server = get_env_var("SERVER_ROLE") ?? "unknown"
+      .hostname = get_hostname()
+
+  # Drop health check requests after JSON parsing so we can match on structured fields.
+  # Filtering on .path avoids accidentally dropping app logs that mention health endpoints.
+  filter_noise:
+    type: filter
+    inputs: ["enrich"]
+    condition:
+      type: vrl
+      source: |
+        path = string(.path) ?? ""
+        path != "/healthz" && path != "/readyz"
+
+sinks:
+  victorialogs:
+    type: http
+    inputs: ["filter_noise"]
+    uri: "http://${VICTORIALOGS_HOST}:9428/insert/jsonline"
+    encoding:
+      codec: json
+    query_string_parameters:
+      _stream_fields: "service,server,hostname"
+      _msg_field: "message"
+      _time_field: "timestamp"
+    healthcheck:
+      enabled: false
+    buffer:
+      type: disk
+      max_size: 268435456  # 256 MB disk buffer — survives logging server restarts
+      when_full: drop_newest

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -3,6 +3,9 @@
 # No Docker socket mount — sandboxes run on worker nodes only.
 # See docs/design/36-docker-agents-vps-architecture.md
 
+include:
+  - docker-compose.vector.yml
+
 services:
   caddy:
     image: caddy:2-alpine
@@ -19,6 +22,7 @@ services:
     environment:
       DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
       PORT: "8080"
+      ENV: production
       MODE: api
       NODE_ID: ${HOSTNAME:-app-1}
       BASE_URL: ${BASE_URL:-https://143.dev}

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,8 +1,22 @@
-# Logging node (VictoriaLogs + Grafana).
+# Logging node (VictoriaLogs + Grafana + Caddy).
 # Receives logs from Vector collectors on app/worker nodes via Hetzner private network.
 # See docs/design/47-logging-victorialogs.md
 
 services:
+  caddy:
+    image: caddy:2-alpine
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./deploy/Caddyfile.logging:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+    environment:
+      GRAFANA_DOMAIN: ${GRAFANA_DOMAIN:-logs.143.dev}
+    depends_on:
+      - grafana
+    restart: unless-stopped
+
   victorialogs:
     image: victoriametrics/victoria-logs:v1.50.0
     volumes:
@@ -30,12 +44,10 @@ services:
     environment:
       GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
-      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3000}
+      GF_SERVER_ROOT_URL: https://${GRAFANA_DOMAIN:-logs.143.dev}
     volumes:
       - grafana-data:/var/lib/grafana
       - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
-    ports:
-      - "127.0.0.1:3000:3000"
     depends_on:
       - victorialogs
     restart: unless-stopped
@@ -65,3 +77,4 @@ services:
 volumes:
   vlogs-data:
   grafana-data:
+  caddy_data:

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -12,7 +12,7 @@ services:
       - -retentionPeriod=30d
       - -httpListenAddr=:9428
     ports:
-      - "${PRIVATE_IP}:9428:9428"
+      - "${VICTORIALOGS_HOST}:9428:9428"
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:9428/health"]
       interval: 15s

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,0 +1,67 @@
+# Logging node (VictoriaLogs + Grafana).
+# Receives logs from Vector collectors on app/worker nodes via Hetzner private network.
+# See docs/design/47-logging-victorialogs.md
+
+services:
+  victorialogs:
+    image: victoriametrics/victoria-logs:v1.50.0
+    volumes:
+      - vlogs-data:/victoria-logs-data
+    command:
+      - -storageDataPath=/victoria-logs-data
+      - -retentionPeriod=30d
+      - -httpListenAddr=:9428
+    ports:
+      - "${PRIVATE_IP}:9428:9428"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9428/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: "1.0"
+
+  grafana:
+    image: grafana/grafana:13.0.0
+    environment:
+      GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
+      GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3000}
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - victorialogs
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+
+  # Lightweight disk usage monitor. Emits JSON to stdout every 5 minutes,
+  # which Vector (on this same host or externally) can pick up via docker_logs.
+  # Grafana alert query: service:disk-monitor AND disk_used_pct:range(80, Inf)
+  disk-monitor:
+    image: alpine:3.21
+    volumes:
+      - /:/host:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        while true; do
+          PCT=$$(df /host | awk 'NR==2 {gsub(/%/,""); print $$5}')
+          echo "{\"level\":\"info\",\"service\":\"disk-monitor\",\"disk_used_pct\":$$PCT,\"message\":\"disk usage check\"}"
+          sleep 300
+        done
+    restart: unless-stopped
+
+volumes:
+  vlogs-data:
+  grafana-data:

--- a/docker-compose.vector.yml
+++ b/docker-compose.vector.yml
@@ -1,0 +1,28 @@
+# Shared Vector log collector — included by app and worker compose files.
+# See docs/design/47-logging-victorialogs.md
+
+services:
+  vector:
+    image: timberio/vector:0.54.0-alpine
+    environment:
+      SERVER_ROLE: ${SERVER_ROLE}
+      VICTORIALOGS_HOST: ${VICTORIALOGS_HOST}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./deploy/vector.yaml:/etc/vector/vector.yaml:ro
+      - vector-buffer:/var/lib/vector
+    command: ["vector", "--config", "/etc/vector/vector.yaml", "--api.enabled=true"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8686/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 128M
+          cpus: "0.5"
+
+volumes:
+  vector-buffer:

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -1,11 +1,15 @@
 # Worker node for agent sandboxes (Phase 3b).
 # See docs/design/36-docker-agents-vps-architecture.md
 
+include:
+  - docker-compose.vector.yml
+
 services:
   worker:
     image: ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}
     environment:
       DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
+      ENV: production
       MODE: worker
       NODE_ID: ${HOSTNAME}
       MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"os"
 	"time"
 
@@ -8,12 +9,24 @@ import (
 )
 
 // NewLogger creates a zerolog logger with the given level.
-func NewLogger(level string) zerolog.Logger {
+// In production (env == "production"), it outputs structured JSON to stdout
+// for consumption by log collectors like Vector. In all other environments,
+// it uses a human-readable console format.
+func NewLogger(level, env string) zerolog.Logger {
+	return newLogger(level, env, os.Stdout)
+}
+
+func newLogger(level, env string, w io.Writer) zerolog.Logger {
 	lvl, err := zerolog.ParseLevel(level)
 	if err != nil {
 		lvl = zerolog.InfoLevel
 	}
 
-	output := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	var output io.Writer
+	if env == "production" {
+		output = w
+	} else {
+		output = zerolog.ConsoleWriter{Out: w, TimeFormat: time.RFC3339}
+	}
 	return zerolog.New(output).Level(lvl).With().Timestamp().Logger()
 }

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,6 +1,8 @@
 package logging
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -13,16 +15,25 @@ func TestNewLogger(t *testing.T) {
 	tests := []struct {
 		name          string
 		level         string
+		env           string
 		expectedLevel zerolog.Level
 	}{
 		{
 			name:          "uses parsed level when valid",
 			level:         "debug",
+			env:           "development",
 			expectedLevel: zerolog.DebugLevel,
 		},
 		{
 			name:          "falls back to info level when invalid",
 			level:         "not-a-valid-level",
+			env:           "development",
+			expectedLevel: zerolog.InfoLevel,
+		},
+		{
+			name:          "production env uses JSON output",
+			level:         "info",
+			env:           "production",
 			expectedLevel: zerolog.InfoLevel,
 		},
 	}
@@ -31,8 +42,36 @@ func TestNewLogger(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := NewLogger(tt.level)
+			logger := NewLogger(tt.level, tt.env)
 			require.Equal(t, tt.expectedLevel, logger.GetLevel(), "NewLogger should set the expected log level")
 		})
 	}
+}
+
+func TestNewLogger_ProductionOutputIsJSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := newLogger("info", "production", &buf)
+	logger.Info().Msg("test message")
+
+	require.True(t, json.Valid(buf.Bytes()), "production logger should output valid JSON, got: %s", buf.String())
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	require.Equal(t, "test message", entry["message"])
+	require.Equal(t, "info", entry["level"])
+	require.Contains(t, entry, "time", "JSON output should include a timestamp")
+}
+
+func TestNewLogger_DevelopmentOutputIsHumanReadable(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := newLogger("info", "development", &buf)
+	logger.Info().Msg("hello world")
+
+	// ConsoleWriter output is not valid JSON — it's human-readable text
+	require.False(t, json.Valid(buf.Bytes()), "development logger should not output JSON")
+	require.Contains(t, buf.String(), "hello world")
 }


### PR DESCRIPTION
## Summary
- Adds a new `logging` server role running VictoriaLogs (log storage) and Grafana (querying) on a dedicated node, with a disk-monitor sidecar
- Deploys Vector log collectors as a shared Docker Compose include on app and worker nodes, shipping structured logs over the private network
- Switches zerolog from ConsoleWriter to JSON output in production (`ENV=production`) so Vector can parse structured fields (level, org_id, agent_run_id, etc.)
- Extends provisioning and deploy scripts with full `logging` role support: bootstrap, secrets, cloud-init template, and Makefile targets (`provision-logging`, `deploy-logging`)

## Test plan
- [ ] Verify `go test ./internal/logging/...` passes (JSON vs console output tests)
- [ ] Provision a logging node: `make provision-logging HOST=<ip> SSH_KEY=<key> GRAFANA_ADMIN_PASSWORD=<pw> PRIVATE_IP=<ip>`
- [ ] Deploy app/worker with `VICTORIALOGS_HOST` set and confirm logs appear in Grafana
- [ ] Verify VictoriaLogs is only reachable on private IP (not public)
- [ ] Confirm disk-monitor reports host disk usage, not container overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)