### PR TITLE
Sandbox: redirect GOTMPDIR off noexec /tmp so go test works

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -259,6 +259,13 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	for k, v := range cfg.Env {
 		envSlice = append(envSlice, k+"="+v)
 	}
+	// /tmp is mounted noexec (see Tmpfs below), which breaks `go test`: Go
+	// compiles test binaries to $GOTMPDIR (default /tmp) and execs them.
+	// Point Go at /var/tmp on the writable+exec rootfs so test binaries can
+	// run without weakening the noexec hardening on /tmp.
+	if _, ok := cfg.Env["GOTMPDIR"]; !ok {
+		envSlice = append(envSlice, "GOTMPDIR=/var/tmp")
+	}
 
 	containerCfg := &container.Config{
 		Image:      cfg.Image,

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -25,6 +25,13 @@ import (
 // Compile-time check that DockerProvider implements agent.SandboxProvider.
 var _ agent.SandboxProvider = (*DockerProvider)(nil)
 
+// defaultGoTmpDir is the default value injected into $GOTMPDIR for sandbox
+// containers. /tmp is mounted noexec, which breaks `go test` / `go run`
+// because Go compiles binaries to $GOTMPDIR and execs them; /var/tmp lives
+// on the writable+exec rootfs, so redirecting there fixes this without
+// weakening the /tmp hardening.
+const defaultGoTmpDir = "/var/tmp"
+
 // DockerClient defines the subset of the Docker API used by DockerProvider.
 type DockerClient interface {
 	Ping(ctx context.Context) (types.Ping, error)
@@ -259,12 +266,9 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	for k, v := range cfg.Env {
 		envSlice = append(envSlice, k+"="+v)
 	}
-	// /tmp is mounted noexec (see Tmpfs below), which breaks `go test`: Go
-	// compiles test binaries to $GOTMPDIR (default /tmp) and execs them.
-	// Point Go at /var/tmp on the writable+exec rootfs so test binaries can
-	// run without weakening the noexec hardening on /tmp.
+	// See defaultGoTmpDir for why this env var is injected.
 	if _, ok := cfg.Env["GOTMPDIR"]; !ok {
-		envSlice = append(envSlice, "GOTMPDIR=/var/tmp")
+		envSlice = append(envSlice, "GOTMPDIR="+defaultGoTmpDir)
 	}
 
 	containerCfg := &container.Config{

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -421,7 +421,7 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		// Verify tmpfs mount options
 		require.Contains(t, capturedHostConfig.Tmpfs["/tmp"], "noexec", "/tmp tmpfs should be noexec")
-		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
 			"GOTMPDIR must be redirected off /tmp so `go test` can exec compiled test binaries")
 
 		// Verify resource limits
@@ -508,7 +508,7 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		require.Contains(t, capturedConfig.Env, "ANTHROPIC_API_KEY=sk-ant-test-key")
 		require.Contains(t, capturedConfig.Env, "OPENAI_API_KEY=sk-test-openai-key")
-		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
 			"GOTMPDIR should be injected so `go test` works despite /tmp being noexec")
 	})
 
@@ -529,7 +529,7 @@ func TestDockerProvider_Create(t *testing.T) {
 		_, err := p.Create(context.Background(), cfg)
 		require.NoError(t, err)
 		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/workspace/.gotmp")
-		require.NotContains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+		require.NotContains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
 			"caller-supplied GOTMPDIR should not be overridden")
 	})
 
@@ -550,7 +550,7 @@ func TestDockerProvider_Create(t *testing.T) {
 		sb, err := p.Create(context.Background(), cfg)
 		require.NoError(t, err)
 		require.Equal(t, "no-env", sb.ID)
-		require.Equal(t, []string{"GOTMPDIR=/var/tmp"}, capturedConfig.Env,
+		require.ElementsMatch(t, []string{"GOTMPDIR=" + defaultGoTmpDir}, capturedConfig.Env,
 			"with nil cfg.Env, only the auto-injected GOTMPDIR should be present")
 	})
 

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -421,6 +421,8 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		// Verify tmpfs mount options
 		require.Contains(t, capturedHostConfig.Tmpfs["/tmp"], "noexec", "/tmp tmpfs should be noexec")
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+			"GOTMPDIR must be redirected off /tmp so `go test` can exec compiled test binaries")
 
 		// Verify resource limits
 		require.Equal(t, int64(2e9), capturedHostConfig.Resources.NanoCPUs, "container should have 2 CPU cores")
@@ -504,9 +506,31 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "env-test", sb.ID)
 
-		require.Len(t, capturedConfig.Env, 2, "container should have 2 env vars")
 		require.Contains(t, capturedConfig.Env, "ANTHROPIC_API_KEY=sk-ant-test-key")
 		require.Contains(t, capturedConfig.Env, "OPENAI_API_KEY=sk-test-openai-key")
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+			"GOTMPDIR should be injected so `go test` works despite /tmp being noexec")
+	})
+
+	t.Run("preserves caller-supplied GOTMPDIR override", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedConfig *container.Config
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			capturedConfig = config
+			return container.CreateResponse{ID: "gotmpdir-override"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		cfg := agent.DefaultSandboxConfig()
+		cfg.Env = map[string]string{"GOTMPDIR": "/workspace/.gotmp"}
+		_, err := p.Create(context.Background(), cfg)
+		require.NoError(t, err)
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/workspace/.gotmp")
+		require.NotContains(t, capturedConfig.Env, "GOTMPDIR=/var/tmp",
+			"caller-supplied GOTMPDIR should not be overridden")
 	})
 
 	t.Run("handles nil env map gracefully", func(t *testing.T) {
@@ -526,7 +550,8 @@ func TestDockerProvider_Create(t *testing.T) {
 		sb, err := p.Create(context.Background(), cfg)
 		require.NoError(t, err)
 		require.Equal(t, "no-env", sb.ID)
-		require.Empty(t, capturedConfig.Env, "container should have no env vars when Env is nil")
+		require.Equal(t, []string{"GOTMPDIR=/var/tmp"}, capturedConfig.Env,
+			"with nil cfg.Env, only the auto-injected GOTMPDIR should be present")
 	})
 
 	t.Run("bind-mounts resolv.conf and clears DNS when WithResolvConf is set", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Session sandboxes mount \`/tmp\` as tmpfs with \`noexec\` for hardening, which breaks \`go test ./...\` because Go compiles test binaries to \`\$GOTMPDIR\` (default \`/tmp\`) and then execs them — agents see permission denied.
- Auto-inject \`GOTMPDIR=/var/tmp\` in the Docker provider so test binaries run from the writable+exec rootfs; \`/tmp\` stays \`noexec\`. Caller-supplied \`GOTMPDIR\` is preserved.

## Test plan

- [x] \`go test ./internal/services/agent/providers/...\` passes (Create, env-injection, nil-env, new GOTMPDIR-override cases)
- [ ] Spin up a session and confirm \`go test ./...\` runs without a manual \`GOTMPDIR\` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)