### PR TITLE
Standardize audit log detail drawer text size to text-xs

### DIFF
--- a/frontend/src/components/audit/audit-log-detail-drawer.test.tsx
+++ b/frontend/src/components/audit/audit-log-detail-drawer.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AuditLogDetailDrawer } from './audit-log-detail-drawer';
+import type { AuditLog, User } from '@/lib/types';
+
+const mockMembers: User[] = [
+  {
+    id: 'user-1',
+    org_id: 'org-1',
+    email: 'alice@example.com',
+    name: 'Alice',
+    role: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+function makeEntry(overrides: Partial<AuditLog> = {}): AuditLog {
+  return {
+    id: 1,
+    org_id: 'org-1',
+    actor_type: 'user',
+    actor_id: 'user-1',
+    user_id: 'user-1',
+    action: 'session.created',
+    resource_type: 'session',
+    resource_id: 'sess-1',
+    created_at: '2026-04-13T21:57:21Z',
+    ...overrides,
+  };
+}
+
+describe('AuditLogDetailDrawer', () => {
+  it('returns null when entry is null', () => {
+    const { container } = render(
+      <AuditLogDetailDrawer entry={null} onClose={vi.fn()} members={mockMembers} />
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders core event details', () => {
+    render(
+      <AuditLogDetailDrawer entry={makeEntry()} onClose={vi.fn()} members={mockMembers} />
+    );
+
+    expect(screen.getByText('Event details')).toBeInTheDocument();
+    expect(screen.getByText('session.created')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('user')).toBeInTheDocument();
+    expect(screen.getByText('session')).toBeInTheDocument();
+    expect(screen.getByText('sess-1')).toBeInTheDocument();
+  });
+
+  it('renders request metadata when present', () => {
+    render(
+      <AuditLogDetailDrawer
+        entry={makeEntry({
+          ip_address: '192.168.1.1',
+          user_agent: 'TestAgent/1.0',
+          request_id: 'req-123',
+        })}
+        onClose={vi.fn()}
+        members={mockMembers}
+      />
+    );
+
+    expect(screen.getByText('Request info')).toBeInTheDocument();
+    expect(screen.getByText('192.168.1.1')).toBeInTheDocument();
+    expect(screen.getByText('TestAgent/1.0')).toBeInTheDocument();
+    expect(screen.getByText('req-123')).toBeInTheDocument();
+  });
+
+  it('renders details payload when present', () => {
+    render(
+      <AuditLogDetailDrawer
+        entry={makeEntry({ details: { changed: 'value', count: 42 } })}
+        onClose={vi.fn()}
+        members={mockMembers}
+      />
+    );
+
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('changed')).toBeInTheDocument();
+    expect(screen.getByText('value')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders correlation IDs when present', () => {
+    render(
+      <AuditLogDetailDrawer
+        entry={makeEntry({ session_id: 'sess-abc', project_id: 'proj-xyz' })}
+        onClose={vi.fn()}
+        members={mockMembers}
+      />
+    );
+
+    expect(screen.getByText('Related')).toBeInTheDocument();
+    expect(screen.getByText('sess-abc')).toBeInTheDocument();
+    expect(screen.getByText('proj-xyz')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/audit/audit-log-detail-drawer.tsx
+++ b/frontend/src/components/audit/audit-log-detail-drawer.tsx
@@ -27,8 +27,8 @@ export function AuditLogDetailDrawer({ entry, onClose, members }: AuditLogDetail
     <Sheet open={!!entry} onOpenChange={(open) => !open && onClose()}>
       <SheetContent>
         <SheetHeader>
-          <SheetTitle className="text-sm">Event details</SheetTitle>
-          <SheetDescription>
+          <SheetTitle className="text-xs">Event details</SheetTitle>
+          <SheetDescription className="text-xs">
             {actorName} {actionLabel}
           </SheetDescription>
         </SheetHeader>
@@ -69,9 +69,9 @@ export function AuditLogDetailDrawer({ entry, onClose, members }: AuditLogDetail
             <div className="space-y-2">
               <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Request info</h3>
               <div className="rounded-md bg-muted/30 border border-border/50 p-3 space-y-2">
-                {entry.ip_address && <DetailRow label="IP Address" value={entry.ip_address} mono small />}
-                {entry.user_agent && <DetailRow label="User Agent" value={entry.user_agent} small />}
-                {entry.request_id && <DetailRow label="Request ID" value={entry.request_id} mono small />}
+                {entry.ip_address && <DetailRow label="IP Address" value={entry.ip_address} mono />}
+                {entry.user_agent && <DetailRow label="User Agent" value={entry.user_agent} />}
+                {entry.request_id && <DetailRow label="Request ID" value={entry.request_id} mono />}
               </div>
             </div>
           )}
@@ -81,8 +81,8 @@ export function AuditLogDetailDrawer({ entry, onClose, members }: AuditLogDetail
             <div className="space-y-2">
               <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Related</h3>
               <div className="rounded-md bg-muted/30 border border-border/50 p-3 space-y-2">
-                {entry.session_id && <DetailRow label="Session ID" value={entry.session_id} mono small />}
-                {entry.project_id && <DetailRow label="Project ID" value={entry.project_id} mono small />}
+                {entry.session_id && <DetailRow label="Session ID" value={entry.session_id} mono />}
+                {entry.project_id && <DetailRow label="Project ID" value={entry.project_id} mono />}
               </div>
             </div>
           )}
@@ -96,20 +96,18 @@ function DetailRow({
   label,
   value,
   mono,
-  small,
   children,
 }: {
   label: string;
   value?: string;
   mono?: boolean;
-  small?: boolean;
   children?: React.ReactNode;
 }) {
   return (
-    <div className={`flex items-start gap-3 ${small ? "text-xs" : "text-sm"}`}>
-      <span className="text-muted-foreground min-w-[100px] shrink-0 text-xs font-medium">{label}</span>
+    <div className="flex items-start gap-3 text-xs">
+      <span className="text-muted-foreground min-w-[100px] shrink-0 font-medium">{label}</span>
       {children ?? (
-        <span className={`text-foreground break-all ${mono ? "font-mono text-xs" : ""}`}>
+        <span className={`text-foreground break-all ${mono ? "font-mono" : ""}`}>
           {value}
         </span>
       )}


### PR DESCRIPTION
## Summary
- Standardizes all text in the audit log event details drawer to use `text-xs`, matching the rest of the app
- Removes the `small` prop from `DetailRow` since all rows now use the same size
- Fixes inconsistency where core info rows used `text-sm` while request info and related sections used `text-xs`

## Test plan
- [ ] Open audit log and click an entry to open the detail drawer
- [ ] Verify all text (title, description, labels, values) renders at consistent `text-xs` size

🤖 Generated with [Claude Code](https://claude.com/claude-code)