### PR TITLE
Add org-level teams with session and project filtering

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -10,6 +10,9 @@ import { cn, formatTimeAgo } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { TeamSelector } from "@/components/team-selector";
+import { useTeamFilter } from "@/hooks/use-team-filter";
 import { projectStatusConfig, projectStatusDotColor } from "@/lib/types";
 import type { Project } from "@/lib/types";
 const filterTabs = [
@@ -35,10 +38,11 @@ export function ProjectSidebar() {
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
+  const { selectedTeamId, myTeams, setTeamFilter } = useTeamFilter();
 
   const { data, isLoading } = useQuery({
-    queryKey: ["projects", activeFilter, repo],
-    queryFn: () => api.projects.list({ limit: 50, repository_id: repo ?? undefined }),
+    queryKey: [...queryKeys.projects.all, activeFilter, repo, selectedTeamId],
+    queryFn: () => api.projects.list({ limit: 50, repository_id: repo ?? undefined, team_id: selectedTeamId }),
     refetchInterval: 10000,
   });
 
@@ -83,6 +87,12 @@ export function ProjectSidebar() {
             className="w-full h-8 pl-8 pr-3 rounded-md border border-border bg-background text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
           />
         </div>
+
+        <TeamSelector
+          teams={myTeams}
+          selectedTeamId={selectedTeamId}
+          onSelect={setTeamFilter}
+        />
 
         {/* New project button */}
         <Link

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -17,6 +17,8 @@ import { SessionOwnerToggle } from "./session-owner-toggle";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
+import { TeamSelector } from "@/components/team-selector";
+import { useTeamFilter } from "@/hooks/use-team-filter";
 import type { SessionListItem } from "@/lib/types";
 import {
   activeSet,
@@ -151,6 +153,7 @@ export function SessionSidebar() {
   const pathname = usePathname();
   const queryClient = useQueryClient();
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
+  const { selectedTeamId, myTeams, setTeamFilter } = useTeamFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
 
@@ -167,23 +170,23 @@ export function SessionSidebar() {
   // Also fetches a filtered query when a tab is active — see sessions-page-content
   // for the rationale on the double-fetch tradeoff.
   const { data: allData, isLoading } = useQuery({
-    queryKey: [...queryKeys.sessions.list(repo), triggeredByUserId],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId }),
+    queryKey: [...queryKeys.sessions.list(repo ?? undefined), triggeredByUserId, selectedTeamId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId, team_id: selectedTeamId }),
     refetchInterval: 10000,
   });
 
   // Fetch filtered sessions from the backend when a specific tab is selected.
   const { data: filteredData } = useQuery({
-    queryKey: [...queryKeys.sessions.list(repo), statusParam, triggeredByUserId],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId }),
+    queryKey: [...queryKeys.sessions.list(repo ?? undefined), statusParam, triggeredByUserId, selectedTeamId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId, team_id: selectedTeamId }),
     refetchInterval: 10000,
     enabled: !!statusParam,
   });
 
   // Fetch archived sessions when the archived tab is active.
   const { data: archivedData, isLoading: isArchivedLoading } = useQuery({
-    queryKey: [...queryKeys.sessions.list(repo), "archived", triggeredByUserId],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId, only_archived: true }),
+    queryKey: [...queryKeys.sessions.list(repo ?? undefined), "archived", triggeredByUserId, selectedTeamId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId, team_id: selectedTeamId, only_archived: true }),
     refetchInterval: 10000,
     enabled: isArchivedView,
   });
@@ -264,6 +267,12 @@ export function SessionSidebar() {
             className="shrink-0"
           />
         </div>
+
+        <TeamSelector
+          teams={myTeams}
+          selectedTeamId={selectedTeamId}
+          onSelect={setTeamFilter}
+        />
 
         {/* New session button */}
         <Link

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -28,9 +28,12 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
+import { useTeamFilter } from "@/hooks/use-team-filter";
+import { TeamSelector } from "@/components/team-selector";
 import { SessionOwnerToggle } from "./session-owner-toggle";
 import type { Session, User } from "@/lib/types";
 import {
@@ -200,6 +203,7 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
 export function SessionsPageContent() {
   const router = useRouter();
   const { currentUserFilter, triggeredByUserId, user, setUserFilter } = useSessionUserFilter();
+  const { selectedTeamId, myTeams, setTeamFilter } = useTeamFilter();
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -229,21 +233,21 @@ export function SessionsPageContent() {
   // the limit. If polling cost becomes a concern, consider a dedicated
   // /sessions/counts endpoint.
   const { data: allData, isLoading, error } = useQuery({
-    queryKey: ["sessions", repo, triggeredByUserId],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId }),
+    queryKey: [...queryKeys.sessions.list(repo ?? undefined), triggeredByUserId, selectedTeamId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, triggered_by_user_id: triggeredByUserId, team_id: selectedTeamId }),
     refetchInterval: 10000,
   });
 
   // Fetch filtered sessions from the backend when a specific tab is selected.
   const { data: filteredData } = useQuery({
-    queryKey: ["sessions", repo, statusParam, triggeredByUserId],
-    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId }),
+    queryKey: [...queryKeys.sessions.list(repo ?? undefined), statusParam, triggeredByUserId, selectedTeamId],
+    queryFn: () => api.sessions.list({ limit: 50, repository_id: repo ?? undefined, status: statusParam, triggered_by_user_id: triggeredByUserId, team_id: selectedTeamId }),
     refetchInterval: 10000,
     enabled: !!statusParam,
   });
 
   const { data: membersData } = useQuery({
-    queryKey: ["team", "members"],
+    queryKey: queryKeys.team.members,
     queryFn: () => api.team.listMembers(),
   });
 
@@ -314,12 +318,17 @@ export function SessionsPageContent() {
           })}
         </div>
 
-        {/* User filter toggle */}
-        <SessionOwnerToggle
-          currentUserFilter={currentUserFilter}
-          onFilterChange={setUserFilter}
-          className="ml-auto shrink-0 mr-2"
-        />
+        <div className="ml-auto flex items-center gap-2 shrink-0 mr-2">
+          <TeamSelector
+            teams={myTeams}
+            selectedTeamId={selectedTeamId}
+            onSelect={setTeamFilter}
+          />
+          <SessionOwnerToggle
+            currentUserFilter={currentUserFilter}
+            onFilterChange={setUserFilter}
+          />
+        </div>
       </div>
 
       {/* ── Decisions tab ──────────────────────────────────────────── */}

