### PR TITLE
Dogfood 143 previews: Go + psql in sandbox, PREVIEW_ORIGIN, auto-detect config

### DIFF
--- a/.143/preview.json
+++ b/.143/preview.json
@@ -19,7 +19,7 @@
       "command": [
         "sh",
         "-c",
-        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"$PREVIEW_ORIGIN\" FRONTEND_URL=\"$PREVIEW_ORIGIN\" go run ./cmd/server"
+        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:3000}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:3000}\" go run ./cmd/server"
       ],
       "port": 8080,
       "env": {

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -24,7 +24,6 @@
       "port": 8080,
       "env": {
         "MODE": "all",
-        "ENV": "development",
         "LOG_LEVEL": "info"
       },
       "ready": {

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -19,14 +19,14 @@
       "command": [
         "sh",
         "-c",
-        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:3000}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:3000}\" go run ./cmd/server"
+        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" go run ./cmd/server"
       ],
       "port": 8080,
       "env": {
         "MODE": "all",
         "ENV": "development",
         "LOG_LEVEL": "info",
-        "SESSION_SECRET": "preview-dogfood-session-secret-change-me"
+        "SESSION_SECRET": "PREVIEW-ONLY-dogfood-ephemeral-DO-NOT-REUSE-outside-previews"
       },
       "ready": {
         "http_path": "/api/v1/health",

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -19,7 +19,7 @@
       "command": [
         "sh",
         "-c",
-        "set -e; go run ./cmd/migrate up; psql \"$DATABASE_URL\" -f .143/seed.sql; BASE_URL=\"$PREVIEW_ORIGIN\" FRONTEND_URL=\"$PREVIEW_ORIGIN\" go run ./cmd/server"
+        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"$PREVIEW_ORIGIN\" FRONTEND_URL=\"$PREVIEW_ORIGIN\" go run ./cmd/server"
       ],
       "port": 8080,
       "env": {

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -12,27 +12,31 @@
       },
       "ready": {
         "http_path": "/",
-        "timeout_seconds": 120
+        "timeout_seconds": 240
       }
     },
     "server": {
-      "command": ["go", "run", "./cmd/server"],
+      "command": [
+        "sh",
+        "-c",
+        "set -e; go run ./cmd/migrate up; psql \"$DATABASE_URL\" -f .143/seed.sql; BASE_URL=\"$PREVIEW_ORIGIN\" FRONTEND_URL=\"$PREVIEW_ORIGIN\" go run ./cmd/server"
+      ],
       "port": 8080,
       "env": {
         "MODE": "all",
+        "ENV": "development",
         "LOG_LEVEL": "info",
-        "SESSION_SECRET": "preview-dogfood-secret"
+        "SESSION_SECRET": "preview-dogfood-session-secret-change-me"
       },
       "ready": {
         "http_path": "/api/v1/health",
-        "timeout_seconds": 90
+        "timeout_seconds": 240
       }
     }
   },
   "infrastructure": {
     "db": {
       "template": "postgres-17",
-      "init_script": ".143/seed.sql",
       "inject_env": {
         "DATABASE_URL": "postgres://{{username}}:{{password}}@{{host}}:{{port}}/{{database}}?sslmode=disable"
       },

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -19,14 +19,13 @@
       "command": [
         "sh",
         "-c",
-        "go run ./cmd/migrate up && psql \"$DATABASE_URL\" -f .143/seed.sql && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" go run ./cmd/server"
+        "export SESSION_SECRET=\"$(head -c 32 /dev/urandom | base64)\" && echo '[143-preview] running migrations...' && go run ./cmd/migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" go run ./cmd/server"
       ],
       "port": 8080,
       "env": {
         "MODE": "all",
         "ENV": "development",
-        "LOG_LEVEL": "info",
-        "SESSION_SECRET": "PREVIEW-ONLY-dogfood-ephemeral-DO-NOT-REUSE-outside-previews"
+        "LOG_LEVEL": "info"
       },
       "ready": {
         "http_path": "/api/v1/health",

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -45,6 +45,11 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
+-- The github_id, installation_id, and clone_url values are placeholders.
+-- The dogfood preview has no GitHub App configured and will not actually
+-- call the GitHub API, so any code path that tries to hit GitHub from
+-- this seeded data will fail — that is expected. If you need real GitHub
+-- integration in the preview, register a throwaway App and replace these.
 INSERT INTO repositories (
   id, org_id, integration_id, github_id, full_name, default_branch,
   private, language, description, clone_url, installation_id, status,

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -1,8 +1,13 @@
 -- Seed data for preview dogfooding.
 -- Creates a default organization and admin user so the preview is
--- immediately usable without requiring the registration flow.
+-- immediately usable without requiring the registration flow, plus a
+-- placeholder integration and a couple of repositories/projects so the
+-- logged-in UI shows populated screens instead of empty states.
 --
 -- Password: "preview-dogfood" (bcrypt hash below).
+--
+-- All rows use fixed UUIDs + ON CONFLICT (id) DO NOTHING so the seed is
+-- safely re-runnable and does not conflict with user-created rows.
 
 INSERT INTO organizations (id, name, settings, created_at, updated_at)
 VALUES (
@@ -26,3 +31,100 @@ VALUES (
   now()
 )
 ON CONFLICT (email) DO NOTHING;
+
+-- Placeholder GitHub integration so repositories have a valid FK target.
+-- The preview does not actually talk to GitHub, so the config is empty.
+INSERT INTO integrations (id, org_id, provider, config, status, created_at)
+VALUES (
+  '00000000-0000-4000-a000-000000000010'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  'github',
+  '{}'::jsonb,
+  'active',
+  now()
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO repositories (
+  id, org_id, integration_id, github_id, full_name, default_branch,
+  private, language, description, clone_url, installation_id, status,
+  settings, created_at, updated_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000100'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000010'::uuid,
+    1001,
+    'assembledhq/143',
+    'main',
+    true,
+    'Go',
+    'The 143 agent platform itself (dogfood).',
+    'https://github.com/assembledhq/143.git',
+    99999,
+    'active',
+    '{}'::jsonb,
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000101'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000010'::uuid,
+    1002,
+    'assembledhq/example-service',
+    'main',
+    true,
+    'TypeScript',
+    'Example service used for walkthroughs in the dogfood preview.',
+    'https://github.com/assembledhq/example-service.git',
+    99999,
+    'active',
+    '{}'::jsonb,
+    now(),
+    now()
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO projects (
+  id, org_id, repository_id, title, goal, scope, status, priority,
+  execution_mode, max_concurrent, auto_merge, base_branch, created_by,
+  created_at, updated_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000200'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000100'::uuid,
+    'Ship preview environments',
+    'Add preview deploys so every session shows a live app.',
+    'Preview provider, gateway routing, and UI integration.',
+    'active',
+    50,
+    'sequential',
+    2,
+    false,
+    'main',
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    now(),
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000201'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000101'::uuid,
+    'Webhook ingestion',
+    'Wire example-service webhooks through the ingestion pipeline.',
+    'Signature verification, idempotent delivery, replay.',
+    'completed',
+    50,
+    'sequential',
+    2,
+    false,
+    'main',
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    now(),
+    now()
+  )
+ON CONFLICT (id) DO NOTHING;

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -6,8 +6,11 @@
 --
 -- Password: "preview-dogfood" (bcrypt hash below).
 --
--- All rows use fixed UUIDs + ON CONFLICT (id) DO NOTHING so the seed is
--- safely re-runnable and does not conflict with user-created rows.
+-- All rows use fixed UUIDs + ON CONFLICT DO NOTHING so the seed is
+-- safely re-runnable. Tables with secondary unique indexes (e.g.
+-- repositories.idx_repositories_org_github) use the unqualified
+-- ON CONFLICT DO NOTHING form so any unique violation — not just on id —
+-- no-ops rather than aborting the transaction.
 
 INSERT INTO organizations (id, name, settings, created_at, updated_at)
 VALUES (
@@ -90,7 +93,7 @@ VALUES
     now(),
     now()
   )
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT DO NOTHING;
 
 INSERT INTO projects (
   id, org_id, repository_id, title, goal, scope, status, priority,

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -192,6 +192,7 @@ Every service receives:
 | Var | Value |
 |-----|-------|
 | `HOST` | `0.0.0.0` — most frameworks honor this for bind address. Override in your service `env` if your app reads `HOST` for something else. |
+| `PREVIEW_ORIGIN` | The public URL the gateway serves this preview on, e.g. `http://<id>.preview.localhost:9090`. Set this as your app's external base URL (e.g. `BASE_URL`, `FRONTEND_URL`) so redirects and absolute links point at the preview instead of `localhost`. Overrides any user-declared value. |
 
 ## Trust Split
 

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -90,32 +90,36 @@ func (h *PreviewHandler) requireManager(w http.ResponseWriter, r *http.Request) 
 const workspacePreviewConfigPath = ".143/preview.json"
 
 // readWorkspacePreviewConfig attempts to read and parse .143/preview.json from
-// the session's sandbox workspace. Returns the parsed config and true when a
-// valid config is found; returns false in every other case (no fileReader
-// wired, file absent, read error, or invalid contents) so the caller can fall
-// back to built-in defaults without surfacing an error to the user.
-func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *agent.Sandbox, sessionID uuid.UUID) (*models.PreviewConfig, bool) {
+// the session's sandbox workspace. Returns:
+//   - (cfg, nil)   when a valid committed config is found and parsed.
+//   - (nil, nil)   for "no config to use" cases where the caller should fall
+//     back to built-in defaults: no fileReader wired, the file is absent, or
+//     its contents fail to parse (a malformed committed config is a user
+//     authoring problem, not an infrastructure failure; surfacing it as a 500
+//     would make the preview worse, not better, than the default).
+//   - (nil, err)   for genuine infrastructure failures (docker exec failed,
+//     context cancelled, sandbox gone) — the caller should surface these
+//     instead of silently swapping in Node.js defaults for what may well be
+//     a Go/Python/etc. project.
+func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *agent.Sandbox, sessionID uuid.UUID) (*models.PreviewConfig, error) {
 	if h.fileReader == nil {
-		return nil, false
+		return nil, nil
 	}
 	content, _, err := h.fileReader.ReadFile(ctx, sb.ID, sb.WorkDir, workspacePreviewConfigPath)
 	if err != nil {
-		// Missing file is the expected "no committed config" case (debug);
-		// anything else (docker exec failure, context cancellation, sandbox
-		// gone) is warned so unexpected failures don't fall through silently.
 		if errors.Is(err, sandbox.ErrFileNotFound) {
 			h.logger.Debug().
 				Str("session_id", sessionID.String()).
 				Str("path", workspacePreviewConfigPath).
 				Msg("no committed preview config in workspace")
-		} else {
-			h.logger.Warn().
-				Err(err).
-				Str("session_id", sessionID.String()).
-				Str("path", workspacePreviewConfigPath).
-				Msg("failed to read committed preview config; falling back to defaults")
+			return nil, nil
 		}
-		return nil, false
+		h.logger.Warn().
+			Err(err).
+			Str("session_id", sessionID.String()).
+			Str("path", workspacePreviewConfigPath).
+			Msg("failed to read committed preview config")
+		return nil, fmt.Errorf("read %s: %w", workspacePreviewConfigPath, err)
 	}
 	cfg, err := preview.ParseConfig([]byte(content))
 	if err != nil {
@@ -124,13 +128,13 @@ func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *age
 			Str("session_id", sessionID.String()).
 			Str("path", workspacePreviewConfigPath).
 			Msg("committed preview config failed to parse; falling back to defaults")
-		return nil, false
+		return nil, nil
 	}
 	h.logger.Info().
 		Str("session_id", sessionID.String()).
 		Str("path", workspacePreviewConfigPath).
 		Msg("using preview config from workspace")
-	return cfg, true
+	return cfg, nil
 }
 
 // requireInspector returns the PreviewInspector or writes a 501 error response.
@@ -216,7 +220,15 @@ func (h *PreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
 		// Auto-detect: first try to read .143/preview.json from the session's
 		// workspace so repos with a committed config just work. Fall back to a
 		// Node.js default (npm start, port 3000) only if no config is present.
-		if cfg, ok := h.readWorkspacePreviewConfig(r.Context(), sb, sessionID); ok {
+		cfg, err := h.readWorkspacePreviewConfig(r.Context(), sb, sessionID)
+		if err != nil {
+			// Infrastructure failure (docker exec, sandbox gone, etc.) — do
+			// not silently swap in Node.js defaults, which would start the
+			// wrong preview for a non-Node project and time out after minutes.
+			writeError(w, r, http.StatusInternalServerError, "PREVIEW_CONFIG_READ_FAILED", "failed to read preview config from workspace", err)
+			return
+		}
+		if cfg != nil {
 			body.Config = cfg
 		} else {
 			h.logger.Info().

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -34,7 +34,9 @@ type PreviewHandler struct {
 // NewPreviewHandler creates a new PreviewHandler. fileReader is used to
 // auto-detect .143/preview.json from the session's sandbox workspace when
 // the client does not supply an explicit config; pass sandbox.NoOpFileReader
-// in environments where workspace introspection is unavailable.
+// in environments where workspace introspection is unavailable — its errors
+// wrap sandbox.ErrFileNotFound so auto-detect cleanly falls through to the
+// built-in default config instead of surfacing a 500.
 func NewPreviewHandler(manager *preview.Manager, store *db.PreviewStore, sessionStore *db.SessionStore, fileReader sandbox.FileReader, logger zerolog.Logger) *PreviewHandler {
 	return &PreviewHandler{
 		manager:      manager,

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
@@ -101,13 +100,10 @@ func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *age
 	}
 	content, _, err := h.fileReader.ReadFile(ctx, sb.ID, sb.WorkDir, workspacePreviewConfigPath)
 	if err != nil {
-		// The FileReader does not expose a dedicated "not found" sentinel, so
-		// pattern-match on the wrapped `head` stderr ("No such file or
-		// directory") to distinguish the expected "no committed config" case
-		// from real breakage (docker exec failure, context cancellation,
-		// sandbox gone). Missing file → debug, everything else → warn so
-		// unexpected failures don't fall through silently.
-		if strings.Contains(err.Error(), "No such file or directory") {
+		// Missing file is the expected "no committed config" case (debug);
+		// anything else (docker exec failure, context cancellation, sandbox
+		// gone) is warned so unexpected failures don't fall through silently.
+		if errors.Is(err, sandbox.ErrFileNotFound) {
 			h.logger.Debug().
 				Str("session_id", sessionID.String()).
 				Str("path", workspacePreviewConfigPath).

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
@@ -100,13 +101,24 @@ func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *age
 	}
 	content, _, err := h.fileReader.ReadFile(ctx, sb.ID, sb.WorkDir, workspacePreviewConfigPath)
 	if err != nil {
-		// File most likely doesn't exist; log at debug so a missing file
-		// doesn't spam warnings on every autodetect attempt.
-		h.logger.Debug().
-			Err(err).
-			Str("session_id", sessionID.String()).
-			Str("path", workspacePreviewConfigPath).
-			Msg("no committed preview config in workspace")
+		// The FileReader does not expose a dedicated "not found" sentinel, so
+		// pattern-match on the wrapped `head` stderr ("No such file or
+		// directory") to distinguish the expected "no committed config" case
+		// from real breakage (docker exec failure, context cancellation,
+		// sandbox gone). Missing file → debug, everything else → warn so
+		// unexpected failures don't fall through silently.
+		if strings.Contains(err.Error(), "No such file or directory") {
+			h.logger.Debug().
+				Str("session_id", sessionID.String()).
+				Str("path", workspacePreviewConfigPath).
+				Msg("no committed preview config in workspace")
+		} else {
+			h.logger.Warn().
+				Err(err).
+				Str("session_id", sessionID.String()).
+				Str("path", workspacePreviewConfigPath).
+				Msg("failed to read committed preview config; falling back to defaults")
+		}
 		return nil, false
 	}
 	cfg, err := preview.ParseConfig([]byte(content))

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -14,6 +14,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/preview"
+	"github.com/assembledhq/143/internal/services/sandbox"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -25,16 +26,21 @@ type PreviewHandler struct {
 	manager      *preview.Manager
 	store        *db.PreviewStore
 	sessionStore *db.SessionStore
+	fileReader   sandbox.FileReader
 	logger       zerolog.Logger
 	audit        *db.AuditEmitter
 }
 
-// NewPreviewHandler creates a new PreviewHandler.
-func NewPreviewHandler(manager *preview.Manager, store *db.PreviewStore, sessionStore *db.SessionStore, logger zerolog.Logger) *PreviewHandler {
+// NewPreviewHandler creates a new PreviewHandler. fileReader is used to
+// auto-detect .143/preview.json from the session's sandbox workspace when
+// the client does not supply an explicit config; pass sandbox.NoOpFileReader
+// in environments where workspace introspection is unavailable.
+func NewPreviewHandler(manager *preview.Manager, store *db.PreviewStore, sessionStore *db.SessionStore, fileReader sandbox.FileReader, logger zerolog.Logger) *PreviewHandler {
 	return &PreviewHandler{
 		manager:      manager,
 		store:        store,
 		sessionStore: sessionStore,
+		fileReader:   fileReader,
 		logger:       logger,
 	}
 }
@@ -77,6 +83,46 @@ func (h *PreviewHandler) requireManager(w http.ResponseWriter, r *http.Request) 
 		return false
 	}
 	return true
+}
+
+// workspacePreviewConfigPath is the repo-relative path 143 looks at when a
+// client calls StartPreview without supplying an explicit config.
+const workspacePreviewConfigPath = ".143/preview.json"
+
+// readWorkspacePreviewConfig attempts to read and parse .143/preview.json from
+// the session's sandbox workspace. Returns the parsed config and true when a
+// valid config is found; returns false in every other case (no fileReader
+// wired, file absent, read error, or invalid contents) so the caller can fall
+// back to built-in defaults without surfacing an error to the user.
+func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *agent.Sandbox, sessionID uuid.UUID) (*models.PreviewConfig, bool) {
+	if h.fileReader == nil {
+		return nil, false
+	}
+	content, _, err := h.fileReader.ReadFile(ctx, sb.ID, sb.WorkDir, workspacePreviewConfigPath)
+	if err != nil {
+		// File most likely doesn't exist; log at debug so a missing file
+		// doesn't spam warnings on every autodetect attempt.
+		h.logger.Debug().
+			Err(err).
+			Str("session_id", sessionID.String()).
+			Str("path", workspacePreviewConfigPath).
+			Msg("no committed preview config in workspace")
+		return nil, false
+	}
+	cfg, err := preview.ParseConfig([]byte(content))
+	if err != nil {
+		h.logger.Warn().
+			Err(err).
+			Str("session_id", sessionID.String()).
+			Str("path", workspacePreviewConfigPath).
+			Msg("committed preview config failed to parse; falling back to defaults")
+		return nil, false
+	}
+	h.logger.Info().
+		Str("session_id", sessionID.String()).
+		Str("path", workspacePreviewConfigPath).
+		Msg("using preview config from workspace")
+	return cfg, true
 }
 
 // requireInspector returns the PreviewInspector or writes a 501 error response.
@@ -141,17 +187,6 @@ func (h *PreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if body.Config == nil {
-		// Auto-detect: build a minimal default config when the client sends no
-		// explicit preview config. This lets the frontend start a preview with
-		// a single click. NOTE: defaults to Node.js (npm start on port 3000);
-		// non-Node projects should provide an explicit config.
-		h.logger.Info().
-			Str("session_id", sessionID.String()).
-			Msg("no preview config provided, using Node.js defaults (npm start, port 3000)")
-		body.Config = defaultPreviewConfig()
-	}
-
 	// Look up the session to get its sandbox container.
 	session, err := h.sessionStore.GetByID(r.Context(), orgID, sessionID)
 	if err != nil {
@@ -167,6 +202,20 @@ func (h *PreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
 		ID:       *session.ContainerID,
 		Provider: "docker",
 		WorkDir:  "/workspace",
+	}
+
+	if body.Config == nil {
+		// Auto-detect: first try to read .143/preview.json from the session's
+		// workspace so repos with a committed config just work. Fall back to a
+		// Node.js default (npm start, port 3000) only if no config is present.
+		if cfg, ok := h.readWorkspacePreviewConfig(r.Context(), sb, sessionID); ok {
+			body.Config = cfg
+		} else {
+			h.logger.Info().
+				Str("session_id", sessionID.String()).
+				Msg("no preview config provided or committed, using Node.js defaults (npm start, port 3000)")
+			body.Config = defaultPreviewConfig()
+		}
 	}
 
 	input := preview.StartPreviewInput{

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -470,10 +471,10 @@ func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
 	t.Parallel()
 
 	// The common "no .143/preview.json committed" case: the underlying FileReader
-	// wraps `head: ... No such file or directory` from the sandbox exec. Must
-	// NOT bubble up — caller falls back to built-in defaults.
+	// returns sandbox.ErrFileNotFound (wrapped). Must NOT bubble up — caller
+	// falls back to built-in defaults.
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{err: errors.New("read file .143/preview.json: head: cannot open '/workspace/.143/preview.json' for reading: No such file or directory")},
+		fileReader: fakeFileReader{err: fmt.Errorf("read file .143/preview.json: %w", sandbox.ErrFileNotFound)},
 		logger:     zerolog.Nop(),
 	}
 	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -430,6 +431,94 @@ func TestNewPreviewHandler(t *testing.T) {
 	require.NotNil(t, h)
 	require.NotNil(t, h.manager)
 	require.NotNil(t, h.store)
+}
+
+// =============================================================================
+// readWorkspacePreviewConfig tests
+// =============================================================================
+
+// fakeFileReader is a stub FileReader that returns canned ReadFile responses.
+// Unused methods panic so this test file fails loudly if something else grows
+// a dependency on them.
+type fakeFileReader struct {
+	content string
+	err     error
+}
+
+func (f fakeFileReader) ListDir(context.Context, string, string, string) ([]sandbox.FileEntry, error) {
+	panic("not used")
+}
+
+func (f fakeFileReader) ReadFile(_ context.Context, _, _, _ string) (string, bool, error) {
+	return f.content, false, f.err
+}
+
+func (f fakeFileReader) ReadFileContext(context.Context, string, string, string, int, int, int) ([]sandbox.FileLine, error) {
+	panic("not used")
+}
+
+func TestReadWorkspacePreviewConfig_NilReader(t *testing.T) {
+	t.Parallel()
+
+	h := &PreviewHandler{logger: zerolog.Nop()}
+	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{}, uuid.New())
+	require.False(t, ok, "nil fileReader must fall through so caller uses defaults")
+	require.Nil(t, cfg)
+}
+
+func TestReadWorkspacePreviewConfig_ReadError(t *testing.T) {
+	t.Parallel()
+
+	// A read error is the common "file not present" case and must NOT bubble
+	// up to the user — the caller falls back to built-in defaults.
+	h := &PreviewHandler{
+		fileReader: fakeFileReader{err: errors.New("not found")},
+		logger:     zerolog.Nop(),
+	}
+	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.False(t, ok)
+	require.Nil(t, cfg)
+}
+
+func TestReadWorkspacePreviewConfig_ParseError(t *testing.T) {
+	t.Parallel()
+
+	h := &PreviewHandler{
+		fileReader: fakeFileReader{content: "{not valid json"},
+		logger:     zerolog.Nop(),
+	}
+	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.False(t, ok, "invalid JSON must fall through to defaults, not surface as an error")
+	require.Nil(t, cfg)
+}
+
+func TestReadWorkspacePreviewConfig_ValidConfig(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"name": "dogfood",
+		"primary": "web",
+		"services": {
+			"web": {
+				"command": ["npm", "run", "dev"],
+				"port": 3000,
+				"ready": {"http_path": "/"}
+			}
+		},
+		"credentials": {"mode": "none"},
+		"network": {"mode": "managed"}
+	}`
+
+	h := &PreviewHandler{
+		fileReader: fakeFileReader{content: raw},
+		logger:     zerolog.Nop(),
+	}
+	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.True(t, ok)
+	require.NotNil(t, cfg)
+	require.Equal(t, "web", cfg.Primary)
+	require.Contains(t, cfg.Services, "web")
+	require.Equal(t, 3000, cfg.Services["web"].Port)
 }
 
 func TestPreviewHandler_SetAuditEmitter(t *testing.T) {

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -466,13 +466,30 @@ func TestReadWorkspacePreviewConfig_NilReader(t *testing.T) {
 	require.Nil(t, cfg)
 }
 
-func TestReadWorkspacePreviewConfig_ReadError(t *testing.T) {
+func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
 	t.Parallel()
 
-	// A read error is the common "file not present" case and must NOT bubble
-	// up to the user — the caller falls back to built-in defaults.
+	// The common "no .143/preview.json committed" case: the underlying FileReader
+	// wraps `head: ... No such file or directory` from the sandbox exec. Must
+	// NOT bubble up — caller falls back to built-in defaults.
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{err: errors.New("not found")},
+		fileReader: fakeFileReader{err: errors.New("read file .143/preview.json: head: cannot open '/workspace/.143/preview.json' for reading: No such file or directory")},
+		logger:     zerolog.Nop(),
+	}
+	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.False(t, ok)
+	require.Nil(t, cfg)
+}
+
+func TestReadWorkspacePreviewConfig_UnexpectedReadError(t *testing.T) {
+	t.Parallel()
+
+	// A non-"not found" read error (docker exec failure, context cancel, sandbox
+	// gone) must still fall through to defaults so a broken sandbox doesn't
+	// block StartPreview entirely. The handler logs it at Warn, but callers
+	// still see (nil, false).
+	h := &PreviewHandler{
+		fileReader: fakeFileReader{err: errors.New("docker exec failed: container not running")},
 		logger:     zerolog.Nop(),
 	}
 	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -546,6 +546,79 @@ func TestReadWorkspacePreviewConfig_ValidConfig(t *testing.T) {
 	require.Equal(t, 3000, cfg.Services["web"].Port)
 }
 
+// sessionRowColumns mirrors db.sessionSelectColumns. Kept inline so a
+// schema change in one file flips this test red instead of silently
+// returning the wrong shape from pgxmock.
+var sessionRowColumns = []string{
+	"id", "issue_id", "org_id", "agent_type", "status", "autonomy_level", "token_mode",
+	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
+	"container_id", "started_at", "completed_at", "token_usage",
+	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
+	"parent_session_id", "revision_context", "error", "result_summary", "diff",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
+	"project_task_id", "model_override", "triggered_by_user_id",
+	"agent_session_id", "current_turn", "last_activity_at",
+	"sandbox_state", "snapshot_key", "target_branch", "working_branch",
+	"repository_id", "diff_stats", "diff_history", "input_manifest",
+	"archived_at", "archived_by_user_id", "automation_run_id", "deleted_at", "created_at",
+}
+
+func sessionRowWithContainer(id, orgID uuid.UUID, containerID string) []interface{} {
+	return []interface{}{
+		id, uuid.Nil, orgID, "claude_code", "running", "supervised", "low",
+		nil, nil, nil, []string{},
+		&containerID, nil, nil, json.RawMessage(`{}`),
+		nil, nil, []string{}, false,
+		nil, json.RawMessage(`{}`), nil, nil, nil,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil,
+		0, nil,
+		"none", nil, nil, nil,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil, time.Now(),
+	}
+}
+
+// TestPreviewHandler_StartPreview_AutoDetectInfraError exercises the auto-detect
+// branch of StartPreview when the workspace file reader returns a non-ENOENT
+// error. The handler must surface a 500 instead of silently swapping in Node.js
+// defaults — see readWorkspacePreviewConfig's docstring for the rationale.
+func TestPreviewHandler_StartPreview_AutoDetectInfraError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowWithContainer(sessionID, orgID, "container-1")...),
+		)
+
+	h := newPreviewHandlerWithMock(mock)
+	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = fakeFileReader{err: errors.New("docker exec failed: container not running")}
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+
+	h.StartPreview(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "non-ENOENT read failure must surface as 500")
+
+	var resp models.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "PREVIEW_CONFIG_READ_FAILED", resp.Error.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPreviewHandler_SetAuditEmitter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -462,9 +462,9 @@ func TestReadWorkspacePreviewConfig_NilReader(t *testing.T) {
 	t.Parallel()
 
 	h := &PreviewHandler{logger: zerolog.Nop()}
-	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{}, uuid.New())
-	require.False(t, ok, "nil fileReader must fall through so caller uses defaults")
-	require.Nil(t, cfg)
+	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{}, uuid.New())
+	require.NoError(t, err, "nil fileReader is the no-op case, not an infrastructure failure")
+	require.Nil(t, cfg, "nil fileReader must fall through so caller uses defaults")
 }
 
 func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
@@ -477,36 +477,43 @@ func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
 		fileReader: fakeFileReader{err: fmt.Errorf("read file .143/preview.json: %w", sandbox.ErrFileNotFound)},
 		logger:     zerolog.Nop(),
 	}
-	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.False(t, ok)
+	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.NoError(t, err, "ENOENT is expected absence, not an error to surface")
 	require.Nil(t, cfg)
 }
 
 func TestReadWorkspacePreviewConfig_UnexpectedReadError(t *testing.T) {
 	t.Parallel()
 
-	// A non-"not found" read error (docker exec failure, context cancel, sandbox
-	// gone) must still fall through to defaults so a broken sandbox doesn't
-	// block StartPreview entirely. The handler logs it at Warn, but callers
-	// still see (nil, false).
+	// A non-ENOENT read error (docker exec failure, context cancel, sandbox
+	// gone) means we cannot tell whether a committed config exists. Returning
+	// (nil, err) makes StartPreview surface a 500 instead of silently swapping
+	// in Node.js defaults — which would start the wrong preview for non-Node
+	// projects and time out after minutes.
+	wantErr := errors.New("docker exec failed: container not running")
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{err: errors.New("docker exec failed: container not running")},
+		fileReader: fakeFileReader{err: wantErr},
 		logger:     zerolog.Nop(),
 	}
-	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.False(t, ok)
+	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.Error(t, err, "non-ENOENT read errors must surface so the caller returns 500")
+	require.ErrorIs(t, err, wantErr, "underlying read error must be wrapped, not discarded")
 	require.Nil(t, cfg)
 }
 
 func TestReadWorkspacePreviewConfig_ParseError(t *testing.T) {
 	t.Parallel()
 
+	// Parse errors are a user authoring problem, not infrastructure. We still
+	// fall back to defaults (returning the 500 would make the preview strictly
+	// worse than just running the default), but log at Warn so the user sees
+	// why their committed config didn't take effect.
 	h := &PreviewHandler{
 		fileReader: fakeFileReader{content: "{not valid json"},
 		logger:     zerolog.Nop(),
 	}
-	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.False(t, ok, "invalid JSON must fall through to defaults, not surface as an error")
+	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.NoError(t, err, "invalid JSON must fall through to defaults, not surface as a 500")
 	require.Nil(t, cfg)
 }
 
@@ -531,8 +538,8 @@ func TestReadWorkspacePreviewConfig_ValidConfig(t *testing.T) {
 		fileReader: fakeFileReader{content: raw},
 		logger:     zerolog.Nop(),
 	}
-	cfg, ok := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.True(t, ok)
+	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
+	require.NoError(t, err)
 	require.NotNil(t, cfg)
 	require.Equal(t, "web", cfg.Primary)
 	require.Contains(t, cfg.Services, "web")

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/preview"
+	"github.com/assembledhq/143/internal/services/sandbox"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
@@ -303,7 +304,7 @@ type mockPreviewProvider struct {
 	startConfig *models.PreviewConfig
 }
 
-func (m *mockPreviewProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig) (*preview.PreviewHandle, error) {
+func (m *mockPreviewProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig, _ map[string]string) (*preview.PreviewHandle, error) {
 	m.startConfig = cfg
 	if m.startHandle != nil {
 		return m.startHandle, nil
@@ -425,7 +426,7 @@ func TestNewPreviewHandler(t *testing.T) {
 	})
 
 	sessionStore := db.NewSessionStore(mock)
-	h := NewPreviewHandler(mgr, store, sessionStore, zerolog.Nop())
+	h := NewPreviewHandler(mgr, store, sessionStore, sandbox.NoOpFileReader{}, zerolog.Nop())
 	require.NotNil(t, h)
 	require.NotNil(t, h.manager)
 	require.NotNil(t, h.store)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -301,14 +301,15 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	}
 
 	previewManager := preview.NewManager(preview.ManagerConfig{
-		Store:         previewStore,
-		SessionStore:  sessionStore,
-		Provider:      previewProvider,
-		Inspector:     previewInspector,
-		SnapshotCache: previewSnapshotCache,
-		HMRWatcher:    hmrWatcher,
-		Logger:        logger,
-		WorkerNodeID:  "local", // MODE=all: single-node
+		Store:                 previewStore,
+		SessionStore:          sessionStore,
+		Provider:              previewProvider,
+		Inspector:             previewInspector,
+		SnapshotCache:         previewSnapshotCache,
+		HMRWatcher:            hmrWatcher,
+		Logger:                logger,
+		WorkerNodeID:          "local", // MODE=all: single-node
+		PreviewOriginTemplate: cfg.PreviewOriginTemplate,
 	})
 
 	recycleWorker := preview.NewRecycleWorker(preview.RecycleWorkerConfig{
@@ -346,7 +347,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		}()
 	}
 
-	previewHandler := handlers.NewPreviewHandler(previewManager, previewStore, sessionStore, logger)
+	previewHandler := handlers.NewPreviewHandler(previewManager, previewStore, sessionStore, fileReader, logger)
 	previewHandler.SetAuditEmitter(auditEmitter)
 
 	// Upload store: use S3 if configured, otherwise fall back to local filesystem.

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2,6 +2,8 @@ package preview
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
@@ -163,8 +165,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "valid single service",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm", "start"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm", "start"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 0,
@@ -184,7 +186,7 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "missing primary",
 			cfg: models.PreviewConfig{
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -192,8 +194,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "primary references missing service",
 			cfg: models.PreviewConfig{
-				Primary:  "missing",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "missing",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -201,8 +203,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "no services",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 2, // no services + primary references missing
@@ -225,8 +227,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "port out of range",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 80, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 80, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -246,8 +248,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "missing command",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -255,8 +257,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "missing ready path",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -264,8 +266,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "shell injection in ready path",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/; rm -rf /"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/; rm -rf /"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -273,8 +275,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "cwd escapes repo root",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Cwd: "../../etc", Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Cwd: "../../etc", Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -282,8 +284,8 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "cwd is absolute path",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Cwd: "/etc/passwd", Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Cwd: "/etc/passwd", Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantErr: 1,
@@ -326,10 +328,10 @@ func TestValidateConfig(t *testing.T) {
 		{
 			name: "credential inject_into unknown service",
 			cfg: models.PreviewConfig{
-				Primary:     "app",
-				Services:    map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
-				Credentials: models.CredentialConfig{Mode: "managed_env", InjectInto: []string{"unknown"}},
+				Credentials:    models.CredentialConfig{Mode: "managed_env", InjectInto: []string{"unknown"}},
 			},
 			wantErr: 1,
 		},
@@ -552,45 +554,45 @@ func TestDetectReadiness(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		cfg      models.PreviewConfig
+		name      string
+		cfg       models.PreviewConfig
 		wantReady models.PreviewReadiness
 	}{
 		{
 			name: "ready - simple config",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
-				Credentials: models.CredentialConfig{Mode: "none"},
+				Credentials:    models.CredentialConfig{Mode: "none"},
 			},
 			wantReady: models.PreviewReadinessReady,
 		},
 		{
 			name: "admin setup - has credentials",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
-				Credentials: models.CredentialConfig{Mode: "managed_env", CredentialSet: "staging", Env: []string{"DB_URL"}},
+				Credentials:    models.CredentialConfig{Mode: "managed_env", CredentialSet: "staging", Env: []string{"DB_URL"}},
 			},
 			wantReady: models.PreviewReadinessAdminSetupRequired,
 		},
 		{
 			name: "admin setup - has destinations",
 			cfg: models.PreviewConfig{
-				Primary:  "app",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "app",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
-				Network: models.NetworkConfig{Mode: "managed", Destinations: []string{"staging_db"}},
+				Network:        models.NetworkConfig{Mode: "managed", Destinations: []string{"staging_db"}},
 			},
 			wantReady: models.PreviewReadinessAdminSetupRequired,
 		},
 		{
 			name: "not supported - invalid config",
 			cfg: models.PreviewConfig{
-				Primary:  "missing",
-				Services: map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
+				Primary:        "missing",
+				Services:       map[string]models.ServiceConfig{"app": {Command: []string{"npm"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}}},
 				Infrastructure: map[string]models.InfrastructureConfig{},
 			},
 			wantReady: models.PreviewReadinessNotSupported,
@@ -690,5 +692,37 @@ func TestParseConfig_RoundTrip(t *testing.T) {
 	}
 	if len(cfg1.Services) != len(cfg2.Services) {
 		t.Errorf("Services count mismatch: %d vs %d", len(cfg1.Services), len(cfg2.Services))
+	}
+}
+
+// TestParseConfig_CommittedDogfoodConfig guards against silent regressions
+// in the committed `.143/preview.json` at the repo root. The dogfood config
+// is the configuration used when a 143 session on this very repo clicks
+// "Start Preview", so a broken file manifests as a broken developer loop.
+func TestParseConfig_CommittedDogfoodConfig(t *testing.T) {
+	t.Parallel()
+
+	// Walk up from the package dir to the repo root (where `.143/` lives).
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		candidate := filepath.Join(dir, ".143", "preview.json")
+		if _, err := os.Stat(candidate); err == nil {
+			raw, err := os.ReadFile(candidate)
+			if err != nil {
+				t.Fatalf("read %s: %v", candidate, err)
+			}
+			if _, err := ParseConfig(raw); err != nil {
+				t.Fatalf("committed .143/preview.json failed to parse: %v", err)
+			}
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skip("repo root .143/preview.json not found from test working directory")
+		}
+		dir = parent
 	}
 }

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -56,6 +56,11 @@ type Manager struct {
 
 	workerNodeID string // identity of this worker for routing
 
+	// previewOriginTemplate is used to compute PREVIEW_ORIGIN for each
+	// preview instance. "{id}" is replaced with the instance UUID. When
+	// empty, PREVIEW_ORIGIN is not injected.
+	previewOriginTemplate string
+
 	// hmrWatcher captures screenshots on HMR updates. May be nil.
 	hmrWatcher *HMRWatcher
 
@@ -93,6 +98,13 @@ type ManagerConfig struct {
 	MaxPerUser    int
 	MaxPerOrg     int
 	MaxPerWorker  int
+
+	// PreviewOriginTemplate is the URL template used to compute the public
+	// origin each preview is served from, with "{id}" replaced by the preview
+	// instance UUID. It is passed through to each service as PREVIEW_ORIGIN so
+	// backends can generate absolute URLs that round-trip through the gateway.
+	// When empty (e.g. in tests), PREVIEW_ORIGIN is not injected.
+	PreviewOriginTemplate string
 }
 
 // NewManager creates a new preview Manager. If cfg.Provider is nil, the
@@ -103,18 +115,19 @@ func NewManager(cfg ManagerConfig) *Manager {
 		cfg.Logger.Warn().Msg("preview.NewManager: Provider is nil — preview operations will fail until a provider is set")
 	}
 	m := &Manager{
-		store:         cfg.Store,
-		sessionStore:  cfg.SessionStore,
-		provider:      cfg.Provider,
-		inspector:     cfg.Inspector,
-		snapshotCache: cfg.SnapshotCache,
-		hmrWatcher:    cfg.HMRWatcher,
-		logger:        cfg.Logger,
-		workerNodeID:  cfg.WorkerNodeID,
-		pollStopChs:   make(map[uuid.UUID]chan struct{}),
-		maxPerUser:    cfg.MaxPerUser,
-		maxPerOrg:     cfg.MaxPerOrg,
-		maxPerWorker:  cfg.MaxPerWorker,
+		store:                 cfg.Store,
+		sessionStore:          cfg.SessionStore,
+		provider:              cfg.Provider,
+		inspector:             cfg.Inspector,
+		snapshotCache:         cfg.SnapshotCache,
+		hmrWatcher:            cfg.HMRWatcher,
+		logger:                cfg.Logger,
+		workerNodeID:          cfg.WorkerNodeID,
+		previewOriginTemplate: cfg.PreviewOriginTemplate,
+		pollStopChs:           make(map[uuid.UUID]chan struct{}),
+		maxPerUser:            cfg.MaxPerUser,
+		maxPerOrg:             cfg.MaxPerOrg,
+		maxPerWorker:          cfg.MaxPerWorker,
 	}
 	if m.maxPerUser <= 0 {
 		m.maxPerUser = DefaultMaxPreviewsPerUser
@@ -260,7 +273,7 @@ func (m *Manager) StartPreview(ctx context.Context, input StartPreviewInput) (*m
 	}
 
 	// 9. Start the preview via the provider (async-friendly).
-	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config)
+	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(instance.ID))
 	if err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, input.OrgID, instance.ID, models.PreviewStatusFailed, err.Error()); statusErr != nil {
 			m.logger.Warn().Err(statusErr).Str("preview_id", instance.ID.String()).Msg("failed to update preview status to failed")
@@ -760,8 +773,9 @@ func (m *Manager) RecyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 		m.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("recycle: failed to revoke access sessions")
 	}
 
-	// Restart via provider with same sandbox and config.
-	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config)
+	// Restart via provider with same sandbox and config. Use the existing
+	// instance ID so PREVIEW_ORIGIN stays stable across recycles.
+	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(previewID))
 	if err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {
 			m.logger.Warn().Err(statusErr).Msg("recycle: failed to set failed status")
@@ -842,6 +856,19 @@ func (m *Manager) Store() *db.PreviewStore {
 // WorkerNodeID returns this worker's identity string (used by recycle workers).
 func (m *Manager) WorkerNodeID() string {
 	return m.workerNodeID
+}
+
+// platformEnv returns environment variables the platform injects into every
+// service of the given preview, overriding any user-declared value. Currently
+// exposes PREVIEW_ORIGIN (computed from PreviewOriginTemplate with "{id}"
+// replaced by the preview UUID). Returns nil when PreviewOriginTemplate is
+// unset, leaving user-declared env untouched.
+func (m *Manager) platformEnv(previewID uuid.UUID) map[string]string {
+	if m.previewOriginTemplate == "" {
+		return nil
+	}
+	origin := strings.ReplaceAll(m.previewOriginTemplate, "{id}", previewID.String())
+	return map[string]string{"PREVIEW_ORIGIN": origin}
 }
 
 // =============================================================================

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -31,7 +31,7 @@ type mockProvider struct {
 	statusErr   error
 }
 
-func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, _ *models.PreviewConfig) (*PreviewHandle, error) {
+func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, _ *models.PreviewConfig, _ map[string]string) (*PreviewHandle, error) {
 	if m.startErr != nil {
 		return nil, m.startErr
 	}

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -888,6 +888,49 @@ func TestInspector_NilByDefault(t *testing.T) {
 	require.Nil(t, mgr.Inspector())
 }
 
+// =============================================================================
+// platformEnv tests
+// =============================================================================
+
+func TestPlatformEnv_SubstitutesPreviewIDIntoTemplate(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(ManagerConfig{
+		PreviewOriginTemplate: "http://{id}.preview.localhost:9090",
+		Logger:                zerolog.Nop(),
+	})
+
+	id := uuid.New()
+	env := mgr.platformEnv(id)
+
+	require.Equal(t, map[string]string{
+		"PREVIEW_ORIGIN": "http://" + id.String() + ".preview.localhost:9090",
+	}, env)
+}
+
+func TestPlatformEnv_EmptyTemplateReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	mgr := NewManager(ManagerConfig{Logger: zerolog.Nop()})
+	require.Nil(t, mgr.platformEnv(uuid.New()), "empty template must skip injection so user-declared env is untouched")
+}
+
+func TestPlatformEnv_ReplacesEveryOccurrenceOfPlaceholder(t *testing.T) {
+	t.Parallel()
+
+	// Guard against anyone swapping strings.ReplaceAll for strings.Replace with
+	// n=1; duplicate {id} in the template (unusual but valid) must all resolve.
+	mgr := NewManager(ManagerConfig{
+		PreviewOriginTemplate: "{id}-{id}",
+		Logger:                zerolog.Nop(),
+	})
+
+	id := uuid.New()
+	env := mgr.platformEnv(id)
+
+	require.Equal(t, id.String()+"-"+id.String(), env["PREVIEW_ORIGIN"])
+}
+
 func TestSetInspector(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -22,8 +22,13 @@ type PreviewCapableProvider interface {
 	//   4. Start application services in dependency order
 	//   5. Wait for all readiness probes to pass
 	//
+	// extraEnv is merged into every service's environment after the user's
+	// declared env and any infrastructure-injected credentials, so it can
+	// carry platform-level values (e.g. PREVIEW_ORIGIN) that must always be
+	// available and should win over user overrides.
+	//
 	// The returned PreviewHandle contains connection details for DialPreview.
-	StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig) (*PreviewHandle, error)
+	StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*PreviewHandle, error)
 
 	// StopPreview gracefully stops all preview processes and tears down
 	// infrastructure containers. Safe to call multiple times.

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -866,13 +866,13 @@ func (d *DockerPreviewProvider) buildServiceEnvs(cfg *models.PreviewConfig, infr
 	}
 
 	// Inject platform-level env vars (e.g. PREVIEW_ORIGIN) into every service,
-	// overriding any user-declared value. This is applied last so it wins over
-	// both service.env and infrastructure.inject_env.
-	for svcName, env := range envs {
+	// overriding any user-declared value. Applied last so it wins over both
+	// service.env and infrastructure.inject_env. Mutation in place is fine —
+	// env is the same map reference stored in envs[svcName].
+	for _, env := range envs {
 		for k, v := range extraEnv {
 			env[k] = v
 		}
-		envs[svcName] = env
 	}
 
 	return envs

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -139,7 +139,7 @@ func NewDockerPreviewProvider(
 // StartPreview
 // =============================================================================
 
-func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig) (*preview.PreviewHandle, error) {
+func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*preview.PreviewHandle, error) {
 	handle, err := generateHandle()
 	if err != nil {
 		return nil, fmt.Errorf("generate preview handle: %w", err)
@@ -208,7 +208,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 	}
 
 	// Phase 4: Build service environment with injected credentials.
-	svcEnvs := d.buildServiceEnvs(cfg, infraCreds)
+	svcEnvs := d.buildServiceEnvs(cfg, infraCreds, extraEnv)
 
 	// Phase 5: Start application services in dependency order
 	// (support services first, then primary).
@@ -837,7 +837,7 @@ func (d *DockerPreviewProvider) resolveSandboxNetwork(ctx context.Context, conta
 // Credential helpers
 // =============================================================================
 
-func (d *DockerPreviewProvider) buildServiceEnvs(cfg *models.PreviewConfig, infraCreds map[string]preview.InfraCredential) map[string]map[string]string {
+func (d *DockerPreviewProvider) buildServiceEnvs(cfg *models.PreviewConfig, infraCreds map[string]preview.InfraCredential, extraEnv map[string]string) map[string]map[string]string {
 	envs := make(map[string]map[string]string, len(cfg.Services))
 
 	// Start with service-declared env vars.
@@ -863,6 +863,16 @@ func (d *DockerPreviewProvider) buildServiceEnvs(cfg *models.PreviewConfig, infr
 				}
 			}
 		}
+	}
+
+	// Inject platform-level env vars (e.g. PREVIEW_ORIGIN) into every service,
+	// overriding any user-declared value. This is applied last so it wins over
+	// both service.env and infrastructure.inject_env.
+	for svcName, env := range envs {
+		for k, v := range extraEnv {
+			env[k] = v
+		}
+		envs[svcName] = env
 	}
 
 	return envs

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -250,7 +250,7 @@ func TestBuildServiceEnvs(t *testing.T) {
 		},
 	}
 
-	envs := d.buildServiceEnvs(cfg, infraCreds)
+	envs := d.buildServiceEnvs(cfg, infraCreds, nil)
 
 	// web should have NODE_ENV + DATABASE_URL
 	require.Equal(t, "development", envs["web"]["NODE_ENV"])
@@ -259,6 +259,28 @@ func TestBuildServiceEnvs(t *testing.T) {
 	// worker should have WORKER_THREADS + DATABASE_URL
 	require.Equal(t, "2", envs["worker"]["WORKER_THREADS"])
 	require.Equal(t, "postgres://preview_db:secret@preview-db-abc:5432/preview_db", envs["worker"]["DATABASE_URL"])
+}
+
+// TestBuildServiceEnvs_ExtraEnvOverrides verifies that platform-level extras
+// (e.g. PREVIEW_ORIGIN) are applied to every service and win over both user
+// env and infra-injected env.
+func TestBuildServiceEnvs_ExtraEnvOverrides(t *testing.T) {
+	t.Parallel()
+	d := &DockerPreviewProvider{}
+
+	cfg := &models.PreviewConfig{
+		Primary: "web",
+		Services: map[string]models.ServiceConfig{
+			"web":    {Port: 3000, Env: map[string]string{"PREVIEW_ORIGIN": "user-wins"}},
+			"worker": {Port: 9000},
+		},
+		Infrastructure: map[string]models.InfrastructureConfig{},
+	}
+
+	envs := d.buildServiceEnvs(cfg, nil, map[string]string{"PREVIEW_ORIGIN": "http://abc.preview.localhost:9090"})
+
+	require.Equal(t, "http://abc.preview.localhost:9090", envs["web"]["PREVIEW_ORIGIN"], "extraEnv must override user-declared value")
+	require.Equal(t, "http://abc.preview.localhost:9090", envs["worker"]["PREVIEW_ORIGIN"], "extraEnv must reach services with no user env")
 }
 
 func TestBuildServiceEnvs_NoInfra(t *testing.T) {
@@ -276,7 +298,7 @@ func TestBuildServiceEnvs_NoInfra(t *testing.T) {
 		Infrastructure: map[string]models.InfrastructureConfig{},
 	}
 
-	envs := d.buildServiceEnvs(cfg, nil)
+	envs := d.buildServiceEnvs(cfg, nil, nil)
 	require.Equal(t, "3000", envs["web"]["PORT"])
 	require.Len(t, envs["web"], 1)
 }

--- a/internal/services/preview/recycler_test.go
+++ b/internal/services/preview/recycler_test.go
@@ -27,9 +27,9 @@ func (p *countingProvider) StopPreview(ctx context.Context, handle string) error
 	return p.mockProvider.StopPreview(ctx, handle)
 }
 
-func (p *countingProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig) (*PreviewHandle, error) {
+func (p *countingProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*PreviewHandle, error) {
 	p.startCount++
-	return p.mockProvider.StartPreview(ctx, sb, cfg)
+	return p.mockProvider.StartPreview(ctx, sb, cfg, extraEnv)
 }
 
 // newPreviewInstanceRowWithRecycleSchedule is like newPreviewInstanceRow but

--- a/internal/services/sandbox/docker_filereader.go
+++ b/internal/services/sandbox/docker_filereader.go
@@ -146,11 +146,24 @@ func (d *DockerFileReader) ReadFile(ctx context.Context, containerID, workDir, f
 		return "", false, fmt.Errorf("read file %s: %w", filePath, err)
 	}
 	if exitCode != 0 {
-		return "", false, fmt.Errorf("read file %s: %s", filePath, strings.TrimSpace(stderrOut))
+		trimmed := strings.TrimSpace(stderrOut)
+		if isNotFoundStderr(trimmed) {
+			return "", false, fmt.Errorf("read file %s: %w", filePath, ErrFileNotFound)
+		}
+		return "", false, fmt.Errorf("read file %s: %s", filePath, trimmed)
 	}
 
 	truncated := len(stdout) >= maxFileReadBytes
 	return stdout, truncated, nil
+}
+
+// isNotFoundStderr detects the ENOENT message produced by the small utilities
+// we exec inside the sandbox (head, sed — GNU coreutils, busybox, or BSD all
+// surface ENOENT with the same phrase). Keeping this in one spot lets
+// ReadFile/ReadFileContext surface a single ErrFileNotFound sentinel to
+// callers instead of forcing them to pattern-match on stderr themselves.
+func isNotFoundStderr(stderr string) bool {
+	return strings.Contains(strings.ToLower(stderr), "no such file or directory")
 }
 
 // ReadFileContext returns lines around a specific line number.
@@ -173,7 +186,11 @@ func (d *DockerFileReader) ReadFileContext(ctx context.Context, containerID, wor
 		return nil, fmt.Errorf("read context %s:%d: %w", filePath, line, err)
 	}
 	if exitCode != 0 {
-		return nil, fmt.Errorf("read context %s:%d: %s", filePath, line, strings.TrimSpace(stderrOut))
+		trimmed := strings.TrimSpace(stderrOut)
+		if isNotFoundStderr(trimmed) {
+			return nil, fmt.Errorf("read context %s:%d: %w", filePath, line, ErrFileNotFound)
+		}
+		return nil, fmt.Errorf("read context %s:%d: %s", filePath, line, trimmed)
 	}
 
 	var lines []FileLine

--- a/internal/services/sandbox/docker_filereader.go
+++ b/internal/services/sandbox/docker_filereader.go
@@ -50,6 +50,10 @@ func (d *DockerFileReader) execCmd(ctx context.Context, containerID, workDir str
 		AttachStdout: true,
 		AttachStderr: true,
 		WorkingDir:   workDir,
+		// Force the C locale so utilities (head, sed, ls) emit stderr in a
+		// known dialect — isNotFoundStderr relies on the English "No such
+		// file or directory" phrase to distinguish ENOENT from other errors.
+		Env: []string{"LC_ALL=C", "LANG=C"},
 	}
 
 	execResp, err := d.client.ContainerExecCreate(ctx, containerID, execCfg)

--- a/internal/services/sandbox/docker_filereader_test.go
+++ b/internal/services/sandbox/docker_filereader_test.go
@@ -25,9 +25,14 @@ type mockDockerClient struct {
 
 	inspectResp container.ExecInspect
 	inspectErr  error
+
+	// lastExecOptions captures the last ExecOptions passed to
+	// ContainerExecCreate so tests can assert on Env, Cmd, etc.
+	lastExecOptions container.ExecOptions
 }
 
-func (m *mockDockerClient) ContainerExecCreate(_ context.Context, _ string, _ container.ExecOptions) (container.ExecCreateResponse, error) {
+func (m *mockDockerClient) ContainerExecCreate(_ context.Context, _ string, cfg container.ExecOptions) (container.ExecCreateResponse, error) {
+	m.lastExecOptions = cfg
 	return m.createResp, m.createErr
 }
 
@@ -271,6 +276,20 @@ func TestDockerFileReader_ReadFile_NonNotFoundNotSentinel(t *testing.T) {
 	_, _, err := reader.ReadFile(context.Background(), "container-1", "/workspace", "locked")
 	require.Error(t, err)
 	require.NotErrorIs(t, err, ErrFileNotFound, "non-ENOENT errors must not be classified as file-not-found")
+}
+
+// TestDockerFileReader_ForcesCLocale guards isNotFoundStderr: if the exec
+// environment ever stops pinning LC_ALL=C, a non-English container locale
+// would emit a translated ENOENT that our matcher would miss.
+func TestDockerFileReader_ForcesCLocale(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClient("ok\n", 0)
+	reader := NewDockerFileReader(client)
+	_, _, err := reader.ReadFile(context.Background(), "container-1", "/workspace", "f")
+	require.NoError(t, err)
+	require.Contains(t, client.lastExecOptions.Env, "LC_ALL=C", "exec must pin LC_ALL=C so ENOENT stderr stays in English")
+	require.Contains(t, client.lastExecOptions.Env, "LANG=C", "exec must pin LANG=C as a belt-and-braces fallback")
 }
 
 func TestDockerFileReader_ReadFileContext(t *testing.T) {

--- a/internal/services/sandbox/docker_filereader_test.go
+++ b/internal/services/sandbox/docker_filereader_test.go
@@ -248,6 +248,31 @@ func TestDockerFileReader_ReadFile(t *testing.T) {
 	}
 }
 
+// TestDockerFileReader_ReadFile_NotFoundSentinel verifies that ENOENT stderr
+// surfaces as ErrFileNotFound so callers can errors.Is against it instead of
+// pattern-matching stderr text themselves.
+func TestDockerFileReader_ReadFile_NotFoundSentinel(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClientWithStderr("head: cannot open '/workspace/missing' for reading: No such file or directory", 1)
+	reader := NewDockerFileReader(client)
+	_, _, err := reader.ReadFile(context.Background(), "container-1", "/workspace", "missing")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrFileNotFound, "ENOENT from head must be surfaced as ErrFileNotFound")
+}
+
+// TestDockerFileReader_ReadFile_NonNotFoundNotSentinel ensures unrelated exec
+// failures (non-ENOENT stderr) do NOT get miscategorized as ErrFileNotFound.
+func TestDockerFileReader_ReadFile_NonNotFoundNotSentinel(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClientWithStderr("head: permission denied", 1)
+	reader := NewDockerFileReader(client)
+	_, _, err := reader.ReadFile(context.Background(), "container-1", "/workspace", "locked")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrFileNotFound, "non-ENOENT errors must not be classified as file-not-found")
+}
+
 func TestDockerFileReader_ReadFileContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/sandbox/docker_filereader_test.go
+++ b/internal/services/sandbox/docker_filereader_test.go
@@ -278,6 +278,19 @@ func TestDockerFileReader_ReadFile_NonNotFoundNotSentinel(t *testing.T) {
 	require.NotErrorIs(t, err, ErrFileNotFound, "non-ENOENT errors must not be classified as file-not-found")
 }
 
+// TestDockerFileReader_ReadFileContext_NotFoundSentinel verifies that ENOENT
+// stderr from `sed` (used by ReadFileContext) surfaces as ErrFileNotFound,
+// matching ReadFile's behavior so callers can use a single sentinel.
+func TestDockerFileReader_ReadFileContext_NotFoundSentinel(t *testing.T) {
+	t.Parallel()
+
+	client := newMockClientWithStderr("sed: can't read /workspace/missing: No such file or directory", 1)
+	reader := NewDockerFileReader(client)
+	_, err := reader.ReadFileContext(context.Background(), "container-1", "/workspace", "missing", 5, 2, 2)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrFileNotFound, "ENOENT from sed must be surfaced as ErrFileNotFound")
+}
+
 // TestDockerFileReader_ForcesCLocale guards isNotFoundStderr: if the exec
 // environment ever stops pinning LC_ALL=C, a non-English container locale
 // would emit a translated ENOENT that our matcher would miss.

--- a/internal/services/sandbox/filereader.go
+++ b/internal/services/sandbox/filereader.go
@@ -3,8 +3,15 @@ package sandbox
 
 import (
 	"context"
+	"errors"
 	"fmt"
 )
+
+// ErrFileNotFound is returned by FileReader implementations when the requested
+// path does not exist inside the sandbox. Callers should use errors.Is to
+// distinguish the expected "no such file" case from real read failures
+// (docker exec error, context cancellation, sandbox gone).
+var ErrFileNotFound = errors.New("file not found")
 
 // FileEntry represents a single entry in a directory listing.
 type FileEntry struct {

--- a/internal/services/sandbox/filereader.go
+++ b/internal/services/sandbox/filereader.go
@@ -47,18 +47,21 @@ type FileReader interface {
 	ReadFileContext(ctx context.Context, containerID, workDir, filePath string, line, above, below int) ([]FileLine, error)
 }
 
-// NoOpFileReader is a FileReader that always returns "unavailable" errors.
-// Use this instead of nil when Docker is not available to avoid nil-pointer panics.
+// NoOpFileReader is a FileReader used when Docker is unavailable so callers
+// don't have to nil-check. Every method returns an error that wraps
+// ErrFileNotFound, so callers using errors.Is(err, ErrFileNotFound) treat the
+// no-Docker case the same as a genuinely missing path — which is what
+// auto-detect callers (e.g. PreviewHandler.readWorkspacePreviewConfig) want.
 type NoOpFileReader struct{}
 
 func (NoOpFileReader) ListDir(_ context.Context, _, _, _ string) ([]FileEntry, error) {
-	return nil, fmt.Errorf("sandbox file browsing is not available")
+	return nil, fmt.Errorf("sandbox file browsing is not available: %w", ErrFileNotFound)
 }
 
 func (NoOpFileReader) ReadFile(_ context.Context, _, _, _ string) (string, bool, error) {
-	return "", false, fmt.Errorf("sandbox file browsing is not available")
+	return "", false, fmt.Errorf("sandbox file browsing is not available: %w", ErrFileNotFound)
 }
 
 func (NoOpFileReader) ReadFileContext(_ context.Context, _, _, _ string, _, _, _ int) ([]FileLine, error) {
-	return nil, fmt.Errorf("sandbox file browsing is not available")
+	return nil, fmt.Errorf("sandbox file browsing is not available: %w", ErrFileNotFound)
 }

--- a/internal/services/sandbox/filereader_test.go
+++ b/internal/services/sandbox/filereader_test.go
@@ -1,10 +1,32 @@
 package sandbox
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+// TestNoOpFileReader_ReturnsErrFileNotFound pins the contract documented on
+// NoOpFileReader and relied on by PreviewHandler.readWorkspacePreviewConfig:
+// every method must wrap ErrFileNotFound so callers using errors.Is can treat
+// the no-Docker case as "no file" and fall through to defaults instead of
+// surfacing a 500.
+func TestNoOpFileReader_ReturnsErrFileNotFound(t *testing.T) {
+	t.Parallel()
+
+	r := NoOpFileReader{}
+	ctx := context.Background()
+
+	_, listErr := r.ListDir(ctx, "c", "/w", ".")
+	require.ErrorIs(t, listErr, ErrFileNotFound, "ListDir must wrap ErrFileNotFound")
+
+	_, _, readErr := r.ReadFile(ctx, "c", "/w", "f")
+	require.ErrorIs(t, readErr, ErrFileNotFound, "ReadFile must wrap ErrFileNotFound")
+
+	_, ctxErr := r.ReadFileContext(ctx, "c", "/w", "f", 1, 0, 0)
+	require.ErrorIs(t, ctxErr, ErrFileNotFound, "ReadFileContext must wrap ErrFileNotFound")
+}
 
 func TestResolvePathInWorkDir(t *testing.T) {
 	t.Parallel()

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -40,25 +40,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Go toolchain matching the builder stage so previews that run the
+# Copy the Go toolchain from the go-builder stage so previews that run the
 # agent's own Go source (e.g. `go run ./cmd/server`) compile inside the
-# sandbox at session-start time.
-#
-# IMPORTANT: keep GO_VERSION below in sync with the `FROM golang:X.Y` pin in
-# the go-builder stage at the top of this Dockerfile. If they drift, a
-# session will compile against a different toolchain than the builder used,
-# which can mask `//go:build` and module-resolution issues.
-ARG TARGETARCH
-RUN set -eux; \
-    GO_VERSION="1.26.0"; \
-    case "${TARGETARCH:-amd64}" in \
-      amd64) GO_ARCH="amd64" ;; \
-      arm64) GO_ARCH="arm64" ;; \
-      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz; \
-    tar -C /usr/local -xzf /tmp/go.tar.gz; \
-    rm /tmp/go.tar.gz
+# sandbox at session-start time. Reusing the builder's /usr/local/go
+# guarantees the runtime and builder toolchains cannot drift — the version
+# is pinned in exactly one place (the `FROM golang:X.Y` line above).
+COPY --from=go-builder /usr/local/go /usr/local/go
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install agent CLIs at pinned versions.

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -23,18 +23,38 @@ FROM ubuntu:24.04
 RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 
 # System dependencies for agent CLIs and typical repo operations.
+# postgresql-client is needed when a preview's command chain seeds a Postgres
+# infrastructure container via `psql -f`; keeping it in the base image avoids
+# per-preview apt installs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
     jq \
     sudo \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 24 LTS via NodeSource.
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Go toolchain matching the builder stage so previews that run the
+# agent's own Go source (e.g. `go run ./cmd/server`) compile inside the sandbox
+# at session-start time. Version tracks the builder FROM directive above.
+ARG TARGETARCH
+RUN set -eux; \
+    GO_VERSION="1.26.0"; \
+    case "${TARGETARCH:-amd64}" in \
+      amd64) GO_ARCH="amd64" ;; \
+      arm64) GO_ARCH="arm64" ;; \
+      *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz" -o /tmp/go.tar.gz; \
+    tar -C /usr/local -xzf /tmp/go.tar.gz; \
+    rm /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install agent CLIs at pinned versions.
 # The npm cache mount avoids re-downloading unchanged packages on rebuilds.

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -41,8 +41,13 @@ RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Go toolchain matching the builder stage so previews that run the
-# agent's own Go source (e.g. `go run ./cmd/server`) compile inside the sandbox
-# at session-start time. Version tracks the builder FROM directive above.
+# agent's own Go source (e.g. `go run ./cmd/server`) compile inside the
+# sandbox at session-start time.
+#
+# IMPORTANT: keep GO_VERSION below in sync with the `FROM golang:X.Y` pin in
+# the go-builder stage at the top of this Dockerfile. If they drift, a
+# session will compile against a different toolchain than the builder used,
+# which can mask `//go:build` and module-resolution issues.
 ARG TARGETARCH
 RUN set -eux; \
     GO_VERSION="1.26.0"; \


### PR DESCRIPTION
## Summary

Follow-up to #397. Turns the committed `.143/preview.json` into a preview that actually runs 143 on 143 against a seeded Postgres.

- **`sandbox/Dockerfile`** — install Go 1.26 (matching the builder `FROM`) and `postgresql-client` in the runtime image so previews can `go run ./cmd/server` and `psql -f .143/seed.sql` inline. One-time ~400 MB image growth; nothing else in the pipeline cares.
- **Auto-detect `.143/preview.json`** — `PreviewHandler.StartPreview` now reads the file from the session workspace via the existing `sandbox.FileReader` (path-traversal-safe, 1 MB cap) before falling back to the Node.js default. Any repo with a committed config just works.
- **`PREVIEW_ORIGIN` platform env** — `Manager` computes it from `PreviewOriginTemplate` (`http://{id}.preview.localhost:9090`) and hands it to the provider via a new `extraEnv` parameter on `PreviewCapableProvider.StartPreview`. Applied last in `buildServiceEnvs`, so it overrides user-declared values. Lets backends emit absolute URLs that round-trip through the gateway.
- **Rewrite `.143/preview.json`** — server command becomes a `sh -c` chain: `go run ./cmd/migrate up && psql "$DATABASE_URL" -f .143/seed.sql && BASE_URL=$PREVIEW_ORIGIN FRONTEND_URL=$PREVIEW_ORIGIN go run ./cmd/server`. Readiness bumped to 240s (first `go run` compiles from scratch). `init_script` dropped — seed runs post-migrate now.
- **Expand `.143/seed.sql`** — adds a placeholder integration + 2 repositories + 2 projects so the logged-in UI shows populated screens. All rows use fixed UUIDs + `ON CONFLICT DO NOTHING` for idempotency. (Skipped the `sessions` table — too many evolving NOT NULL columns to keep robust.)
- **Docs** — `PREVIEW_ORIGIN` added to the platform-injected env table in `docs/guides/previews.md`.
- **New test** — `TestParseConfig_CommittedDogfoodConfig` parses the committed config to catch future silent regressions.

## Notes

- **No Docker-in-Docker**: the 143 server inside the preview can't spawn its own sandboxes. Verified that `cmd/server/main.go` already degrades gracefully when the Docker socket is unreachable (`main.go:136-139` and `canBuildServices`) — Phase 3+ services are disabled, HTTP API still boots.
- **Cold-start is slow** (~3-4 min first run: go module download + compile + migrate). Preview uses a fresh sandbox per session, so this is the norm.

## Test plan
- [x] `make test` — full suite green.
- [x] `make lint` — 0 issues.
- [x] `TestParseConfig_CommittedDogfoodConfig` passes against the rewritten config.
- [ ] Local end-to-end: `docker build -t 143-sandbox:latest -f sandbox/Dockerfile .`, start a session against this repo, click **Start Preview**, log in as `dogfood@143.dev` / `preview-dogfood`, confirm repos + projects screens are populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
