### PR TITLE
Agent sandbox: split HOME from repo checkout, richer clone, exec scratch tmpfs

### DIFF
--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -194,8 +194,9 @@ func DefaultSandboxConfig() SandboxConfig {
 
 // SlugForRepo converts a repo full name ("org/repo") into a filesystem-safe
 // slug suitable for use as a directory name (the repo portion only). Returns
-// an empty string for inputs that don't contain a "/" or resolve to an empty
-// slug; callers should treat that as "no repo known" and fall back to defaults.
+// an empty string for inputs that don't contain a "/", resolve to an empty
+// slug, or resolve to a traversal component ("." / ".."); callers should
+// treat that as "no repo known" and fall back to defaults.
 func SlugForRepo(fullName string) string {
 	_, slug, ok := strings.Cut(fullName, "/")
 	if !ok {
@@ -203,7 +204,15 @@ func SlugForRepo(fullName string) string {
 	}
 	// Replace path separators defensively — GitHub repo names don't contain "/"
 	// but the sandbox dir must be a single path component.
-	return strings.ReplaceAll(slug, "/", "-")
+	slug = strings.ReplaceAll(slug, "/", "-")
+	// Reject traversal components so /home/sandbox/<slug> can't resolve to a
+	// parent dir (e.g. "/home/sandbox/.." = "/home"). GitHub's repo-name
+	// grammar already excludes these, but this keeps the function safe for
+	// any future caller that feeds it less-trusted input.
+	if slug == "." || slug == ".." {
+		return ""
+	}
+	return slug
 }
 
 // Sandbox represents a running isolated environment for agent execution.

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/models"
@@ -155,7 +156,8 @@ type SandboxConfig struct {
 	MemoryLimitMB int               // memory in MB (default: 4096)
 	Timeout       time.Duration     // max execution time (default: 5 min)
 	NetworkPolicy string            // "restricted" — allow only LLM API endpoints
-	WorkDir       string            // /workspace
+	WorkDir       string            // path to the repo checkout inside the sandbox (e.g. /home/sandbox/<repo>)
+	HomeDir       string            // sandbox user's home dir (e.g. /home/sandbox); HOME env var points here
 	Env           map[string]string // environment variables injected into the container (e.g. API keys)
 	DiskLimitGB   int               // max container rootfs size in GB (default: 10); requires overlay2+xfs backing store
 
@@ -186,14 +188,30 @@ func DefaultSandboxConfig() SandboxConfig {
 		Timeout:       5 * time.Minute,
 		NetworkPolicy: "restricted",
 		WorkDir:       "/workspace",
+		HomeDir:       "/home/sandbox",
 	}
+}
+
+// SlugForRepo converts a repo full name ("org/repo") into a filesystem-safe
+// slug suitable for use as a directory name (the repo portion only). Returns
+// an empty string for inputs that don't contain a "/" or resolve to an empty
+// slug; callers should treat that as "no repo known" and fall back to defaults.
+func SlugForRepo(fullName string) string {
+	_, slug, ok := strings.Cut(fullName, "/")
+	if !ok {
+		return ""
+	}
+	// Replace path separators defensively — GitHub repo names don't contain "/"
+	// but the sandbox dir must be a single path component.
+	return strings.ReplaceAll(slug, "/", "-")
 }
 
 // Sandbox represents a running isolated environment for agent execution.
 type Sandbox struct {
 	ID       string            // unique sandbox identifier (container ID, VM ID, etc.)
 	Provider string            // which provider created this sandbox
-	WorkDir  string            // path to the workspace inside the sandbox
+	WorkDir  string            // path to the repo checkout inside the sandbox
+	HomeDir  string            // sandbox user's home dir (HOME env); distinct from WorkDir
 	Metadata map[string]string // provider-specific metadata
 
 	// Tracing identifiers copied from SandboxConfig at Create time. Providers

--- a/internal/services/agent/adapter_test.go
+++ b/internal/services/agent/adapter_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import "testing"
+
+func TestSlugForRepo(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"valid org/repo", "assembledhq/143", "143"},
+		{"no slash returns empty", "norepo", ""},
+		{"empty input returns empty", "", ""},
+		{"empty repo portion returns empty", "org/", ""},
+		{"nested slashes collapse to hyphens", "org/repo/sub", "repo-sub"},
+		{"leading slash treats left as empty", "/repo", "repo"},
+		// Path-traversal guards: even though GitHub's repo-name grammar
+		// excludes these, SlugForRepo must never produce a slug that
+		// resolves "/home/sandbox/<slug>" to a parent directory.
+		{"dot component is rejected", "org/.", ""},
+		{"dotdot component is rejected", "org/..", ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := SlugForRepo(tc.in)
+			if got != tc.want {
+				t.Fatalf("SlugForRepo(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -97,9 +97,10 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 			msg,
 		)
 	} else {
-		// First turn: write prompt file and run fresh.
+		// First turn: write prompt file and run fresh. Put it under $HOME
+		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
-		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.WorkDir)
+		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -215,7 +215,7 @@ func TestClaudeCodeAdapter_Execute(t *testing.T) {
 			}
 
 			adapter := NewClaudeCodeAdapter(zerolog.Nop())
-			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace"}
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
 				UserPrompt:   "Null pointer error.",
@@ -242,7 +242,7 @@ func TestClaudeCodeAdapter_Execute(t *testing.T) {
 			tt.checkResult(t, result, logs)
 
 			// Verify prompt file was written.
-			promptData, exists := provider.Files["/workspace/.143-prompt.md"]
+			promptData, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 			require.True(t, exists, "prompt file should have been written")
 			require.Contains(t, string(promptData), "Fix the bug.")
 		})
@@ -261,7 +261,7 @@ func TestClaudeCodeAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -281,7 +281,7 @@ func TestClaudeCodeAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -296,7 +296,7 @@ func TestClaudeCodeAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -327,7 +327,7 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please tighten the guard clause.",
 		MaxTokens:    50_000,
@@ -340,7 +340,7 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	require.NoError(t, err, "continuation should succeed")
 	require.NotNil(t, result, "continuation should return a result")
 	require.Contains(t, provider.ExecCalls[0], "--continue", "continuation should use Claude's continue mode")
-	_, exists := provider.Files["/workspace/.143-prompt.md"]
+	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 	require.False(t, exists, "continuation should not write a fresh prompt file")
 }
 
@@ -1129,7 +1129,7 @@ func TestCollectDiff(t *testing.T) {
 				return 0, nil
 			}
 
-			sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+			sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 			diff, err := collectDiff(context.Background(), provider, sandbox)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -81,9 +81,10 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 			)
 		}
 	} else {
-		// First turn: write prompt file and run fresh.
+		// First turn: write prompt file and run fresh. Put it under $HOME
+		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
-		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.WorkDir)
+		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
@@ -482,13 +483,13 @@ func parseCodexOutput(output []byte, result *agent.AgentResult, logCh chan<- age
 // codexItem represents a nested item inside a Codex CLI stream event
 // (used by item.started / item.completed events).
 type codexItem struct {
-	ID               string  `json:"id,omitempty"`
-	Type             string  `json:"type,omitempty"`
-	Text             string  `json:"text,omitempty"`
-	Command          string  `json:"command,omitempty"`
-	AggregatedOutput string  `json:"aggregated_output,omitempty"`
-	ExitCode         *int    `json:"exit_code,omitempty"`
-	Status           string  `json:"status,omitempty"`
+	ID               string `json:"id,omitempty"`
+	Type             string `json:"type,omitempty"`
+	Text             string `json:"text,omitempty"`
+	Command          string `json:"command,omitempty"`
+	AggregatedOutput string `json:"aggregated_output,omitempty"`
+	ExitCode         *int   `json:"exit_code,omitempty"`
+	Status           string `json:"status,omitempty"`
 }
 
 // codexStreamEvent represents a single line of Codex CLI's stream-json output.

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -650,7 +650,7 @@ func TestCodexAdapter_Execute(t *testing.T) {
 			}
 
 			adapter := NewCodexAdapter(zerolog.Nop())
-			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace"}
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
 				UserPrompt:   "Null pointer error.",
@@ -677,7 +677,7 @@ func TestCodexAdapter_Execute(t *testing.T) {
 			tt.checkResult(t, result, logs)
 
 			// Verify prompt file was written.
-			promptData, exists := provider.Files["/workspace/.143-prompt.md"]
+			promptData, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 			require.True(t, exists, "prompt file should have been written")
 			require.Contains(t, string(promptData), "Fix the bug.")
 		})
