### PR TITLE
Show descriptive tool-call labels across all agents

### DIFF
--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -67,19 +67,24 @@ describe("ChatTimeline", () => {
     const entries: TimelineEntry[] = [
       {
         kind: "tool_group",
-        toolUse: makeLog({ id: 1, level: "tool_use", message: "using tool: Read", metadata: { tool: "Read" } }),
+        toolUse: makeLog({
+          id: 1,
+          level: "tool_use",
+          message: "using tool: Read",
+          metadata: { tool: "Read", input: { file_path: "/repo/app.ts" } },
+        }),
         toolResult: makeLog({ id: 2, level: "output", message: "file contents here", metadata: { type: "tool_result" } }),
       },
     ];
     render(<ChatTimeline entries={entries} isRunning={false} />);
 
-    // Tool name badge visible
-    expect(screen.getByText("Read")).toBeInTheDocument();
+    // Derived label visible on the row.
+    expect(screen.getByText("Read app.ts")).toBeInTheDocument();
     // Result hidden initially
     expect(screen.queryByText("file contents here")).not.toBeInTheDocument();
 
     // Click to expand
-    await userEvent.click(screen.getByText("Read"));
+    await userEvent.click(screen.getByText("Read app.ts"));
     expect(screen.getByText("file contents here")).toBeInTheDocument();
   });
 

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { ChevronRight, AlertTriangle, Wrench, FileCode2, X, FileText, ClipboardList, Check, PenLine } from "lucide-react";
+import { ChevronRight, AlertTriangle, Wrench, FileCode2, X, FileText, ClipboardList, Check, PenLine, Terminal, FileSearch, Search, FolderSearch, Globe, Bot, ListTodo } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MarkdownContent } from "@/components/markdown";
@@ -9,6 +9,7 @@ import { PLAN_MODE_PREFIX } from "@/lib/timeline";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
 import { isImageURL, fileNameFromURL } from "@/lib/utils";
+import { deriveToolDisplay, formatToolInput, type ToolIconKind } from "@/lib/tool-label";
 
 function safeDate(dateStr: string): Date | null {
   const d = new Date(dateStr);
@@ -24,9 +25,23 @@ function formatTimestamp(dateStr: string): string {
   });
 }
 
