### PR TITLE
Fix worker deploy: replace placeholder SESSION_SECRET

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -2,7 +2,7 @@ PORT=ENC[AES256_GCM,data:ew7zGQ==,iv:M7eUz26/FJNZorV7vry9L/U0QGAXTat9fFIbtFfsSFY
 LOG_LEVEL=ENC[AES256_GCM,data:WfxG3w==,iv:D4D4rwW+p4oNJJnwVtGM32ZObVhu/WFOORL2Htt+iY8=,tag:enBXo8xsS93AOQSimCtdCQ==,type:str]
 MODE=ENC[AES256_GCM,data:64jD,iv:LMINq2jNH8l91M//yBjQkVaP7ja1cTatOi4CIiLUGaU=,tag:QD+XiwUzsHK6pzQfFZCycg==,type:str]
 BASE_URL=ENC[AES256_GCM,data:4LGr6dvnA8s1Yyz4EhEpMIgCzg==,iv:zl51cEQlKgGa1//wj5uIjQpwIZbIlgezt2II2cSYeiM=,tag:SmE/04L3ePyrLxcELd70aQ==,type:str]
-SESSION_SECRET=ENC[AES256_GCM,data:YCYM9zvdEi4tpawLO/E+gAfuhf+NZ6uaq9M=,iv:p8Z6xGL+Vmry033eHE+xVpesFPS45xROPVcOOFGqdhw=,tag:3ZdUdAhLg+DKZ++oeaf7kA==,type:str]
+SESSION_SECRET=ENC[AES256_GCM,data:tDMUeVsaYFSn9X4q2naHBEqsLTg+MVMvizjBkal8Z1M5bG99ZDKYBkT8zIpMKiFv5sdqQKZPiJyOIxIWLQHx0A==,iv:VjLGD/XFz6YMEjb60YQg0vAfkWi7ymTcbi6Yzl/J+ww=,tag:8E1PBVniGIyCU1fWc97VDQ==,type:str]
 GITHUB_OAUTH_CLIENT_ID=ENC[AES256_GCM,data:rvwSKC9f/orwUG9+D375xkHuzhE=,iv:oQ1i7AJoi/sw+HCJsGAYL+AUfReMh3nxzOwxFQiPQZ8=,tag:nNGnvysi/SyAW7FTKcjx7A==,type:str]
 GITHUB_OAUTH_CLIENT_SECRET=ENC[AES256_GCM,data:U7eMUG1KZMss7Zy+ObQtcG2KMkTn/sp7BfRNDSNJzj7KgG0E+7MyxA==,iv:0X4nQQSeLMRr7WqdgCPeD1/0y792JpXFmCaAKRAKAB4=,tag:wN3sa3xkAjPr9pbm95NHYw==,type:str]
 LINEAR_OAUTH_CLIENT_ID=ENC[AES256_GCM,data:lRwW9mTdeKUk9KFgCsD7JtLTbt0CKrcEVgzbSGW+5ks=,iv:NC5YyN7R24F6EwTnsMk7fOZ28fgol6o9qE+Y8ahICxo=,tag:LM0EvPEI03uRzAdKpo3MlQ==,type:str]
@@ -41,7 +41,7 @@ sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-15T03:51:29Z
-sops_mac=ENC[AES256_GCM,data:qc7ZVBPbY37mfEpW+yjjQjGNbSe+6j+skodZ8ulv+bKsTPM3lSMgKbXH/DN/W/fRZJZoih7jcxPaQqIXykSRSgzJtozbymgRwGoJbTYH6B3X1mva7EiyCN8oOFDjUuI6JjvFp8BFo2ZXcqAj9IofUXpu92cv3GSf7SaYYsTbupM=,iv:yAweSqQenYwo8nX42NJAKPne7P6welQ85Q1heYet500=,tag:hmICZ9CId39Ypf2SDaAA+Q==,type:str]
+sops_lastmodified=2026-04-15T05:06:57Z
+sops_mac=ENC[AES256_GCM,data:snaiZXLIl+4hgTNbQZ0KEMRO6oqg+U2la/z/S7Vfx6+2J85l3Sjt31OkBuao8r4UYxO/He3YN2T/XhFW2E0ROyvhmMLhr7W2JzwCznkXwsNQ3nlbz4P/SIeaqck928xmmJkHh0y5KIW4VAnfVveVWXjgPvoCip/5VMvuIRT4PRE=,iv:O4DKqQKWG93QsaMEJb22tL9lSG/sGb/IeGaw0TtyE34=,tag:B4yJoJSuCd46PmuQ1IKxuw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1


### PR DESCRIPTION
## Summary
- Worker deploy was failing with `SESSION_SECRET must be set to a strong random value in production (min 32 characters)`
- The `SESSION_SECRET` in `.env.production.enc` was still the placeholder `change-me-to-random-secret` (27 chars) from `.env.example`
- Replaced it with a proper 64-character hex secret generated via `openssl rand -hex 32`

## Test plan
- [ ] Redeploy worker: `make deploy-worker HOST=87.99.158.39 SSH_KEY=~/.ssh/143-deploy`
- [ ] Verify health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)