### PR TITLE
Bind-mount resolv.conf into sandboxes so DNS works under runsc

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -131,7 +131,7 @@ func main() {
 
 		// Build preview provider so the preview subsystem can start/stop
 		// sandbox previews.
-		sandboxExec := providers.NewDockerProvider(apiDockerCli, logger)
+		sandboxExec := providers.NewDockerProvider(apiDockerCli, logger, providers.WithResolvConf(cfg.SandboxResolvConf))
 		pvProvider = previewproviders.NewDockerPreviewProvider(apiDockerCli, sandboxExec, logger)
 		snapshotExec = sandboxExec
 	} else {
@@ -344,7 +344,7 @@ func buildServices(
 		logger.Error().Err(err).Msg("Docker not available — all Phase 3+ services disabled")
 		return nil
 	}
-	sandboxProvider := providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime(cfg.SandboxRuntime))
+	sandboxProvider := providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime(cfg.SandboxRuntime), providers.WithResolvConf(cfg.SandboxResolvConf))
 
 	// Startup health check: verify Docker daemon connectivity and, for gVisor,
 	// that the runsc runtime is functional. Retry a few times because Docker and
@@ -367,7 +367,7 @@ func buildServices(
 		if healthErr != nil {
 			if cfg.SandboxRuntime == "runsc" && !cfg.SandboxRequireGVisor {
 				logger.Warn().Err(healthErr).Msg("gVisor not available, falling back to runc — NOT RECOMMENDED FOR PRODUCTION")
-				sandboxProvider = providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime("runc"))
+				sandboxProvider = providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime("runc"), providers.WithResolvConf(cfg.SandboxResolvConf))
 			} else {
 				logger.Error().Err(healthErr).Msg("sandbox health check failed — Phase 3+ services disabled")
 				return nil

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -232,6 +232,20 @@ PULL_APP
       if [ -x /opt/143/deploy/scripts/sandbox-firewall.sh ]; then
         /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
       fi
+      # Provision /etc/143/sandbox-resolv.conf for sandboxes to bind-mount at
+      # /etc/resolv.conf. Required because user-defined Docker networks inject
+      # 127.0.0.11 (Docker's embedded DNS) into resolv.conf, and gVisor's
+      # netstack can't reach it. HostConfig.DNS doesn't help — it only changes
+      # the upstream the embedded resolver forwards to. Bind-mounting our own
+      # resolv.conf bypasses 127.0.0.11 entirely. Future: point this at a
+      # host-local DNS forwarder (dnsmasq on 172.19.0.1) for filtering/logging.
+      mkdir -p /etc/143
+      cat > /etc/143/sandbox-resolv.conf <<RESOLV
+nameserver 1.1.1.1
+nameserver 8.8.8.8
+options edns0 trust-ad ndots:0
+RESOLV
+      chmod 644 /etc/143/sandbox-resolv.conf
 PULL_WORKER
     ;;
   db|logging)

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -37,6 +37,10 @@ services:
       SANDBOX_IMAGE: ghcr.io/assembledhq/143-sandbox:${IMAGE_TAG:-latest}
       SANDBOX_RUNTIME: runsc
       SANDBOX_REQUIRE_GVISOR: "true"
