### PR TITLE
Update README and landing page: team-first, cloud agents, Loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 143 — AI agents that fix and improve production systems
+# 143 — AI coding agents, built for teams
 
-**from issues to validated PRs, on autopilot**
+**Transparent automations. Cloud agents. Eval-driven loops.**
 
 [Getting Started](#getting-started) · [Development Setup](docs/contributing/development-setup.md) · [Architecture](docs/design/overall.md) · [143.dev](https://www.143.dev)
 
@@ -8,37 +8,65 @@
 
 ## Why 143
 
-Most issues in your backlog don't need a sprint planning meeting. They need someone (or something) to analyze the landscape, prioritize what matters, write the fix, validate it, and open the PR.
+Most coding agent tools are built for solo developers. But most professional engineering teams need a high level of visibility. When someone sets up an automation to improve test coverage or scan for security vulnerabilities, the whole team should be able to access and have visibility by default. When a coding agent opens a PR, everyone should be able to see the prompt that drove it.
 
-143 gives you two things:
+143 is built from the ground up for teams (engineers and non-engineers alike). It was born from the experience of working on a small team where nobody had visibility into what others were doing, knowledge stayed siloed, and non-technical teammates had a hard time contributing code even when they knew exactly what needed to change.
 
-### Bring your own coding agent
+### Built for teams
 
-Use whatever coding agent you trust — Claude Code, Codex, Cursor, or your own custom agent. 143 orchestrates the work: it ingests issues, plans the approach, spins up sandboxed containers, and hands off execution to the coding agent you configure. You stay in control of how code gets written while 143 handles everything around it.
+By default, every automation, prompt, and agent run is visible to your entire team. When someone configures an automation to fix flaky tests or audit API endpoints, the rest of the team can see exactly what's been set up, what's running, and what it produced. This means non-engineers can contribute code too — they write prompts, the agent writes code, and the whole team can review both the prompt and the output in the open.
 
-### An autopilot PM that learns your product
+### Cloud agents you already use
 
-143 includes an AI product manager agent that understands your product roadmap and engineering philosophy. It analyzes your full issue landscape across Sentry errors, Linear tickets, and support requests — clusters related problems, identifies root causes, and builds a prioritized plan. Every PR review teaches it more about your codebase conventions and preferences, creating a flywheel that compounds over time.
+The big labs are constantly one-upping each other with newer and better models and agent harnesses. 143 has no vendor lock-in: use Claude Code, Codex, or whatever comes next. When a better model drops, you can swap it in and keep going.
 
-The result: bugs get triaged, planned, fixed, validated, and shipped as PRs — without context-switching your team away from the work that matters.
+143 runs your agents in the cloud so your whole team can use them without local setup. You can spin up the same workflow across branches, get preview environments automatically, and let anyone on the team kick off runs.
 
-> **Don't want to self-host?** [143.dev](https://www.143.dev) is the hosted version — connect your repos and start shipping fixes in minutes.
+### Loops: eval-driven improvement
+
+Based on Karpathy's autoresearch concept, you can define an eval and have your coding agents hill-climb toward better results. Want to improve API latency? Define a latency benchmark, and 143 will run your coding agent in a loop — each iteration measuring against the eval, learning what worked, and pushing further.
+
+This works for anything measurable: test coverage, bundle size, response times, error rates. Define the target, and let the agents grind toward it.
 
 ## How it works
 
 ```
-issues in → PM agent plans → coding agents execute → validate → ship PRs → measure impact
-                                                                                  ↓
-                                                                         learn from outcomes
+┌─────────────────────────────────────────────────────────┐
+│  Your Team (engineers + non-engineers)                  │
+│  Configure automations, projects, loops via 143 UI      │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+                       ▼
+┌─────────────────────────────────────────────────────────┐
+│  143 Orchestrator                                       │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐     │
+│  │ Automations │  │  Sessions   │  │   Loops     │     │
+│  │ (recurring) │  │ (one-shot)  │  │ (eval-driven│     │
+│  └──────┬──────┘  └──────┬──────┘  │  iteration) │     │
+│         │                │         └──────┬──────┘     │
+│         └────────────────┼────────────────┘             │
+│                          ▼                              │
+│  ┌──────────────────────────────────────────────┐       │
+│  │  Cloud Sandboxes (gVisor-isolated Docker)    │       │
+│  │  ┌────────────┐ ┌───────┐ ┌────────────────┐│       │
+│  │  │ Claude Code│ │ Codex │ │ Any future agent││       │
+│  │  └────────────┘ └───────┘ └────────────────┘│       │
+│  └──────────────────────┬───────────────────────┘       │
+│                         ▼                               │
+│  Validate (CI + security scan + quality checks)         │
+└──────────────────────┬──────────────────────────────────┘
+                       │
+          ┌────────────┼────────────┐
+          ▼            ▼            ▼
+    GitHub PRs   Preview Envs   Eval Results
+    (for review) (for testing)  (feed back into loops)
 ```
 
-1. **Ingest** — pull issues from Sentry, Linear, support tickets via webhooks
-2. **Plan** — AI product manager analyzes all issues, clusters related problems, and builds a prioritized work plan
-3. **Execute** — coding agents run in isolated Docker containers with the PM's approach hints
-4. **Validate** — direction/correctness/quality checks + CI + regression tests
-5. **Ship** — open GitHub PRs with full context for human review
-6. **Observe** — measure post-deploy impact on error rates and support volume
-7. **Learn** — extract review feedback into conventions, feed back into future runs
+1. **Configure** — set up automations, projects, or loops — shared with the team by default
+2. **Execute** — coding agents run in isolated Docker containers in the cloud
+3. **Validate** — CI, security scanning (gitleaks, semgrep), and quality checks
+4. **Ship** — open GitHub PRs with full context and preview environments
+5. **Loop** — for eval-driven tasks, measure results and iterate automatically
 
 ## Built for production
 

--- a/frontend/src/components/landing/cta-section.tsx
+++ b/frontend/src/components/landing/cta-section.tsx
@@ -21,14 +21,15 @@ export default function CtaSection({ isDark }: CtaSectionProps) {
             isDark ? "text-white" : "text-slate-900"
           }`}
         >
-          Start building
+          Give your team superpowers
         </h2>
         <p
           className={`text-sm leading-relaxed max-w-md mx-auto ${
             isDark ? "text-white/45" : "text-slate-600"
           }`}
         >
-          Connect your repos and your favorite coding agents.
+          Connect your repos, pick your agents, and start shipping
+          as a team.
         </p>
         <div>
           <Button

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -41,16 +41,17 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-white" : "text-slate-900"
             }`}
           >
