### PR TITLE
Fix sandbox image mismatch on provisioned workers

### DIFF
--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"os"
 	"time"
 
 	"github.com/assembledhq/143/internal/models"
@@ -161,8 +162,12 @@ type SandboxConfig struct {
 
 // DefaultSandboxConfig returns a SandboxConfig populated with sensible defaults.
 func DefaultSandboxConfig() SandboxConfig {
+	image := "143-sandbox:latest"
+	if v := os.Getenv("SANDBOX_IMAGE"); v != "" {
+		image = v
+	}
 	return SandboxConfig{
-		Image:         "143-sandbox:latest",
+		Image:         image,
 		CPULimit:      2,
 		MemoryLimitMB: 4096,
 		DiskLimitGB:   10,

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -781,6 +781,12 @@ func TestDefaultSandboxConfig(t *testing.T) {
 	require.Equal(t, 10, cfg.DiskLimitGB, "default disk limit should be 10GB")
 }
 
+func TestDefaultSandboxConfigEnvOverride(t *testing.T) {
+	t.Setenv("SANDBOX_IMAGE", "ghcr.io/assembledhq/143-sandbox:latest")
+	cfg := agent.DefaultSandboxConfig()
+	require.Equal(t, "ghcr.io/assembledhq/143-sandbox:latest", cfg.Image, "SANDBOX_IMAGE env should override default")
+}
+
 func TestShellEscape(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- `DefaultSandboxConfig()` hardcoded `"143-sandbox:latest"` as the sandbox image, but provisioned workers pull `ghcr.io/assembledhq/143-sandbox:latest` via GHCR — Docker treats these as different image references
- The worker compose file already sets `SANDBOX_IMAGE` env var with the correct GHCR-prefixed name, but the code never read it
- Now `DefaultSandboxConfig()` reads `SANDBOX_IMAGE` from the environment, falling back to the local name for dev

## Test plan
- [x] Added `TestDefaultSandboxConfigEnvOverride` verifying env var override
- [ ] Deploy to worker node and confirm sessions start without "No such image" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)