### PR TITLE
Make Sessions the default landing; reorder sidebar nav

### DIFF
--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -61,7 +61,7 @@ function LoginPageContent() {
     setLoading(true);
     try {
       await api.auth.loginEmail(signInEmail, signInPassword);
-      window.location.href = "/autopilot";
+      window.location.href = "/sessions";
     } catch (err: unknown) {
       captureError(err, { feature: "auth-signin" });
       const message = err instanceof Error ? err.message : "Sign in failed";
@@ -77,7 +77,7 @@ function LoginPageContent() {
     setLoading(true);
     try {
       await api.auth.register(signUpEmail, signUpPassword, signUpName, invitation);
-      window.location.href = "/autopilot";
+      window.location.href = "/sessions";
     } catch (err: unknown) {
       captureError(err, { feature: "auth-signup" });
       const message = err instanceof Error ? err.message : "Sign up failed";

--- a/frontend/src/app/invite/accept/page.tsx
+++ b/frontend/src/app/invite/accept/page.tsx
@@ -65,7 +65,7 @@ function AcceptInvitationContent() {
         if (data?.action === "login" || data?.action === "register") {
           setStatus(data.action);
         } else {
-          // Fallback: redirect to onboarding (which redirects to autopilot if setup is complete)
+          // Fallback: redirect to onboarding (which redirects to sessions if setup is complete)
           router.replace("/onboarding");
         }
       } catch (err) {

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -276,7 +276,7 @@ describe("AuthenticatedLayout", () => {
     });
   });
 
-  it("org name links to /autopilot", async () => {
+  it("org name links to /sessions", async () => {
     renderWithProviders(
       <AuthenticatedLayout>
         <div>content</div>
@@ -285,7 +285,7 @@ describe("AuthenticatedLayout", () => {
 
     await waitFor(() => {
       const orgLink = screen.getByText("Test Org").closest("a");
-      expect(orgLink).toHaveAttribute("href", "/autopilot");
+      expect(orgLink).toHaveAttribute("href", "/sessions");
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -84,10 +84,10 @@ function VersionInfo() {
 }
 
 const navItems = [
-  { label: "Autopilot", icon: Zap, href: "/autopilot", showProposalBadge: false },
   { label: "Sessions", icon: Play, href: "/sessions", showProposalBadge: false },
-  { label: "Projects", icon: FolderKanban, href: "/projects", showProposalBadge: true },
   { label: "Automations", icon: RefreshCw, href: "/automations", showProposalBadge: false },
+  { label: "Projects", icon: FolderKanban, href: "/projects", showProposalBadge: true },
+  { label: "Autopilot", icon: Zap, href: "/autopilot", showProposalBadge: false },
 ];
 
 export function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
@@ -184,7 +184,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
         <div className="relative flex items-center justify-between px-4 py-3.5">
           <div className="flex items-center gap-1.5 min-w-0">
             <Link
-              href="/autopilot"
+              href="/sessions"
               className="flex items-center gap-1.5 min-w-0 rounded-md px-1.5 py-1 -ml-1.5 hover:bg-sidebar-accent transition-colors"
             >
               <div className="flex h-5 w-5 items-center justify-center rounded bg-foreground text-background text-xs font-semibold shrink-0">

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -2,6 +2,7 @@ import {
   Zap,
   Play,
   FolderKanban,
+  RefreshCw,
   Settings,
   CircleUser,
   Users,
@@ -32,9 +33,10 @@ export interface PaletteAction {
 
 export const staticActions: PaletteAction[] = [
   // Navigation
-  { id: "nav-autopilot", label: "Autopilot", icon: Zap, href: "/autopilot", group: "navigation" },
   { id: "nav-sessions", label: "Sessions", icon: Play, href: "/sessions", preserveRepo: true, group: "navigation" },
+  { id: "nav-automations", label: "Automations", icon: RefreshCw, href: "/automations", group: "navigation" },
   { id: "nav-projects", label: "Projects", icon: FolderKanban, href: "/projects", preserveRepo: true, group: "navigation" },
+  { id: "nav-autopilot", label: "Autopilot", icon: Zap, href: "/autopilot", group: "navigation" },
 
   // Settings & admin
   { id: "settings-account", label: "Account", icon: CircleUser, href: "/settings/account", group: "settings" },

--- a/frontend/src/components/onboarding/onboarding-page-content.tsx
+++ b/frontend/src/components/onboarding/onboarding-page-content.tsx
@@ -14,7 +14,7 @@ export function OnboardingPageContent() {
 
   useEffect(() => {
     if (!isLoading && isSetupComplete) {
-      router.replace("/autopilot");
+      router.replace("/sessions");
     }
   }, [isLoading, isSetupComplete, router]);
 

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -4,11 +4,11 @@ import type { NextRequest } from "next/server";
 export function middleware(request: NextRequest) {
   const sessionToken = request.cookies.get("session_token");
 
-  // If user has a session cookie and is visiting /login, redirect to /autopilot.
+  // If user has a session cookie and is visiting /login, redirect to /sessions.
   // The cookie is not validated here — if it's expired or invalid, the dashboard's
   // auth check will catch it and redirect back to /login.
   if (sessionToken?.value) {
-    return NextResponse.redirect(new URL("/autopilot", request.url));
+    return NextResponse.redirect(new URL("/sessions", request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- Swap the post-auth landing from `/autopilot` to `/sessions` — updates the login, onboarding, middleware, and sidebar org-name redirects.
- Reorder the sidebar nav to Sessions, Automations, Projects, Autopilot.
- Mirror the new order in the command palette and add a missing Automations entry there.

## Test plan
- [ ] Sign in and confirm you land on `/sessions`.
- [ ] Visit `/login` while signed in and confirm the redirect goes to `/sessions`.
- [ ] Open the sidebar and verify the nav order is Sessions, Automations, Projects, Autopilot.
- [ ] Open the command palette and verify Automations appears in the navigation group.

Generated with [Claude Code](https://claude.com/claude-code)