-            Open-source autopilot
+            AI coding agents,
             <br />
-            for Claude Code
+            built for teams
           </h1>
 
           <p
             className={`max-w-md text-sm leading-relaxed ${isDark ? "text-white/45" : "text-slate-600"}`}
           >
-            Fix bugs and ship projects automatically. Works with
-            Claude Code, Codex, or any coding agent.
+            Run Claude Code, Codex, or any agent in the cloud. Engineers
+            and non-engineers ship together — every prompt and run is shared
+            by default.
           </p>
 
           <div className="pt-2 pointer-events-auto">

--- a/frontend/src/components/landing/hero-section.tsx
+++ b/frontend/src/components/landing/hero-section.tsx
@@ -41,7 +41,7 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
               isDark ? "text-white" : "text-slate-900"
             }`}
           >
-            AI coding agents,
+            Open-source coding agents,
             <br />
             built for teams
           </h1>
@@ -49,9 +49,8 @@ export default function HeroSection({ isDark }: HeroSectionProps) {
           <p
             className={`max-w-md text-sm leading-relaxed ${isDark ? "text-white/45" : "text-slate-600"}`}
           >
-            Run Claude Code, Codex, or any agent in the cloud. Engineers
-            and non-engineers ship together — every prompt and run is shared
-            by default.
+            Pick any coding agent. Run it in the cloud. Your whole team
+            sees what shipped and why.
           </p>
 
           <div className="pt-2 pointer-events-auto">

--- a/frontend/src/components/landing/how-it-works-section.tsx
+++ b/frontend/src/components/landing/how-it-works-section.tsx
@@ -40,21 +40,21 @@ const dispatches = [
 
 const terminalLines = [
   {
-    prefix: "SCAN",
+    prefix: "AGENT",
     prefixColor: "text-yellow-400",
-    text: "3 Sentry errors, 2 Linear tickets",
+    text: "claude-code spinning up in cloud sandbox",
     threshold: 0.15,
   },
   {
-    prefix: "PRIO",
+    prefix: "EXEC",
     prefixColor: "text-orange-400",
-    text: "Auth flow TypeError → highest impact",
+    text: "running: fix null ref in auth flow",
     threshold: 0.3,
   },
   {
-    prefix: "SEND",
+    prefix: "PREV",
     prefixColor: "text-blue-400",
-    text: "→ claude-code: fix null ref in handleLogin()",
+    text: "preview env ready → preview-342.143.dev",
     threshold: 0.45,
   },
   {
@@ -66,21 +66,21 @@ const terminalLines = [
 ];
 
 const projectTasks = [
-  { task: "Add session store schema", baseStatus: "done" as const },
-  { task: "Update login endpoint", baseStatus: "done" as const },
+  { task: "Baseline: p95 latency 420ms", baseStatus: "done" as const },
+  { task: "Iteration 1: optimize DB queries → 380ms", baseStatus: "done" as const },
   {
-    task: "Migrate middleware",
+    task: "Iteration 2: add response caching → 310ms",
     baseStatus: "active" as const,
     completeAt: 0.2,
   },
   {
-    task: "Remove JWT dependencies",
+    task: "Iteration 3: reduce serialization → 265ms",
     baseStatus: "pending" as const,
     activateAt: 0.2,
     completeAt: 0.4,
   },
   {
-    task: "Update integration tests",
+    task: "Target: p95 latency < 250ms",
     baseStatus: "pending" as const,
     activateAt: 0.4,
     completeAt: 0.6,
@@ -152,7 +152,7 @@ function TerminalContent({ progress }: { progress: number }) {
       >
         <span>{">"}</span>
         <span>
-          sleeping... next scan in 2h 14m
+          done · team notified · PR visible to all
           <span className="animate-pulse">_</span>
         </span>
       </div>
@@ -195,7 +195,7 @@ function ProjectsContent({
               isDark ? "text-white/80" : "text-slate-800"
             }`}
           >
