### PR TITLE
Fix VRL error coalescing on infallible field access

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -11,7 +11,7 @@ transforms:
     inputs: ["docker_logs"]
     source: |
       # Extract Docker Compose service name
-      .service = .label."com.docker.compose.service" ?? "unknown"
+      .service = .label."com.docker.compose.service" || "unknown"
 
       # Parse structured JSON logs from our Go services (zerolog output).
       # Selectively extract known zerolog fields rather than merging the entire parsed


### PR DESCRIPTION
## Summary
- VRL rejects `??` on infallible expressions. `.label."com.docker.compose.service"` is a simple field access that returns null (not an error), so use `||` for null-coalescing instead.

Follow-up to #351.

## Test plan
- [ ] Deploy and verify Vector starts without VRL errors
- [ ] Verify logs appear in Grafana/VictoriaLogs