### PR TITLE
Stop spurious logouts and extend sessions across deploys

### DIFF
--- a/docs/design/implemented/27-csrf-protection.md
+++ b/docs/design/implemented/27-csrf-protection.md
@@ -188,7 +188,7 @@ Apply the CSRF middleware **only to the protected route group**, after auth midd
 ```go
 // Protected routes (authenticated)
 r.Group(func(r chi.Router) {
-    r.Use(middleware.Auth(sessionStore, userStore, []byte(cfg.CSRFSigningKey)))
+    r.Use(middleware.Auth(sessionStore, userStore, []byte(cfg.CSRFSigningKey), logger))
     r.Use(middleware.OrgContext)
     r.Use(middleware.CSRF(cfg.CSRFSigningKey))  // <-- ADD HERE
 

--- a/docs/design/implemented/27-csrf-protection.md
+++ b/docs/design/implemented/27-csrf-protection.md
@@ -188,7 +188,7 @@ Apply the CSRF middleware **only to the protected route group**, after auth midd
 ```go
 // Protected routes (authenticated)
 r.Group(func(r chi.Router) {
-    r.Use(middleware.Auth(sessionStore, userStore))
+    r.Use(middleware.Auth(sessionStore, userStore, []byte(cfg.CSRFSigningKey)))
     r.Use(middleware.OrgContext)
     r.Use(middleware.CSRF(cfg.CSRFSigningKey))  // <-- ADD HERE
 

--- a/docs/design/implemented/27-csrf-protection.md
+++ b/docs/design/implemented/27-csrf-protection.md
@@ -202,6 +202,8 @@ This means:
 - **Public auth routes** (`/auth/providers`, `/auth/github/*`, `/auth/google/*`, `/auth/register`, `/auth/login`): No CSRF (pre-authentication)
 - **All protected routes:** CSRF enforced on POST/PUT/PATCH/DELETE
 
+The auth middleware now also performs sliding-window session refresh: when a cookie-based session is within the refresh window of its expiry, `expires_at` is pushed back out to the full session TTL and the session cookie is reissued. The CSRF cookie is re-emitted in lockstep via `ExtendCSRFCookie`, which preserves the existing signed token value when valid, so an active user never ends up with a live session but an expired CSRF cookie.
+
 ### 4. CORS Update (`internal/api/middleware/cors.go`)
 
 Allow the CSRF header in preflight responses:

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -92,6 +92,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   const {
     user,
     isLoading,
+    isFetching,
     isAuthenticated,
     isUnauthorized,
     isTransientError,
@@ -165,11 +166,12 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
           <Button
             variant="outline"
             size="sm"
+            disabled={isFetching}
             onClick={() => {
               void refetchUser();
             }}
           >
-            Try again
+            {isFetching ? "Retrying…" : "Try again"}
           </Button>
         </div>
       </div>

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -89,7 +89,15 @@ const navItems = [
 export function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { user, isLoading, isAuthenticated, isUnauthorized, logout } = useAuth();
+  const {
+    user,
+    isLoading,
+    isAuthenticated,
+    isUnauthorized,
+    isTransientError,
+    refetchUser,
+    logout,
+  } = useAuth();
 
   const { data: proposalSummary } = useQuery({
     queryKey: ["proposalSummary"],
@@ -133,10 +141,36 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   }, [isLoading, isUnauthorized, router]);
 
   // Show the loading skeleton while the initial /me call is in flight OR
-  // while a transient error is being retried without a cached user yet.
-  // Only confirmed 401s (isUnauthorized) bypass the skeleton and fall through
-  // to the redirect path below.
-  const showLoadingSkeleton = isLoading || (!user && !isUnauthorized);
+  // while retries are still in progress without a cached user. Confirmed
+  // 401s fall through to the redirect path; exhausted non-401 retries fall
+  // through to the error UI below.
+  const showLoadingSkeleton =
+    !user && !isUnauthorized && !isTransientError && isLoading;
+
+  if (!user && isTransientError) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background px-6">
+        <div className="max-w-sm text-center space-y-4">
+          <h2 className="text-base font-semibold text-foreground">
+            Can&apos;t reach the server
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            We couldn&apos;t load your session. This usually clears up on its own
+            during a deploy.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              void refetchUser();
+            }}
+          >
+            Try again
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   if (showLoadingSkeleton) {
     return (

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -149,7 +149,11 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   if (!user && isTransientError) {
     return (
-      <div className="flex h-screen items-center justify-center bg-background px-6">
+      <div
+        role="alert"
+        aria-live="polite"
+        className="flex h-screen items-center justify-center bg-background px-6"
+      >
         <div className="max-w-sm text-center space-y-4">
           <h2 className="text-base font-semibold text-foreground">
             Can&apos;t reach the server

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -89,7 +89,7 @@ const navItems = [
 export function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
-  const { user, isLoading, isAuthenticated, logout } = useAuth();
+  const { user, isLoading, isAuthenticated, isUnauthorized, logout } = useAuth();
 
   const { data: proposalSummary } = useQuery({
     queryKey: ["proposalSummary"],
@@ -124,12 +124,21 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   const handlePaletteOpen = useCallback(() => setPaletteOpen(true), []);
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    // Only redirect on a confirmed 401. Transient network errors (5xx during
+    // a rolling deploy, offline blips) leave isAuthenticated false but must
+    // not kick the user to /login — the query will retry and recover.
+    if (!isLoading && isUnauthorized) {
       router.replace("/login");
     }
-  }, [isLoading, isAuthenticated, router]);
+  }, [isLoading, isUnauthorized, router]);
 
-  if (isLoading) {
+  // Show the loading skeleton while the initial /me call is in flight OR
+  // while a transient error is being retried without a cached user yet.
+  // Only confirmed 401s (isUnauthorized) bypass the skeleton and fall through
+  // to the redirect path below.
+  const showLoadingSkeleton = isLoading || (!user && !isUnauthorized);
+
+  if (showLoadingSkeleton) {
     return (
       <div className="flex h-screen">
         <aside className="w-[260px] border-r border-border bg-sidebar flex flex-col">
@@ -169,7 +178,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     );
   }
 
-  if (!isAuthenticated) {
+  if (isUnauthorized || !user) {
     return null;
   }
 

--- a/frontend/src/hooks/use-auth.test.ts
+++ b/frontend/src/hooks/use-auth.test.ts
@@ -80,7 +80,23 @@ describe('useAuth', () => {
 
     expect(result.current.isAuthenticated).toBe(false);
     expect(result.current.isUnauthorized).toBe(false);
+    expect(result.current.isTransientError).toBe(true);
     expect(result.current.user).toBeNull();
+  });
+
+  it('is neither unauthorized nor transient-error on success', async () => {
+    meMock.mockResolvedValue({
+      data: { id: '1', email: 'test@test.com', name: 'Test' },
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isUnauthorized).toBe(false);
+    expect(result.current.isTransientError).toBe(false);
   });
 
   it('starts in loading state', () => {

--- a/frontend/src/hooks/use-auth.test.ts
+++ b/frontend/src/hooks/use-auth.test.ts
@@ -8,6 +8,13 @@ const meMock = vi.hoisted(() => vi.fn());
 const providersMock = vi.hoisted(() => vi.fn());
 const logoutMock = vi.hoisted(() => vi.fn());
 
+// Build an error object matching the ApiError duck-type (has a `code` field).
+function apiError(code: string, message: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
 vi.mock('@/lib/api', () => ({
   api: {
     auth: {
@@ -48,8 +55,8 @@ describe('useAuth', () => {
     expect(result.current.user?.email).toBe('test@test.com');
   });
 
-  it('returns unauthenticated state when API returns error', async () => {
-    meMock.mockRejectedValue(new Error('Unauthorized'));
+  it('returns unauthenticated state when API returns 401', async () => {
+    meMock.mockRejectedValue(apiError('UNAUTHORIZED', 'Unauthorized'));
 
     const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
 
@@ -58,6 +65,21 @@ describe('useAuth', () => {
     });
 
     expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isUnauthorized).toBe(true);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('does not mark unauthorized on transient non-401 errors', async () => {
+    meMock.mockRejectedValue(apiError('INTERNAL_ERROR', 'boom'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isUnauthorized).toBe(false);
     expect(result.current.user).toBeNull();
   });
 

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -20,7 +20,7 @@ function isUnauthorizedError(err: unknown): boolean {
 export function useAuth() {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
     queryKey: ["auth", "me"],
     queryFn: () => api.auth.me(),
     // Only treat a confirmed 401 as terminal. Network blips and 5xx
@@ -51,6 +51,7 @@ export function useAuth() {
   return {
     user: data?.data ?? null,
     isLoading,
+    isFetching,
     isAuthenticated: !!data?.data,
     isUnauthorized,
     isTransientError,

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -17,7 +17,7 @@ function isUnauthorizedError(err: unknown): boolean {
 export function useAuth() {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ["auth", "me"],
     queryFn: () => api.auth.me(),
     // Only treat a confirmed 401 as terminal. Network blips and 5xx
@@ -34,6 +34,10 @@ export function useAuth() {
   });
 
   const isUnauthorized = isUnauthorizedError(error);
+  // Retries exhausted with a non-401 failure. Callers should render an
+  // explicit error state (with a retry affordance) rather than hang on a
+  // loading skeleton forever.
+  const isTransientError = !!error && !isUnauthorized;
 
   const logout = async () => {
     await api.auth.logout();
@@ -46,6 +50,8 @@ export function useAuth() {
     isLoading,
     isAuthenticated: !!data?.data,
     isUnauthorized,
+    isTransientError,
+    refetchUser: refetch,
     logout,
   };
 }

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -3,9 +3,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
-// Duck-typed 401 check. The backend's Auth middleware writes error.code =
-// "UNAUTHORIZED" for every 401. Using a duck check (not `instanceof ApiError`)
-// means component test mocks don't need to re-export ApiError to interop.
+// Duck-typed 401 check. The backend's `writeError` helper is the single
+// source of truth for this contract: every 401 response carries
+// error.code = "UNAUTHORIZED" (see internal/api/middleware/auth.go and
+// callers of writeError with http.StatusUnauthorized). Using a duck
+// check (not `instanceof ApiError`) means component test mocks don't
+// need to re-export ApiError to interop.
 function isUnauthorizedError(err: unknown): boolean {
   return (
     typeof err === "object" &&

--- a/frontend/src/hooks/use-auth.ts
+++ b/frontend/src/hooks/use-auth.ts
@@ -3,15 +3,37 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 
+// Duck-typed 401 check. The backend's Auth middleware writes error.code =
+// "UNAUTHORIZED" for every 401. Using a duck check (not `instanceof ApiError`)
+// means component test mocks don't need to re-export ApiError to interop.
+function isUnauthorizedError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: unknown }).code === "UNAUTHORIZED"
+  );
+}
+
 export function useAuth() {
   const queryClient = useQueryClient();
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading, error } = useQuery({
     queryKey: ["auth", "me"],
     queryFn: () => api.auth.me(),
-    retry: false,
+    // Only treat a confirmed 401 as terminal. Network blips and 5xx
+    // (e.g. during a rolling deploy) retry a few times instead of
+    // instantly logging the user out.
+    retry: (failureCount, err) => {
+      if (isUnauthorizedError(err)) return false;
+      return failureCount < 2;
+    },
+    // Short backoff so a transient deploy blip clears in under a second
+    // rather than stalling on React Query's default exponential backoff.
+    retryDelay: (attempt) => Math.min(200 * 2 ** attempt, 1000),
     staleTime: 5 * 60 * 1000,
   });
+
+  const isUnauthorized = isUnauthorizedError(error);
 
   const logout = async () => {
     await api.auth.logout();
@@ -22,7 +44,8 @@ export function useAuth() {
   return {
     user: data?.data ?? null,
     isLoading,
-    isAuthenticated: !!data?.data && !isError,
+    isAuthenticated: !!data?.data,
+    isUnauthorized,
     logout,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
 const SENTRY_REDIRECT_URI = process.env.NEXT_PUBLIC_SENTRY_REDIRECT_URI || '';
 
-export class ApiError extends Error {
+class ApiError extends Error {
   constructor(public code: string, message: string, public details?: unknown) {
     super(message);
     this.name = 'ApiError';

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,7 +2,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
 const SENTRY_REDIRECT_URI = process.env.NEXT_PUBLIC_SENTRY_REDIRECT_URI || '';
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(public code: string, message: string, public details?: unknown) {
     super(message);
     this.name = 'ApiError';

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -544,11 +544,13 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session_token",
+		Name:     middleware.SessionCookieName,
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.IsRequestSecure(r),
 	})
 
 	// Clear CSRF cookie on logout.
@@ -558,6 +560,8 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: false,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.IsRequestSecure(r),
 	})
 
 	user := middleware.UserFromContext(r.Context())
@@ -579,7 +583,7 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 		UserID:    user.ID,
 		OrgID:     user.OrgID,
 		Token:     sessionToken,
-		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		ExpiresAt: time.Now().Add(middleware.SessionTTL),
 	}
 	if err := h.sessionStore.Create(r.Context(), session); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session", err)
@@ -587,12 +591,13 @@ func (h *AuthHandler) createSessionAndRedirect(w http.ResponseWriter, r *http.Re
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session_token",
+		Name:     middleware.SessionCookieName,
 		Value:    sessionToken,
 		Path:     "/",
-		MaxAge:   30 * 24 * 60 * 60,
+		MaxAge:   int(middleware.SessionTTL.Seconds()),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.IsRequestSecure(r),
 	})
 
 	if err := middleware.SetCSRFCookie(w, r, []byte(h.cfg.CSRFSigningKey)); err != nil {
@@ -623,7 +628,7 @@ func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Req
 		UserID:    user.ID,
 		OrgID:     user.OrgID,
 		Token:     sessionToken,
-		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+		ExpiresAt: time.Now().Add(middleware.SessionTTL),
 	}
 	if err := h.sessionStore.Create(r.Context(), session); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "SESSION_CREATE_FAILED", "failed to create session", err)
@@ -631,12 +636,13 @@ func (h *AuthHandler) createSessionAndRespond(w http.ResponseWriter, r *http.Req
 	}
 
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session_token",
+		Name:     middleware.SessionCookieName,
 		Value:    sessionToken,
 		Path:     "/",
-		MaxAge:   30 * 24 * 60 * 60,
+		MaxAge:   int(middleware.SessionTTL.Seconds()),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Secure:   middleware.IsRequestSecure(r),
 	})
 
 	if err := middleware.SetCSRFCookie(w, r, []byte(h.cfg.CSRFSigningKey)); err != nil {

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -1149,3 +1149,98 @@ type mockInvitationLookupStore struct {
 func (m *mockInvitationLookupStore) GetByToken(ctx context.Context, token string) (models.Invitation, error) {
 	return m.getByTokenFn(ctx, token)
 }
+
+func TestAuthHandler_createSessionAndRespond_SetsCookiesWithMiddlewareConstants(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(uuid.New(), time.Now()),
+		)
+
+	handler := NewAuthHandler(
+		&config.Config{CSRFSigningKey: "test-signing-key-that-is-long-enough-for-hmac"},
+		nil,
+		nil,
+		db.NewAuthSessionStore(mock),
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", nil)
+	req.TLS = nil
+	w := httptest.NewRecorder()
+
+	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
+	handler.createSessionAndRespond(w, req, user)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var foundSession bool
+	for _, c := range w.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName {
+			foundSession = true
+			require.NotEmpty(t, c.Value)
+			require.Equal(t, int(middleware.SessionTTL.Seconds()), c.MaxAge)
+			require.True(t, c.HttpOnly)
+			require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+			require.False(t, c.Secure, "plain HTTP request should not set Secure")
+		}
+	}
+	require.True(t, foundSession, "session cookie should be set")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuthHandler_createSessionAndRedirect_SetsCookiesAndRedirects(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(uuid.New(), time.Now()),
+		)
+
+	handler := NewAuthHandler(
+		&config.Config{
+			CSRFSigningKey: "test-signing-key-that-is-long-enough-for-hmac",
+			FrontendURL:    "https://app.example.com",
+		},
+		nil,
+		nil,
+		db.NewAuthSessionStore(mock),
+		nil,
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github/callback", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
+	handler.createSessionAndRedirect(w, req, user)
+
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+
+	var foundSession bool
+	for _, c := range w.Result().Cookies() {
+		if c.Name == middleware.SessionCookieName {
+			foundSession = true
+			require.NotEmpty(t, c.Value)
+			require.Equal(t, int(middleware.SessionTTL.Seconds()), c.MaxAge)
+			require.True(t, c.HttpOnly)
+			require.Equal(t, http.SameSiteLaxMode, c.SameSite)
+			require.True(t, c.Secure, "X-Forwarded-Proto=https should set Secure")
+		}
+	}
+	require.True(t, foundSession, "session cookie should be set")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -15,6 +16,15 @@ type contextKey string
 const (
 	userContextKey  contextKey = "user"
 	orgIDContextKey contextKey = "org_id"
+
+	// SessionCookieName is the cookie holding the opaque session token.
+	SessionCookieName = "session_token"
+	// SessionTTL is how far ahead the session's expires_at is set.
+	SessionTTL = 30 * 24 * time.Hour
+	// sessionRefreshWindow: if a session has less than (TTL - refreshWindow)
+	// remaining, we extend it back to TTL. With these values, an active user's
+	// session gets pushed out by at most once every 5 days.
+	sessionRefreshWindow = 5 * 24 * time.Hour
 )
 
 func UserFromContext(ctx context.Context) *models.User {
@@ -39,7 +49,7 @@ func WithOrgID(ctx context.Context, id uuid.UUID) context.Context {
 func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			cookie, err := r.Cookie("session_token")
+			cookie, err := r.Cookie(SessionCookieName)
 			if err != nil {
 				// Also check Authorization header for API access
 				auth := r.Header.Get("Authorization")
@@ -56,11 +66,11 @@ func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore) func(http.
 	}
 }
 
-func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, token string, clearCookieOnFailure bool) {
+func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, token string, cookieBased bool) {
 	session, err := sessionStore.GetByToken(r.Context(), token)
 	if err != nil {
-		if clearCookieOnFailure {
-			clearSessionCookie(w)
+		if cookieBased {
+			clearSessionCookie(w, r)
 		}
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid session")
 		return
@@ -68,11 +78,19 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 
 	user, err := userStore.GetByID(r.Context(), session.OrgID, session.UserID)
 	if err != nil {
-		if clearCookieOnFailure {
-			clearSessionCookie(w)
+		if cookieBased {
+			clearSessionCookie(w, r)
 		}
 		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
 		return
+	}
+
+	// Sliding-window refresh: if the cookie is more than refreshWindow old
+	// (i.e. expires_at is inside (now, now + TTL - refreshWindow)), push it
+	// back out to TTL so active users don't get a hard logout at 30 days.
+	// Only for cookie-based auth — bearer tokens manage their own lifetime.
+	if cookieBased {
+		maybeRefreshSession(w, r, sessionStore, session)
 	}
 
 	ctx := WithUser(r.Context(), &user)
@@ -80,13 +98,35 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-func clearSessionCookie(w http.ResponseWriter) {
+func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthSessionStore, session models.AuthSession) {
+	if time.Until(session.ExpiresAt) > SessionTTL-sessionRefreshWindow {
+		return
+	}
+	newExpiresAt := time.Now().Add(SessionTTL)
+	if err := store.Touch(r.Context(), session.Token, newExpiresAt); err != nil {
+		// Best-effort: session is still valid; the user will just need to
+		// re-login at the original expiry if this keeps failing.
+		return
+	}
 	http.SetCookie(w, &http.Cookie{
-		Name:     "session_token",
+		Name:     SessionCookieName,
+		Value:    session.Token,
+		Path:     "/",
+		MaxAge:   int(SessionTTL.Seconds()),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   IsRequestSecure(r),
+	})
+}
+
+func clearSessionCookie(w http.ResponseWriter, r *http.Request) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     SessionCookieName,
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
+		Secure:   IsRequestSecure(r),
 	})
 }

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -46,7 +46,10 @@ func WithOrgID(ctx context.Context, id uuid.UUID) context.Context {
 }
 
 // Auth middleware reads the session cookie, validates the session, and sets user on context.
-func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore) func(http.Handler) http.Handler {
+// csrfKey is used to extend the CSRF cookie in lockstep with sliding session
+// refresh so its lifetime never trails the session. Pass nil to skip CSRF
+// extension (e.g. in tests that don't exercise CSRF).
+func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cookie, err := r.Cookie(SessionCookieName)
@@ -58,15 +61,15 @@ func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore) func(http.
 					return
 				}
 				token := strings.TrimPrefix(auth, "Bearer ")
-				handleToken(w, r, next, sessionStore, userStore, token, false)
+				handleToken(w, r, next, sessionStore, userStore, csrfKey, token, false)
 				return
 			}
-			handleToken(w, r, next, sessionStore, userStore, cookie.Value, true)
+			handleToken(w, r, next, sessionStore, userStore, csrfKey, cookie.Value, true)
 		})
 	}
 }
 
-func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, token string, cookieBased bool) {
+func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte, token string, cookieBased bool) {
 	session, err := sessionStore.GetByToken(r.Context(), token)
 	if err != nil {
 		if cookieBased {
@@ -90,7 +93,7 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 	// back out to TTL so active users don't get a hard logout at 30 days.
 	// Only for cookie-based auth — bearer tokens manage their own lifetime.
 	if cookieBased {
-		maybeRefreshSession(w, r, sessionStore, session)
+		maybeRefreshSession(w, r, sessionStore, csrfKey, session)
 	}
 
 	ctx := WithUser(r.Context(), &user)
@@ -98,7 +101,7 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthSessionStore, session models.AuthSession) {
+func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthSessionStore, csrfKey []byte, session models.AuthSession) {
 	if time.Until(session.ExpiresAt) > SessionTTL-sessionRefreshWindow {
 		return
 	}
@@ -117,6 +120,13 @@ func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthS
 		SameSite: http.SameSiteLaxMode,
 		Secure:   IsRequestSecure(r),
 	})
+	// Keep CSRF cookie lifetime pinned to the session so an active user
+	// can't end up with a live session but an expired CSRF cookie. Best-
+	// effort: failure just means the CSRF cookie expires on its own clock
+	// and ensureCSRFCookie reissues on the next safe-method request.
+	if len(csrfKey) > 0 {
+		_ = ExtendCSRFCookie(w, r, csrfKey)
+	}
 }
 
 func clearSessionCookie(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 type contextKey string
@@ -48,8 +49,9 @@ func WithOrgID(ctx context.Context, id uuid.UUID) context.Context {
 // Auth middleware reads the session cookie, validates the session, and sets user on context.
 // csrfKey is used to extend the CSRF cookie in lockstep with sliding session
 // refresh so its lifetime never trails the session. Pass nil to skip CSRF
-// extension (e.g. in tests that don't exercise CSRF).
-func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte) func(http.Handler) http.Handler {
+// extension (e.g. in tests that don't exercise CSRF). logger is used to
+// surface best-effort refresh failures at Warn level.
+func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte, logger zerolog.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			cookie, err := r.Cookie(SessionCookieName)
@@ -61,15 +63,15 @@ func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []
 					return
 				}
 				token := strings.TrimPrefix(auth, "Bearer ")
-				handleToken(w, r, next, sessionStore, userStore, csrfKey, token, false)
+				handleToken(w, r, next, sessionStore, userStore, csrfKey, logger, token, false)
 				return
 			}
-			handleToken(w, r, next, sessionStore, userStore, csrfKey, cookie.Value, true)
+			handleToken(w, r, next, sessionStore, userStore, csrfKey, logger, cookie.Value, true)
 		})
 	}
 }
 
-func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte, token string, cookieBased bool) {
+func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte, logger zerolog.Logger, token string, cookieBased bool) {
 	session, err := sessionStore.GetByToken(r.Context(), token)
 	if err != nil {
 		if cookieBased {
@@ -93,7 +95,7 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 	// back out to TTL so active users don't get a hard logout at 30 days.
 	// Only for cookie-based auth — bearer tokens manage their own lifetime.
 	if cookieBased {
-		maybeRefreshSession(w, r, sessionStore, csrfKey, session)
+		maybeRefreshSession(w, r, sessionStore, csrfKey, logger, session)
 	}
 
 	ctx := WithUser(r.Context(), &user)
@@ -101,7 +103,7 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sess
 	next.ServeHTTP(w, r.WithContext(ctx))
 }
 
-func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthSessionStore, csrfKey []byte, session models.AuthSession) {
+func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthSessionStore, csrfKey []byte, logger zerolog.Logger, session models.AuthSession) {
 	if time.Until(session.ExpiresAt) > SessionTTL-sessionRefreshWindow {
 		return
 	}
@@ -109,6 +111,7 @@ func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthS
 	if err := store.Touch(r.Context(), session.Token, newExpiresAt); err != nil {
 		// Best-effort: session is still valid; the user will just need to
 		// re-login at the original expiry if this keeps failing.
+		logger.Warn().Err(err).Msg("auth: sliding session refresh failed")
 		return
 	}
 	http.SetCookie(w, &http.Cookie{
@@ -125,7 +128,9 @@ func maybeRefreshSession(w http.ResponseWriter, r *http.Request, store *db.AuthS
 	// effort: failure just means the CSRF cookie expires on its own clock
 	// and ensureCSRFCookie reissues on the next safe-method request.
 	if len(csrfKey) > 0 {
-		_ = ExtendCSRFCookie(w, r, csrfKey)
+		if err := ExtendCSRFCookie(w, r, csrfKey); err != nil {
+			logger.Warn().Err(err).Msg("auth: CSRF cookie extension failed")
+		}
 	}
 }
 

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -240,6 +241,56 @@ func TestAuth(t *testing.T) {
 				require.Equal(t, uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002"), user.ID, "should set correct user ID in context")
 			},
 			checkResponse: nil,
+		},
+		{
+			name: "does not refresh bearer-token session even when inside refresh window",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				sessionRows := pgxmock.NewRows([]string{"id", "user_id", "org_id", "token", "expires_at", "created_at"}).
+					AddRow(
+						uuid.MustParse("cccccccc-0000-0000-0000-000000000001"),
+						uuid.MustParse("cccccccc-0000-0000-0000-000000000002"),
+						uuid.MustParse("cccccccc-0000-0000-0000-000000000003"),
+						"stale-bearer-token",
+						now.Add(24*time.Hour), // well inside the refresh window
+						now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(sessionRows)
+
+				ghID := int64(12345)
+				ghLogin := "testuser"
+				avatarURL := "https://example.com/avatar.png"
+				userRows := pgxmock.NewRows([]string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "password_hash", "google_id", "created_at"}).
+					AddRow(
+						uuid.MustParse("cccccccc-0000-0000-0000-000000000002"),
+						uuid.MustParse("cccccccc-0000-0000-0000-000000000003"),
+						"test@example.com", "Test User", "member",
+						&ghID, &ghLogin, &avatarURL, nil, nil, now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM users").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(userRows)
+				// Deliberately no UPDATE expectation: bearer tokens must not
+				// trigger sliding refresh. pgxmock fails on unexpected calls.
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.Header.Set("Authorization", "Bearer stale-bearer-token")
+				return req
+			},
+			expectedCode: http.StatusOK,
+			checkContext: nil,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName || c.Name == CSRFCookieName {
+						t.Fatalf("bearer-token auth must not emit %s cookie, got %+v", c.Name, c)
+					}
+				}
+			},
 		},
 		{
 			name:      "returns 401 when no cookie and no authorization header present",
@@ -505,7 +556,7 @@ func TestAuth(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := Auth(sessionStore, userStore, []byte("test-signing-key-that-is-long-enough-for-hmac"))(next)
+			handler := Auth(sessionStore, userStore, []byte("test-signing-key-that-is-long-enough-for-hmac"), zerolog.Nop())(next)
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req = tt.setupRequest(req)
 			w := httptest.NewRecorder()

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -439,6 +439,8 @@ func TestAuth(t *testing.T) {
 				require.Equal(t, "stale-token", refreshed.Value, "reissued cookie should carry the same opaque token")
 				require.Equal(t, int(SessionTTL.Seconds()), refreshed.MaxAge, "reissued cookie should use the full TTL")
 				require.True(t, refreshed.HttpOnly, "reissued cookie should stay HttpOnly")
+				require.Equal(t, http.SameSiteLaxMode, refreshed.SameSite, "reissued cookie should stay SameSite=Lax")
+				require.False(t, refreshed.Secure, "plain httptest request should not set Secure on reissued cookie")
 				require.NotNil(t, csrf, "CSRF cookie should be extended in lockstep with session refresh")
 				require.Equal(t, int(SessionTTL.Seconds()), csrf.MaxAge, "CSRF cookie MaxAge should match session TTL")
 			},

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -144,11 +144,11 @@ func TestAuth(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		setupMock    func(mock pgxmock.PgxPoolIface)
-		setupRequest func(req *http.Request) *http.Request
-		expectedCode int
-		checkContext func(t *testing.T, r *http.Request)
+		name          string
+		setupMock     func(mock pgxmock.PgxPoolIface)
+		setupRequest  func(req *http.Request) *http.Request
+		expectedCode  int
+		checkContext  func(t *testing.T, r *http.Request)
 		checkResponse func(t *testing.T, w *httptest.ResponseRecorder)
 	}{
 		{
@@ -246,8 +246,8 @@ func TestAuth(t *testing.T) {
 			setupRequest: func(req *http.Request) *http.Request {
 				return req
 			},
-			expectedCode: http.StatusUnauthorized,
-			checkContext: nil,
+			expectedCode:  http.StatusUnauthorized,
+			checkContext:  nil,
 			checkResponse: nil,
 		},
 		{
@@ -281,6 +281,112 @@ func TestAuth(t *testing.T) {
 			},
 		},
 		{
+			name: "does not refresh when session expires_at is far in the future",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				sessionRows := pgxmock.NewRows([]string{"id", "user_id", "org_id", "token", "expires_at", "created_at"}).
+					AddRow(
+						uuid.MustParse("dddddddd-0000-0000-0000-000000000001"),
+						uuid.MustParse("dddddddd-0000-0000-0000-000000000002"),
+						uuid.MustParse("dddddddd-0000-0000-0000-000000000003"),
+						"fresh-token",
+						now.Add(29*24*time.Hour), // fresher than TTL - refreshWindow (25d)
+						now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(sessionRows)
+
+				ghID := int64(12345)
+				ghLogin := "testuser"
+				avatarURL := "https://example.com/avatar.png"
+				userRows := pgxmock.NewRows([]string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "password_hash", "google_id", "created_at"}).
+					AddRow(
+						uuid.MustParse("dddddddd-0000-0000-0000-000000000002"),
+						uuid.MustParse("dddddddd-0000-0000-0000-000000000003"),
+						"test@example.com", "Test User", "member",
+						&ghID, &ghLogin, &avatarURL, nil, nil, now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM users").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(userRows)
+				// No UPDATE expected — expecting no refresh on fresh sessions.
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: "fresh-token"})
+				return req
+			},
+			expectedCode: http.StatusOK,
+			checkContext: nil,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName {
+						t.Fatalf("did not expect session cookie to be reissued, got %+v", c)
+					}
+				}
+			},
+		},
+		{
+			name: "refreshes cookie and expires_at when session is past the refresh window",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				sessionRows := pgxmock.NewRows([]string{"id", "user_id", "org_id", "token", "expires_at", "created_at"}).
+					AddRow(
+						uuid.MustParse("eeeeeeee-0000-0000-0000-000000000001"),
+						uuid.MustParse("eeeeeeee-0000-0000-0000-000000000002"),
+						uuid.MustParse("eeeeeeee-0000-0000-0000-000000000003"),
+						"stale-token",
+						now.Add(24*time.Hour), // well inside TTL - refreshWindow (25d)
+						now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(sessionRows)
+
+				ghID := int64(12345)
+				ghLogin := "testuser"
+				avatarURL := "https://example.com/avatar.png"
+				userRows := pgxmock.NewRows([]string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "password_hash", "google_id", "created_at"}).
+					AddRow(
+						uuid.MustParse("eeeeeeee-0000-0000-0000-000000000002"),
+						uuid.MustParse("eeeeeeee-0000-0000-0000-000000000003"),
+						"test@example.com", "Test User", "member",
+						&ghID, &ghLogin, &avatarURL, nil, nil, now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM users").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(userRows)
+
+				mock.ExpectExec("UPDATE auth_sessions SET expires_at").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: "stale-token"})
+				return req
+			},
+			expectedCode: http.StatusOK,
+			checkContext: nil,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				var refreshed *http.Cookie
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName {
+						refreshed = c
+					}
+				}
+				require.NotNil(t, refreshed, "expected session cookie to be reissued with fresh MaxAge")
+				require.Equal(t, "stale-token", refreshed.Value, "reissued cookie should carry the same opaque token")
+				require.Equal(t, int(SessionTTL.Seconds()), refreshed.MaxAge, "reissued cookie should use the full TTL")
+				require.True(t, refreshed.HttpOnly, "reissued cookie should stay HttpOnly")
+			},
+		},
+		{
 			name: "returns 401 when session is valid but user not found",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				now := time.Now()
@@ -306,8 +412,8 @@ func TestAuth(t *testing.T) {
 				req.AddCookie(&http.Cookie{Name: "session_token", Value: "valid-token"})
 				return req
 			},
-			expectedCode: http.StatusUnauthorized,
-			checkContext: nil,
+			expectedCode:  http.StatusUnauthorized,
+			checkContext:  nil,
 			checkResponse: nil,
 		},
 	}

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -374,16 +374,21 @@ func TestAuth(t *testing.T) {
 				t.Helper()
 				resp := w.Result()
 				defer resp.Body.Close()
-				var refreshed *http.Cookie
+				var refreshed, csrf *http.Cookie
 				for _, c := range resp.Cookies() {
-					if c.Name == SessionCookieName {
+					switch c.Name {
+					case SessionCookieName:
 						refreshed = c
+					case CSRFCookieName:
+						csrf = c
 					}
 				}
 				require.NotNil(t, refreshed, "expected session cookie to be reissued with fresh MaxAge")
 				require.Equal(t, "stale-token", refreshed.Value, "reissued cookie should carry the same opaque token")
 				require.Equal(t, int(SessionTTL.Seconds()), refreshed.MaxAge, "reissued cookie should use the full TTL")
 				require.True(t, refreshed.HttpOnly, "reissued cookie should stay HttpOnly")
+				require.NotNil(t, csrf, "CSRF cookie should be extended in lockstep with session refresh")
+				require.Equal(t, int(SessionTTL.Seconds()), csrf.MaxAge, "CSRF cookie MaxAge should match session TTL")
 			},
 		},
 		{
@@ -439,7 +444,7 @@ func TestAuth(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			handler := Auth(sessionStore, userStore)(next)
+			handler := Auth(sessionStore, userStore, []byte("test-signing-key-that-is-long-enough-for-hmac"))(next)
 			req := httptest.NewRequest(http.MethodGet, "/", nil)
 			req = tt.setupRequest(req)
 			w := httptest.NewRecorder()

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -389,6 +390,66 @@ func TestAuth(t *testing.T) {
 				require.True(t, refreshed.HttpOnly, "reissued cookie should stay HttpOnly")
 				require.NotNil(t, csrf, "CSRF cookie should be extended in lockstep with session refresh")
 				require.Equal(t, int(SessionTTL.Seconds()), csrf.MaxAge, "CSRF cookie MaxAge should match session TTL")
+			},
+		},
+		{
+			name: "authenticates request when Touch fails and does not reissue cookie",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				sessionRows := pgxmock.NewRows([]string{"id", "user_id", "org_id", "token", "expires_at", "created_at"}).
+					AddRow(
+						uuid.MustParse("ffffffff-0000-0000-0000-000000000001"),
+						uuid.MustParse("ffffffff-0000-0000-0000-000000000002"),
+						uuid.MustParse("ffffffff-0000-0000-0000-000000000003"),
+						"stale-token",
+						now.Add(24*time.Hour),
+						now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(sessionRows)
+
+				ghID := int64(12345)
+				ghLogin := "testuser"
+				avatarURL := "https://example.com/avatar.png"
+				userRows := pgxmock.NewRows([]string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "password_hash", "google_id", "created_at"}).
+					AddRow(
+						uuid.MustParse("ffffffff-0000-0000-0000-000000000002"),
+						uuid.MustParse("ffffffff-0000-0000-0000-000000000003"),
+						"test@example.com", "Test User", "member",
+						&ghID, &ghLogin, &avatarURL, nil, nil, now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM users").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(userRows)
+
+				// Refresh UPDATE fails — request should still succeed using the
+				// existing session, and no refreshed cookie should be emitted.
+				mock.ExpectExec("UPDATE auth_sessions SET expires_at").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(fmt.Errorf("connection lost"))
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: "stale-token"})
+				return req
+			},
+			expectedCode: http.StatusOK,
+			checkContext: func(t *testing.T, r *http.Request) {
+				t.Helper()
+				require.NotNil(t, UserFromContext(r.Context()), "user should still be set on context when Touch fails")
+			},
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName {
+						t.Fatalf("did not expect session cookie to be reissued when Touch fails, got %+v", c)
+					}
+					if c.Name == CSRFCookieName {
+						t.Fatalf("did not expect CSRF cookie to be reissued when Touch fails, got %+v", c)
+					}
+				}
 			},
 		},
 		{

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -91,16 +91,33 @@ func SetCSRFCookie(w http.ResponseWriter, r *http.Request, key []byte) error {
 	if err != nil {
 		return err
 	}
+	writeCSRFCookie(w, r, token)
+	return nil
+}
+
+// ExtendCSRFCookie re-emits the existing valid CSRF cookie with a fresh
+// MaxAge so its lifetime stays aligned with a sliding session refresh.
+// If no valid cookie is present, a new signed token is issued instead.
+// Keeps the same token value when possible so in-flight requests that
+// already read document.cookie continue to validate.
+func ExtendCSRFCookie(w http.ResponseWriter, r *http.Request, key []byte) error {
+	if c, err := r.Cookie(CSRFCookieName); err == nil && validSignedToken(c.Value, key) {
+		writeCSRFCookie(w, r, c.Value)
+		return nil
+	}
+	return SetCSRFCookie(w, r, key)
+}
+
+func writeCSRFCookie(w http.ResponseWriter, r *http.Request, token string) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     CSRFCookieName,
 		Value:    token,
 		Path:     "/",
-		MaxAge:   30 * 24 * 60 * 60, // match session cookie lifetime
-		HttpOnly: false,             // frontend JS must read this
+		MaxAge:   int(SessionTTL.Seconds()), // match session cookie lifetime
+		HttpOnly: false,                     // frontend JS must read this
 		SameSite: http.SameSiteLaxMode,
 		Secure:   IsRequestSecure(r),
 	})
-	return nil
 }
 
 func isSafeMethod(method string) bool {

--- a/internal/api/middleware/csrf.go
+++ b/internal/api/middleware/csrf.go
@@ -98,7 +98,7 @@ func SetCSRFCookie(w http.ResponseWriter, r *http.Request, key []byte) error {
 		MaxAge:   30 * 24 * 60 * 60, // match session cookie lifetime
 		HttpOnly: false,             // frontend JS must read this
 		SameSite: http.SameSiteLaxMode,
-		Secure:   isRequestSecure(r),
+		Secure:   IsRequestSecure(r),
 	})
 	return nil
 }
@@ -123,7 +123,10 @@ func ensureCSRFCookie(w http.ResponseWriter, r *http.Request, key []byte, logger
 	}
 }
 
-func isRequestSecure(r *http.Request) bool {
+// IsRequestSecure reports whether the request arrived over HTTPS, either
+// directly or via a TLS-terminating reverse proxy. Exported so other
+// packages can set the Secure attribute on cookies consistently.
+func IsRequestSecure(r *http.Request) bool {
 	if r == nil {
 		return false
 	}

--- a/internal/api/middleware/csrf_test.go
+++ b/internal/api/middleware/csrf_test.go
@@ -225,6 +225,78 @@ func TestCSRF(t *testing.T) {
 	}
 }
 
+func TestExtendCSRFCookie(t *testing.T) {
+	t.Parallel()
+
+	key := []byte(testCSRFKey)
+
+	t.Run("preserves an existing valid cookie and refreshes MaxAge", func(t *testing.T) {
+		t.Parallel()
+
+		existing := mustGenerateToken(t, testCSRFKey)
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: existing})
+		w := httptest.NewRecorder()
+
+		require.NoError(t, ExtendCSRFCookie(w, req, key))
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		var got *http.Cookie
+		for _, c := range resp.Cookies() {
+			if c.Name == CSRFCookieName {
+				got = c
+			}
+		}
+		require.NotNil(t, got, "CSRF cookie should be re-emitted")
+		require.Equal(t, existing, got.Value, "existing token value should be preserved to avoid breaking in-flight requests")
+		require.Equal(t, int(SessionTTL.Seconds()), got.MaxAge, "re-emitted cookie should use the session TTL")
+	})
+
+	t.Run("issues a fresh token when no valid cookie is present", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		w := httptest.NewRecorder()
+
+		require.NoError(t, ExtendCSRFCookie(w, req, key))
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		var got *http.Cookie
+		for _, c := range resp.Cookies() {
+			if c.Name == CSRFCookieName {
+				got = c
+			}
+		}
+		require.NotNil(t, got, "CSRF cookie should be issued when none is present")
+		require.True(t, validSignedToken(got.Value, key), "issued token should be validly signed")
+		require.Equal(t, int(SessionTTL.Seconds()), got.MaxAge, "issued cookie should use the session TTL")
+	})
+
+	t.Run("replaces an invalid cookie with a fresh token", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.AddCookie(&http.Cookie{Name: CSRFCookieName, Value: "garbage.badsig"})
+		w := httptest.NewRecorder()
+
+		require.NoError(t, ExtendCSRFCookie(w, req, key))
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		var got *http.Cookie
+		for _, c := range resp.Cookies() {
+			if c.Name == CSRFCookieName {
+				got = c
+			}
+		}
+		require.NotNil(t, got, "CSRF cookie should be re-issued when existing is invalid")
+		require.NotEqual(t, "garbage.badsig", got.Value, "invalid token should not be re-emitted")
+		require.True(t, validSignedToken(got.Value, key), "replacement token should be validly signed")
+	})
+}
+
 func TestGenerateSignedToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -415,7 +415,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 
 	// Protected routes (authenticated)
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.Auth(authSessionStore, userStore, []byte(cfg.CSRFSigningKey)))
+		r.Use(middleware.Auth(authSessionStore, userStore, []byte(cfg.CSRFSigningKey), logger))
 		r.Use(middleware.OrgContext)
 		r.Use(middleware.LogContext(logger))
 		r.Use(middleware.CSRF(cfg.CSRFSigningKey, logger))

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -415,7 +415,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 
 	// Protected routes (authenticated)
 	r.Group(func(r chi.Router) {
-		r.Use(middleware.Auth(authSessionStore, userStore))
+		r.Use(middleware.Auth(authSessionStore, userStore, []byte(cfg.CSRFSigningKey)))
 		r.Use(middleware.OrgContext)
 		r.Use(middleware.LogContext(logger))
 		r.Use(middleware.CSRF(cfg.CSRFSigningKey, logger))

--- a/internal/db/auth_sessions.go
+++ b/internal/db/auth_sessions.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -48,6 +49,16 @@ func (s *AuthSessionStore) GetByToken(ctx context.Context, token string) (models
 		return models.AuthSession{}, fmt.Errorf("query session: %w", err)
 	}
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.AuthSession])
+}
+
+// Touch extends the session's expires_at to the given time. Used by the
+// Auth middleware to implement sliding-window session refresh so active
+// users aren't forcibly logged out at the 30-day boundary.
+// lint:allow-no-orgid reason="touched by opaque token during request auth"
+func (s *AuthSessionStore) Touch(ctx context.Context, token string, expiresAt time.Time) error {
+	query := `UPDATE auth_sessions SET expires_at = @expires_at WHERE token = @token`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{"token": token, "expires_at": expiresAt})
+	return err
 }
 
 // DeleteByToken removes the session for the given opaque token (logout).

