### PR TITLE
Fix gVisor sandbox EOF by disabling runsc cgroup management

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -33,7 +33,7 @@ runcmd:
   - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
   - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
   - apt-get update && apt-get install -y runsc
-  - runsc install
+  - runsc install -- --ignore-cgroups
   - systemctl restart docker
 
   # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ if [ "$ROLE" = "worker" ]; then
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \
       > /etc/apt/sources.list.d/gvisor.list
     apt-get update && apt-get install -y runsc
-    runsc install
+    runsc install -- --ignore-cgroups
     systemctl restart docker
   }
 fi

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -175,6 +175,18 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     done
   }
 
+  # Ensure gVisor runtime is configured with --ignore-cgroups so Docker
+  # handles cgroup management (prevents EOF errors from cgroup conflicts).
+  if [ "$ROLE" = "worker" ] && command -v runsc &>/dev/null; then
+    DAEMON_JSON="/etc/docker/daemon.json"
+    if [ -f "$DAEMON_JSON" ] && ! grep -q "ignore-cgroups" "$DAEMON_JSON"; then
+      echo "Patching runsc runtime to use --ignore-cgroups..."
+      sudo runsc install -- --ignore-cgroups
+      sudo systemctl restart docker
+      echo "Docker restarted with updated gVisor config."
+    fi
+  fi
+
   docker compose -f "$COMPOSE_FILE" pull
 
   # Run migrations BEFORE restarting the app so the DB schema is ready when

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -19,7 +19,7 @@ services:
         echo "Cgroup driver: $(docker info --format '{{.CgroupDriver}}')"
         echo "Cgroup version: $(docker info --format '{{.CgroupVersion}}')"
         docker run --rm --runtime=runsc busybox:latest echo "gVisor basic: OK"
-        docker run --rm --runtime=runsc --pids-limit 16 busybox:latest echo "gVisor pids-limit: OK"
+        docker run --rm --runtime=runsc --pids-limit 64 busybox:latest echo "gVisor pids-limit: OK"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: "no"


### PR DESCRIPTION
## Summary
- Pass `--ignore-cgroups` to `runsc install` in bootstrap, cloud-init, and a new deploy-time patch so Docker handles all cgroup management instead of gVisor conflicting with Docker's systemd cgroup driver
- The deploy script auto-patches existing hosts that lack `--ignore-cgroups` in daemon.json, restarting Docker before the worker starts
- Aligns docker-compose gvisor-check `--pids-limit` to 64, matching the Go health check

## Test plan
- [ ] Deploy to a worker node and verify the gVisor health check passes without EOF errors
- [ ] Confirm `/etc/docker/daemon.json` contains `--ignore-cgroups` in runsc runtimeArgs after deploy
- [ ] Verify sandbox containers can be created successfully (run an agent session)

Generated with [Claude Code](https://claude.com/claude-code)