### PR TITLE
Fix Vector HTTP sink encoding and VRL parse_json warning

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -16,8 +16,8 @@ transforms:
       # Parse structured JSON logs from our Go services (zerolog output).
       # Selectively extract known zerolog fields rather than merging the entire parsed
       # object into root, which would clobber Vector metadata (source_type, container_name, etc.).
-      parsed, err = parse_json(.message)
-      if err == null {
+      parsed = parse_json(.message) ?? null
+      if parsed != null {
         .message = string(parsed.message) ?? .message
         .timestamp = string(parsed.time) ?? .timestamp
         .level = string(parsed.level) ?? .level
@@ -52,7 +52,7 @@ sinks:
     inputs: ["filter_noise"]
     uri: "http://${VICTORIALOGS_HOST}:9428/insert/jsonline?_stream_fields=service,server,hostname&_msg_field=message&_time_field=timestamp"
     encoding:
-      codec: json
+      codec: json_lines
     healthcheck:
       enabled: false
     buffer:


### PR DESCRIPTION
## Summary
- Use `json_lines` codec (NDJSON) instead of `json` — VictoriaLogs `/insert/jsonline` expects newline-delimited JSON, not a JSON array. This was causing 400 Bad Request responses.
- Fix unused `err` variable warning from `parse_json` by using `?? null` instead.

Follow-up to #352.

## Test plan
- [ ] Deploy and verify Vector stops getting 400s from VictoriaLogs
- [ ] Verify logs appear in Grafana