@@ -696,7 +696,7 @@ func TestCodexAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -716,7 +716,7 @@ func TestCodexAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -731,7 +731,7 @@ func TestCodexAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -762,7 +762,7 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please tighten the test case.",
 		MaxTokens:    50_000,
@@ -775,7 +775,7 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	require.NoError(t, err, "continuation should succeed without an explicit session ID")
 	require.NotNil(t, result, "continuation should return a result")
 	require.Contains(t, provider.ExecCalls[0], "codex exec resume --last --dangerously-bypass-approvals-and-sandbox", "continuation without a session ID should resume the latest restored Codex session")
-	_, exists := provider.Files["/workspace/.143-prompt.md"]
+	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 	require.False(t, exists, "continuation should not write a fresh prompt file")
 }
 
@@ -814,7 +814,6 @@ func TestIsDuplicateOutput(t *testing.T) {
 		require.False(t, isDuplicateOutput("message", "", m))
 	})
 }
-
 
 func TestParseCodexStreamLine_DeduplicatesConsecutiveOutput(t *testing.T) {
 	t.Parallel()

--- a/internal/services/agent/adapters/gemini_cli.go
+++ b/internal/services/agent/adapters/gemini_cli.go
@@ -78,9 +78,10 @@ func (a *GeminiCLIAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, 
 			)
 		}
 	} else {
-		// First turn: write prompt file and run fresh.
+		// First turn: write prompt file and run fresh. Put it under $HOME
+		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
-		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.WorkDir)
+		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}

--- a/internal/services/agent/adapters/gemini_cli_test.go
+++ b/internal/services/agent/adapters/gemini_cli_test.go
@@ -216,6 +216,7 @@ func TestGeminiCLIAdapter_Execute(t *testing.T) {
 			sandbox := &agent.Sandbox{
 				ID:      "test-sandbox",
 				WorkDir: "/workspace",
+				HomeDir: "/home/sandbox",
 			}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
@@ -244,7 +245,7 @@ func TestGeminiCLIAdapter_Execute(t *testing.T) {
 			tt.checkResult(t, result, logs)
 
 			// Verify prompt file was written.
-			promptData, exists := provider.Files["/workspace/.143-prompt.md"]
+			promptData, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 			require.True(t, exists, "prompt file should have been written")
 			require.Contains(t, string(promptData), "Fix the bug.", "prompt file should contain system prompt")
 		})
@@ -260,7 +261,7 @@ func TestGeminiCLIAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -283,7 +284,7 @@ func TestGeminiCLIAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -298,7 +299,7 @@ func TestGeminiCLIAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -649,7 +650,7 @@ func TestGeminiCLIAdapter_Execute_StreamingOutput(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{SystemPrompt: "Fix the bug.", UserPrompt: "Null pointer error.", MaxTokens: 50_000}
 
 	logCh := make(chan agent.LogEntry, 100)
@@ -699,7 +700,7 @@ func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please include a regression test.",
 		MaxTokens:    50_000,
@@ -713,7 +714,7 @@ func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *
 	require.NoError(t, err, "continuation should succeed without an explicit Gemini session ID")
 	require.NotNil(t, result, "continuation should return a result")
 	require.Contains(t, provider.ExecCalls[0], "gemini --resume", "continuation without a session ID should still use Gemini resume mode")
-	_, exists := provider.Files["/workspace/.143-prompt.md"]
+	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 	require.False(t, exists, "continuation should not write a fresh prompt file")
 }
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -733,11 +733,35 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		}
 	}
 	// Look up the session's repo to derive the same WorkDir used on the
-	// initial run (see RunAgent). Must match the original so snapshot restore
-	// lands files where the agent expects them. Best-effort: if the lookup
-	// fails we fall back to the default WorkDir and log; resume works either
-	// way because the snapshot tar uses absolute paths.
-	if slug := o.sessionRepoSlug(ctx, session); slug != "" {
+	// initial run (see RunAgent). This must match the original: the container
+	// WorkingDir and HOME are driven off WorkDir, and the snapshot tar restores
+	// files at the original absolute paths, so drifting here leaves the agent
+	// running in an empty /workspace while the checkout sits elsewhere.
+	// Treat a lookup failure as fatal — revert to idle so the user can retry.
+	slug, slugErr := o.sessionRepoSlug(ctx, session)
+	if slugErr != nil {
+		log.Error().Err(slugErr).Msg("sandbox workdir resolution failed during continue_session")
+		if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusIdle)); revertErr != nil {
+			log.Error().Err(revertErr).Msg("failed to revert session to idle after workdir resolution failure")
+		}
+		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
+			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after workdir resolution failure")
+		}
+		if o.sessionMessages != nil {
+			errMsg := &models.SessionMessage{
+				SessionID:  session.ID,
+				OrgID:      session.OrgID,
+				TurnNumber: session.CurrentTurn + 1,
+				Role:       models.MessageRoleAssistant,
+				Content:    fmt.Sprintf("Failed to resolve the sandbox workspace: %s\n\nPlease try again in a moment.", slugErr),
+			}
+			if createErr := o.sessionMessages.Create(ctx, errMsg); createErr != nil {
+				log.Error().Err(createErr).Msg("failed to create error message for workdir resolution failure")
+			}
+		}
+		return fmt.Errorf("resolve workdir: %w", slugErr)
+	}
+	if slug != "" {
 		sandboxCfg.WorkDir = sandboxCfg.HomeDir + "/" + slug
 	}
 	if _, ok := sandboxCfg.Env["HOME"]; !ok {
@@ -991,30 +1015,30 @@ func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Se
 	return issue, repoFullName, nil
 }
 
