### PR TITLE
Refine session overview layout and tighten AuditLogTrigger

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -136,11 +136,20 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
 
     const updatedTrigger = await screen.findByRole('button', { name: /Updated.*ago by/i });
-    const metadataStack = updatedTrigger.parentElement;
+    const metadataRow = updatedTrigger.parentElement;
 
-    expect(metadataStack?.className).toContain('space-y-1');
-    expect(updatedTrigger.className).toContain('px-1');
+    // The audit trigger now shares the timestamps flex row so "Failed X ago"
+    // and "Updated X ago by Y" sit on the same baseline.
+    expect(metadataRow?.className).toContain('flex');
+    expect(metadataRow?.className).toContain('items-center');
+    expect(metadataRow?.textContent).toMatch(/Failed.*ago/);
+
+    // Inline variant: zero horizontal padding, muted color, preceded by a
+    // decorative middle-dot separator marked aria-hidden.
+    expect(updatedTrigger.className).toContain('px-0');
     expect(updatedTrigger.className).toContain('text-muted-foreground');
+    expect(updatedTrigger.previousElementSibling?.getAttribute('aria-hidden')).toBe('true');
+    expect(updatedTrigger.previousElementSibling?.textContent).toBe('·');
   });
 
   it('shows error state when session not found', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -20,10 +20,6 @@ import {
   PanelRightOpen,
   PanelRightClose,
   Clock,
-  Timer,
-  User as UserIcon,
-  Bot,
-  Cpu,
   MessageSquare,
   Paperclip,
   X,
@@ -258,89 +254,60 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
         />
       )}
 
-      {/* Session vitals — primary info row */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${status.color}`}>
-              {isActive && (
-                <span className="relative mr-1.5 flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
-                </span>
-              )}
-              {status.label}
-            </span>
-            <span className="h-3.5 w-px bg-border" />
-            <span className="inline-flex items-center gap-1.5 text-xs">
-              <Cpu className="h-3 w-3 text-muted-foreground" />
-              <span className="font-medium">{agentTypeLabels[session.agent_type] || session.agent_type}</span>
-            </span>
-            <span className="h-3.5 w-px bg-border" />
-            <span className="inline-flex items-center gap-1.5 text-xs">
-              {session.pm_plan_id && !session.triggered_by_user_id ? (
-                <Bot className="h-3 w-3 text-primary" />
-              ) : (
-                <UserIcon className="h-3 w-3 text-muted-foreground" />
-              )}
-              <span className="font-medium">{triggeredByLabel}</span>
-            </span>
-          </div>
-        </CardContent>
-      </Card>
-
-      <div className="space-y-1">
-        {/* Timestamps — secondary reference data */}
-        <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-xs text-muted-foreground px-1">
-          {/* Hide duration for failed/cancelled sessions with no meaningful runtime */}
-          {!((session.status === "failed" || session.status === "cancelled") &&
-            !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
-            <span className="inline-flex items-center gap-1.5">
-              <Timer className="h-3 w-3" />
-              {session.status === "pending"
-                ? formatDuration(session.created_at)
-                : isActive
-                  ? formatDuration(session.started_at)
-                  : formatDuration(session.started_at, session.completed_at)}
-            </span>
-          )}
-          <span className="inline-flex items-center gap-1.5">
-            {!isActive && session.completed_at ? (
-              session.status === "failed" ? (
-                <>
-                  <XCircle className="h-3 w-3" />
-                  Failed {formatTimeAgo(session.completed_at)}
-                </>
-              ) : session.status === "cancelled" ? (
-                <>
-                  <MinusCircle className="h-3 w-3" />
-                  Cancelled {formatTimeAgo(session.completed_at)}
-                </>
-              ) : (
-                <>
-                  <CheckCircle2 className="h-3 w-3" />
-                  Completed {formatTimeAgo(session.completed_at)}
-                </>
-              )
-            ) : session.started_at ? (
-              <>
-                <Clock className="h-3 w-3" />
-                Started {formatTimeAgo(session.started_at)}
-              </>
-            ) : (
-              <>
-                <Clock className="h-3 w-3" />
-                Queued {formatTimeAgo(session.created_at)}
-              </>
+      {/* Session vitals — identity row (status + agent + who triggered) */}
+      <div className="space-y-2">
+        <div className="flex items-center gap-x-3 gap-y-1 flex-wrap text-xs">
+          <span className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium ${status.color}`}>
+            {isActive && (
+              <span className="relative mr-1.5 flex h-2 w-2">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-500" />
+              </span>
             )}