+const TOOL_ICONS: Record<ToolIconKind, React.ComponentType<{ className?: string }>> = {
+  terminal: Terminal,
+  "file-read": FileSearch,
+  "file-edit": PenLine,
+  search: Search,
+  glob: FolderSearch,
+  web: Globe,
+  agent: Bot,
+  plan: ListTodo,
+  wrench: Wrench,
+};
+
 function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResult?: SessionLog }) {
   const [open, setOpen] = useState(false);
-  const toolName = (toolUse.metadata?.tool as string) || "unknown";
+  const { label, icon } = deriveToolDisplay(toolUse);
+  const Icon = TOOL_ICONS[icon];
+  const inputDetail = formatToolInput(toolUse);
 
   return (
     <div className="mx-2">
@@ -35,27 +50,34 @@ function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResu
         className="flex items-center gap-2 w-full text-left py-1.5 px-2 rounded-md hover:bg-muted/50 transition-colors text-xs group"
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-150 ${open ? "rotate-90" : ""}`} />
-        <Wrench className="h-3 w-3 text-blue-600 dark:text-blue-400 shrink-0" />
-        <Badge
-          variant="secondary"
-          className="bg-blue-500/10 text-blue-700 dark:text-blue-400 text-xs px-1.5 py-0"
-        >
-          {toolName}
-        </Badge>
+        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+        <span className="text-foreground truncate min-w-0">{label}</span>
         <span className="ml-auto text-muted-foreground/60 text-xs tabular-nums shrink-0">
           {formatTimestamp(toolUse.created_at)}
         </span>
       </button>
-      {open && toolResult && (
-        <div className="ml-7 mt-1 mb-2 rounded-md border border-border bg-muted/30 p-2 overflow-x-auto">
-          <pre className="text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground">
-            {toolResult.message}
-          </pre>
-        </div>
-      )}
-      {open && !toolResult && (
-        <div className="ml-7 mt-1 mb-2 text-xs text-muted-foreground italic">
-          No result captured
+      {open && (
+        <div className="ml-7 mt-1 mb-2 space-y-1.5">
+          {inputDetail && (
+            <div className="rounded-md border border-border bg-muted/30 p-2 overflow-x-auto">
+              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-foreground/80">
+                {inputDetail}
+              </pre>
+            </div>
+          )}
+          {toolResult ? (
+            <div className="rounded-md border border-border bg-muted/30 p-2 overflow-x-auto">
+              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground">
+                {toolResult.message}
+              </pre>
+            </div>
+          ) : (
+            !inputDetail && (
+              <div className="text-xs text-muted-foreground italic">
+                No result captured
+              </div>
+            )
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/lib/tool-label.test.ts
+++ b/frontend/src/lib/tool-label.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import { deriveToolDisplay, formatToolInput } from "./tool-label";
+import type { SessionLog } from "./types";
+
+function makeLog(metadata: Record<string, unknown> | null): SessionLog {
+  return {
+    id: 1,
+    session_id: "sess_test",
+    level: "tool_use",
+    message: "",
+    metadata,
+    turn_number: 1,
+    created_at: "2026-04-20T00:00:00Z",
+  };
+}
+
+describe("deriveToolDisplay", () => {
+  describe("Claude Code Bash tool", () => {
+    it("uses model-supplied description when present", () => {
+      const log = makeLog({
+        tool: "Bash",
+        input: { command: "git status", description: "Check git status" },
+      });
+      expect(deriveToolDisplay(log)).toEqual({
+        label: "Ran Check git status",
+        icon: "terminal",
+        canonical: "bash",
+      });
+    });
+
+    it("falls back to shortened command when no description", () => {
+      const log = makeLog({ tool: "Bash", input: { command: "ls -la" } });
+      expect(deriveToolDisplay(log).label).toBe("Ran `ls -la`");
+    });
+
+    it("truncates very long commands", () => {
+      const longCmd = "git log --pretty=format:'%h %s' --author=wangjohn --since=2026-01-01 --oneline";
+      const log = makeLog({ tool: "Bash", input: { command: longCmd } });
+      const { label } = deriveToolDisplay(log);
+      expect(label.startsWith("Ran `")).toBe(true);
+      expect(label.endsWith("`")).toBe(true);
+      // label body (between backticks) should not exceed 60 chars
+      const body = label.slice("Ran `".length, -1);
+      expect(body.length).toBeLessThanOrEqual(60);
+    });
+
+    it("collapses multiline commands to a single line", () => {
+      const log = makeLog({
+        tool: "Bash",
+        input: { command: "cat <<'EOF'\nhello\nworld\nEOF" },
+      });
+      expect(deriveToolDisplay(log).label).not.toContain("\n");
+    });
+  });
+
+  describe("Codex command_execution", () => {
+    it("renders raw command with shell icon", () => {
+      const log = makeLog({
+        tool: "command_execution",
+        input: { command: "go test ./..." },
+      });
+      expect(deriveToolDisplay(log)).toMatchObject({
+        label: "Ran `go test ./...`",
+        icon: "terminal",
+        canonical: "bash",
+      });
+    });
+  });
+
+  describe("Gemini CLI run_shell_command", () => {
+    it("maps to bash canonical", () => {
+      const log = makeLog({
+        tool: "run_shell_command",
+        input: { command: "ls" },
+      });
+      expect(deriveToolDisplay(log)).toMatchObject({
+        label: "Ran `ls`",
+        icon: "terminal",
+        canonical: "bash",
+      });
+    });
+  });
+
+  describe("Read tool", () => {
+    it("shows basename for Claude Read path", () => {
+      const log = makeLog({ tool: "Read", input: { file_path: "/repo/src/main.go" } });
+      expect(deriveToolDisplay(log).label).toBe("Read main.go");
+    });
+
+    it("accepts `path` key (Gemini read_file)", () => {
+      const log = makeLog({ tool: "read_file", input: { path: "/app/config.yaml" } });
+      expect(deriveToolDisplay(log)).toMatchObject({
+        label: "Read config.yaml",
+        icon: "file-read",
+      });
+    });
+  });
+
+  describe("Edit/Write tools", () => {
+    it("renders Edited label with basename", () => {
+      const log = makeLog({ tool: "Edit", input: { file_path: "/repo/src/app.tsx" } });
+      expect(deriveToolDisplay(log).label).toBe("Edited app.tsx");
+    });
+
+    it("handles write_file alias", () => {
+      const log = makeLog({ tool: "write_file", input: { path: "/tmp/out.txt" } });
+      expect(deriveToolDisplay(log)).toMatchObject({
+        label: "Edited out.txt",
+        icon: "file-edit",
+      });
+    });
+  });
+
+  describe("Grep", () => {
+    it("shows search pattern", () => {
+      const log = makeLog({ tool: "Grep", input: { pattern: "TODO" } });
+      expect(deriveToolDisplay(log).label).toBe("Searched for `TODO`");
+    });
+
+    it("accepts Gemini search_file_content alias", () => {
+      const log = makeLog({ tool: "search_file_content", input: { pattern: "bug" } });
+      expect(deriveToolDisplay(log).canonical).toBe("grep");
+    });
+  });
+
+  describe("WebFetch", () => {
+    it("shows hostname", () => {
+      const log = makeLog({
+        tool: "WebFetch",
+        input: { url: "https://example.com/foo/bar" },
+      });
+      expect(deriveToolDisplay(log).label).toBe("Fetched example.com");
+    });
+
+    it("falls back cleanly on malformed URL", () => {
+      const log = makeLog({ tool: "WebFetch", input: { url: "not-a-url" } });
+      expect(deriveToolDisplay(log).label).toBe("Fetched not-a-url");
+    });
+  });
+
+  describe("Agent / Task", () => {
+    it("uses description as the subagent task, not the Ran prefix", () => {
+      const log = makeLog({
+        tool: "Agent",
+        input: { description: "Audit branch readiness", prompt: "..." },
+      });
+      expect(deriveToolDisplay(log).label).toBe("Ran agent: Audit branch readiness");
+    });
+  });
+
+  describe("fallbacks", () => {
+    it("handles unknown tool names", () => {
+      const log = makeLog({ tool: "frobnicate" });
+      expect(deriveToolDisplay(log)).toEqual({
+        label: "Ran frobnicate",
+        icon: "wrench",
+        canonical: "frobnicate",
+      });
+    });
+
+    it("handles null metadata without crashing", () => {
+      const log = makeLog(null);
+      expect(deriveToolDisplay(log).label).toBe("Ran unknown");
+    });
+
+    it("handles missing input without crashing", () => {
+      const log = makeLog({ tool: "Bash" });
+      expect(deriveToolDisplay(log).label).toBe("Ran shell command");
+    });
+
+    it("handles malformed input (not an object)", () => {
+      const log = makeLog({ tool: "Bash", input: "raw string" });
+      expect(deriveToolDisplay(log).label).toBe("Ran shell command");
+    });
+  });
+});
+
+describe("formatToolInput", () => {
+  it("shows bash command as shell-prefixed line", () => {
+    const log = makeLog({ tool: "Bash", input: { command: "git status" } });
+    expect(formatToolInput(log)).toBe("$ git status");
+  });
+
+  it("preserves multiline bash commands verbatim", () => {
+    const log = makeLog({
+      tool: "Bash",
+      input: { command: "cat <<EOF\nhi\nEOF" },
+    });
+    expect(formatToolInput(log)).toBe("$ cat <<EOF\nhi\nEOF");
+  });
+
+  it("JSON-prints other tools", () => {
+    const log = makeLog({ tool: "Read", input: { file_path: "/a.go" } });
+    expect(formatToolInput(log)).toContain("\"file_path\": \"/a.go\"");
+  });
+
+  it("returns null when there is no input", () => {
+    const log = makeLog({ tool: "Bash" });
+    expect(formatToolInput(log)).toBeNull();
+  });
+});