+      # Bind-mounted into every sandbox at /etc/resolv.conf. The path here is
+      # the *host* path because docker.sock resolves bind sources against the
+      # host, not this worker container. Provisioned by provision.sh.
+      SANDBOX_RESOLV_CONF: /etc/143/sandbox-resolv.conf
     env_file:
       - .env
     group_add:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,14 @@ type Config struct {
 	// Sandbox
 	SandboxRuntime       string `env:"SANDBOX_RUNTIME" envDefault:"runc"`
 	SandboxRequireGVisor bool   `env:"SANDBOX_REQUIRE_GVISOR" envDefault:"false"`
+	// SandboxResolvConf, when set, is bind-mounted read-only at /etc/resolv.conf
+	// inside every sandbox container. Required under runsc on user-defined
+	// networks because gVisor's netstack can't reach Docker's embedded DNS at
+	// 127.0.0.11 and the HostConfig.DNS field doesn't replace it on user
+	// networks. The file lives on the worker host (e.g. /etc/143/sandbox-resolv.conf)
+	// and typically contains "nameserver 1.1.1.1\nnameserver 8.8.8.8". Leaving
+	// this empty falls back to whatever resolv.conf Docker injects.
+	SandboxResolvConf string `env:"SANDBOX_RESOLV_CONF"`
 	// Data retention
 	DataRetentionWebhookDays int `env:"DATA_RETENTION_WEBHOOK_DAYS" envDefault:"30"`
 	DataRetentionLogsDays    int `env:"DATA_RETENTION_LOGS_DAYS"    envDefault:"90"`

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -13,6 +13,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/pkg/stdcopy"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -42,10 +43,11 @@ type DockerClient interface {
 // DockerProvider implements SandboxProvider using Docker containers
 // with optional gVisor (runsc) runtime for enhanced isolation.
 type DockerProvider struct {
-	client  DockerClient
-	runtime string // "runsc" (gVisor) or "runc" (standard Docker)
-	network string // pre-created Docker network with egress restrictions
-	logger  zerolog.Logger
+	client     DockerClient
+	runtime    string // "runsc" (gVisor) or "runc" (standard Docker)
+	network    string // pre-created Docker network with egress restrictions
+	resolvConf string // host path bind-mounted at /etc/resolv.conf in sandboxes
+	logger     zerolog.Logger
 }
 
 // DockerProviderOption configures a DockerProvider.
@@ -62,6 +64,19 @@ func WithRuntime(runtime string) DockerProviderOption {
 func WithNetwork(network string) DockerProviderOption {
 	return func(p *DockerProvider) {
 		p.network = network
+	}
+}
+
+// WithResolvConf sets a host path that will be bind-mounted read-only at
+// /etc/resolv.conf inside every sandbox container. Required under runsc on
+// user-defined networks: gVisor's netstack can't reach Docker's embedded DNS
+// at 127.0.0.11, and HostConfig.DNS doesn't replace 127.0.0.11 in resolv.conf
+// on user networks — it only changes the upstream the embedded resolver
+// forwards to. Empty path disables the mount; the container falls back to
+// whatever resolv.conf Docker injects.
+func WithResolvConf(path string) DockerProviderOption {
+	return func(p *DockerProvider) {
+		p.resolvConf = path
 	}
 }
 
@@ -226,18 +241,31 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 			Memory:    int64(cfg.MemoryLimitMB) * 1024 * 1024,
 			PidsLimit: &pidsLimit,
 		},
-		NetworkMode: container.NetworkMode(d.network),
-		// Bypass Docker's embedded DNS resolver at 127.0.0.11. gVisor's
-		// netstack can't reliably reach it on user-defined bridge networks,
-		// so DNS lookups from inside the sandbox silently fail under runsc.
-		// Public resolvers work from gVisor's stack directly.
-		DNS:            []string{"1.1.1.1", "8.8.8.8"},
+		NetworkMode:    container.NetworkMode(d.network),
 		CapDrop:        []string{"ALL"},
 		CapAdd:         []string{"SETUID", "SETGID", "DAC_OVERRIDE"}, // minimum caps for sudo
 		ReadonlyRootfs: false,
 		Tmpfs: map[string]string{
 			"/tmp": "rw,noexec,nosuid,size=1073741824",
 		},
+	}
+
+	// On user-defined networks Docker injects 127.0.0.11 into /etc/resolv.conf,
+	// which gVisor's netstack can't reach — so DNS in runsc sandboxes fails
+	// regardless of HostConfig.DNS (that field only changes the upstream the
+	// embedded resolver forwards to, not the resolver itself). Bind-mounting a
+	// host-managed resolv.conf bypasses the embedded resolver entirely and
+	// works for any runtime. The host path is provisioned out-of-band; see
+	// deploy/scripts/provision.sh and the SANDBOX_RESOLV_CONF env var.
+	if d.resolvConf != "" {
+		hostCfg.Mounts = append(hostCfg.Mounts, mount.Mount{
+			Type:     mount.TypeBind,
+			Source:   d.resolvConf,
+			Target:   "/etc/resolv.conf",
+			ReadOnly: true,
+		})
+	} else {
+		hostCfg.DNS = []string{"1.1.1.1", "8.8.8.8"}
 	}
 
 	if cfg.DiskLimitGB > 0 {

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -13,6 +13,7 @@ import (
 	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
@@ -428,7 +429,9 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, int64(256), *capturedHostConfig.Resources.PidsLimit, "container should have PID limit of 256")
 
 		require.Equal(t, []string{"1.1.1.1", "8.8.8.8"}, capturedHostConfig.DNS,
-			"container should bypass Docker embedded DNS — gVisor netstack can't reach 127.0.0.11")
+			"without resolv.conf bind mount, fall back to HostConfig.DNS (only effective on default bridge / runc)")
+		require.Empty(t, capturedHostConfig.Mounts,
+			"no bind mounts should be added when WithResolvConf is not set")
 
 		// Verify sandbox result
 		require.Equal(t, "abc123", sb.ID, "sandbox ID should match container ID")
