### PR TITLE
Switch Vector to elasticsearch sink for VictoriaLogs

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -48,13 +48,17 @@ transforms:
 
 sinks:
   victorialogs:
-    type: http
+    type: elasticsearch
     inputs: ["filter_noise"]
-    uri: "http://${VICTORIALOGS_HOST}:9428/insert/jsonline?_stream_fields=service,server,hostname&_msg_field=message&_time_field=timestamp"
-    encoding:
-      codec: json
-      framing:
-        method: newline_delimited
+    endpoints:
+      - "http://${VICTORIALOGS_HOST}:9428/insert/elasticsearch"
+    api_version: v8
+    mode: bulk
+    query:
+      _stream_fields: "service,server,hostname"
+      _msg_field: "message"
+      _time_field: "timestamp"
+    compression: gzip
     healthcheck:
       enabled: false
     buffer:


### PR DESCRIPTION
## Summary
- Replace the HTTP sink with the `elasticsearch` sink using VictoriaLogs' officially recommended bulk API endpoint. The HTTP sink wraps batches in JSON arrays which VictoriaLogs rejects with 400. The elasticsearch sink handles serialization and batching correctly out of the box.

## Test plan
- [ ] Deploy and verify Vector starts without errors
- [ ] Verify logs appear in Grafana/VictoriaLogs