### PR TITLE
Add missing ENCRYPTION_MASTER_KEY and CSRF_SIGNING_KEY to production secrets

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -35,13 +35,15 @@ FLEET_HOSTS=ENC[AES256_GCM,data:cVON+Bd+WuuCaaZSMcloJ3ynSj+QhiDZd0Q74eZpVtX6rccf
 OPENAI_API_KEY=ENC[AES256_GCM,data:+2nrofAW1Flz5Xh2MO+jYkbdAoRgyFba3rP064e/BHfsAB8HcOjx5wEmT+HgvM/UBnKMHvPoekO0tG0Zprh5S3L2FUGCJoZe7RG3mCd9Wxmd35mRKuWC1W1r9tgwttKvNQQ9iHna2mZZM5c61Ajyf7rnToXF7GiSTOsaaGN2qgID5OO2kHfLMDLFOSrVtHWzTUOVEx+IV2xpdLraZTnJaa0Lor2k2l4=,iv:g+06NdD4AuXseqjxVI+dxk8nORFbbHCP5FSeio1HmZA=,tag:qE8ogT1i0uI12Ritv1h5Qw==,type:str]
 GRAFANA_ADMIN_PASSWORD=ENC[AES256_GCM,data:ZIJvOUHvc/FI3enYrilH+qmDoMeN2sluNdWc8KU8xuk=,iv:FsYZzgXi6tNJ5z/Nl5++Hq406bgr88h9Q4xS0sIC0ZQ=,tag:qvaoezVKTOACNe/4dkW5zA==,type:str]
 VICTORIALOGS_HOST=ENC[AES256_GCM,data:kkLo2cSW28s=,iv:F+ghGcp0NG9Xj/NtkEBmulkThzJwsie4Lsy6lNabud4=,tag:BE0G/xhmKeT3euZatKWZQg==,type:str]
+ENCRYPTION_MASTER_KEY=ENC[AES256_GCM,data:J5NzSq/58dgx2XByFMiSFCYeqlW4QOrQeVRP9bWGn5HwMjitq1r82d/+ADm+cEkJA+U/V0k8YJ125I7t62ihVQ==,iv:63jRIHqYXWHkcKmwQPdQCyTn3iBPiUbcMMBhLC8zULU=,tag:XsPLDeiw6JrfrdA5qj2/cA==,type:str]
+CSRF_SIGNING_KEY=ENC[AES256_GCM,data:K1Cdyl66HIkWbKdONnTjCkkFSMiJ5+9xSg0tTLnaw/pGcU0ai+f2/v+EDdumf7Js1R9TP7mzYKcJh+WnhSZ7ng==,iv:gqfhfpmC8HG0YOC8Ogn4c3HWUyTa8bN6qsRfwRw60/Q=,tag:fyItT43JUVk6eq4f3t/nYg==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwRVlNOEU0YUwzZ3ByQ3Qv\nUjdnbVhNN1ZzeWJHK2hYcGhyY01NenlMZ1dVClhYL3IzcWRpZU43dklJL3l4ZDVK\nUnZLNjJ2OWFpTlpVS2xONFA0TXkxcWMKLS0tIFltaUNOQW5LUG9OcVU0Y2RrTy83\naVhzM1I2TlhpTThDNU93TXk2dGxOVUEKeW+oZNn1lOtsKMnsqzCHm7Ob842xYbtY\nuXNOLcRQc70SxVD1DKHnzYt//hDWNiF6P5DEfZDuAFJ44fn1U7fXlw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1xyvl6ral4fq757tpnz30cuzefrpngnuv6zutjsg7wtnmza4uyqlshc2ucl
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNMGR2ZWtiVTNLMjVBMC9p\nbk9XUnpMMWMvZzhsM2dPcmc3QU9VNUpOV0NRCldaWmIzWWZuNlp2em9PVU14ek1m\nOUhnRW1ZVS9oM3VubThobjQxbGtMQmsKLS0tIHZqWlpDRjNsL2MyL1hWeHFvb2tj\nVmpXRDRMQmxYaythdTFUUFQ2cUVCTWsKvzGFG7rpanzjg6/yCWWvlHOnufRItdcH\nnAscSVItc051kzQRW2lvVTlZ+Dzc7pGvdHRKXOAA1cF62ZO3l4HrUg==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-15T05:06:57Z
-sops_mac=ENC[AES256_GCM,data:snaiZXLIl+4hgTNbQZ0KEMRO6oqg+U2la/z/S7Vfx6+2J85l3Sjt31OkBuao8r4UYxO/He3YN2T/XhFW2E0ROyvhmMLhr7W2JzwCznkXwsNQ3nlbz4P/SIeaqck928xmmJkHh0y5KIW4VAnfVveVWXjgPvoCip/5VMvuIRT4PRE=,iv:O4DKqQKWG93QsaMEJb22tL9lSG/sGb/IeGaw0TtyE34=,tag:B4yJoJSuCd46PmuQ1IKxuw==,type:str]
+sops_lastmodified=2026-04-15T05:21:28Z
+sops_mac=ENC[AES256_GCM,data:RAB9bofP+Tgr1ETzCQAnv+ttBBxRcS1mwUV3bPnjxYNivw+tVfbEdUOvnB0iMuQw41bLdvaVCr31Rcg8dQvoMv4A4a9j+qUnD0Fsi4k9xOsWguDHjnoJ04QL7J9zIdz1HDF0JJEkR3DafHle07zboIdNqs9PbCZtp2UNUCj1/XQ=,iv:Nt46ZW1+/hX3zzCpXWCXJVzmbiCPGQo1wRRcY//crEQ=,tag:LSewTMiJxUgJymZfCcYqpg==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1


### PR DESCRIPTION
## Summary
- Adds `ENCRYPTION_MASTER_KEY` and `CSRF_SIGNING_KEY` to `.env.production.enc`
- These secrets are required by `ValidateSecrets()` when `ENV=production`, but were never added — causing the worker to fatal on startup with `"ENCRYPTION_MASTER_KEY must be set in production"`
- `SESSION_SECRET` was fixed in #336, but the other two required secrets were still missing

## Test plan
- [ ] Deploy worker and verify it starts without the `security configuration check failed` fatal error
- [ ] Verify credential encryption feature shows `configured: true` in startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)