### PR TITLE
Fix continue_session error not displaying in UI

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -860,6 +860,12 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
       addSSEListener(eventSource, SSE_EVENT.STATUS, (updated) => {
         queryClient.setQueryData(["session", sessionId], { data: updated });
+        // When the session transitions out of running (e.g. sandbox creation
+        // failure reverts to idle), fetch the latest messages so any error
+        // message posted by the backend is displayed immediately.
+        if (updated.status !== "running") {
+          queryClient.invalidateQueries({ queryKey: ["session", sessionId, "messages"] });
+        }
       });
 
       addSSEListener(eventSource, SSE_EVENT.DONE, (updated) => {


### PR DESCRIPTION
## Summary
- When sandbox creation fails during `continue_session`, the backend reverts the session to idle and posts an error message — but the frontend never showed it
- The SSE STATUS handler updated session data without refetching messages, and since message polling stops when `isRunning` becomes false, the error message was invisible
- Now the STATUS handler invalidates the messages query when the session transitions out of running, so error messages display immediately

## Test plan
- [ ] Trigger a continue_session with Docker stopped to cause sandbox creation failure
- [ ] Verify the error message appears in the chat UI instead of silently going to idle
- [ ] Verify normal continue_session flow still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)