-            Migrate auth from JWT to sessions
+            Loop: reduce API latency
           </span>
           <span
             className={`text-xs font-mono ${
@@ -484,7 +484,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
       />
 
       <div className="relative mx-auto max-w-5xl space-y-40 sm:space-y-52">
-        {/* ── Step 01: Everything Connects ── text LEFT, radar RIGHT */}
+        {/* ── Step 01: Built for Teams ── text LEFT, radar RIGHT */}
         <FadeInStep>
           <div className="flex flex-col md:flex-row items-center gap-12 md:gap-20">
             <div className="md:w-1/2 space-y-4">
@@ -496,12 +496,15 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Everything connects
+                Built for teams,
+                <br />
+                not solo devs
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Sentry errors, Linear tickets, Slack threads, your product
-                roadmap. The PM watches all of it so your team doesn&rsquo;t have
-                to.
+                By default, every automation, prompt, and agent run is visible
+                to your whole team. Non-engineers can write prompts, kick off
+                runs, and contribute code &mdash; and the team sees exactly
+                what was asked for and what was produced.
               </p>
             </div>
             <div className="md:w-1/2 w-full max-w-[400px] md:max-w-none relative">
@@ -521,7 +524,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           </div>
         </FadeInStep>
 
-        {/* ── Step 02: Always On ── terminal LEFT, text RIGHT (flipped) */}
+        {/* ── Step 02: Cloud Agents ── terminal LEFT, text RIGHT (flipped) */}
         <FadeInStep>
           <div
             ref={termRef}
@@ -536,13 +539,16 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Wakes up. Fixes bugs.
+                Your agents,
                 <br />
-                Goes back to sleep.
+                running in the cloud
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                The PM scans for bugs on a loop, sends them to your coding
-                agents, and opens PRs when CI passes. No prompt needed.
+                The big labs are constantly one-upping each other. With 143,
+                there&rsquo;s no vendor lock-in &mdash; use Claude Code, Codex,
+                or whatever comes next. When a better model drops, swap it in.
+                Everything runs in sandboxed cloud containers with preview
+                environments.
               </p>
             </div>
             <div className="md:w-1/2 relative">
@@ -571,7 +577,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                   <div className="w-2.5 h-2.5 rounded-full bg-[#febc2e]" />
                   <div className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
                   <span className="ml-3 text-xs font-mono text-white/25">
-                    pm-agent · loop
+                    143 · cloud agent
                   </span>
                 </div>
                 <TerminalContent progress={termProgress} />
@@ -580,7 +586,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           </div>
         </FadeInStep>
 
-        {/* ── Step 03: You Direct ── text LEFT, app window RIGHT */}
+        {/* ── Step 03: Loops ── text LEFT, app window RIGHT */}
         <FadeInStep>
           <div
             ref={projRef}
@@ -595,13 +601,15 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Create projects.
+                Loops: define an eval,
                 <br />
-                The PM chips away.
+                let agents improve it
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Describe what you want built and the PM breaks it into tasks.
-                It works through them one by one, opening PRs as it goes.
+                Want better latency? Define a benchmark. 143 runs your coding
+                agent in a loop &mdash; each iteration measures against the eval
+                and hill-climbs toward the target. Works for test coverage,
+                bundle size, error rates, or anything measurable.
               </p>
             </div>
             <div className="md:w-1/2 relative">
@@ -638,7 +646,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                       isDark ? "text-white/25" : "text-slate-400"
                     }`}
                   >
