### PR TITLE
Fix worker deploys failing on root-owned sandbox-firewall.sh

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -107,6 +107,10 @@ fi
 if [ "$ROLE" = "worker" ]; then
   # Keep the sandbox firewall script in sync so every deploy can re-apply
   # the egress rules (they read the sandbox network's current subnet).
+  # Older workers may have a root-owned copy from cloud-init bootstrap;
+  # chown the scripts dir first so deploy can overwrite via plain scp.
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo chown -R deploy:deploy /opt/143/deploy/scripts"
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
     deploy@"$HOST":/opt/143/deploy/scripts/
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh"


### PR DESCRIPTION
## Summary
- scp was failing on worker deploys because /opt/143/deploy/scripts/sandbox-firewall.sh is root-owned on workers bootstrapped via cloud-init, so the deploy user could not overwrite it.
- Chown the scripts dir via sudo (the deploy user has NOPASSWD sudo) before scp so deploys are self-healing on any ownership state.

## Test plan
- [ ] Run make deploy-worker against the failing worker (87.99.158.39) and confirm the scp step succeeds.
- [ ] Confirm subsequent deploys still succeed (idempotent chown).
