### PR TITLE
Remove VictoriaLogs healthcheck (image lacks wget/curl)

### DIFF
--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -27,11 +27,6 @@ services:
       - -httpListenAddr=:9428
     ports:
       - "${VICTORIALOGS_HOST}:9428:9428"
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:9428/health"]
-      interval: 15s
-      timeout: 5s
-      retries: 3
     restart: unless-stopped
     deploy:
       resources:


### PR DESCRIPTION
## Summary
- Removes the VictoriaLogs healthcheck from docker-compose.logging.yml since the minimal VictoriaLogs Docker image does not include wget or curl, causing the container to permanently report unhealthy

## Test plan
- [ ] Redeploy logging node and verify VictoriaLogs container no longer shows unhealthy status
- [ ] Confirm Grafana can still query VictoriaLogs normally