### PR TITLE
Add readonly Postgres role and make targets for prod DB access

### DIFF
--- a/.env.production.enc
+++ b/.env.production.enc
@@ -30,6 +30,7 @@ AWS_ACCESS_KEY_ID=ENC[AES256_GCM,data:N9FChj8H9njQJqhSsv6swePDi8c=,iv:0yjcCjNjvB
 AWS_SECRET_ACCESS_KEY=ENC[AES256_GCM,data:H0LCeQTN/vGeqMLL6/p1qVvSkT7qElqsYK1ZOvTG3B0gb7E0MNDYuw==,iv:GGQHHp2HGLWTOvLEaPwebdYobl1TaReHeoh4x7n/c0w=,tag:uFXxTmCkl+m4EBw/s5dcgA==,type:str]
 DB_PASSWORD=ENC[AES256_GCM,data:4uAdUTHVbTeRnm4ZHMJihP+G/becWQr0tRHtqYnLu7N0YW6wxBf0pReqdOQ=,iv:yxdVt93IOY089HymOfscRGqNCdPnHYR8txykLYoNPPU=,tag:wzbx3/H+Mt8G5WOMdXsH5w==,type:str]
 DB_HOST=ENC[AES256_GCM,data:N4o3L5UqnE0=,iv:kbVv+a/onFxRA/292N9REjYa8nodnp9v7dgRFedqdVg=,tag:9WZDuWUq8icThV0IjEzzUg==,type:str]
+DB_READONLY_PASSWORD=ENC[AES256_GCM,data:KqRU/zQQrtnmkxsrHluRwJSkvBCova5JjshNjurjnMp6i3VUbTUq4aN8pRw1uRB2rY4oCO3sibp4cNxPdF4aNw==,iv:f2Cl81nuQ3U7W5caGTRpDbCLKpUAT/59lMGjYYe2Rr0=,tag:LFN2PeADMinvbHQ64R2ggg==,type:str]
 GHCR_TOKEN=ENC[AES256_GCM,data:vhSaR8Vbr/yqziTtn5Xj6ZlOHfW+rMBrMidOF56CVsyO5AqvzMnwdA==,iv:05pmXoqk/tgyrVKBpkfTkjT1TW3Cb/60roBU9rMw/Ao=,tag:C/qkU5ZNhQea/zTNJTDBdQ==,type:str]
 FLEET_HOSTS=ENC[AES256_GCM,data:cVON+Bd+WuuCaaZSMcloJ3ynSj+QhiDZd0Q74eZpVtX6rccfLuB9iXrqxIGbDfjJE3N3CCstEyeUA8FmNJOB/yZxfrwJ6IrGHIjn,iv:K8n3Z7TFf1mDMv2xpBygnp0KtpzBaj0dHxp9/LjzdFw=,tag:J59FF+9f1gv3zr0TuOcaRQ==,type:str]
 OPENAI_API_KEY=ENC[AES256_GCM,data:+2nrofAW1Flz5Xh2MO+jYkbdAoRgyFba3rP064e/BHfsAB8HcOjx5wEmT+HgvM/UBnKMHvPoekO0tG0Zprh5S3L2FUGCJoZe7RG3mCd9Wxmd35mRKuWC1W1r9tgwttKvNQQ9iHna2mZZM5c61Ajyf7rnToXF7GiSTOsaaGN2qgID5OO2kHfLMDLFOSrVtHWzTUOVEx+IV2xpdLraZTnJaa0Lor2k2l4=,iv:g+06NdD4AuXseqjxVI+dxk8nORFbbHCP5FSeio1HmZA=,tag:qE8ogT1i0uI12Ritv1h5Qw==,type:str]
@@ -43,7 +44,7 @@ sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-15T05:21:28Z
-sops_mac=ENC[AES256_GCM,data:RAB9bofP+Tgr1ETzCQAnv+ttBBxRcS1mwUV3bPnjxYNivw+tVfbEdUOvnB0iMuQw41bLdvaVCr31Rcg8dQvoMv4A4a9j+qUnD0Fsi4k9xOsWguDHjnoJ04QL7J9zIdz1HDF0JJEkR3DafHle07zboIdNqs9PbCZtp2UNUCj1/XQ=,iv:Nt46ZW1+/hX3zzCpXWCXJVzmbiCPGQo1wRRcY//crEQ=,tag:LSewTMiJxUgJymZfCcYqpg==,type:str]
+sops_lastmodified=2026-04-20T04:51:03Z
+sops_mac=ENC[AES256_GCM,data:mTZkS6DorJl+u/u+zodqymYIwlsI4g0kG6qZF2JtJzhrvdqCO10c+eYr0q7PeWP4ml+bfa7SjH0LjG7e3+NZFIiEGeM+LC7eGfFcuSftJNiSb4cnVJT6RP4ez0HsBB+H4l2j0koaXuIwW/0iDFhJqfgUGbHtob8QUInTcu6S7ls=,iv:hUGanP3eytkoyHKmgc0O7Zc27wwPKW72GUMKUhGE8fE=,tag:kOToiW9lyZ8aW0ueUXpFtQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -425,3 +425,73 @@ logs:
 	echo "Opening Grafana tunnel → http://localhost:9999"; \
 	echo "Press Ctrl+C to close."; \
 	ssh -i $(SSH_KEY) -L 9999:localhost:9999 -N deploy@$$LOGGING_HOST
+
+# ── Read-only prod DB access ─────────────────────────────────────────
+# The `readonly` Postgres role is safe for ad-hoc inspection by humans and
+# coding agents: SELECT only, every connection opens a read-only txn, and
+# a 30s statement_timeout bounds runaway queries.
+
+# $(call resolve-db-and-readonly-env,REQUIRE_ADMIN)
+# Resolves DB_HOST from FLEET_HOSTS and DB_READONLY_PASSWORD (+ DB_PASSWORD
+# when REQUIRE_ADMIN is non-empty) from .env.production.enc into exported
+# shell vars. Use inside a recipe joined with `\` so the vars persist.
+define resolve-db-and-readonly-env
+DB_HOST="$${DB_HOST:-}"; \
+DB_PASSWORD="$${DB_PASSWORD:-}"; \
+DB_READONLY_PASSWORD="$${DB_READONLY_PASSWORD:-}"; \
+if [ -z "$$DB_HOST" ] || [ -z "$$DB_PASSWORD" ] || [ -z "$$DB_READONLY_PASSWORD" ]; then \
+	ENV_DUMP="$$(sops --decrypt --input-type dotenv --output-type dotenv .env.production.enc 2>/dev/null || true)"; \
+	if [ -z "$$DB_HOST" ]; then \
+		FLEET="$$(printf '%s\n' "$$ENV_DUMP" | grep '^FLEET_HOSTS=' | cut -d= -f2-)"; \
+		DB_HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^db:' | cut -d: -f2 | head -1)"; \
+	fi; \
+	if [ -z "$$DB_PASSWORD" ]; then \
+		DB_PASSWORD="$$(printf '%s\n' "$$ENV_DUMP" | grep '^DB_PASSWORD=' | cut -d= -f2-)"; \
+	fi; \
+	if [ -z "$$DB_READONLY_PASSWORD" ]; then \
+		DB_READONLY_PASSWORD="$$(printf '%s\n' "$$ENV_DUMP" | grep '^DB_READONLY_PASSWORD=' | cut -d= -f2-)"; \
+	fi; \
+fi; \
+if [ -z "$$DB_HOST" ]; then echo "ERROR: DB_HOST not set. Add db:<ip> to FLEET_HOSTS in .env.production.enc."; exit 1; fi; \
+if [ -z "$$DB_READONLY_PASSWORD" ]; then echo "ERROR: DB_READONLY_PASSWORD not set. Add to .env.production.enc (use 'make secrets-edit ENV=production')."; exit 1; fi; \
+if [ -n "$(1)" ] && [ -z "$$DB_PASSWORD" ]; then echo "ERROR: DB_PASSWORD (admin) not set. Needed to apply the readonly role."; exit 1; fi; \
+export DB_HOST DB_PASSWORD DB_READONLY_PASSWORD
+endef
+
+# Run once to create the readonly role on prod. Rerun only to rotate the
+# password (the SQL is idempotent).
+setup-readonly-user:
+	$(check-ssh-key)
+	@$(call resolve-db-and-readonly-env,admin); \
+	DB_HOST="$$DB_HOST" \
+	DB_PASSWORD="$$DB_PASSWORD" \
+	DB_READONLY_PASSWORD="$$DB_READONLY_PASSWORD" \
+	SSH_KEY="$(SSH_KEY)" \
+	./deploy/scripts/setup-readonly-user.sh
+
+# Interactive read-only psql session on prod.
+# Usage: make db-psql
+db-psql:
+	$(check-ssh-key)
+	@$(call resolve-db-and-readonly-env); \
+	echo "Connecting to $$DB_HOST as readonly (statement_timeout=30s — 'SET statement_timeout=0' to disable)..."; \
+	ssh -i $(SSH_KEY) -t deploy@$$DB_HOST \
+	  "docker exec -it -e PGPASSWORD='$$DB_READONLY_PASSWORD' -e PGOPTIONS='-c statement_timeout=30000' 143-postgres-1 \
+	     psql -U readonly -d onefortythree"
+
+# One-shot read-only query. Prints results to stdout. Bounded by a 30s
+# statement timeout (connection-level PGOPTIONS).
+# Usage: make db-query Q='SELECT id,status FROM sessions ORDER BY created_at DESC LIMIT 5'
+#
+# The query text is passed through a target-specific exported env var so
+# shell metacharacters inside Q (quotes, semicolons, backticks) cannot
+# escape into the recipe shell. Note: Make still eats single `$` — use
+# `$$` on the command line for a literal dollar sign (e.g. `$$1`, `$$foo`).
+db-query: export DB_QUERY_SQL := $(Q)
+db-query:
+	@test -n "$$DB_QUERY_SQL" || { echo "Usage: make db-query Q='SELECT ...'"; exit 1; }
+	$(check-ssh-key)
+	@$(call resolve-db-and-readonly-env); \
+	printf '%s\n' "$$DB_QUERY_SQL" | ssh -i $(SSH_KEY) deploy@$$DB_HOST \
+	  "docker exec -i -e PGPASSWORD='$$DB_READONLY_PASSWORD' -e PGOPTIONS='-c statement_timeout=30000' 143-postgres-1 \
+	     psql -U readonly -d onefortythree -v ON_ERROR_STOP=1"

--- a/deploy/scripts/setup-readonly-user.sh
+++ b/deploy/scripts/setup-readonly-user.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply the readonly Postgres role to the prod DB. Idempotent — safe to rerun
+# (reruns rotate the readonly password to match DB_READONLY_PASSWORD).
+#
+# Driven by `make setup-readonly-user`, which resolves DB_HOST from
+# FLEET_HOSTS and DB_PASSWORD / DB_READONLY_PASSWORD from .env.production.enc.
+#
+# Required env:
+#   DB_HOST                (IP or hostname of the db fleet node)
+#   DB_PASSWORD            (admin password for the onefortythree role)
+#   DB_READONLY_PASSWORD   (password to set on the readonly role)
+# Optional env:
+#   SSH_KEY                (default ~/.ssh/143-deploy)
+#   POSTGRES_CONTAINER     (default 143-postgres-1)
+#   DB_NAME / DB_ADMIN_USER (defaults: onefortythree / onefortythree)
+
+: "${DB_HOST:?DB_HOST required}"
+: "${DB_PASSWORD:?DB_PASSWORD required (admin password)}"
+: "${DB_READONLY_PASSWORD:?DB_READONLY_PASSWORD required}"
+
+SSH_KEY="${SSH_KEY:-$HOME/.ssh/143-deploy}"
+CONTAINER="${POSTGRES_CONTAINER:-143-postgres-1}"
+DB_NAME="${DB_NAME:-onefortythree}"
+DB_ADMIN_USER="${DB_ADMIN_USER:-onefortythree}"
+
+SQL_FILE="$(cd "$(dirname "$0")" && pwd)/setup-readonly-user.sql"
+if [[ ! -f "$SQL_FILE" ]]; then
+  echo "ERROR: SQL file not found: $SQL_FILE" >&2
+  exit 1
+fi
+
+echo "Applying readonly role on $DB_HOST (container: $CONTAINER)"
+
+# Stream the SQL file over SSH to psql running inside the postgres container.
+# PGPASSWORD and the psql -v variable land in the remote process's arg list
+# for the short command lifetime; acceptable since that host is already
+# trusted with the DB admin credentials.
+ssh -i "$SSH_KEY" -o LogLevel=ERROR "deploy@$DB_HOST" \
+  "docker exec -i -e PGPASSWORD='$DB_PASSWORD' '$CONTAINER' \
+     psql -U '$DB_ADMIN_USER' -d '$DB_NAME' \
+       -v ON_ERROR_STOP=1 \
+       -v ropass='$DB_READONLY_PASSWORD' \
+       -v dbname='$DB_NAME' \
+       -v owner='$DB_ADMIN_USER'" \
+  < "$SQL_FILE"
+
+echo "Readonly role applied. Test with: make db-query Q='SELECT current_user'"

--- a/deploy/scripts/setup-readonly-user.sql
+++ b/deploy/scripts/setup-readonly-user.sql
@@ -1,0 +1,30 @@
+-- Idempotent setup for the `readonly` Postgres role.
+-- Run via deploy/scripts/setup-readonly-user.sh (or `make setup-readonly-user`).
+-- Requires psql variables:
+--   ropass — the readonly password
+--   dbname — database name (e.g. onefortythree)
+--   owner  — the app role that owns migration-created tables (e.g. onefortythree)
+
+\set ON_ERROR_STOP on
+
+-- Create role if it doesn't exist. \gexec materializes the SQL text from the
+-- SELECT and executes it, so this is a no-op when the role is already present.
+SELECT 'CREATE ROLE readonly NOLOGIN'
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'readonly') \gexec
+
+-- Always (re)apply login + password + read-only default so reruns rotate cleanly.
+ALTER ROLE readonly WITH LOGIN PASSWORD :'ropass';
+ALTER ROLE readonly SET default_transaction_read_only = on;
+
+-- Grants on the current set of objects.
+GRANT CONNECT ON DATABASE :"dbname" TO readonly;
+GRANT USAGE ON SCHEMA public TO readonly;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readonly;
+GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO readonly;
+
+-- Future tables/sequences added by migrations: grant SELECT automatically,
+-- but only for objects created by the app owner.
+ALTER DEFAULT PRIVILEGES FOR ROLE :"owner" IN SCHEMA public
+  GRANT SELECT ON TABLES TO readonly;
+ALTER DEFAULT PRIVILEGES FOR ROLE :"owner" IN SCHEMA public
+  GRANT SELECT ON SEQUENCES TO readonly;


### PR DESCRIPTION
## Summary
- Introduces an idempotent `readonly` Postgres role (SELECT-only grants, session-level `default_transaction_read_only = on`, 30s `statement_timeout` via `PGOPTIONS`) applied via `deploy/scripts/setup-readonly-user.sql` + `.sh`.
- Adds three Make targets — `setup-readonly-user` (one-time create/rotate), `db-psql` (interactive), `db-query Q='...'` (one-shot) — that SSH to the `db:` host from `FLEET_HOSTS` and `docker exec` into the postgres container using credentials from `.env.production.enc`.
- Stores `DB_READONLY_PASSWORD` in `.env.production.enc` alongside existing secrets.
- Hardened against shell injection: `db-query` flows `Q` through an exported env var instead of textual Make interpolation, so quotes/semicolons/backticks in a query cannot escape the recipe shell.

## Test plan
- [ ] `make setup-readonly-user` succeeds on prod and is idempotent on rerun
- [ ] `make db-query Q='SELECT current_user'` prints `readonly`
- [ ] An UPDATE/DELETE through `db-query` fails with a read-only transaction error
- [ ] `make db-psql` opens an interactive session; `\dt` lists tables; writes fail
- [ ] A malformed `Q` with embedded quotes does not execute anything on the host

Generated with [Claude Code](https://claude.com/claude-code)
