### PR TITLE
Fix Codex sandbox egress and lock down network access

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -27,6 +27,7 @@ packages:
   - git
   - jq
   - curl
+  - iptables-persistent
 
 runcmd:
   # Install gVisor
@@ -51,8 +52,13 @@ runcmd:
 
   # Create the shared sandbox egress network (idempotent). The worker also
   # self-heals this at startup, but pre-creating it on bootstrap means the
-  # first health check never has to.
-  - su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --label managed-by=143 143-sandbox'
+  # first health check never has to. enable_icc=false blocks one sandbox
+  # from TCP-connecting to another on the same bridge.
+  - su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
+
+  # Apply host-level egress rules: block sandbox traffic to cloud metadata
+  # and RFC1918. Must run AFTER the network exists (reads its subnet).
+  - /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
 
   # Apply kernel tuning
   - sysctl -p /etc/sysctl.d/99-worker.conf

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -101,8 +101,15 @@ fi
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
 if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" deploy@"$HOST":/opt/143/
-  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy"
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy /opt/143/deploy/scripts"
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
+fi
+if [ "$ROLE" = "worker" ]; then
+  # Keep the sandbox firewall script in sync so every deploy can re-apply
+  # the egress rules (they read the sandbox network's current subnet).
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
+    deploy@"$HOST":/opt/143/deploy/scripts/
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh"
 fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
@@ -196,9 +203,20 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     docker pull "ghcr.io/assembledhq/143-sandbox:$IMAGE_TAG"
     # Ensure the shared sandbox egress network exists (idempotent). Older hosts
     # provisioned before this was added won't have it, and session creation
-    # will fail until it does.
+    # will fail until it does. enable_icc=false blocks one sandbox from
+    # TCP-connecting to another on the same bridge.
     docker network inspect 143-sandbox >/dev/null 2>&1 || \
-      docker network create --driver bridge --label managed-by=143 143-sandbox
+      docker network create --driver bridge \
+        --opt com.docker.network.bridge.enable_icc=false \
+        --label managed-by=143 143-sandbox
+    # Install iptables-persistent on hosts that predate it (no-op otherwise).
+    sudo apt-get install -y --no-install-recommends iptables-persistent >/dev/null 2>&1 || true
+    # Re-apply sandbox egress firewall. Script is idempotent — safe to run
+    # on every deploy. Ensures rules exist even if someone flushed iptables
+    # or the sandbox network was recreated with a new subnet.
+    if [ -x /opt/143/deploy/scripts/sandbox-firewall.sh ]; then
+      sudo /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
+    fi
   fi
 
   # Run migrations BEFORE restarting the app so the DB schema is ready when

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -220,7 +220,15 @@ PULL_APP
       su - deploy -c 'docker pull ghcr.io/assembledhq/143-server:latest'
       su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
       # Ensure the shared sandbox egress network exists (idempotent).
-      su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --label managed-by=143 143-sandbox'
+      # enable_icc=false blocks one sandbox from TCP-connecting to another.
+      su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
+      # Install iptables-persistent so the egress block survives reboots.
+      apt-get install -y --no-install-recommends iptables-persistent >/dev/null 2>&1 || true
+      # Apply sandbox egress firewall. Script is idempotent and reads the
+      # network's current subnet, so safe to re-run on every provision.
+      if [ -x /opt/143/deploy/scripts/sandbox-firewall.sh ]; then
+        /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
+      fi
 PULL_WORKER
     ;;
   db|logging)

