### PR TITLE
Bootstrap sandbox workdir as root via exec API instead of sudo

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -250,7 +250,10 @@ func (d *DockerProvider) configLogger(cfg agent.SandboxConfig) zerolog.Logger {
 
 // Create spins up a new Docker container with the given resource limits and
 // security hardening (dropped capabilities, gVisor runtime, non-root user).
-// The rootfs is writable so agents can install packages via sudo apt-get.
+// The rootfs is writable so the orchestrator can seed per-session state via
+// docker exec User="root" (see bootstrap below). Runtime apt-get is not
+// supported — every dependency is baked into the sandbox image — because
+// sudo's setuid bit is stripped under gVisor / nosuid mounts.
 func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 	log := d.configLogger(cfg)
 	log.Info().
@@ -295,9 +298,13 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 			Memory:    int64(cfg.MemoryLimitMB) * 1024 * 1024,
 			PidsLimit: &pidsLimit,
 		},
-		NetworkMode:    container.NetworkMode(d.network),
-		CapDrop:        []string{"ALL"},
-		CapAdd:         []string{"SETUID", "SETGID", "DAC_OVERRIDE"}, // minimum caps for sudo
+		NetworkMode: container.NetworkMode(d.network),
+		CapDrop:     []string{"ALL"},
+		// No CapAdd: sudo was removed from the sandbox image (setuid bits
+		// are stripped under gVisor / nosuid), and bootstrap provisioning
+		// runs via docker exec User="root", which doesn't need container
+		// capabilities. Keeping the cap set empty shrinks the attack
+		// surface for any agent code that escapes into the sandbox.
 		ReadonlyRootfs: false,
 		Tmpfs: map[string]string{
 			// /tmp is hardened (noexec,nosuid) so exploits can't drop a binary

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -382,13 +382,20 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// idempotently so the case where WorkDir already exists (e.g. /workspace
 	// baked into the image) is a harmless no-op too. Run with WorkDir="/" so
 	// the exec's own cwd doesn't race with creation.
+	//
+	// Invoke docker exec with User="root" rather than prefixing `sudo`: sudo
+	// relies on its setuid bit, which the kernel strips under gVisor (and
+	// under no-new-privileges, userns-remap, or any nosuid mount), yielding
+	// "sudo: effective uid is not 0, is /usr/bin/sudo on a file system with
+	// the 'nosuid' option set". The exec API sets the uid via the runtime's
+	// control plane, so no setuid is involved.
 	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
 	bootstrapCmd := fmt.Sprintf(
-		"sudo mkdir -p '%s' && sudo chown sandbox:sandbox '%s'",
+		"mkdir -p '%s' && chown sandbox:sandbox '%s'",
 		shellEscape(cfg.WorkDir), shellEscape(cfg.WorkDir),
 	)
 	var bootErr bytes.Buffer
-	if code, err := d.Exec(ctx, bootstrapSB, bootstrapCmd, io.Discard, &bootErr); err != nil || code != 0 {
+	if code, err := d.execAs(ctx, bootstrapSB, "root", bootstrapCmd, io.Discard, &bootErr); err != nil || code != 0 {
 		removeErr := d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		if removeErr != nil {
 			log.Error().Err(removeErr).Str("container_id", resp.ID).Msg("failed to remove container after bootstrap failure")
@@ -460,12 +467,23 @@ func (d *DockerProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoU
 // Exec runs a command inside the sandbox container and streams output to the
 // provided writers. Returns the command's exit code.
 func (d *DockerProvider) Exec(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+	return d.execAs(ctx, sb, "", cmd, stdout, stderr)
+}
+
+// execAs runs a command in the container as a specific user. An empty user
+// means "use the container's default" (sandbox, per containerCfg.User).
+// Bootstrap uses user="root" to mkdir/chown without relying on sudo's setuid
+// bit, which the kernel strips under gVisor / no-new-privileges / userns.
+func (d *DockerProvider) execAs(ctx context.Context, sb *agent.Sandbox, user, cmd string, stdout, stderr io.Writer) (int, error) {
 	log := d.scopedLogger(sb)
-	log.Debug().
-		Str("cmd", cmd).
-		Msg("executing command in sandbox")
+	logEvent := log.Debug().Str("cmd", cmd)
+	if user != "" {
+		logEvent = logEvent.Str("user", user)
+	}
+	logEvent.Msg("executing command in sandbox")
 
 	execCfg := container.ExecOptions{
+		User:         user,
 		Cmd:          []string{"sh", "-c", cmd},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -413,8 +413,8 @@ func TestDockerProvider_Create(t *testing.T) {
 		// Verify security hardening
 		require.Equal(t, "runsc", capturedHostConfig.Runtime, "container should use gVisor runtime")
 		require.Equal(t, []string(capturedHostConfig.CapDrop), []string{"ALL"}, "container should drop all capabilities")
-		require.Equal(t, []string(capturedHostConfig.CapAdd), []string{"SETUID", "SETGID", "DAC_OVERRIDE"}, "container should add minimum caps for sudo")
-		require.Empty(t, capturedHostConfig.SecurityOpt, "container should not set security options (no-new-privileges blocks sudo)")
+		require.Empty(t, capturedHostConfig.CapAdd, "container should not add back any caps — sudo is gone from the image and bootstrap uses docker exec User=root")
+		require.Empty(t, capturedHostConfig.SecurityOpt, "container should not set security options — no-new-privileges is moot without sudo, keep it unset for parity with the pre-sudo-removal behavior")
 		require.False(t, capturedHostConfig.ReadonlyRootfs, "container should have writable rootfs for package installation")
 		require.Contains(t, capturedHostConfig.Tmpfs, "/tmp", "container should have tmpfs at /tmp")
 		require.Contains(t, capturedHostConfig.Tmpfs, "/var/tmp", "container should have exec-allowed tmpfs at /var/tmp for scratch binaries")
@@ -908,11 +908,13 @@ func TestDockerProvider_Exec(t *testing.T) {
 		t.Parallel()
 
 		var capturedCmd []string
+		var capturedUser string
 		var capturedAttachStdout, capturedAttachStderr bool
 
 		mock := &mockDockerClient{}
 		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
 			capturedCmd = config.Cmd
+			capturedUser = config.User
 			capturedAttachStdout = config.AttachStdout
 			capturedAttachStderr = config.AttachStderr
 			return container.ExecCreateResponse{ID: "exec-1"}, nil
@@ -931,6 +933,7 @@ func TestDockerProvider_Exec(t *testing.T) {
 		require.NoError(t, err, "Exec should not return an error")
 		require.Equal(t, 0, code, "exit code should be 0")
 		require.Equal(t, []string{"sh", "-c", "echo hello"}, capturedCmd, "command should be wrapped in sh -c")
+		require.Empty(t, capturedUser, "public Exec must leave User empty so the exec runs as the container's default (sandbox); only bootstrap opts in to root")
 		require.True(t, capturedAttachStdout, "should attach stdout")
 		require.True(t, capturedAttachStderr, "should attach stderr")
 	})

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -669,6 +669,39 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, "agent_run", sb.Purpose, "Purpose should be copied from config")
 	})
 
+	t.Run("bootstrap runs as root without sudo", func(t *testing.T) {
+		t.Parallel()
+
+		// The bootstrap mkdir/chown must NOT shell out to `sudo`: under gVisor
+		// (and no-new-privileges / userns-remap / any nosuid mount) the setuid
+		// bit on /usr/bin/sudo is stripped, producing "sudo: effective uid is
+		// not 0 ... nosuid" and failing session startup. Running the exec with
+		// ExecOptions.User="root" goes through Docker's control plane instead,
+		// so it works under every runtime and security profile we support.
+		var execCfgs []container.ExecOptions
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			return container.CreateResponse{ID: "bootstrap-root"}, nil
+		}
+		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+			execCfgs = append(execCfgs, config)
+			return container.ExecCreateResponse{ID: fmt.Sprintf("exec-%d", len(execCfgs))}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		_, err := p.Create(context.Background(), agent.DefaultSandboxConfig())
+		require.NoError(t, err)
+
+		require.Len(t, execCfgs, 1, "Create should issue exactly one bootstrap exec")
+		boot := execCfgs[0]
+		require.Equal(t, "root", boot.User, "bootstrap exec must run as root via ExecOptions.User (not via sudo)")
+		require.Len(t, boot.Cmd, 3, "bootstrap cmd should be wrapped by sh -c")
+		require.NotContains(t, boot.Cmd[2], "sudo", "bootstrap shell cmd must not invoke sudo — the setuid bit is stripped under gVisor/no-new-privileges")
+		require.Contains(t, boot.Cmd[2], "mkdir -p", "bootstrap must still create the workdir idempotently")
+		require.Contains(t, boot.Cmd[2], "chown sandbox:sandbox", "bootstrap must chown the workdir to the sandbox user")
+	})
+
 	t.Run("cleans up on bootstrap workdir failure", func(t *testing.T) {
 		t.Parallel()
 

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -26,12 +26,18 @@ RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 # postgresql-client is needed when a preview's command chain seeds a Postgres
 # infrastructure container via `psql -f`; keeping it in the base image avoids
 # per-preview apt installs.
+#
+# sudo is intentionally omitted: under gVisor (and no-new-privileges /
+# userns-remap / nosuid mounts) the kernel strips setuid bits, so `sudo`
+# fails with "effective uid is not 0 ... nosuid". Any provisioning that
+# needs root runs via docker exec User="root" from the provider instead.
+# Consequence: agents cannot `sudo apt-get install` at runtime — every
+# dependency must be baked into this image up front.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
     jq \
-    sudo \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
@@ -64,9 +70,8 @@ RUN --mount=type=cache,target=/root/.npm \
 # Copy 143-tools binary from Go builder.
 COPY --from=go-builder /bin/143-tools /usr/local/bin/143-tools
 
-# Non-root user for sandbox execution with passwordless sudo.
-RUN useradd -m -s /bin/bash sandbox \
-    && echo 'sandbox ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/sandbox \
-    && chmod 0440 /etc/sudoers.d/sandbox
+# Non-root user for sandbox execution. No sudo is provisioned — see the
+# comment on the apt-get block above.
+RUN useradd -m -s /bin/bash sandbox
 USER sandbox
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Session startup was failing with `bootstrap workdir (exit 1): sudo: effective uid is not 0, is /usr/bin/sudo on a file system with the 'nosuid' option set`. sudo relies on its setuid bit, which the kernel strips under gVisor (and no-new-privileges / userns-remap / any nosuid mount), so the bootstrap mkdir/chown always failed in prod.
- Run the bootstrap exec as root via Docker's `ExecOptions.User` instead of prefixing `sudo` — the runtime sets the uid through the control plane, so no setuid bit is involved and it works under every runtime/security profile we support.
- Factored `Exec` into a private `execAs(ctx, sb, user, cmd, …)` helper; `Exec` delegates with `user=""` (container default = sandbox) and bootstrap passes `user="root"`.

## Test plan
- [x] `go test ./internal/services/agent/...` — passes, including new `TestDockerProvider_Create/bootstrap_runs_as_root_without_sudo` that pins: exactly one bootstrap exec, `User=="root"`, shell cmd contains `mkdir -p` + `chown sandbox:sandbox`, and does NOT contain `sudo`.
- [ ] Deploy to prod and trigger a PM agent session to confirm the original failure is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
