### PR TITLE
Fix Vector crash-loop: move API config to YAML

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -1,3 +1,6 @@
+api:
+  enabled: true
+
 sources:
   docker_logs:
     type: docker_logs

--- a/docker-compose.vector.yml
+++ b/docker-compose.vector.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./deploy/vector.yaml:/etc/vector/vector.yaml:ro
       - vector-buffer:/var/lib/vector
-    command: ["--config", "/etc/vector/vector.yaml", "--api.enabled=true"]
+    command: ["--config", "/etc/vector/vector.yaml"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8686/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Vector 0.54.0 doesn't support `--api.enabled` as a CLI flag, causing a crash-loop on app/worker nodes
- Moved the API enablement into `deploy/vector.yaml` and removed the unsupported flag from the compose command
- This was preventing all log collection, explaining why Grafana/VictoriaLogs showed no data

## Test plan
- [ ] Deploy to app node (`make deploy-app`) and verify Vector starts without errors
- [ ] Check `docker compose -f docker-compose.app.yml logs vector` shows successful startup
- [ ] Verify logs appear in Grafana via `make logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)