### PR TITLE
Fix worker Docker socket permissions and mount encrypted secrets

### DIFF
--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -16,8 +16,11 @@ services:
       SANDBOX_RUNTIME: runsc
     env_file:
       - .env
+    group_add:
+      - ${DOCKER_GID:-988}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - .env.production.enc:/.env.production.enc:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
       interval: 15s


### PR DESCRIPTION
## Summary

- Add group_add with the host Docker socket GID so the worker container (running as appuser) can connect to the Docker daemon. This fixes "Cannot connect to the Docker daemon" errors when processing sandbox jobs.
- Mount .env.production.enc into the worker container so it gets fresh secrets on deploy, matching the app compose setup.

## Test plan

- [ ] Verify stat -c %g /var/run/docker.sock on the worker host matches the default GID (988), or set DOCKER_GID in .env
- [ ] Deploy to worker node and confirm continue_session jobs create sandbox containers successfully
- [ ] Verify secrets are decrypted at boot via printenv ANTHROPIC_API_KEY