### PR TITLE
Always default to a repo when creating a session

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -110,10 +110,17 @@ export function ManualSessionCreatePageContent() {
     queryFn: () => api.codexAuth.status(),
   });
 
-  // Auto-select the only repo for single-repo orgs; otherwise use user's choice.
+  // Auto-select: user's choice > last used repo > first repo.
   const selectedRepoId = useMemo(() => {
     if (userSelectedRepoId !== null) return userSelectedRepoId;
     if (repositories.length === 1) return repositories[0].id;
+    if (repositories.length > 0) {
+      try {
+        const lastUsed = localStorage.getItem("143:lastUsedRepoId");
+        if (lastUsed && repositories.some((r) => r.id === lastUsed)) return lastUsed;
+      } catch {}
+      return repositories[0].id;
+    }
     return "";
   }, [userSelectedRepoId, repositories]);
 
@@ -181,6 +188,9 @@ export function ManualSessionCreatePageContent() {
       return { optimisticId: addOptimisticSession(title) };
     },
     onSuccess: async (response, _variables, context) => {
+      if (selectedRepoId) {
+        try { localStorage.setItem("143:lastUsedRepoId", selectedRepoId); } catch {}
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       removeOptimisticSession(context.optimisticId);
       router.push(`/sessions/${response.data.id}`);
@@ -447,12 +457,6 @@ export function ManualSessionCreatePageContent() {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="start" className="w-72">
-                    <DropdownMenuItem
-                      onClick={() => setSelectedRepoId("")}
-                      className={!selectedRepoId ? "font-medium" : ""}
-                    >
-                      No specific repo
-                    </DropdownMenuItem>
                     {repositories.map((repo) => (
                       <DropdownMenuItem
                         key={repo.id}

--- a/frontend/src/components/create-session-dialog.test.tsx
+++ b/frontend/src/components/create-session-dialog.test.tsx
@@ -169,8 +169,9 @@ describe("CreateSessionDialog", () => {
       <CreateSessionDialog open onOpenChange={onOpenChange} />,
     );
 
+    // With multiple repos the first one is auto-selected, so the button shows its name
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Repo/ })).toBeInTheDocument();
+      expect(screen.getByText("api-server")).toBeInTheDocument();
     });
   });
 
@@ -302,23 +303,22 @@ describe("CreateSessionDialog", () => {
       <CreateSessionDialog open onOpenChange={onOpenChange} />,
     );
 
-    // Wait for repo selector to appear
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Repo/ })).toBeInTheDocument();
-    });
-
-    // Open repo dropdown and select a repo
-    await user.click(screen.getByRole("button", { name: /Repo/ }));
-    await user.click(screen.getByText("acme/api-server"));
-
-    // Should show the repo short name
+    // First repo is auto-selected; switch to the second one
     await waitFor(() => {
       expect(screen.getByText("api-server")).toBeInTheDocument();
+    });
+
+    // Open repo dropdown and select the other repo
+    await user.click(screen.getByText("api-server"));
+    await user.click(screen.getByText("acme/web-app"));
+
+    // Should show the new repo short name
+    await waitFor(() => {
+      expect(screen.getByText("web-app")).toBeInTheDocument();
     });
   });
 
   it("shows branch selector after selecting a repo", async () => {
-    const user = userEvent.setup();
     setupRepoHandlers();
 
     server.use(
@@ -337,15 +337,9 @@ describe("CreateSessionDialog", () => {
       <CreateSessionDialog open onOpenChange={onOpenChange} />,
     );
 
+    // First repo is auto-selected, so branch selector should appear
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Repo/ })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole("button", { name: /Repo/ }));
-    await user.click(screen.getByText("acme/api-server"));
-
-    // Should show a branch selector button with default branch
-    await waitFor(() => {
+      expect(screen.getByText("api-server")).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /Target branch/ })).toBeInTheDocument();
     });
   });
@@ -362,20 +356,11 @@ describe("CreateSessionDialog", () => {
       }),
     );
 
-    const user = userEvent.setup();
-
     renderWithProviders(
       <CreateSessionDialog open onOpenChange={onOpenChange} />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Repo/ })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole("button", { name: /Repo/ }));
-    await user.click(screen.getByText("acme/web-app"));
-
-    // Should show a text input for branch instead of dropdown
+    // First repo is auto-selected and branch fetch fails, so fallback input should appear
     await waitFor(() => {
       expect(screen.getByLabelText("Target branch")).toBeInTheDocument();
     });
@@ -454,15 +439,7 @@ describe("CreateSessionDialog", () => {
         "Fix the bug",
       );
 
-      // Wait for repo selector and select a repo
-      const repoButton = await screen.findByRole("button", { name: /Repo/ });
-      await user.click(repoButton);
-
-      // Wait for dropdown to fully open and select repo
-      const repoOption = await screen.findByText("acme/api-server");
-      await user.click(repoOption);
-
-      // Wait for dropdown to close, selection to settle, and branch data to load
+      // First repo is auto-selected; wait for branch data to load
       await waitFor(() => {
         expect(screen.getByText("api-server")).toBeInTheDocument();
         expect(screen.getByRole("button", { name: /Target branch/ })).toBeInTheDocument();

--- a/frontend/src/components/create-session-dialog.tsx
+++ b/frontend/src/components/create-session-dialog.tsx
@@ -84,6 +84,14 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
   const selectedRepoId = useMemo(() => {
     if (userSelectedRepoId !== null) return userSelectedRepoId;
     if (repositories.length === 1) return repositories[0].id;
+    // Default to the last used repo if available
+    if (repositories.length > 0) {
+      try {
+        const lastUsed = localStorage.getItem("143:lastUsedRepoId");
+        if (lastUsed && repositories.some((r) => r.id === lastUsed)) return lastUsed;
+      } catch {}
+      return repositories[0].id;
+    }
     return "";
   }, [userSelectedRepoId, repositories]);
 
@@ -155,6 +163,9 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
       return { optimisticId: addOptimisticSession(title) };
     },
     onSuccess: async (response, _variables, context) => {
+      if (selectedRepoId) {
+        try { localStorage.setItem("143:lastUsedRepoId", selectedRepoId); } catch {}
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       removeOptimisticSession(context.optimisticId);
       onOpenChange(false);
@@ -332,12 +343,6 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="w-72">
-                <DropdownMenuItem
-                  onClick={() => setUserSelectedRepoId("")}
-                  className={!selectedRepoId ? "font-medium" : ""}
-                >
-                  No specific repo
-                </DropdownMenuItem>
                 {repositories.map((repo) => (
                   <DropdownMenuItem
                     key={repo.id}


### PR DESCRIPTION
## Summary
- Sessions now always have a repo selected — removed the "No specific repo" option from both the session creation dialog and the full-page composer
- The last used repo is persisted in localStorage and automatically selected as the default for the next session, falling back to the first repo in the list
- Applied consistently to both `CreateSessionDialog` and `ManualSessionCreatePageContent`

## Test plan
- [ ] Create a session with multiple repos available — verify a repo is pre-selected
- [ ] Create a session, then open the new session dialog again — verify the previously used repo is selected
- [ ] Clear localStorage and reload — verify it falls back to the first repo
- [ ] Verify single-repo orgs still auto-select their only repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)