### PR TITLE
Fix Vector VRL fallible assignment and buffer min size

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -33,7 +33,7 @@ transforms:
 
       # Add server identity
       .server = get_env_var("SERVER_ROLE") ?? "unknown"
-      .hostname = get_hostname()
+      .hostname, err = get_hostname()
 
   # Drop health check requests after JSON parsing so we can match on structured fields.
   # Filtering on .path avoids accidentally dropping app logs that mention health endpoints.
@@ -57,5 +57,5 @@ sinks:
       enabled: false
     buffer:
       type: disk
-      max_size: 268435456  # 256 MB disk buffer — survives logging server restarts
+      max_size: 268435488  # 256 MB disk buffer — survives logging server restarts
       when_full: drop_newest


### PR DESCRIPTION
## Summary
- `get_hostname()` is fallible in VRL and requires the error-handling assignment syntax (`.hostname, err = get_hostname()`).
- Buffer `max_size` must be >= 268435488 bytes (Vector enforces a 32-byte overhead on top of the 256 MB value).

Follow-up to #350 which fixed the `query_string_parameters` and deploy ordering issues.

## Test plan
- [ ] Deploy to app node and verify Vector starts without crash-loop
- [ ] Verify logs appear in Grafana/VictoriaLogs