### PR TITLE
Fix usage rollup: use sessions.triggered_by_user_id, not created_by

### DIFF
--- a/internal/db/usage_rollup_store.go
+++ b/internal/db/usage_rollup_store.go
@@ -65,7 +65,7 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 		SELECT
 			e.id,
 			e.session_id,
-			s.created_by AS user_id,
+			COALESCE(s.triggered_by_user_id, '00000000-0000-0000-0000-000000000000'::uuid) AS user_id,
 			e.cpu_limit,
 			e.memory_limit_mb,
 			e.started_at,
@@ -165,7 +165,7 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 	// complete after that hour has already been rolled up.
 	tokenRows, err := s.db.Query(ctx, `
 		SELECT
-			s.created_by AS user_id,
+			COALESCE(s.triggered_by_user_id, '00000000-0000-0000-0000-000000000000'::uuid) AS user_id,
 			COALESCE((s.token_usage->>'input_tokens')::bigint, 0) AS input_tokens,
 			COALESCE((s.token_usage->>'output_tokens')::bigint, 0) AS output_tokens,
 			COALESCE((s.token_usage->>'total_cost_usd')::double precision, 0) AS cost_usd
@@ -227,6 +227,12 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 	// at the per-user level (Level 2) since session token_usage isn't broken
 	// down by capacity tier.
 	for key, agg := range aggregates {
+		// Skip sessions with no attributed user (e.g. automation-triggered).
+		// They still contribute to per-tier and org totals below; we just can't
+		// emit a per-user row because user_id has a FK to users(id).
+		if key.userID == uuid.Nil {
+			continue
+		}
 		uid := key.userID
 		tier := key.capacityTier
 		peak := computePeakConcurrent(agg.intervals)
@@ -263,6 +269,9 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 		ua.intervals = append(ua.intervals, agg.intervals...)
 	}
 	for uid, agg := range userAgg {
+		if uid == uuid.Nil {
+			continue
+		}
 		peak := computePeakConcurrent(agg.intervals)
 		avgDur, p95Dur := computeDurationStats(agg.durations)
 		ta := tokensByUser[uid]
@@ -291,6 +300,9 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 	// events in this hour. Without this, token spend is visible at the org
 	// level but cannot be attributed to these users in per-user views.
 	for uid, ta := range tokensByUser {
+		if uid == uuid.Nil {
+			continue
+		}
 		if _, hasContainer := userAgg[uid]; hasContainer {
 			continue // already handled above
 		}
@@ -692,14 +704,15 @@ func (s *UsageRollupStore) GetBreakdown(ctx context.Context, orgID uuid.UUID, st
 		query = fmt.Sprintf(`
 			WITH session_counts AS (
 				SELECT
-					s.created_by AS user_id,
+					s.triggered_by_user_id AS user_id,
 					COUNT(DISTINCT e.session_id) AS distinct_sessions
 				FROM container_usage_events e
 				JOIN sessions s ON s.id = e.session_id
 				WHERE e.org_id = @org_id
 				  AND e.started_at < @end
 				  AND COALESCE(e.stopped_at, @now) > @start
-				GROUP BY s.created_by
+				  AND s.triggered_by_user_id IS NOT NULL
+				GROUP BY s.triggered_by_user_id
 			)
 			SELECT
 				uh.user_id::text AS key,
@@ -840,7 +853,7 @@ func (s *UsageRollupStore) GetDailySessionCounts(ctx context.Context, orgID uuid
 			  ON s.id = e.session_id
 			 AND s.org_id = e.org_id
 			LEFT JOIN users u
-			  ON u.id = s.created_by
+			  ON u.id = s.triggered_by_user_id
 			 AND u.org_id = s.org_id
 			GROUP BY days.local_day, COALESCE(u.email, '')
 			ORDER BY days.local_day, user_email`

--- a/internal/db/usage_rollup_store_test.go
+++ b/internal/db/usage_rollup_store_test.go
@@ -506,6 +506,58 @@ func TestRollupHour_TokenQueryError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestRollupHour_UnattributedUser exercises the uuid.Nil skip branches for
+// sessions without an attributed user (e.g. automation-triggered). Such rows
+// must roll up at the per-tier and org-total levels, but never emit a per-user
+// upsert because usage_hourly.user_id has a FK to users(id).
+func TestRollupHour_UnattributedUser(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewUsageRollupStore(mock)
+	orgID := uuid.New()
+	hour := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	sessionID := uuid.New()
+	eventID := uuid.New()
+
+	// Container event with uuid.Nil user (unattributed session).
+	eventCols := []string{"id", "session_id", "user_id", "cpu_limit", "memory_limit_mb", "started_at", "stopped_at", "container_minutes", "duration_ms"}
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "hour_start": hour, "hour_end": hour.Add(time.Hour), "now": pgxmock.AnyArg()}).
+		WillReturnRows(pgxmock.NewRows(eventCols).AddRow(
+			eventID, sessionID, uuid.Nil, 2.0, 4096,
+			hour, hour.Add(30*time.Minute), 30.0, 1800000.0,
+		))
+
+	// Token row also unattributed — must not emit a per-user token upsert.
+	tokenCols := []string{"user_id", "input_tokens", "output_tokens", "cost_usd"}
+	mock.ExpectQuery("SELECT").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "hour": hour}).
+		WillReturnRows(pgxmock.NewRows(tokenCols).AddRow(
+			uuid.Nil, int64(1000), int64(500), 0.25,
+		))
+
+	// Only 2 upserts expected: Level 3 (per-tier) + Level 4 (org-total).
+	// Level 1 (per-user-tier) and Level 2 (per-user) are skipped for uuid.Nil.
+	mock.ExpectBegin()
+	anyArgs := []any{
+		pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		pgxmock.AnyArg(),
+	}
+	eb := mock.ExpectBatch()
+	eb.ExpectExec("INSERT INTO usage_hourly").WithArgs(anyArgs...).WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	eb.ExpectExec("INSERT INTO usage_hourly").WithArgs(anyArgs...).WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+
+	err = store.RollupHour(context.Background(), orgID, hour)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestRollupHour_WithEvents(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()
@@ -693,8 +745,8 @@ func TestGetBreakdown_UserDimension(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, rows, 2)
 	require.Equal(t, "alice@test.com", rows[0].Label)
-	require.Equal(t, 60.0, rows[0].Percentage)  // 60/100 * 100 = 60.0%
-	require.Equal(t, 40.0, rows[1].Percentage)  // 40/100 * 100 = 40.0%
+	require.Equal(t, 60.0, rows[0].Percentage) // 60/100 * 100 = 60.0%
+	require.Equal(t, 40.0, rows[1].Percentage) // 40/100 * 100 = 40.0%
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## Summary

The reaper rollup job was failing every 5 minutes in production with `column s.created_by does not exist` — the `sessions` table only ever had `triggered_by_user_id`. This PR renames all 5 references in `internal/db/usage_rollup_store.go`, `COALESCE`s nullable values to `uuid.Nil` at the scan boundary so pgx can scan cleanly, and skips `uuid.Nil` keys at per-user emission to avoid FK violations on `usage_hourly.user_id REFERENCES users(id)`. Org-level and per-tier rollups still include unattributed (e.g. automation-triggered) sessions.

## Test plan
- [x] `make lint` passes
- [x] `go test ./internal/db/...` passes
- [ ] After deploy, confirm reaper logs no longer show `column s.created_by does not exist`