### PR TITLE
Fix validation and bcrypt hash in dogfood preview config

### DIFF
--- a/.143/preview.json
+++ b/.143/preview.json
@@ -43,6 +43,6 @@
     "mode": "none"
   },
   "network": {
-    "mode": "restricted"
+    "mode": "managed"
   }
 }

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -22,7 +22,7 @@ VALUES (
   'Preview Admin',
   'admin',
   -- bcrypt hash of "preview-dogfood" (cost 10)
-  '$2a$10$ZQ3Kx6R4Y5V7x8VbKjO0aOQzWkVxJkZqT5mN3nL2rP1sH4gF6dC0e',
+  '$2a$10$yq0Z0nFAzgJa1IuC.zbMh.RmEdX2dAJk8XQwELbmOA1AztcbCUyVi',
   now()
 )
 ON CONFLICT (email) DO NOTHING;


### PR DESCRIPTION
## Summary
- `.143/preview.json` shipped with `network.mode: "restricted"`, but only `"managed"` and `""` are accepted at `internal/services/preview/config.go:212`. Fixed to `"managed"`.
- `.143/seed.sql` shipped with a placeholder bcrypt string that doesn't decode — logging in as `dogfood@143.dev` with `preview-dogfood` would always fail. Replaced with a real `$2a$10$` hash verified against `golang.org/x/crypto/bcrypt`.

Both bugs were added together in #329 but never exercised. This PR is intentionally narrow; getting the preview to actually run end-to-end needs a Go runtime and `psql` in the sandbox image plus a few server-side changes, which will land separately.

## Test plan
- [x] `make test` — full suite green.
- [x] `make lint` — 0 issues.
- [x] Scratch `bcrypt.CompareHashAndPassword` test against the new hash passes.
- [x] `ValidateConfig` against the committed `.143/preview.json` returns no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
