### PR TITLE
Return 200+null for empty PR/plan lookups; unblock worker deploy

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -107,12 +107,25 @@ fi
 if [ "$ROLE" = "worker" ]; then
   # Keep the sandbox firewall script in sync so every deploy can re-apply
   # the egress rules (they read the sandbox network's current subnet).
-  # Older workers may have a root-owned copy from cloud-init bootstrap;
-  # chown the scripts dir first so deploy can overwrite via plain scp.
+  # Older workers may have a root-owned copy from cloud-init bootstrap.
+  # Try to normalize ownership non-interactively; tolerate failure so the
+  # scp below still runs on hosts where files are already deploy-owned.
+  # If sudo has no NOPASSWD entry, `sudo -n` exits immediately instead of
+  # hanging waiting for a password that CI can't provide.
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "sudo chown -R deploy:deploy /opt/143/deploy/scripts"
-  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
-    deploy@"$HOST":/opt/143/deploy/scripts/
+    "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>/dev/null || true"
+  if ! scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
+      deploy@"$HOST":/opt/143/deploy/scripts/; then
+    echo "ERROR: scp of sandbox-firewall.sh failed."
+    echo "  Hint: the worker likely has root-owned files under /opt/143/deploy/scripts AND"
+    echo "  the 'deploy' user lacks NOPASSWD sudo. One-time fix on the worker host:"
+    echo "    1) Log in as root (provider console) and run:"
+    echo "       echo 'deploy ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-deploy"
+    echo "       chmod 440 /etc/sudoers.d/99-deploy"
+    echo "       chown -R deploy:deploy /opt/143/deploy"
+    echo "    2) Re-run the deploy."
+    exit 1
+  fi
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh"
 fi
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -113,7 +113,7 @@ if [ "$ROLE" = "worker" ]; then
   # If sudo has no NOPASSWD entry, `sudo -n` exits immediately instead of
   # hanging waiting for a password that CI can't provide.
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>/dev/null || true"
+    "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
   if ! scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
       deploy@"$HOST":/opt/143/deploy/scripts/; then
     echo "ERROR: scp of sandbox-firewall.sh failed."

--- a/frontend/src/app/(dashboard)/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/autopilot/page.test.tsx
@@ -74,17 +74,10 @@ function mockStatus(data: PMStatus) {
   );
 }
 