+            {status.label}
+          </span>
+          <span className="inline-flex items-center gap-x-1.5 text-muted-foreground">
+            <span className="font-medium text-foreground">{agentTypeLabels[session.agent_type] || session.agent_type}</span>
+            <span aria-hidden="true" className="text-muted-foreground/50">·</span>
+            <span>{triggeredByLabel}</span>
           </span>
         </div>
 
-        <AuditLogTrigger
-          filters={{ session_id: session.id }}
-          members={members}
-          title="Session activity"
-        />
+        {/* Timestamps + audit — secondary reference data, single unified row */}
+        <div className="flex items-center gap-x-1.5 gap-y-1 flex-wrap text-xs text-muted-foreground">
+          {!((session.status === "failed" || session.status === "cancelled") &&
+            !hasMeaningfulDuration(session.started_at, session.completed_at)) && (
+            <>
+              <span>
+                {session.status === "pending"
+                  ? formatDuration(session.created_at)
+                  : isActive
+                    ? formatDuration(session.started_at)
+                    : formatDuration(session.started_at, session.completed_at)}
+              </span>
+              <span aria-hidden="true" className="text-muted-foreground/50">·</span>
+            </>
+          )}
+          <span>
+            {!isActive && session.completed_at ? (
+              session.status === "failed"
+                ? <>Failed {formatTimeAgo(session.completed_at)}</>
+                : session.status === "cancelled"
+                  ? <>Cancelled {formatTimeAgo(session.completed_at)}</>
+                  : <>Completed {formatTimeAgo(session.completed_at)}</>
+            ) : session.started_at ? (
+              <>Started {formatTimeAgo(session.started_at)}</>
+            ) : (
+              <>Queued {formatTimeAgo(session.created_at)}</>
+            )}
+          </span>
+          <AuditLogTrigger
+            filters={{ session_id: session.id }}
+            members={members}
+            title="Session activity"
+            variant="inline"
+          />
+        </div>
       </div>
 
       {/* PM context */}

--- a/frontend/src/components/audit/audit-log-trigger.test.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.test.tsx
@@ -72,6 +72,55 @@ describe('AuditLogTrigger', () => {
     });
   });
 
