### PR TITLE
Fix worker nodes missing secrets for sandbox creation

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -63,10 +63,9 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
   if [ "$ROLE" = "db" ]; then
     printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
-  elif [ "$ROLE" = "worker" ]; then
-    printf 'DB_PASSWORD=%s\nDB_HOST=%s\n' "$DB_PASSWORD" "$DB_HOST" \
-      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   else
+    # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
+    # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
     printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/


### PR DESCRIPTION
## Summary
- The deploy script was only sending `DB_PASSWORD` and `DB_HOST` to worker nodes, but they also need `SOPS_AGE_KEY` and `.env.production.enc` so the entrypoint can decrypt GitHub App credentials at boot
- Without these secrets, `canBuildServices` returns false and all Phase 3+ services (sandbox creation, agent orchestration) are disabled on the worker
- This caused PM analyze jobs to be picked up by the app node (which runs `mode=all` due to a stale container) where they fail with "Cannot connect to the Docker daemon" since the app node has no Docker socket mounted

## Test plan
- [ ] Redeploy worker node and verify startup logs show `GitHub App configured=true` and `Phase 3+ services initialized`
- [ ] Redeploy app node (force-recreate) and verify it starts with `mode=api`
- [ ] Trigger a PM analyze and confirm it runs successfully on the worker node

🤖 Generated with [Claude Code](https://claude.com/claude-code)