### PR TITLE
Add make logs-query and document prod debugging commands in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,29 @@
 Use docs/design/overall.md as the overall design of the system, think of it as a living doc that should get parts added to it, but only high level details. As more designs are made, put them into folders and subdocs inside of docs/design, and build them out. Please keep track of updates and keep them updated as designs are completed.
 
+## Debugging Production
+
+When investigating bugs or unexpected behavior, three Make targets give read-only access to prod. All require `SSH_KEY` (defaults to `~/.ssh/143-deploy`) and resolve hosts/credentials from `.env.production.enc` via sops.
+
+### Querying the database
+
+- **`make db-query Q='SELECT ...'`** — runs a one-shot SQL query against the prod Postgres as the `readonly` role. SELECT-only, every connection is a read-only txn, bounded by a 30s `statement_timeout`. Use single quotes around `Q` and escape literal `$` as `$$` (Make eats single `$`). For an interactive session, use `make db-psql`.
+
+### Searching logs
+
+Logs are shipped via Vector to a VictoriaLogs instance and visualized in Grafana. Use the CLI for scripted/agent searches and the UI for interactive exploration:
+
+- **`make logs-query Q='<LogsQL>' [LIMIT=100]`** — runs a one-shot LogsQL query against VictoriaLogs and prints NDJSON to stdout. Always include a `_time:` filter — without one VictoriaLogs scans the full 30-day retention. Common fields: `service`, `level`, `org_id`, `agent_run_id`, `request_id`, `trace_id`. Examples:
+
+  ```bash
+  make logs-query Q='service:api AND level:error AND _time:[now-1h,now]'
+  make logs-query Q='agent_run_id:"run-abc123" AND _time:[now-24h,now]' LIMIT=500
+  make logs-query Q='"timeout waiting for sandbox" AND _time:[now-15m,now]' | jq -r '.message'
+  ```
+
+  See `docs/design/47-logging-victorialogs.md` for more examples and the [LogsQL reference](https://docs.victoriametrics.com/victorialogs/logsql/).
+
+- **`make logs`** — opens an SSH tunnel to the prod Grafana instance at <http://localhost:9999> for interactive UI-based exploration. Press Ctrl+C to close the tunnel. Prefer `make logs-query` for anything scriptable.
+
 ## Backend Architecture (Go)
 
 **Key libraries**: `go-chi/chi` (router), `jackc/pgx` (Postgres driver + connection pooling), `rs/zerolog` (structured logging), `go-playground/validator` (request validation), `golang-migrate/migrate` (schema migrations). See `docs/design/02-api-server.md` for full dependency list.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -425,6 +425,36 @@ logs:
 	echo "Opening Grafana tunnel → http://localhost:9999"; \
 	echo "Press Ctrl+C to close."; \
 	ssh -i $(SSH_KEY) -L 9999:localhost:9999 -N deploy@$$LOGGING_HOST
+
+# One-shot LogsQL query against VictoriaLogs. Prints NDJSON results to stdout
+# (one JSON log line per result). Bounded by a 30s curl timeout. The query
+# text travels over ssh stdin so shell metacharacters cannot escape.
+#
+# Usage: make logs-query Q='service:api AND level:error AND _time:[now-1h,now]' [LIMIT=100]
+#
+# Add `_time:[now-1h,now]` (or similar) to bound the time range, otherwise
+# VictoriaLogs scans the full retention window. LogsQL reference:
+# https://docs.victoriametrics.com/victorialogs/logsql/
+logs-query: export LOGS_QUERY := $(Q)
+logs-query: export LOGS_LIMIT := $(or $(LIMIT),100)
+logs-query:
+	@test -n "$$LOGS_QUERY" || { echo "Usage: make logs-query Q='service:api AND level:error' [LIMIT=100]"; exit 1; }
+	$(check-ssh-key)
+	@LOGGING_HOST="$(LOGGING_HOST)"; \
+	if [ -z "$$LOGGING_HOST" ]; then \
+		$(read-fleet-hosts); \
+		LOGGING_HOST="$$(echo "$$FLEET" | tr ',' '\n' | grep '^logging:' | cut -d: -f2 | head -1)"; \
+	fi; \
+	if [ -z "$$LOGGING_HOST" ]; then \
+		echo "ERROR: Could not find logging host. Set LOGGING_HOST or add logging:<ip> to FLEET_HOSTS."; \
+		exit 1; \
+	fi; \
+	printf '%s' "$$LOGS_QUERY" | ssh -i $(SSH_KEY) deploy@$$LOGGING_HOST \
+	  "VLOGS_HOST=\$$(grep ^VICTORIALOGS_HOST= /opt/143/.env | cut -d= -f2); \
+	   curl -sS --max-time 30 \
+	     --data-urlencode query@- \
+	     --data-urlencode limit=$$LOGS_LIMIT \
+	     http://\$$VLOGS_HOST:9428/select/logsql/query"
 
 # ── Read-only prod DB access ─────────────────────────────────────────
 # The `readonly` Postgres role is safe for ad-hoc inspection by humans and


### PR DESCRIPTION
## Summary
- New `make logs-query Q='<LogsQL>' [LIMIT=100]` target runs a one-shot LogsQL query against the prod VictoriaLogs instance and prints NDJSON to stdout. Query text is piped over ssh stdin so shell metacharacters in `Q` cannot escape into the recipe.
- Added a **Debugging Production** section to the top of `AGENTS.md` covering `make db-query`, `make logs-query`, and `make logs` (Grafana UI tunnel) so coding agents can investigate prod issues from the CLI.

## Test plan
- [ ] `make -n logs-query Q='service:api AND _time:[now-1h,now]'` produces the expected command (verified locally)
- [ ] `make logs-query Q='service:api AND level:error AND _time:[now-15m,now]' LIMIT=10` returns NDJSON from prod
- [ ] `make logs-query` with no `Q` prints usage and exits non-zero

Generated with [Claude Code](https://claude.com/claude-code)