### PR TITLE
Align automations pages with shared layout and form conventions

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -25,6 +25,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { Automation, AutomationRun, AutomationRunStatus } from "@/lib/types";
@@ -178,12 +180,12 @@ function SettingsTab({ automation }: { automation: Automation }) {
   const updateMutation = useMutation({
     mutationFn: () =>
       api.automations.update(automation.id, {
-        name,
-        goal,
-        scope: scope || undefined,
+        name: name.trim(),
+        goal: goal.trim(),
+        scope: scope.trim() || undefined,
         interval_value: intervalValue,
         interval_unit: intervalUnit,
-        base_branch: baseBranch,
+        base_branch: baseBranch.trim() || undefined,
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["automation", automation.id] });
@@ -191,23 +193,26 @@ function SettingsTab({ automation }: { automation: Automation }) {
   });
 
   return (
-    <div className="space-y-4">
-      <div>
+    <div className="space-y-4 rounded-lg border border-border bg-card p-5">
+      <div className="space-y-1.5">
         <Label htmlFor="name">Name</Label>
         <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
       </div>
-      <div>
+      <div className="space-y-1.5">
         <Label htmlFor="goal">Goal</Label>
         <Textarea id="goal" value={goal} onChange={(e) => setGoal(e.target.value)} rows={3} />
       </div>
-      <div>
-        <Label htmlFor="scope">Scope</Label>
+      <div className="space-y-1.5">
+        <Label htmlFor="scope">
+          Scope{" "}
+          <span className="text-muted-foreground font-normal">(optional)</span>
+        </Label>
         <Input id="scope" value={scope} onChange={(e) => setScope(e.target.value)} />
       </div>
-      <div>
+      <div className="space-y-1.5">
         <Label id="schedule-label">Schedule</Label>
         <div
-          className="flex items-center gap-2 mt-1"
+          className="flex items-center gap-2"
           role="group"
           aria-labelledby="schedule-label"
         >
@@ -240,11 +245,11 @@ function SettingsTab({ automation }: { automation: Automation }) {
           </Select>
         </div>
       </div>
-      <div>
+      <div className="space-y-1.5">
         <Label htmlFor="baseBranch">Base branch</Label>
         <Input id="baseBranch" value={baseBranch} onChange={(e) => setBaseBranch(e.target.value)} />
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 pt-2">
         <Button
           onClick={() => updateMutation.mutate()}
           disabled={updateMutation.isPending}
@@ -313,23 +318,36 @@ export default function AutomationDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="max-w-4xl mx-auto px-6 py-8 text-center text-sm text-muted-foreground">
-        Loading...
-      </div>
+      <PageContainer size="default">
+        <div className="text-center py-12 text-sm text-muted-foreground">
+          Loading...
+        </div>
+      </PageContainer>
     );
   }
 
   if (!automation) {
     return (
-      <div className="max-w-4xl mx-auto px-6 py-8 text-center text-sm text-muted-foreground">
-        Automation not found.
-      </div>
+      <PageContainer size="default">
+        <div className="space-y-6">
+          <PageHeader
+            title="Automation not found"
+            description="This automation does not exist or has been deleted."
+          />
+        </div>
+      </PageContainer>
     );
   }
 
   const schedule = automation.schedule_type === "cron" && automation.cron_expression
     ? `cron: ${automation.cron_expression}`
     : `every ${automation.interval_value ?? 1} ${automation.interval_unit ?? "days"}`;
+
+  const headerDescription = automation.enabled
+    ? automation.next_run_at
+      ? `${schedule} · Next: ${new Date(automation.next_run_at).toLocaleString()}`
+      : schedule
+    : `${schedule} · Paused`;
 
   // Surface the most recent failure across the header mutations. These are
   // user-initiated actions (pause/resume/run now/delete) so silent failure is
@@ -343,88 +361,77 @@ export default function AutomationDetailPage() {
     null;
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      {/* Header */}
-      <div className="flex items-start justify-between mb-6">
-        <div>
-          <div className="flex items-center gap-2.5 mb-1">
-            <RefreshCw className={cn("h-5 w-5", automation.enabled ? "text-blue-500" : "text-muted-foreground")} />
-            <h1 className="text-lg font-semibold text-foreground">{automation.name}</h1>
-          </div>
-          <div className="flex items-center gap-3 text-sm text-muted-foreground">
-            <span>{schedule}</span>
-            {automation.next_run_at && automation.enabled && (
-              <>
-                <span>&middot;</span>
-                <span>Next: {new Date(automation.next_run_at).toLocaleString()}</span>
-              </>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          {automation.enabled ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => pauseMutation.mutate()}
-              disabled={pauseMutation.isPending}
-            >
-              {pauseMutation.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title={automation.name}
+          description={headerDescription}
+          action={
+            <div className="flex items-center gap-2">
+              {automation.enabled ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => pauseMutation.mutate()}
+                  disabled={pauseMutation.isPending}
+                >
+                  {pauseMutation.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                  ) : (
+                    <Pause className="h-3.5 w-3.5 mr-1.5" />
+                  )}
+                  Pause
+                </Button>
               ) : (
-                <Pause className="h-3.5 w-3.5 mr-1.5" />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => resumeMutation.mutate()}
+                  disabled={resumeMutation.isPending}
+                >
+                  {resumeMutation.isPending ? (
+                    <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                  ) : (
+                    <Play className="h-3.5 w-3.5 mr-1.5" />
+                  )}
+                  Resume
+                </Button>
               )}
-              Pause
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => resumeMutation.mutate()}
-              disabled={resumeMutation.isPending}
-            >
-              {resumeMutation.isPending ? (
-                <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-              ) : (
-                <Play className="h-3.5 w-3.5 mr-1.5" />
-              )}
-              Resume
-            </Button>
-          )}
-          <Button
-            size="sm"
-            onClick={handleRunNow}
-            disabled={runNowMutation.isPending}
-          >
-            {runNowMutation.isPending ? (
-              <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
-            ) : (
-              <Play className="h-3.5 w-3.5 mr-1.5" />
-            )}
-            Run now
-          </Button>
-        </div>
+              <Button
+                size="sm"
+                onClick={handleRunNow}
+                disabled={runNowMutation.isPending}
+              >
+                {runNowMutation.isPending ? (
+                  <Loader2 className="h-3.5 w-3.5 mr-1.5 animate-spin" />
+                ) : (
+                  <Play className="h-3.5 w-3.5 mr-1.5" />
+                )}
+                Run now
+              </Button>
+            </div>
+          }
+        />
+
+        {headerError && (
+          <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+            {headerError}
+          </div>
+        )}
+
+        <Tabs defaultValue="runs">
+          <TabsList>
+            <TabsTrigger value="runs">Runs</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+          </TabsList>
+          <TabsContent value="runs" className="mt-4">
+            <RunsTab automationId={automationId} />
+          </TabsContent>
+          <TabsContent value="settings" className="mt-4">
+            <SettingsTab automation={automation} />
+          </TabsContent>
+        </Tabs>
       </div>