@@ -524,6 +527,31 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "no-env", sb.ID)
 		require.Empty(t, capturedConfig.Env, "container should have no env vars when Env is nil")
+	})
+
+	t.Run("bind-mounts resolv.conf and clears DNS when WithResolvConf is set", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedHostConfig *container.HostConfig
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			capturedHostConfig = hostConfig
+			return container.CreateResponse{ID: "resolv-mount"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger(), WithResolvConf("/etc/143/sandbox-resolv.conf"))
+
+		_, err := p.Create(context.Background(), agent.DefaultSandboxConfig())
+		require.NoError(t, err)
+
+		require.Empty(t, capturedHostConfig.DNS,
+			"HostConfig.DNS must be empty when bind-mounting resolv.conf — leaving it set would let Docker re-inject 127.0.0.11 as upstream-forwarder on user-defined networks")
+		require.Len(t, capturedHostConfig.Mounts, 1, "exactly one bind mount expected")
+		m := capturedHostConfig.Mounts[0]
+		require.Equal(t, mount.TypeBind, m.Type)
+		require.Equal(t, "/etc/143/sandbox-resolv.conf", m.Source)
+		require.Equal(t, "/etc/resolv.conf", m.Target)
+		require.True(t, m.ReadOnly, "resolv.conf mount must be read-only — sandboxes shouldn't mutate host DNS config")
 	})
 
 	t.Run("returns error when container create fails", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Manual session creation was failing with `Could not resolve host: github.com` during `git clone`. Root cause: on user-defined Docker networks, Docker injects `127.0.0.11` (its embedded DNS) into `/etc/resolv.conf` and `HostConfig.DNS` does not replace it — it only changes the upstream the embedded resolver forwards to. gVisor's netstack can't reach `127.0.0.11`, so DNS in every runsc sandbox silently failed.

This adds `SANDBOX_RESOLV_CONF` / `WithResolvConf` which bind-mounts a host-managed `resolv.conf` read-only at `/etc/resolv.conf`, bypassing the embedded resolver entirely. `provision.sh` writes `/etc/143/sandbox-resolv.conf` (public nameservers) on workers and the worker compose passes the host path through. The seam is intentional — pointing the file at a host-local DNS forwarder (e.g. dnsmasq on `172.19.0.1`) for filtering and query logging is a one-line follow-up with no code changes.

## Test plan

- [x] `make lint` clean
- [x] `go test ./internal/services/agent/providers/...` passes (added bind-mount test, updated DNS-fallback test)
- [ ] Reprovision a worker and confirm `git clone` succeeds in a runsc sandbox
