### PR TITLE
Fix deploy permission denied on .env.production.enc

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -80,7 +80,7 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 644 /opt/143/.env.production.enc"
   else
     # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
     # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
@@ -90,7 +90,7 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 600 /opt/143/.env.production.enc"
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 644 /opt/143/.env.production.enc"
   fi
   echo "Secrets refreshed."
 else

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -191,7 +191,7 @@ else
   # having it on disk lets you re-decrypt without rebuilding)
   if [ -f "$ENC_FILE" ]; then
     scp "${SCP_OPTS[@]}" "$ENC_FILE" root@"$HOST":/opt/143/
-    ssh "${SSH_OPTS[@]}" root@"$HOST" "chown deploy:deploy /opt/143/.env.production.enc && chmod 600 /opt/143/.env.production.enc"
+    ssh "${SSH_OPTS[@]}" root@"$HOST" "chown deploy:deploy /opt/143/.env.production.enc && chmod 644 /opt/143/.env.production.enc"
   fi
 fi
 


### PR DESCRIPTION
## Summary
- The encrypted secrets file (`.env.production.enc`) was `chmod 600` on the host, but the Docker container runs as `appuser` (different UID than `deploy`), causing "permission denied" when the entrypoint reads the bind-mounted file via sops.
- Changed to `chmod 644` in deploy.sh (worker + app branches) and provision.sh. The file is sops-encrypted so world-readable permissions are safe.

## Test plan
- [ ] Run `make deploy` and verify migrations complete without permission error
- [ ] Verify the entrypoint successfully decrypts secrets on both app and worker nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)