### PR TITLE
Surface git stderr when sandbox clone fails

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -290,12 +290,17 @@ func (d *DockerProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoU
 
 	cmd := fmt.Sprintf("git clone --depth 1 --branch '%s' '%s' '%s'",
 		shellEscape(branch), shellEscape(authURL), shellEscape(sb.WorkDir))
-	exitCode, err := d.Exec(ctx, sb, cmd, io.Discard, io.Discard)
+	var stderr bytes.Buffer
+	exitCode, err := d.Exec(ctx, sb, cmd, io.Discard, &stderr)
 	if err != nil {
-		return fmt.Errorf("clone repo: %w", err)
+		return fmt.Errorf("exec git clone: %w", err)
 	}
 	if exitCode != 0 {
-		return fmt.Errorf("clone repo: git exited with code %d", exitCode)
+		msg := redactToken(strings.TrimSpace(stderr.String()), token)
+		if msg == "" {
+			return fmt.Errorf("git exited with code %d (no stderr)", exitCode)
+		}
+		return fmt.Errorf("git exited with code %d: %s", exitCode, msg)
 	}
 
 	d.logger.Info().
@@ -598,4 +603,13 @@ func (l *lineSplitter) flush() {
 // shellEscape escapes single quotes in a string for safe use in shell commands.
 func shellEscape(s string) string {
 	return strings.ReplaceAll(s, "'", "'\\''")
+}
+
+// redactToken removes an auth token from a string so it is safe to surface in
+// error messages or logs.
+func redactToken(s, token string) string {
+	if token != "" {
+		s = strings.ReplaceAll(s, token, "***")
+	}
+	return s
 }

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -1115,6 +1115,15 @@ func TestDockerProvider_CloneRepo(t *testing.T) {
 
 		err := p.CloneRepo(context.Background(), sb, "https://github.com/org/repo.git", "main", "")
 		require.Error(t, err, "CloneRepo should return an error")
-		require.Contains(t, err.Error(), "clone repo", "error should contain expected message")
+		require.Contains(t, err.Error(), "git exited with code 128", "error should contain git exit code")
 	})
+}
+
+func TestRedactToken(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "fatal: ***@github.com/org/repo.git not found",
+		redactToken("fatal: ghp_secret@github.com/org/repo.git not found", "ghp_secret"))
+	require.Equal(t, "fatal: repo not found",
+		redactToken("fatal: repo not found", ""))
 }


### PR DESCRIPTION
## Summary
- PM Agent clone failures were surfacing as "clone repo: clone repo: git exited with code 128" with no hint of the actual cause because stderr was piped to io.Discard.
- DockerProvider.CloneRepo now captures stderr, redacts the installation token, and includes the git error message in the returned error so auth, missing-branch, and access-revocation failures are diagnosable.
- Also drops the redundant inner "clone repo:" prefix and adds a redactToken helper plus tests.

## Test plan
- [x] go test ./internal/services/agent/providers/... -run 'TestDockerProvider_CloneRepo|TestDockerProvider_ShellInjection|TestRedactToken'
- [x] make lint
- [ ] Retry a failing PM Agent run and confirm the failure card now shows git's real error message

Generated with [Claude Code](https://claude.com/claude-code)
