### PR TITLE
Fix Vector encoding: json codec with newline_delimited framing

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -52,7 +52,9 @@ sinks:
     inputs: ["filter_noise"]
     uri: "http://${VICTORIALOGS_HOST}:9428/insert/jsonline?_stream_fields=service,server,hostname&_msg_field=message&_time_field=timestamp"
     encoding:
-      codec: json_lines
+      codec: json
+      framing:
+        method: newline_delimited
     healthcheck:
       enabled: false
     buffer:


### PR DESCRIPTION
## Summary
- `json_lines` is not a valid codec in Vector 0.54.0. Use `json` codec with `newline_delimited` framing to produce NDJSON for VictoriaLogs.

Follow-up to #353.

## Test plan
- [ ] Deploy and verify Vector starts without config errors
- [ ] Verify logs appear in Grafana/VictoriaLogs