### PR TITLE
Fix gVisor cgroup driver mismatch causing sandbox EOF errors

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -33,7 +33,7 @@ runcmd:
   - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
   - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
   - apt-get update && apt-get install -y runsc
-  - runsc install
+  - runsc install -- --systemd-cgroup
   - systemctl restart docker
 
   # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ if [ "$ROLE" = "worker" ]; then
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \
       > /etc/apt/sources.list.d/gvisor.list
     apt-get update && apt-get install -y runsc
-    runsc install
+    runsc install -- --systemd-cgroup
     systemctl restart docker
   }
 fi


### PR DESCRIPTION
## Summary
- `runsc install` was registering gVisor with the default `cgroupfs` cgroup driver, but Docker uses `systemd`. This mismatch caused sandbox creation to fail with EOF when PID limits were set (both in the health check and real agent sessions).
- Adds `--systemd-cgroup` flag to `runsc install` in both cloud-init and bootstrap provisioning paths.
- Existing workers need reprovisioning (`make provision-worker HOST=<ip> REPROVISION=true`) or manual fix (`sudo runsc install -- --systemd-cgroup && sudo systemctl restart docker`).

## Test plan
- [ ] Reprovision worker node and verify `docker run --rm --runtime=runsc --pids-limit 16 busybox echo ok` succeeds
- [ ] Deploy and confirm worker health check passes
- [ ] Run an agent session end-to-end to verify sandboxes work with PID limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)