-// sessionRepoSlug returns the repo-name slug for the session's repository, or
-// an empty string if no repo is attached. Used to pick a WorkDir that matches
-// the original run's WorkDir so snapshot restores land files where the agent
-// expects them. Errors are logged and swallowed — the fallback (empty slug →
-// default WorkDir) keeps sessions recoverable when the DB is briefly flaky.
-func (o *Orchestrator) sessionRepoSlug(ctx context.Context, session *models.Session) string {
+// sessionRepoSlug returns the repo-name slug for the session's repository. The
+// returned slug drives WorkDir selection on resume and MUST match what RunAgent
+// chose originally, or the container's WorkingDir/HOME diverge from where the
+// snapshot tar restored the repo checkout. An empty slug with nil error means
+// "no repo is attached" (legitimate, falls back to default WorkDir). Any lookup
+// failure is returned as an error so the caller can surface it rather than
+// silently diverging.
+func (o *Orchestrator) sessionRepoSlug(ctx context.Context, session *models.Session) (string, error) {
 	repoID := session.RepositoryID
 	if repoID == nil {
 		issue, err := o.issues.GetByID(ctx, session.OrgID, session.IssueID)
 		if err != nil {
-			o.logger.Debug().Err(err).Str("session_id", session.ID.String()).Msg("sessionRepoSlug: fetch issue failed; falling back to default WorkDir")
-			return ""
+			return "", fmt.Errorf("fetch issue for session repo lookup: %w", err)
 		}
 		if issue.RepositoryID == nil {
-			return ""
+			return "", nil
 		}
 		repoID = issue.RepositoryID
 	}
 	repo, err := o.repositories.GetByID(ctx, session.OrgID, *repoID)
 	if err != nil {
-		o.logger.Debug().Err(err).Str("session_id", session.ID.String()).Msg("sessionRepoSlug: fetch repo failed; falling back to default WorkDir")
-		return ""
+		return "", fmt.Errorf("fetch repo for session workdir: %w", err)
 	}
-	return SlugForRepo(repo.FullName)
+	return SlugForRepo(repo.FullName), nil
 }
 
 // maxDiffCharsInPrompt is the maximum number of characters from a stored diff

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -380,10 +380,15 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	sandboxCfg.OrgID = run.OrgID.String()
 	sandboxCfg.Purpose = "agent_run"
 	sandboxCfg.Env = o.resolveAgentEnv(ctx, run.OrgID, run.AgentType, run.TriggeredByUserID)
-	// Ensure HOME points to the sandbox workdir so CLI tools (e.g. Codex
-	// resolving ~/.codex/auth.json) find files written to the workdir.
 	if sandboxCfg.Env == nil {
 		sandboxCfg.Env = make(map[string]string)
+	}
+	// Route the sandbox workdir into a repo-named subdir of HomeDir so the
+	// agent's cwd reads like `/home/sandbox/<repo>` — matching what a human
+	// would see after `git clone && cd <repo>`. Falls back to the default
+	// (/workspace) when no repo is attached.
+	if slug := SlugForRepo(repoFullName); slug != "" {
+		sandboxCfg.WorkDir = sandboxCfg.HomeDir + "/" + slug
 	}
 	// Inject GitHub token and repo info for 143-tools CLI only when the agent
 	// has integration skills (i.e. the prompt references CLI tools). This avoids
@@ -405,7 +410,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 	}
 	if _, ok := sandboxCfg.Env["HOME"]; !ok {
-		sandboxCfg.Env["HOME"] = sandboxCfg.WorkDir
+		sandboxCfg.Env["HOME"] = sandboxCfg.HomeDir
 	}
 	sandbox, err := o.provider.Create(ctx, sandboxCfg)
 	if err != nil {
@@ -727,8 +732,16 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			sandboxCfg.Env[envVar] = *session.ModelOverride
 		}
 	}
+	// Look up the session's repo to derive the same WorkDir used on the
+	// initial run (see RunAgent). Must match the original so snapshot restore
+	// lands files where the agent expects them. Best-effort: if the lookup
+	// fails we fall back to the default WorkDir and log; resume works either
+	// way because the snapshot tar uses absolute paths.
+	if slug := o.sessionRepoSlug(ctx, session); slug != "" {
+		sandboxCfg.WorkDir = sandboxCfg.HomeDir + "/" + slug
+	}
 	if _, ok := sandboxCfg.Env["HOME"]; !ok {
-		sandboxCfg.Env["HOME"] = sandboxCfg.WorkDir
+		sandboxCfg.Env["HOME"] = sandboxCfg.HomeDir
 	}
 
 	sandbox, err := o.provider.Create(ctx, sandboxCfg)
@@ -976,6 +989,32 @@ func (o *Orchestrator) setupFreshSandbox(ctx context.Context, session *models.Se
 	}
 
 	return issue, repoFullName, nil
+}
+
+// sessionRepoSlug returns the repo-name slug for the session's repository, or
+// an empty string if no repo is attached. Used to pick a WorkDir that matches
+// the original run's WorkDir so snapshot restores land files where the agent
+// expects them. Errors are logged and swallowed — the fallback (empty slug →
+// default WorkDir) keeps sessions recoverable when the DB is briefly flaky.
+func (o *Orchestrator) sessionRepoSlug(ctx context.Context, session *models.Session) string {
+	repoID := session.RepositoryID
+	if repoID == nil {
+		issue, err := o.issues.GetByID(ctx, session.OrgID, session.IssueID)
+		if err != nil {
+			o.logger.Debug().Err(err).Str("session_id", session.ID.String()).Msg("sessionRepoSlug: fetch issue failed; falling back to default WorkDir")
+			return ""
+		}
+		if issue.RepositoryID == nil {
+			return ""
+		}
+		repoID = issue.RepositoryID
+	}
+	repo, err := o.repositories.GetByID(ctx, session.OrgID, *repoID)
+	if err != nil {
+		o.logger.Debug().Err(err).Str("session_id", session.ID.String()).Msg("sessionRepoSlug: fetch repo failed; falling back to default WorkDir")
+		return ""
+	}
+	return SlugForRepo(repo.FullName)
 }
 
 // maxDiffCharsInPrompt is the maximum number of characters from a stored diff
@@ -1419,10 +1458,10 @@ func (o *Orchestrator) injectCodexAuth(ctx context.Context, orgID uuid.UUID, san
 		return false, fmt.Errorf("marshal auth.json: %w", err)
 	}
 
-	// Write auth.json under the sandbox workdir/.codex. The sandbox env
-	// sets HOME to the workdir (see RunAgent step 7) so the Codex CLI
+	// Write auth.json under $HOME/.codex. The sandbox env sets HOME to the
+	// sandbox user's home dir (see RunAgent step 7) so the Codex CLI
 	// resolves ~/.codex/auth.json to this path.
