### PR TITLE
Guard session create against rapid Enter double-submits

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -66,6 +66,9 @@ export function ManualSessionCreatePageContent() {
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  // Synchronous guard: React Query's isPending flips on the next render, so
+  // rapid Enter presses can all pass the isPending check in the same tick.
+  const submittingRef = useRef(false);
 
   // Read the currently selected repository from the URL query params
   // (set by the RepoContextSwitcher) so we clone the codebase into the sandbox.
@@ -203,8 +206,16 @@ export function ManualSessionCreatePageContent() {
       setCreationError(
         error instanceof Error ? error.message : "Could not start session. Please try again.",
       );
+      submittingRef.current = false;
     },
   });
+
+  function submitManualSession() {
+    if (submittingRef.current) return;
+    if (message.trim().length === 0) return;
+    submittingRef.current = true;
+    createManualSessionMutation.mutate();
+  }
 
   function resizeMessageInput() {
     const element = messageInputRef.current;
@@ -354,9 +365,7 @@ export function ManualSessionCreatePageContent() {
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
-                  if (message.trim().length > 0 && !createManualSessionMutation.isPending) {
-                    createManualSessionMutation.mutate();
-                  }
+                  submitManualSession();
                 }
               }}
               placeholder="Tell the agent what to do..."
@@ -553,7 +562,7 @@ export function ManualSessionCreatePageContent() {
                 <Button
                   type="button"
                   size="icon"
-                  onClick={() => createManualSessionMutation.mutate()}
+                  onClick={submitManualSession}
                   disabled={message.trim().length === 0 || createManualSessionMutation.isPending}
                   className="h-8 w-8 rounded-full"
                   aria-label="Start session"

--- a/frontend/src/components/create-session-dialog.tsx
+++ b/frontend/src/components/create-session-dialog.tsx
@@ -52,6 +52,9 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
   const queryClient = useQueryClient();
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
+  // Synchronous guard: React Query's isPending flips on the next render, so
+  // rapid Enter presses can all pass the isPending check in the same tick.
+  const submittingRef = useRef(false);
 
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<string[]>([]);
@@ -136,6 +139,7 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
       setUserSelectedRepoId(null);
       setBranchByRepoId({});
       setCreationError(null);
+      submittingRef.current = false;
     }
   }, [open]);
 
@@ -179,8 +183,16 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
       setCreationError(
         error instanceof Error ? error.message : "Could not start session. Please try again.",
       );
+      submittingRef.current = false;
     },
   });
+
+  function submitCreateSession() {
+    if (submittingRef.current) return;
+    if (message.trim().length === 0) return;
+    submittingRef.current = true;
+    createMutation.mutate();
+  }
 
   function resizeMessageInput() {
     const element = messageInputRef.current;
@@ -250,9 +262,7 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();
-                if (message.trim().length > 0 && !createMutation.isPending) {
-                  createMutation.mutate();
-                }
+                submitCreateSession();
               }
             }}
             placeholder="Tell the agent what to do..."
@@ -417,7 +427,7 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
             <Button
               type="button"
               size="sm"
-              onClick={() => createMutation.mutate()}
+              onClick={submitCreateSession}
               disabled={message.trim().length === 0 || createMutation.isPending}
               className="h-7 px-3 text-xs rounded-md"
             >


### PR DESCRIPTION
## Summary
Pressing Enter rapidly in the new-session composer briefly rendered multiple optimistic sessions in the sidebar (and fired multiple real create POSTs). React Query's `isPending` only flips on the next render, so the `!createMutation.isPending` check wasn't a real guard against same-tick re-submits.

Routed both submit paths (Enter key + send button) through a single helper backed by a synchronous `useRef` so only the first press wins; the ref resets on error / dialog close (success navigates away). Applied to both `ManualSessionCreatePageContent` and `CreateSessionDialog`.

## Test plan
- [ ] On `/sessions/new`, mash Enter with a prompt typed in — only one optimistic row appears, one session gets created.
- [ ] A failed create (e.g. no repo configured) surfaces the error and lets you retry.
- [ ] Same behavior in the `CreateSessionDialog` variant (Cmd-K / wherever it's opened).
