### PR TITLE
Speed up PR CI with diff-coverage gating and affected-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      # actions/checkout on pull_request checks out refs/pull/N/merge and does not
+      # always set up origin/main as a remote-tracking ref — fetch it explicitly so
+      # diff-cover's `--compare-branch=origin/main` resolves.
+      - name: Fetch base branch (PR only)
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         if: github.event_name == 'pull_request'
@@ -184,12 +191,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+
+      # actions/checkout on pull_request checks out refs/pull/N/merge and does not
+      # always set up origin/main as a remote-tracking ref — fetch it explicitly so
+      # vitest --changed=origin/main and diff-cover both resolve.
+      - name: Fetch base branch (PR only)
+        if: github.event_name == 'pull_request'
+        working-directory: ${{ github.workspace }}
+        run: git fetch --no-tags --prune origin +refs/heads/main:refs/remotes/origin/main
 
       - uses: actions/setup-python@v5
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,9 +94,22 @@ jobs:
       DATABASE_URL: postgres://onefortythree:dev@localhost:5432/onefortythree?sslmode=disable
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/setup-python@v5
+        if: github.event_name == 'pull_request'
+        with:
+          python-version: '3.x'
+
+      - name: Install diff-cover tooling (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          pip install 'diff_cover==10.2.0'
+          go install github.com/boumenot/gocover-cobertura@v1.4.0
 
       - name: Run go vet and migrations
         run: |
@@ -104,12 +117,24 @@ jobs:
           go run cmd/migrate/main.go up
           wait
 
-      - name: Run tests with coverage
+      - name: Run tests (PR — no race)
+        if: github.event_name == 'pull_request'
         run: |
-          go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=120s
+          go test ./internal/... -coverprofile=coverage.out -covermode=count -timeout=120s
+          gocover-cobertura < coverage.out > coverage.xml
+
+      - name: Patch coverage gate (PR only)
+        if: github.event_name == 'pull_request'
+        run: diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+
+      - name: Run tests with race + coverage (main only)
+        if: github.event_name == 'push'
+        run: |
+          go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=180s
           go tool cover -func=coverage.out
 
-      - name: Check backend coverage floor
+      - name: Check backend coverage floor (main only)
+        if: github.event_name == 'push'
         run: |
           COVERAGE=$(go tool cover -func=coverage.out | grep total | awk '{print $3}' | sed 's/%//')
           echo "Total coverage: ${COVERAGE}%"
@@ -122,6 +147,7 @@ jobs:
           fi
 
       - name: Upload coverage artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage
@@ -157,18 +183,56 @@ jobs:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
+
+      - uses: actions/setup-python@v5
+        if: github.event_name == 'pull_request'
+        with:
+          python-version: '3.x'
+
+      - name: Install diff-cover (PR only)
+        if: github.event_name == 'pull_request'
+        run: pip install 'diff_cover==10.2.0'
+
       - run: npm ci
 
-      - name: Run tests with coverage
+      - name: Run affected tests (PR)
+        if: github.event_name == 'pull_request'
         timeout-minutes: 10
-        run: npx vitest run --coverage --coverage.reporter=text --coverage.reporter=json-summary
+        run: npx vitest run --changed=origin/main --passWithNoTests --coverage --coverage.reporter=lcov --coverage.reporter=json-summary
 
-      - name: Check frontend coverage floor
+      - name: Patch coverage gate (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          if [ ! -f coverage/lcov.info ]; then
+            # vitest --changed found no affected tests, so no coverage was emitted.
+            # Fail if the diff includes frontend source files — uncovered changes shouldn't merge silently.
+            CHANGED_SOURCES=$(cd .. && git diff --name-only origin/main...HEAD \
+              | grep -E '^frontend/src/.*\.(ts|tsx)$' \
+              | grep -v '\.test\.' || true)
+            if [ -n "$CHANGED_SOURCES" ]; then
+              echo "::error::Frontend source files changed but no tests cover them:"
+              echo "$CHANGED_SOURCES"
+              exit 1
+            fi
+            echo "::notice::No frontend source files in diff; skipping patch-coverage gate."
+            exit 0
+          fi
+          diff-cover coverage/lcov.info --compare-branch=origin/main --fail-under=80
+
+      - name: Run full tests with coverage (main only)
+        if: github.event_name == 'push'
+        timeout-minutes: 10
+        run: npx vitest run --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov
+
+      - name: Check frontend coverage floor (main only)
+        if: github.event_name == 'push'
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
@@ -184,6 +248,7 @@ jobs:
           fi
 
       - name: Upload coverage artifact
+        if: github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-coverage migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -118,6 +118,21 @@ test-race:
 test-coverage:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+# Mirror the PR backend job: no -race, coverage on, no absolute floor.
+test-pr:
+	go test ./internal/... -coverprofile=coverage.out -covermode=count -timeout=120s
+
+# Patch coverage gate vs origin/main (mirrors the PR diff-cover step).
+# Requires: pip install 'diff_cover==10.2.0' && go install github.com/boumenot/gocover-cobertura@v1.4.0
+test-coverage-diff: test-pr
+	gocover-cobertura < coverage.out > coverage.xml
+	diff-cover coverage.xml --compare-branch=origin/main --fail-under=80
+
+# Mirror the merge-to-main backend job: race detector on + absolute floor check.
+test-main:
+	go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=180s
+	go tool cover -func=coverage.out
 
 migrate-up:
 	go run cmd/migrate/main.go up


### PR DESCRIPTION
## Summary

Splits backend and frontend test jobs into two tiers gated on `github.event_name`: PR runs drop `-race`, scope vitest to `--changed=origin/main`, and gate on **patch coverage ≥80%** via `diff-cover` (with a fallback that catches uncovered source-file changes when vitest finds no affected tests). Push-to-`main` keeps the full suite with `-race` and the existing absolute coverage floors (70/80%). Adds Makefile targets (`test-pr`, `test-coverage-diff`, `test-main`) so devs can reproduce the gates locally, scopes `fetch-depth: 0` and coverage-artifact uploads to the runs that need them, and pins `diff_cover==10.2.0` + `gocover-cobertura@v1.4.0` for reproducibility.

## Test plan

- [ ] Open a PR with a deliberately uncovered new function — diff-cover step fails with the uncovered lines listed
- [ ] Open a PR touching one frontend component — vitest runs only the transitively affected tests
- [ ] Open a PR touching only `frontend/src/**` non-source files (e.g. CSS) — patch-coverage step skips with a notice
- [ ] Merge to `main` — full suite runs with `-race` and absolute floor checks active

🤖 Generated with [Claude Code](https://claude.com/claude-code)