-	authDir := path.Join(sandbox.WorkDir, ".codex")
+	authDir := path.Join(sandbox.HomeDir, ".codex")
 	mkdirCmd := fmt.Sprintf("mkdir -p %s", authDir)
 
 	var mkdirOut, mkdirErr bytes.Buffer

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1005,7 +1005,7 @@ func TestRunAgent_AgentCredentialsInjected(t *testing.T) {
 	var capturedCfg agent.SandboxConfig
 	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 		capturedCfg = cfg
-		return &agent.Sandbox{ID: "env-sandbox", Provider: "mock", WorkDir: "/workspace"}, nil
+		return &agent.Sandbox{ID: "env-sandbox", Provider: "mock", WorkDir: cfg.WorkDir, HomeDir: cfg.HomeDir}, nil
 	}
 
 	d.creds = &mockCredentialProvider{
@@ -1055,7 +1055,7 @@ func TestRunAgent_NoAgentEnvForUnknownType(t *testing.T) {
 	var capturedCfg agent.SandboxConfig
 	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 		capturedCfg = cfg
-		return &agent.Sandbox{ID: "no-env-sandbox", Provider: "mock", WorkDir: "/workspace"}, nil
+		return &agent.Sandbox{ID: "no-env-sandbox", Provider: "mock", WorkDir: cfg.WorkDir, HomeDir: cfg.HomeDir}, nil
 	}
 
 	// No credential configured for "claude_code".
@@ -1083,8 +1083,8 @@ func TestRunAgent_NoAgentEnvForUnknownType(t *testing.T) {
 	// when integration skills are available (independent of agent type).
 	require.NotContains(t, capturedCfg.Env, "ANTHROPIC_API_KEY",
 		"sandbox config should not have agent-specific env for unconfigured agent type")
-	require.Equal(t, "/workspace", capturedCfg.Env["HOME"],
-		"HOME should always be set")
+	require.Equal(t, "/home/sandbox", capturedCfg.Env["HOME"],
+		"HOME should always be set to the sandbox user's home dir")
 }
 
 func TestRunAgent_CodexUsesAuthJsonNotEnvVar(t *testing.T) {
@@ -1108,7 +1108,7 @@ func TestRunAgent_CodexUsesAuthJsonNotEnvVar(t *testing.T) {
 	var capturedCfg agent.SandboxConfig
 	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 		capturedCfg = cfg
-		return &agent.Sandbox{ID: "codex-oauth", Provider: "mock", WorkDir: "/workspace"}, nil
+		return &agent.Sandbox{ID: "codex-oauth", Provider: "mock", WorkDir: cfg.WorkDir, HomeDir: cfg.HomeDir}, nil
 	}
 
 	orch := buildOrchestrator(d)
@@ -1120,7 +1120,7 @@ func TestRunAgent_CodexUsesAuthJsonNotEnvVar(t *testing.T) {
 	require.Empty(t, capturedCfg.Env["CODEX_API_KEY"], "CODEX_API_KEY should not be set as env var")
 
 	// Instead, the token should be injected via auth.json.
-	authData, ok := d.provider.Files["/workspace/.codex/auth.json"]
+	authData, ok := d.provider.Files["/home/sandbox/.codex/auth.json"]
 	require.True(t, ok, "auth.json should be written to sandbox")
 	var authJSON map[string]interface{}
 	require.NoError(t, json.Unmarshal(authData, &authJSON))
@@ -1181,12 +1181,12 @@ func TestRunAgent_CodexAuthWritesToSandboxWorkdir(t *testing.T) {
 	require.Contains(
 		t,
 		d.provider.ExecCalls,
-		"mkdir -p /workspace/.codex",
-		"codex auth setup should create the auth directory inside the writable sandbox workdir",
+		"mkdir -p /home/sandbox/.codex",
+		"codex auth setup should create the auth directory under the sandbox user's home",
 	)
 
-	authData, ok := d.provider.Files["/workspace/.codex/auth.json"]
-	require.True(t, ok, "codex auth injection should write auth.json under /workspace/.codex")
+	authData, ok := d.provider.Files["/home/sandbox/.codex/auth.json"]
+	require.True(t, ok, "codex auth injection should write auth.json under /home/sandbox/.codex")
 
 	var authJSON map[string]interface{}
 	unmarshalErr := json.Unmarshal(authData, &authJSON)
@@ -1246,14 +1246,14 @@ func TestRunAgent_CodexSandboxHasHomeEnv(t *testing.T) {
 	var capturedCfg agent.SandboxConfig
 	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 		capturedCfg = cfg
-		return &agent.Sandbox{ID: "test-sandbox", WorkDir: cfg.WorkDir}, nil
+		return &agent.Sandbox{ID: "test-sandbox", WorkDir: cfg.WorkDir, HomeDir: cfg.HomeDir}, nil
 	}
 
 	orch := buildOrchestrator(d)
 	_ = orch.RunAgent(context.Background(), run)
 
-	require.Equal(t, "/workspace", capturedCfg.Env["HOME"],
-		"sandbox env should set HOME to the workdir so Codex CLI finds ~/.codex/auth.json")
+	require.Equal(t, "/home/sandbox", capturedCfg.Env["HOME"],
+		"sandbox env should set HOME to the sandbox user's home so Codex CLI finds ~/.codex/auth.json")
 }
 
 func TestRunAgent_IssueWithoutRepository(t *testing.T) {
@@ -1506,7 +1506,7 @@ func TestRunAgent_CodexAuthInjectsTokenFromGetValidToken(t *testing.T) {
 	err := orch.RunAgent(context.Background(), run)
 	require.NoError(t, err)
 
-	authData, ok := d.provider.Files["/workspace/.codex/auth.json"]
+	authData, ok := d.provider.Files["/home/sandbox/.codex/auth.json"]
 	require.True(t, ok, "auth.json should be written to sandbox")
 	var authJSON map[string]interface{}
 	require.NoError(t, json.Unmarshal(authData, &authJSON))
@@ -1621,4 +1621,3 @@ func TestRunAgent_CancelWithoutSnapshotMarksCancelled(t *testing.T) {
 	turnUpdates := d.sessions.getTurnUpdates()
 	require.Empty(t, turnUpdates, "cancelled session without snapshot should not have turn updates")
 }
-

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1391,6 +1391,110 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Equal(t, 2, messages[1].TurnNumber, "assistant reply should use the new turn number")
 }
 
+// TestContinueSession_SessionRepoSlug drives ContinueSession through the
+// sessionRepoSlug fallback branches by capturing the WorkDir passed to
+// provider.Create. Create is forced to fail so the test doesn't need a full
+// snapshot/restore harness; the relevant code runs before Create is invoked.
+func TestContinueSession_SessionRepoSlug(t *testing.T) {
+	t.Parallel()
+
+	const defaultWorkDir = "/workspace"
+	const slugWorkDir = "/home/sandbox/backend"
+
+	type tc struct {
+		name         string
+		prepSession  func(s *models.Session)
+		prepDeps     func(d testDeps)
+		wantWorkDir  string
+		wantErrMatch string
+	}
+
+	cases := []tc{
+		{
+			name: "session without repo falls back to issue's repo",
+			prepSession: func(s *models.Session) {
+				s.RepositoryID = nil
+			},
+			prepDeps:     func(d testDeps) {},
+			wantWorkDir:  slugWorkDir,
+			wantErrMatch: "create sandbox",
+		},
+		{
+			name: "session without repo and issue fetch fails falls back to default",
+			prepSession: func(s *models.Session) {
+				s.RepositoryID = nil
+			},
+			prepDeps: func(d testDeps) {
+				d.issues.err = errors.New("boom")
+			},
+			wantWorkDir:  defaultWorkDir,
+			wantErrMatch: "create sandbox",
+		},
+		{
+			name: "session without repo and issue has no repo falls back to default",
+			prepSession: func(s *models.Session) {
+				s.RepositoryID = nil
+			},
+			prepDeps: func(d testDeps) {
+				issue := d.issues.issue
+				issue.RepositoryID = nil
+				d.issues.issue = issue
+			},
+			wantWorkDir:  defaultWorkDir,
+			wantErrMatch: "create sandbox",
+		},
+		{
+			name:        "repo fetch fails falls back to default",
+			prepSession: func(s *models.Session) {},
+			prepDeps: func(d testDeps) {
+				d.repos.err = errors.New("boom")
+			},
+			wantWorkDir:  defaultWorkDir,
+			wantErrMatch: "create sandbox",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := testOrg()
+			issue := testIssue(orgID)
+			session := testRun(orgID, issue.ID)
+			session.Status = string(models.SessionStatusIdle)
+			session.CurrentTurn = 1
+			c.prepSession(session)
+
+			d := defaultDeps()
+			// mockIssueStore / mockRepositoryStore are value-holders; update in place.
+			d.issues.issue = issue
+			c.prepDeps(d)
+
+			// Pre-populate a user message so ContinueSession reaches the Create call.
+			d.messages.messages = []models.SessionMessage{{
+				ID:         1,
+				SessionID:  session.ID,
+				OrgID:      orgID,
+				TurnNumber: 2,
+				Role:       models.MessageRoleUser,
+				Content:    "continue please",
+			}}
+
+			var gotWorkDir string
+			d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+				gotWorkDir = cfg.WorkDir
+				return nil, errors.New("forced create failure to short-circuit test")
+			}
+
+			orch := buildOrchestrator(d)
+			err := orch.ContinueSession(context.Background(), session)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), c.wantErrMatch)
+			require.Equal(t, c.wantWorkDir, gotWorkDir, "sessionRepoSlug should drive WorkDir selection")
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // WithSandboxProvider / SandboxProviderFromContext
 // ---------------------------------------------------------------------------

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1391,10 +1391,21 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Equal(t, 2, messages[1].TurnNumber, "assistant reply should use the new turn number")
 }
 
-// TestContinueSession_SessionRepoSlug drives ContinueSession through the
-// sessionRepoSlug fallback branches by capturing the WorkDir passed to
-// provider.Create. Create is forced to fail so the test doesn't need a full
-// snapshot/restore harness; the relevant code runs before Create is invoked.
+// errForcedCreateFailure is used by tests that short-circuit provider.Create so
+// the test can inspect the SandboxConfig without running the full sandbox
+// lifecycle. Named so grep picks it up and future refactors don't silently
+// change behavior if Create's call site moves.
+var errForcedCreateFailure = errors.New("forced create failure to short-circuit test")
+
+// TestContinueSession_SessionRepoSlug exercises every branch of
+// sessionRepoSlug through ContinueSession.
+//   - The two "happy" branches (session.RepositoryID set; issue.RepositoryID
+//     set) must produce the slug-derived WorkDir and then fail at provider.Create.
+//   - The "no repo at all" branch (issue.RepositoryID == nil) must fall back to
+//     the default WorkDir and fail at Create.
+//   - Both lookup-failure branches must hard-fail (resolve workdir error) WITHOUT
+//     ever calling Create — otherwise we'd risk running the agent in /workspace
+//     while the snapshot tar restored files under /home/sandbox/<slug>.
 func TestContinueSession_SessionRepoSlug(t *testing.T) {
 	t.Parallel()
 
@@ -1405,11 +1416,18 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 		name         string
 		prepSession  func(s *models.Session)
 		prepDeps     func(d testDeps)
-		wantWorkDir  string
+		wantWorkDir  string // "" means Create must not be invoked
 		wantErrMatch string
 	}
 
 	cases := []tc{
+		{
+			name:         "session with repo uses slug-derived workdir",
+			prepSession:  func(s *models.Session) {},
+			prepDeps:     func(d testDeps) {},
+			wantWorkDir:  slugWorkDir,
+			wantErrMatch: "create sandbox",
+		},
 		{
 			name: "session without repo falls back to issue's repo",
 			prepSession: func(s *models.Session) {
@@ -1420,18 +1438,7 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 			wantErrMatch: "create sandbox",
 		},
 		{
-			name: "session without repo and issue fetch fails falls back to default",
-			prepSession: func(s *models.Session) {
-				s.RepositoryID = nil
-			},
-			prepDeps: func(d testDeps) {
-				d.issues.err = errors.New("boom")
-			},
-			wantWorkDir:  defaultWorkDir,
-			wantErrMatch: "create sandbox",
-		},
-		{
-			name: "session without repo and issue has no repo falls back to default",
+			name: "session and issue both without repo use default workdir",
 			prepSession: func(s *models.Session) {
 				s.RepositoryID = nil
 			},
@@ -1444,17 +1451,29 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 			wantErrMatch: "create sandbox",
 		},
 		{
-			name:        "repo fetch fails falls back to default",
+			name: "issue fetch failure hard-fails resume",
+			prepSession: func(s *models.Session) {
+				s.RepositoryID = nil
+			},
+			prepDeps: func(d testDeps) {
+				d.issues.err = errors.New("db flaky")
+			},
+			wantWorkDir:  "",
+			wantErrMatch: "resolve workdir",
+		},
+		{
+			name:        "repo fetch failure hard-fails resume",
 			prepSession: func(s *models.Session) {},
 			prepDeps: func(d testDeps) {
-				d.repos.err = errors.New("boom")
+				d.repos.err = errors.New("db flaky")
 			},
-			wantWorkDir:  defaultWorkDir,
-			wantErrMatch: "create sandbox",
+			wantWorkDir:  "",
+			wantErrMatch: "resolve workdir",
 		},
 	}
 
 	for _, c := range cases {
+		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1481,15 +1500,22 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 			}}
 
 			var gotWorkDir string
+			var createCalls int
 			d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+				createCalls++
 				gotWorkDir = cfg.WorkDir
-				return nil, errors.New("forced create failure to short-circuit test")
+				return nil, errForcedCreateFailure
 			}
 
 			orch := buildOrchestrator(d)
 			err := orch.ContinueSession(context.Background(), session)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), c.wantErrMatch)