--- a/deploy/scripts/sandbox-firewall.sh
+++ b/deploy/scripts/sandbox-firewall.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# sandbox-firewall.sh — apply host-level egress rules for the sandbox network.
+#
+# Blocks sandbox container traffic to cloud metadata (169.254/16) and
+# RFC1918 (10/8, 172.16/12, 192.168/16). A prompt-injected agent could
+# otherwise pivot to internal infra (DB, monitoring, metadata API) that
+# happens to be reachable from the worker host.
+#
+# Idempotent: drops any prior rules tagged with our comment before re-adding.
+# Safe to call on every deploy and on boot.
+#
+# Requires: docker, iptables, netfilter-persistent (for reboot survival).
+#
+# Usage: sudo deploy/scripts/sandbox-firewall.sh [network-name]
+#        Default network: 143-sandbox.
+
+set -euo pipefail
+
+NETWORK="${1:-143-sandbox}"
+COMMENT_TAG="143-sandbox-egress"
+BLOCKED_DESTS=(
+  "169.254.0.0/16"   # cloud metadata (all major providers)
+  "10.0.0.0/8"       # RFC1918
+  "172.16.0.0/12"    # RFC1918 (includes Docker default pools)
+  "192.168.0.0/16"   # RFC1918
+)
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker not installed" >&2
+  exit 1
+fi
+
+if ! command -v iptables >/dev/null 2>&1; then
+  echo "ERROR: iptables not installed" >&2
+  exit 1
+fi
+
+# Read the actual subnet Docker assigned to the sandbox network. If the
+# network doesn't exist yet, bail — the caller (deploy/provision) must
+# create it first.
+SUBNET=$(docker network inspect "$NETWORK" \
+  -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || true)
+
+if [ -z "$SUBNET" ]; then
+  echo "ERROR: docker network '$NETWORK' not found or has no subnet. Create it first." >&2
+  exit 1
+fi
+
+# DOCKER-USER is appended to FORWARD by Docker on install; create it if
+# the host is pre-Docker-17.06 or had it flushed.
+iptables -N DOCKER-USER 2>/dev/null || true
+
+# Drop any rules we previously inserted. Detect by comment tag so we can
+# change the source subnet or destination list across versions without
+# leaking stale rules.
+while :; do
+  LINE=$(iptables -L DOCKER-USER --line-numbers -n 2>/dev/null \
+    | awk -v tag="$COMMENT_TAG" '$0 ~ tag {print $1; exit}')
+  [ -z "$LINE" ] && break
+  iptables -D DOCKER-USER "$LINE"
+done
+
+# Insert fresh rules at the top of DOCKER-USER so Docker's default
+# RETURN/ACCEPT at the bottom can't shadow them.
+for dest in "${BLOCKED_DESTS[@]}"; do
+  iptables -I DOCKER-USER -s "$SUBNET" -d "$dest" \
+    -m comment --comment "$COMMENT_TAG" -j DROP
+done
+
+# Persist across reboots if iptables-persistent is installed.
+if command -v netfilter-persistent >/dev/null 2>&1; then
+  netfilter-persistent save >/dev/null
+fi
+
+echo "Applied sandbox egress block ($NETWORK, $SUBNET):"
+iptables -L DOCKER-USER -n --line-numbers | grep "$COMMENT_TAG" || true

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -170,6 +170,13 @@ func (d *DockerProvider) ensureNetwork(ctx context.Context) error {
 	_, err := d.client.NetworkCreate(ctx, d.network, network.CreateOptions{
 		Driver: "bridge",
 		Labels: map[string]string{"managed-by": "143"},
+		// Disable inter-container chatter so one sandbox can't TCP-connect
+		// to another on the same bridge. Existing networks created before
+		// this was added are NOT updated — Docker rejects option changes on
+		// existing networks, so the host provisioning path handles migration.
+		Options: map[string]string{
+			"com.docker.network.bridge.enable_icc": "false",
+		},
 	})
 	if err != nil && !cerrdefs.IsConflict(err) && !cerrdefs.IsAlreadyExists(err) {
 		return fmt.Errorf("create network %q: %w", d.network, err)
@@ -219,7 +226,12 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 			Memory:    int64(cfg.MemoryLimitMB) * 1024 * 1024,
 			PidsLimit: &pidsLimit,
 		},
-		NetworkMode:    container.NetworkMode(d.network),
+		NetworkMode: container.NetworkMode(d.network),
+		// Bypass Docker's embedded DNS resolver at 127.0.0.11. gVisor's
+		// netstack can't reliably reach it on user-defined bridge networks,
+		// so DNS lookups from inside the sandbox silently fail under runsc.
+		// Public resolvers work from gVisor's stack directly.
+		DNS:            []string{"1.1.1.1", "8.8.8.8"},
 		CapDrop:        []string{"ALL"},
 		CapAdd:         []string{"SETUID", "SETGID", "DAC_OVERRIDE"}, // minimum caps for sudo
 		ReadonlyRootfs: false,
@@ -296,6 +308,21 @@ func (d *DockerProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoU
 	}
 	if exitCode != 0 {
 		return fmt.Errorf("clone repo: git exited with code %d", exitCode)
+	}
+
+	// Strip the token out of .git/config. git clone embeds the whole
+	// authenticated URL (including x-access-token:TOKEN@github.com) into
+	// the origin remote, so `cat .git/config` from inside the sandbox
+	// leaks the short-lived installation token. Resetting the remote to
+	// the bare URL keeps push/pull working via GITHUB_TOKEN + credential
+	// helpers without leaving the token at rest on disk.
+	if token != "" {
+		resetCmd := fmt.Sprintf("git -C '%s' remote set-url origin '%s'",
+			shellEscape(sb.WorkDir), shellEscape(repoURL))
+		var resetErr bytes.Buffer
+		if code, err := d.Exec(ctx, sb, resetCmd, io.Discard, &resetErr); err != nil || code != 0 {
+			return fmt.Errorf("scrub clone token from .git/config (exit %d): %w: %s", code, err, resetErr.String())
+		}
 	}
 
 	d.logger.Info().

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -315,6 +315,8 @@ func TestDockerProvider_EnsureNetwork(t *testing.T) {
 			require.Equal(t, "143-sandbox", name)
 			require.Equal(t, "bridge", options.Driver)
 			require.Equal(t, "143", options.Labels["managed-by"])
+			require.Equal(t, "false", options.Options["com.docker.network.bridge.enable_icc"],
+				"sandbox network must disable inter-container chatter")
 			return network.CreateResponse{ID: "net-id"}, nil
 		}
 		p := NewDockerProvider(mock, newTestLogger(), WithRuntime("runc"))
@@ -424,6 +426,9 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, int64(4096*1024*1024), capturedHostConfig.Resources.Memory, "container should have 4GB memory")
 		require.NotNil(t, capturedHostConfig.Resources.PidsLimit, "container should have PID limit")
 		require.Equal(t, int64(256), *capturedHostConfig.Resources.PidsLimit, "container should have PID limit of 256")