--- a/frontend/src/app/(dashboard)/settings/teams/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/teams/page.tsx
@@ -94,8 +94,16 @@ export default function TeamsSettingsPage() {
 
   const syncGitHubMutation = useMutation({
     mutationFn: () => api.teams.syncGitHub(),
-    onSuccess: () => {
-      toast.success("Teams synced from GitHub");
+    onSuccess: (res) => {
+      if (res.skipped > 0) {
+        const preview = res.skipped_slugs.slice(0, 3).join(", ");
+        const more = res.skipped_slugs.length > 3 ? ` (+${res.skipped_slugs.length - 3} more)` : "";
+        toast.warning(
+          `Synced ${res.synced} team${res.synced === 1 ? "" : "s"}; ${res.skipped} skipped: ${preview}${more}. Try again.`
+        );
+      } else {
+        toast.success(`Synced ${res.synced} team${res.synced === 1 ? "" : "s"} from GitHub`);
+      }
       invalidateTeams();
     },
     onError: () => toast.error("Failed to sync teams from GitHub"),

--- a/frontend/src/app/(dashboard)/settings/teams/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/teams/page.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { RefreshCw, Plus, Trash2, UserPlus } from "lucide-react";
+import { toast } from "sonner";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { PageHeader } from "@/components/page-header";
+import { PageContainer } from "@/components/page-container";
+import type { Team, TeamWithMembers, User, ListResponse, SingleResponse } from "@/lib/types";
+
+export default function TeamsSettingsPage() {
+  const queryClient = useQueryClient();
+  const [newTeamName, setNewTeamName] = useState("");
+  const [newTeamDesc, setNewTeamDesc] = useState("");
+  const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
+  const [deleteTeamId, setDeleteTeamId] = useState<string | null>(null);
+  const [addMemberUserId, setAddMemberUserId] = useState("");
+
+  // Fetch all teams
+  const { data: teamsData, isLoading: teamsLoading } = useQuery({
+    queryKey: queryKeys.teams.all,
+    queryFn: () => api.teams.list(),
+  });
+
+  // Fetch selected team details
+  const { data: teamDetailData } = useQuery({
+    queryKey: queryKeys.teams.detail(selectedTeamId ?? ""),
+    queryFn: () => api.teams.get(selectedTeamId!),
+    enabled: !!selectedTeamId,
+  });
+
+  // Fetch org members for the add-member dropdown
+  const { data: membersData } = useQuery({
+    queryKey: queryKeys.team.members,
+    queryFn: () => api.team.listMembers() as Promise<ListResponse<User>>,
+  });
+
+  const teams = teamsData?.data ?? [];
+  const teamDetail = teamDetailData?.data;
+  const orgMembers = membersData?.data ?? [];
+
+  const invalidateTeams = () => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.teams.all });
+    queryClient.invalidateQueries({ queryKey: queryKeys.teams.mine });
+    if (selectedTeamId) {
+      queryClient.invalidateQueries({ queryKey: queryKeys.teams.detail(selectedTeamId) });
+    }
+  };
+
+  const createMutation = useMutation({
+    mutationFn: () => api.teams.create({ name: newTeamName, description: newTeamDesc || undefined }),
+    onSuccess: (data: SingleResponse<Team>) => {
+      toast.success(`Team "${data.data.name}" created`);
+      setNewTeamName("");
+      setNewTeamDesc("");
+      invalidateTeams();
+    },
+    onError: () => toast.error("Failed to create team"),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => api.teams.del(id),
+    onSuccess: () => {
+      toast.success("Team deleted");
+      if (selectedTeamId === deleteTeamId) setSelectedTeamId(null);
+      setDeleteTeamId(null);
+      invalidateTeams();
+    },
+    onError: () => toast.error("Failed to delete team"),
+  });
+
+  const syncGitHubMutation = useMutation({
+    mutationFn: () => api.teams.syncGitHub(),
+    onSuccess: () => {
+      toast.success("Teams synced from GitHub");
+      invalidateTeams();
+    },
+    onError: () => toast.error("Failed to sync teams from GitHub"),
+  });
+
+  const addMemberMutation = useMutation({
+    mutationFn: ({ teamId, userId }: { teamId: string; userId: string }) =>
+      api.teams.addMember(teamId, userId),
+    onSuccess: () => {
+      toast.success("Member added");
+      setAddMemberUserId("");
+      invalidateTeams();
+    },
+    onError: () => toast.error("Failed to add member"),
+  });
+
+  const removeMemberMutation = useMutation({
+    mutationFn: ({ teamId, userId }: { teamId: string; userId: string }) =>
+      api.teams.removeMember(teamId, userId),
+    onSuccess: () => {
+      toast.success("Member removed");
+      invalidateTeams();
+    },
+    onError: () => toast.error("Failed to remove member"),
+  });
+
+  // Members not yet in the selected team
+  const availableMembers = teamDetail
+    ? orgMembers.filter((m) => !teamDetail.members.some((tm) => tm.id === m.id))
+    : [];
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Teams"
+        description="Organize your team into groups. Teams can be synced from GitHub and used to filter sessions and projects."
+        action={
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => syncGitHubMutation.mutate()}
+            disabled={syncGitHubMutation.isPending}
+          >
+            <RefreshCw className={`h-4 w-4 mr-1.5 ${syncGitHubMutation.isPending ? "animate-spin" : ""}`} />
+            Sync from GitHub
+          </Button>
+        }
+      />
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[1fr_1.5fr]">
+        {/* Left column: team list + create */}
+        <div className="space-y-4">
+          {/* Create team form */}
+          <Card>
+            <CardContent className="pt-6 space-y-3">
+              <div>
+                <Label htmlFor="team-name" className="text-xs">Team name</Label>
+                <Input
+                  id="team-name"
+                  value={newTeamName}
+                  onChange={(e) => setNewTeamName(e.target.value)}
+                  placeholder="e.g. Frontend, Platform, Mobile"
+                  className="mt-1"
+                />
+              </div>
+              <div>
+                <Label htmlFor="team-desc" className="text-xs">Description (optional)</Label>
+                <Input
+                  id="team-desc"
+                  value={newTeamDesc}
+                  onChange={(e) => setNewTeamDesc(e.target.value)}
+                  placeholder="What does this team work on?"
+                  className="mt-1"
+                />
+              </div>
+              <Button
+                size="sm"
+                onClick={() => createMutation.mutate()}
+                disabled={!newTeamName.trim() || createMutation.isPending}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Create team
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Team list */}
+          {teamsLoading && (
+            <p className="text-xs text-muted-foreground px-1">Loading teams...</p>
+          )}
+
+          {teams.map((team) => (
+            <Card
+              key={team.id}
+              className={`cursor-pointer transition-colors ${selectedTeamId === team.id ? "ring-2 ring-primary" : ""}`}
+              onClick={() => setSelectedTeamId(team.id)}
+            >
+              <CardContent className="pt-4 pb-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm font-medium">{team.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {team.member_count} member{team.member_count !== 1 ? "s" : ""}
+                      {team.github_team_slug && (
+                        <span className="ml-2 text-muted-foreground/60">
+                          (GitHub: {team.github_team_slug})
+                        </span>
+                      )}
+                    </p>
+                  </div>
+                  <Button
+                    size="icon-xs"
+                    variant="ghost"
+                    className="text-muted-foreground hover:text-destructive"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteTeamId(team.id);
+                    }}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+
+          {!teamsLoading && teams.length === 0 && (
+            <p className="text-xs text-muted-foreground px-1">
+              No teams yet. Create one above or sync from GitHub.
+            </p>
+          )}
+        </div>
+
+        {/* Right column: team detail */}
+        <div>
+          {selectedTeamId && teamDetail ? (
+            <Card>
+              <CardContent className="pt-6 space-y-4">
+                <div>
+                  <h3 className="text-sm font-medium">{teamDetail.name}</h3>
+                  {teamDetail.description && (
+                    <p className="text-xs text-muted-foreground mt-1">{teamDetail.description}</p>
+                  )}
+                </div>
+
+                {/* Add member */}
+                <div className="flex items-end gap-2">
+                  <div className="flex-1">
+                    <Label className="text-xs">Add member</Label>
+                    <Select value={addMemberUserId} onValueChange={setAddMemberUserId}>
+                      <SelectTrigger className="mt-1" size="sm">
+                        <SelectValue placeholder="Select a member" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {availableMembers.map((m) => (
+                          <SelectItem key={m.id} value={m.id}>
+                            {m.name} ({m.email})
+                          </SelectItem>
+                        ))}
+                        {availableMembers.length === 0 && (
+                          <SelectItem value="__none__" disabled>
+                            All org members are already in this team
+                          </SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    size="sm"
+                    disabled={!addMemberUserId || addMemberMutation.isPending}
+                    onClick={() => {
+                      if (addMemberUserId) {
+                        addMemberMutation.mutate({ teamId: selectedTeamId, userId: addMemberUserId });
+                      }
+                    }}
+                  >
+                    <UserPlus className="h-4 w-4 mr-1" />
+                    Add
+                  </Button>
+                </div>
+
+                {/* Members list */}
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-muted-foreground">
+                    Members ({teamDetail.members.length})
+                  </p>
+                  {teamDetail.members.map((member) => (
+                    <div
+                      key={member.id}
+                      className="flex items-center justify-between py-2 px-2 rounded-md hover:bg-muted/50"
+                    >
+                      <div className="flex items-center gap-2">
+                        {member.avatar_url ? (
+                          <img
+                            src={member.avatar_url}
+                            alt=""
+                            className="h-6 w-6 rounded-full"
+                          />
+                        ) : (
+                          <div className="h-6 w-6 rounded-full bg-muted flex items-center justify-center text-xs font-medium">
+                            {member.name?.[0] || "?"}
+                          </div>
+                        )}
+                        <div>
+                          <p className="text-xs font-medium">{member.name}</p>
+                          <p className="text-xs text-muted-foreground">{member.email}</p>
+                        </div>
+                      </div>
+                      <Button
+                        size="icon-xs"
+                        variant="ghost"
+                        className="text-muted-foreground hover:text-destructive"
+                        onClick={() =>
+                          removeMemberMutation.mutate({ teamId: selectedTeamId, userId: member.id })
+                        }
+                      >
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                  {teamDetail.members.length === 0 && (
+                    <p className="text-xs text-muted-foreground py-2">
+                      No members yet. Add members above.
+                    </p>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            <Card>
+              <CardContent className="py-12 text-center">
+                <p className="text-xs text-muted-foreground">
+                  Select a team to view and manage its members.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      <AlertDialog open={!!deleteTeamId} onOpenChange={() => setDeleteTeamId(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete team</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove the team and unset team assignments on sessions and projects.
+              Members will not be removed from the organization. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={() => {
+                if (deleteTeamId) deleteMutation.mutate(deleteTeamId);
+              }}
+            >
+              Delete team
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </PageContainer>
+  );
+}

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -11,6 +11,7 @@ import {
   Target,
   FlaskConical,
   Users,
+  UsersRound,
   ScrollText,
   BarChart3,
   ChevronRight,
@@ -57,6 +58,7 @@ const settingsGroups: SettingsGroup[] = [
     items: [
       { label: "General", icon: Settings, href: "/settings" },
       { label: "Team", icon: Users, href: "/settings/team" },
+      { label: "Teams", icon: UsersRound, href: "/settings/teams", adminOnly: true },
       { label: "Usage", icon: BarChart3, href: "/settings/usage", adminOnly: true },
       { label: "Audit log", icon: ScrollText, href: "/settings/audit-log", adminOnly: true },
     ],

--- a/frontend/src/components/team-selector.test.tsx
+++ b/frontend/src/components/team-selector.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen } from '@/test/test-utils';
+import { fireEvent } from '@testing-library/react';
+import { TeamSelector } from './team-selector';
+import type { Team } from '@/lib/types';
+
+const makeTeam = (overrides: Partial<Team> = {}): Team => ({
+  id: 't1',
+  org_id: 'org1',
+  name: 'Platform',
+  slug: 'platform',
+  member_count: 3,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('TeamSelector', () => {
+  it('renders nothing when there are no teams', () => {
+    const { container } = renderWithProviders(
+      <TeamSelector teams={[]} selectedTeamId={undefined} onSelect={() => {}} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the placeholder "All teams" when no team is selected', () => {
+    renderWithProviders(
+      <TeamSelector
+        teams={[makeTeam()]}
+        selectedTeamId={undefined}
+        onSelect={() => {}}
+      />,
+    );
+    expect(screen.getByText('All teams')).toBeInTheDocument();
+  });
+
+  it('calls onSelect with null when "All teams" is chosen', () => {
+    const onSelect = vi.fn();
+    renderWithProviders(
+      <TeamSelector
+        teams={[makeTeam({ id: 'a', name: 'Alpha' })]}
+        selectedTeamId="a"
+        onSelect={onSelect}
+      />,
+    );
+    // Open the select
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByText('All teams'));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it('calls onSelect with team id when a specific team is chosen', () => {
+    const onSelect = vi.fn();
+    renderWithProviders(
+      <TeamSelector
+        teams={[
+          makeTeam({ id: 'a', name: 'Alpha' }),
+          makeTeam({ id: 'b', name: 'Beta' }),
+        ]}
+        selectedTeamId={undefined}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByText('Beta'));
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+});

--- a/frontend/src/components/team-selector.tsx
+++ b/frontend/src/components/team-selector.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Users } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { Team } from "@/lib/types";
+
+interface TeamSelectorProps {
+  teams: Team[];
+  selectedTeamId: string | undefined;
+  onSelect: (teamId: string | null) => void;
+  className?: string;
+}
+
+export function TeamSelector({
+  teams,
+  selectedTeamId,
+  onSelect,
+  className,
+}: TeamSelectorProps) {
+  if (teams.length === 0) return null;
+
+  return (
+    <Select
+      value={selectedTeamId ?? "__all__"}
+      onValueChange={(v) => onSelect(v === "__all__" ? null : v)}
+    >
+      <SelectTrigger className={className} size="sm">
+        <div className="flex items-center gap-1.5 text-xs">
+          <Users className="h-3.5 w-3.5 text-muted-foreground" />
+          <SelectValue placeholder="All teams" />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="__all__">All teams</SelectItem>
+        {teams.map((team) => (
+          <SelectItem key={team.id} value={team.id}>
+            {team.name}
+            {team.member_count > 0 && (
+              <span className="text-muted-foreground ml-1">({team.member_count})</span>
+            )}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/frontend/src/hooks/use-team-filter.ts
+++ b/frontend/src/hooks/use-team-filter.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useQueryState, parseAsString } from "nuqs";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+
+export function useTeamFilter() {
+  const [teamParam, setTeamParam] = useQueryState("team", parseAsString);
+
+  const { data: teamsData } = useQuery({
+    queryKey: queryKeys.teams.mine,
+    queryFn: () => api.teams.listMine(),
+    staleTime: 60_000,
+  });
+
+  const myTeams = teamsData?.data ?? [];
+
+  const selectedTeamId = teamParam ?? undefined;
+
+  return { selectedTeamId, myTeams, setTeamFilter: setTeamParam };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -686,6 +686,6 @@ export const api = {
     removeMember: (teamId: string, userId: string) =>
       del(`/api/v1/teams/${teamId}/members/${userId}`),
     syncGitHub: (org?: string) =>
-      post<import('./types').ListResponse<import('./types').Team>>('/api/v1/teams/sync-github', org ? { org } : {}),
+      post<import('./types').SyncTeamsResponse>('/api/v1/teams/sync-github', org ? { org } : {}),
   },
 };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -206,7 +206,7 @@ export const api = {
       del(`/api/v1/pm/documents/${docId}`),
   },
   sessions: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string; search?: string; include_archived?: boolean; only_archived?: boolean }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; triggered_by_user_id?: string; search?: string; include_archived?: boolean; only_archived?: boolean; team_id?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
@@ -214,6 +214,7 @@ export const api = {
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       if (params?.triggered_by_user_id) searchParams.set('triggered_by_user_id', params.triggered_by_user_id);
       if (params?.search) searchParams.set('search', params.search);
+      if (params?.team_id) searchParams.set('team_id', params.team_id);
       if (params?.only_archived) searchParams.set('only_archived', 'true');
       else if (params?.include_archived) searchParams.set('include_archived', 'true');
       const qs = searchParams.toString();
@@ -433,7 +434,7 @@ export const api = {
       ),
   },
   projects: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string; proposed_by_pm?: boolean }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string; proposed_by_pm?: boolean; team_id?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
@@ -441,6 +442,7 @@ export const api = {
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.proposed_by_pm !== undefined) searchParams.set('proposed_by_pm', String(params.proposed_by_pm));
+      if (params?.team_id) searchParams.set('team_id', params.team_id);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Project>>(`/api/v1/projects${qs ? `?${qs}` : ''}`);
     },
@@ -669,5 +671,21 @@ export const api = {
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').ReviewComment>>(`/api/v1/review-comments${qs ? `?${qs}` : ''}`);
     },
+  },
+  teams: {
+    list: () => get<import('./types').ListResponse<import('./types').Team>>('/api/v1/teams'),
+    listMine: () => get<import('./types').ListResponse<import('./types').Team>>('/api/v1/teams/mine'),
+    get: (id: string) => get<import('./types').SingleResponse<import('./types').TeamWithMembers>>(`/api/v1/teams/${id}`),
+    create: (body: { name: string; slug?: string; description?: string }) =>
+      post<import('./types').SingleResponse<import('./types').Team>>('/api/v1/teams', body),
+    update: (id: string, body: { name: string; slug?: string; description?: string }) =>
+      patch<import('./types').SingleResponse<import('./types').Team>>(`/api/v1/teams/${id}`, body),
+    del: (id: string) => del(`/api/v1/teams/${id}`),
+    addMember: (teamId: string, userId: string, role?: string) =>
+      post(`/api/v1/teams/${teamId}/members`, { user_id: userId, role: role || 'member' }),
+    removeMember: (teamId: string, userId: string) =>
+      del(`/api/v1/teams/${teamId}/members/${userId}`),
+    syncGitHub: (org?: string) =>
+      post<import('./types').ListResponse<import('./types').Team>>('/api/v1/teams/sync-github', org ? { org } : {}),
   },
 };

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -51,6 +51,11 @@ export const queryKeys = {
   team: {
     members: ["team", "members"] as const,
   },
+  teams: {
+    all: ["teams"] as const,
+    mine: ["teams", "mine"] as const,
+    detail: (id: string) => ["teams", id] as const,
+  },
   usage: {
     summary: (params: { start: string; end: string }) =>
       ["usage", "summary", params] as const,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -120,6 +120,7 @@ export interface Session {
   diff_history?: Array<{ pass: number; diff: string; diff_stats: { added: number; removed: number; files_changed: number }; created_at: string }>;
   archived_at?: string;
   archived_by_user_id?: string;
+  team_id?: string;
   created_at: string;
 }
 
@@ -643,6 +644,7 @@ export interface Project {
   schedule_unit: 'hours' | 'days' | 'weeks';
   next_run_at?: string;
   created_by?: string;
+  team_id?: string;
   created_at: string;
   updated_at: string;
   completed_at?: string;
@@ -1082,4 +1084,23 @@ export interface AutomationRun {
   result_summary?: string;
   created_at: string;
   updated_at: string;
+}
+
+// ── Teams ─────────────────────────────────────────────────────────────
+
+export interface Team {
+  id: string;
+  org_id: string;
+  name: string;
+  slug: string;
+  description?: string;
+  github_team_id?: number;
+  github_team_slug?: string;
+  member_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TeamWithMembers extends Team {
+  members: User[];
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1104,3 +1104,10 @@ export interface Team {
 export interface TeamWithMembers extends Team {
   members: User[];
 }
+
+export interface SyncTeamsResponse {
+  data: Team[];
+  synced: number;
+  skipped: number;
+  skipped_slugs: string[];
+}

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -214,6 +214,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ScheduleEnabled    *bool   `json:"schedule_enabled"`
 		ScheduleInterval   *int    `json:"schedule_interval"`
 		ScheduleUnit       *string `json:"schedule_unit"`
+		TeamID             *string `json:"team_id"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -230,6 +231,16 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 		return
+	}
+
+	var teamID *uuid.UUID
+	if req.TeamID != nil && *req.TeamID != "" {
+		parsed, err := uuid.Parse(*req.TeamID)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+			return
+		}
+		teamID = &parsed
 	}
 
 	execMode := models.ProjectExecModeSequential
@@ -323,6 +334,7 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		ScheduleUnit:       scheduleUnit,
 		NextRunAt:          nextRunAt,
 		CreatedBy:          &user.ID,
+		TeamID:             teamID,
 	}
 
 	if err := h.projectStore.Create(r.Context(), &project); err != nil {
@@ -364,6 +376,7 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 		ScheduleEnabled    *bool   `json:"schedule_enabled"`
 		ScheduleInterval   *int    `json:"schedule_interval"`
 		ScheduleUnit       *string `json:"schedule_unit"`
+		TeamID             *string `json:"team_id"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -445,6 +458,18 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 		// When disabling schedule, clear next_run_at.
 		if !*req.ScheduleEnabled && wasEnabled {
 			project.NextRunAt = nil
+		}
+	}
+	if req.TeamID != nil {
+		if *req.TeamID == "" {
+			project.TeamID = nil
+		} else {
+			parsed, err := uuid.Parse(*req.TeamID)
+			if err != nil {
+				writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+				return
+			}
+			project.TeamID = &parsed
 		}
 	}
 

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -21,12 +21,28 @@ type ProjectHandler struct {
 	attachmentStore   *db.ProjectAttachmentStore
 	specStore         *db.ProjectSpecStore
 	jobStore          *db.JobStore
+	teamStore         *db.TeamStore // optional — enables cross-tenant team_id verification
 	audit             *db.AuditEmitter
 }
 
 // SetAuditEmitter injects the audit emitter for logging project events.
 func (h *ProjectHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 	h.audit = audit
+}
+
+// SetTeamStore injects the team store so the handler can verify that any
+// incoming team_id belongs to the caller's org.
+func (h *ProjectHandler) SetTeamStore(ts *db.TeamStore) {
+	h.teamStore = ts
+}
+
+// teamLookup returns the store as the teamLookup interface, or nil when unset.
+// Needed because a typed-nil *db.TeamStore is not equal to a nil interface.
+func (h *ProjectHandler) teamLookup() teamLookup {
+	if h.teamStore == nil {
+		return nil
+	}
+	return h.teamStore
 }
 
 func NewProjectHandler(
@@ -233,14 +249,13 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var teamID *uuid.UUID
-	if req.TeamID != nil && *req.TeamID != "" {
-		parsed, err := uuid.Parse(*req.TeamID)
-		if err != nil {
-			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
-			return
-		}
-		teamID = &parsed
+	var teamIDRaw string
+	if req.TeamID != nil {
+		teamIDRaw = *req.TeamID
+	}
+	teamID, ok := resolveTeamID(w, r, h.teamLookup(), orgID, teamIDRaw)
+	if !ok {
+		return
 	}
 
 	execMode := models.ProjectExecModeSequential
@@ -461,16 +476,11 @@ func (h *ProjectHandler) Update(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if req.TeamID != nil {
-		if *req.TeamID == "" {
-			project.TeamID = nil
-		} else {
-			parsed, err := uuid.Parse(*req.TeamID)
-			if err != nil {
-				writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
-				return
-			}
-			project.TeamID = &parsed
+		resolved, ok := resolveTeamID(w, r, h.teamLookup(), orgID, *req.TeamID)
+		if !ok {
+			return
 		}
+		project.TeamID = resolved
 	}
 
 	if err := h.projectStore.Update(r.Context(), &project); err != nil {

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -99,6 +99,15 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 		filters.RepositoryID = repoID
 	}
 
+	if teamIDStr := r.URL.Query().Get("team_id"); teamIDStr != "" {
+		teamID, err := uuid.Parse(teamIDStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+			return
+		}
+		filters.TeamID = teamID
+	}
+
 	projects, err := h.projectStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list projects", err)

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -30,7 +30,7 @@ func projectColumns() []string {
 		"proposed_by_pm", "source_issue_ids", "proposal_reasoning", "similar_projects",
 		"agent_type", "model_override",
 		"schedule_enabled", "schedule_interval", "schedule_unit", "next_run_at",
-		"created_by", "deleted_at", "created_at", "updated_at", "completed_at",
+		"created_by", "team_id", "deleted_at", "created_at", "updated_at", "completed_at",
 	}
 }
 
@@ -44,7 +44,7 @@ func newProjectRow(id, orgID, repoID uuid.UUID, status models.ProjectStatus, now
 		false, []uuid.UUID{}, nil, json.RawMessage("[]"),
 		nil, nil, // agent_type, model_override
 		false, 1, "days", nil, // schedule_enabled, schedule_interval, schedule_unit, next_run_at
-		&createdBy, (*time.Time)(nil), now, now, nil,
+		&createdBy, nil, (*time.Time)(nil), now, now, nil,
 	}
 }
 
@@ -207,7 +207,8 @@ func TestProjectHandler_Update(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	body, _ := json.Marshal(map[string]string{"title": "Updated Title"})
@@ -404,7 +405,7 @@ func TestProjectHandler_Create(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
 	mock.ExpectCommit()
 

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -200,7 +200,7 @@ func TestProjectHandler_Update(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(projectColumns()).AddRow(newProjectRow(projectID, orgID, repoID, models.ProjectStatusDraft, now)...))
 
-	// Update (24 named args: 19 original + 4 schedule fields + similar_projects)
+	// Update (25 named args: 19 original + 4 schedule fields + similar_projects + team_id)
 	mock.ExpectExec("UPDATE projects SET").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),

--- a/internal/api/handlers/session_files_test.go
+++ b/internal/api/handlers/session_files_test.go
@@ -78,7 +78,7 @@ var sessionColumnsForFiles = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 func setupSessionMock(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, containerID *string) {
@@ -101,6 +101,7 @@ func setupSessionMock(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, con
 				nil,                                // input_manifest
 				nil, nil,                           // archived_at, archived_by_user_id
 				nil,                                // automation_run_id
+				nil,                                // team_id
 				nil,                                // deleted_at
 				now,                                // created_at
 			),

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -43,7 +43,8 @@ type SessionHandler struct {
 	messageStore     *db.SessionMessageStore
 	threadStore      *db.SessionThreadStore
 	viewStore        *db.SessionViewStore
-	llmClient        llm.Client // optional, used for generating manual session titles
+	teamStore        *db.TeamStore // optional — enables cross-tenant team_id verification
+	llmClient        llm.Client    // optional, used for generating manual session titles
 	logger           zerolog.Logger
 	audit            *db.AuditEmitter
 	canceller        SessionCanceller // optional — enables cancelling running sessions
@@ -62,6 +63,21 @@ func (h *SessionHandler) SetCanceller(c SessionCanceller) {
 // SetViewStore injects the session view store for tracking unread sessions.
 func (h *SessionHandler) SetViewStore(vs *db.SessionViewStore) {
 	h.viewStore = vs
+}
+
+// SetTeamStore injects the team store so the handler can verify that any
+// incoming team_id belongs to the caller's org.
+func (h *SessionHandler) SetTeamStore(ts *db.TeamStore) {
+	h.teamStore = ts
+}
+
+// teamLookup returns the store as the teamLookup interface, or nil when unset.
+// Needed because a typed-nil *db.TeamStore is not equal to a nil interface.
+func (h *SessionHandler) teamLookup() teamLookup {
+	if h.teamStore == nil {
+		return nil
+	}
+	return h.teamStore
 }
 
 func NewSessionHandler(
@@ -329,14 +345,9 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	// Ignore decode errors — body is optional, fields default below.
 	_ = json.NewDecoder(r.Body).Decode(&body)
 
-	var teamID *uuid.UUID
-	if body.TeamID != "" {
-		parsed, err := uuid.Parse(body.TeamID)
-		if err != nil {
-			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
-			return
-		}
-		teamID = &parsed
+	teamID, ok := resolveTeamID(w, r, h.teamLookup(), orgID, body.TeamID)
+	if !ok {
+		return
 	}
 
 	agentType := models.AgentType(body.AgentType)
@@ -1065,14 +1076,9 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var manualTeamID *uuid.UUID
-	if body.TeamID != "" {
-		parsed, err := uuid.Parse(body.TeamID)
-		if err != nil {
-			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
-			return
-		}
-		manualTeamID = &parsed
+	manualTeamID, ok := resolveTeamID(w, r, h.teamLookup(), orgID, body.TeamID)
+	if !ok {
+		return
 	}
 
 	// Resolve repository for the manual session so the orchestrator can

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -175,6 +175,15 @@ func (h *SessionHandler) List(w http.ResponseWriter, r *http.Request) {
 		filters.TriggeredByUserID = userID
 	}
 
+	if teamIDStr := r.URL.Query().Get("team_id"); teamIDStr != "" {
+		teamID, err := uuid.Parse(teamIDStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+			return
+		}
+		filters.TeamID = teamID
+	}
+
 	runs, err := h.runStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list runs", err)

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -324,9 +324,20 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		AgentType     string `json:"agent_type"`
 		AutonomyLevel string `json:"autonomy_level"`
 		TokenMode     string `json:"token_mode"`
+		TeamID        string `json:"team_id"`
 	}
 	// Ignore decode errors — body is optional, fields default below.
 	_ = json.NewDecoder(r.Body).Decode(&body)
+
+	var teamID *uuid.UUID
+	if body.TeamID != "" {
+		parsed, err := uuid.Parse(body.TeamID)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+			return
+		}
+		teamID = &parsed
+	}
 
 	agentType := models.AgentType(body.AgentType)
 	if agentType == "" {
@@ -383,6 +394,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		AutonomyLevel:     autonomyLevel,
 		TokenMode:         tokenMode,
 		TriggeredByUserID: triggeredByUserID,
+		TeamID:            teamID,
 	}
 	if err := h.runStore.Create(r.Context(), run); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create agent run", err)
@@ -1040,6 +1052,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		TokenMode     string   `json:"token_mode"`
 		RepositoryID  string   `json:"repository_id"`
 		Branch        string   `json:"branch"`
+		TeamID        string   `json:"team_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
@@ -1050,6 +1063,16 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	if body.Message == "" {
 		writeError(w, r, http.StatusBadRequest, "MISSING_MESSAGE", "message is required")
 		return
+	}
+
+	var manualTeamID *uuid.UUID
+	if body.TeamID != "" {
+		parsed, err := uuid.Parse(body.TeamID)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+			return
+		}
+		manualTeamID = &parsed
 	}
 
 	// Resolve repository for the manual session so the orchestrator can
@@ -1179,6 +1202,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		PMApproach:        &title,
 		TargetBranch:      targetBranch,
 		RepositoryID:      repoID,
+		TeamID:            manualTeamID,
 	}
 	if err := h.runStore.Create(r.Context(), session); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create manual session", err)

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -84,12 +84,12 @@ func TestSessionHandler_List(t *testing.T) {
 							nil,                      // model_override
 							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -170,12 +170,12 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -267,12 +267,12 @@ func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil,
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -317,7 +317,7 @@ func TestDecodeSessionCursor_Invalid(t *testing.T) {
 		cursor string
 	}{
 		{name: "not base64", cursor: "!!!invalid!!!"},
-		{name: "missing comma", cursor: "bm9jb21tYQ=="},                                                     // "nocomma"
+		{name: "missing comma", cursor: "bm9jb21tYQ=="},                                                 // "nocomma"
 		{name: "bad timestamp", cursor: "YmFkdGltZSwwMTIzNDU2Ny04OWFiLWNkZWYtMDEyMy00NTY3ODlhYmNkZWY="}, // "badtime,..."
 	}
 
@@ -359,7 +359,7 @@ func TestSessionHandler_List_WithCursor(t *testing.T) {
 				nil, nil, nil, nil,
 				nil, nil, nil,
 				nil, 0, nil, "none", nil,
-				nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, now,
+				nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, now,
 			),
 		)
 
@@ -429,12 +429,12 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil,                      // model_override
 							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -512,7 +512,7 @@ func triggerFixIssueMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 			),
 		)
 
-	// Mock agent run create (17 named args)
+	// Mock agent run create (19 named args)
 	runID := uuid.New()
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -560,7 +560,7 @@ func triggerFixIssueAndOrgDefaultMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID
 				AddRow(orgID, "Acme", []byte(settings), now, now),
 		)
 
-	// Mock agent run create (17 named args)
+	// Mock agent run create (19 named args)
 	runID := uuid.New()
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -1146,12 +1146,12 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1237,12 +1237,12 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1301,12 +1301,12 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1329,12 +1329,12 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1419,7 +1419,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(issueID, now, now))
 
-				// Mock session create (17 named args)
+				// Mock session create (19 named args)
 				mock.ExpectQuery("INSERT INTO sessions").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -1626,12 +1626,12 @@ func TestSessionHandler_EndSession_EnqueuesValidation(t *testing.T) {
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1689,12 +1689,12 @@ func TestSessionHandler_EndSession_ManualSkipsValidation(t *testing.T) {
 				nil, nil,
 				&userID, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -1873,12 +1873,12 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -1916,12 +1916,12 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2001,12 +2001,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2028,12 +2028,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2072,12 +2072,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 2, &now, "running", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2120,12 +2120,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2164,7 +2164,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 3, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
-							nil, // input_manifest
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2195,7 +2195,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 2, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
-							nil, // input_manifest
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2226,12 +2226,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2257,12 +2257,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // team_id
@@ -2588,12 +2588,12 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -2658,7 +2658,7 @@ func TestSessionHandler_CreatePR_NoDiff(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -2713,7 +2713,7 @@ func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -2811,7 +2811,7 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -2882,7 +2882,7 @@ func TestSessionHandler_CancelSession_Success(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -2937,7 +2937,7 @@ func TestSessionHandler_CancelSession_NotRunning(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id
@@ -3016,7 +3016,7 @@ func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // team_id

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -52,7 +52,7 @@ var sessionColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 func TestSessionHandler_List(t *testing.T) {
@@ -92,6 +92,7 @@ func TestSessionHandler_List(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -177,6 +178,7 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -273,6 +275,7 @@ func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -434,6 +437,7 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -515,7 +519,7 @@ func triggerFixIssueMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)
@@ -563,7 +567,7 @@ func triggerFixIssueAndOrgDefaultMock(mock pgxmock.PgxPoolIface, orgID uuid.UUID
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock job enqueue (6 named args)
@@ -1150,6 +1154,7 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1240,6 +1245,7 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1303,6 +1309,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1330,6 +1337,7 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1417,7 +1425,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 				// Mock concurrency check
@@ -1465,7 +1473,7 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 				// Mock concurrency check
@@ -1626,6 +1634,7 @@ func TestSessionHandler_EndSession_EnqueuesValidation(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1688,6 +1697,7 @@ func TestSessionHandler_EndSession_ManualSkipsValidation(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -1871,6 +1881,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -1913,6 +1924,7 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -1997,6 +2009,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2023,6 +2036,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2066,6 +2080,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2113,6 +2128,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2151,6 +2167,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2181,6 +2198,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2216,6 +2234,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2246,6 +2265,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
+							nil, // team_id
 							nil, // deleted_at
 							now,
 						),
@@ -2413,7 +2433,7 @@ func TestSessionHandler_CreateManual_WithLLMTitle(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock concurrency check
@@ -2505,7 +2525,7 @@ func TestSessionHandler_CreateManual_LLMError_Returns500(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(runID, now))
 
 	// Mock concurrency check
@@ -2576,6 +2596,7 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2640,6 +2661,7 @@ func TestSessionHandler_CreatePR_NoDiff(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2694,6 +2716,7 @@ func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2791,6 +2814,7 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2861,6 +2885,7 @@ func TestSessionHandler_CancelSession_Success(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2915,6 +2940,7 @@ func TestSessionHandler_CancelSession_NotRunning(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),
@@ -2993,6 +3019,7 @@ func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
 				nil, // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
+				nil, // team_id
 				nil, // deleted_at
 				now,
 			),

--- a/internal/api/handlers/team_resolve.go
+++ b/internal/api/handlers/team_resolve.go
@@ -1,0 +1,44 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// teamLookup is the subset of *db.TeamStore needed to verify a team_id.
+type teamLookup interface {
+	GetByID(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error)
+}
+
+// resolveTeamID parses and validates a team_id string from a request body,
+// optionally verifying that it belongs to orgID via lookup (pass nil to skip
+// the lookup — useful in tests or for handlers that don't have a team store).
+// Returns (nil, true) when raw is empty.
+// Returns (nil, false) after writing an error response on validation failure.
+func resolveTeamID(w http.ResponseWriter, r *http.Request, lookup teamLookup, orgID uuid.UUID, raw string) (*uuid.UUID, bool) {
+	if raw == "" {
+		return nil, true
+	}
+	parsed, err := uuid.Parse(raw)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_TEAM_ID", "invalid team_id")
+		return nil, false
+	}
+	if lookup != nil {
+		if _, err := lookup.GetByID(r.Context(), orgID, parsed); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				writeError(w, r, http.StatusNotFound, "TEAM_NOT_FOUND", "team not found in this organization")
+				return nil, false
+			}
+			writeError(w, r, http.StatusInternalServerError, "TEAM_LOOKUP_FAILED", "failed to verify team", err)
+			return nil, false
+		}
+	}
+	return &parsed, true
+}

--- a/internal/api/handlers/team_resolve_test.go
+++ b/internal/api/handlers/team_resolve_test.go
@@ -1,0 +1,116 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type mockTeamLookup struct {
+	getByIDFn func(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error)
+}
+
+func (m *mockTeamLookup) GetByID(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, orgID, teamID)
+	}
+	return models.Team{ID: teamID, OrgID: orgID}, nil
+}
+
+func TestResolveTeamID_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	id, ok := resolveTeamID(rec, req, nil, uuid.New(), "")
+	require.True(t, ok)
+	require.Nil(t, id)
+	require.Equal(t, http.StatusOK, rec.Code) // no response written
+}
+
+func TestResolveTeamID_InvalidUUID(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	id, ok := resolveTeamID(rec, req, nil, uuid.New(), "not-a-uuid")
+	require.False(t, ok)
+	require.Nil(t, id)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "INVALID_TEAM_ID")
+}
+
+func TestResolveTeamID_CrossTenantRejected(t *testing.T) {
+	t.Parallel()
+
+	lookup := &mockTeamLookup{
+		getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.Team, error) {
+			return models.Team{}, pgx.ErrNoRows
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	id, ok := resolveTeamID(rec, req, lookup, uuid.New(), uuid.NewString())
+	require.False(t, ok)
+	require.Nil(t, id)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "TEAM_NOT_FOUND")
+}
+
+func TestResolveTeamID_LookupError(t *testing.T) {
+	t.Parallel()
+
+	lookup := &mockTeamLookup{
+		getByIDFn: func(_ context.Context, _, _ uuid.UUID) (models.Team, error) {
+			return models.Team{}, errors.New("boom")
+		},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	id, ok := resolveTeamID(rec, req, lookup, uuid.New(), uuid.NewString())
+	require.False(t, ok)
+	require.Nil(t, id)
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+	require.Contains(t, rec.Body.String(), "TEAM_LOOKUP_FAILED")
+}
+
+func TestResolveTeamID_NilLookupSkipsVerification(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	raw := uuid.NewString()
+	id, ok := resolveTeamID(rec, req, nil, uuid.New(), raw)
+	require.True(t, ok)
+	require.NotNil(t, id)
+	require.Equal(t, raw, id.String())
+}
+
+func TestResolveTeamID_ValidLookupSucceeds(t *testing.T) {
+	t.Parallel()
+
+	lookup := &mockTeamLookup{} // default returns team found
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	raw := uuid.NewString()
+	id, ok := resolveTeamID(rec, req, lookup, uuid.New(), raw)
+	require.True(t, ok)
+	require.NotNil(t, id)
+	require.Equal(t, raw, id.String())
+}

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -1,0 +1,536 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	ghservice "github.com/assembledhq/143/internal/services/github"
+)
+
+// orgTeamStore is the interface the org teams handler depends on.
+type orgTeamStore interface {
+	Create(ctx context.Context, team *models.Team) error
+	Update(ctx context.Context, orgID, teamID uuid.UUID, name, slug string, description *string) error
+	Delete(ctx context.Context, orgID, teamID uuid.UUID) error
+	GetByID(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error)
+	ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Team, error)
+	ListByUser(ctx context.Context, orgID, userID uuid.UUID) ([]models.Team, error)
+	AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID, role string) error
+	RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error
+	ListMembers(ctx context.Context, orgID, teamID uuid.UUID) ([]models.User, error)
+	SyncFromGitHub(ctx context.Context, orgID uuid.UUID, ghTeams []db.GitHubTeamSync) error
+}
+
+// orgTeamUserStore verifies a user belongs to the org.
+type orgTeamUserStore interface {
+	GetByID(ctx context.Context, orgID, userID uuid.UUID) (models.User, error)
+}
+
+// orgTeamIntegrationStore is needed to look up the GitHub integration for sync.
+type orgTeamIntegrationStore interface {
+	ListByOrgAndProvider(ctx context.Context, orgID uuid.UUID, provider string) ([]models.Integration, error)
+}
+
+// orgTeamRepoStore is needed to derive the GitHub org name from repos.
+type orgTeamRepoStore interface {
+	ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error)
+}
+
+// OrgTeamHandler serves the /api/v1/teams/* endpoints.
+type OrgTeamHandler struct {
+	teams        orgTeamStore
+	users        orgTeamUserStore
+	integrations orgTeamIntegrationStore
+	repos        orgTeamRepoStore
+	githubSvc    *ghservice.Service
+	audit        *db.AuditEmitter
+}
+
+// NewOrgTeamHandler creates a new org teams handler.
+func NewOrgTeamHandler(teams orgTeamStore, users orgTeamUserStore) *OrgTeamHandler {
+	return &OrgTeamHandler{teams: teams, users: users}
+}
+
+// SetAuditEmitter injects the audit emitter.
+func (h *OrgTeamHandler) SetAuditEmitter(audit *db.AuditEmitter) { h.audit = audit }
+
+// SetGitHubSync injects the dependencies needed for GitHub team sync.
+func (h *OrgTeamHandler) SetGitHubSync(ghSvc *ghservice.Service, integrations orgTeamIntegrationStore, repos orgTeamRepoStore) {
+	h.githubSvc = ghSvc
+	h.integrations = integrations
+	h.repos = repos
+}
+
+var slugRE = regexp.MustCompile(`[^a-z0-9-]+`)
+
+func toSlug(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = slugRE.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "team"
+	}
+	return s
+}
+
+type teamBody struct {
+	Name        string  `json:"name"`
+	Slug        string  `json:"slug"`
+	Description *string `json:"description"`
+}
+
+// decodeTeamBody decodes and validates a team create/update request body.
+// Returns false (and writes an error response) when validation fails.
+func decodeTeamBody(w http.ResponseWriter, r *http.Request) (teamBody, bool) {
+	var body teamBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return body, false
+	}
+	body.Name = strings.TrimSpace(body.Name)
+	if body.Name == "" {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "name is required")
+		return body, false
+	}
+	if body.Slug == "" {
+		body.Slug = toSlug(body.Name)
+	} else {
+		body.Slug = toSlug(body.Slug)
+	}
+	return body, true
+}
+
+// List returns all teams in the org.
+func (h *OrgTeamHandler) List(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teams, err := h.teams.ListByOrg(r.Context(), orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list teams", err)
+		return
+	}
+	if teams == nil {
+		teams = []models.Team{}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.Team]{Data: teams})
+}
+
+// ListMine returns teams the current user belongs to.
+func (h *OrgTeamHandler) ListMine(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+
+	teams, err := h.teams.ListByUser(r.Context(), orgID, user.ID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list user teams", err)
+		return
+	}
+	if teams == nil {
+		teams = []models.Team{}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.Team]{Data: teams})
+}
+
+// Create creates a new team.
+func (h *OrgTeamHandler) Create(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	body, ok := decodeTeamBody(w, r)
+	if !ok {
+		return
+	}
+
+	team := &models.Team{
+		OrgID:       orgID,
+		Name:        body.Name,
+		Slug:        body.Slug,
+		Description: body.Description,
+	}
+
+	if err := h.teams.Create(r.Context(), team); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			writeError(w, r, http.StatusConflict, "SLUG_EXISTS", "a team with this slug already exists")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create team", err)
+		return
+	}
+
+	teamIDStr := team.ID.String()
+	details, _ := json.Marshal(map[string]string{"name": team.Name, "slug": team.Slug})
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamCreated, models.AuditResourceOrgTeam, &teamIDStr, details)
+
+	writeJSON(w, http.StatusCreated, models.SingleResponse[models.Team]{Data: *team})
+}
+
+// Get returns a single team with its members.
+func (h *OrgTeamHandler) Get(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teamID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid team ID")
+		return
+	}
+
+	team, err := h.teams.GetByID(r.Context(), orgID, teamID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "GET_FAILED", "failed to get team", err)
+		return
+	}
+
+	members, err := h.teams.ListMembers(r.Context(), orgID, teamID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_MEMBERS_FAILED", "failed to list members", err)
+		return
+	}
+	if members == nil {
+		members = []models.User{}
+	}
+
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.TeamWithMembers]{
+		Data: models.TeamWithMembers{Team: team, Members: members},
+	})
+}
+
+// Update modifies a team's name, slug, and description.
+func (h *OrgTeamHandler) Update(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teamID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid team ID")
+		return
+	}
+
+	body, ok := decodeTeamBody(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.teams.Update(r.Context(), orgID, teamID, body.Name, body.Slug, body.Description); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team not found")
+			return
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			writeError(w, r, http.StatusConflict, "SLUG_EXISTS", "a team with this slug already exists")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update team", err)
+		return
+	}
+
+	teamIDStr := teamID.String()
+	details, _ := json.Marshal(map[string]string{"name": body.Name, "slug": body.Slug})
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamUpdated, models.AuditResourceOrgTeam, &teamIDStr, details)
+
+	team, err := h.teams.GetByID(r.Context(), orgID, teamID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "GET_FAILED", "failed to get updated team", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.Team]{Data: team})
+}
+
+// Delete removes a team.
+func (h *OrgTeamHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teamID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid team ID")
+		return
+	}
+
+	if err := h.teams.Delete(r.Context(), orgID, teamID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "DELETE_FAILED", "failed to delete team", err)
+		return
+	}
+
+	teamIDStr := teamID.String()
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamDeleted, models.AuditResourceOrgTeam, &teamIDStr, nil)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// AddMember adds a user to a team.
+func (h *OrgTeamHandler) AddMember(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teamID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid team ID")
+		return
+	}
+
+	var body struct {
+		UserID string `json:"user_id"`
+		Role   string `json:"role"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+
+	userID, err := uuid.Parse(body.UserID)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid user_id")
+		return
+	}
+
+	if body.Role == "" {
+		body.Role = models.TeamRoleMember
+	}
+	if body.Role != models.TeamRoleMember && body.Role != models.TeamRoleLead {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", fmt.Sprintf("role must be '%s' or '%s'", models.TeamRoleMember, models.TeamRoleLead))
+		return
+	}
+
+	// Verify team exists in this org.
+	if _, err := h.teams.GetByID(r.Context(), orgID, teamID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "GET_FAILED", "failed to verify team", err)
+		return
+	}
+
+	// Verify the target user belongs to the same org.
+	if _, err := h.users.GetByID(r.Context(), orgID, userID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "USER_NOT_FOUND", "user not found in this organization")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "GET_USER_FAILED", "failed to verify user", err)
+		return
+	}
+
+	if err := h.teams.AddMember(r.Context(), orgID, teamID, userID, body.Role); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team or user not found in this organization")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "ADD_MEMBER_FAILED", "failed to add member", err)
+		return
+	}
+
+	teamIDStr := teamID.String()
+	details, _ := json.Marshal(map[string]string{"user_id": userID.String(), "role": body.Role})
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamMemberAdded, models.AuditResourceOrgTeam, &teamIDStr, details)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// RemoveMember removes a user from a team.
+func (h *OrgTeamHandler) RemoveMember(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	teamID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid team ID")
+		return
+	}
+
+	userID, err := uuid.Parse(chi.URLParam(r, "userId"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid user ID")
+		return
+	}
+
+	// Verify team exists in this org.
+	if _, err := h.teams.GetByID(r.Context(), orgID, teamID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "team not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "GET_FAILED", "failed to verify team", err)
+		return
+	}
+
+	if err := h.teams.RemoveMember(r.Context(), orgID, teamID, userID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "MEMBER_NOT_FOUND", "user is not a member of this team")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "REMOVE_MEMBER_FAILED", "failed to remove member", err)
+		return
+	}
+
+	teamIDStr := teamID.String()
+	details, _ := json.Marshal(map[string]string{"user_id": userID.String()})
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamMemberRemoved, models.AuditResourceOrgTeam, &teamIDStr, details)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// SyncGitHub syncs teams and memberships from GitHub.
+func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	orgID := middleware.OrgIDFromContext(ctx)
+
+	// Read the optional request body up front so it's available later.
+	// An empty body is allowed (we fall back to deriving org from repos), but a
+	// malformed body is rejected so the caller knows the org field was ignored.
+	var reqBody struct {
+		Org string `json:"org"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil && !errors.Is(err, io.EOF) {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+
+	if h.githubSvc == nil || h.integrations == nil || h.repos == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_NOT_CONFIGURED", "GitHub App is not configured")
+		return
+	}
+
+	// Find GitHub integration for this org.
+	integrations, err := h.integrations.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_INTEGRATIONS_FAILED", "failed to list integrations", err)
+		return
+	}
+	if len(integrations) == 0 {
+		writeError(w, r, http.StatusNotFound, "NO_GITHUB_INTEGRATION", "no active GitHub integration found")
+		return
+	}
+
+	integration := integrations[0]
+	var config struct {
+		InstallationID int64 `json:"installation_id"`
+	}
+	if integration.Config != nil {
+		if err := json.Unmarshal(integration.Config, &config); err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_CONFIG", "failed to parse integration config")
+			return
+		}
+	}
+	if config.InstallationID == 0 {
+		writeError(w, r, http.StatusBadRequest, "NO_INSTALLATION", "GitHub integration has no installation ID")
+		return
+	}
+
+	token, err := h.githubSvc.GetInstallationToken(ctx, config.InstallationID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "TOKEN_FAILED", "failed to get GitHub installation token", err)
+		return
+	}
+
+	// Derive GitHub org name from repos, falling back to the request body.
+	githubOrg := reqBody.Org
+	if githubOrg == "" {
+		repos, repoErr := h.repos.ListByOrg(ctx, orgID)
+		if repoErr == nil {
+			for _, repo := range repos {
+				if parts := strings.SplitN(repo.FullName, "/", 2); len(parts) == 2 {
+					githubOrg = parts[0]
+					break
+				}
+			}
+		}
+	}
+
+	if githubOrg == "" {
+		writeError(w, r, http.StatusBadRequest, "NO_GITHUB_ORG", "could not determine GitHub org name — pass {\"org\": \"...\"} in request body")
+		return
+	}
+
+	// Fetch teams from GitHub.
+	ghTeams, err := h.githubSvc.ListOrgTeams(ctx, token, githubOrg)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "GITHUB_TEAMS_FAILED", "failed to fetch GitHub teams", err)
+		return
+	}
+
+	type syncResult struct {
+		sync db.GitHubTeamSync
+		ok   bool
+	}
+	results := make([]syncResult, len(ghTeams))
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 10)
+	for i, ght := range ghTeams {
+		wg.Add(1)
+		go func(idx int, ght ghservice.GitHubTeam) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			members, memberErr := h.githubSvc.ListTeamMembers(ctx, token, githubOrg, ght.Slug)
+			if memberErr != nil {
+				zerolog.Ctx(ctx).Warn().Err(memberErr).Str("team", ght.Slug).Msg("failed to fetch team members, skipping")
+				return
+			}
+
+			memberIDs := make([]int64, len(members))
+			for j, m := range members {
+				memberIDs[j] = m.ID
+			}
+
+			desc := ght.Description
+			results[idx] = syncResult{
+				sync: db.GitHubTeamSync{
+					GitHubTeamID:    ght.ID,
+					GitHubTeamSlug:  ght.Slug,
+					Name:            ght.Name,
+					Description:     &desc,
+					MemberGitHubIDs: memberIDs,
+				},
+				ok: true,
+			}
+		}(i, ght)
+	}
+	wg.Wait()
+
+	syncTeams := make([]db.GitHubTeamSync, 0, len(ghTeams))
+	for _, r := range results {
+		if r.ok {
+			syncTeams = append(syncTeams, r.sync)
+		}
+	}
+
+	if err := h.teams.SyncFromGitHub(ctx, orgID, syncTeams); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "SYNC_FAILED", "failed to sync teams from GitHub", err)
+		return
+	}
+
+	emitUserAudit(h.audit, r, models.AuditActionOrgTeamGitHubSynced, models.AuditResourceOrgTeam, nil, nil)
+
+	// Return updated team list.
+	teams, err := h.teams.ListByOrg(ctx, orgID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "sync succeeded but failed to list teams", err)
+		return
+	}
+	if teams == nil {
+		teams = []models.Team{}
+	}
+	writeJSON(w, http.StatusOK, models.ListResponse[models.Team]{Data: teams})
+}

--- a/internal/api/handlers/teams.go
+++ b/internal/api/handlers/teams.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 
@@ -412,18 +413,25 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find GitHub integration for this org.
+	// Find GitHub integration for this org. Filter to active integrations so a
+	// stale/revoked integration ahead of an active one doesn't leak bad creds.
 	integrations, err := h.integrations.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_INTEGRATIONS_FAILED", "failed to list integrations", err)
 		return
 	}
-	if len(integrations) == 0 {
+	var integration *models.Integration
+	for i := range integrations {
+		if integrations[i].Status == models.IntegrationStatusActive {
+			integration = &integrations[i]
+			break
+		}
+	}
+	if integration == nil {
 		writeError(w, r, http.StatusNotFound, "NO_GITHUB_INTEGRATION", "no active GitHub integration found")
 		return
 	}
 
-	integration := integrations[0]
 	var config struct {
 		InstallationID int64 `json:"installation_id"`
 	}
@@ -445,15 +453,34 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Derive GitHub org name from repos, falling back to the request body.
+	// Pick the owner that appears most often across the org's repos so we're
+	// deterministic when repos span multiple GitHub orgs; ties break
+	// alphabetically to keep the choice stable across calls.
 	githubOrg := reqBody.Org
 	if githubOrg == "" {
 		repos, repoErr := h.repos.ListByOrg(ctx, orgID)
 		if repoErr == nil {
+			counts := map[string]int{}
 			for _, repo := range repos {
-				if parts := strings.SplitN(repo.FullName, "/", 2); len(parts) == 2 {
-					githubOrg = parts[0]
-					break
+				if parts := strings.SplitN(repo.FullName, "/", 2); len(parts) == 2 && parts[0] != "" {
+					counts[parts[0]]++
 				}
+			}
+			maxCount := 0
+			for _, n := range counts {
+				if n > maxCount {
+					maxCount = n
+				}
+			}
+			tied := make([]string, 0, len(counts))
+			for owner, n := range counts {
+				if n == maxCount {
+					tied = append(tied, owner)
+				}
+			}
+			sort.Strings(tied)
+			if len(tied) > 0 {
+				githubOrg = tied[0]
 			}
 		}
 	}
@@ -470,11 +497,11 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type syncResult struct {
-		sync db.GitHubTeamSync
-		ok   bool
-	}
-	results := make([]syncResult, len(ghTeams))
+	// Each slot holds a non-nil *db.GitHubTeamSync on success, nil on failure.
+	// A nil pointer is an explicit "skipped" marker rather than relying on an
+	// uninitialised zero-value struct.
+	results := make([]*db.GitHubTeamSync, len(ghTeams))
+	skippedSlugs := make([]string, len(ghTeams))
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 10)
 	for i, ght := range ghTeams {
@@ -486,6 +513,7 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 			members, memberErr := h.githubSvc.ListTeamMembers(ctx, token, githubOrg, ght.Slug)
 			if memberErr != nil {
 				zerolog.Ctx(ctx).Warn().Err(memberErr).Str("team", ght.Slug).Msg("failed to fetch team members, skipping")
+				skippedSlugs[idx] = ght.Slug
 				return
 			}
 
@@ -494,25 +522,29 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 				memberIDs[j] = m.ID
 			}
 
-			desc := ght.Description
-			results[idx] = syncResult{
-				sync: db.GitHubTeamSync{
-					GitHubTeamID:    ght.ID,
-					GitHubTeamSlug:  ght.Slug,
-					Name:            ght.Name,
-					Description:     &desc,
-					MemberGitHubIDs: memberIDs,
-				},
-				ok: true,
+			var descPtr *string
+			if ght.Description != "" {
+				desc := ght.Description
+				descPtr = &desc
+			}
+			results[idx] = &db.GitHubTeamSync{
+				GitHubTeamID:    ght.ID,
+				GitHubTeamSlug:  ght.Slug,
+				Name:            ght.Name,
+				Description:     descPtr,
+				MemberGitHubIDs: memberIDs,
 			}
 		}(i, ght)
 	}
 	wg.Wait()
 
 	syncTeams := make([]db.GitHubTeamSync, 0, len(ghTeams))
-	for _, r := range results {
-		if r.ok {
-			syncTeams = append(syncTeams, r.sync)
+	skipped := make([]string, 0)
+	for i, res := range results {
+		if res != nil {
+			syncTeams = append(syncTeams, *res)
+		} else if skippedSlugs[i] != "" {
+			skipped = append(skipped, skippedSlugs[i])
 		}
 	}
 
@@ -523,7 +555,10 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 
 	emitUserAudit(h.audit, r, models.AuditActionOrgTeamGitHubSynced, models.AuditResourceOrgTeam, nil, nil)
 
-	// Return updated team list.
+	// Return updated team list. `skipped_slugs` lists GitHub teams whose member
+	// fetch failed and were excluded from this sync — non-empty means callers
+	// should retry to pick up missing teams. Stale teams that no longer exist
+	// on GitHub are intentionally left untouched; this sync only upserts.
 	teams, err := h.teams.ListByOrg(ctx, orgID)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "sync succeeded but failed to list teams", err)
@@ -532,5 +567,17 @@ func (h *OrgTeamHandler) SyncGitHub(w http.ResponseWriter, r *http.Request) {
 	if teams == nil {
 		teams = []models.Team{}
 	}
-	writeJSON(w, http.StatusOK, models.ListResponse[models.Team]{Data: teams})
+	writeJSON(w, http.StatusOK, syncResponse{
+		Data:         teams,
+		Synced:       len(syncTeams),
+		Skipped:      len(skipped),
+		SkippedSlugs: skipped,
+	})
+}
+
+type syncResponse struct {
+	Data         []models.Team `json:"data"`
+	Synced       int           `json:"synced"`
+	Skipped      int           `json:"skipped"`
+	SkippedSlugs []string      `json:"skipped_slugs"`
 }

--- a/internal/api/handlers/teams_test.go
+++ b/internal/api/handlers/teams_test.go
@@ -266,6 +266,122 @@ func TestOrgTeamHandler_SyncGitHub_503WhenNotConfigured(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "GITHUB_NOT_CONFIGURED")
 }
 
+// --- Update ---
+
+func TestOrgTeamHandler_Update_Success(t *testing.T) {
+	t.Parallel()
+
+	var capturedName, capturedSlug string
+	teams := &mockOrgTeamStore{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, name, slug string, _ *string) error {
+			capturedName = name
+			capturedSlug = slug
+			return nil
+		},
+		getByIDFn: func(_ context.Context, orgID, teamID uuid.UUID) (models.Team, error) {
+			return models.Team{ID: teamID, OrgID: orgID, Name: "Renamed", Slug: "renamed"}, nil
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	body := map[string]string{"name": "Renamed"}
+	buf, _ := json.Marshal(body)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/teams/"+teamID.String(), bytes.NewReader(buf))
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "Renamed", capturedName)
+	require.Equal(t, "renamed", capturedSlug)
+	require.Contains(t, rec.Body.String(), "Renamed")
+}
+
+func TestOrgTeamHandler_Update_NotFound(t *testing.T) {
+	t.Parallel()
+
+	teams := &mockOrgTeamStore{
+		updateFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID, _, _ string, _ *string) error {
+			return pgx.ErrNoRows
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	body := map[string]string{"name": "X"}
+	buf, _ := json.Marshal(body)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/teams/"+teamID.String(), bytes.NewReader(buf))
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.Update(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "NOT_FOUND")
+}
+
+// --- Delete ---
+
+func TestOrgTeamHandler_Delete_Success(t *testing.T) {
+	t.Parallel()
+
+	var capturedOrgID, capturedTeamID uuid.UUID
+	teams := &mockOrgTeamStore{
+		deleteFn: func(_ context.Context, orgID, teamID uuid.UUID) error {
+			capturedOrgID = orgID
+			capturedTeamID = teamID
+			return nil
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	orgID := uuid.New()
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/teams/"+teamID.String(), nil)
+	req = req.WithContext(withChiParam(orgTeamCtx(orgID, &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.Delete(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Equal(t, orgID, capturedOrgID)
+	require.Equal(t, teamID, capturedTeamID)
+}
+
+func TestOrgTeamHandler_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	teams := &mockOrgTeamStore{
+		deleteFn: func(_ context.Context, _, _ uuid.UUID) error {
+			return pgx.ErrNoRows
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/teams/"+teamID.String(), nil)
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.Delete(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "NOT_FOUND")
+}
+
+func TestOrgTeamHandler_Delete_RejectsInvalidID(t *testing.T) {
+	t.Parallel()
+
+	h := newOrgTeamHandler(nil, nil)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/teams/not-a-uuid", nil)
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", "not-a-uuid"))
+	rec := httptest.NewRecorder()
+
+	h.Delete(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "INVALID_ID")
+}
+
 // --- toSlug helper ---
 
 func TestToSlug(t *testing.T) {

--- a/internal/api/handlers/teams_test.go
+++ b/internal/api/handlers/teams_test.go
@@ -1,0 +1,284 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// --- mocks for orgTeamStore and orgTeamUserStore ---
+
+type mockOrgTeamStore struct {
+	createFn       func(ctx context.Context, team *models.Team) error
+	updateFn       func(ctx context.Context, orgID, teamID uuid.UUID, name, slug string, description *string) error
+	deleteFn       func(ctx context.Context, orgID, teamID uuid.UUID) error
+	getByIDFn      func(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error)
+	listByOrgFn    func(ctx context.Context, orgID uuid.UUID) ([]models.Team, error)
+	listByUserFn   func(ctx context.Context, orgID, userID uuid.UUID) ([]models.Team, error)
+	addMemberFn    func(ctx context.Context, orgID, teamID, userID uuid.UUID, role string) error
+	removeMemberFn func(ctx context.Context, orgID, teamID, userID uuid.UUID) error
+	listMembersFn  func(ctx context.Context, orgID, teamID uuid.UUID) ([]models.User, error)
+	syncFn         func(ctx context.Context, orgID uuid.UUID, ghTeams []db.GitHubTeamSync) error
+}
+
+func (m *mockOrgTeamStore) Create(ctx context.Context, team *models.Team) error {
+	if m.createFn != nil {
+		return m.createFn(ctx, team)
+	}
+	team.ID = uuid.New()
+	return nil
+}
+func (m *mockOrgTeamStore) Update(ctx context.Context, orgID, teamID uuid.UUID, name, slug string, description *string) error {
+	if m.updateFn != nil {
+		return m.updateFn(ctx, orgID, teamID, name, slug, description)
+	}
+	return nil
+}
+func (m *mockOrgTeamStore) Delete(ctx context.Context, orgID, teamID uuid.UUID) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(ctx, orgID, teamID)
+	}
+	return nil
+}
+func (m *mockOrgTeamStore) GetByID(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, orgID, teamID)
+	}
+	return models.Team{ID: teamID, OrgID: orgID, Name: "Frontend", Slug: "frontend"}, nil
+}
+func (m *mockOrgTeamStore) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Team, error) {
+	if m.listByOrgFn != nil {
+		return m.listByOrgFn(ctx, orgID)
+	}
+	return nil, nil
+}
+func (m *mockOrgTeamStore) ListByUser(ctx context.Context, orgID, userID uuid.UUID) ([]models.Team, error) {
+	if m.listByUserFn != nil {
+		return m.listByUserFn(ctx, orgID, userID)
+	}
+	return nil, nil
+}
+func (m *mockOrgTeamStore) AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID, role string) error {
+	if m.addMemberFn != nil {
+		return m.addMemberFn(ctx, orgID, teamID, userID, role)
+	}
+	return nil
+}
+func (m *mockOrgTeamStore) RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error {
+	if m.removeMemberFn != nil {
+		return m.removeMemberFn(ctx, orgID, teamID, userID)
+	}
+	return nil
+}
+func (m *mockOrgTeamStore) ListMembers(ctx context.Context, orgID, teamID uuid.UUID) ([]models.User, error) {
+	if m.listMembersFn != nil {
+		return m.listMembersFn(ctx, orgID, teamID)
+	}
+	return nil, nil
+}
+func (m *mockOrgTeamStore) SyncFromGitHub(ctx context.Context, orgID uuid.UUID, ghTeams []db.GitHubTeamSync) error {
+	if m.syncFn != nil {
+		return m.syncFn(ctx, orgID, ghTeams)
+	}
+	return nil
+}
+
+type mockOrgTeamUserStore struct {
+	getByIDFn func(ctx context.Context, orgID, userID uuid.UUID) (models.User, error)
+}
+
+func (m *mockOrgTeamUserStore) GetByID(ctx context.Context, orgID, userID uuid.UUID) (models.User, error) {
+	if m.getByIDFn != nil {
+		return m.getByIDFn(ctx, orgID, userID)
+	}
+	return models.User{ID: userID, OrgID: orgID}, nil
+}
+
+// --- helpers ---
+
+func newOrgTeamHandler(teams *mockOrgTeamStore, users *mockOrgTeamUserStore) *OrgTeamHandler {
+	if teams == nil {
+		teams = &mockOrgTeamStore{}
+	}
+	if users == nil {
+		users = &mockOrgTeamUserStore{}
+	}
+	return NewOrgTeamHandler(teams, users)
+}
+
+func orgTeamCtx(orgID uuid.UUID, user *models.User) context.Context {
+	ctx := context.Background()
+	ctx = middleware.WithOrgID(ctx, orgID)
+	if user != nil {
+		ctx = middleware.WithUser(ctx, user)
+	}
+	return ctx
+}
+
+// --- Create validation ---
+
+func TestOrgTeamHandler_Create_RejectsMissingName(t *testing.T) {
+	t.Parallel()
+
+	h := newOrgTeamHandler(nil, nil)
+	body := map[string]string{"name": "   "}
+	buf, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams", bytes.NewReader(buf))
+	req = req.WithContext(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}))
+	rec := httptest.NewRecorder()
+
+	h.Create(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOrgTeamHandler_Create_DerivesSlugFromName(t *testing.T) {
+	t.Parallel()
+
+	var captured *models.Team
+	teams := &mockOrgTeamStore{
+		createFn: func(_ context.Context, team *models.Team) error {
+			captured = team
+			team.ID = uuid.New()
+			return nil
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	body := map[string]string{"name": "Mobile Apps"}
+	buf, _ := json.Marshal(body)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams", bytes.NewReader(buf))
+	req = req.WithContext(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}))
+	rec := httptest.NewRecorder()
+
+	h.Create(rec, req)
+	require.Equal(t, http.StatusCreated, rec.Code)
+	require.NotNil(t, captured)
+	require.Equal(t, "mobile-apps", captured.Slug)
+}
+
+// --- AddMember validation ---
+
+func TestOrgTeamHandler_AddMember_RejectsInvalidRole(t *testing.T) {
+	t.Parallel()
+
+	h := newOrgTeamHandler(nil, nil)
+	body := map[string]string{"user_id": uuid.NewString(), "role": "captain"}
+	buf, _ := json.Marshal(body)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams/"+teamID.String()+"/members", bytes.NewReader(buf))
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.AddMember(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "VALIDATION_ERROR")
+}
+
+func TestOrgTeamHandler_AddMember_RejectsInvalidUserID(t *testing.T) {
+	t.Parallel()
+
+	h := newOrgTeamHandler(nil, nil)
+	body := map[string]string{"user_id": "not-a-uuid"}
+	buf, _ := json.Marshal(body)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams/"+teamID.String()+"/members", bytes.NewReader(buf))
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.AddMember(rec, req)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "INVALID_USER_ID")
+}
+
+func TestOrgTeamHandler_AddMember_RejectsCrossOrgUser(t *testing.T) {
+	t.Parallel()
+
+	users := &mockOrgTeamUserStore{
+		getByIDFn: func(_ context.Context, _ uuid.UUID, _ uuid.UUID) (models.User, error) {
+			return models.User{}, pgx.ErrNoRows
+		},
+	}
+	h := newOrgTeamHandler(nil, users)
+
+	body := map[string]string{"user_id": uuid.NewString()}
+	buf, _ := json.Marshal(body)
+
+	teamID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams/"+teamID.String()+"/members", bytes.NewReader(buf))
+	req = req.WithContext(withChiParam(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}), "id", teamID.String()))
+	rec := httptest.NewRecorder()
+
+	h.AddMember(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	require.Contains(t, rec.Body.String(), "USER_NOT_FOUND")
+}
+
+// --- ListMine ---
+
+func TestOrgTeamHandler_ListMine_ReturnsCallerTeams(t *testing.T) {
+	t.Parallel()
+
+	userID := uuid.New()
+	teams := &mockOrgTeamStore{
+		listByUserFn: func(_ context.Context, _ uuid.UUID, uid uuid.UUID) ([]models.Team, error) {
+			require.Equal(t, userID, uid)
+			return []models.Team{{ID: uuid.New(), Name: "Platform"}}, nil
+		},
+	}
+	h := newOrgTeamHandler(teams, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/teams/mine", nil)
+	req = req.WithContext(orgTeamCtx(uuid.New(), &models.User{ID: userID}))
+	rec := httptest.NewRecorder()
+
+	h.ListMine(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "Platform")
+}
+
+// --- SyncGitHub guard ---
+
+func TestOrgTeamHandler_SyncGitHub_503WhenNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	h := newOrgTeamHandler(nil, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/teams/sync-github", nil)
+	req = req.WithContext(orgTeamCtx(uuid.New(), &models.User{ID: uuid.New()}))
+	rec := httptest.NewRecorder()
+
+	h.SyncGitHub(rec, req)
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "GITHUB_NOT_CONFIGURED")
+}
+
+// --- toSlug helper ---
+
+func TestToSlug(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct{ in, want string }{
+		{"Frontend", "frontend"},
+		{"  Mobile Apps  ", "mobile-apps"},
+		{"!!!", "team"},
+		{"data/eng", "data-eng"},
+		{"a___b", "a-b"},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.want, toSlug(c.in), "input=%q", c.in)
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -164,6 +164,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger,
 	)
 	sessionHandler.SetViewStore(sessionViewStore)
+	sessionHandler.SetTeamStore(teamStore)
 	threadSvc := threadservice.NewService(
 		sessionThreadStore,
 		sessionStore,
@@ -209,6 +210,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 
 	projectHandler := handlers.NewProjectHandler(projectStore, projectTaskStore, projectCycleStore, projectAttachmentStore, projectSpecStore)
 	projectHandler.SetJobStore(jobStore)
+	projectHandler.SetTeamStore(teamStore)
 
 	automationStore := db.NewAutomationStore(pool)
 	automationRunStore := db.NewAutomationRunStore(pool)
@@ -445,9 +447,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/settings/credentials/resolved", userCredentialHandler.ListResolved)
 			r.Get("/api/v1/settings/credentials/team", userCredentialHandler.ListTeamDefaults)
 
-			// Teams — summary list and caller-scoped list are safe for all roles.
-			// Full team detail (with members) is admin-only; see below.
-			r.Get("/api/v1/teams", orgTeamHandler.List)
+			// Non-admins can only see the teams they belong to. The full org-wide
+			// list (and member details) is admin-only; see below.
 			r.Get("/api/v1/teams/mine", orgTeamHandler.ListMine)
 
 			r.Get("/api/v1/repositories", repoHandler.List)
@@ -683,6 +684,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/audit-logs/{id}", auditLogHandler.Get)
 
 			// Org teams management
+			r.Get("/api/v1/teams", orgTeamHandler.List)
 			r.Post("/api/v1/teams", orgTeamHandler.Create)
 			r.Get("/api/v1/teams/{id}", orgTeamHandler.Get)
 			r.Patch("/api/v1/teams/{id}", orgTeamHandler.Update)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -69,6 +69,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	evalBatchStore := db.NewEvalBatchStore(pool)
 	evalBootstrapStore := db.NewEvalBootstrapStore(pool)
 	sessionReviewCommentStore := db.NewSessionReviewCommentStore(pool)
+	teamStore := db.NewTeamStore(pool)
 	previewStore := db.NewPreviewStore(pool)
 	auditLogStore := db.NewAuditLogStore(pool)
 	auditEmitter := db.NewAuditEmitter(auditLogStore, logger)
@@ -194,6 +195,15 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
 			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
+		}
+	}
+
+	orgTeamHandler := handlers.NewOrgTeamHandler(teamStore, userStore)
+	orgTeamHandler.SetAuditEmitter(auditEmitter)
+	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+		if err == nil {
+			orgTeamHandler.SetGitHubSync(ghSvc, integrationStore, repoStore)
 		}
 	}
 
@@ -435,6 +445,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Get("/api/v1/settings/credentials/resolved", userCredentialHandler.ListResolved)
 			r.Get("/api/v1/settings/credentials/team", userCredentialHandler.ListTeamDefaults)
 
+			// Teams — summary list and caller-scoped list are safe for all roles.
+			// Full team detail (with members) is admin-only; see below.
+			r.Get("/api/v1/teams", orgTeamHandler.List)
+			r.Get("/api/v1/teams/mine", orgTeamHandler.ListMine)
+
 			r.Get("/api/v1/repositories", repoHandler.List)
 			r.Get("/api/v1/repositories/summary", repoHandler.Summary)
 			r.Get("/api/v1/repositories/{id}", repoHandler.Get)
@@ -666,6 +681,15 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			// Audit logs
 			r.Get("/api/v1/audit-logs", auditLogHandler.List)
 			r.Get("/api/v1/audit-logs/{id}", auditLogHandler.Get)
+
+			// Org teams management
+			r.Post("/api/v1/teams", orgTeamHandler.Create)
+			r.Get("/api/v1/teams/{id}", orgTeamHandler.Get)
+			r.Patch("/api/v1/teams/{id}", orgTeamHandler.Update)
+			r.Delete("/api/v1/teams/{id}", orgTeamHandler.Delete)
+			r.Post("/api/v1/teams/{id}/members", orgTeamHandler.AddMember)
+			r.Delete("/api/v1/teams/{id}/members/{userId}", orgTeamHandler.RemoveMember)
+			r.Post("/api/v1/teams/sync-github", orgTeamHandler.SyncGitHub)
 
 			// Team management
 			r.Get("/api/v1/team/members", teamHandler.ListMembers)

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -36,24 +36,24 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil, nil, []string{}, false,
 		nil, json.RawMessage(`{}`), nil, nil, nil,
 		nil, nil, nil, nil,
-		nil, // project_task_id
-		nil, // model_override
-		nil, // triggered_by_user_id
-		nil, // agent_session_id
-		0,   // current_turn
-		nil, // last_activity_at
-		"none", // sandbox_state
-		nil,    // snapshot_key
-		nil,    // target_branch
-		nil,    // working_branch
-		nil,    // repository_id
-		nil,    // diff_stats
-		nil,    // diff_history
-		nil,    // input_manifest
+		nil,      // project_task_id
+		nil,      // model_override
+		nil,      // triggered_by_user_id
+		nil,      // agent_session_id
+		0,        // current_turn
+		nil,      // last_activity_at
+		"none",   // sandbox_state
+		nil,      // snapshot_key
+		nil,      // target_branch
+		nil,      // working_branch
+		nil,      // repository_id
+		nil,      // diff_stats
+		nil,      // diff_history
+		nil,      // input_manifest
 		nil, nil, // archived_at, archived_by_user_id
-		nil,    // automation_run_id
-		nil,    // team_id
-		nil,    // deleted_at
+		nil, // automation_run_id
+		nil, // team_id
+		nil, // deleted_at
 		now,
 	}
 }

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -25,7 +25,7 @@ var sessionColumns = []string{
 	"agent_session_id", "current_turn", "last_activity_at",
 	"sandbox_state", "snapshot_key", "target_branch", "working_branch",
 	"repository_id", "diff_stats", "diff_history", "input_manifest",
-	"archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
@@ -52,6 +52,7 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil,    // input_manifest
 		nil, nil, // archived_at, archived_by_user_id
 		nil,    // automation_run_id
+		nil,    // team_id
 		nil,    // deleted_at
 		now,
 	}
@@ -262,7 +263,7 @@ func TestSessionStore_Create(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),
@@ -300,7 +301,7 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at"}).
 				AddRow(generatedID, now),

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -59,7 +59,7 @@ func TestProjectStore_Create(t *testing.T) {
 
 	// Create wraps insert + join-table writes in a transaction.
 	mock.ExpectBegin()
-	// Create has 26 named args (including agent_type, model_override, schedule, and similar_projects fields)
+	// Create has 27 named args (incl. agent_type, model_override, schedule fields, similar_projects, team_id)
 	mock.ExpectQuery("INSERT INTO projects").
 		WithArgs(anyArgs(27)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(projectID, now, now))
@@ -273,7 +273,7 @@ func TestProjectStore_Update(t *testing.T) {
 	orgID := uuid.New()
 	projectID := uuid.New()
 
-	// Update has 24 named args (including schedule and similar_projects fields)
+	// Update has 25 named args (incl. schedule, similar_projects, team_id)
 	mock.ExpectExec("UPDATE projects SET").
 		WithArgs(anyArgs(25)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -21,7 +21,7 @@ var projectTestColumns = []string{
 	"proposed_by_pm", "source_issue_ids", "proposal_reasoning", "similar_projects",
 	"agent_type", "model_override",
 	"schedule_enabled", "schedule_interval", "schedule_unit", "next_run_at",
-	"created_by", "deleted_at", "created_at", "updated_at", "completed_at",
+	"created_by", "team_id", "deleted_at", "created_at", "updated_at", "completed_at",
 }
 
 func newProjectRow(projectID, orgID, repoID uuid.UUID, now time.Time) []interface{} {
@@ -33,7 +33,7 @@ func newProjectRow(projectID, orgID, repoID uuid.UUID, now time.Time) []interfac
 		false, []uuid.UUID{}, nil, json.RawMessage(`[]`),
 		nil, nil,
 		false, 1, "days", nil,
-		nil, (*time.Time)(nil), now, now, nil,
+		nil, nil, (*time.Time)(nil), now, now, nil,
 	}
 }
 
@@ -61,7 +61,7 @@ func TestProjectStore_Create(t *testing.T) {
 	mock.ExpectBegin()
 	// Create has 26 named args (including agent_type, model_override, schedule, and similar_projects fields)
 	mock.ExpectQuery("INSERT INTO projects").
-		WithArgs(anyArgs(26)...).
+		WithArgs(anyArgs(27)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(projectID, now, now))
 	mock.ExpectCommit()
 
@@ -275,7 +275,7 @@ func TestProjectStore_Update(t *testing.T) {
 
 	// Update has 24 named args (including schedule and similar_projects fields)
 	mock.ExpectExec("UPDATE projects SET").
-		WithArgs(anyArgs(24)...).
+		WithArgs(anyArgs(25)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	project := &models.Project{

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -27,7 +27,7 @@ type ProjectFilters struct {
 	Cursor       string
 	RepositoryID uuid.UUID
 	Search       string    // When non-empty, filter projects by title or goal (case-insensitive substring match).
-	ProposedByPM *bool    // When non-nil, filter by proposed_by_pm flag.
+	ProposedByPM *bool     // When non-nil, filter by proposed_by_pm flag.
 	TeamID       uuid.UUID // When non-zero, filter projects by team.
 }
 

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -26,8 +26,9 @@ type ProjectFilters struct {
 	Limit        int
 	Cursor       string
 	RepositoryID uuid.UUID
-	Search       string // When non-empty, filter projects by title or goal (case-insensitive substring match).
-	ProposedByPM *bool  // When non-nil, filter by proposed_by_pm flag.
+	Search       string    // When non-empty, filter projects by title or goal (case-insensitive substring match).
+	ProposedByPM *bool    // When non-nil, filter by proposed_by_pm flag.
+	TeamID       uuid.UUID // When non-zero, filter projects by team.
 }
 
 // projectColumns is the column list shared across all project queries.
@@ -38,7 +39,7 @@ const projectColumns = `id, org_id, repository_id, title, goal, scope, completio
 	proposed_by_pm, source_issue_ids, proposal_reasoning, similar_projects,
 	agent_type, model_override,
 	schedule_enabled, schedule_interval, schedule_unit, next_run_at,
-	created_by, deleted_at, created_at, updated_at, completed_at`
+	created_by, team_id, deleted_at, created_at, updated_at, completed_at`
 
 func scanProject(row pgx.Row) (models.Project, error) {
 	var p models.Project
@@ -53,7 +54,7 @@ func scanProject(row pgx.Row) (models.Project, error) {
 		&p.ProposedByPM, &sourceIssueIDs, &p.ProposalReasoning, &p.SimilarProjects,
 		&p.AgentType, &p.ModelOverride,
 		&p.ScheduleEnabled, &p.ScheduleInterval, &p.ScheduleUnit, &p.NextRunAt,
-		&p.CreatedBy, &p.DeletedAt, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
+		&p.CreatedBy, &p.TeamID, &p.DeletedAt, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
 	)
 	if err != nil {
 		return models.Project{}, err
@@ -89,7 +90,7 @@ func scanProjects(rows pgx.Rows) ([]models.Project, error) {
 			&p.ProposedByPM, &sourceIssueIDs, &p.ProposalReasoning, &p.SimilarProjects,
 			&p.AgentType, &p.ModelOverride,
 			&p.ScheduleEnabled, &p.ScheduleInterval, &p.ScheduleUnit, &p.NextRunAt,
-			&p.CreatedBy, &p.DeletedAt, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
+			&p.CreatedBy, &p.TeamID, &p.DeletedAt, &p.CreatedAt, &p.UpdatedAt, &p.CompletedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -142,7 +143,8 @@ func (s *ProjectStore) Create(ctx context.Context, p *models.Project) error {
 			current_phase, lessons_learned, approach_history,
 			proposed_by_pm, source_issue_ids, proposal_reasoning, similar_projects, created_by,
 			agent_type, model_override,
-			schedule_enabled, schedule_interval, schedule_unit, next_run_at
+			schedule_enabled, schedule_interval, schedule_unit, next_run_at,
+			team_id
 		)
 		VALUES (
 			@org_id, @repository_id, @title, @goal, @scope, @completion_criteria,
@@ -150,7 +152,8 @@ func (s *ProjectStore) Create(ctx context.Context, p *models.Project) error {
 			@current_phase, @lessons_learned, @approach_history,
 			@proposed_by_pm, @source_issue_ids, @proposal_reasoning, @similar_projects, @created_by,
 			@agent_type, @model_override,
-			@schedule_enabled, @schedule_interval, @schedule_unit, @next_run_at
+			@schedule_enabled, @schedule_interval, @schedule_unit, @next_run_at,
+			@team_id
 		)
 		RETURNING id, created_at, updated_at`
 
@@ -181,6 +184,7 @@ func (s *ProjectStore) Create(ctx context.Context, p *models.Project) error {
 		"schedule_interval":   p.ScheduleInterval,
 		"schedule_unit":       p.ScheduleUnit,
 		"next_run_at":         p.NextRunAt,
+		"team_id":             p.TeamID,
 	})
 	if err := row.Scan(&p.ID, &p.CreatedAt, &p.UpdatedAt); err != nil {
 		return err
@@ -222,6 +226,10 @@ func applyProjectFilters(query string, args pgx.NamedArgs, filters ProjectFilter
 	if filters.ProposedByPM != nil {
 		query += ` AND proposed_by_pm = @proposed_by_pm`
 		args["proposed_by_pm"] = *filters.ProposedByPM
+	}
+	if filters.TeamID != uuid.Nil {
+		query += ` AND team_id = @team_id`
+		args["team_id"] = filters.TeamID
 	}
 	if filters.Search != "" {
 		query += ` AND (title ILIKE @search OR goal ILIKE @search)`
@@ -298,6 +306,7 @@ func (s *ProjectStore) Update(ctx context.Context, p *models.Project) error {
 			total_tasks = @total_tasks, completed_tasks = @completed_tasks, failed_tasks = @failed_tasks,
 			schedule_enabled = @schedule_enabled, schedule_interval = @schedule_interval,
 			schedule_unit = @schedule_unit, next_run_at = @next_run_at,
+			team_id = @team_id,
 			completed_at = @completed_at, updated_at = now()
 		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 
@@ -325,6 +334,7 @@ func (s *ProjectStore) Update(ctx context.Context, p *models.Project) error {
 		"schedule_interval":   p.ScheduleInterval,
 		"schedule_unit":       p.ScheduleUnit,
 		"next_run_at":         p.NextRunAt,
+		"team_id":             p.TeamID,
 		"completed_at":        p.CompletedAt,
 	})
 	return err

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -38,6 +38,7 @@ type SessionFilters struct {
 	Search            string     // When non-empty, filter sessions by title (case-insensitive prefix/substring match).
 	IncludeArchived   bool       // When true, include archived sessions in the results.
 	OnlyArchived      bool       // When true, return only archived sessions.
+	TeamID            uuid.UUID  // When non-zero, filter sessions by team.
 }
 
 // sessionSelectColumns is used for single-session queries where we want all fields.
@@ -49,7 +50,7 @@ const sessionSelectColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-00
 	parent_session_id, revision_context, error, result_summary, diff,
 	pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 	model_override, triggered_by_user_id, agent_session_id, current_turn, last_activity_at,
-	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, deleted_at, created_at`
+	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, team_id, deleted_at, created_at`
 
 // sessionListColumns excludes large JSONB blobs (diff_history) from list queries
 // to avoid returning multi-megabyte payloads when listing many sessions.
@@ -61,7 +62,7 @@ const sessionListColumns = `id, COALESCE(issue_id, '00000000-0000-0000-0000-0000
 	parent_session_id, revision_context, error, result_summary, diff,
 	pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
 	model_override, triggered_by_user_id, agent_session_id, current_turn, last_activity_at,
-	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, deleted_at, created_at`
+	sandbox_state, snapshot_key, target_branch, working_branch, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, team_id, deleted_at, created_at`
 
 // maxDiffHistoryEntries caps the number of entries kept in diff_history.
 // Older entries beyond this limit are pruned when a new entry is appended.
@@ -141,6 +142,10 @@ func (s *SessionStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters S
 		escaped := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(filters.Search)
 		args["search"] = "%" + escaped + "%"
 	}
+	if filters.TeamID != uuid.Nil {
+		query += ` AND team_id = @team_id`
+		args["team_id"] = filters.TeamID
+	}
 	if filters.AdHocOnly {
 		query += ` AND pm_plan_id IS NULL`
 	}
@@ -188,12 +193,12 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 		INSERT INTO sessions (
 			issue_id, org_id, agent_type, status, autonomy_level, token_mode, complexity_tier,
 			parent_session_id, revision_context, pm_plan_id, title, pm_approach, pm_reasoning, project_task_id,
-			model_override, triggered_by_user_id, target_branch, repository_id, automation_run_id
+			model_override, triggered_by_user_id, target_branch, repository_id, automation_run_id, team_id
 		)
 		VALUES (
 			@issue_id, @org_id, @agent_type, @status, @autonomy_level, @token_mode, @complexity_tier,
 			@parent_session_id, @revision_context, @pm_plan_id, @title, @pm_approach, @pm_reasoning, @project_task_id,
-			@model_override, @triggered_by_user_id, @target_branch, @repository_id, @automation_run_id
+			@model_override, @triggered_by_user_id, @target_branch, @repository_id, @automation_run_id, @team_id
 		)
 		RETURNING id, created_at`
 
@@ -222,6 +227,7 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 		"target_branch":        run.TargetBranch,
 		"repository_id":        run.RepositoryID,
 		"automation_run_id":    run.AutomationRunID,
+		"team_id":              run.TeamID,
 	}
 
 	row := s.db.QueryRow(ctx, query, args)

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -21,7 +21,7 @@ var sessionTestColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []interface{} {
@@ -42,6 +42,7 @@ func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []in
 		nil, // input_manifest
 		nil, nil, // archived_at, archived_by_user_id
 		nil, // automation_run_id
+		nil, // team_id
 		nil, // deleted_at
 		now,
 	}

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -66,19 +66,10 @@ func (s *TeamStore) Update(ctx context.Context, orgID, teamID uuid.UUID, name, s
 	return nil
 }
 
-// Delete removes a team. Memberships cascade-delete.
+// Delete removes a team. Memberships cascade-delete; sessions and projects
+// have their team_id cleared by the FK ON DELETE SET NULL.
 func (s *TeamStore) Delete(ctx context.Context, orgID, teamID uuid.UUID) error {
-	// Clear team_id references on sessions and projects before deleting the team.
-	query := `
-		WITH clear_sessions AS (
-			UPDATE sessions SET team_id = NULL WHERE team_id = @id AND org_id = @org_id
-		),
-		clear_projects AS (
-			UPDATE projects SET team_id = NULL WHERE team_id = @id AND org_id = @org_id
-		)
-		DELETE FROM teams WHERE id = @id AND org_id = @org_id`
-
-	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+	ct, err := s.db.Exec(ctx, `DELETE FROM teams WHERE id = @id AND org_id = @org_id`, pgx.NamedArgs{
 		"id":     teamID,
 		"org_id": orgID,
 	})
@@ -389,6 +380,12 @@ func upsertGitHubTeam(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, ght GitHu
 		},
 	).Scan(&teamID)
 	if err == nil {
+		zerolog.Ctx(ctx).Info().
+			Str("team", ght.Name).
+			Str("slug", ght.GitHubTeamSlug).
+			Int64("github_team_id", ght.GitHubTeamID).
+			Str("team_id", teamID.String()).
+			Msg("adopted manually-created team into GitHub sync (slug match)")
 		return teamID, false, nil
 	}
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -1,0 +1,435 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// TeamStore handles CRUD for teams and team memberships.
+type TeamStore struct {
+	db TxStarter
+}
+
+// NewTeamStore creates a new TeamStore.
+func NewTeamStore(db TxStarter) *TeamStore {
+	return &TeamStore{db: db}
+}
+
+const teamColumns = `id, org_id, name, slug, description, github_team_id, github_team_slug, created_at, updated_at`
+
+// Create inserts a new team.
+func (s *TeamStore) Create(ctx context.Context, team *models.Team) error {
+	query := `
+		INSERT INTO teams (org_id, name, slug, description, github_team_id, github_team_slug)
+		VALUES (@org_id, @name, @slug, @description, @github_team_id, @github_team_slug)
+		RETURNING id, created_at, updated_at`
+
+	args := pgx.NamedArgs{
+		"org_id":           team.OrgID,
+		"name":             team.Name,
+		"slug":             team.Slug,
+		"description":      team.Description,
+		"github_team_id":   team.GitHubTeamID,
+		"github_team_slug": team.GitHubTeamSlug,
+	}
+
+	return s.db.QueryRow(ctx, query, args).Scan(&team.ID, &team.CreatedAt, &team.UpdatedAt)
+}
+
+// Update modifies an existing team.
+func (s *TeamStore) Update(ctx context.Context, orgID, teamID uuid.UUID, name, slug string, description *string) error {
+	query := `
+		UPDATE teams
+		SET name = @name, slug = @slug, description = @description, updated_at = now()
+		WHERE id = @id AND org_id = @org_id`
+
+	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":          teamID,
+		"org_id":      orgID,
+		"name":        name,
+		"slug":        slug,
+		"description": description,
+	})
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// Delete removes a team. Memberships cascade-delete.
+func (s *TeamStore) Delete(ctx context.Context, orgID, teamID uuid.UUID) error {
+	// Clear team_id references on sessions and projects before deleting the team.
+	query := `
+		WITH clear_sessions AS (
+			UPDATE sessions SET team_id = NULL WHERE team_id = @id AND org_id = @org_id
+		),
+		clear_projects AS (
+			UPDATE projects SET team_id = NULL WHERE team_id = @id AND org_id = @org_id
+		)
+		DELETE FROM teams WHERE id = @id AND org_id = @org_id`
+
+	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     teamID,
+		"org_id": orgID,
+	})
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// GetByID returns a single team.
+func (s *TeamStore) GetByID(ctx context.Context, orgID, teamID uuid.UUID) (models.Team, error) {
+	query := fmt.Sprintf(`
+		SELECT %s,
+			(SELECT COUNT(*) FROM team_memberships WHERE team_id = t.id) AS member_count
+		FROM teams t
+		WHERE t.id = @id AND t.org_id = @org_id`, teamColumns)
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"id":     teamID,
+		"org_id": orgID,
+	})
+	if err != nil {
+		return models.Team{}, fmt.Errorf("query team: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Team])
+}
+
+// ListByOrg returns all teams in the org with member counts.
+func (s *TeamStore) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Team, error) {
+	query := fmt.Sprintf(`
+		SELECT %s,
+			COALESCE(mc.cnt, 0) AS member_count
+		FROM teams t
+		LEFT JOIN (
+			SELECT team_id, COUNT(*) AS cnt FROM team_memberships GROUP BY team_id
+		) mc ON mc.team_id = t.id
+		WHERE t.org_id = @org_id
+		ORDER BY t.name ASC`, teamColumns)
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
+	if err != nil {
+		return nil, fmt.Errorf("query teams: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Team])
+}
+
+// ListByUser returns teams the given user belongs to.
+func (s *TeamStore) ListByUser(ctx context.Context, orgID, userID uuid.UUID) ([]models.Team, error) {
+	query := fmt.Sprintf(`
+		SELECT %s,
+			COALESCE(mc.cnt, 0) AS member_count
+		FROM teams t
+		JOIN team_memberships tm ON tm.team_id = t.id AND tm.user_id = @user_id
+		LEFT JOIN (
+			SELECT team_id, COUNT(*) AS cnt FROM team_memberships GROUP BY team_id
+		) mc ON mc.team_id = t.id
+		WHERE t.org_id = @org_id
+		ORDER BY t.name ASC`, teamColumns)
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":  orgID,
+		"user_id": userID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query user teams: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Team])
+}
+
+// AddMember adds a user to a team. The team and user must belong to orgID.
+func (s *TeamStore) AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID, role string) error {
+	query := `
+		INSERT INTO team_memberships (org_id, team_id, user_id, role)
+		SELECT @org_id, @team_id, @user_id, @role
+		FROM teams t
+		WHERE t.id = @team_id AND t.org_id = @org_id
+		  AND EXISTS (SELECT 1 FROM users u WHERE u.id = @user_id AND u.org_id = @org_id)
+		ON CONFLICT (team_id, user_id) DO UPDATE SET role = EXCLUDED.role`
+
+	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"org_id":  orgID,
+		"team_id": teamID,
+		"user_id": userID,
+		"role":    role,
+	})
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// RemoveMember removes a user from a team scoped to orgID.
+func (s *TeamStore) RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error {
+	query := `
+		DELETE FROM team_memberships
+		WHERE team_id = @team_id AND user_id = @user_id AND org_id = @org_id`
+	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"org_id":  orgID,
+		"team_id": teamID,
+		"user_id": userID,
+	})
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// ListMembers returns all users in a team scoped to orgID.
+func (s *TeamStore) ListMembers(ctx context.Context, orgID, teamID uuid.UUID) ([]models.User, error) {
+	query := fmt.Sprintf(`
+		SELECT %s
+		FROM users u
+		JOIN team_memberships tm ON tm.user_id = u.id AND tm.org_id = @org_id
+		WHERE tm.team_id = @team_id AND u.org_id = @org_id
+		ORDER BY u.name ASC`, userSelectColumns)
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":  orgID,
+		"team_id": teamID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query team members: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.User])
+}
+
+// GitHubTeamSync is the input for bulk-syncing teams from GitHub.
+type GitHubTeamSync struct {
+	GitHubTeamID   int64
+	GitHubTeamSlug string
+	Name           string
+	Description    *string
+	// MemberGitHubIDs are the GitHub user IDs that belong to this team.
+	MemberGitHubIDs []int64
+}
+
+// SyncFromGitHub upserts teams and memberships from GitHub in a single transaction.
+// It creates/updates teams, adds new memberships, and removes stale memberships.
+func (s *TeamStore) SyncFromGitHub(ctx context.Context, orgID uuid.UUID, ghTeams []GitHubTeamSync) error {
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	for _, ght := range ghTeams {
+		teamID, skip, err := upsertGitHubTeam(ctx, tx, orgID, ght)
+		if err != nil {
+			return err
+		}
+		if skip {
+			continue
+		}
+
+		if len(ght.MemberGitHubIDs) == 0 {
+			if _, err := tx.Exec(ctx, `DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`,
+				pgx.NamedArgs{"team_id": teamID, "org_id": orgID}); err != nil {
+				return fmt.Errorf("clear memberships for team %s: %w", ght.Name, err)
+			}
+			continue
+		}
+
+		rows, err := tx.Query(ctx, `
+			SELECT id FROM users
+			WHERE org_id = @org_id AND github_id = ANY(@github_ids)`,
+			pgx.NamedArgs{
+				"org_id":     orgID,
+				"github_ids": ght.MemberGitHubIDs,
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("resolve github users for team %s: %w", ght.Name, err)
+		}
+
+		var localUserIDs []uuid.UUID
+		for rows.Next() {
+			var uid uuid.UUID
+			if err := rows.Scan(&uid); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan user: %w", err)
+			}
+			localUserIDs = append(localUserIDs, uid)
+		}
+		rows.Close()
+		// Guard against partial iteration: a stream error would leave localUserIDs
+		// incomplete and cause the prune step below to delete valid memberships.
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("iterate github users for team %s: %w", ght.Name, err)
+		}
+
+		if len(localUserIDs) > 0 {
+			batch := &pgx.Batch{}
+			for _, uid := range localUserIDs {
+				batch.Queue(`
+					INSERT INTO team_memberships (org_id, team_id, user_id, role)
+					VALUES (@org_id, @team_id, @user_id, @role)
+					ON CONFLICT (team_id, user_id) DO NOTHING`,
+					pgx.NamedArgs{
+						"org_id":  orgID,
+						"team_id": teamID,
+						"user_id": uid,
+						"role":    models.TeamRoleMember,
+					},
+				)
+			}
+			br := tx.SendBatch(ctx, batch)
+			for range localUserIDs {
+				if _, err := br.Exec(); err != nil {
+					br.Close()
+					return fmt.Errorf("upsert membership: %w", err)
+				}
+			}
+			br.Close()
+		}
+
+		// Remove memberships for users no longer in the GitHub team.
+		if len(localUserIDs) > 0 {
+			_, err = tx.Exec(ctx, `
+				DELETE FROM team_memberships
+				WHERE team_id = @team_id AND org_id = @org_id AND user_id != ALL(@user_ids)`,
+				pgx.NamedArgs{
+					"team_id":  teamID,
+					"org_id":   orgID,
+					"user_ids": localUserIDs,
+				},
+			)
+		} else {
+			_, err = tx.Exec(ctx, `DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`,
+				pgx.NamedArgs{"team_id": teamID, "org_id": orgID})
+		}
+		if err != nil {
+			return fmt.Errorf("prune memberships for team %s: %w", ght.Name, err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+// upsertGitHubTeam inserts or updates a single team row, handling both
+// (org_id, github_team_id) and (org_id, slug) unique constraints without
+// aborting the caller's transaction. If the GitHub team's slug collides
+// with another github-linked team, the sync skips this team (skip=true).
+func upsertGitHubTeam(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, ght GitHubTeamSync) (teamID uuid.UUID, skip bool, err error) {
+	// 1. Look for an existing row linked by github_team_id.
+	err = tx.QueryRow(ctx, `
+		SELECT id FROM teams
+		WHERE org_id = @org_id AND github_team_id = @github_team_id`,
+		pgx.NamedArgs{"org_id": orgID, "github_team_id": ght.GitHubTeamID},
+	).Scan(&teamID)
+	if err == nil {
+		// Update by id. If the desired slug collides with another team, keep the existing slug.
+		if updErr := updateGitHubTeamByID(ctx, tx, teamID, ght); updErr != nil {
+			return uuid.Nil, false, updErr
+		}
+		return teamID, false, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, false, fmt.Errorf("lookup team %s: %w", ght.Name, err)
+	}
+
+	// 2. Not linked yet — attempt insert, skipping if the slug is taken.
+	err = tx.QueryRow(ctx, `
+		INSERT INTO teams (org_id, name, slug, description, github_team_id, github_team_slug)
+		VALUES (@org_id, @name, @slug, @description, @github_team_id, @github_team_slug)
+		ON CONFLICT (org_id, slug) DO NOTHING
+		RETURNING id`,
+		pgx.NamedArgs{
+			"org_id":           orgID,
+			"name":             ght.Name,
+			"slug":             ght.GitHubTeamSlug,
+			"description":      ght.Description,
+			"github_team_id":   ght.GitHubTeamID,
+			"github_team_slug": ght.GitHubTeamSlug,
+		},
+	).Scan(&teamID)
+	if err == nil {
+		return teamID, false, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, false, fmt.Errorf("insert team %s: %w", ght.Name, err)
+	}
+
+	// 3. Slug is taken — adopt the existing row if it isn't already linked to
+	// a different GitHub team.
+	err = tx.QueryRow(ctx, `
+		UPDATE teams
+		SET name = @name, description = @description,
+			github_team_id = @github_team_id, github_team_slug = @github_team_slug,
+			updated_at = now()
+		WHERE org_id = @org_id AND slug = @slug AND github_team_id IS NULL
+		RETURNING id`,
+		pgx.NamedArgs{
+			"org_id":           orgID,
+			"slug":             ght.GitHubTeamSlug,
+			"name":             ght.Name,
+			"description":      ght.Description,
+			"github_team_id":   ght.GitHubTeamID,
+			"github_team_slug": ght.GitHubTeamSlug,
+		},
+	).Scan(&teamID)
+	if err == nil {
+		return teamID, false, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		zerolog.Ctx(ctx).Warn().
+			Str("team", ght.Name).
+			Str("slug", ght.GitHubTeamSlug).
+			Int64("github_team_id", ght.GitHubTeamID).
+			Msg("slug already owned by a different GitHub team; skipping sync for this team")
+		return uuid.Nil, true, nil
+	}
+	return uuid.Nil, false, fmt.Errorf("adopt team %s by slug: %w", ght.Name, err)
+}
+
+// updateGitHubTeamByID applies the desired GitHub metadata to an existing team row.
+// The slug change is only applied if it doesn't conflict with another team — any
+// unique violation here would otherwise abort the caller's transaction.
+func updateGitHubTeamByID(ctx context.Context, tx pgx.Tx, id uuid.UUID, ght GitHubTeamSync) error {
+	_, err := tx.Exec(ctx, `
+		UPDATE teams AS t
+		SET name = @name,
+			slug = CASE
+				WHEN NOT EXISTS (
+					SELECT 1 FROM teams t2
+					WHERE t2.org_id = t.org_id AND t2.slug = @slug AND t2.id <> t.id
+				) THEN @slug
+				ELSE t.slug
+			END,
+			description = @description,
+			github_team_slug = @github_team_slug,
+			updated_at = now()
+		WHERE t.id = @id`,
+		pgx.NamedArgs{
+			"id":               id,
+			"name":             ght.Name,
+			"slug":             ght.GitHubTeamSlug,
+			"description":      ght.Description,
+			"github_team_slug": ght.GitHubTeamSlug,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("update team %s: %w", ght.Name, err)
+	}
+	return nil
+}

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -295,8 +295,11 @@ func (s *TeamStore) SyncFromGitHub(ctx context.Context, orgID uuid.UUID, ghTeams
 		}
 
 		// Remove memberships for users no longer in the GitHub team.
+		// If GitHub reported members but none resolve to local users (e.g., users
+		// haven't onboarded yet), skip pruning so we don't wipe manually-added
+		// memberships. The earlier branch already handles the truly-empty case.
 		if len(localUserIDs) > 0 {
-			_, err = tx.Exec(ctx, `
+			if _, err := tx.Exec(ctx, `
 				DELETE FROM team_memberships
 				WHERE team_id = @team_id AND org_id = @org_id AND user_id != ALL(@user_ids)`,
 				pgx.NamedArgs{
@@ -304,13 +307,14 @@ func (s *TeamStore) SyncFromGitHub(ctx context.Context, orgID uuid.UUID, ghTeams
 					"org_id":   orgID,
 					"user_ids": localUserIDs,
 				},
-			)
+			); err != nil {
+				return fmt.Errorf("prune memberships for team %s: %w", ght.Name, err)
+			}
 		} else {
-			_, err = tx.Exec(ctx, `DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`,
-				pgx.NamedArgs{"team_id": teamID, "org_id": orgID})
-		}
-		if err != nil {
-			return fmt.Errorf("prune memberships for team %s: %w", ght.Name, err)
+			zerolog.Ctx(ctx).Warn().
+				Str("team", ght.Name).
+				Int("github_member_count", len(ght.MemberGitHubIDs)).
+				Msg("GitHub team has members but none resolve to local users; skipping membership prune to preserve manually-added members")
 		}
 	}
 

--- a/internal/db/teams_test.go
+++ b/internal/db/teams_test.go
@@ -1,0 +1,299 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func newTeamRow(orgID uuid.UUID, name, slug string, ghTeamID *int64, memberCount int, now time.Time) ([]string, []any) {
+	cols := []string{
+		"id", "org_id", "name", "slug", "description",
+		"github_team_id", "github_team_slug",
+		"created_at", "updated_at", "member_count",
+	}
+	id := uuid.New()
+	return cols, []any{
+		id, orgID, name, slug, nil,
+		ghTeamID, nil,
+		now, now, memberCount,
+	}
+}
+
+func TestTeamStore_Create(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	now := time.Now()
+	generatedID := uuid.New()
+
+	mock.ExpectQuery("INSERT INTO teams").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(generatedID, now, now))
+
+	team := &models.Team{OrgID: orgID, Name: "Frontend", Slug: "frontend"}
+	require.NoError(t, store.Create(context.Background(), team))
+	require.Equal(t, generatedID, team.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTeamStore_Delete_PlainDelete(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	teamID := uuid.New()
+
+	// Verifies the CTE was dropped — only a plain DELETE FROM teams remains;
+	// FK ON DELETE SET NULL clears session/project team_id references.
+	mock.ExpectExec(`^DELETE FROM teams WHERE id = @id AND org_id = @org_id$`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+	require.NoError(t, store.Delete(context.Background(), orgID, teamID))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTeamStore_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	mock.ExpectExec("DELETE FROM teams").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+
+	err = store.Delete(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTeamStore_AddMember_NoMatchingTeamOrUser(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	mock.ExpectExec("INSERT INTO team_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 0))
+
+	err = store.AddMember(context.Background(), uuid.New(), uuid.New(), uuid.New(), models.TeamRoleMember)
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTeamStore_RemoveMember_NotInTeam(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	mock.ExpectExec("DELETE FROM team_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+
+	err = store.RemoveMember(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, pgx.ErrNoRows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTeamStore_ListByOrg(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	now := time.Now()
+	cols, row := newTeamRow(orgID, "Frontend", "frontend", nil, 3, now)
+
+	mock.ExpectQuery("SELECT .+ FROM teams t").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(cols).AddRow(row...))
+
+	teams, err := store.ListByOrg(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Len(t, teams, 1)
+	require.Equal(t, "Frontend", teams[0].Name)
+	require.Equal(t, 3, teams[0].MemberCount)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// --- SyncFromGitHub branches ---
+
+// expectGitHubLookupHit sets up the SELECT-by-github_team_id branch returning a row.
+func expectGitHubLookupHit(mock pgxmock.PgxPoolIface, existingTeamID uuid.UUID) {
+	mock.ExpectQuery(`SELECT id FROM teams\s+WHERE org_id = @org_id AND github_team_id = @github_team_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(existingTeamID))
+}
+
+// expectGitHubLookupMiss sets up the SELECT-by-github_team_id branch returning no rows.
+func expectGitHubLookupMiss(mock pgxmock.PgxPoolIface) {
+	mock.ExpectQuery(`SELECT id FROM teams\s+WHERE org_id = @org_id AND github_team_id = @github_team_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+}
+
+func TestSyncFromGitHub_LinkByGitHubTeamID(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	existingID := uuid.New()
+
+	mock.ExpectBegin()
+	expectGitHubLookupHit(mock, existingID)
+	// updateGitHubTeamByID
+	mock.ExpectExec(`UPDATE teams AS t`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// No members → DELETE clear
+	mock.ExpectExec(`DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectCommit()
+
+	err = store.SyncFromGitHub(context.Background(), orgID, []GitHubTeamSync{{
+		GitHubTeamID:   42,
+		GitHubTeamSlug: "frontend",
+		Name:           "Frontend",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncFromGitHub_FreshInsert(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	newID := uuid.New()
+
+	mock.ExpectBegin()
+	expectGitHubLookupMiss(mock)
+	// INSERT ... ON CONFLICT DO NOTHING RETURNING id → returns id
+	mock.ExpectQuery(`INSERT INTO teams \(org_id, name, slug, description, github_team_id, github_team_slug\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(newID))
+	// No members → DELETE clear
+	mock.ExpectExec(`DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectCommit()
+
+	err = store.SyncFromGitHub(context.Background(), orgID, []GitHubTeamSync{{
+		GitHubTeamID: 99, GitHubTeamSlug: "platform", Name: "Platform",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncFromGitHub_AdoptManualTeamBySlug(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+	adoptedID := uuid.New()
+
+	mock.ExpectBegin()
+	expectGitHubLookupMiss(mock)
+	// INSERT collides on slug → returns ErrNoRows
+	mock.ExpectQuery(`INSERT INTO teams \(org_id, name, slug, description, github_team_id, github_team_slug\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+	// UPDATE adopts manual team (github_team_id IS NULL) → returns adopted id
+	mock.ExpectQuery(`UPDATE teams\s+SET name = @name`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(adoptedID))
+	mock.ExpectExec(`DELETE FROM team_memberships WHERE team_id = @team_id AND org_id = @org_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("DELETE", 0))
+	mock.ExpectCommit()
+
+	err = store.SyncFromGitHub(context.Background(), orgID, []GitHubTeamSync{{
+		GitHubTeamID: 7, GitHubTeamSlug: "frontend", Name: "Frontend",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncFromGitHub_SkipWhenSlugOwnedByDifferentGitHubTeam(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+
+	mock.ExpectBegin()
+	expectGitHubLookupMiss(mock)
+	mock.ExpectQuery(`INSERT INTO teams \(org_id, name, slug, description, github_team_id, github_team_slug\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+	// UPDATE adoption fails because slug is owned by another github-linked team
+	// (WHERE github_team_id IS NULL filters us out).
+	mock.ExpectQuery(`UPDATE teams\s+SET name = @name`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectCommit()
+
+	err = store.SyncFromGitHub(context.Background(), orgID, []GitHubTeamSync{{
+		GitHubTeamID: 13, GitHubTeamSlug: "frontend", Name: "Frontend",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSyncFromGitHub_RollsBackOnLookupError(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewTeamStore(mock)
+	orgID := uuid.New()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`SELECT id FROM teams\s+WHERE org_id = @org_id AND github_team_id = @github_team_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("boom"))
+	mock.ExpectRollback()
+
+	err = store.SyncFromGitHub(context.Background(), orgID, []GitHubTeamSync{{
+		GitHubTeamID: 1, GitHubTeamSlug: "x", Name: "X",
+	}})
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -90,12 +90,12 @@ const (
 	AuditActionTeamInvitationAccepted AuditAction = "team.invitation_accepted"
 
 	// Org-level teams actions (distinct from team member management above)
-	AuditActionOrgTeamCreated     AuditAction = "org_team.created"
-	AuditActionOrgTeamUpdated     AuditAction = "org_team.updated"
-	AuditActionOrgTeamDeleted     AuditAction = "org_team.deleted"
-	AuditActionOrgTeamMemberAdded AuditAction = "org_team.member_added"
+	AuditActionOrgTeamCreated       AuditAction = "org_team.created"
+	AuditActionOrgTeamUpdated       AuditAction = "org_team.updated"
+	AuditActionOrgTeamDeleted       AuditAction = "org_team.deleted"
+	AuditActionOrgTeamMemberAdded   AuditAction = "org_team.member_added"
 	AuditActionOrgTeamMemberRemoved AuditAction = "org_team.member_removed"
-	AuditActionOrgTeamGitHubSynced AuditAction = "org_team.github_synced"
+	AuditActionOrgTeamGitHubSynced  AuditAction = "org_team.github_synced"
 
 	// Integration & credential actions
 	AuditActionIntegrationConnected AuditAction = "integration.connected"

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -89,6 +89,14 @@ const (
 	AuditActionTeamInvitationRevoked  AuditAction = "team.invitation_revoked"
 	AuditActionTeamInvitationAccepted AuditAction = "team.invitation_accepted"
 
+	// Org-level teams actions (distinct from team member management above)
+	AuditActionOrgTeamCreated     AuditAction = "org_team.created"
+	AuditActionOrgTeamUpdated     AuditAction = "org_team.updated"
+	AuditActionOrgTeamDeleted     AuditAction = "org_team.deleted"
+	AuditActionOrgTeamMemberAdded AuditAction = "org_team.member_added"
+	AuditActionOrgTeamMemberRemoved AuditAction = "org_team.member_removed"
+	AuditActionOrgTeamGitHubSynced AuditAction = "org_team.github_synced"
+
 	// Integration & credential actions
 	AuditActionIntegrationConnected AuditAction = "integration.connected"
 	AuditActionCredentialUpdated    AuditAction = "credential.updated" // #nosec G101 -- not a credential
@@ -133,7 +141,9 @@ func (a AuditAction) Validate() error {
 		AuditActionIntegrationConnected, AuditActionCredentialUpdated, AuditActionCredentialDeleted,
 		AuditActionAuthLogin, AuditActionAuthLogout, AuditActionAuthRegister,
 		AuditActionEvalTaskCreated, AuditActionEvalTaskUpdated, AuditActionEvalTaskArchived,
-		AuditActionEvalRunStarted, AuditActionEvalRunCompleted, AuditActionEvalBatchStarted:
+		AuditActionEvalRunStarted, AuditActionEvalRunCompleted, AuditActionEvalBatchStarted,
+		AuditActionOrgTeamCreated, AuditActionOrgTeamUpdated, AuditActionOrgTeamDeleted,
+		AuditActionOrgTeamMemberAdded, AuditActionOrgTeamMemberRemoved, AuditActionOrgTeamGitHubSynced:
 		return nil
 	default:
 		return fmt.Errorf("invalid AuditAction: %q", a)
@@ -163,6 +173,7 @@ const (
 	AuditResourceEvalRun              AuditResourceType = "eval_run"
 	AuditResourceEvalBatch            AuditResourceType = "eval_batch"
 	AuditResourceAutomation           AuditResourceType = "automation"
+	AuditResourceOrgTeam              AuditResourceType = "org_team"
 )
 
 func (t AuditResourceType) Validate() error {
@@ -173,7 +184,7 @@ func (t AuditResourceType) Validate() error {
 		AuditResourceIntegration, AuditResourceCredential, AuditResourceUser,
 		AuditResourceSessionReviewComment, AuditResourcePMDocument, AuditResourcePMDocumentSet,
 		AuditResourceEvalTask, AuditResourceEvalRun, AuditResourceEvalBatch,
-		AuditResourceAutomation:
+		AuditResourceAutomation, AuditResourceOrgTeam:
 		return nil
 	default:
 		return fmt.Errorf("invalid AuditResourceType: %q", t)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -16,11 +16,11 @@ type Organization struct {
 }
 
 type User struct {
-	ID          uuid.UUID `db:"id" json:"id"`
-	OrgID       uuid.UUID `db:"org_id" json:"org_id"`
-	Email       string    `db:"email" json:"email"`
-	Name        string    `db:"name" json:"name"`
-	Role        string    `db:"role" json:"role"`
+	ID           uuid.UUID `db:"id" json:"id"`
+	OrgID        uuid.UUID `db:"org_id" json:"org_id"`
+	Email        string    `db:"email" json:"email"`
+	Name         string    `db:"name" json:"name"`
+	Role         string    `db:"role" json:"role"`
 	GitHubID     *int64    `db:"github_id" json:"github_id,omitempty"`
 	GitHubLogin  *string   `db:"github_login" json:"github_login,omitempty"`
 	AvatarURL    *string   `db:"avatar_url" json:"avatar_url,omitempty"`
@@ -39,13 +39,13 @@ type AuthSession struct {
 }
 
 type Integration struct {
-	ID           uuid.UUID       `db:"id" json:"id"`
-	OrgID        uuid.UUID       `db:"org_id" json:"org_id"`
+	ID           uuid.UUID           `db:"id" json:"id"`
+	OrgID        uuid.UUID           `db:"org_id" json:"org_id"`
 	Provider     IntegrationProvider `db:"provider" json:"provider"`
-	Config       json.RawMessage `db:"config" json:"-"` // never expose config in JSON (contains secrets)
-	Status       IntegrationStatus `db:"status" json:"status"`
-	LastSyncedAt *time.Time      `db:"last_synced_at" json:"last_synced_at,omitempty"`
-	CreatedAt    time.Time       `db:"created_at" json:"created_at"`
+	Config       json.RawMessage     `db:"config" json:"-"` // never expose config in JSON (contains secrets)
+	Status       IntegrationStatus   `db:"status" json:"status"`
+	LastSyncedAt *time.Time          `db:"last_synced_at" json:"last_synced_at,omitempty"`
+	CreatedAt    time.Time           `db:"created_at" json:"created_at"`
 }
 
 type Repository struct {
@@ -103,60 +103,60 @@ type Issue struct {
 
 // Session represents an attempt to fix an issue via a coding agent.
 type Session struct {
-	ID                   uuid.UUID       `db:"id" json:"id"`
-	IssueID              uuid.UUID       `db:"issue_id" json:"issue_id"`
-	OrgID                uuid.UUID       `db:"org_id" json:"org_id"`
-	AgentType            AgentType       `db:"agent_type" json:"agent_type"`
-	Status               string          `db:"status" json:"status"`
-	AutonomyLevel        string          `db:"autonomy_level" json:"autonomy_level"`
-	TokenMode            string          `db:"token_mode" json:"token_mode"`
-	ComplexityTier       *int            `db:"complexity_tier" json:"complexity_tier,omitempty"`
-	ConfidenceScore      *float64        `db:"confidence_score" json:"confidence_score,omitempty"`
-	ConfidenceReasoning  *string         `db:"confidence_reasoning" json:"confidence_reasoning,omitempty"`
-	RiskFactors          []string        `db:"risk_factors" json:"risk_factors,omitempty"`
-	ContainerID          *string         `db:"container_id" json:"container_id,omitempty"`
-	StartedAt            *time.Time      `db:"started_at" json:"started_at,omitempty"`
-	CompletedAt          *time.Time      `db:"completed_at" json:"completed_at,omitempty"`
-	TokenUsage           json.RawMessage `db:"token_usage" json:"token_usage,omitempty"`
-	FailureExplanation   *string         `db:"failure_explanation" json:"failure_explanation,omitempty"`
-	FailureCategory      *string         `db:"failure_category" json:"failure_category,omitempty"`
-	FailureNextSteps     []string        `db:"failure_next_steps" json:"failure_next_steps,omitempty"`
+	ID                  uuid.UUID       `db:"id" json:"id"`
+	IssueID             uuid.UUID       `db:"issue_id" json:"issue_id"`
+	OrgID               uuid.UUID       `db:"org_id" json:"org_id"`
+	AgentType           AgentType       `db:"agent_type" json:"agent_type"`
+	Status              string          `db:"status" json:"status"`
+	AutonomyLevel       string          `db:"autonomy_level" json:"autonomy_level"`
+	TokenMode           string          `db:"token_mode" json:"token_mode"`
+	ComplexityTier      *int            `db:"complexity_tier" json:"complexity_tier,omitempty"`
+	ConfidenceScore     *float64        `db:"confidence_score" json:"confidence_score,omitempty"`
+	ConfidenceReasoning *string         `db:"confidence_reasoning" json:"confidence_reasoning,omitempty"`
+	RiskFactors         []string        `db:"risk_factors" json:"risk_factors,omitempty"`
+	ContainerID         *string         `db:"container_id" json:"container_id,omitempty"`
+	StartedAt           *time.Time      `db:"started_at" json:"started_at,omitempty"`
+	CompletedAt         *time.Time      `db:"completed_at" json:"completed_at,omitempty"`
+	TokenUsage          json.RawMessage `db:"token_usage" json:"token_usage,omitempty"`
+	FailureExplanation  *string         `db:"failure_explanation" json:"failure_explanation,omitempty"`
+	FailureCategory     *string         `db:"failure_category" json:"failure_category,omitempty"`
+	FailureNextSteps    []string        `db:"failure_next_steps" json:"failure_next_steps,omitempty"`
 	// FailureRetryAdvised uses plain bool (not *bool) because false is the
 	// meaningful default — a session that hasn't failed never advises retry.
 	// The DB column is NOT NULL DEFAULT false, so pgx scans cleanly into bool.
-	FailureRetryAdvised  bool            `db:"failure_retry_advised" json:"failure_retry_advised"`
-	ParentSessionID      *uuid.UUID      `db:"parent_session_id" json:"parent_session_id,omitempty"`
-	RevisionContext      json.RawMessage `db:"revision_context" json:"revision_context,omitempty"`
-	Error                *string         `db:"error" json:"error,omitempty"`
-	ResultSummary        *string         `db:"result_summary" json:"result_summary,omitempty"`
-	Diff                 *string         `db:"diff" json:"diff,omitempty"`
-	PMPlanID             *uuid.UUID      `db:"pm_plan_id" json:"pm_plan_id,omitempty"`
-	Title                *string         `db:"title" json:"title,omitempty"`
-	PMApproach           *string         `db:"pm_approach" json:"pm_approach,omitempty"`
-	PMReasoning          *string         `db:"pm_reasoning" json:"pm_reasoning,omitempty"`
-	ProjectTaskID        *uuid.UUID      `db:"project_task_id" json:"project_task_id,omitempty"`
-	ModelOverride        *string         `db:"model_override" json:"model_override,omitempty"`
-	TriggeredByUserID    *uuid.UUID      `db:"triggered_by_user_id" json:"triggered_by_user_id,omitempty"`
-	AgentSessionID       *string         `db:"agent_session_id" json:"agent_session_id,omitempty"`
-	CurrentTurn          int             `db:"current_turn" json:"current_turn"`
-	LastActivityAt       *time.Time      `db:"last_activity_at" json:"last_activity_at,omitempty"`
-	SandboxState         string          `db:"sandbox_state" json:"sandbox_state"`
-	SnapshotKey          *string         `db:"snapshot_key" json:"snapshot_key,omitempty"`
-	TargetBranch         *string         `db:"target_branch" json:"target_branch,omitempty"`
-	WorkingBranch        *string         `db:"working_branch" json:"working_branch,omitempty"`
-	RepositoryID         *uuid.UUID      `db:"repository_id" json:"repository_id,omitempty"`
-	DiffStats   json.RawMessage `db:"diff_stats" json:"diff_stats,omitempty"`   // nil for list queries (excluded to reduce payload size)
+	FailureRetryAdvised bool            `db:"failure_retry_advised" json:"failure_retry_advised"`
+	ParentSessionID     *uuid.UUID      `db:"parent_session_id" json:"parent_session_id,omitempty"`
+	RevisionContext     json.RawMessage `db:"revision_context" json:"revision_context,omitempty"`
+	Error               *string         `db:"error" json:"error,omitempty"`
+	ResultSummary       *string         `db:"result_summary" json:"result_summary,omitempty"`
+	Diff                *string         `db:"diff" json:"diff,omitempty"`
+	PMPlanID            *uuid.UUID      `db:"pm_plan_id" json:"pm_plan_id,omitempty"`
+	Title               *string         `db:"title" json:"title,omitempty"`
+	PMApproach          *string         `db:"pm_approach" json:"pm_approach,omitempty"`
+	PMReasoning         *string         `db:"pm_reasoning" json:"pm_reasoning,omitempty"`
+	ProjectTaskID       *uuid.UUID      `db:"project_task_id" json:"project_task_id,omitempty"`
+	ModelOverride       *string         `db:"model_override" json:"model_override,omitempty"`
+	TriggeredByUserID   *uuid.UUID      `db:"triggered_by_user_id" json:"triggered_by_user_id,omitempty"`
+	AgentSessionID      *string         `db:"agent_session_id" json:"agent_session_id,omitempty"`
+	CurrentTurn         int             `db:"current_turn" json:"current_turn"`
+	LastActivityAt      *time.Time      `db:"last_activity_at" json:"last_activity_at,omitempty"`
+	SandboxState        string          `db:"sandbox_state" json:"sandbox_state"`
+	SnapshotKey         *string         `db:"snapshot_key" json:"snapshot_key,omitempty"`
+	TargetBranch        *string         `db:"target_branch" json:"target_branch,omitempty"`
+	WorkingBranch       *string         `db:"working_branch" json:"working_branch,omitempty"`
+	RepositoryID        *uuid.UUID      `db:"repository_id" json:"repository_id,omitempty"`
+	DiffStats           json.RawMessage `db:"diff_stats" json:"diff_stats,omitempty"` // nil for list queries (excluded to reduce payload size)
 	// DiffHistory is only populated on single-session fetches (GetByID, ClaimIdle, etc.).
 	// List queries return NULL to avoid multi-megabyte payloads — do not rely on this
 	// field being non-nil unless the session was fetched individually.
-	DiffHistory   json.RawMessage `db:"diff_history" json:"diff_history,omitempty"`
-	InputManifest json.RawMessage `db:"input_manifest" json:"input_manifest,omitempty"`
-	ArchivedAt       *time.Time  `db:"archived_at" json:"archived_at,omitempty"`
-	ArchivedByUserID *uuid.UUID  `db:"archived_by_user_id" json:"archived_by_user_id,omitempty"`
-	AutomationRunID  *uuid.UUID  `db:"automation_run_id" json:"automation_run_id,omitempty"`
-	TeamID           *uuid.UUID  `db:"team_id" json:"team_id,omitempty"`
-	DeletedAt        *time.Time  `db:"deleted_at" json:"-"`
-	CreatedAt     time.Time       `db:"created_at" json:"created_at"`
+	DiffHistory      json.RawMessage `db:"diff_history" json:"diff_history,omitempty"`
+	InputManifest    json.RawMessage `db:"input_manifest" json:"input_manifest,omitempty"`
+	ArchivedAt       *time.Time      `db:"archived_at" json:"archived_at,omitempty"`
+	ArchivedByUserID *uuid.UUID      `db:"archived_by_user_id" json:"archived_by_user_id,omitempty"`
+	AutomationRunID  *uuid.UUID      `db:"automation_run_id" json:"automation_run_id,omitempty"`
+	TeamID           *uuid.UUID      `db:"team_id" json:"team_id,omitempty"`
+	DeletedAt        *time.Time      `db:"deleted_at" json:"-"`
+	CreatedAt        time.Time       `db:"created_at" json:"created_at"`
 }
 
 // SessionDetail is the API response for a single session, enriched with threads.
@@ -180,7 +180,7 @@ type SessionResult struct {
 // Validation represents validation results for an agent run.
 type Validation struct {
 	ID                  uuid.UUID       `db:"id" json:"id"`
-	SessionID          uuid.UUID       `db:"session_id" json:"session_id"`
+	SessionID           uuid.UUID       `db:"session_id" json:"session_id"`
 	OrgID               uuid.UUID       `db:"org_id" json:"org_id"`
 	Status              string          `db:"status" json:"status"`
 	DirectionCheck      string          `db:"direction_check" json:"direction_check"`
@@ -201,7 +201,7 @@ type Validation struct {
 // without an associated session. API consumers should handle null session_id.
 type PullRequest struct {
 	ID             uuid.UUID  `db:"id" json:"id"`
-	SessionID     *uuid.UUID `db:"session_id" json:"session_id,omitempty"`
+	SessionID      *uuid.UUID `db:"session_id" json:"session_id,omitempty"`
 	OrgID          uuid.UUID  `db:"org_id" json:"org_id"`
 	GitHubPRNumber int        `db:"github_pr_number" json:"github_pr_number"`
 	GitHubPRURL    string     `db:"github_pr_url" json:"github_pr_url"`
@@ -264,32 +264,32 @@ type SessionMessage struct {
 // Each thread is one agent doing one piece of work. All threads in a session
 // share the same container and filesystem.
 type SessionThread struct {
-	ID                 uuid.UUID  `db:"id" json:"id"`
-	SessionID          uuid.UUID  `db:"session_id" json:"session_id"`
-	OrgID              uuid.UUID  `db:"org_id" json:"org_id"`
-	AgentType          AgentType  `db:"agent_type" json:"agent_type"`
-	ModelOverride      *string    `db:"model_override" json:"model_override,omitempty"`
-	Label              string     `db:"label" json:"label"`
-	Instructions       *string    `db:"instructions" json:"instructions,omitempty"`
-	FileScope          []string   `db:"file_scope" json:"file_scope,omitempty"`
+	ID                 uuid.UUID    `db:"id" json:"id"`
+	SessionID          uuid.UUID    `db:"session_id" json:"session_id"`
+	OrgID              uuid.UUID    `db:"org_id" json:"org_id"`
+	AgentType          AgentType    `db:"agent_type" json:"agent_type"`
+	ModelOverride      *string      `db:"model_override" json:"model_override,omitempty"`
+	Label              string       `db:"label" json:"label"`
+	Instructions       *string      `db:"instructions" json:"instructions,omitempty"`
+	FileScope          []string     `db:"file_scope" json:"file_scope,omitempty"`
 	Status             ThreadStatus `db:"status" json:"status"`
-	AgentSessionID     *string    `db:"agent_session_id" json:"agent_session_id,omitempty"`
-	CurrentTurn        int        `db:"current_turn" json:"current_turn"`
-	LastActivityAt     *time.Time `db:"last_activity_at" json:"last_activity_at,omitempty"`
-	ConfidenceScore    *float64   `db:"confidence_score" json:"confidence_score,omitempty"`
-	ResultSummary      *string    `db:"result_summary" json:"result_summary,omitempty"`
-	Diff               *string    `db:"diff" json:"diff,omitempty"`
-	FailureExplanation *string    `db:"failure_explanation" json:"failure_explanation,omitempty"`
-	FailureCategory    *string    `db:"failure_category" json:"failure_category,omitempty"`
-	StartedAt          *time.Time `db:"started_at" json:"started_at,omitempty"`
-	CompletedAt        *time.Time `db:"completed_at" json:"completed_at,omitempty"`
-	CreatedAt          time.Time  `db:"created_at" json:"created_at"`
+	AgentSessionID     *string      `db:"agent_session_id" json:"agent_session_id,omitempty"`
+	CurrentTurn        int          `db:"current_turn" json:"current_turn"`
+	LastActivityAt     *time.Time   `db:"last_activity_at" json:"last_activity_at,omitempty"`
+	ConfidenceScore    *float64     `db:"confidence_score" json:"confidence_score,omitempty"`
+	ResultSummary      *string      `db:"result_summary" json:"result_summary,omitempty"`
+	Diff               *string      `db:"diff" json:"diff,omitempty"`
+	FailureExplanation *string      `db:"failure_explanation" json:"failure_explanation,omitempty"`
+	FailureCategory    *string      `db:"failure_category" json:"failure_category,omitempty"`
+	StartedAt          *time.Time   `db:"started_at" json:"started_at,omitempty"`
+	CompletedAt        *time.Time   `db:"completed_at" json:"completed_at,omitempty"`
+	CreatedAt          time.Time    `db:"created_at" json:"created_at"`
 }
 
 // SessionQuestion represents a question the agent asks a human during a run.
 type SessionQuestion struct {
 	ID           uuid.UUID  `db:"id" json:"id"`
-	SessionID   uuid.UUID  `db:"session_id" json:"session_id"`
+	SessionID    uuid.UUID  `db:"session_id" json:"session_id"`
 	OrgID        uuid.UUID  `db:"org_id" json:"org_id"`
 	QuestionText string     `db:"question_text" json:"question_text"`
 	Options      []string   `db:"options" json:"options,omitempty"`
@@ -422,22 +422,22 @@ type SessionReviewComment struct {
 
 // ReviewComment represents a captured review comment on a 143-generated PR.
 type ReviewComment struct {
-	ID              uuid.UUID  `db:"id" json:"id"`
-	PullRequestID   uuid.UUID  `db:"pull_request_id" json:"pull_request_id"`
-	OrgID           uuid.UUID  `db:"org_id" json:"org_id"`
-	GitHubCommentID int64      `db:"github_comment_id" json:"github_comment_id"`
-	Reviewer        string     `db:"reviewer" json:"reviewer"`
-	Body            string     `db:"body" json:"body"`
-	DiffPath        *string    `db:"diff_path" json:"diff_path,omitempty"`
-	DiffPosition    *int       `db:"diff_position" json:"diff_position,omitempty"`
-	FilterStatus    string     `db:"filter_status" json:"filter_status"`
-	Category        *string    `db:"category" json:"category,omitempty"`
-	Actionable      bool       `db:"actionable" json:"actionable"`
-	Generalizable   bool       `db:"generalizable" json:"generalizable"`
-	GeneralizedRule *string    `db:"generalized_rule" json:"generalized_rule,omitempty"`
-	Summary         *string    `db:"summary" json:"summary,omitempty"`
-	Applied         bool       `db:"applied" json:"applied"`
-	CreatedAt       time.Time  `db:"created_at" json:"created_at"`
+	ID              uuid.UUID `db:"id" json:"id"`
+	PullRequestID   uuid.UUID `db:"pull_request_id" json:"pull_request_id"`
+	OrgID           uuid.UUID `db:"org_id" json:"org_id"`
+	GitHubCommentID int64     `db:"github_comment_id" json:"github_comment_id"`
+	Reviewer        string    `db:"reviewer" json:"reviewer"`
+	Body            string    `db:"body" json:"body"`
+	DiffPath        *string   `db:"diff_path" json:"diff_path,omitempty"`
+	DiffPosition    *int      `db:"diff_position" json:"diff_position,omitempty"`
+	FilterStatus    string    `db:"filter_status" json:"filter_status"`
+	Category        *string   `db:"category" json:"category,omitempty"`
+	Actionable      bool      `db:"actionable" json:"actionable"`
+	Generalizable   bool      `db:"generalizable" json:"generalizable"`
+	GeneralizedRule *string   `db:"generalized_rule" json:"generalized_rule,omitempty"`
+	Summary         *string   `db:"summary" json:"summary,omitempty"`
+	Applied         bool      `db:"applied" json:"applied"`
+	CreatedAt       time.Time `db:"created_at" json:"created_at"`
 }
 
 // Memory represents a learned convention or rule for a repo or org.

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -154,6 +154,7 @@ type Session struct {
 	ArchivedAt       *time.Time  `db:"archived_at" json:"archived_at,omitempty"`
 	ArchivedByUserID *uuid.UUID  `db:"archived_by_user_id" json:"archived_by_user_id,omitempty"`
 	AutomationRunID  *uuid.UUID  `db:"automation_run_id" json:"automation_run_id,omitempty"`
+	TeamID           *uuid.UUID  `db:"team_id" json:"team_id,omitempty"`
 	DeletedAt        *time.Time  `db:"deleted_at" json:"-"`
 	CreatedAt     time.Time       `db:"created_at" json:"created_at"`
 }

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -61,29 +61,29 @@ type ProposalOverlap struct {
 
 // ProjectTask is a single work item within a project, created by the PM each cycle.
 type ProjectTask struct {
-	ID            uuid.UUID         `db:"id" json:"id"`
-	ProjectID     uuid.UUID         `db:"project_id" json:"project_id"`
-	OrgID         uuid.UUID         `db:"org_id" json:"org_id"`
-	Title         string            `db:"title" json:"title"`
-	Description   *string           `db:"description" json:"description,omitempty"`
-	Approach      *string           `db:"approach" json:"approach,omitempty"`
-	Reasoning     *string           `db:"reasoning" json:"reasoning,omitempty"`
-	SortOrder     int               `db:"sort_order" json:"sort_order"`
-	DependsOn     []uuid.UUID       `json:"depends_on,omitempty"`
-	BatchNumber   int               `db:"batch_number" json:"batch_number"`
-	Status        ProjectTaskStatus `db:"status" json:"status"`
-	Complexity    *string           `db:"complexity" json:"complexity,omitempty"`
-	Confidence    *string           `db:"confidence" json:"confidence,omitempty"`
+	ID           uuid.UUID         `db:"id" json:"id"`
+	ProjectID    uuid.UUID         `db:"project_id" json:"project_id"`
+	OrgID        uuid.UUID         `db:"org_id" json:"org_id"`
+	Title        string            `db:"title" json:"title"`
+	Description  *string           `db:"description" json:"description,omitempty"`
+	Approach     *string           `db:"approach" json:"approach,omitempty"`
+	Reasoning    *string           `db:"reasoning" json:"reasoning,omitempty"`
+	SortOrder    int               `db:"sort_order" json:"sort_order"`
+	DependsOn    []uuid.UUID       `json:"depends_on,omitempty"`
+	BatchNumber  int               `db:"batch_number" json:"batch_number"`
+	Status       ProjectTaskStatus `db:"status" json:"status"`
+	Complexity   *string           `db:"complexity" json:"complexity,omitempty"`
+	Confidence   *string           `db:"confidence" json:"confidence,omitempty"`
 	SessionID    *uuid.UUID        `db:"session_id" json:"session_id,omitempty"`
-	IssueID       *uuid.UUID        `db:"issue_id" json:"issue_id,omitempty"`
-	BranchName    *string           `db:"branch_name" json:"branch_name,omitempty"`
-	PRURL         *string           `db:"pr_url" json:"pr_url,omitempty"`
-	OutcomeNotes  *string           `db:"outcome_notes" json:"outcome_notes,omitempty"`
-	RetryCount    int               `db:"retry_count" json:"retry_count"`
-	MaxRetries    int               `db:"max_retries" json:"max_retries"`
-	CreatedAt     time.Time         `db:"created_at" json:"created_at"`
-	UpdatedAt     time.Time         `db:"updated_at" json:"updated_at"`
-	CompletedAt   *time.Time        `db:"completed_at" json:"completed_at,omitempty"`
+	IssueID      *uuid.UUID        `db:"issue_id" json:"issue_id,omitempty"`
+	BranchName   *string           `db:"branch_name" json:"branch_name,omitempty"`
+	PRURL        *string           `db:"pr_url" json:"pr_url,omitempty"`
+	OutcomeNotes *string           `db:"outcome_notes" json:"outcome_notes,omitempty"`
+	RetryCount   int               `db:"retry_count" json:"retry_count"`
+	MaxRetries   int               `db:"max_retries" json:"max_retries"`
+	CreatedAt    time.Time         `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time         `db:"updated_at" json:"updated_at"`
+	CompletedAt  *time.Time        `db:"completed_at" json:"completed_at,omitempty"`
 }
 
 // ProjectCycle records a PM planning cycle for a project.

--- a/internal/models/project.go
+++ b/internal/models/project.go
@@ -39,6 +39,7 @@ type Project struct {
 	ScheduleUnit       string           `db:"schedule_unit" json:"schedule_unit"`
 	NextRunAt          *time.Time       `db:"next_run_at" json:"next_run_at,omitempty"`
 	CreatedBy          *uuid.UUID       `db:"created_by" json:"created_by,omitempty"`
+	TeamID             *uuid.UUID       `db:"team_id" json:"team_id,omitempty"`
 	DeletedAt          *time.Time       `db:"deleted_at" json:"-"`
 	CreatedAt          time.Time        `db:"created_at" json:"created_at"`
 	UpdatedAt          time.Time        `db:"updated_at" json:"updated_at"`

--- a/internal/models/team.go
+++ b/internal/models/team.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	TeamRoleMember = "member"
+	TeamRoleLead   = "lead"
+)
+
+// Team is a group of users within an organization. Teams can be synced from
+// GitHub Teams or created manually. Sessions and projects can be scoped to a
+// team for filtering.
+type Team struct {
+	ID             uuid.UUID `db:"id" json:"id"`
+	OrgID          uuid.UUID `db:"org_id" json:"org_id"`
+	Name           string    `db:"name" json:"name"`
+	Slug           string    `db:"slug" json:"slug"`
+	Description    *string   `db:"description" json:"description,omitempty"`
+	GitHubTeamID   *int64    `db:"github_team_id" json:"github_team_id,omitempty"`
+	GitHubTeamSlug *string   `db:"github_team_slug" json:"github_team_slug,omitempty"`
+	CreatedAt      time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt      time.Time `db:"updated_at" json:"updated_at"`
+
+	// MemberCount is populated by list queries via a subquery; not stored in DB.
+	MemberCount int `db:"member_count" json:"member_count"`
+}
+
+// TeamMembership links a user to a team.
+type TeamMembership struct {
+	ID        uuid.UUID `db:"id" json:"id"`
+	TeamID    uuid.UUID `db:"team_id" json:"team_id"`
+	UserID    uuid.UUID `db:"user_id" json:"user_id"`
+	Role      string    `db:"role" json:"role"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+}
+
+// TeamWithMembers is the API response for a single team including its members.
+type TeamWithMembers struct {
+	Team
+	Members []User `json:"members"`
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -40,7 +40,7 @@ var sessionColumns = []string{
 	"pm_plan_id", "title", "pm_approach", "pm_reasoning", "project_task_id",
 	"model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
-	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 // newMockPool creates a pgxmock pool and returns it with a cleanup.
@@ -148,6 +148,7 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 					nil, // input_manifest
 					nil, nil, // archived_at, archived_by_user_id
 					nil, // automation_run_id
+					nil, // team_id
 					nil, // deleted_at
 					now),
 		)

--- a/internal/services/github/teams.go
+++ b/internal/services/github/teams.go
@@ -1,0 +1,105 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// GitHubTeam represents a team from the GitHub API.
+type GitHubTeam struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Slug        string `json:"slug"`
+	Description string `json:"description"`
+}
+
+// GitHubTeamMember represents a member from the GitHub Teams API.
+type GitHubTeamMember struct {
+	ID    int64  `json:"id"`
+	Login string `json:"login"`
+}
+
+// ListOrgTeams fetches all teams for the given GitHub organization.
+// Uses pagination to handle orgs with many teams.
+func (s *Service) ListOrgTeams(ctx context.Context, installationToken, org string) ([]GitHubTeam, error) {
+	var allTeams []GitHubTeam
+	page := 1
+
+	for {
+		url := fmt.Sprintf("https://api.github.com/orgs/%s/teams?per_page=100&page=%d", org, page)
+		teams, hasMore, err := fetchPage[GitHubTeam](ctx, s.httpClient, url, installationToken)
+		if err != nil {
+			return nil, fmt.Errorf("list org teams (page %d): %w", page, err)
+		}
+		allTeams = append(allTeams, teams...)
+		if !hasMore {
+			break
+		}
+		page++
+	}
+
+	return allTeams, nil
+}
+
+// ListTeamMembers fetches all members of a team in the given GitHub organization.
+func (s *Service) ListTeamMembers(ctx context.Context, installationToken, org, teamSlug string) ([]GitHubTeamMember, error) {
+	var allMembers []GitHubTeamMember
+	page := 1
+
+	for {
+		url := fmt.Sprintf("https://api.github.com/orgs/%s/teams/%s/members?per_page=100&page=%d", org, teamSlug, page)
+		members, hasMore, err := fetchPage[GitHubTeamMember](ctx, s.httpClient, url, installationToken)
+		if err != nil {
+			return nil, fmt.Errorf("list team members (page %d): %w", page, err)
+		}
+		allMembers = append(allMembers, members...)
+		if !hasMore {
+			break
+		}
+		page++
+	}
+
+	return allMembers, nil
+}
+
+// fetchPage fetches a single page from the GitHub API, closing the response body
+// immediately. Returns the decoded items and whether there are more pages (via
+// the Link header or a full page of results).
+func fetchPage[T any](ctx context.Context, client *http.Client, url, token string) ([]T, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, false, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, false, fmt.Errorf("GitHub API error %d: %s", resp.StatusCode, body)
+	}
+
+	var items []T
+	if err := json.NewDecoder(resp.Body).Decode(&items); err != nil {
+		return nil, false, fmt.Errorf("decode response: %w", err)
+	}
+
+	// Check the Link header for a "next" relation; only fall back to
+	// page-size heuristic when no Link header is present.
+	linkHeader := resp.Header.Get("Link")
+	hasMore := strings.Contains(linkHeader, `rel="next"`)
+	if linkHeader == "" && len(items) >= 100 {
+		hasMore = true
+	}
+
+	return items, hasMore, nil
+}

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -150,7 +150,7 @@ var sessionTestCols = []string{
 	"project_task_id", "model_override", "triggered_by_user_id",
 	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
 	"target_branch", "working_branch", "repository_id", "diff_stats", "diff_history", "input_manifest",
-	"archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+	"archived_at", "archived_by_user_id", "automation_run_id", "team_id", "deleted_at", "created_at",
 }
 
 func newPreviewInstanceRow(id, sessionID, orgID, userID uuid.UUID, status models.PreviewStatus, handle string, now time.Time) []any {
@@ -181,7 +181,7 @@ func newSessionRow(sessionID, orgID uuid.UUID, containerID *string, now time.Tim
 		nil, nil, nil,
 		nil, 0, nil, "running", nil,
 		nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, nil, now,
+		nil, nil, nil, nil, nil, now,
 	}
 }
 

--- a/migrations/000066_teams.down.sql
+++ b/migrations/000066_teams.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE projects DROP COLUMN IF EXISTS team_id;
+ALTER TABLE sessions DROP COLUMN IF EXISTS team_id;
+DROP TABLE IF EXISTS team_memberships;
+DROP TABLE IF EXISTS teams;

--- a/migrations/000066_teams.up.sql
+++ b/migrations/000066_teams.up.sql
@@ -1,0 +1,44 @@
+-- Teams: first-class organizational units within an org.
+CREATE TABLE teams (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id),
+    name TEXT NOT NULL,
+    slug TEXT NOT NULL,
+    description TEXT,
+    github_team_id BIGINT,
+    github_team_slug TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(org_id, slug)
+);
+
+CREATE INDEX idx_teams_org_id ON teams(org_id);
+
+-- Partial unique index: only one row per (org_id, github_team_id) when github_team_id is set.
+CREATE UNIQUE INDEX idx_teams_org_github_team
+    ON teams(org_id, github_team_id)
+    WHERE github_team_id IS NOT NULL;
+
+-- Team memberships: many-to-many users <-> teams.
+-- org_id is denormalized from teams/users so queries can enforce tenant isolation
+-- without an extra join, and can be used as a filter in indexes.
+CREATE TABLE team_memberships (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    org_id UUID NOT NULL REFERENCES organizations(id),
+    team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role TEXT NOT NULL DEFAULT 'member',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(team_id, user_id)
+);
+
+CREATE INDEX idx_team_memberships_user_id ON team_memberships(user_id);
+CREATE INDEX idx_team_memberships_team_id ON team_memberships(team_id);
+CREATE INDEX idx_team_memberships_org_user ON team_memberships(org_id, user_id);
+
+-- Add team_id to sessions and projects for fast filtering.
+ALTER TABLE sessions ADD COLUMN team_id UUID REFERENCES teams(id) ON DELETE SET NULL;
+CREATE INDEX idx_sessions_team_id ON sessions(team_id) WHERE team_id IS NOT NULL;
+
+ALTER TABLE projects ADD COLUMN team_id UUID REFERENCES teams(id) ON DELETE SET NULL;
+CREATE INDEX idx_projects_team_id ON projects(team_id) WHERE team_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- New `teams` and `team_memberships` tables (migration 000066) with `team_id` columns added to `sessions` and `projects` for fast filtering.
- Full team CRUD at `/api/v1/teams` (admin-only writes), plus `/teams/mine` for the current user and an optional GitHub team sync via the GitHub App.
- Frontend `TeamSelector` filter wired into the sessions sidebar, sessions page, and projects sidebar; admin-only `/settings/teams` page for managing teams and memberships.

## Test plan
- [ ] Run migration up/down cleanly
- [ ] Verify non-admin users can list `/teams/mine` but not create/update/delete
- [ ] Filter sessions and projects by team and confirm queries return only the expected rows
- [ ] Sync GitHub teams (when GitHub App is configured) and confirm idempotency on re-sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)