### PR TITLE
Fix gVisor sandbox EOF by raising health check PidsLimit to 64

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -33,7 +33,7 @@ runcmd:
   - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
   - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
   - apt-get update && apt-get install -y runsc
-  - runsc install -- --systemd-cgroup
+  - runsc install
   - systemctl restart docker
 
   # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ if [ "$ROLE" = "worker" ]; then
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \
       > /etc/apt/sources.list.d/gvisor.list
     apt-get update && apt-get install -y runsc
-    runsc install -- --systemd-cgroup
+    runsc install
     systemctl restart docker
   }
 fi

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -16,7 +16,10 @@ services:
           echo "Install gVisor: https://gvisor.dev/docs/user_guide/install/"
           exit 1
         fi
-        docker run --rm --runtime=runsc busybox:latest echo "gVisor OK"
+        echo "Cgroup driver: $(docker info --format '{{.CgroupDriver}}')"
+        echo "Cgroup version: $(docker info --format '{{.CgroupVersion}}')"
+        docker run --rm --runtime=runsc busybox:latest echo "gVisor basic: OK"
+        docker run --rm --runtime=runsc --pids-limit 16 busybox:latest echo "gVisor pids-limit: OK"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: "no"

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -85,7 +85,7 @@ func (d *DockerProvider) HealthCheck(ctx context.Context) error {
 
 	d.logger.Info().Str("runtime", d.runtime).Msg("running sandbox runtime health check")
 
-	pidsLimit := int64(16)
+	pidsLimit := int64(64)
 	resp, err := d.client.ContainerCreate(ctx, &container.Config{
 		Image: "busybox:latest",
 		Cmd:   []string{"echo", "runtime-ok"},

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -160,7 +160,7 @@ func TestDockerProvider_HealthCheck(t *testing.T) {
 			require.Equal(t, []string(config.Cmd), []string{"echo", "runtime-ok"}, "health check should run echo command")
 			require.Equal(t, "runsc", hostConfig.Runtime, "health check should use configured runtime")
 			require.NotNil(t, hostConfig.Resources.PidsLimit)
-			require.Equal(t, int64(16), *hostConfig.Resources.PidsLimit)
+			require.Equal(t, int64(64), *hostConfig.Resources.PidsLimit)
 			return container.CreateResponse{ID: "health-check-container"}, nil
 		}
 		mock.containerStartFn = func(ctx context.Context, containerID string, options container.StartOptions) error {


### PR DESCRIPTION
## Summary
- gVisor userspace kernel needs ~20+ threads to initialize (sentry, gofer, platform threads), so a PidsLimit of 16 killed the sandbox before it could start — causing the recurring EOF errors
- Raises health check PidsLimit from 16 to 64 (sandbox containers already use 256)
- Reverts the --systemd-cgroup flag from #359 which was not the actual fix
- Improves gvisor-check in docker-compose to test with --pids-limit and log cgroup driver/version for diagnostics

## Test plan
- [x] Verified on production worker (87.99.150.138): --pids-limit 64 and --pids-limit 32 both pass, --pids-limit 16 fails
- [x] Unit tests pass
- [ ] Deploy to worker and confirm health check passes