### PR TITLE
Replace platform-intel UI section with self-hosting alert + guide

### DIFF
--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -8,5 +8,6 @@ For general usage docs that apply regardless of who's hosting, see [`../guides/`
 
 - **[GitHub App setup](github-app-setup.md)** — create your own GitHub OAuth App + GitHub App and wire them into your deployment.
 - **[Production deployment checklist](production-deployment-checklist.md)** — minimum steps to deploy the 143 backend + frontend in production.
+- **[Platform LLM](platform-llm.md)** — configure the small background-features model (session titles, PR descriptions, validation, prioritization).
 
 For local development (running 143 on your laptop while working on the codebase), see [`../local-development.md`](../local-development.md) instead.

--- a/docs/self-hosting/platform-llm.md
+++ b/docs/self-hosting/platform-llm.md
@@ -1,0 +1,45 @@
+# Platform LLM (Self-Hosting)
+
+143 uses a small, cheap LLM internally to power background features that aren't part of an agent session. On the hosted version at [143.dev](https://www.143.dev) this is already configured. If you're running your own instance, you need to provide a key for it.
+
+If no platform LLM is configured, the in-app alert on **Settings → LLM** points here, and the affected features silently no-op.
+
+## What it powers
+
+The platform LLM runs background tasks that the user doesn't directly invoke — things like summarizing a session into a title, drafting PR descriptions, generating project drafts from raw input, scoring priority, and validating proposed work. These are intentionally cheap, latency-tolerant calls, which is why they run on a smaller model than the one you use for coding agent sessions.
+
+This list is not load-bearing on this doc — for the authoritative set, search the codebase for `PlatformLLMConfig`.
+
+## How to enable it
+
+Set one of the following provider keys on the **backend** environment:
+
+- `ANTHROPIC_API_KEY`
+- `OPENAI_API_KEY`
+- `OPENROUTER_API_KEY`
+
+Then pick a model with `PLATFORM_LLM_MODEL`. The default is `gpt-5-nano`, which assumes an OpenAI-compatible key. If you've only set an Anthropic key, set `PLATFORM_LLM_MODEL` to a corresponding small Anthropic model (e.g. `claude-haiku-4-5-20251001`); same idea for OpenRouter.
+
+The agent-session model (`LLM_MODEL`) is independent — the platform LLM does not use it.
+
+### Minimal example (OpenAI)
+
+```sh
+OPENAI_API_KEY=sk-...
+# PLATFORM_LLM_MODEL is gpt-5-nano by default; no need to set it
+```
+
+### Minimal example (Anthropic)
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-...
+PLATFORM_LLM_MODEL=claude-haiku-4-5-20251001
+```
+
+## Cost notes
+
+The defaults are deliberately cheap. Background features fire often (every new session, every PR, every project draft), so picking a frontier model here is mostly waste — the latency hurts the UX more than the quality helps it. Stick with a `nano` / `haiku` / equivalently small model unless you have a specific reason not to.
+
+## Verifying it works
+
+After setting the env vars and restarting the backend, the alert on **Settings → LLM** disappears. To confirm end-to-end, start a new session and watch for the auto-generated title within a few seconds — that call goes through the platform LLM.

--- a/docs/self-hosting/production-deployment-checklist.md
+++ b/docs/self-hosting/production-deployment-checklist.md
@@ -48,11 +48,12 @@ Notes:
 
 ### LLM (required for LLM-dependent checks/features)
 
-- [ ] `LLM_MODEL`
+- [ ] `LLM_MODEL` (model used for agent sessions)
 - [ ] At least one provider key:
   - `ANTHROPIC_API_KEY`, or
   - `OPENAI_API_KEY`, or
   - `OPENROUTER_API_KEY`
+- [ ] `PLATFORM_LLM_MODEL` (small model used for background features — defaults to `gpt-5-nano`; see [platform-llm.md](platform-llm.md))
 
 Optional LLM routing vars:
 - `OPENAI_API_TYPE`, `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `OPENROUTER_BASE_URL`, `OPENROUTER_APP_NAME`, `OPENROUTER_SITE_URL`

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -99,11 +99,36 @@ describe("LLMPage", () => {
     });
   });
 