+  it('inline variant: renders a leading separator dot and no icon', async () => {
+    auditLogListMock.mockResolvedValue({
+      data: [{
+        id: 'audit-inline',
+        actor_type: 'user',
+        user_id: 'user-1',
+        action: 'session.created',
+        created_at: new Date(Date.now() - 2 * 60000).toISOString(),
+      }],
+      meta: {},
+    });
+
+    const { container } = renderWithProviders(
+      <AuditLogTrigger filters={{ session_id: 'sess-1' }} members={mockMembers} variant="inline" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Updated.*ago by Alice/)).toBeInTheDocument();
+    });
+
+    const separator = container.querySelector('span[aria-hidden="true"]');
+    expect(separator?.textContent).toBe('·');
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('default variant: renders the Clock icon and no separator', async () => {
+    auditLogListMock.mockResolvedValue({
+      data: [{
+        id: 'audit-default',
+        actor_type: 'user',
+        user_id: 'user-1',
+        action: 'session.created',
+        created_at: new Date(Date.now() - 2 * 60000).toISOString(),
+      }],
+      meta: {},
+    });
+
+    const { container } = renderWithProviders(
+      <AuditLogTrigger filters={{ session_id: 'sess-1' }} members={mockMembers} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Updated.*ago by Alice/)).toBeInTheDocument();
+    });
+
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
   it('renders system actor label for non-user actors', async () => {
     auditLogListMock.mockResolvedValue({
       data: [{

--- a/frontend/src/components/audit/audit-log-trigger.tsx
+++ b/frontend/src/components/audit/audit-log-trigger.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Clock } from "lucide-react";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
-import { formatTimeAgo } from "@/lib/utils";
+import { cn, formatTimeAgo } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import type { User } from "@/lib/types";
 import { Button } from "@/components/ui/button";
@@ -18,9 +18,16 @@ interface AuditLogTriggerProps {
   members?: User[];
   /** Sidesheet title. */
   title?: string;
+  /**
+   * Visual variant.
+   * - `default`: standalone row with a leading Clock icon.
+   * - `inline`: drops the icon, adds a leading middle-dot separator, and removes
+   *   horizontal padding so the trigger reads as part of a surrounding sentence.
+   */
+  variant?: "default" | "inline";
 }
 
-export function AuditLogTrigger({ filters, members: membersProp, title }: AuditLogTriggerProps) {
+export function AuditLogTrigger({ filters, members: membersProp, title, variant = "default" }: AuditLogTriggerProps) {
   const [open, setOpen] = useState(false);
   const { user } = useAuth();
   const isAdmin = user?.role === "admin";
@@ -61,15 +68,23 @@ export function AuditLogTrigger({ filters, members: membersProp, title }: AuditL
     return latestEntry.actor_id;
   })();
 
+  const isInline = variant === "inline";
+
   return (
     <>
+      {isInline && (
+        <span aria-hidden="true" className="text-muted-foreground/50 text-xs">·</span>
+      )}
       <Button
         variant="ghost"
         size="xs"
         onClick={() => setOpen(true)}
-        className="inline-flex h-auto items-center gap-1.5 px-1 py-0.5 text-xs font-normal text-muted-foreground transition-all duration-150 hover:text-muted-foreground"
+        className={cn(
+          "inline-flex h-auto items-center py-0.5 text-xs font-normal text-muted-foreground transition-colors hover:text-foreground",
+          isInline ? "px-0" : "gap-1.5 px-1",
+        )}
       >
-        <Clock className="h-3 w-3" />
+        {!isInline && <Clock className="h-3 w-3" />}
         <span className="text-xs">
           Updated {formatTimeAgo(latestEntry.created_at)} by {actorName}
         </span>


### PR DESCRIPTION
## Summary
- Flatten the session Overview tab: drop the Card wrapper, remove redundant/duplicate icons (two Clocks, Timer, Cpu, UserIcon, Bot, and the Check/X/MinusCircle decorations on timestamps), and unify alignment under one left edge with middle-dot separators carrying \`aria-hidden\`.
- Give \`AuditLogTrigger\` a \`variant: "default" | "inline"\` prop so the session overview composes it inline (leading \`·\`, no icon, \`px-0\`) while the three standalone call-sites in settings, team, and project pages keep their original Clock-icon appearance.
- Fix a stale \`hover:text-muted-foreground\` no-op on the trigger to \`hover:text-foreground\` so the hover state actually signals interactivity.

## Test plan
- [x] \`npm run typecheck\` — passes
- [x] \`npx vitest run src/components/audit/audit-log-trigger.test.tsx\` — 5/5 (2 new tests covering \`variant="inline"\` and \`variant="default"\`)
- [x] \`npx eslint\` on changed files — no new warnings
- [ ] Visual QA: open a running session, verify the Overview tab shows \`[● Running] Codex · John Doe\` on one line and \`104m 40s · Started 1h ago · Updated 1h ago by John Doe\` aligned flush beneath it
- [ ] Visual QA: verify \`settings\`, \`settings/team\`, and a project detail page still show the Clock-icon audit trigger as before