### PR TITLE
Fix stale completed_at showing "Completed just now" on running sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -133,14 +133,16 @@ function checkResultBadge(result: string | null) {
 
 type DetailTab = "overview" | "changes" | "validation" | "preview";
 
+const terminalSessionStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
+
 function OverviewTab({ session, members }: { session: Session; members: User[] }) {
   const queryClient = useQueryClient();
   const [showDeviceCodeModal, setShowDeviceCodeModal] = useState(false);
 
-  // Force re-render every 5s while pending so the elapsed time stays current.
+  // Force re-render every 5s while the session is active so elapsed time stays current.
   const [, setTick] = useState(0);
   useEffect(() => {
-    if (session.status !== "pending") return;
+    if (terminalSessionStatuses.has(session.status)) return;
     const id = setInterval(() => setTick((t) => t + 1), 5000);
     return () => clearInterval(id);
   }, [session.status]);
@@ -162,8 +164,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
   });
 
   const status = statusConfig[session.status] || statusConfig.pending;
-  const terminalStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
-  const isActive = !terminalStatuses.has(session.status);
+  const isActive = !terminalSessionStatuses.has(session.status);
 
   const triggeredByLabel = session.pm_plan_id && !session.triggered_by_user_id
     ? "PM Agent"
@@ -296,11 +297,15 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
             <span className="inline-flex items-center gap-1.5">
               <Timer className="h-3 w-3" />
-              {session.status === "pending" ? formatDuration(session.created_at) : formatDuration(session.started_at, session.completed_at)}
+              {session.status === "pending"
+                ? formatDuration(session.created_at)
+                : isActive
+                  ? formatDuration(session.started_at)
+                  : formatDuration(session.started_at, session.completed_at)}
             </span>
           )}
           <span className="inline-flex items-center gap-1.5">
-            {session.completed_at ? (
+            {!isActive && session.completed_at ? (
               session.status === "failed" ? (
                 <>
                   <XCircle className="h-3 w-3" />

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -231,7 +231,10 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 func (s *SessionStore) UpdateStatus(ctx context.Context, orgID, runID uuid.UUID, status string) error {
 	query := `UPDATE sessions SET status = @status WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	if status == "running" {
-		query = `UPDATE sessions SET status = @status, started_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
+		// Clear completed_at so a resumed session doesn't display as "completed"
+		// while actively running. Duration is computed from started_at, so that is
+		// also refreshed to reflect the current run.
+		query = `UPDATE sessions SET status = @status, started_at = now(), completed_at = NULL WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	} else if status == "completed" || status == "failed" || status == "cancelled" {
 		query = `UPDATE sessions SET status = @status, completed_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	}
@@ -294,7 +297,7 @@ func (s *SessionStore) UpdateResult(ctx context.Context, orgID, runID uuid.UUID,
 func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
-		SET status = 'running'
+		SET status = 'running', started_at = now(), completed_at = NULL
 		WHERE id = @id AND org_id = @org_id AND status = 'idle'
 		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns


### PR DESCRIPTION
## Summary
- When a session resumed from idle/terminal, the session overview briefly showed a negative duration and "Completed just now" even though the status was Running.
- Backend: `UpdateStatus('running')` and `ClaimIdle` now clear `completed_at` (and refresh `started_at`) so a resumed session cannot carry a stale terminal timestamp.
- Frontend: the session Overview panel now keys its duration and status-line text on `session.status` rather than on `completed_at` truthiness, and ticks every 5s for any non-terminal status so elapsed time stays current.

## Test plan
- [x] `go test ./internal/db/ ./internal/api/handlers/ ./internal/services/agent/`
- [ ] Manually: send a follow-up message to an idle/completed session and confirm the Overview shows "Started Ns ago" with a non-negative duration while running.