-  it("renders platform intelligence section", async () => {
+  it("shows the platform-LLM alert when no platform provider is configured", async () => {
+    llmDefaultsMock.mockResolvedValueOnce({
+      data: {},
+      platform_model: "gpt-5-nano",
+    });
+
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Platform intelligence")).toBeInTheDocument();
+      expect(screen.getByText(/Platform LLM not configured/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: /self-hosting guide/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/docs/self-hosting/platform-llm.md"),
+    );
+  });
+
+  it("hides the platform-LLM alert when a platform provider is configured", async () => {
+    llmDefaultsMock.mockResolvedValueOnce({
+      data: { openai: "sk-...abc" },
+      platform_model: "gpt-5-nano",
+    });
+
+    renderWithProviders(<LLMPage />);
+
+    await waitFor(() => {
+      expect(llmDefaultsMock).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.queryByText(/Platform LLM not configured/i)).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -31,6 +31,7 @@ import {
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { AlertTriangle, Check, Eye, EyeOff } from "lucide-react";
+import Link from "next/link";
 import {
   LLM_MODELS_BY_PROVIDER,
   LLM_PROVIDER_INFO,
@@ -70,7 +71,6 @@ export default function LLMPage() {
     queryFn: () => api.settings.getLLMDefaults(),
   });
   const platformProviders = useMemo(() => llmDefaultsResp?.data ?? {}, [llmDefaultsResp?.data]);
-  const platformModel = llmDefaultsResp?.platform_model;
   const hasPlatformLLM = Object.keys(platformProviders).length > 0;
 
   // Fetch available models from backend (source of truth)
@@ -215,49 +215,28 @@ export default function LLMPage() {
           description="Configure agent credentials and the AI model for your organization."
         />
 
-        {/* Platform Intelligence (read-only) */}
-        <section className="space-y-3">
-          <h2 className="text-xs font-medium text-foreground">Platform intelligence</h2>
-          <Card>
+        {!hasPlatformLLM && (
+          <Card className="border-amber-300 dark:border-amber-700/60 bg-amber-50 dark:bg-amber-950/20">
             <CardContent>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
-                  <p className="text-sm text-muted-foreground">
-                    These features are powered by the platform and work automatically. No configuration needed.
-                  </p>
-                  {hasPlatformLLM ? (
-                    <Badge variant="success" className="text-xs px-1.5 py-0 shrink-0">
-                      <Check className="mr-0.5 h-3 w-3" />
-                      Active
-                    </Badge>
-                  ) : (
-                    <Badge variant="secondary" className="text-xs px-1.5 py-0 shrink-0">
-                      <AlertTriangle className="mr-0.5 h-3 w-3" />
-                      Not configured
-                    </Badge>
-                  )}
-                </div>
-                <ul className="text-xs text-muted-foreground space-y-1">
-                  <li>Session titles</li>
-                  <li>PR descriptions</li>
-                  <li>Project generation</li>
-                  <li>Validation checks</li>
-                  <li>Priority scoring</li>
-                </ul>
-                {platformModel && (
-                  <p className="text-xs text-muted-foreground">
-                    Model: <span className="font-mono">{platformModel}</span>
-                  </p>
-                )}
-                {!hasPlatformLLM && (
-                  <p className="text-xs text-amber-600 dark:text-amber-400">
-                    The platform administrator has not configured an LLM provider. These features will be unavailable.
-                  </p>
-                )}
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p className="text-xs text-amber-700 dark:text-amber-300">
+                  Platform LLM not configured. Background features (session titles, PR descriptions,
+                  project generation, validation, prioritization) will be unavailable. See the{" "}
+                  <Link
+                    href="https://github.com/assembledhq/143/blob/main/docs/self-hosting/platform-llm.md"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline underline-offset-2 hover:text-amber-900 dark:hover:text-amber-200"
+                  >
+                    self-hosting guide
+                  </Link>{" "}
+                  to enable them.
+                </p>
               </div>
             </CardContent>
           </Card>
-        </section>
+        )}
 
         {/* Agent Credentials */}
         <section className="space-y-3">


### PR DESCRIPTION
## Summary

- Replaces the hardcoded "Platform intelligence" card on **Settings → LLM** with a small amber alert that only renders when no platform LLM provider is configured — hosted users see nothing, self-hosters see it until they set a key.
- Adds `docs/self-hosting/platform-llm.md` as the single source of truth for what the platform LLM powers and how to configure it (env vars, per-provider examples, cost guidance); linked from the in-app alert, the self-hosting README, and the production deployment checklist.

## Test plan

- [ ] `Settings → LLM` shows the amber alert when `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `OPENROUTER_API_KEY` are all unset
- [ ] Alert disappears after setting one of those keys and restarting the backend
- [ ] Alert's "self-hosting guide" link opens the new `docs/self-hosting/platform-llm.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