+			if c.wantWorkDir == "" {
+				require.Zero(t, createCalls, "resume must not create a sandbox when repo lookup fails")
+				return
+			}
+			require.Equal(t, 1, createCalls, "Create should be called exactly once when workdir resolution succeeds")
 			require.Equal(t, c.wantWorkDir, gotWorkDir, "sessionRepoSlug should drive WorkDir selection")
 		})
 	}

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -393,7 +393,13 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		if removeErr != nil {
 			log.Error().Err(removeErr).Str("container_id", resp.ID).Msg("failed to remove container after bootstrap failure")
 		}
-		return nil, fmt.Errorf("bootstrap workdir (exit %d): %w: %s", code, err, bootErr.String())
+		// Split the error construction so %w only wraps a non-nil error.
+		// When the exec itself succeeds but the command returns a non-zero
+		// exit code, err is nil and we surface only the exit code + stderr.
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap workdir (exit %d): %w: %s", code, err, bootErr.String())
+		}
+		return nil, fmt.Errorf("bootstrap workdir (exit %d): %s", code, bootErr.String())
 	}
 
 	return sb, nil

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -25,12 +25,14 @@ import (
 // Compile-time check that DockerProvider implements agent.SandboxProvider.
 var _ agent.SandboxProvider = (*DockerProvider)(nil)
 
-// defaultGoTmpDir is the default value injected into $GOTMPDIR for sandbox
-// containers. /tmp is mounted noexec, which breaks `go test` / `go run`
-// because Go compiles binaries to $GOTMPDIR and execs them; /var/tmp lives
-// on the writable+exec rootfs, so redirecting there fixes this without
-// weakening the /tmp hardening.
-const defaultGoTmpDir = "/var/tmp"
+// defaultScratchDir is the exec-allowed scratch dir injected as $TMPDIR (and
+// $GOTMPDIR) for sandbox containers. /tmp is mounted noexec for defense in
+// depth, which breaks any tool that compiles a binary into its tempdir and
+// execs it (most famously `go test` / `go run`, but the same pattern shows up
+// in pytest-xdist, native-extension installers, etc.). /var/tmp is mounted as
+// a separate writable+exec tmpfs so well-behaved tooling has a place to work
+// without weakening the /tmp hardening.
+const defaultScratchDir = "/var/tmp"
 
 // DockerClient defines the subset of the Docker API used by DockerProvider.
 type DockerClient interface {
@@ -266,9 +268,14 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	for k, v := range cfg.Env {
 		envSlice = append(envSlice, k+"="+v)
 	}
-	// See defaultGoTmpDir for why this env var is injected.
+	// Point TMPDIR at the exec-allowed scratch tmpfs (see defaultScratchDir)
+	// so well-behaved tools don't trip over the noexec /tmp. GOTMPDIR is kept
+	// as belt-and-suspenders in case a caller overrides TMPDIR.
+	if _, ok := cfg.Env["TMPDIR"]; !ok {
+		envSlice = append(envSlice, "TMPDIR="+defaultScratchDir)
+	}
 	if _, ok := cfg.Env["GOTMPDIR"]; !ok {
-		envSlice = append(envSlice, "GOTMPDIR="+defaultGoTmpDir)
+		envSlice = append(envSlice, "GOTMPDIR="+defaultScratchDir)
 	}
 
 	containerCfg := &container.Config{
@@ -293,7 +300,12 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		CapAdd:         []string{"SETUID", "SETGID", "DAC_OVERRIDE"}, // minimum caps for sudo
 		ReadonlyRootfs: false,
 		Tmpfs: map[string]string{
-			"/tmp": "rw,noexec,nosuid,size=1073741824",
+			// /tmp is hardened (noexec,nosuid) so exploits can't drop a binary
+			// and run it. /var/tmp is the exec-allowed scratch dir for tools
+			// that need to compile and exec in their tempdir; TMPDIR points
+			// here by default (see defaultScratchDir).
+			"/tmp":     "rw,noexec,nosuid,size=1073741824",
+			"/var/tmp": "rw,exec,nosuid,size=1073741824",
 		},
 	}
 
@@ -351,10 +363,11 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		Str("container_id", resp.ID).
 		Msg("sandbox container started")
 
-	return &agent.Sandbox{
+	sb := &agent.Sandbox{
 		ID:       resp.ID,
 		Provider: "docker",
 		WorkDir:  cfg.WorkDir,
+		HomeDir:  cfg.HomeDir,
 		Metadata: map[string]string{
 			"runtime": d.runtime,
 			"network": d.network,
@@ -362,7 +375,28 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		SessionID: cfg.SessionID,
 		OrgID:     cfg.OrgID,
 		Purpose:   cfg.Purpose,
-	}, nil
+	}
+
+	// Bootstrap WorkDir: Docker creates a missing WorkingDir as root, so the
+	// sandbox user can't write to it (e.g. git clone). We mkdir -p + chown
+	// idempotently so the case where WorkDir already exists (e.g. /workspace
+	// baked into the image) is a harmless no-op too. Run with WorkDir="/" so
+	// the exec's own cwd doesn't race with creation.
+	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
+	bootstrapCmd := fmt.Sprintf(
+		"sudo mkdir -p %s && sudo chown sandbox:sandbox %s",
+		shellEscape(cfg.WorkDir), shellEscape(cfg.WorkDir),
+	)
+	var bootErr bytes.Buffer
+	if code, err := d.Exec(ctx, bootstrapSB, bootstrapCmd, io.Discard, &bootErr); err != nil || code != 0 {
+		removeErr := d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
+		if removeErr != nil {
+			log.Error().Err(removeErr).Str("container_id", resp.ID).Msg("failed to remove container after bootstrap failure")
+		}
+		return nil, fmt.Errorf("bootstrap workdir (exit %d): %w: %s", code, err, bootErr.String())
+	}
+
+	return sb, nil
 }
 
 // CloneRepo clones a repository into the sandbox's workspace using git.
@@ -378,7 +412,11 @@ func (d *DockerProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoU
 		authURL = strings.Replace(repoURL, "https://", fmt.Sprintf("https://x-access-token:%s@", token), 1)
 	}
 
-	cmd := fmt.Sprintf("git clone --depth 1 --branch '%s' '%s' '%s'",
+	// Partial clone (--filter=blob:none) keeps the full commit graph so agents
+	// can use `git log`, `git blame`, `git show <sha>` to understand history,
+	// while deferring blob downloads to first access. Setup cost is similar
+	// to --depth 1 but unlocks history-based reasoning.
+	cmd := fmt.Sprintf("git clone --filter=blob:none --branch '%s' '%s' '%s'",
 		shellEscape(branch), shellEscape(authURL), shellEscape(sb.WorkDir))
 	var stderr bytes.Buffer
 	exitCode, err := d.Exec(ctx, sb, cmd, io.Discard, &stderr)
@@ -532,12 +570,13 @@ func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.Re
 		Msg("snapshotting sandbox")
 
 	// Tar workspace + agent state dirs. --ignore-failed-read handles missing dirs gracefully.
-	// Agent state dirs (e.g. .claude/, .codex/, .gemini/) live under WorkDir since
-	// HOME is set to WorkDir in the sandbox config.
+	// Agent state dirs (.claude/, .codex/, .gemini/) live under HomeDir, not WorkDir —
+	// HOME is set to the sandbox user's home so CLI configs resolve there.
 	workDirRel := strings.TrimPrefix(sb.WorkDir, "/")
+	homeDirRel := strings.TrimPrefix(sb.HomeDir, "/")
 	cmd := fmt.Sprintf(
 		"tar czf - --ignore-failed-read -C / '%s' '%s/.claude' '%s/.codex' '%s/.gemini' 2>/dev/null",
-		workDirRel, workDirRel, workDirRel, workDirRel,
+		workDirRel, homeDirRel, homeDirRel, homeDirRel,
 	)
 
 	execCfg := container.ExecOptions{

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -384,7 +384,7 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// the exec's own cwd doesn't race with creation.
 	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
 	bootstrapCmd := fmt.Sprintf(
-		"sudo mkdir -p %s && sudo chown sandbox:sandbox %s",
+		"sudo mkdir -p '%s' && sudo chown sandbox:sandbox '%s'",
 		shellEscape(cfg.WorkDir), shellEscape(cfg.WorkDir),
 	)
 	var bootErr bytes.Buffer

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"strings"
 	"testing"
@@ -668,6 +669,35 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, "agent_run", sb.Purpose, "Purpose should be copied from config")
 	})
 
+	t.Run("cleans up on bootstrap workdir failure", func(t *testing.T) {
+		t.Parallel()
+
+		var removedID string
+		var removeForce bool
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			return container.CreateResponse{ID: "bootstrap-fail"}, nil
+		}
+		// ContainerStart succeeds (default). Bootstrap exec runs, but inspect
+		// reports a non-zero exit code so the bootstrap branch in Create trips.
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{ExitCode: 1}, nil
+		}
+		mock.containerRemoveFn = func(ctx context.Context, containerID string, options container.RemoveOptions) error {
+			removedID = containerID
+			removeForce = options.Force
+			return nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		_, err := p.Create(context.Background(), agent.DefaultSandboxConfig())
+		require.Error(t, err, "Create should return an error when bootstrap fails")
+		require.Contains(t, err.Error(), "bootstrap workdir", "error should identify bootstrap failure")
+		require.Equal(t, "bootstrap-fail", removedID, "should force-remove the container after bootstrap failure")
+		require.True(t, removeForce, "bootstrap failure cleanup should force-remove")
+	})
+
 	t.Run("configLogger tolerates partial tracing fields", func(t *testing.T) {
 		t.Parallel()
 
@@ -738,6 +768,44 @@ func TestDockerProvider_ScopedLogger(t *testing.T) {
 
 		err := p.Destroy(context.Background(), sb)
 		require.NoError(t, err)
+	})
+}
+
+func TestDockerProvider_Snapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tars workdir plus agent state dirs under HomeDir", func(t *testing.T) {
+		t.Parallel()
+
+		var gotCmd []string
+
+		mock := &mockDockerClient{}
+		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+			gotCmd = config.Cmd
+			return container.ExecCreateResponse{ID: "snap-exec"}, nil
+		}
+		// Default attach returns empty data; stdcopy returns EOF and the pipe
+		// closes cleanly without blocking the test.
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{
+			ID:       "snap-container",
+			Provider: "docker",
+			WorkDir:  "/home/sandbox/backend",
+			HomeDir:  "/home/sandbox",
+		}
+
+		rc, err := p.Snapshot(context.Background(), sb)
+		require.NoError(t, err)
+		require.NotNil(t, rc)
+		_, _ = io.Copy(io.Discard, rc)
+		_ = rc.Close()
+
+		require.Len(t, gotCmd, 3, "Snapshot exec should be sh -c <cmd>")
+		tarCmd := gotCmd[2]
+		require.Contains(t, tarCmd, "'home/sandbox/backend'", "tar should include the WorkDir relative path")
+		require.Contains(t, tarCmd, "'home/sandbox/.claude'", "tar should include the .claude dir under HomeDir")
+		require.Contains(t, tarCmd, "'home/sandbox/.codex'", "tar should include the .codex dir under HomeDir")
+		require.Contains(t, tarCmd, "'home/sandbox/.gemini'", "tar should include the .gemini dir under HomeDir")
 	})
 }
 

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -416,12 +416,16 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Empty(t, capturedHostConfig.SecurityOpt, "container should not set security options (no-new-privileges blocks sudo)")
 		require.False(t, capturedHostConfig.ReadonlyRootfs, "container should have writable rootfs for package installation")
 		require.Contains(t, capturedHostConfig.Tmpfs, "/tmp", "container should have tmpfs at /tmp")
