### PR TITLE
Improve sync-keys dry run output and add github-actions key

### DIFF
--- a/deploy/authorized_keys/github-actions.pub
+++ b/deploy/authorized_keys/github-actions.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPapGlCnCbfS/hGUPXhMd/9c3lxn1TzrAIqrAaL+XmnN github-actions-deploy

--- a/deploy/scripts/sync-keys.sh
+++ b/deploy/scripts/sync-keys.sh
@@ -65,9 +65,15 @@ for HOST in "${HOSTS[@]}"; do
     continue
   fi
 
-  # Show diff
-  diff <(printf '%s\n' "$REMOTE_KEYS") <(printf '%s\n' "$AUTHORIZED_KEYS") \
-    | sed 's/^/  /' || true
+  # Show diff: removed lines in red with -, added lines in green with +
+  while IFS= read -r line; do
+    case "$line" in
+      "< "*)  printf '  \033[31m- %s\033[0m\n' "${line#< }" ;;
+      "> "*)  printf '  \033[32m+ %s\033[0m\n' "${line#> }" ;;
+      ---*)   ;;
+      *)      ;;
+    esac
+  done < <(diff <(printf '%s\n' "$REMOTE_KEYS") <(printf '%s\n' "$AUTHORIZED_KEYS") || true)
 
   if [ "$APPLY" = true ]; then
     printf '%s\n' "$AUTHORIZED_KEYS" | ssh "${SSH_OPTS[@]}" deploy@"$HOST" \


### PR DESCRIPTION
## Summary
- Replaces the raw diff output in sync-keys dry run with a git-style +/- format, colored red/green for easy scanning.
- Adds the github-actions-deploy public key to deploy/authorized_keys/ so it is preserved across syncs.

## Test plan
- Run make sync-keys and verify the dry run output uses colored +/- lines
- Verify github-actions.pub is included in the key count

Generated with Claude Code