### PR TITLE
Fix Vector crash-loop and harden deploy

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -101,6 +101,7 @@ fi
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
 if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" deploy@"$HOST":/opt/143/
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy"
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
 fi
 
@@ -159,6 +160,23 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
     sleep 2
   done
+
+  # Verify Vector is running on app/worker nodes
+  if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+    echo "Checking Vector log collector..."
+    VECTOR_ID="$(docker compose -f "$COMPOSE_FILE" ps -q vector)"
+    if [ -z "$VECTOR_ID" ]; then
+      echo "ERROR: Vector container not found — logs will not be collected"
+      exit 1
+    fi
+    VECTOR_STATUS="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$VECTOR_ID")"
+    if [ "$VECTOR_STATUS" = "exited" ] || [ "$VECTOR_STATUS" = "dead" ]; then
+      echo "ERROR: Vector is not running (status: $VECTOR_STATUS)"
+      docker compose -f "$COMPOSE_FILE" logs --tail=20 vector 2>&1 || true
+      exit 1
+    fi
+    echo "Vector is running (status: $VECTOR_STATUS)."
+  fi
 
   echo "Deploy complete ($ROLE)."
 REMOTE

--- a/docker-compose.vector.yml
+++ b/docker-compose.vector.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./deploy/vector.yaml:/etc/vector/vector.yaml:ro
       - vector-buffer:/var/lib/vector
-    command: ["vector", "--config", "/etc/vector/vector.yaml", "--api.enabled=true"]
+    command: ["--config", "/etc/vector/vector.yaml", "--api.enabled=true"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8686/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- **Fix Vector command**: The `docker-compose.vector.yml` command array started with `"vector"`, but the container entrypoint is already `vector`, causing `vector vector --config ...` → "unrecognized subcommand" crash-loop. Removed the duplicate.
- **Ensure deploy dir exists**: Added `mkdir -p /opt/143/deploy` before SCPing `vector.yaml` to prevent first-deploy failures on freshly provisioned nodes.
- **Add Vector health check**: Deploy script now verifies Vector is running on app/worker nodes after deployment, failing loudly instead of silently missing log collection.

## Test plan
- [ ] Merge and let CI deploy to fleet
- [ ] Verify `docker ps | grep vector` shows a running container on app/worker nodes
- [ ] Check Grafana Explore tab shows logs flowing in

🤖 Generated with [Claude Code](https://claude.com/claude-code)