### PR TITLE
Add Docker daemon ping to sandbox health check

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -311,9 +311,10 @@ func buildServices(
 	}
 	sandboxProvider := providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime(cfg.SandboxRuntime))
 
-	// Runtime health check: verify gVisor works if required.
-	// Retry a few times because gVisor can fail transiently during startup.
-	if cfg.SandboxRuntime == "runsc" {
+	// Startup health check: verify Docker daemon connectivity and, for gVisor,
+	// that the runsc runtime is functional. Retry a few times because Docker and
+	// gVisor can fail transiently during startup.
+	{
 		const maxRetries = 3
 		var healthErr error
 		for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -323,17 +324,18 @@ func buildServices(
 			if healthErr == nil {
 				break
 			}
-			logger.Warn().Err(healthErr).Int("attempt", attempt).Int("max", maxRetries).Msg("gVisor health check failed, retrying")
+			logger.Warn().Err(healthErr).Int("attempt", attempt).Int("max", maxRetries).Msg("sandbox health check failed, retrying")
 			if attempt < maxRetries {
 				time.Sleep(2 * time.Second)
 			}
 		}
 		if healthErr != nil {
-			if cfg.SandboxRequireGVisor {
-				logger.Fatal().Err(healthErr).Msg("gVisor health check failed — set SANDBOX_REQUIRE_GVISOR=false to disable")
-			} else {
+			if cfg.SandboxRuntime == "runsc" && !cfg.SandboxRequireGVisor {
 				logger.Warn().Err(healthErr).Msg("gVisor not available, falling back to runc — NOT RECOMMENDED FOR PRODUCTION")
 				sandboxProvider = providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime("runc"))
+			} else {
+				logger.Error().Err(healthErr).Msg("sandbox health check failed — Phase 3+ services disabled")
+				return nil
 			}
 		}
 	}

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -26,6 +26,7 @@ var _ agent.SandboxProvider = (*DockerProvider)(nil)
 
 // DockerClient defines the subset of the Docker API used by DockerProvider.
 type DockerClient interface {
+	Ping(ctx context.Context) (types.Ping, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	ContainerStart(ctx context.Context, containerID string, options container.StartOptions) error
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
@@ -76,11 +77,17 @@ func NewDockerProvider(cli DockerClient, logger zerolog.Logger, opts ...DockerPr
 	return p
 }
 
-// HealthCheck verifies the configured runtime is available by running a test
-// container. Returns an error if the runtime (e.g. gVisor/runsc) is not functional.
+// HealthCheck verifies Docker daemon connectivity and, for non-runc runtimes,
+// that the configured runtime is functional by running a test container.
 func (d *DockerProvider) HealthCheck(ctx context.Context) error {
+	// Always verify we can reach the Docker daemon.
+	if _, err := d.client.Ping(ctx); err != nil {
+		return fmt.Errorf("docker health check: cannot connect to Docker daemon: %w", err)
+	}
+
 	if d.runtime == "runc" {
-		return nil // runc is always available
+		d.logger.Info().Msg("docker health check passed (runc)")
+		return nil
 	}
 
 	d.logger.Info().Str("runtime", d.runtime).Msg("running sandbox runtime health check")

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -23,6 +23,7 @@ import (
 
 // mockDockerClient implements DockerClient for testing.
 type mockDockerClient struct {
+	pingFn                 func(ctx context.Context) (types.Ping, error)
 	containerCreateFn      func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	containerStartFn       func(ctx context.Context, containerID string, options container.StartOptions) error
 	containerStopFn        func(ctx context.Context, containerID string, options container.StopOptions) error
@@ -31,6 +32,13 @@ type mockDockerClient struct {
 	containerExecCreateFn  func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	containerExecAttachFn  func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
 	containerExecInspectFn func(ctx context.Context, execID string) (container.ExecInspect, error)
+}
+
+func (m *mockDockerClient) Ping(ctx context.Context) (types.Ping, error) {
+	if m.pingFn != nil {
+		return m.pingFn(ctx)
+	}
+	return types.Ping{}, nil
 }
 
 func (m *mockDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
@@ -132,12 +140,16 @@ func newTestLogger() zerolog.Logger {
 func TestDockerProvider_HealthCheck(t *testing.T) {
 	t.Parallel()
 
-	t.Run("runc skips health check", func(t *testing.T) {
+	t.Run("runc pings but skips container test", func(t *testing.T) {
 		t.Parallel()
 
+		var pingCalled bool
 		mock := &mockDockerClient{}
-		// If ContainerCreate were called, it would panic or return default — but we
-		// verify it's never called by setting a function that fails the test.
+		mock.pingFn = func(ctx context.Context) (types.Ping, error) {
+			pingCalled = true
+			return types.Ping{}, nil
+		}
+		// ContainerCreate should not be called for runc runtime.
 		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
 			t.Fatal("ContainerCreate should not be called for runc runtime")
 			return container.CreateResponse{}, nil
@@ -146,6 +158,21 @@ func TestDockerProvider_HealthCheck(t *testing.T) {
 
 		err := p.HealthCheck(context.Background())
 		require.NoError(t, err, "HealthCheck should return nil for runc runtime")
+		require.True(t, pingCalled, "Ping should be called to verify Docker connectivity")
+	})
+
+	t.Run("ping failure returns error", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockDockerClient{}
+		mock.pingFn = func(ctx context.Context) (types.Ping, error) {
+			return types.Ping{}, fmt.Errorf("Cannot connect to the Docker daemon")
+		}
+		p := NewDockerProvider(mock, newTestLogger(), WithRuntime("runc"))
+
+		err := p.HealthCheck(context.Background())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot connect to Docker daemon")
 	})
 
 	t.Run("success with non-runc runtime", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- `HealthCheck` previously skipped all checks for `runc` runtime, so Docker connectivity issues were only discovered when a `run_agent` job failed at container creation time
- Now `HealthCheck` always pings the Docker daemon at startup regardless of runtime, catching "Cannot connect to Docker daemon" errors early
- `buildServices` runs the health check unconditionally and disables Phase 3+ services if Docker is unreachable, instead of silently failing per-job

## Test plan
- [ ] Verify existing health check tests pass (updated runc test, new ping-failure test)
- [ ] Deploy worker with Docker running — should start normally
- [ ] Stop Docker daemon on worker — server should log clear error and disable sandbox services at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)