### PR TITLE
Log archive failures and pin sandbox to ubuntu:24.04

### DIFF
--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1314,6 +1314,12 @@ func (h *SessionHandler) ArchiveSession(w http.ResponseWriter, r *http.Request) 
 		if errors.Is(err, db.ErrSessionAlreadyArchived) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or already archived")
 		} else {
+			zerolog.Ctx(r.Context()).Error().
+				Err(err).
+				Str("session_id", sessionID.String()).
+				Str("org_id", orgID.String()).
+				Str("user_id", user.ID.String()).
+				Msg("failed to archive session")
 			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to archive session", err)
 		}
 		return
@@ -1338,6 +1344,11 @@ func (h *SessionHandler) UnarchiveSession(w http.ResponseWriter, r *http.Request
 		if errors.Is(err, db.ErrSessionNotArchived) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found or not archived")
 		} else {
+			zerolog.Ctx(r.Context()).Error().
+				Err(err).
+				Str("session_id", sessionID.String()).
+				Str("org_id", orgID.String()).
+				Msg("failed to unarchive session")
 			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to unarchive session", err)
 		}
 		return

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     CGO_ENABLED=0 go build -o /bin/143-tools ./cmd/tools
 
 # Stage 2: Runtime
-FROM ubuntu:26.04
+FROM ubuntu:24.04
 
 # System dependencies for agent CLIs and typical repo operations.
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Attach `session_id`, `org_id`, and `user_id` to the error log when archive/unarchive returns a 500, so the recent "failed to archive session" errors can be traced back to a specific session.
- Pin the sandbox runtime back to `ubuntu:24.04`. The `ubuntu:26.04` image is unusable right now - `apt-get install` can't locate `jq` or `sudo`, which broke the sandbox image build.

## Test plan
- [ ] Sandbox image builds cleanly on CI
- [ ] Triggering an archive failure produces a log line with session/org/user IDs
