### PR TITLE
Pin sandbox base image to ubuntu:24.04

### DIFF
--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -o /bin/143-tools ./cmd/tools
 
 # Stage 2: Runtime
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 # System dependencies for agent CLIs and typical repo operations.
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- The `ubuntu:26.04` tag on Docker Hub is currently a broken pre-release image (26.04 LTS ships April 23, 2026) — `apt-get install` fails with "Unable to locate package jq / sudo", breaking the sandbox image build on main.
- Pin to `ubuntu:24.04` LTS, which matches what the design doc (`docs/design/36-docker-agents-vps-architecture.md`) already specifies and is supported through 2029.

## Test plan
- [ ] Docker build workflow succeeds on main after merge