### PR TITLE
Fix session status metadata spacing and color

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -109,6 +109,40 @@ describe('SessionDetailPage', () => {
     expect(screen.getByText('Could not reproduce the error in test environment')).toBeInTheDocument();
   });
 
+  it('keeps failed and updated timestamps visually aligned', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[1],
+            failure_explanation: 'Could not reproduce the error in test environment',
+          },
+        });
+      }),
+      http.get('/api/v1/audit-logs', () => {
+        return HttpResponse.json({
+          data: [{
+            id: 'audit-1',
+            actor_type: 'user',
+            user_id: mockMembers[0].id,
+            action: 'session.failed',
+            created_at: new Date(Date.now() - 12 * 60000).toISOString(),
+          }],
+          meta: {},
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+
+    const updatedTrigger = await screen.findByRole('button', { name: /Updated.*ago by/i });
+    const metadataStack = updatedTrigger.parentElement;
+
+    expect(metadataStack?.className).toContain('space-y-1');
+    expect(updatedTrigger.className).toContain('px-1');
+    expect(updatedTrigger.className).toContain('text-muted-foreground');
+  });
+
   it('shows error state when session not found', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -282,46 +282,54 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
         </CardContent>
       </Card>
 
-      {/* Timestamps — secondary reference data */}
-      <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs text-muted-foreground px-1">
-        {/* Hide duration for failed/cancelled sessions with no meaningful runtime */}
-        {!((session.status === "failed" || session.status === "cancelled") &&
-          !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
+      <div className="space-y-1">
+        {/* Timestamps — secondary reference data */}
+        <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs text-muted-foreground px-1">
+          {/* Hide duration for failed/cancelled sessions with no meaningful runtime */}
+          {!((session.status === "failed" || session.status === "cancelled") &&
+            !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
+            <span className="inline-flex items-center gap-1.5">
+              <Timer className="h-3 w-3" />
+              {session.status === "pending" ? formatDuration(session.created_at) : formatDuration(session.started_at, session.completed_at)}
+            </span>
+          )}
           <span className="inline-flex items-center gap-1.5">
-            <Timer className="h-3 w-3" />
-            {session.status === "pending" ? formatDuration(session.created_at) : formatDuration(session.started_at, session.completed_at)}
-          </span>
-        )}
-        <span className="inline-flex items-center gap-1.5">
-          {session.completed_at ? (
-            session.status === "failed" ? (
+            {session.completed_at ? (
+              session.status === "failed" ? (
+                <>
+                  <XCircle className="h-3 w-3" />
+                  Failed {formatTimeAgo(session.completed_at)}
+                </>
+              ) : session.status === "cancelled" ? (
+                <>
+                  <MinusCircle className="h-3 w-3" />
+                  Cancelled {formatTimeAgo(session.completed_at)}
+                </>
+              ) : (
+                <>
+                  <CheckCircle2 className="h-3 w-3" />
+                  Completed {formatTimeAgo(session.completed_at)}
+                </>
+              )
+            ) : session.started_at ? (
               <>
-                <XCircle className="h-3 w-3" />
-                Failed {formatTimeAgo(session.completed_at)}
-              </>
-            ) : session.status === "cancelled" ? (
-              <>
-                <MinusCircle className="h-3 w-3" />
-                Cancelled {formatTimeAgo(session.completed_at)}
+                <Clock className="h-3 w-3" />
+                Started {formatTimeAgo(session.started_at)}
               </>
             ) : (
               <>
-                <CheckCircle2 className="h-3 w-3" />
-                Completed {formatTimeAgo(session.completed_at)}
+                <Clock className="h-3 w-3" />
+                Queued {formatTimeAgo(session.created_at)}
               </>
-            )
-          ) : session.started_at ? (
-            <>
-              <Clock className="h-3 w-3" />
-              Started {formatTimeAgo(session.started_at)}
-            </>
-          ) : (
-            <>
-              <Clock className="h-3 w-3" />
-              Queued {formatTimeAgo(session.created_at)}
-            </>
-          )}
-        </span>
+            )}
+          </span>
+        </div>
+
+        <AuditLogTrigger
+          filters={{ session_id: session.id }}
+          members={members}
+          title="Session activity"
+        />
       </div>
 
       {/* PM context */}
@@ -347,11 +355,6 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
         </Card>
       )}
 
-      <AuditLogTrigger
-        filters={{ session_id: session.id }}
-        members={members}
-        title="Session activity"
-      />
     </div>
   );
 }

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -67,7 +67,7 @@ export function AuditLogTrigger({ filters, members: membersProp, title }: AuditL
         variant="ghost"
         size="xs"
         onClick={() => setOpen(true)}
-        className="inline-flex items-center gap-1.5 text-xs text-muted-foreground transition-all duration-150 h-auto px-1 py-0.5"
+        className="inline-flex h-auto items-center gap-1.5 px-1 py-0.5 text-xs font-normal text-muted-foreground transition-all duration-150 hover:text-muted-foreground"
       >
         <Clock className="h-3 w-3" />
         <span className="text-xs">


### PR DESCRIPTION
## Summary
- Tighten the spacing between the failed timestamp and the updated audit timestamp in the session detail overview
- Align the updated row’s left padding with the failed row
- Match the updated audit text color to the failed timestamp styling
- Add a regression test for the aligned metadata stack

## Testing
- `vitest --run src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`