### PR TITLE
Remove Caddy from logging, add make logs tunnel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy-app deploy-worker deploy-db deploy-logging deploy-fleet
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -291,6 +291,24 @@ deploy-logging:
 	@test -n "$(HOST)" || { echo "HOST is required."; exit 1; }
 	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required."; exit 1; }
 	./deploy/scripts/deploy.sh logging $(HOST) $(SSH_KEY)
+
+# Open Grafana via SSH tunnel.
+# Usage: make logs SSH_KEY=~/.ssh/143-deploy
+# Reads LOGGING_HOST from FLEET_HOSTS in .env.production.enc automatically.
+logs:
+	@test -n "$(SSH_KEY)" || { echo "SSH_KEY is required. Usage: make logs SSH_KEY=~/.ssh/143-deploy"; exit 1; }
+	@LOGGING_HOST="$(LOGGING_HOST)"; \
+	if [ -z "$$LOGGING_HOST" ]; then \
+		FLEET="$$(sops --decrypt --input-type dotenv --output-type dotenv .env.production.enc 2>/dev/null | grep '^FLEET_HOSTS=' | cut -d= -f2-)"; \
+		LOGGING_HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^logging:' | cut -d: -f2 | head -1)"; \
+	fi; \
+	if [ -z "$$LOGGING_HOST" ]; then \
+		echo "ERROR: Could not find logging host. Set LOGGING_HOST or add logging:<ip> to FLEET_HOSTS."; \
+		exit 1; \
+	fi; \
+	echo "Opening Grafana tunnel → http://localhost:9999"; \
+	echo "Press Ctrl+C to close."; \
+	ssh -i $(SSH_KEY) -L 9999:localhost:3000 -N deploy@$$LOGGING_HOST
 
 # Deploy all nodes in the fleet.
 # Requires FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.

--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ logs:
 	fi; \
 	echo "Opening Grafana tunnel → http://localhost:9999"; \
 	echo "Press Ctrl+C to close."; \
-	ssh -i $(SSH_KEY) -L 9999:localhost:3000 -N deploy@$$LOGGING_HOST
+	ssh -i $(SSH_KEY) -L 9999:localhost:9999 -N deploy@$$LOGGING_HOST
 
 # Deploy all nodes in the fleet.
 # Requires FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.

--- a/deploy/Caddyfile.logging
+++ b/deploy/Caddyfile.logging
@@ -1,9 +1,0 @@
-# Reverse proxy for Grafana on the logging node.
-# Caddy handles TLS automatically via Let's Encrypt.
-#
-# GRAFANA_DOMAIN defaults to logs.143.dev — override via .env:
-#   GRAFANA_DOMAIN=logs.example.com
-
-{$GRAFANA_DOMAIN:logs.143.dev} {
-	reverse_proxy grafana:3000
-}

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -26,12 +26,12 @@ services:
     environment:
       GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
-      GF_SERVER_ROOT_URL: http://localhost:3000
+      GF_SERVER_ROOT_URL: http://localhost:9999
     volumes:
       - grafana-data:/var/lib/grafana
       - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:9999:3000"
     depends_on:
       - victorialogs
     restart: unless-stopped

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -1,22 +1,9 @@
-# Logging node (VictoriaLogs + Grafana + Caddy).
+# Logging node (VictoriaLogs + Grafana).
 # Receives logs from Vector collectors on app/worker nodes via Hetzner private network.
+# Access Grafana via SSH tunnel: make logs SSH_KEY=~/.ssh/143-deploy
 # See docs/design/47-logging-victorialogs.md
 
 services:
-  caddy:
-    image: caddy:2-alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./deploy/Caddyfile.logging:/etc/caddy/Caddyfile:ro
-      - caddy_data:/data
-    environment:
-      GRAFANA_DOMAIN: ${GRAFANA_DOMAIN:-logs.143.dev}
-    depends_on:
-      - grafana
-    restart: unless-stopped
-
   victorialogs:
     image: victoriametrics/victoria-logs:v1.50.0
     volumes:
@@ -39,10 +26,12 @@ services:
     environment:
       GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}
-      GF_SERVER_ROOT_URL: https://${GRAFANA_DOMAIN:-logs.143.dev}
+      GF_SERVER_ROOT_URL: http://localhost:3000
     volumes:
       - grafana-data:/var/lib/grafana
       - ./deploy/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "127.0.0.1:3000:3000"
     depends_on:
       - victorialogs
     restart: unless-stopped
@@ -72,4 +61,3 @@ services:
 volumes:
   vlogs-data:
   grafana-data:
-  caddy_data:


### PR DESCRIPTION
## Summary
- Removes Caddy reverse proxy from logging node — Grafana binds to localhost:3000 only, eliminating public attack surface
- Adds `make logs SSH_KEY=~/.ssh/143-deploy` command that auto-discovers the logging server from FLEET_HOSTS and opens an SSH tunnel on port 9999
- Deletes deploy/Caddyfile.logging

## Test plan
- [ ] `make logs SSH_KEY=~/.ssh/143-deploy` opens tunnel, Grafana accessible at http://localhost:9999
- [ ] Redeploy logging node and verify Caddy container is gone