--- a/frontend/src/lib/tool-label.ts
+++ b/frontend/src/lib/tool-label.ts
@@ -1,0 +1,228 @@
+import type { SessionLog } from "./types";
+
+/**
+ * Maps a derived tool call to one of a small set of semantic icon kinds.
+ * The actual lucide-react component is resolved at the call site.
+ */
+export type ToolIconKind =
+  | "terminal"
+  | "file-read"
+  | "file-edit"
+  | "search"
+  | "glob"
+  | "web"
+  | "agent"
+  | "plan"
+  | "wrench";
+
+export interface ToolDisplay {
+  /** Short human-readable label like `Ran \`git log\`` or `Read models.go`. */
+  label: string;
+  /** Semantic icon kind — callers map to concrete icon components. */
+  icon: ToolIconKind;
+  /** Normalized canonical tool name used for the template (for debugging/analytics). */
+  canonical: string;
+}
+
+const MAX_COMMAND_LEN = 60;
+const MAX_PATTERN_LEN = 40;
+
+/**
+ * Canonicalizes agent-specific tool names into a common vocabulary so the
+ * same template can serve Claude Code, Codex, Gemini CLI, and future agents.
+ */
+const TOOL_ALIAS: Record<string, string> = {
+  // shell / command execution
+  bash: "bash",
+  shell: "bash",
+  run_shell_command: "bash",
+  command_execution: "bash",
+  local_shell_call: "bash",
+
+  // file read
+  read: "read",
+  read_file: "read",
+
+  // file edit / write
+  edit: "edit",
+  multiedit: "edit",
+  write: "edit",
+  write_file: "edit",
+  replace: "edit",
+  apply_patch: "edit",
+  str_replace_editor: "edit",
+
+  // search
+  grep: "grep",
+  search_file_content: "grep",
+
+  // glob
+  glob: "glob",
+
+  // web
+  webfetch: "web_fetch",
+  web_fetch: "web_fetch",
+
+  // agent / task
+  agent: "agent",
+  task: "agent",
+
+  // plan / todos
+  todowrite: "plan",
+  update_plan: "plan",
+  exitplanmode: "plan",
+};
+
+function canonicalize(toolName: string): string {
+  const key = toolName.toLowerCase();
+  return TOOL_ALIAS[key] ?? toolName;
+}
+
+function basename(path: string): string {
+  const clean = path.split("?")[0].split("#")[0];
+  const last = clean.split("/").filter(Boolean).pop();
+  return last ?? path;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + "…";
+}
+
+/**
+ * Shortens a shell command for inline display. Keeps it roughly one terminal
+ * line wide and collapses whitespace/newlines so multi-line heredocs don't
+ * blow out the row.
+ */
+function shortCommand(cmd: string): string {
+  const oneLine = cmd.replace(/\s+/g, " ").trim();
+  return truncate(oneLine, MAX_COMMAND_LEN);
+}
+
+function hostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function asRecord(v: unknown): Record<string, unknown> | undefined {
+  return v && typeof v === "object" && !Array.isArray(v) ? (v as Record<string, unknown>) : undefined;
+}
+
+/**
+ * Produces a scannable label and icon for a tool_use log entry, using the
+ * same normalized metadata shape all adapters emit (`metadata.tool`,
+ * `metadata.input`). Claude Code's Bash tool supplies an `input.description`
+ * written by the model — when present that wins over derived templates.
+ */
+export function deriveToolDisplay(toolUse: SessionLog): ToolDisplay {
+  const metadata = toolUse.metadata ?? {};
+  const rawTool = asString(metadata.tool) ?? "unknown";
+  const canonical = canonicalize(rawTool);
+  const input = asRecord(metadata.input);
+
+  // 1. Model-supplied description (Claude Bash) — most specific, use as-is.
+  //    Only honor it for tools where it's actually a human-readable summary,
+  //    not for Agent/Task where `description` is the subagent task name.
+  const description = input && asString(input.description);
+  if (description && canonical !== "agent") {
+    return { label: `Ran ${description}`, icon: iconFor(canonical), canonical };
+  }
+
+  // 2. Per-canonical-tool templates.
+  switch (canonical) {
+    case "bash": {
+      const cmd = input && asString(input.command);
+      if (cmd) return { label: `Ran \`${shortCommand(cmd)}\``, icon: "terminal", canonical };
+      return { label: "Ran shell command", icon: "terminal", canonical };
+    }
+    case "read": {
+      const path = input && (asString(input.path) ?? asString(input.file_path) ?? asString(input.absolute_path));
+      if (path) return { label: `Read ${basename(path)}`, icon: "file-read", canonical };
+      return { label: "Read file", icon: "file-read", canonical };
+    }
+    case "edit": {
+      const path = input && (asString(input.path) ?? asString(input.file_path) ?? asString(input.absolute_path));
+      if (path) return { label: `Edited ${basename(path)}`, icon: "file-edit", canonical };
+      return { label: "Edited file", icon: "file-edit", canonical };
+    }
+    case "grep": {
+      const pattern = input && asString(input.pattern);
+      if (pattern) return { label: `Searched for \`${truncate(pattern, MAX_PATTERN_LEN)}\``, icon: "search", canonical };
+      return { label: "Searched files", icon: "search", canonical };
+    }
+    case "glob": {
+      const pattern = input && asString(input.pattern);
+      if (pattern) return { label: `Found files matching \`${truncate(pattern, MAX_PATTERN_LEN)}\``, icon: "glob", canonical };
+      return { label: "Listed files", icon: "glob", canonical };
+    }
+    case "web_fetch": {
+      const url = input && asString(input.url);
+      if (url) return { label: `Fetched ${hostname(url)}`, icon: "web", canonical };
+      return { label: "Fetched URL", icon: "web", canonical };
+    }
+    case "agent": {
+      const desc = input && (asString(input.description) ?? asString(input.prompt));
+      if (desc) return { label: `Ran agent: ${truncate(desc, 50)}`, icon: "agent", canonical };
+      return { label: "Ran subagent", icon: "agent", canonical };
+    }
+    case "plan": {
+      return { label: "Updated plan", icon: "plan", canonical };
+    }
+    default:
+      return { label: `Ran ${rawTool}`, icon: "wrench", canonical: rawTool };
+  }
+}
+
+function iconFor(canonical: string): ToolIconKind {
+  switch (canonical) {
+    case "bash":
+      return "terminal";
+    case "read":
+      return "file-read";
+    case "edit":
+      return "file-edit";
+    case "grep":
+      return "search";
+    case "glob":
+      return "glob";
+    case "web_fetch":
+      return "web";
+    case "agent":
+      return "agent";
+    case "plan":
+      return "plan";
+    default:
+      return "wrench";
+  }
+}
+
+/**
+ * Pretty-prints the tool input for the expanded detail panel. For Bash-style
+ * tools we show just the raw command on its own line; for other tools we JSON
+ * the whole input object so nothing is hidden.
+ */
+export function formatToolInput(toolUse: SessionLog): string | null {
+  const metadata = toolUse.metadata ?? {};
+  const rawTool = asString(metadata.tool) ?? "";
+  const canonical = canonicalize(rawTool);
+  const input = asRecord(metadata.input);
+  if (!input) return null;
+
+  if (canonical === "bash") {
+    const cmd = asString(input.command);
+    if (cmd) return `$ ${cmd}`;
+  }
+
+  try {
+    return JSON.stringify(input, null, 2);
+  } catch {
+    return null;
+  }
+}

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -156,7 +156,7 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 				Timestamp: time.Now(),
 				Level:     "tool_use",
 				Message:   fmt.Sprintf("using tool: %s", event.Tool),