--- a/internal/db/auth_sessions_test.go
+++ b/internal/db/auth_sessions_test.go
@@ -92,6 +92,43 @@ func TestAuthSessionStore_GetByToken_QueryError(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestAuthSessionStore_Touch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewAuthSessionStore(mock)
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
+
+	mock.ExpectExec("UPDATE auth_sessions SET expires_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.Touch(context.Background(), "test-token", expiresAt)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestAuthSessionStore_Touch_QueryError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewAuthSessionStore(mock)
+
+	mock.ExpectExec("UPDATE auth_sessions SET expires_at").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("connection lost"))
+
+	err = store.Touch(context.Background(), "bad-token", time.Now())
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestAuthSessionStore_DeleteByToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Users were getting kicked to `/login` around deploys even though their session cookie was still valid, and true 30-day hard expiries were causing additional surprise logouts. Three fixes:

- **Frontend** (`use-auth.ts`, `authenticated-layout.tsx`): retry non-401 errors on `/auth/me` with short backoff and only redirect on a confirmed `UNAUTHORIZED` code, so a 5xx blip during a rolling deploy no longer logs the user out; transient errors render the loading skeleton while the query recovers.
- **Sliding session refresh** (`middleware/auth.go`, `db/auth_sessions.go`): auth middleware now extends `expires_at` back to 30 days (and reissues the cookie) once a session is more than ~5 days old, so active users don't hit a hard cliff.
- **Cookie hardening** (`handlers/auth.go`, `middleware/csrf.go`): `session_token` and logout-clear cookies now set `Secure` (via the newly exported `middleware.IsRequestSecure`) and `SameSite=Lax`, matching the CSRF cookie's behavior.

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./internal/...` — all green
- [x] Frontend `npm test` — 1177 tests pass (6 for useAuth including new unauthorized-vs-transient cases)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: trigger a rolling deploy and confirm an active tab stays signed in