### PR TITLE
Bump Grafana to 13.0.1 (13.0.0 never published)

### DIFF
--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -22,7 +22,7 @@ services:
           cpus: "1.0"
 
   grafana:
-    image: grafana/grafana:13.0.0
+    image: grafana/grafana:13.0.1
     environment:
       GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}

--- a/docs/design/47-logging-victorialogs.md
+++ b/docs/design/47-logging-victorialogs.md
@@ -83,7 +83,7 @@ services:
           cpus: "1.0"
 
   grafana:
-    image: grafana/grafana:13.0.0
+    image: grafana/grafana:13.0.1
     environment:
       GF_INSTALL_PLUGINS: victoriametrics-logs-datasource
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD}  # injected via `sops exec-env secrets.enc.env -- docker compose up`


### PR DESCRIPTION
## Summary
- `make deploy-fleet` failed pulling `grafana/grafana:13.0.0` because that tag was never pushed to Docker Hub — the 13.0 line went straight from RCs to `13.0.1`.
- Bump the image reference in `docker-compose.logging.yml` and the matching snippet in `docs/design/47-logging-victorialogs.md` to `13.0.1`.

## Test plan
- [ ] Rerun `make deploy-fleet` and confirm the logging node pulls and starts Grafana cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)