-                    Projects
+                    Loops
                   </span>
                 </div>
                 <ProjectsContent isDark={isDark} progress={projProgress} />
@@ -653,7 +661,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
                       isDark ? "text-white/20" : "text-slate-400"
                     }`}
                   >
-                    &ldquo;focus on auth this sprint&rdquo;
+                    eval: p95 latency &lt; 250ms &middot; 3 iterations complete
                   </p>
                 </div>
               </div>
@@ -661,7 +669,7 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
           </div>
         </FadeInStep>
 
-        {/* ── Step 04: Your Agents ── dashboard LEFT, text RIGHT (flipped) */}
+        {/* ── Step 04: Full Transparency ── dashboard LEFT, text RIGHT (flipped) */}
         <FadeInStep>
           <div
             ref={dispRef}
@@ -676,14 +684,14 @@ export default function HowItWorksSection({ isDark }: HowItWorksSectionProps) {
               <h2
                 className={`text-2xl sm:text-3xl font-light tracking-tight ${heading}`}
               >
-                Cloud agents for
+                Full visibility
                 <br />
-                the whole team
+                across the team
               </h2>
               <p className={`text-sm leading-relaxed max-w-sm ${body}`}>
-                Agents run in the cloud, so anyone on your team can use them.
-                Each engineer picks their own, whether it&rsquo;s Claude Code,
-                Codex, or Gemini CLI.
+                By default, every agent run, prompt, and automation is shared
+                with the team &mdash; all in one place. No more wondering
+                what other engineers are working on or duplicating effort.
               </p>
             </div>
             <div className="md:w-1/2 relative">


### PR DESCRIPTION
## Summary
- Rewrites README and landing page messaging around three differentiators: built for teams (default visibility, non-engineers can contribute code), no vendor lock-in cloud agents, and eval-driven Loops (based on Karpathy's autoresearch concept)
- Adds architecture diagram to README showing orchestrator, cloud sandboxes, and output flow
- Updates hero headline, all four how-it-works steps, and CTA section to match new positioning
- Uses 'by default' language for team visibility to leave room for future personal sessions

## Test plan
- [ ] Verify landing page renders correctly in light and dark mode
- [ ] Check README renders properly on GitHub (especially the ASCII architecture diagram)
- [ ] Review copy for accuracy and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)