### PR TITLE
Fix worker deploy by mounting encrypted secrets on app only

### DIFF
--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -24,11 +24,12 @@ services:
       PORT: "8080"
       ENV: production
       MODE: api
-      NODE_ID: ${HOSTNAME:-app-1}
       BASE_URL: ${BASE_URL:-https://143.dev}
       FRONTEND_URL: ${FRONTEND_URL:-https://143.dev}
     env_file:
       - .env
+    volumes:
+      - .env.production.enc:/.env.production.enc:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
       interval: 10s

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -11,7 +11,6 @@ services:
       DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
       ENV: production
       MODE: worker
-      NODE_ID: ${HOSTNAME}
       MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}
       SANDBOX_IMAGE: ghcr.io/assembledhq/143-sandbox:${IMAGE_TAG:-latest}
       SANDBOX_RUNTIME: runsc


### PR DESCRIPTION
Remove unused `NODE_ID` env var from both app and worker compose files since the server uses `os.Hostname()` directly. Mount `.env.production.enc` read-only on the app container where the entrypoint expects it, but not on workers where cloud-init does not provision this file.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>