### PR TITLE
Lock chat input while agent is responding

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -239,7 +239,7 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id={runningSession.id} />);
     expect(await screen.findByText('Agent is working...')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('Send a message to the agent...')).toBeEnabled();
+    expect(screen.getByPlaceholderText('Agent is responding...')).toBeDisabled();
   });
 
   it('disables input for pending session', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1043,7 +1043,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (hasContent && canSendMessage && !sendMutation.isPending) {
+      if (hasContent && canSendMessage && !sendMutation.isPending && !isRunning) {
         sendMutation.mutate({});
       }
     }
@@ -1173,10 +1173,10 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
                 : planMode
                 ? "Describe what you want to plan..."
                 : isRunning
-                ? "Send a message to the agent..."
+                ? "Agent is responding..."
                 : "Send a follow-up message..."
             }
-            disabled={!canSendMessage || sendMutation.isPending}
+            disabled={!canSendMessage || sendMutation.isPending || isRunning}
             className="min-h-[44px] max-h-[200px] resize-none border-none bg-transparent shadow-none focus-visible:ring-0"
           />
 


### PR DESCRIPTION
## Summary
- Disable the session chat textarea for the full `isRunning` window, not just the brief `sendMutation.isPending` POST — matches Claude Code / Codex behavior so users cannot keep typing while the agent is responding.
- Update the placeholder to "Agent is responding..." while locked, and add a defensive `!isRunning` guard to the Enter handler.

## Test plan
- [ ] Start a session, submit a message, confirm the textarea is locked (no typing, no deleting) until the agent finishes.
- [ ] Confirm the cancel button still replaces the send button while running and works as before.
- [ ] Confirm the textarea re-enables automatically once the session leaves `running`.
- [ ] Confirm Shift+Enter newlines still work before submission; Shift+Tab plan-mode toggle unaffected.

Generated with [Claude Code](https://claude.com/claude-code)
