### PR TITLE
Fail fast on anemic worker; drop shared MODE override

### DIFF
--- a/.env.enc
+++ b/.env.enc
@@ -19,7 +19,6 @@ DATABASE_URL=ENC[AES256_GCM,data:+2Ec4apRBp+3Lj3NjRy2w6lKVBFKh6NPJrRYnAY5Nb6Gicf
 #ENC[AES256_GCM,data:SxiNn4/2nQ==,iv:6+aEi4pXlVHyt4Oqew9gtsaEv1nedMT0T7xyYwnp7/w=,tag:FBwVhjS9OaP7OTjm88qg/Q==,type:comment]
 PORT=ENC[AES256_GCM,data:ZOOEFA==,iv:xe0tftnS42qg0oqMUvMEHoC4xkP1puhu+IVT5XocOmI=,tag:0R176lghxQey1AOpi0iswg==,type:str]
 LOG_LEVEL=ENC[AES256_GCM,data:/iZ6VBw=,iv:DmFHUNDQ9qL3LKtEeun271oaILCTUhNOS9JyKkPYr70=,tag:jemff+aSi7z8qeHZeL9apQ==,type:str]
-MODE=ENC[AES256_GCM,data:4SO3,iv:fml9AE2PaVTdaqXd+0CfQD1YeW6+3/6lzt+SMjSEJaU=,tag:lDv1c7OtDPQaWGRLnMVkyQ==,type:str]
 BASE_URL=ENC[AES256_GCM,data:4WSwm9qyfdmoqeGQkukiZjZdD7EGEb4GH/eW,iv:7seRQKPX84pLUNauRGJPBD6WfJTSWviCBVFLrBdaK/Q=,tag:KkHGI9KXr76OayOa+hGKYA==,type:str]
 FRONTEND_URL=ENC[AES256_GCM,data:1QZxPTcygostuM70VzOgs3Wxe9KWVeZjM24+,iv:sltCjZr9Vb2w+hKIlqSqvMcJh1x1S3OyTkIQovbOf+0=,tag:Nk95EoDDkxzSSLckQRQCgw==,type:str]
 SESSION_SECRET=ENC[AES256_GCM,data:OAt6xgHU5bCHjObdJ0C3xMsXAHrvU/l2Acg=,iv:4yNmsOlxpnrhnBwzzw6xvXB7bet7ygiPFysHdq8MaFA=,tag:2eP9GvzlbLGA/bR14JR0Vg==,type:str]
@@ -76,7 +75,7 @@ AWS_ACCESS_KEY_ID=ENC[AES256_GCM,data:Ad44wDehITnz5a9Mrpeg6d1k+fk=,iv:jH7Y5VD5+0
 AWS_SECRET_ACCESS_KEY=ENC[AES256_GCM,data:kuwHq/rIsxxcP2rNZ+kj2Y16hd4o1NlWgBvXGeNNOX4nTxJ5Q6LOZg==,iv:8g0fRBzXr2HPBiU3VN4zJqbJbI4zXgnEp3Po3/DGgzA=,tag:EwriwMszD0ldFe17ljcckQ==,type:str]
 sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0YjZqVVhXdFRuSFRLZ1pG\nYVNnNmdEQ3NVQXNIUk5NUWNadEtsQzY2cG04CnE3WSthZVdlV01pRkRESkNuTTZY\nQU5Ua0lrcDFBZ1VEKzE1cGFLVmo5UlUKLS0tIHRra0xURnUvSkZlZXhwZXZOOHk5\ncWphSm42TklKNkdsY3RwOUhlZ0daaTgKcbHSu2zRgIN5J4Ji/TDld6VXnzQRZf58\niTslfoDgs8TnouacagHG57q5kG1TIbUuT3QyYSE8C7dnIzyQzjfg5w==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age1xyvl6ral4fq757tpnz30cuzefrpngnuv6zutjsg7wtnmza4uyqlshc2ucl
-sops_lastmodified=2026-04-14T23:11:48Z
-sops_mac=ENC[AES256_GCM,data:IsaB3780GsT05TwJISEqU7cKwkktufrZoaySsBVKUf3laNv9a6ftSRtixkUNN18ow7epXgS5qTxIdiNCcnPPYq7dw3hGEzdoMbSwWzfd3fRM5NIkUL/AgDRXiD8lkP7BfSgDlPujLU/kehq1YTLfprJuaMBM7Iglr2UewQ9JHUg=,iv:xE/hsBmGH4BFrRMRuWV4Yf1aE+mzlYcVeV8uSt2l5b8=,tag:s5mrMbd+lMNOCpskuro8Dg==,type:str]
+sops_lastmodified=2026-04-20T06:52:59Z
+sops_mac=ENC[AES256_GCM,data:GzdsdaYerUkpVu24iqSXZTPXcuBe9/yTvO8iqDngzNuilccUIgNw6oD9bX3HkvjiImnjynrhDiYPmE5r4qEIA5MlPvCssFbe6KpgCDq4ttb3V/FYJvWzJG/SpvOVKhWXqsArJMTfC92G6f4I6CCGYfAw2D68RWeyQhC8v2strrI=,iv:kYgYFFHemI/0SbHcAG2sf/i3nZGLWFVFYsihETMyYZo=,tag:z7QeFRCU9e9hdvFRE9vwjQ==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/.env.production.enc
+++ b/.env.production.enc
@@ -1,6 +1,5 @@
 PORT=ENC[AES256_GCM,data:ew7zGQ==,iv:M7eUz26/FJNZorV7vry9L/U0QGAXTat9fFIbtFfsSFY=,tag:8fa8Pmmi+ZklT+r5fJInxw==,type:str]
 LOG_LEVEL=ENC[AES256_GCM,data:WfxG3w==,iv:D4D4rwW+p4oNJJnwVtGM32ZObVhu/WFOORL2Htt+iY8=,tag:enBXo8xsS93AOQSimCtdCQ==,type:str]
-MODE=ENC[AES256_GCM,data:64jD,iv:LMINq2jNH8l91M//yBjQkVaP7ja1cTatOi4CIiLUGaU=,tag:QD+XiwUzsHK6pzQfFZCycg==,type:str]
 BASE_URL=ENC[AES256_GCM,data:4LGr6dvnA8s1Yyz4EhEpMIgCzg==,iv:zl51cEQlKgGa1//wj5uIjQpwIZbIlgezt2II2cSYeiM=,tag:SmE/04L3ePyrLxcELd70aQ==,type:str]
 SESSION_SECRET=ENC[AES256_GCM,data:tDMUeVsaYFSn9X4q2naHBEqsLTg+MVMvizjBkal8Z1M5bG99ZDKYBkT8zIpMKiFv5sdqQKZPiJyOIxIWLQHx0A==,iv:VjLGD/XFz6YMEjb60YQg0vAfkWi7ymTcbi6Yzl/J+ww=,tag:8E1PBVniGIyCU1fWc97VDQ==,type:str]
 GITHUB_OAUTH_CLIENT_ID=ENC[AES256_GCM,data:rvwSKC9f/orwUG9+D375xkHuzhE=,iv:oQ1i7AJoi/sw+HCJsGAYL+AUfReMh3nxzOwxFQiPQZ8=,tag:nNGnvysi/SyAW7FTKcjx7A==,type:str]
@@ -44,7 +43,7 @@ sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_1__map_recipient=age1javfprksts8jt07rga3ltdnhllstv7rkt09s9lvgz8twy9sgps7q3xtgs5
 sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBdU1CVnFjOFZleDNUTWky\naWJnWTVvVUxybDIxSUc5M2Q5RjY4OTFURUhzCjdQZ0N4TWZoVk5XSFVmcS9LbGUz\nVTc1V0VXVmpqTk0welo5eEF6SXJVQ28KLS0tIDZaOENVN0dxMzNGUlBjZEhUTlJM\nZzRxR0IwT3JrendlT0RZc3c4WS9wNVEKa9TPpVNdCB1Ca8yShUZ8ZDgwNbvx4DBw\nVI/LQh6nmXUbJrSsVslEtdOmjpmFxYlYDQuhZyf7LXEE6JagjR5ouA==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1uty3jxw8a5nv27rn4kf7sjn5ugtemyyuadn6wh7lky8acqlxvdnsp6tvhj
-sops_lastmodified=2026-04-20T04:51:03Z
-sops_mac=ENC[AES256_GCM,data:mTZkS6DorJl+u/u+zodqymYIwlsI4g0kG6qZF2JtJzhrvdqCO10c+eYr0q7PeWP4ml+bfa7SjH0LjG7e3+NZFIiEGeM+LC7eGfFcuSftJNiSb4cnVJT6RP4ez0HsBB+H4l2j0koaXuIwW/0iDFhJqfgUGbHtob8QUInTcu6S7ls=,iv:hUGanP3eytkoyHKmgc0O7Zc27wwPKW72GUMKUhGE8fE=,tag:kOToiW9lyZ8aW0ueUXpFtQ==,type:str]
+sops_lastmodified=2026-04-20T06:51:44Z
+sops_mac=ENC[AES256_GCM,data:mWJlhqMzWbfbB1k8SmgMEiUDAsCUwBy0Kmzf6ReNB5mtrszbQLK4WpgUUZu1p7xfe90vQLZlOkJ24Oe1mgORrK1XzKsVUDURLuCNGg02oXmxhgXvT9XOkUn27juqKX3+VSxEusnYRXdhYr2fcRvFMO0xAHzgcxWh/4VOLd6ut6E=,iv:R702vhXHzL2TCUfPdkwBlg/Q8YC+hs0VHYbKJKWJusw=,tag:56Bj1u0PDLhv0VrAm3jztw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.1

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -208,6 +208,17 @@ func main() {
 				projectStore, projectTaskStore, projectCycleStore, pmDocumentStore, integrationStore,
 				sessionMessageStore, automationRunStore, snapshotStore, billingMetrics, cancelRegistry)
 		}
+		// Refuse to start an anemic worker. Without agent services (GitHub App,
+		// Docker, sandbox health), run_agent won't register, but the worker will
+		// still dequeue run_agent jobs and dead-letter them as "no handler" —
+		// poisoning session starts on peer nodes that would have served them.
+		// Operators that don't want a worker should set MODE=api.
+		if services == nil {
+			logger.Fatal().
+				Str("mode", cfg.Mode).
+				Msg("worker mode requires agent services (GitHub App + Docker + sandbox health check). " +
+					"Fix the missing dependencies, or set MODE=api to disable the in-process worker.")
+		}
 		retentionCfg := worker.DataRetentionConfig{
 			WebhookDays: cfg.DataRetentionWebhookDays,
 			LogsDays:    cfg.DataRetentionLogsDays,


### PR DESCRIPTION
## Summary

Fix for stuck "Setting up environment" sessions: the shared encrypted env files had MODE=all, which docker-entrypoint.sh injected via sops exec-env and clobbered the per-role MODE values from the compose files (MODE=api on app, MODE=worker on worker). The app container therefore started an in-process worker without Docker; buildServices returned nil, so run_agent never registered — but the app's worker still dequeued run_agent jobs and dead-lettered them as "no handler for job type: run_agent", leaving new sessions pending forever.

- Drop MODE from .env.enc and .env.production.enc so the per-role compose values are the source of truth.
- Add a fatal guard in cmd/server/main.go: if cfg.Mode is all or worker but buildServices returned nil, refuse to start instead of silently registering an anemic worker that poisons the job queue for healthy peers.

## Why the guard matters

Without the guard, any future regression that makes canBuildServices or buildServices return nil on a node running in all/worker mode would repeat this incident silently. With the guard, the container crash-loops with an actionable log message pointing operators at either setting MODE=api or fixing the missing agent deps, and ops notices immediately.

## Test plan

- [x] make lint - clean
- [x] go build ./cmd/server/... - clean
- [ ] Deploy to prod; confirm app logs show mode=api and worker logs show mode=worker after rollout
- [ ] Start a new session and confirm it transitions out of "Setting up environment"

Generated with Claude Code.