-
-      {headerError && (
-        <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-          {headerError}
-        </div>
-      )}
-
-      {/* Tabs */}
-      <Tabs defaultValue="runs">
-        <TabsList>
-          <TabsTrigger value="runs">Runs</TabsTrigger>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-        </TabsList>
-        <TabsContent value="runs" className="mt-4">
-          <RunsTab automationId={automationId} />
-        </TabsContent>
-        <TabsContent value="settings" className="mt-4">
-          <SettingsTab automation={automation} />
-        </TabsContent>
-      </Tabs>
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/components/ui/collapsible";
 import { api } from "@/lib/api";
 import { NoReposWarning } from "@/components/no-repos-warning";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { cn } from "@/lib/utils";
 import { automationTemplates } from "@/lib/automation-templates";
 
@@ -62,13 +64,13 @@ export default function NewAutomationPage() {
   const createMutation = useMutation({
     mutationFn: () =>
       api.automations.create({
-        name,
-        goal,
-        repository_id: repoId || undefined,
-        scope: scope || undefined,
+        name: name.trim(),
+        goal: goal.trim(),
+        repository_id: repoId,
+        scope: scope.trim() || undefined,
         interval_value: intervalValue,
         interval_unit: intervalUnit,
-        base_branch: baseBranch,
+        base_branch: baseBranch.trim() || undefined,
         priority,
       }),
     onSuccess: (res) => {
@@ -78,193 +80,221 @@ export default function NewAutomationPage() {
 
   if (repos.length === 0 && reposData) {
     return (
-      <div className="max-w-2xl mx-auto px-6 py-8">
-        <h1 className="text-lg font-semibold mb-4">New Automation</h1>
-        <NoReposWarning />
-      </div>
+      <PageContainer size="default">
+        <div className="space-y-6">
+          <PageHeader
+            title="New automation"
+            description="Recurring agents that run on a schedule for your team."
+          />
+          <NoReposWarning />
+        </div>
+      </PageContainer>
     );
   }
 
+  const canSubmit =
+    name.trim().length > 0 && goal.trim().length > 0 && repoId.length > 0;
+
   return (
-    <div className="max-w-2xl mx-auto px-6 py-8">
-      <h1 className="text-lg font-semibold text-foreground mb-6">New Automation</h1>
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title="New automation"
+          description="Recurring agents that run on a schedule for your team."
+        />
 
-      {/* Templates */}
-      <div className="mb-6">
-        <Label className="text-xs text-muted-foreground mb-2 block">
-          Start from a template
-        </Label>
-        <div className="flex flex-wrap gap-2">
-          {automationTemplates.map((t) => {
-            const Icon = t.icon;
-            return (
-              <Button
-                key={t.id}
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => applyTemplate(t.id)}
-                className={cn(
-                  "rounded-full h-7 px-3 text-xs",
-                  name === t.name && "border-primary bg-primary/5"
-                )}
-              >
-                <Icon className="h-3.5 w-3.5 mr-1.5" />
-                {t.name}
-              </Button>
-            );
-          })}
-        </div>
-      </div>
-
-      <div className="space-y-4">
-        {/* Name */}
-        <div>
-          <Label htmlFor="name">Name</Label>
-          <Input
-            id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="e.g. Find flaky tests"
-          />
-        </div>
-
-        {/* Goal */}
-        <div>
-          <Label htmlFor="goal">Goal</Label>
-          <Textarea
-            id="goal"
-            value={goal}
-            onChange={(e) => setGoal(e.target.value)}
-            placeholder="Describe what the automation should do each run..."
-            rows={3}
-          />
-        </div>
-
-        {/* Scope (optional) */}
-        <div>
-          <Label htmlFor="scope">
-            Scope <span className="text-muted-foreground font-normal">(optional)</span>
+        {/* Templates */}
+        <div className="space-y-2">
+          <Label className="text-xs text-muted-foreground">
+            Start from a template
           </Label>
-          <Input
-            id="scope"
-            value={scope}
-            onChange={(e) => setScope(e.target.value)}
-            placeholder="e.g. src/payments/, tests/"
-          />
-        </div>
-
-        {/* Repository */}
-        <div>
-          <Label>Repository</Label>
-          <Select value={repoId} onValueChange={setSelectedRepoId}>
-            <SelectTrigger>
-              <SelectValue placeholder="Select repo" />
-            </SelectTrigger>
-            <SelectContent>
-              {repos.map((repo) => (
-                <SelectItem key={repo.id} value={repo.id}>
-                  {repo.full_name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        {/* Schedule */}
-        <div>
-          <Label id="schedule-label">Schedule</Label>
-          <div
-            className="flex items-center gap-2 mt-1"
-            role="group"
-            aria-labelledby="schedule-label"
-          >
-            <span className="text-sm text-muted-foreground">Run every</span>
-            <Input
-              id="interval-value"
-              aria-label="Interval value"
-              type="number"
-              min={1}
-              max={365}
-              value={intervalValue}
-              onChange={(e) => {
-                const parsed = parseInt(e.target.value, 10);
-                setIntervalValue(Number.isNaN(parsed) ? 1 : Math.max(1, parsed));
-              }}
-              className="w-20"
-            />
-            <Select
-              value={intervalUnit}
-              onValueChange={(v) => {
-                // Validated against the SelectItem values below; if the tuple
-                // ever drifts from the Select options, fall back rather than
-                // coercing an unexpected value through `as`.
-                if (v === "hours" || v === "days" || v === "weeks") {
-                  setIntervalUnit(v);
-                }
-              }}
-            >
-              <SelectTrigger className="w-28" aria-label="Interval unit">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="hours">hours</SelectItem>
-                <SelectItem value="days">days</SelectItem>
-                <SelectItem value="weeks">weeks</SelectItem>
-              </SelectContent>
-            </Select>
+          <div className="flex flex-wrap gap-2">
+            {automationTemplates.map((t) => {
+              const Icon = t.icon;
+              return (
+                <Button
+                  key={t.id}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => applyTemplate(t.id)}
+                  className={cn(
+                    "rounded-full h-7 px-3 text-xs",
+                    name === t.name && "border-primary bg-primary/5"
+                  )}
+                >
+                  <Icon className="h-3.5 w-3.5 mr-1.5" />
+                  {t.name}
+                </Button>
+              );
+            })}
           </div>
         </div>
 
-        {/* Advanced settings */}
-        <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-          <CollapsibleTrigger className="flex items-center gap-2 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors py-2">
-            <ChevronDown className={cn("h-3.5 w-3.5 transition-transform", advancedOpen && "rotate-180")} />
-            Advanced
-          </CollapsibleTrigger>
-          <CollapsibleContent className="space-y-4 pt-2">
-            <div>
-              <Label htmlFor="baseBranch">Base branch</Label>
+        {/* Main form */}
+        <div className="space-y-4 rounded-lg border border-border bg-card p-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="name">Name</Label>
+            <Input
+              id="name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Find flaky tests"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="goal">Goal</Label>
+            <Textarea
+              id="goal"
+              value={goal}
+              onChange={(e) => setGoal(e.target.value)}
+              placeholder="Describe what the automation should do each run..."
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="scope">
+              Scope{" "}
+              <span className="text-muted-foreground font-normal">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id="scope"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              placeholder="e.g. src/payments/, tests/"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Repository</Label>
+            <Select value={repoId} onValueChange={setSelectedRepoId}>
+              <SelectTrigger>
+                <SelectValue placeholder="Select a repository" />
+              </SelectTrigger>
+              <SelectContent>
+                {repos.map((repo) => (
+                  <SelectItem key={repo.id} value={repo.id}>
+                    {repo.full_name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label id="schedule-label">Schedule</Label>
+            <div
+              className="flex items-center gap-2"
+              role="group"
+              aria-labelledby="schedule-label"
+            >
+              <span className="text-sm text-muted-foreground">Run every</span>
               <Input
-                id="baseBranch"
-                value={baseBranch}
-                onChange={(e) => setBaseBranch(e.target.value)}
-                placeholder="main"
+                id="interval-value"
+                aria-label="Interval value"
+                type="number"
+                min={1}
+                max={365}
+                value={intervalValue}
+                onChange={(e) => {
+                  const parsed = parseInt(e.target.value, 10);
+                  setIntervalValue(
+                    Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
+                  );
+                }}
+                className="w-20"
               />
-            </div>
-            <div>
-              <Label>Priority</Label>
-              <Select value={String(priority)} onValueChange={(v) => setPriority(parseInt(v, 10))}>
-                <SelectTrigger>
+              <Select
+                value={intervalUnit}
+                onValueChange={(v) => {
+                  // Validated against the SelectItem values below; if the tuple
+                  // ever drifts from the Select options, fall back rather than
+                  // coercing an unexpected value through `as`.
+                  if (v === "hours" || v === "days" || v === "weeks") {
+                    setIntervalUnit(v);
+                  }
+                }}
+              >
+                <SelectTrigger className="w-28" aria-label="Interval unit">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="0">Critical</SelectItem>
-                  <SelectItem value="25">High</SelectItem>
-                  <SelectItem value="50">Medium</SelectItem>
-                  <SelectItem value="75">Low</SelectItem>
+                  <SelectItem value="hours">hours</SelectItem>
+                  <SelectItem value="days">days</SelectItem>
+                  <SelectItem value="weeks">weeks</SelectItem>
                 </SelectContent>
               </Select>
             </div>
-          </CollapsibleContent>
-        </Collapsible>
+          </div>
 
-        {/* Submit */}
-        <Button
-          onClick={() => createMutation.mutate()}
-          disabled={!name || !goal || createMutation.isPending}
-          className="w-full"
-        >
-          {createMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-          Create automation
-        </Button>
+          {/* Advanced settings */}
+          <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+            <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors py-1">
+              <ChevronDown
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform",
+                  advancedOpen && "rotate-180",
+                )}
+              />
+              Advanced options
+            </CollapsibleTrigger>
+            <CollapsibleContent className="space-y-4 pt-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="baseBranch">Base branch</Label>
+                <Input
+                  id="baseBranch"
+                  value={baseBranch}
+                  onChange={(e) => setBaseBranch(e.target.value)}
+                  placeholder="main"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label>Priority</Label>
+                <Select
+                  value={String(priority)}
+                  onValueChange={(v) => setPriority(parseInt(v, 10))}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="0">Critical</SelectItem>
+                    <SelectItem value="25">High</SelectItem>
+                    <SelectItem value="50">Medium</SelectItem>
+                    <SelectItem value="75">Low</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
 
-        {createMutation.isError && (
-          <p className="text-sm text-destructive">
-            Failed to create automation. Please try again.
-          </p>
-        )}
+          {/* Submit */}
+          <div className="flex items-center gap-3 pt-2">
+            <Button
+              onClick={() => createMutation.mutate()}
+              disabled={!canSubmit || createMutation.isPending}
+            >
+              {createMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                "Create automation"
+              )}
+            </Button>
+            {createMutation.isError && (
+              <p className="text-xs text-destructive">
+                Failed to create automation. Please try again.
+              </p>
+            )}
+          </div>
+        </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 
 function formatSchedule(a: Automation): string {
   if (a.schedule_type === "cron" && a.cron_expression) {
@@ -154,66 +156,66 @@ export default function AutomationsPage() {
   const paused = useMemo(() => automations.filter((a) => !a.enabled), [automations]);
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-lg font-semibold text-foreground">Automations</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Recurring agents that run on a schedule for your team.
-          </p>
-        </div>
-        <Button asChild size="sm">
-          <Link href="/automations/new">
-            <Plus className="h-4 w-4 mr-1.5" />
-            New
-          </Link>
-        </Button>
+    <PageContainer size="default">
+      <div className="space-y-6">
+        <PageHeader
+          title="Automations"
+          description="Recurring agents that run on a schedule for your team."
+          action={
+            <Button asChild size="sm">
+              <Link href="/automations/new">
+                <Plus className="h-4 w-4 mr-1.5" />
+                New
+              </Link>
+            </Button>
+          }
+        />
+
+        {isLoading && (
+          <div className="text-center py-12 text-sm text-muted-foreground">
+            Loading automations...
+          </div>
+        )}
+
+        {!isLoading && automations.length === 0 && (
+          <div className="text-center py-16 space-y-3">
+            <RefreshCw className="h-8 w-8 mx-auto text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">No automations yet</p>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/automations/new">
+                <Plus className="h-4 w-4 mr-1.5" />
+                Create your first automation
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {enabled.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Enabled ({enabled.length})
+            </h2>
+            <div className="space-y-2">
+              {enabled.map((a) => (
+                <AutomationCard key={a.id} automation={a} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {paused.length > 0 && (
+          <section className="space-y-3">
+            <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+              Paused ({paused.length})
+            </h2>
+            <div className="space-y-2">
+              {paused.map((a) => (
+                <AutomationCard key={a.id} automation={a} />
+              ))}
+            </div>
+          </section>
+        )}
       </div>
-
-      {isLoading && (
-        <div className="text-center py-12 text-sm text-muted-foreground">
-          Loading automations...
-        </div>
-      )}
-
-      {!isLoading && automations.length === 0 && (
-        <div className="text-center py-16 space-y-3">
-          <RefreshCw className="h-8 w-8 mx-auto text-muted-foreground/40" />
-          <p className="text-sm text-muted-foreground">No automations yet</p>
-          <Button asChild variant="outline" size="sm">
-            <Link href="/automations/new">
-              <Plus className="h-4 w-4 mr-1.5" />
-              Create your first automation
-            </Link>
-          </Button>
-        </div>
-      )}
-
-      {enabled.length > 0 && (
-        <div className="mb-6">
-          <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-            Enabled ({enabled.length})
-          </h2>
-          <div className="space-y-2">
-            {enabled.map((a) => (
-              <AutomationCard key={a.id} automation={a} />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {paused.length > 0 && (
-        <div>
-          <h2 className="text-xs font-medium text-muted-foreground uppercase tracking-wider mb-3">
-            Paused ({paused.length})
-          </h2>
-          <div className="space-y-2">
-            {paused.map((a) => (
-              <AutomationCard key={a.id} automation={a} />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- Wraps the automations list, detail, and new-automation pages in `PageContainer` + `PageHeader` so the section matches the settings shell (max-w-5xl, text-2xl heading).
- Restructures the new-automation form to mirror `projects/new`: bordered card wrapper, `space-y-1.5` field groups (fixes label↔input padding), inline submit row; applies the same treatment to the detail page settings tab.
- Trims `name`/`goal`/`scope`/`base_branch` before mutation and requires a repo selection on create.

## Test plan
- [ ] Visit `/automations` — header, "New" action, and section spacing match settings.
- [ ] Visit `/automations/new` — labels have visible padding above inputs; submit disabled until name/goal/repo are filled.
- [ ] Visit `/automations/[id]` — header shows schedule + next-run (or "Paused"); Settings tab uses the same card layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)