### PR TITLE
Add build version display and fix worker deploy secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
           tags: |
             ${{ matrix.image }}:latest
             ${{ matrix.image }}:${{ github.sha }}
+          build-args: |
+            BUILD_SHA=${{ github.sha }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -6,6 +6,8 @@ WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 COPY frontend/ .
+ARG BUILD_SHA=dev
+ENV NEXT_PUBLIC_BUILD_SHA=$BUILD_SHA
 RUN npm run build
 
 FROM node:22-alpine

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -77,8 +77,10 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for worker role (set it or add to .env.production.enc)}"
     : "${DB_HOST:?DB_HOST is required for worker role (set it or add to .env.production.enc)}"
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for worker role (set it or add to .env.production.enc)}"
-    printf 'DB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
+    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+    scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"
   else
     # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
     # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -8,6 +8,9 @@ import {
   ChevronsUpDown,
   Search,
   PenSquare,
+  Info,
+  Copy,
+  Check,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -36,6 +39,48 @@ import { CommandPalette } from "@/components/command-palette/command-palette";
 import { SidebarSettingsSection } from "@/components/sidebar-settings-section";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 import type { Organization, SingleResponse } from "@/lib/types";
+
+const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "dev";
+
+function VersionInfo() {
+  const [copied, setCopied] = useState(false);
+  const shortSha = buildSha.slice(0, 7);
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(buildSha);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, []);
+
+  return (
+    <div className="relative px-2 pb-2 pt-0.5">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button className="flex items-center gap-1.5 px-2.5 py-1 text-xs text-muted-foreground/50 hover:text-muted-foreground transition-colors w-full rounded-md hover:bg-sidebar-accent/40">
+            <Info className="h-3 w-3 shrink-0" />
+            <span className="font-mono">{shortSha}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="top" className="w-64">
+          <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+            Build Info
+          </div>
+          <DropdownMenuItem onClick={handleCopy} className="gap-2">
+            {copied ? (
+              <Check className="h-3.5 w-3.5 text-green-500" />
+            ) : (
+              <Copy className="h-3.5 w-3.5" />
+            )}
+            <div className="flex flex-col gap-0.5">
+              <span className="text-xs text-muted-foreground">Commit SHA</span>
+              <span className="font-mono text-xs">{buildSha === "dev" ? "dev (local)" : buildSha}</span>
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 const navItems = [
   { label: "Autopilot", icon: Zap, href: "/autopilot", showProposalBadge: false },
@@ -216,7 +261,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
         </div>
 
         {/* User menu */}
-        <div className="relative px-2 pb-3 border-t border-border/50 pt-2">
+        <div className="relative px-2 pb-1 border-t border-border/50 pt-2">
           {user && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -250,6 +295,9 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
             </DropdownMenu>
           )}
         </div>
+
+        {/* Version info */}
+        <VersionInfo />
       </aside>
       <main className="flex-1 overflow-auto bg-background relative flex flex-col">
         <div className="relative max-w-none px-8 py-6 lg:px-10 flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- Injects the git commit SHA into the frontend Docker image at build time via NEXT_PUBLIC_BUILD_SHA build arg, so the running app knows which commit it was built from.
- Adds a version info dropdown at the bottom of the sidebar (below the user menu) that shows the short commit hash and lets you copy the full SHA.
- Fixes worker node deploys failing because SESSION_SECRET (and other secrets) were not available — the worker role now gets SOPS_AGE_KEY and the encrypted env file, matching how the app role works.

## Test plan
- [ ] Verify the sidebar shows dev locally and the commit SHA in production
- [ ] Clicking the version dropdown shows full SHA with a copy button
- [ ] Redeploy and confirm the worker node health check passes
- [ ] Confirm the frontend image tag matches the displayed SHA