### PR TITLE
Refine audit log trigger button styling

### DIFF
--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -67,7 +67,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title }: AuditL
         variant="ghost"
         size="xs"
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground/70 hover:text-muted-foreground transition-all duration-150 h-auto px-1.5 py-0.5 -ml-1.5"
+        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-all duration-150 h-auto px-1 py-0.5"
       >
         <Clock className="h-3 w-3" />
         <span className="text-xs">


### PR DESCRIPTION
## Summary
Updated the styling of the audit log trigger button to improve visual consistency and reduce unnecessary opacity variations.

## Changes
- Removed the `/70` opacity modifier from `text-muted-foreground` to use the standard muted foreground color
- Removed the `hover:text-muted-foreground` hover state (now redundant since base color matches)
- Adjusted horizontal padding from `px-1.5` to `px-1` for tighter spacing
- Removed the negative left margin (`-ml-1.5`) for cleaner layout

## Details
These changes simplify the button's appearance by eliminating the opacity-based color distinction and hover state, while also tightening the padding to create a more compact component. The button maintains its core functionality while presenting a cleaner visual presentation.

https://claude.ai/code/session_016jDtiJYkEGr8HyGwDn2ZFT