+
+		require.Equal(t, []string{"1.1.1.1", "8.8.8.8"}, capturedHostConfig.DNS,
+			"container should bypass Docker embedded DNS — gVisor netstack can't reach 127.0.0.11")
 
 		// Verify sandbox result
 		require.Equal(t, "abc123", sb.ID, "sandbox ID should match container ID")
@@ -968,7 +973,11 @@ func TestDockerProvider_ShellInjection(t *testing.T) {
 
 		mock := &mockDockerClient{}
 		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
-			capturedCmd = config.Cmd
+			// Capture only the first exec (the git clone). The second is a
+			// post-clone `git remote set-url` that scrubs the token.
+			if capturedCmd == nil {
+				capturedCmd = config.Cmd
+			}
 			return container.ExecCreateResponse{ID: "exec-inject"}, nil
 		}
 		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
@@ -1058,14 +1067,14 @@ func TestDockerProvider_ShellInjection(t *testing.T) {
 func TestDockerProvider_CloneRepo(t *testing.T) {
 	t.Parallel()
 
-	t.Run("clones repository with auth token", func(t *testing.T) {
+	t.Run("clones repository with auth token and scrubs token from .git/config", func(t *testing.T) {
 		t.Parallel()
 
-		var capturedCmd string
+		var capturedCmds []string
 
 		mock := &mockDockerClient{}
 		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
-			capturedCmd = strings.Join(config.Cmd, " ")
+			capturedCmds = append(capturedCmds, strings.Join(config.Cmd, " "))
 			return container.ExecCreateResponse{ID: "exec-clone"}, nil
 		}
 		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
@@ -1076,10 +1085,18 @@ func TestDockerProvider_CloneRepo(t *testing.T) {
 
 		err := p.CloneRepo(context.Background(), sb, "https://github.com/org/repo.git", "main", "ghp_test123")
 		require.NoError(t, err, "CloneRepo should not return an error")
-		require.Contains(t, capturedCmd, "git clone", "should run git clone command")
-		require.Contains(t, capturedCmd, "--depth 1", "should do shallow clone")
-		require.Contains(t, capturedCmd, "--branch 'main'", "should clone the specified branch")
-		require.Contains(t, capturedCmd, "x-access-token:ghp_test123@", "should include auth token in URL")
+		require.Len(t, capturedCmds, 2, "should run clone then remote set-url")
+
+		cloneCmd := capturedCmds[0]
+		require.Contains(t, cloneCmd, "git clone", "should run git clone command")
+		require.Contains(t, cloneCmd, "--depth 1", "should do shallow clone")
+		require.Contains(t, cloneCmd, "--branch 'main'", "should clone the specified branch")
+		require.Contains(t, cloneCmd, "x-access-token:ghp_test123@", "should include auth token in URL")
+
+		scrubCmd := capturedCmds[1]
+		require.Contains(t, scrubCmd, "remote set-url origin", "should reset origin to scrub token")
+		require.Contains(t, scrubCmd, "https://github.com/org/repo.git", "should reset to bare URL")
+		require.NotContains(t, scrubCmd, "ghp_test123", "scrub command must not reintroduce the token")
 	})
 
 	t.Run("clones without token when empty", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Codex CLI couldn't reach `chatgpt.com` from sandboxes: gVisor's netstack can't use Docker's embedded DNS resolver, so we now set `DNS: 1.1.1.1, 8.8.8.8` on sandbox containers to restore name resolution under runsc.
- Hardens the sandbox: new sandbox networks use `enable_icc=false` (no cross-sandbox TCP), `git clone` no longer leaves the GitHub installation token in `.git/config`, and a new idempotent `deploy/scripts/sandbox-firewall.sh` blocks sandbox egress to cloud metadata (169.254/16) and RFC1918.
- The firewall script runs from cloud-init, provision, and every worker deploy; `iptables-persistent` is installed so rules survive reboots.

## Test plan
- [x] Reproduced original failure on `143-worker-1`: `docker run --runtime=runsc --network=143-sandbox ghcr.io/assembledhq/143-sandbox curl chatgpt.com` returned `Could not resolve host` before the fix; resolves with `--dns=1.1.1.1`.
- [x] Applied firewall script on `143-worker-1`: confirmed 4 DROP rules in `DOCKER-USER` sourced from 172.19.0.0/16 to metadata/RFC1918 destinations.
- [ ] Kick off a fresh Codex session end-to-end and confirm it completes (no stream-disconnected errors).
- [ ] Verify sandbox cannot reach `169.254.169.254` or `10.x.x.x` from inside a running container.
- [ ] `make lint` and Go unit tests pass.