+		require.Contains(t, capturedHostConfig.Tmpfs, "/var/tmp", "container should have exec-allowed tmpfs at /var/tmp for scratch binaries")
 		require.NotContains(t, capturedHostConfig.Tmpfs, "/workspace", "workspace should not be a tmpfs (lives on writable rootfs)")
 		require.Equal(t, "10G", capturedHostConfig.StorageOpt["size"], "container should have 10GB disk quota")
 
 		// Verify tmpfs mount options
 		require.Contains(t, capturedHostConfig.Tmpfs["/tmp"], "noexec", "/tmp tmpfs should be noexec")
-		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
+		require.Contains(t, capturedHostConfig.Tmpfs["/var/tmp"], "exec", "/var/tmp tmpfs should allow exec so `go test` can run compiled binaries")
+		require.Contains(t, capturedConfig.Env, "TMPDIR="+defaultScratchDir,
+			"TMPDIR must be redirected off /tmp so tools writing executables to tempdir can exec them")
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultScratchDir,
 			"GOTMPDIR must be redirected off /tmp so `go test` can exec compiled test binaries")
 
 		// Verify resource limits
@@ -508,7 +512,9 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		require.Contains(t, capturedConfig.Env, "ANTHROPIC_API_KEY=sk-ant-test-key")
 		require.Contains(t, capturedConfig.Env, "OPENAI_API_KEY=sk-test-openai-key")