-				Metadata:  map[string]interface{}{"tool": event.Tool},
+				Metadata:  claudeToolUseMetadata(event),
 			}
 
 		case "tool_result":
@@ -509,8 +509,25 @@ type claudeStreamEvent struct {
 	Content   string          `json:"content,omitempty"`
 	Message   string          `json:"message,omitempty"`
 	Tool      string          `json:"tool,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
 	Result    json.RawMessage `json:"result,omitempty"`
 	SessionID string          `json:"session_id,omitempty"`
+}
+
+// claudeToolUseMetadata builds the metadata map for a tool_use log entry,
+// preserving the tool name and the parsed input arguments so downstream
+// consumers (UI, analytics) can render a descriptive label. Claude's Bash
+// tool includes an `input.description` field that the frontend surfaces as
+// the primary label — dropping Input here would discard that signal.
+func claudeToolUseMetadata(event claudeStreamEvent) map[string]interface{} {
+	metadata := map[string]interface{}{"tool": event.Tool}
+	if len(event.Input) > 0 {
+		var inputMap map[string]interface{}
+		if err := json.Unmarshal(event.Input, &inputMap); err == nil {
+			metadata["input"] = inputMap
+		}
+	}
+	return metadata
 }
 
 // parseStreamOutput processes the streaming JSON output line by line,
@@ -555,7 +572,7 @@ func parseStreamOutput(output []byte, result *agent.AgentResult, logCh chan<- ag
 				Timestamp: time.Now(),
 				Level:     "tool_use",
 				Message:   fmt.Sprintf("using tool: %s", event.Tool),
-				Metadata:  map[string]interface{}{"tool": event.Tool},
+				Metadata:  claudeToolUseMetadata(event),
 			}
 
 		case "tool_result":

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -379,6 +379,20 @@ func TestParseStreamOutput(t *testing.T) {
 				require.Len(t, logs, 1)
 				require.Equal(t, "tool_use", logs[0].Level)
 				require.Contains(t, logs[0].Message, "edit_file")
+				require.Equal(t, "edit_file", logs[0].Metadata["tool"])
+			},
+		},
+		{
+			name:   "tool_use event with input preserves description",
+			output: `{"type":"tool_use","tool":"Bash","input":{"command":"ls -la","description":"List files"}}`,
+			checkResult: func(t *testing.T, result *agent.AgentResult, logs []agent.LogEntry) {
+				t.Helper()
+				require.Len(t, logs, 1)
+				require.Equal(t, "tool_use", logs[0].Level)
+				input, ok := logs[0].Metadata["input"].(map[string]interface{})
+				require.True(t, ok, "expected input metadata to be a map")
+				require.Equal(t, "ls -la", input["command"])
+				require.Equal(t, "List files", input["description"])
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Replaces the generic "command_execution" badge in the session timeline with a human-readable label + per-tool icon, uniformly across Claude Code, Codex, and Gemini CLI.
- New shared `deriveToolDisplay()` helper normalizes tool-name aliases (Bash / shell / run_shell_command / command_execution collapse to one template) and derives labels from `metadata.input` — falling back through model-supplied description (Claude Bash) → per-tool template (Read, Edit, Grep, Glob, WebFetch, Agent, plan) → raw tool name.
- Fixes a pre-existing bug where the Claude Code adapter dropped `event.Input` in tool_use metadata, which meant the model-authored `description` field never reached the UI.
- Expanded tool-call detail now shows both the input command and the result, not just the result.

## Test plan
- [x] `vitest run` — 1176/1176 tests pass (23 new tool-label tests + updated chat-timeline test).
- [x] `go vet ./...` clean; adapter tests pass.
- [ ] Manual: start a session with each agent and confirm rows render as "Read X" / "Ran ..." instead of a blue badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)