### PR TITLE
Auto-archive sessions when linked PR merges or closes

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -27,6 +27,7 @@ function PRAuthorshipSettings() {
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const currentAuthorship = settings.pr_authorship ?? "user_preferred";
   const currentDraftDefault = settings.pr_draft_default ?? false;
+  const currentAutoArchive = settings.auto_archive_on_pr_close ?? false;
 
   const mutation = useMutation({
     mutationFn: (payload: Record<string, unknown>) => api.settings.update(payload),
@@ -35,7 +36,7 @@ function PRAuthorshipSettings() {
 
   return (
     <section className="space-y-3">
-      <h2 className="text-xs font-medium text-foreground">Pull request defaults</h2>
+      <h2 className="text-xs font-medium text-foreground">Pull requests</h2>
       <Card>
         <CardContent className="space-y-4">
           <div className="space-y-2">
@@ -79,6 +80,24 @@ function PRAuthorshipSettings() {
             <Label htmlFor="pr-draft-default" className="cursor-pointer">
               Create PRs as drafts by default
             </Label>
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                id="auto-archive-on-pr-close"
+                checked={currentAutoArchive}
+                onChange={(e) =>
+                  mutation.mutate({ settings: { auto_archive_on_pr_close: e.target.checked } })
+                }
+              />
+              <Label htmlFor="auto-archive-on-pr-close" className="cursor-pointer">
+                Auto-archive after PR merge or close
+              </Label>
+            </div>
+            <p className="text-xs text-muted-foreground pl-6">
+              Automatically archive sessions when their associated pull request is merged or closed.
+            </p>
           </div>
         </CardContent>
       </Card>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -320,6 +320,7 @@ export interface OrgSettings {
   default_agent_type?: 'codex' | 'claude_code' | 'gemini_cli';
   pr_authorship?: 'user_preferred' | 'app_only' | 'user_required';
   pr_draft_default?: boolean;
+  auto_archive_on_pr_close?: boolean;
 }
 
 export interface ProductContext {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -208,6 +208,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		prService.SetOrgStore(orgStore)
 		prService.SetLLMClient(llmClient)
 		prService.SetPRTemplateStore(prTemplateStore)
+		prService.SetAuditEmitter(auditEmitter)
 	}
 
 	// Wire user credential store into auth handler for token storage on login.

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -663,6 +663,17 @@ func (s *SessionStore) Archive(ctx context.Context, orgID, sessionID, userID uui
 	return nil
 }
 
+// ArchiveSystem archives a session without a user actor (e.g. webhook-driven auto-archive).
+// archived_by_user_id is left NULL, and an already-archived session is a no-op rather than an error.
+func (s *SessionStore) ArchiveSystem(ctx context.Context, orgID, sessionID uuid.UUID) error {
+	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = NULL, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	})
+	return err
+}
+
 // Unarchive removes the archived flag from a session, restoring it to default views.
 func (s *SessionStore) Unarchive(ctx context.Context, orgID, sessionID uuid.UUID) error {
 	query := `UPDATE sessions SET archived_at = NULL, archived_by_user_id = NULL, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NOT NULL`

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -592,6 +592,44 @@ func TestSessionStore_Archive(t *testing.T) {
 	})
 }
 
+func TestSessionStore_ArchiveSystem(t *testing.T) {
+	t.Parallel()
+
+	t.Run("archives session without a user actor", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = now\\(\\), archived_by_user_id = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		err = store.ArchiveSystem(context.Background(), uuid.New(), uuid.New())
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("is a no-op when the session is already archived", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionStore(mock)
+
+		mock.ExpectExec("UPDATE sessions SET archived_at = now\\(\\), archived_by_user_id = NULL").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+		err = store.ArchiveSystem(context.Background(), uuid.New(), uuid.New())
+		require.NoError(t, err, "already-archived sessions should not produce an error")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
 func TestSessionStore_Unarchive(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -193,6 +193,7 @@ type OrgSettings struct {
 	ContextLimits              ContextLimits   `json:"context_limits,omitempty"`
 	PRAuthorship               PRAuthorship    `json:"pr_authorship,omitempty"`
 	PRDraftDefault             bool            `json:"pr_draft_default,omitempty"`
+	AutoArchiveOnPRClose       bool            `json:"auto_archive_on_pr_close,omitempty"`
 }
 
 // Agent autonomy mode constants.

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -45,6 +45,7 @@ type PRService struct {
 	orgs            *db.OrganizationStore
 	prTemplates     *db.PRTemplateStore
 	llmClient       llm.Client
+	audit           *db.AuditEmitter
 	logger          zerolog.Logger
 	baseURL         string
 	httpClient      *http.Client
@@ -94,6 +95,11 @@ func (s *PRService) SetLLMClient(client llm.Client) {
 // SetUserStore sets the user store for fetching user info during PR creation.
 func (s *PRService) SetUserStore(store *db.UserStore) {
 	s.users = store
+}
+
+// SetAuditEmitter sets the audit emitter used for webhook-triggered audit events.
+func (s *PRService) SetAuditEmitter(audit *db.AuditEmitter) {
+	s.audit = audit
 }
 
 // SetOrgStore sets the organization store for fetching org settings.
@@ -468,23 +474,25 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 
 	// Auto-archive the linked session if the org has opted in.
 	if pr.SessionID != nil && s.orgs != nil {
-		org, err := s.orgs.GetByID(ctx, pr.OrgID)
-		if err != nil {
+		if org, err := s.orgs.GetByID(ctx, pr.OrgID); err != nil {
 			s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to load org for auto-archive check")
-		} else {
-			var settings models.OrgSettings
-			if len(org.Settings) > 0 {
-				if err := json.Unmarshal(org.Settings, &settings); err != nil {
-					s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to parse org settings for auto-archive")
-				}
-			}
-			if settings.AutoArchiveOnPRClose {
-				if err := s.sessions.ArchiveSystem(ctx, pr.OrgID, *pr.SessionID); err != nil {
-					s.logger.Warn().Err(err).
-						Str("session_id", pr.SessionID.String()).
-						Str("pr_id", pr.ID.String()).
-						Msg("failed to auto-archive session on PR close")
-				}
+		} else if settings, err := models.ParseOrgSettings(org.Settings); err != nil {
+			s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to parse org settings for auto-archive")
+		} else if settings.AutoArchiveOnPRClose {
+			if err := s.sessions.ArchiveSystem(ctx, pr.OrgID, *pr.SessionID); err != nil {
+				s.logger.Warn().Err(err).
+					Str("session_id", pr.SessionID.String()).
+					Str("pr_id", pr.ID.String()).
+					Msg("failed to auto-archive session on PR close")
+			} else if s.audit != nil {
+				sessionIDStr := pr.SessionID.String()
+				s.audit.EmitWebhookAction(ctx, db.WebhookActionParams{
+					OrgID:        pr.OrgID,
+					ProviderName: "github",
+					Action:       models.AuditActionSessionArchived,
+					ResourceType: models.AuditResourceSession,
+					ResourceID:   &sessionIDStr,
+				})
 			}
 		}
 	}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -466,6 +466,29 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 		}
 	}
 
+	// Auto-archive the linked session if the org has opted in.
+	if pr.SessionID != nil && s.orgs != nil {
+		org, err := s.orgs.GetByID(ctx, pr.OrgID)
+		if err != nil {
+			s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to load org for auto-archive check")
+		} else {
+			var settings models.OrgSettings
+			if len(org.Settings) > 0 {
+				if err := json.Unmarshal(org.Settings, &settings); err != nil {
+					s.logger.Warn().Err(err).Str("org_id", pr.OrgID.String()).Msg("failed to parse org settings for auto-archive")
+				}
+			}
+			if settings.AutoArchiveOnPRClose {
+				if err := s.sessions.ArchiveSystem(ctx, pr.OrgID, *pr.SessionID); err != nil {
+					s.logger.Warn().Err(err).
+						Str("session_id", pr.SessionID.String()).
+						Str("pr_id", pr.ID.String()).
+						Msg("failed to auto-archive session on PR close")
+				}
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -301,6 +301,118 @@ func TestHandlePullRequestEvent_ClosedWithoutMergeFlow(t *testing.T) {
 	require.NoError(t, prMock.ExpectationsWereMet(), "all PR store expectations should be met")
 }
 
+// organizationColumns matches OrganizationStore.GetByID's SELECT list.
+var organizationColumns = []string{"id", "name", "settings", "created_at", "updated_at"}
+
+func TestHandlePullRequestEvent_AutoArchiveOnCloseWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	sessionMock := newMockPool(t)
+	orgMock := newMockPool(t)
+
+	svc := &PRService{
+		pullRequests: db.NewPullRequestStore(prMock),
+		sessions:     db.NewSessionStore(sessionMock),
+		orgs:         db.NewOrganizationStore(orgMock),
+		logger:       zerolog.Nop(),
+	}
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
+		)
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	orgMock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(organizationColumns).
+				AddRow(orgID, "Test Org", json.RawMessage(`{"auto_archive_on_pr_close": true}`), now, now),
+		)
+	sessionMock.ExpectExec("UPDATE sessions SET archived_at = now\\(\\), archived_by_user_id = NULL").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 42,
+	}
+	event.PR.Merged = false
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err)
+	require.NoError(t, prMock.ExpectationsWereMet())
+	require.NoError(t, orgMock.ExpectationsWereMet(), "org settings should be fetched")
+	require.NoError(t, sessionMock.ExpectationsWereMet(), "session should be archived")
+}
+
+func TestHandlePullRequestEvent_AutoArchiveSkippedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	sessionMock := newMockPool(t)
+	orgMock := newMockPool(t)
+
+	svc := &PRService{
+		pullRequests: db.NewPullRequestStore(prMock),
+		sessions:     db.NewSessionStore(sessionMock),
+		orgs:         db.NewOrganizationStore(orgMock),
+		logger:       zerolog.Nop(),
+	}
+
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "", (*time.Time)(nil), now, now),
+		)
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	orgMock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(organizationColumns).
+				AddRow(orgID, "Test Org", json.RawMessage(`{}`), now, now),
+		)
+	// No session archive expected — pgxmock.ExpectationsWereMet passes only if
+	// no unmocked calls were made, but it does not fail on un-called expectations
+	// that we never set. Leaving sessionMock with zero expectations asserts that
+	// ArchiveSystem was not invoked.
+
+	event := PullRequestEvent{
+		Action: "closed",
+		Number: 42,
+	}
+	event.PR.Merged = false
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err)
+	require.NoError(t, prMock.ExpectationsWereMet())
+	require.NoError(t, orgMock.ExpectationsWereMet())
+	require.NoError(t, sessionMock.ExpectationsWereMet(), "no session archive should happen when toggle is off")
+}
+
 func TestHandlePullRequestEvent_NonClosedAction(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds an org-level "Auto-archive after PR merge or close" setting that mirrors Anthropic's equivalent Claude Code toggle. When enabled, the GitHub `pull_request` webhook handler archives the session linked to the PR as soon as the PR is merged or closed. New `SessionStore.ArchiveSystem` performs the archive without a user actor and no-ops when the session is already archived. The toggle is added under the existing admin-only "Pull requests" card on the General settings page and defaults to off.

## Test plan

- [ ] Flip the toggle on in Settings → General and verify `GET /api/v1/settings` reflects `auto_archive_on_pr_close: true`
- [ ] Create a session linked to a real GitHub PR, merge the PR, and confirm the session is archived and drops off the default list
- [ ] Repeat with a close-without-merge
- [ ] Flip the toggle off and confirm newly-closed PRs leave their sessions intact
- [ ] Manually archive a session before the PR closes and confirm no error is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
