### PR TITLE
Drop phantom updated_at from session archive/delete writes

### DIFF
--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -651,7 +651,7 @@ func (s *SessionStore) ListExpiredSnapshots(ctx context.Context, olderThan time.
 
 // Archive marks a session as archived, hiding it from default list views.
 func (s *SessionStore) Archive(ctx context.Context, orgID, sessionID, userID uuid.UUID) error {
-	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = @user_id, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
+	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = @user_id WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
 	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":      sessionID,
 		"org_id":  orgID,
@@ -669,7 +669,7 @@ func (s *SessionStore) Archive(ctx context.Context, orgID, sessionID, userID uui
 // ArchiveSystem archives a session without a user actor (e.g. webhook-driven auto-archive).
 // archived_by_user_id is left NULL, and an already-archived session is a no-op rather than an error.
 func (s *SessionStore) ArchiveSystem(ctx context.Context, orgID, sessionID uuid.UUID) error {
-	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = NULL, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
+	query := `UPDATE sessions SET archived_at = now(), archived_by_user_id = NULL WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NULL`
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,
@@ -679,7 +679,7 @@ func (s *SessionStore) ArchiveSystem(ctx context.Context, orgID, sessionID uuid.
 
 // Unarchive removes the archived flag from a session, restoring it to default views.
 func (s *SessionStore) Unarchive(ctx context.Context, orgID, sessionID uuid.UUID) error {
-	query := `UPDATE sessions SET archived_at = NULL, archived_by_user_id = NULL, updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NOT NULL`
+	query := `UPDATE sessions SET archived_at = NULL, archived_by_user_id = NULL WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL AND archived_at IS NOT NULL`
 	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,
@@ -696,7 +696,7 @@ func (s *SessionStore) Unarchive(ctx context.Context, orgID, sessionID uuid.UUID
 // SoftDelete marks a session as deleted without removing the row.
 // Child rows (logs, messages, threads, etc.) remain intact for audit purposes.
 func (s *SessionStore) SoftDelete(ctx context.Context, orgID, sessionID uuid.UUID) error {
-	query := `UPDATE sessions SET deleted_at = now(), updated_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
+	query := `UPDATE sessions SET deleted_at = now() WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,


### PR DESCRIPTION
## Summary
- The `sessions` table has no `updated_at` column, so `SessionStore.Archive`, `ArchiveSystem`, `Unarchive`, and `SoftDelete` all failed with `SQLSTATE 42703` (`column "updated_at" of relation "sessions" does not exist`), surfacing in the UI as "failed to archive session".
- Removed `updated_at = now()` from those four UPDATE queries. The existing pgxmock tests still pass because they match the SQL string by regex and never validated against the real schema.

## Test plan
- [ ] Archive a session in the UI and confirm the request succeeds.
- [ ] Unarchive and confirm it reappears in default lists.
- [ ] Verify auto-archive on PR merge/close still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)