### PR TITLE
Pull sandbox image on worker deploys

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -189,6 +189,13 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 
   docker compose -f "$COMPOSE_FILE" pull
 
+  # The sandbox image is referenced via SANDBOX_IMAGE env var, not as a compose
+  # service, so `docker compose pull` doesn't fetch it. Pull it explicitly —
+  # ContainerCreate doesn't auto-pull, so the worker would fail on first launch.
+  if [ "$ROLE" = "worker" ]; then
+    docker pull "ghcr.io/assembledhq/143-sandbox:$IMAGE_TAG"
+  fi
+
   # Run migrations BEFORE restarting the app so the DB schema is ready when
   # the new code starts serving traffic. Uses `docker compose run` on the new
   # image (already pulled) to execute the migration binary without replacing


### PR DESCRIPTION
## Summary
- Worker nodes never pulled the sandbox image on deploy because it's only referenced via the `SANDBOX_IMAGE` env var, not as a compose service — `docker compose pull` skipped it.
- `ContainerCreate` does not auto-pull, so the first sandbox launch after every release failed with `No such image: ghcr.io/assembledhq/143-sandbox:<sha>`.
- Add an explicit `docker pull` for `ghcr.io/assembledhq/143-sandbox:$IMAGE_TAG` during the worker branch of `deploy.sh`.

## Context
Hit in prod on commit `5cd8e9d9` — sandbox creation failed with the "No such image" error until the image was pulled manually on the worker. Same failure mode would repeat on every subsequent deploy without this fix.

## Test plan
- [ ] Next worker deploy pulls the sandbox image by SHA before the rolling restart
- [ ] First sandbox launch post-deploy succeeds without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
