### PR TITLE
Fix claude CLI invocation: drop non-existent --max-tokens/--prompt flags

### DIFF
--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -90,23 +90,23 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	var cmd string
 	if prompt.Continuation {
 		// Subsequent turn: resume the latest session with --continue.
+		// The prompt is a positional argument to --print.
 		msg := shellEscapeDouble(prompt.UserMessage)
 		cmd = fmt.Sprintf(
-			"claude --print --output-format stream-json --continue --max-tokens %d --prompt \"%s\"",
-			prompt.MaxTokens,
+			"claude --print --output-format stream-json --continue \"%s\"",
 			msg,
 		)
 	} else {
-		// First turn: write prompt file and run fresh. Put it under $HOME
-		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
+		// First turn: write prompt file under $HOME (not WorkDir so it
+		// doesn't pollute the cloned repo's git status) and pipe it into
+		// claude via stdin.
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
 		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"claude --print --output-format stream-json --max-tokens %d --prompt-file %s",
-			prompt.MaxTokens,
+			"claude --print --output-format stream-json < %s",
 			promptPath,
 		)
 	}


### PR DESCRIPTION
## Summary
- The Claude Code CLI has no `--max-tokens`, `--prompt`, or `--prompt-file` flags, so every `claude_code` session (including the PM agent) failed immediately with `error: unknown option '--max-tokens'`.
- Downstream, the PM plan parser then failed with `pm plan tags not found` because nothing was ever produced on stdout.
- Now the first turn pipes the prompt file into `claude` via stdin redirect, and continuations pass the message as a positional argument to `--print`.

## Test plan
- [x] `go test ./internal/services/agent/adapters/...`
- [x] `go test ./internal/services/pm/...`
- [ ] Kick off a PM run end-to-end and confirm the "PM Analysis" session produces a valid `<pm-plan>` block instead of the two errors in the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)