-function mockLatestPlan(plan: PMPlan | null, status = 200) {
+function mockLatestPlan(plan: PMPlan | null) {
   server.use(
-    http.get("/api/v1/pm/plans/latest", () => {
-      if (!plan) {
-        return HttpResponse.json(
-          { error: { code: "NOT_FOUND", message: "No PM plan found" } },
-          { status }
-        );
-      }
-      return HttpResponse.json({ data: plan } satisfies SingleResponse<PMPlan>);
-    })
+    http.get("/api/v1/pm/plans/latest", () =>
+      HttpResponse.json({ data: plan } satisfies SingleResponse<PMPlan | null>))
   );
 }
 
@@ -143,7 +136,7 @@ describe("AutopilotPage", () => {
       success_count: 0,
       total_delegated: 0,
     });
-    mockLatestPlan(null, 404);
+    mockLatestPlan(null);
     mockDocuments([]);
     mockIntegrations([]);
     mockRepositories([]);
@@ -174,7 +167,7 @@ describe("AutopilotPage", () => {
       success_count: 0,
       total_delegated: 0,
     });
-    mockLatestPlan(null, 404);
+    mockLatestPlan(null);
     mockDocuments([]);
     mockIntegrations([
       {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -433,11 +433,7 @@ const prStatusColor: Record<string, string> = {
 function PRCard({ sessionId }: { sessionId: string }) {
   const { data: prData, isLoading: prLoading } = useQuery({
     queryKey: ["session", sessionId, "pr"],
-    queryFn: () => api.sessions.getPR(sessionId).catch((err) => {
-      // 404 means no PR exists yet — treat as empty data, not an error.
-      if (err?.code === "NOT_FOUND") return { data: null };
-      throw err;
-    }),
+    queryFn: () => api.sessions.getPR(sessionId),
   });
 
   const pr = prData?.data;
@@ -962,11 +958,7 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
 
   const { data: prData } = useQuery({
     queryKey: ["session", sessionId, "pr"],
-    queryFn: () => api.sessions.getPR(sessionId).catch((err) => {
-      // 404 means no PR exists yet — treat as empty data, not an error.
-      if (err?.code === "NOT_FOUND") return { data: null };
-      throw err;
-    }),
+    queryFn: () => api.sessions.getPR(sessionId),
   });
   const hasPR = !!prData?.data;
   const hasDiff = !!session.diff_stats;
@@ -1358,10 +1350,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   // PR state for the detail-panel header button
   const { data: prData } = useQuery({
     queryKey: ["session", id, "pr"],
-    queryFn: () => api.sessions.getPR(id).catch((err) => {
-      if (err?.code === "NOT_FOUND") return { data: null };
-      throw err;
-    }),
+    queryFn: () => api.sessions.getPR(id),
   });
   // Record that the user has viewed this session (for unread tracking).
   useEffect(() => {

--- a/frontend/src/components/autopilot/use-autopilot-page-data.ts
+++ b/frontend/src/components/autopilot/use-autopilot-page-data.ts
@@ -28,13 +28,6 @@ const DEFAULT_PM_STATUS: PMStatus = {
   total_delegated: 0,
 };
 
-function isNotFoundError(error: unknown): boolean {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && (error as { code?: string }).code === "NOT_FOUND";
-}
-
 export function useAutopilotPageData() {
   const { isLoading: setupLoading, isSetupComplete } = useSetupStatus();
 
@@ -50,17 +43,7 @@ export function useAutopilotPageData() {
 
   const { data: latestPlan, isLoading: latestPlanLoading } = useQuery<PMPlan | null>({
     queryKey: queryKeys.pm.latest,
-    queryFn: async () => {
-      try {
-        const response = await api.pm.latest();
-        return response.data;
-      } catch (error) {
-        if (isNotFoundError(error)) {
-          return null;
-        }
-        throw error;
-      }
-    },
+    queryFn: async () => (await api.pm.latest()).data,
   });
 
   const { data: documentsResponse, isLoading: documentsLoading } = useQuery<ListResponse<PMDocument>>({

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -663,7 +663,7 @@ describe('api client', () => {
       );
 
       const result = await api.pm.latest();
-      expect(result.data.id).toBe('plan-latest');
+      expect(result.data?.id).toBe('plan-latest');
     });
 
     it('fetches single plan', async () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -181,7 +181,7 @@ export const api = {
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').PMPlan>>(`/api/v1/pm/plans${qs ? `?${qs}` : ''}`);
     },
-    latest: () => get<import('./types').SingleResponse<import('./types').PMPlan>>('/api/v1/pm/plans/latest'),
+    latest: () => get<import('./types').SingleResponse<import('./types').PMPlan | null>>('/api/v1/pm/plans/latest'),
     get: (id: string) => get<import('./types').SingleResponse<import('./types').PMPlan>>(`/api/v1/pm/plans/${id}`),
     decisions: (params?: { cursor?: string; limit?: number; decision_type?: string; outcome?: string }) => {
       const searchParams = new URLSearchParams();
@@ -223,7 +223,7 @@ export const api = {
     get: (id: string) => get<import('./types').SingleResponse<import('./types').SessionDetail>>(`/api/v1/sessions/${id}`),
     getLogs: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionLog>>(`/api/v1/sessions/${sessionId}/logs`),
     getValidation: (sessionId: string) => get<import('./types').SingleResponse<import('./types').Validation>>(`/api/v1/sessions/${sessionId}/validation`),
-    getPR: (sessionId: string) => get<import('./types').SingleResponse<import('./types').PullRequest>>(`/api/v1/sessions/${sessionId}/pr`),
+    getPR: (sessionId: string) => get<import('./types').SingleResponse<import('./types').PullRequest | null>>(`/api/v1/sessions/${sessionId}/pr`),
     createPR: (sessionId: string, options?: { draft?: boolean }) =>
       post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr`, options),
     getQuestions: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions`),

--- a/internal/api/handlers/pm.go
+++ b/internal/api/handlers/pm.go
@@ -106,15 +106,23 @@ func (h *PMHandler) Get(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.PMPlan]{Data: plan})
 }
 
+// Latest returns the most recent PM plan for the org, or null if none exist.
+// "No plans yet" is a normal empty state, not a missing resource, so we return
+// 200 with a null body rather than 404.
 func (h *PMHandler) Latest(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 
 	plan, err := h.planStore.GetLatestByOrg(r.Context(), orgID)
 	if err != nil {
-		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "plan not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeJSON(w, http.StatusOK, models.SingleResponse[*models.PMPlan]{Data: nil})
+			return
+		}
+		zerolog.Ctx(r.Context()).Error().Err(err).Msg("failed to load latest PM plan")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load plan", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, models.SingleResponse[models.PMPlan]{Data: plan})
+	writeJSON(w, http.StatusOK, models.SingleResponse[*models.PMPlan]{Data: &plan})
 }
 
 // Current returns the PM's latest recommendation in a presentation-friendly

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -821,5 +822,73 @@ func TestPMHandler_Latest_NoPlan_Returns200Null(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, rr.Code, "empty state should be 200, not 404")
 	require.JSONEq(t, `{"data":null}`, rr.Body.String(), "body should be data:null")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPMHandler_Latest_ReturnsPlan(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	decisionLogStore := db.NewPMDecisionLogStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
+
+	orgID := uuid.New()
+	planID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(pmPlanColumnsWithContext).
+				AddRow(planID, orgID, nil, "completed", "analysis",
+					json.RawMessage(`[]`), json.RawMessage(`[]`), json.RawMessage(`[]`),
+					1, 2, 3, 4, 5, 6,
+					json.RawMessage(`{}`), json.RawMessage(`{}`), "cron",
+					now, &now,
+				),
+		)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/plans/latest", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.Latest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "should return OK")
+	require.Contains(t, rr.Body.String(), planID.String(), "body should include the plan id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPMHandler_Latest_DBError_Returns500(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	decisionLogStore := db.NewPMDecisionLogStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
+
+	orgID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(errors.New("db exploded"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/plans/latest", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.Latest(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "real DB errors should 500, not 200")
+	require.Contains(t, rr.Body.String(), "INTERNAL_ERROR", "error code should surface")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -324,8 +324,8 @@ func TestPMHandler_StatusNextRunAtAccountsForFailure(t *testing.T) {
 
 	orgID := uuid.New()
 	now := time.Now()
-	planCreatedAt := now.Add(-5 * time.Hour)  // plan was 5h ago
-	failedAt := now.Add(-30 * time.Minute)    // failure was 30min ago (more recent)
+	planCreatedAt := now.Add(-5 * time.Hour) // plan was 5h ago
+	failedAt := now.Add(-30 * time.Minute)   // failure was 30min ago (more recent)
 
 	// Mock GetLatestByOrg — old successful plan.
 	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
@@ -566,7 +566,7 @@ func TestPMHandler_AcceptRefresh(t *testing.T) {
 					true, activeID, "",
 					nil, now, now),
 		)
-	mock.ExpectCommit()  // savepoint release
+	mock.ExpectCommit()   // savepoint release
 	mock.ExpectRollback() // deferred rollback (no-op after commit)
 
 	// Delete is now soft-delete (UPDATE SET active = false).
@@ -574,7 +574,7 @@ func TestPMHandler_AcceptRefresh(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-	mock.ExpectCommit()  // outer tx commit
+	mock.ExpectCommit()   // outer tx commit
 	mock.ExpectRollback() // deferred rollback (no-op)
 
 	rctx := chi.NewRouteContext()
@@ -792,5 +792,34 @@ func TestPMHandler_CurrentNotFound(t *testing.T) {
 	handler.Current(rr, req)
 
 	require.Equal(t, http.StatusNotFound, rr.Code, "should return 404 when no plan exists")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPMHandler_Latest_NoPlan_Returns200Null(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	planStore := db.NewPMPlanStore(mock)
+	decisionLogStore := db.NewPMDecisionLogStore(mock)
+	jobStore := db.NewJobStore(mock)
+	handler := NewPMHandler(planStore, decisionLogStore, jobStore, nil)
+
+	orgID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM pm_plans WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pmPlanColumnsWithContext))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/pm/plans/latest", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.Latest(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "empty state should be 200, not 404")
+	require.JSONEq(t, `{"data":null}`, rr.Body.String(), "body should be data:null")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -615,7 +615,9 @@ func (h *SessionHandler) GetValidation(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Validation]{Data: v})
 }
 
-// GetPullRequest returns the PR associated with an agent run.
+// GetPullRequest returns the PR associated with an agent run, or null if none exists.
+// "No PR yet" is a normal empty state for an active session, not a missing resource,
+// so we return 200 with a null body rather than 404.
 func (h *SessionHandler) GetPullRequest(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
@@ -626,10 +628,15 @@ func (h *SessionHandler) GetPullRequest(w http.ResponseWriter, r *http.Request) 
 
 	pr, err := h.pullRequestStore.GetBySessionID(r.Context(), orgID, runID)
 	if err != nil {
-		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "pull request not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeJSON(w, http.StatusOK, models.SingleResponse[*models.PullRequest]{Data: nil})
+			return
+		}
+		zerolog.Ctx(r.Context()).Error().Err(err).Str("session_id", runID.String()).Msg("failed to load PR for session")
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load pull request", err)
 		return
 	}
-	writeJSON(w, http.StatusOK, models.SingleResponse[models.PullRequest]{Data: pr})
+	writeJSON(w, http.StatusOK, models.SingleResponse[*models.PullRequest]{Data: &pr})
 }
 
 // CreatePR handles POST /sessions/{id}/pr — enqueues a job to create a GitHub

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -982,6 +983,36 @@ func TestSessionHandler_GetPullRequest_NoPR_Returns200Null(t *testing.T) {
 	handler.GetPullRequest(w, req)
 	require.Equal(t, http.StatusOK, w.Code, "empty state should be 200, not 404")
 	require.JSONEq(t, `{"data":null}`, w.Body.String(), "body should be data:null")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionHandler_GetPullRequest_DBError_Returns500(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("db exploded"))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID.String()+"/pull-request", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", runID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.GetPullRequest(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code, "real DB errors should 500, not 200")
+	require.Contains(t, w.Body.String(), "INTERNAL_ERROR", "error code should surface")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -84,12 +84,12 @@ func TestSessionHandler_List(t *testing.T) {
 							nil,                      // model_override
 							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -169,12 +169,12 @@ func TestSessionHandler_List_WithRepositoryID(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -265,12 +265,12 @@ func TestSessionHandler_List_CommaSeparatedStatuses(t *testing.T) {
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 0, nil, "none", nil,
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -314,7 +314,7 @@ func TestDecodeSessionCursor_Invalid(t *testing.T) {
 		cursor string
 	}{
 		{name: "not base64", cursor: "!!!invalid!!!"},
-		{name: "missing comma", cursor: "bm9jb21tYQ=="},                                                     // "nocomma"
+		{name: "missing comma", cursor: "bm9jb21tYQ=="},                                                 // "nocomma"
 		{name: "bad timestamp", cursor: "YmFkdGltZSwwMTIzNDU2Ny04OWFiLWNkZWYtMDEyMy00NTY3ODlhYmNkZWY="}, // "badtime,..."
 	}
 
@@ -426,12 +426,12 @@ func TestSessionHandler_Get(t *testing.T) {
 							nil,                      // model_override
 							nil,                      // triggered_by_user_id
 							nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -951,6 +951,40 @@ func TestSessionHandler_GetPullRequest_Success(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestSessionHandler_GetPullRequest_NoPR_Returns200Null(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url",
+			"github_repo", "title", "body", "status", "review_status",
+			"authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID.String()+"/pull-request", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", runID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.GetPullRequest(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "empty state should be 200, not 404")
+	require.JSONEq(t, `{"data":null}`, w.Body.String(), "body should be data:null")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSessionHandler_GetPullRequest_InvalidID(t *testing.T) {
 	t.Parallel()
 
@@ -1142,12 +1176,12 @@ func TestSessionHandler_GetLogs_Success(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1232,12 +1266,12 @@ func TestSessionHandler_GetLogs_EmptyLogs(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1295,12 +1329,12 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1322,12 +1356,12 @@ func TestSessionHandler_StreamLogs_TerminalRun(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1618,12 +1652,12 @@ func TestSessionHandler_EndSession_EnqueuesValidation(t *testing.T) {
 				nil, nil,
 				nil, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1680,12 +1714,12 @@ func TestSessionHandler_EndSession_ManualSkipsValidation(t *testing.T) {
 				nil, nil,
 				&userID, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -1863,12 +1897,12 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -1905,12 +1939,12 @@ func TestSessionHandler_ListMessages(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -1989,12 +2023,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2015,12 +2049,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2058,12 +2092,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 2, &now, "running", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2105,12 +2139,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 0, nil, "none", nil,
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2148,7 +2182,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 3, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
-							nil, // input_manifest
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2178,7 +2212,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, // triggered_by_user_id
 							nil, 2, &now, "destroyed", nil,
 							nil, nil, nil, nil, nil,
-							nil, // input_manifest
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2208,12 +2242,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2238,12 +2272,12 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							nil, nil,
 							nil, // triggered_by_user_id
 							nil, 1, &now, "snapshotted", stringPtr("snapshots/test"),
-							nil, // target_branch
-							nil, // working_branch
-							nil, // repository_id
-							nil, // diff_stats
-							nil, // diff_history
-							nil, // input_manifest
+							nil,      // target_branch
+							nil,      // working_branch
+							nil,      // repository_id
+							nil,      // diff_stats
+							nil,      // diff_history
+							nil,      // input_manifest
 							nil, nil, // archived_at, archived_by_user_id
 							nil, // automation_run_id
 							nil, // deleted_at
@@ -2568,12 +2602,12 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 				nil, nil,
 				nil,                      // triggered_by_user_id
 				nil, 0, nil, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
-				nil, // target_branch
-				nil, // working_branch
-				nil, // repository_id
-				nil, // diff_stats
-				nil, // diff_history
-				nil, // input_manifest
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2637,7 +2671,7 @@ func TestSessionHandler_CreatePR_NoDiff(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2691,7 +2725,7 @@ func TestSessionHandler_CreatePR_AlreadyExists(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2788,7 +2822,7 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 				nil,
 				nil, 0, nil, "none", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2858,7 +2892,7 @@ func TestSessionHandler_CancelSession_Success(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2912,7 +2946,7 @@ func TestSessionHandler_CancelSession_NotRunning(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "snapshotted", stringPtr("snapshots/test.tar"),
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at
@@ -2990,7 +3024,7 @@ func TestSessionHandler_CancelSession_NoCanceller(t *testing.T) {
 				nil, // triggered_by_user_id
 				nil, 1, &now, "running", nil,
 				nil, nil, nil, nil, nil,
-				nil, // input_manifest
+				nil,      // input_manifest
 				nil, nil, // archived_at, archived_by_user_id
 				nil, // automation_run_id
 				nil, // deleted_at


### PR DESCRIPTION
## Summary
- Empty-state single-resource lookups (`GET /sessions/{id}/pr`, `GET /pm/plans/latest`) now return `{"data":null}` with HTTP 200 instead of 404. This matches modern REST conventions (a lookup that "found no row" is a valid result, not an error), silences console 404 noise on fresh logins, and removes the need for every React Query call site to special-case a `NOT_FOUND` code.
- Simplified the matching frontend call sites: `session-detail-content.tsx` no longer needs three `.catch(NOT_FOUND → null)` shims, and `use-autopilot-page-data.ts` drops its `isNotFoundError` helper.
- Worker deploy (`deploy/scripts/deploy.sh`) now fails gracefully when `/opt/143/deploy/scripts` is root-owned from an older provisioning era: the `sudo -n chown` becomes non-blocking and, if the subsequent `scp` still fails, we print concrete remediation steps (run on the Hetzner console: add `/etc/sudoers.d/99-deploy` NOPASSWD entry, then `chown -R deploy:deploy /opt/143/deploy`) instead of partially deploying.

## Test plan
- [x] `go build ./...` passes
- [x] New handler test `TestSessionHandler_GetPullRequest_NoPR_Returns200Null` verifies empty rows return 200 with `{"data":null}`
- [x] Frontend `tsc` typecheck passes
- [x] Frontend vitest (84/84) passes, including updated `autopilot/page.test.tsx` mock that returns `{data: null}` instead of a 404
- [x] `bash -n deploy/scripts/deploy.sh` syntax OK
- [ ] Manually verify on prod: log in fresh and confirm no 404s for `/pr` or `/pm/plans/latest` in the console
- [ ] Manually verify: after running the one-time Hetzner console fix, a worker deploy completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)