-		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
+		require.Contains(t, capturedConfig.Env, "TMPDIR="+defaultScratchDir,
+			"TMPDIR should be injected so tools dropping executables in tempdir can exec them")
+		require.Contains(t, capturedConfig.Env, "GOTMPDIR="+defaultScratchDir,
 			"GOTMPDIR should be injected so `go test` works despite /tmp being noexec")
 	})
 
@@ -529,8 +535,29 @@ func TestDockerProvider_Create(t *testing.T) {
 		_, err := p.Create(context.Background(), cfg)
 		require.NoError(t, err)
 		require.Contains(t, capturedConfig.Env, "GOTMPDIR=/workspace/.gotmp")
-		require.NotContains(t, capturedConfig.Env, "GOTMPDIR="+defaultGoTmpDir,
+		require.NotContains(t, capturedConfig.Env, "GOTMPDIR="+defaultScratchDir,
 			"caller-supplied GOTMPDIR should not be overridden")
+	})
+
+	t.Run("preserves caller-supplied TMPDIR override", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedConfig *container.Config
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			capturedConfig = config
+			return container.CreateResponse{ID: "tmpdir-override"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		cfg := agent.DefaultSandboxConfig()
+		cfg.Env = map[string]string{"TMPDIR": "/workspace/.tmp"}
+		_, err := p.Create(context.Background(), cfg)
+		require.NoError(t, err)
+		require.Contains(t, capturedConfig.Env, "TMPDIR=/workspace/.tmp")
+		require.NotContains(t, capturedConfig.Env, "TMPDIR="+defaultScratchDir,
+			"caller-supplied TMPDIR should not be overridden")
 	})
 
 	t.Run("handles nil env map gracefully", func(t *testing.T) {
@@ -550,8 +577,8 @@ func TestDockerProvider_Create(t *testing.T) {
 		sb, err := p.Create(context.Background(), cfg)
 		require.NoError(t, err)
 		require.Equal(t, "no-env", sb.ID)
-		require.ElementsMatch(t, []string{"GOTMPDIR=" + defaultGoTmpDir}, capturedConfig.Env,
-			"with nil cfg.Env, only the auto-injected GOTMPDIR should be present")
+		require.ElementsMatch(t, []string{"TMPDIR=" + defaultScratchDir, "GOTMPDIR=" + defaultScratchDir}, capturedConfig.Env,
+			"with nil cfg.Env, only the auto-injected TMPDIR/GOTMPDIR should be present")
 	})
 
 	t.Run("bind-mounts resolv.conf and clears DNS when WithResolvConf is set", func(t *testing.T) {
@@ -1235,7 +1262,7 @@ func TestDockerProvider_CloneRepo(t *testing.T) {
 
 		cloneCmd := capturedCmds[0]
 		require.Contains(t, cloneCmd, "git clone", "should run git clone command")
-		require.Contains(t, cloneCmd, "--depth 1", "should do shallow clone")
+		require.Contains(t, cloneCmd, "--filter=blob:none", "should do partial clone so history is preserved")
 		require.Contains(t, cloneCmd, "--branch 'main'", "should clone the specified branch")
 		require.Contains(t, cloneCmd, "x-access-token:ghp_test123@", "should include auth token in URL")
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -14,20 +14,20 @@ import (
 // MockSandboxProvider is a configurable mock for agent.SandboxProvider.
 // Set the function fields to control behavior in tests.
 type MockSandboxProvider struct {
-	Name_          string
-	CreateFn       func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error)
-	CloneRepoFn    func(ctx context.Context, sb *agent.Sandbox, repoURL, branch, token string) error
-	ExecFn         func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error)
-	ExecStreamFn   func(ctx context.Context, sb *agent.Sandbox, cmd string, onLine func(line []byte), stderr io.Writer) (int, error)
-	ReadFileFn     func(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error)
-	WriteFileFn    func(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error
-	DestroyFn      func(ctx context.Context, sb *agent.Sandbox) error
-	ConnInfoFn     func(ctx context.Context, sb *agent.Sandbox) (*agent.SandboxConnectionInfo, error)
-	SnapshotFn     func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error)
-	RestoreFn      func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error
+	Name_        string
+	CreateFn     func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error)
+	CloneRepoFn  func(ctx context.Context, sb *agent.Sandbox, repoURL, branch, token string) error
+	ExecFn       func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error)
+	ExecStreamFn func(ctx context.Context, sb *agent.Sandbox, cmd string, onLine func(line []byte), stderr io.Writer) (int, error)
+	ReadFileFn   func(ctx context.Context, sb *agent.Sandbox, path string) ([]byte, error)
+	WriteFileFn  func(ctx context.Context, sb *agent.Sandbox, path string, data []byte) error
+	DestroyFn    func(ctx context.Context, sb *agent.Sandbox) error
+	ConnInfoFn   func(ctx context.Context, sb *agent.Sandbox) (*agent.SandboxConnectionInfo, error)
+	SnapshotFn   func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error)
+	RestoreFn    func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error
 
-	Files        map[string][]byte
-	ExecCalls    []string
+	Files     map[string][]byte
+	ExecCalls []string
 
 	mu           sync.Mutex
 	destroyCalls int
@@ -47,7 +47,7 @@ func (m *MockSandboxProvider) Create(ctx context.Context, cfg agent.SandboxConfi
 	if m.CreateFn != nil {
 		return m.CreateFn(ctx, cfg)
 	}
-	return &agent.Sandbox{ID: "test-sandbox", Provider: m.Name_, WorkDir: "/workspace"}, nil
+	return &agent.Sandbox{ID: "test-sandbox", Provider: m.Name_, WorkDir: cfg.WorkDir, HomeDir: cfg.HomeDir}, nil
 }
 
 func (m *MockSandboxProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoURL, branch, token string) error {

--- a/internal/testutil/mocks_test.go
+++ b/internal/testutil/mocks_test.go
@@ -1,0 +1,24 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+func TestMockSandboxProvider_CreateDefaultReturnsConfiguredDirs(t *testing.T) {
+	t.Parallel()
+
+	m := NewMockSandboxProvider()
+	cfg := agent.SandboxConfig{WorkDir: "/home/sandbox/backend", HomeDir: "/home/sandbox"}
+
+	sb, err := m.Create(context.Background(), cfg)
+	require.NoError(t, err)
+	require.Equal(t, "test-sandbox", sb.ID)
+	require.Equal(t, "mock", sb.Provider)
+	require.Equal(t, cfg.WorkDir, sb.WorkDir, "default Create should propagate WorkDir from cfg")
+	require.Equal(t, cfg.HomeDir, sb.HomeDir, "default Create should propagate HomeDir from cfg")
+}


### PR DESCRIPTION
## Summary

- Separates the sandbox user's `$HOME` (`/home/sandbox`) from the repo checkout so agent config (`.claude`, `.codex`, `.gemini`) no longer lives inside the git working tree, and clones the repo into `/home/sandbox/<repo-slug>` — matching what a developer sees after `git clone && cd <repo>` locally. Snapshot/Restore is updated to capture both paths so auth persists across session restores.
- Switches the clone from `--depth 1` to `--filter=blob:none`, giving agents full commit history for `git log`/`git blame` without pulling every blob upfront.
- Adds a second exec-allowed tmpfs at `/var/tmp` (1 GB, `rw,exec,nosuid`) and injects `TMPDIR` + `GOTMPDIR` pointing at it, so tools that write executables to the temp dir (`go test`, build tooling) work while `/tmp` stays `noexec`.

## Test plan

- [ ] Kick off a new session and confirm agents open in `/home/sandbox/<repo-slug>` with config visible at `~/.codex`, `~/.claude`, `~/.gemini`.
- [ ] Run `go test ./...` inside a sandbox and verify it succeeds (exec tempdir).
- [ ] Suspend + resume a session and confirm auth state survives the snapshot/restore round-trip.

Generated with [Claude Code](https://claude.com/claude-code)
