### PR TITLE
Make 143.dev dogfood preview reviewable and clean up on PR close

### DIFF
--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -12,10 +12,20 @@
 # SESSION_SECRET intentionally lives in /tmp/ (not committed): a full
 # sandbox recycle generates a fresh secret, at which point the reviewer
 # simply re-signs-in with the public demo credentials.
-set -e
+#
+# -u catches typos in required env vars (DATABASE_URL, PREVIEW_ORIGIN)
+# instead of silently substituting empty strings and failing downstream.
+set -eu
 
 SECRET_DIR=/tmp/143-preview
 SECRET_FILE="${SECRET_DIR}/session_secret"
+
+# Persist the Go build cache across in-sandbox server restarts so rebuilds
+# after a code edit reuse object files instead of recompiling the world.
+# A full sandbox recycle wipes /tmp and pays the cold-build cost once.
+GOCACHE="${SECRET_DIR}/gocache"
+export GOCACHE
+mkdir -p "$GOCACHE"
 
 echo '[143-preview] building binaries...'
 go build -o /tmp/143-migrate ./cmd/migrate

--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -35,12 +35,15 @@ echo '[143-preview] running migrations...'
 /tmp/143-migrate up
 
 echo '[143-preview] seeding database...'
-psql "$DATABASE_URL" -f .143/seed.sql
+psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f .143/seed.sql
 
 mkdir -p "$SECRET_DIR"
 chmod 700 "$SECRET_DIR"
 if [ ! -s "$SECRET_FILE" ]; then
-    head -c 32 /dev/urandom | base64 > "$SECRET_FILE"
+    # tr strips the trailing newline base64 appends — SESSION_SECRET is
+    # consumed as an opaque byte string and a stray \n causes subtle
+    # value-mismatch bugs if anything byte-compares it.
+    head -c 32 /dev/urandom | base64 | tr -d '\n' > "$SECRET_FILE"
     chmod 600 "$SECRET_FILE"
 fi
 SESSION_SECRET="$(cat "$SECRET_FILE")"

--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# preview-start.sh — dogfood preview server entrypoint.
+#
+# Runs inside the 143 preview sandbox for this repo. Ordered as:
+#   1. build binaries once (go run would rebuild twice for migrate+server)
+#   2. run migrations
+#   3. seed the database
+#   4. generate + cache SESSION_SECRET at /tmp/143-preview/session_secret so
+#      a server restart inside the same sandbox keeps the reviewer signed in
+#   5. exec the server
+#
+# SESSION_SECRET intentionally lives in /tmp/ (not committed): a full
+# sandbox recycle generates a fresh secret, at which point the reviewer
+# simply re-signs-in with the public demo credentials.
+set -e
+
+SECRET_DIR=/tmp/143-preview
+SECRET_FILE="${SECRET_DIR}/session_secret"
+
+echo '[143-preview] building binaries...'
+go build -o /tmp/143-migrate ./cmd/migrate
+go build -o /tmp/143-server ./cmd/server
+
+echo '[143-preview] running migrations...'
+/tmp/143-migrate up
+
+echo '[143-preview] seeding database...'
+psql "$DATABASE_URL" -f .143/seed.sql
+
+mkdir -p "$SECRET_DIR"
+chmod 700 "$SECRET_DIR"
+if [ ! -s "$SECRET_FILE" ]; then
+    head -c 32 /dev/urandom | base64 > "$SECRET_FILE"
+    chmod 600 "$SECRET_FILE"
+fi
+SESSION_SECRET="$(cat "$SECRET_FILE")"
+export SESSION_SECRET
+
+echo '[143-preview] starting server...'
+BASE_URL="${PREVIEW_ORIGIN:-http://localhost:8080}" \
+FRONTEND_URL="${PREVIEW_ORIGIN:-http://localhost:8080}" \
+exec /tmp/143-server

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -16,11 +16,7 @@
       }
     },
     "server": {
-      "command": [
-        "sh",
-        "-c",
-        "set -e && echo '[143-preview] building binaries...' && go build -o /tmp/143-migrate ./cmd/migrate && go build -o /tmp/143-server ./cmd/server && echo '[143-preview] running migrations...' && /tmp/143-migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && mkdir -p /tmp/143-preview && chmod 700 /tmp/143-preview && if [ ! -s /tmp/143-preview/session_secret ]; then head -c 32 /dev/urandom | base64 > /tmp/143-preview/session_secret && chmod 600 /tmp/143-preview/session_secret; fi && export SESSION_SECRET=\"$(cat /tmp/143-preview/session_secret)\" && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" /tmp/143-server"
-      ],
+      "command": ["sh", ".143/preview-start.sh"],
       "port": 8080,
       "env": {
         "MODE": "api",

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -19,14 +19,13 @@
       "command": [
         "sh",
         "-c",
-        "set -e && echo '[143-preview] building binaries...' && go build -o /tmp/143-migrate ./cmd/migrate && go build -o /tmp/143-server ./cmd/server && echo '[143-preview] running migrations...' && /tmp/143-migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" /tmp/143-server"
+        "set -e && echo '[143-preview] building binaries...' && go build -o /tmp/143-migrate ./cmd/migrate && go build -o /tmp/143-server ./cmd/server && echo '[143-preview] running migrations...' && /tmp/143-migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && mkdir -p /tmp/143-preview && chmod 700 /tmp/143-preview && if [ ! -s /tmp/143-preview/session_secret ]; then head -c 32 /dev/urandom | base64 > /tmp/143-preview/session_secret && chmod 600 /tmp/143-preview/session_secret; fi && export SESSION_SECRET=\"$(cat /tmp/143-preview/session_secret)\" && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" /tmp/143-server"
       ],
       "port": 8080,
       "env": {
         "MODE": "api",
         "LOG_LEVEL": "info",
-        "DEMO_MODE": "true",
-        "SESSION_SECRET": "dogfood-preview-session-secret-public-not-for-prod-use"
+        "DEMO_MODE": "true"
       },
       "ready": {
         "http_path": "/api/v1/health",

--- a/.143/preview.json
+++ b/.143/preview.json
@@ -8,7 +8,7 @@
       "port": 3000,
       "env": {
         "API_PROXY_TARGET": "http://localhost:8080",
-        "NODE_OPTIONS": "--max-old-space-size=768"
+        "NODE_OPTIONS": "--max-old-space-size=1280"
       },
       "ready": {
         "http_path": "/",
@@ -19,12 +19,14 @@
       "command": [
         "sh",
         "-c",
-        "export SESSION_SECRET=\"$(head -c 32 /dev/urandom | base64)\" && echo '[143-preview] running migrations...' && go run ./cmd/migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" go run ./cmd/server"
+        "set -e && echo '[143-preview] building binaries...' && go build -o /tmp/143-migrate ./cmd/migrate && go build -o /tmp/143-server ./cmd/server && echo '[143-preview] running migrations...' && /tmp/143-migrate up && echo '[143-preview] seeding database...' && psql \"$DATABASE_URL\" -f .143/seed.sql && echo '[143-preview] starting server...' && BASE_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" FRONTEND_URL=\"${PREVIEW_ORIGIN:-http://localhost:8080}\" /tmp/143-server"
       ],
       "port": 8080,
       "env": {
-        "MODE": "all",
-        "LOG_LEVEL": "info"
+        "MODE": "api",
+        "LOG_LEVEL": "info",
+        "DEMO_MODE": "true",
+        "SESSION_SECRET": "dogfood-preview-session-secret-public-not-for-prod-use"
       },
       "ready": {
         "http_path": "/api/v1/health",

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -363,8 +363,35 @@ VALUES (
 )
 ON CONFLICT (id) DO NOTHING;
 
--- PR-preview tracking for the "pr_created" session. pr_number is placeholder;
--- no real PR exists on GitHub in the dogfood.
+-- Pull request row backing the pr_preview_state below. Any UI that joins
+-- pr_preview_state to pull_requests (by org_id + github_repo + pr_number)
+-- needs a pull_requests row to render a working link — without this, the
+-- PR preview panel renders a broken "PR #42" link in the dogfood.
+-- Note: github_pr_url points at a real PR on the public repo so the link
+-- resolves; nothing in the dogfood actually calls the GitHub API.
+INSERT INTO pull_requests (
+  id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
+  title, body, status, review_status, authored_by, created_at, updated_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000501'::uuid,
+  '00000000-0000-4000-a000-000000000300'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  42,
+  'https://github.com/assembledhq/143/pull/42',
+  'assembledhq/143',
+  'Ship PR preview auto-teardown',
+  'Wire preview teardown into pull_request.closed / merged.',
+  'open',
+  'pending',
+  'app',
+  now() - interval '30 minutes',
+  now() - interval '2 minutes'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- PR-preview tracking for the "pr_created" session, backed by the seeded
+-- pull_requests row above.
 INSERT INTO pr_preview_state (
   id, org_id, repo_id, pr_number, last_preview_instance_id, status, created_at, updated_at
 )

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -154,6 +154,15 @@ ON CONFLICT (id) DO NOTHING;
 -- preview_instances.worker_node_id is set to the sentinel 'seeded' so the
 -- real RecycleWorker (which scans WHERE worker_node_id = <this worker>) never
 -- touches these rows. expires_at is far in the future for the same reason.
+--
+-- Idempotency: rows with fixed PKs use ON CONFLICT (id) DO NOTHING. Rows in
+-- tables where we don't own an id (session_messages, session_logs) have no
+-- unique constraint on the seeded columns, so ON CONFLICT alone cannot
+-- deduplicate them. To stay idempotent across repeated seed runs (e.g. a
+-- sandbox restart against a persistent Postgres volume) we DELETE the seed
+-- rows by their fixed session_ids before re-INSERTing. The session_ids
+-- 00000000-0000-4000-a000-00000000030x are owned by this seed and cannot
+-- collide with real sessions, which use gen_random_uuid().
 -- =============================================================================
 
 -- Three sessions: one "active PR", one "completed", one "idle" -- spread
@@ -226,6 +235,13 @@ VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- A few chat messages per session so the detail pages render a conversation.
+-- DELETE first to keep reseeds idempotent (see note at top of the illusory
+-- section — session_messages has no unique constraint on the seeded cols).
+DELETE FROM session_messages WHERE session_id IN (
+  '00000000-0000-4000-a000-000000000300'::uuid,
+  '00000000-0000-4000-a000-000000000301'::uuid,
+  '00000000-0000-4000-a000-000000000302'::uuid
+);
 INSERT INTO session_messages (session_id, org_id, user_id, turn_number, role, content, created_at)
 VALUES
   (
@@ -279,6 +295,12 @@ VALUES
 ON CONFLICT DO NOTHING;
 
 -- A few log lines per session so the log stream UI has something to show.
+-- DELETE first for the same idempotency reason as session_messages above.
+DELETE FROM session_logs WHERE session_id IN (
+  '00000000-0000-4000-a000-000000000300'::uuid,
+  '00000000-0000-4000-a000-000000000301'::uuid,
+  '00000000-0000-4000-a000-000000000302'::uuid
+);
 INSERT INTO session_logs (session_id, org_id, timestamp, level, message, turn_number)
 VALUES
   ('00000000-0000-4000-a000-000000000300'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '34 minutes', 'info', 'sandbox provisioned', 1),

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -4,6 +4,12 @@
 -- placeholder integration and a couple of repositories/projects so the
 -- logged-in UI shows populated screens instead of empty states.
 --
+-- IMPORTANT: the seeded admin email + password below must match the
+-- DEMO_EMAIL / DEMO_PASSWORD defaults in internal/config/config.go, since
+-- the login-page banner renders those values and a reviewer copy-pastes
+-- them into the sign-in form. If you change either side, regenerate the
+-- bcrypt hash below (cost 10) and update the config defaults in lockstep.
+--
 -- Password: "preview-dogfood" (bcrypt hash below).
 --
 -- All rows use fixed UUIDs + ON CONFLICT DO NOTHING so the seed is

--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -136,3 +136,218 @@ VALUES
     now()
   )
 ON CONFLICT (id) DO NOTHING;
+
+-- =============================================================================
+-- Illusory session + preview rows.
+--
+-- The dogfood preview runs as OS processes inside a sandbox container and has
+-- no access to a Docker socket, so it cannot actually spawn sessions or
+-- previews. These rows exist so that the sessions list, session detail, and
+-- preview panels render populated state for a reviewer clicking around.
+--
+-- preview_instances.worker_node_id is set to the sentinel 'seeded' so the
+-- real RecycleWorker (which scans WHERE worker_node_id = <this worker>) never
+-- touches these rows. expires_at is far in the future for the same reason.
+-- =============================================================================
+
+-- Three sessions: one "active PR", one "completed", one "idle" -- spread
+-- across the two seeded repos and ordered by last_activity_at DESC so the
+-- sessions list has a natural MRU shape.
+INSERT INTO sessions (
+  id, org_id, repository_id, triggered_by_user_id, title, working_branch,
+  target_branch, agent_type, status, autonomy_level, token_mode,
+  sandbox_state, current_turn, last_activity_at, started_at, completed_at,
+  created_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000300'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000100'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    'Ship PR preview auto-teardown',
+    'feat/preview-teardown',
+    'main',
+    'codex',
+    'pr_created',
+    'semi',
+    'low',
+    'snapshotted',
+    4,
+    now() - interval '2 minutes',
+    now() - interval '35 minutes',
+    now() - interval '3 minutes',
+    now() - interval '35 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000301'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000101'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    'Retry webhook signature on transient GitHub 5xx',
+    'fix/webhook-retry',
+    'main',
+    'codex',
+    'completed',
+    'semi',
+    'low',
+    'snapshotted',
+    3,
+    now() - interval '1 hour',
+    now() - interval '2 hours',
+    now() - interval '1 hour' - interval '5 minutes',
+    now() - interval '2 hours'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000302'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000100'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    'Investigate preview cold-start latency',
+    NULL,
+    'main',
+    'codex',
+    'idle',
+    'semi',
+    'low',
+    'none',
+    1,
+    now() - interval '3 days',
+    now() - interval '3 days' - interval '10 minutes',
+    NULL,
+    now() - interval '3 days' - interval '10 minutes'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- A few chat messages per session so the detail pages render a conversation.
+INSERT INTO session_messages (session_id, org_id, user_id, turn_number, role, content, created_at)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000300'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    1, 'user',
+    'Please wire the preview recycler up to pull_request.closed so we stop paying for previews after a merge.',
+    now() - interval '35 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000300'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    NULL,
+    1, 'assistant',
+    'Plan: inject preview manager into PRService, call StopPreview from the closed branch, mark pr_preview_state.status = ''closed''. Opened PR with a regression test.',
+    now() - interval '34 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000300'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    2, 'user',
+    'Looks good. Can you also make sure we do not blow up if the preview manager is not wired (self-hosted path)?',
+    now() - interval '6 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000301'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    1, 'user',
+    'Webhook deliveries are failing intermittently when GitHub returns a 502. Add a retry with backoff.',
+    now() - interval '2 hours'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000301'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    NULL,
+    1, 'assistant',
+    'Added exponential backoff retry (3 attempts, 500ms/1s/2s) around the signature verification call. Tests cover 502, 503, and network timeouts.',
+    now() - interval '1 hour' - interval '10 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000302'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    1, 'user',
+    'Preview cold start is 90s+ on the dogfood env. Where is the time actually going?',
+    now() - interval '3 days'
+  )
+ON CONFLICT DO NOTHING;
+
+-- A few log lines per session so the log stream UI has something to show.
+INSERT INTO session_logs (session_id, org_id, timestamp, level, message, turn_number)
+VALUES
+  ('00000000-0000-4000-a000-000000000300'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '34 minutes', 'info', 'sandbox provisioned', 1),
+  ('00000000-0000-4000-a000-000000000300'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '30 minutes', 'info', 'pushed branch feat/preview-teardown', 1),
+  ('00000000-0000-4000-a000-000000000300'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '28 minutes', 'info', 'opened pull request #42', 1),
+  ('00000000-0000-4000-a000-000000000301'::uuid, '00000000-0000-4000-a000-000000000001'::uuid, now() - interval '1 hour' - interval '5 minutes', 'info', 'session completed successfully', 1)
+ON CONFLICT DO NOTHING;
+
+-- A seeded "ready" preview instance pointing at session 300.
+-- worker_node_id = 'seeded' keeps the real recycler from touching this row.
+INSERT INTO preview_instances (
+  id, session_id, org_id, user_id, profile_name, name, status, provider,
+  worker_node_id, preview_handle, primary_service, port, expires_at, created_at, updated_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000400'::uuid,
+  '00000000-0000-4000-a000-000000000300'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000002'::uuid,
+  'manado',
+  'Ship PR preview auto-teardown',
+  'ready',
+  'seeded',
+  'seeded',
+  '',
+  'frontend',
+  3000,
+  now() + interval '24 hours',
+  now() - interval '30 minutes',
+  now() - interval '2 minutes'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO preview_services (
+  id, preview_instance_id, service_name, role, status, port, created_at
+)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000410'::uuid,
+    '00000000-0000-4000-a000-000000000400'::uuid,
+    'frontend', 'primary', 'ready', 3000,
+    now() - interval '30 minutes'
+  ),
+  (
+    '00000000-0000-4000-a000-000000000411'::uuid,
+    '00000000-0000-4000-a000-000000000400'::uuid,
+    'server', 'support', 'ready', 8080,
+    now() - interval '30 minutes'
+  )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO preview_infrastructure (
+  id, preview_instance_id, infra_name, template, status, created_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000420'::uuid,
+  '00000000-0000-4000-a000-000000000400'::uuid,
+  'db', 'postgres-17', 'healthy',
+  now() - interval '30 minutes'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- PR-preview tracking for the "pr_created" session. pr_number is placeholder;
+-- no real PR exists on GitHub in the dogfood.
+INSERT INTO pr_preview_state (
+  id, org_id, repo_id, pr_number, last_preview_instance_id, status, created_at, updated_at
+)
+VALUES (
+  '00000000-0000-4000-a000-000000000500'::uuid,
+  '00000000-0000-4000-a000-000000000001'::uuid,
+  '00000000-0000-4000-a000-000000000100'::uuid,
+  42,
+  '00000000-0000-4000-a000-000000000400'::uuid,
+  'running',
+  now() - interval '30 minutes',
+  now() - interval '2 minutes'
+)
+ON CONFLICT DO NOTHING;

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -31,6 +31,10 @@ The UI is populated by fixed rows in `.143/seed.sql`; the preview system itself 
 
 Set `DEMO_MODE=true` on the server when launching a dogfood environment. This enables the login-page credential banner and short-circuits GitHub client construction so stubbed handlers return cleanly instead of 500-ing.
 
+**Why the dogfood hard-codes `SESSION_SECRET`:** The preview runs inside a 143 session sandbox, which has no access to sops-encrypted production secrets. The server config in `.143/preview.json` is the only place the sandbox can pick up a `SESSION_SECRET`, and it must stay stable across preview recycles so a reviewer's session isn't silently invalidated. The committed value is intentionally public, labeled as such, and does not protect any real data — the only accounts it covers are the seeded demo user whose password is also public. Do not reuse this secret for anything that matters.
+
+**Why `MODE=api` and not `MODE=all`:** The dogfood sandbox has no Docker socket, so the background worker mode (which spawns session sandboxes and previews) cannot function. Running it would only produce worker-loop errors in the logs. Any UI that polls job status will therefore show the seeded snapshot forever — no background processing advances it.
+
 ## Quickstart
 
 Add `.143/preview.json` at the root of your repo:

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -6,7 +6,7 @@ This guide covers how to add preview support to a repo. For the underlying archi
 
 ## Dogfood preview
 
-143 ships its own `.143/preview.json` + `.143/seed.sql` so a reviewer can spin up 143 inside 143 to click through the UI. This is the environment exposed at `143.dev`.
+143 ships its own `.143/preview.json`, `.143/preview-start.sh`, and `.143/seed.sql` so a reviewer can spin up 143 inside 143 to click through the UI. This is the environment exposed at `143.dev`.
 
 **How to launch it locally:**
 
@@ -18,6 +18,8 @@ This guide covers how to add preview support to a repo. For the underlying archi
 
 - Email: `dogfood@143.dev`
 - Password: `preview-dogfood`
+
+The banner renders whatever `DEMO_EMAIL` / `DEMO_PASSWORD` the server was started with (defaults match the values above and the seeded admin in `.143/seed.sql`). If you override those env vars, regenerate the bcrypt hash in `seed.sql` in lockstep or the banner will point at credentials that don't log in.
 
 **What you can and cannot do in the dogfood:**
 

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -31,7 +31,7 @@ The UI is populated by fixed rows in `.143/seed.sql`; the preview system itself 
 
 Set `DEMO_MODE=true` on the server when launching a dogfood environment. This enables the login-page credential banner and short-circuits GitHub client construction so stubbed handlers return cleanly instead of 500-ing.
 
-**Why the dogfood hard-codes `SESSION_SECRET`:** The preview runs inside a 143 session sandbox, which has no access to sops-encrypted production secrets. The server config in `.143/preview.json` is the only place the sandbox can pick up a `SESSION_SECRET`, and it must stay stable across preview recycles so a reviewer's session isn't silently invalidated. The committed value is intentionally public, labeled as such, and does not protect any real data — the only accounts it covers are the seeded demo user whose password is also public. Do not reuse this secret for anything that matters.
+**How the dogfood handles `SESSION_SECRET`:** The preview runs inside a 143 session sandbox, which has no access to sops-encrypted production secrets, so the secret is generated at boot from `/dev/urandom` and cached at `/tmp/143-preview/session_secret`. Server restarts within the same sandbox reuse the cached value, so a reviewer stays signed in. A full sandbox recycle generates a fresh secret — reviewers just re-sign-in with the public demo credentials.
 
 **Why `MODE=api` and not `MODE=all`:** The dogfood sandbox has no Docker socket, so the background worker mode (which spawns session sandboxes and previews) cannot function. Running it would only produce worker-loop errors in the logs. Any UI that polls job status will therefore show the seeded snapshot forever — no background processing advances it.
 

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -25,9 +25,11 @@ The banner renders whatever `DEMO_EMAIL` / `DEMO_PASSWORD` the server was starte
 
 | Works | Does not work |
 |---|---|
-| Browse seeded sessions / PR previews / activity | Start a new agent session (no Docker socket inside the sandbox) |
-| Sign in as the seeded admin | Spin up a nested preview from inside the dogfood |
-| Open the session detail / messages | Any flow that calls the GitHub API (stubbed — no real GitHub App) |
+| Browse seeded sessions / PR previews / activity | **Start session** (no Docker socket — the button will error) |
+| Sign in as the seeded admin | **Connect GitHub** on Settings → Integrations (no OAuth app; button is hidden) |
+| Open the session detail, messages, logs | **Import repositories** (no GitHub App; install-redirect no-ops) |
+| View the seeded PR preview panel and its linked PR | **Comment on a PR / retry CI / merge** (all route through the GitHub API) |
+| Navigate projects, sessions list, activity feed | **Start Preview** from a new session (needs a live sandbox) |
 
 The UI is populated by fixed rows in `.143/seed.sql`; the preview system itself is not actually running underneath them. This is a deliberate tradeoff — giving the dogfood a Docker socket would expand the attack surface far beyond what's warranted for a public demo. If you need a real end-to-end test, run 143 on your own machine with a configured GitHub App.
 

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -4,6 +4,33 @@ A preview is a live, iframed view of your app running inside a 143 session. When
 
 This guide covers how to add preview support to a repo. For the underlying architecture (preview gateway, trust split, isolation model), see [`design/44-sandbox-preview-server.md`](design/44-sandbox-preview-server.md).
 
+## Dogfood preview
+
+143 ships its own `.143/preview.json` + `.143/seed.sql` so a reviewer can spin up 143 inside 143 to click through the UI. This is the environment exposed at `143.dev`.
+
+**How to launch it locally:**
+
+1. Boot the local stack (`docker compose up` or the repo-specific make target).
+2. Open a session against the 143 repo (or anything on `main`).
+3. Click **Start Preview**.
+
+**Demo credentials** (shown on the login page when `DEMO_MODE=true`):
+
+- Email: `dogfood@143.dev`
+- Password: `preview-dogfood`
+
+**What you can and cannot do in the dogfood:**
+
+| Works | Does not work |
+|---|---|
+| Browse seeded sessions / PR previews / activity | Start a new agent session (no Docker socket inside the sandbox) |
+| Sign in as the seeded admin | Spin up a nested preview from inside the dogfood |
+| Open the session detail / messages | Any flow that calls the GitHub API (stubbed — no real GitHub App) |
+
+The UI is populated by fixed rows in `.143/seed.sql`; the preview system itself is not actually running underneath them. This is a deliberate tradeoff — giving the dogfood a Docker socket would expand the attack surface far beyond what's warranted for a public demo. If you need a real end-to-end test, run 143 on your own machine with a configured GitHub App.
+
+Set `DEMO_MODE=true` on the server when launching a dogfood environment. This enables the login-page credential banner and short-circuits GitHub client construction so stubbed handlers return cleanly instead of 500-ing.
+
 ## Quickstart
 
 Add `.143/preview.json` at the root of your repo:

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -89,6 +89,26 @@ describe('LoginPage', () => {
     expect(screen.queryByRole('button', { name: 'Continue with Google' })).not.toBeInTheDocument();
   });
 
+  it('shows demo banner with seeded credentials when demo mode is on', () => {
+    useAuthProvidersMock.mockReturnValue({
+      providers: { github: false, google: false, email: true, demo: true },
+      isLoading: false,
+    });
+
+    renderWithProviders(<LoginPage />);
+
+    const banner = screen.getByTestId('demo-banner');
+    expect(banner).toHaveTextContent('Demo environment');
+    expect(banner).toHaveTextContent('dogfood@143.dev');
+    expect(banner).toHaveTextContent('preview-dogfood');
+  });
+
+  it('hides demo banner when demo mode is off', () => {
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.queryByTestId('demo-banner')).not.toBeInTheDocument();
+  });
+
   it('calls login on GitHub button click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<LoginPage />);

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -89,9 +89,16 @@ describe('LoginPage', () => {
     expect(screen.queryByRole('button', { name: 'Continue with Google' })).not.toBeInTheDocument();
   });
 
-  it('shows demo banner with seeded credentials when demo mode is on', () => {
+  it('shows demo banner with credentials from /providers when demo mode is on', () => {
     useAuthProvidersMock.mockReturnValue({
-      providers: { github: false, google: false, email: true, demo: true },
+      providers: {
+        github: false,
+        google: false,
+        email: true,
+        demo: true,
+        demo_email: 'dogfood@143.dev',
+        demo_password: 'preview-dogfood',
+      },
       isLoading: false,
     });
 
@@ -103,7 +110,39 @@ describe('LoginPage', () => {
     expect(banner).toHaveTextContent('preview-dogfood');
   });
 
+  it('renders banner text returned by /providers verbatim (server is source of truth)', () => {
+    useAuthProvidersMock.mockReturnValue({
+      providers: {
+        github: false,
+        google: false,
+        email: true,
+        demo: true,
+        demo_email: 'override@example.com',
+        demo_password: 'override-pw',
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<LoginPage />);
+
+    const banner = screen.getByTestId('demo-banner');
+    expect(banner).toHaveTextContent('override@example.com');
+    expect(banner).toHaveTextContent('override-pw');
+    expect(banner).not.toHaveTextContent('dogfood@143.dev');
+  });
+
   it('hides demo banner when demo mode is off', () => {
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.queryByTestId('demo-banner')).not.toBeInTheDocument();
+  });
+
+  it('hides demo banner when demo is on but credentials are missing', () => {
+    useAuthProvidersMock.mockReturnValue({
+      providers: { github: false, google: false, email: true, demo: true },
+      isLoading: false,
+    });
+
     renderWithProviders(<LoginPage />);
 
     expect(screen.queryByTestId('demo-banner')).not.toBeInTheDocument();

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -131,16 +131,16 @@ function LoginPageContent() {
             </div>
           )}
 
-          {providers?.demo && (
+          {providers?.demo && providers.demo_email && providers.demo_password && (
             <div
               className="rounded-md border border-amber-300/50 bg-amber-50/50 px-3 py-2 text-sm text-muted-foreground dark:border-amber-500/30 dark:bg-amber-950/30"
               data-testid="demo-banner"
             >
               <div className="font-medium text-foreground">Demo environment</div>
               <div className="mt-1">
-                Sign in with <code className="font-mono">dogfood@143.dev</code>
+                Sign in with <code className="font-mono">{providers.demo_email}</code>
                 {" / "}
-                <code className="font-mono">preview-dogfood</code>.
+                <code className="font-mono">{providers.demo_password}</code>.
               </div>
               <div className="mt-1 text-xs">
                 Data resets when the preview recycles. GitHub actions are stubbed.

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -131,6 +131,23 @@ function LoginPageContent() {
             </div>
           )}
 
+          {providers?.demo && (
+            <div
+              className="rounded-md border border-amber-300/50 bg-amber-50/50 px-3 py-2 text-sm text-muted-foreground dark:border-amber-500/30 dark:bg-amber-950/30"
+              data-testid="demo-banner"
+            >
+              <div className="font-medium text-foreground">Demo environment</div>
+              <div className="mt-1">
+                Sign in with <code className="font-mono">dogfood@143.dev</code>
+                {" / "}
+                <code className="font-mono">preview-dogfood</code>.
+              </div>
+              <div className="mt-1 text-xs">
+                Data resets when the preview recycles. GitHub actions are stubbed.
+              </div>
+            </div>
+          )}
+
           {/* Social login buttons */}
           <div className="space-y-2">
             {providers?.github !== false && (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface AuthProviders {
   github: boolean;
   google: boolean;
   email: boolean;
+  demo?: boolean;
 }
 
 export interface Repository {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -24,6 +24,8 @@ export interface AuthProviders {
   google: boolean;
   email: boolean;
   demo?: boolean;
+  demo_email?: string;
+  demo_password?: string;
 }
 
 export interface Repository {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -61,17 +61,22 @@ func NewAuthHandler(cfg *config.Config, orgStore *db.OrganizationStore, userStor
 // When DemoMode is on, "github" is forced to false regardless of OAuth
 // configuration so the login page does not offer a button that would 500
 // against the stubbed GitHub client. "demo" tells the frontend to render
-// the seeded-credentials banner.
+// the seeded-credentials banner, and "demo_email" / "demo_password" carry
+// the banner text so a reviewer sees whatever the server was actually
+// seeded with (server is the single source of truth, not the TSX).
 func (h *AuthHandler) Providers(w http.ResponseWriter, r *http.Request) {
 	githubEnabled := h.cfg.GitHubOAuthClientID != "" && !h.cfg.DemoMode
-	writeJSON(w, http.StatusOK, map[string]any{
-		"data": map[string]any{
-			"github": githubEnabled,
-			"google": h.cfg.GoogleOAuthClientID != "",
-			"email":  true,
-			"demo":   h.cfg.DemoMode,
-		},
-	})
+	data := map[string]any{
+		"github": githubEnabled,
+		"google": h.cfg.GoogleOAuthClientID != "",
+		"email":  true,
+		"demo":   h.cfg.DemoMode,
+	}
+	if h.cfg.DemoMode {
+		data["demo_email"] = h.cfg.DemoEmail
+		data["demo_password"] = h.cfg.DemoPassword
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"data": data})
 }
 
 // Me returns the currently authenticated user.

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -57,12 +57,19 @@ func NewAuthHandler(cfg *config.Config, orgStore *db.OrganizationStore, userStor
 }
 
 // Providers returns which auth methods are configured.
+//
+// When DemoMode is on, "github" is forced to false regardless of OAuth
+// configuration so the login page does not offer a button that would 500
+// against the stubbed GitHub client. "demo" tells the frontend to render
+// the seeded-credentials banner.
 func (h *AuthHandler) Providers(w http.ResponseWriter, r *http.Request) {
+	githubEnabled := h.cfg.GitHubOAuthClientID != "" && !h.cfg.DemoMode
 	writeJSON(w, http.StatusOK, map[string]any{
-		"data": map[string]bool{
-			"github": h.cfg.GitHubOAuthClientID != "",
+		"data": map[string]any{
+			"github": githubEnabled,
 			"google": h.cfg.GoogleOAuthClientID != "",
 			"email":  true,
+			"demo":   h.cfg.DemoMode,
 		},
 	})
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -195,7 +195,7 @@ func TestAuthHandler_Providers(t *testing.T) {
 	tests := []struct {
 		name     string
 		cfg      *config.Config
-		expected map[string]bool
+		expected map[string]any
 	}{
 		{
 			name: "all providers configured",
@@ -203,27 +203,36 @@ func TestAuthHandler_Providers(t *testing.T) {
 				GitHubOAuthClientID: "gh-id",
 				GoogleOAuthClientID: "g-id",
 			},
-			expected: map[string]bool{"github": true, "google": true, "email": true, "demo": false},
+			expected: map[string]any{"github": true, "google": true, "email": true, "demo": false},
 		},
 		{
 			name: "only github configured",
 			cfg: &config.Config{
 				GitHubOAuthClientID: "gh-id",
 			},
-			expected: map[string]bool{"github": true, "google": false, "email": true, "demo": false},
+			expected: map[string]any{"github": true, "google": false, "email": true, "demo": false},
 		},
 		{
 			name:     "no oauth configured",
 			cfg:      &config.Config{},
-			expected: map[string]bool{"github": false, "google": false, "email": true, "demo": false},
+			expected: map[string]any{"github": false, "google": false, "email": true, "demo": false},
 		},
 		{
-			name: "demo mode hides github oauth",
+			name: "demo mode hides github oauth and exposes banner credentials",
 			cfg: &config.Config{
 				GitHubOAuthClientID: "gh-id",
 				DemoMode:            true,
+				DemoEmail:           "dogfood@143.dev",
+				DemoPassword:        "preview-dogfood",
 			},
-			expected: map[string]bool{"github": false, "google": false, "email": true, "demo": true},
+			expected: map[string]any{
+				"github":        false,
+				"google":        false,
+				"email":         true,
+				"demo":          true,
+				"demo_email":    "dogfood@143.dev",
+				"demo_password": "preview-dogfood",
+			},
 		},
 	}
 
@@ -239,12 +248,38 @@ func TestAuthHandler_Providers(t *testing.T) {
 			require.Equal(t, http.StatusOK, w.Code)
 
 			var resp struct {
-				Data map[string]bool `json:"data"`
+				Data map[string]any `json:"data"`
 			}
 			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 			require.Equal(t, tt.expected, resp.Data)
 		})
 	}
+}
+
+// TestAuthHandler_Providers_OmitsDemoCredentialsWhenOff confirms that the
+// demo_email / demo_password fields do NOT leak into the response when
+// DemoMode is off, even if the config happens to have defaults populated.
+func TestAuthHandler_Providers_OmitsDemoCredentialsWhenOff(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		DemoMode:     false,
+		DemoEmail:    "dogfood@143.dev",
+		DemoPassword: "preview-dogfood",
+	}
+	handler := NewAuthHandler(cfg, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/providers", nil)
+	w := httptest.NewRecorder()
+
+	handler.Providers(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp struct {
+		Data map[string]any `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotContains(t, resp.Data, "demo_email", "must not expose demo_email when DemoMode is off")
+	require.NotContains(t, resp.Data, "demo_password", "must not expose demo_password when DemoMode is off")
 }
 
 func TestAuthHandler_Me(t *testing.T) {

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -203,19 +203,27 @@ func TestAuthHandler_Providers(t *testing.T) {
 				GitHubOAuthClientID: "gh-id",
 				GoogleOAuthClientID: "g-id",
 			},
-			expected: map[string]bool{"github": true, "google": true, "email": true},
+			expected: map[string]bool{"github": true, "google": true, "email": true, "demo": false},
 		},
 		{
 			name: "only github configured",
 			cfg: &config.Config{
 				GitHubOAuthClientID: "gh-id",
 			},
-			expected: map[string]bool{"github": true, "google": false, "email": true},
+			expected: map[string]bool{"github": true, "google": false, "email": true, "demo": false},
 		},
 		{
 			name:     "no oauth configured",
 			cfg:      &config.Config{},
-			expected: map[string]bool{"github": false, "google": false, "email": true},
+			expected: map[string]bool{"github": false, "google": false, "email": true, "demo": false},
+		},
+		{
+			name: "demo mode hides github oauth",
+			cfg: &config.Config{
+				GitHubOAuthClientID: "gh-id",
+				DemoMode:            true,
+			},
+			expected: map[string]bool{"github": false, "google": false, "email": true, "demo": true},
 		},
 	}
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -89,8 +89,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	ingestionSvc := ingestion.NewService(issueStore, webhookDeliveryStore, jobStore, logger)
 
 	// Create PRService if GitHub App credentials are configured.
+	// DemoMode short-circuits all GitHub App construction so the dogfood preview
+	// can run with placeholder credentials without 500-ing on integration calls.
 	var prService *ghservice.PRService
-	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to initialize GitHub App service, PR webhooks will be disabled")
@@ -118,7 +120,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	}
 	// If the GitHub App service is available, let the integration handler
 	// fetch repos directly from the API during the install redirect.
-	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
 			integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
@@ -190,7 +192,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
-	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
 			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
@@ -318,6 +320,12 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		Logger:  logger,
 	})
 	recycleWorker.Start()
+
+	// Wire preview teardown into the PR service so closing a PR stops any
+	// active preview for it. No-op when PRService is nil (no GitHub App).
+	if prService != nil {
+		prService.SetPreviewTeardown(previewStore, previewManager)
+	}
 
 	// Preview gateway (separate HTTP listener for <id>.preview.* origins).
 	// gwSrv is stored so callers can shut it down gracefully.

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -89,10 +89,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	ingestionSvc := ingestion.NewService(issueStore, webhookDeliveryStore, jobStore, logger)
 
 	// Create PRService if GitHub App credentials are configured.
-	// DemoMode short-circuits all GitHub App construction so the dogfood preview
-	// can run with placeholder credentials without 500-ing on integration calls.
 	var prService *ghservice.PRService
-	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if cfg.GitHubAppEnabled() {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to initialize GitHub App service, PR webhooks will be disabled")
@@ -120,7 +118,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	}
 	// If the GitHub App service is available, let the integration handler
 	// fetch repos directly from the API during the install redirect.
-	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if cfg.GitHubAppEnabled() {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
 			integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
@@ -192,7 +190,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
-	if !cfg.DemoMode && cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
+	if cfg.GitHubAppEnabled() {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {
 			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -88,19 +88,28 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	// Create services
 	ingestionSvc := ingestion.NewService(issueStore, webhookDeliveryStore, jobStore, logger)
 
-	// Create PRService if GitHub App credentials are configured.
-	var prService *ghservice.PRService
+	// Build the GitHub App service once and reuse it across PRService, the
+	// integration handler, and the team handler. Left nil when the app is
+	// disabled or its credentials fail to parse — downstream sites nil-check
+	// before using it.
+	var ghSvc *ghservice.Service
 	if cfg.GitHubAppEnabled() {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
+		svc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err != nil {
 			logger.Warn().Err(err).Msg("failed to initialize GitHub App service, PR webhooks will be disabled")
 		} else {
-			prService = ghservice.NewPRService(
-				ghSvc, pullRequestStore, sessionStore, issueStore,
-				deployStore, validationStore, repoStore, jobStore, logger,
-			)
-			prService.SetReviewCommentStore(reviewCommentStore)
+			ghSvc = svc
 		}
+	}
+
+	// Create PRService if the GitHub App service is available.
+	var prService *ghservice.PRService
+	if ghSvc != nil {
+		prService = ghservice.NewPRService(
+			ghSvc, pullRequestStore, sessionStore, issueStore,
+			deployStore, validationStore, repoStore, jobStore, logger,
+		)
+		prService.SetReviewCommentStore(reviewCommentStore)
 	}
 
 	// Create handlers
@@ -118,11 +127,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	}
 	// If the GitHub App service is available, let the integration handler
 	// fetch repos directly from the API during the install redirect.
-	if cfg.GitHubAppEnabled() {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
-		if err == nil {
-			integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
-		}
+	if ghSvc != nil {
+		integrationOpts = append(integrationOpts, handlers.WithGitHubApp(ghSvc, repoStore))
 	}
 	integrationOpts = append(integrationOpts, handlers.WithPMContextAutoTrigger(jobStore, pmDocumentStore, logger))
 	integrationHandler := handlers.NewIntegrationHandler(
@@ -190,11 +196,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
-	if cfg.GitHubAppEnabled() {
-		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
-		if err == nil {
-			teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
-		}
+	if ghSvc != nil {
+		teamHandler.SetGitHubIntegration(integrationStore, ghSvc)
 	}
 
 	projectHandler := handlers.NewProjectHandler(projectStore, projectTaskStore, projectCycleStore, projectAttachmentStore, projectSpecStore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -29,6 +31,12 @@ type Config struct {
 	// with seeded data and no real GitHub App. Enables a credential banner
 	// on the login page and short-circuits GitHub client construction.
 	DemoMode bool `env:"DEMO_MODE" envDefault:"false"`
+	// DemoEmail / DemoPassword are the public credentials rendered in the
+	// login-page banner when DemoMode is on. Defaults match the seeded
+	// admin user in .143/seed.sql — override via env only if you also
+	// regenerate the bcrypt hash in the seed.
+	DemoEmail    string `env:"DEMO_EMAIL"    envDefault:"dogfood@143.dev"`
+	DemoPassword string `env:"DEMO_PASSWORD" envDefault:"preview-dogfood"`
 
 	// GitHub OAuth
 	GitHubOAuthClientID     string `env:"GITHUB_OAUTH_CLIENT_ID"`
@@ -182,6 +190,32 @@ func (c *Config) GitHubAppEnabled() bool {
 	return !c.DemoMode && c.GitHubAppID != 0 && c.GitHubAppPrivateKey != ""
 }
 
+// previewOriginHostIsLocal reports whether the template's host resolves to
+// a loopback address in the way a browser would — i.e. the literal
+// "localhost", any "*.localhost" subdomain (RFC 6761), or a loopback IP.
+// Used by LogStatus to warn when PREVIEW_ORIGIN_TEMPLATE is still
+// unconfigured in production. A simple substring search would false-
+// positive on legitimate hostnames like "localhost.example.com".
+func previewOriginHostIsLocal(template string) bool {
+	// Replace the placeholder with something parseable. We only care about
+	// the host, so the value of the replacement doesn't matter as long as
+	// it's a valid DNS label.
+	candidate := strings.ReplaceAll(template, "{id}", "x")
+	u, err := url.Parse(candidate)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	host = strings.ToLower(host)
+	return host == "localhost" || strings.HasSuffix(host, ".localhost")
+}
+
 // LLMConfig returns the llm.Config derived from this Config.
 func (c *Config) LLMConfig() llm.Config {
 	return llm.Config{
@@ -312,7 +346,7 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		logger.Warn().Msg("CSRF_SIGNING_KEY is empty — CSRF protection will be ineffective")
 	}
 
-	if c.Env == "production" && strings.Contains(c.PreviewOriginTemplate, "localhost") {
+	if c.Env == "production" && previewOriginHostIsLocal(c.PreviewOriginTemplate) {
 		logger.Warn().Str("preview_origin_template", c.PreviewOriginTemplate).Msg("PREVIEW_ORIGIN_TEMPLATE points at localhost in production — preview URLs in PR comments and the gateway will not resolve. Set PREVIEW_ORIGIN_TEMPLATE to e.g. https://{id}.preview.example.com.")
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -371,6 +371,12 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 			logger.Warn().
 				Msg("DEMO_EMAIL or DEMO_PASSWORD overridden but the seeded admin in .143/seed.sql still uses the defaults — the login banner will advertise credentials that don't sign in. Regenerate the bcrypt hash in the seed, or unset the override.")
 		}
+		// Operators enabling DemoMode on top of real GitHub App credentials
+		// will see integrations silently no-op. Call that out so the cause
+		// is easy to find in logs.
+		if c.GitHubAppID != 0 && c.GitHubAppPrivateKey != "" {
+			logger.Warn().Msg("DEMO_MODE suppresses the configured GitHub App — integrations will be skipped. Unset DEMO_MODE to re-enable.")
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,10 @@ type Config struct {
 	FrontendURL        string   `env:"FRONTEND_URL"`
 	CORSAllowedOrigins []string `env:"CORS_ALLOWED_ORIGINS"  envSeparator:","`
 	Mode               string   `env:"MODE"                  envDefault:"all"`
+	// DemoMode tells the server it is running a public demo/dogfood preview
+	// with seeded data and no real GitHub App. Enables a credential banner
+	// on the login page and short-circuits GitHub client construction.
+	DemoMode bool `env:"DEMO_MODE" envDefault:"false"`
 
 	// GitHub OAuth
 	GitHubOAuthClientID     string `env:"GITHUB_OAUTH_CLIENT_ID"`
@@ -297,6 +301,14 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 
 	if c.CSRFSigningKey == "" {
 		logger.Warn().Msg("CSRF_SIGNING_KEY is empty — CSRF protection will be ineffective")
+	}
+
+	if c.Env == "production" && c.PreviewOriginTemplate == "http://{id}.preview.localhost:9090" {
+		logger.Warn().Msg("PREVIEW_ORIGIN_TEMPLATE is using the localhost default in production — preview URLs in PR comments and the gateway will not resolve. Set PREVIEW_ORIGIN_TEMPLATE to e.g. https://{id}.preview.example.com.")
+	}
+
+	if c.DemoMode {
+		logger.Warn().Msg("DEMO_MODE is enabled — GitHub integrations are stubbed, seeded credentials are public. Do not use this configuration for production data.")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,17 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// Default demo credentials. Must stay in sync with the envDefault tags on
+// Config.DemoEmail / Config.DemoPassword and with the seeded admin row in
+// .143/seed.sql (where the password is stored as a bcrypt hash). Overriding
+// DemoPassword via env without regenerating the seed hash results in a
+// login-page banner that advertises credentials that won't actually sign in
+// — LogStatus warns about this at boot.
+const (
+	defaultDemoEmail    = "dogfood@143.dev"
+	defaultDemoPassword = "preview-dogfood"
+)
+
 type Config struct {
 	// Environment
 	Env string `env:"ENV" envDefault:"development"`
@@ -32,9 +43,9 @@ type Config struct {
 	// on the login page and short-circuits GitHub client construction.
 	DemoMode bool `env:"DEMO_MODE" envDefault:"false"`
 	// DemoEmail / DemoPassword are the public credentials rendered in the
-	// login-page banner when DemoMode is on. Defaults match the seeded
-	// admin user in .143/seed.sql — override via env only if you also
-	// regenerate the bcrypt hash in the seed.
+	// login-page banner when DemoMode is on. Defaults must match the seeded
+	// admin in .143/seed.sql and the constants below — override via env
+	// only if you also regenerate the bcrypt hash in the seed.
 	DemoEmail    string `env:"DEMO_EMAIL"    envDefault:"dogfood@143.dev"`
 	DemoPassword string `env:"DEMO_PASSWORD" envDefault:"preview-dogfood"`
 
@@ -291,7 +302,7 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		{"Google OAuth", c.GoogleOAuthClientID != "" && c.GoogleOAuthClientSecret != "", "login"},
 		{"Linear OAuth", c.LinearOAuthClientID != "" && c.LinearOAuthClientSecret != "", "integration auth"},
 		{"Sentry OAuth", c.SentryOAuthClientID != "" && c.SentryOAuthClientSecret != "", "integration auth"},
-		{"GitHub App", c.GitHubAppID != 0 && c.GitHubAppPrivateKey != "", "webhooks, PRs"},
+		{"GitHub App", c.GitHubAppEnabled(), "webhooks, PRs"},
 		{"Credential encryption", c.EncryptionMasterKey != "", "encrypted credential storage"},
 	}
 
@@ -352,6 +363,14 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 
 	if c.DemoMode {
 		logger.Warn().Msg("DEMO_MODE is enabled — GitHub integrations are stubbed, seeded credentials are public. Do not use this configuration for production data.")
+		// The seeded admin in .143/seed.sql stores a bcrypt hash of
+		// defaultDemoPassword. Overriding DEMO_PASSWORD without regenerating
+		// the hash leaves the login-page banner pointing at credentials that
+		// do not log in — a subtle footgun, so warn loudly.
+		if c.DemoPassword != defaultDemoPassword || c.DemoEmail != defaultDemoEmail {
+			logger.Warn().
+				Msg("DEMO_EMAIL or DEMO_PASSWORD overridden but the seeded admin in .143/seed.sql still uses the defaults — the login banner will advertise credentials that don't sign in. Regenerate the bcrypt hash in the seed, or unset the override.")
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/llm"
@@ -173,6 +174,14 @@ func Load() *Config {
 	return cfg
 }
 
+// GitHubAppEnabled reports whether the GitHub App integration should be
+// wired up. Requires both app credentials and a non-demo environment: in
+// DemoMode we skip GitHub App construction so the dogfood preview can boot
+// with placeholder credentials without 500-ing on integration calls.
+func (c *Config) GitHubAppEnabled() bool {
+	return !c.DemoMode && c.GitHubAppID != 0 && c.GitHubAppPrivateKey != ""
+}
+
 // LLMConfig returns the llm.Config derived from this Config.
 func (c *Config) LLMConfig() llm.Config {
 	return llm.Config{
@@ -303,8 +312,8 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		logger.Warn().Msg("CSRF_SIGNING_KEY is empty — CSRF protection will be ineffective")
 	}
 
-	if c.Env == "production" && c.PreviewOriginTemplate == "http://{id}.preview.localhost:9090" {
-		logger.Warn().Msg("PREVIEW_ORIGIN_TEMPLATE is using the localhost default in production — preview URLs in PR comments and the gateway will not resolve. Set PREVIEW_ORIGIN_TEMPLATE to e.g. https://{id}.preview.example.com.")
+	if c.Env == "production" && strings.Contains(c.PreviewOriginTemplate, "localhost") {
+		logger.Warn().Str("preview_origin_template", c.PreviewOriginTemplate).Msg("PREVIEW_ORIGIN_TEMPLATE points at localhost in production — preview URLs in PR comments and the gateway will not resolve. Set PREVIEW_ORIGIN_TEMPLATE to e.g. https://{id}.preview.example.com.")
 	}
 
 	if c.DemoMode {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -420,6 +420,67 @@ func TestLogStatus_DemoCredentialMismatch(t *testing.T) {
 	}
 }
 
+// TestLogStatus_DemoSuppressesGitHubApp covers the boot-time warning emitted
+// when DemoMode is on but GitHub App credentials are also configured — the
+// integration is silently suppressed, so we log once at startup so the cause
+// is easy to find in logs.
+func TestLogStatus_DemoSuppressesGitHubApp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      Config
+		wantWarn bool
+	}{
+		{
+			name: "demo on + github app creds warns",
+			cfg: Config{
+				SessionSecret:       "s",
+				CSRFSigningKey:      "c",
+				DemoMode:            true,
+				GitHubAppID:         123,
+				GitHubAppPrivateKey: "key",
+			},
+			wantWarn: true,
+		},
+		{
+			name: "demo on + no github app creds does not warn",
+			cfg: Config{
+				SessionSecret:  "s",
+				CSRFSigningKey: "c",
+				DemoMode:       true,
+			},
+			wantWarn: false,
+		},
+		{
+			name: "demo off + github app creds does not warn",
+			cfg: Config{
+				SessionSecret:       "s",
+				CSRFSigningKey:      "c",
+				GitHubAppID:         123,
+				GitHubAppPrivateKey: "key",
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			tc.cfg.LogStatus(zerolog.New(&buf))
+
+			if tc.wantWarn {
+				require.Contains(t, buf.String(), "DEMO_MODE suppresses the configured GitHub App")
+			} else {
+				require.NotContains(t, buf.String(), "DEMO_MODE suppresses the configured GitHub App")
+			}
+		})
+	}
+}
+
 func TestLogStatus_PreviewOriginTemplateLocalhostInProduction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -567,3 +567,35 @@ func TestLogStatus_PreviewOriginTemplateLocalhostInProduction(t *testing.T) {
 		})
 	}
 }
+
+func TestPreviewOriginHostIsLocal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		want     bool
+	}{
+		{name: "localhost host", template: "http://localhost:9090/{id}", want: true},
+		{name: "wildcard localhost subdomain", template: "http://{id}.preview.localhost:9090", want: true},
+		{name: "loopback IPv4", template: "http://127.0.0.1:9090/{id}", want: true},
+		{name: "loopback IPv6", template: "http://[::1]:9090/{id}", want: true},
+		{name: "real host", template: "https://{id}.preview.example.com", want: false},
+		{name: "substring localhost in real host", template: "https://{id}.localhost.example.com", want: false},
+		// url.Parse error branch: stray percent escape
+		{name: "malformed percent escape", template: "http://%zz", want: false},
+		// u.Host == "" branch: no authority component
+		{name: "relative path without scheme", template: "relative/path", want: false},
+		{name: "scheme only", template: "http:", want: false},
+		// u.Hostname() == "" branch: authority with port but empty host
+		{name: "empty host with port", template: "http://:8080/{id}", want: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, previewOriginHostIsLocal(tc.template))
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -345,6 +345,81 @@ func TestLogStatus_DemoModeWarns(t *testing.T) {
 	require.Contains(t, buf.String(), "DEMO_MODE is enabled", "LogStatus should warn when DemoMode is set")
 }
 
+// TestLogStatus_DemoCredentialMismatch covers the boot-time warning emitted
+// when DemoMode is on but DemoEmail/DemoPassword have been overridden away
+// from the seeded defaults — the banner would advertise credentials that
+// don't actually sign in against the seeded bcrypt hash.
+func TestLogStatus_DemoCredentialMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      Config
+		wantWarn bool
+	}{
+		{
+			name: "demo on + defaults does not warn",
+			cfg: Config{
+				SessionSecret:  "s",
+				CSRFSigningKey: "c",
+				DemoMode:       true,
+				DemoEmail:      defaultDemoEmail,
+				DemoPassword:   defaultDemoPassword,
+			},
+			wantWarn: false,
+		},
+		{
+			name: "demo on + overridden password warns",
+			cfg: Config{
+				SessionSecret:  "s",
+				CSRFSigningKey: "c",
+				DemoMode:       true,
+				DemoEmail:      defaultDemoEmail,
+				DemoPassword:   "something-else",
+			},
+			wantWarn: true,
+		},
+		{
+			name: "demo on + overridden email warns",
+			cfg: Config{
+				SessionSecret:  "s",
+				CSRFSigningKey: "c",
+				DemoMode:       true,
+				DemoEmail:      "other@example.com",
+				DemoPassword:   defaultDemoPassword,
+			},
+			wantWarn: true,
+		},
+		{
+			name: "demo off + overridden creds does not warn",
+			cfg: Config{
+				SessionSecret:  "s",
+				CSRFSigningKey: "c",
+				DemoMode:       false,
+				DemoEmail:      "other@example.com",
+				DemoPassword:   "something-else",
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			tc.cfg.LogStatus(zerolog.New(&buf))
+
+			if tc.wantWarn {
+				require.Contains(t, buf.String(), "DEMO_EMAIL or DEMO_PASSWORD overridden")
+			} else {
+				require.NotContains(t, buf.String(), "DEMO_EMAIL or DEMO_PASSWORD overridden")
+			}
+		})
+	}
+}
+
 func TestLogStatus_PreviewOriginTemplateLocalhostInProduction(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -287,4 +288,126 @@ func TestValidateSecrets_ProductionMissingCSRFKey(t *testing.T) {
 	err := cfg.ValidateSecrets()
 	require.Error(t, err, "missing CSRF_SIGNING_KEY in production should error")
 	require.Contains(t, err.Error(), "CSRF_SIGNING_KEY")
+}
+
+func TestGitHubAppEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{
+			name: "fully configured",
+			cfg:  Config{GitHubAppID: 123, GitHubAppPrivateKey: "key"},
+			want: true,
+		},
+		{
+			name: "missing app id",
+			cfg:  Config{GitHubAppPrivateKey: "key"},
+			want: false,
+		},
+		{
+			name: "missing private key",
+			cfg:  Config{GitHubAppID: 123},
+			want: false,
+		},
+		{
+			name: "demo mode disables even with credentials",
+			cfg:  Config{GitHubAppID: 123, GitHubAppPrivateKey: "key", DemoMode: true},
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, tc.cfg.GitHubAppEnabled())
+		})
+	}
+}
+
+func TestLogStatus_DemoModeWarns(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+
+	cfg := &Config{
+		SessionSecret:  "s",
+		CSRFSigningKey: "c",
+		DemoMode:       true,
+	}
+	cfg.LogStatus(logger)
+
+	require.Contains(t, buf.String(), "DEMO_MODE is enabled", "LogStatus should warn when DemoMode is set")
+}
+
+func TestLogStatus_PreviewOriginTemplateLocalhostInProduction(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      Config
+		wantWarn bool
+	}{
+		{
+			name: "production + localhost template warns",
+			cfg: Config{
+				Env:                   "production",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "http://{id}.preview.localhost:9090",
+			},
+			wantWarn: true,
+		},
+		{
+			name: "production + custom localhost variant warns",
+			cfg: Config{
+				Env:                   "production",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "http://localhost:8080/{id}",
+			},
+			wantWarn: true,
+		},
+		{
+			name: "production + real host does not warn",
+			cfg: Config{
+				Env:                   "production",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "https://{id}.preview.example.com",
+			},
+			wantWarn: false,
+		},
+		{
+			name: "development + localhost does not warn",
+			cfg: Config{
+				Env:                   "development",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "http://{id}.preview.localhost:9090",
+			},
+			wantWarn: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			tc.cfg.LogStatus(zerolog.New(&buf))
+
+			if tc.wantWarn {
+				require.Contains(t, buf.String(), "PREVIEW_ORIGIN_TEMPLATE points at localhost")
+			} else {
+				require.NotContains(t, buf.String(), "PREVIEW_ORIGIN_TEMPLATE points at localhost")
+			}
+		})
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -384,6 +384,26 @@ func TestLogStatus_PreviewOriginTemplateLocalhostInProduction(t *testing.T) {
 			wantWarn: false,
 		},
 		{
+			name: "production + host containing 'localhost' as substring does not warn",
+			cfg: Config{
+				Env:                   "production",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "https://{id}.preview.localhost.example.com",
+			},
+			wantWarn: false,
+		},
+		{
+			name: "production + loopback IP warns",
+			cfg: Config{
+				Env:                   "production",
+				SessionSecret:         "s",
+				CSRFSigningKey:        "c",
+				PreviewOriginTemplate: "http://127.0.0.1:9090/{id}",
+			},
+			wantWarn: true,
+		},
+		{
 			name: "development + localhost does not warn",
 			cfg: Config{
 				Env:                   "development",

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -140,15 +140,18 @@ func (s *RepositoryStore) UpsertFromGitHub(ctx context.Context, repo *models.Rep
 	return row.Scan(&repo.ID, &repo.CreatedAt, &repo.UpdatedAt)
 }
 
-// GetByFullName returns the active repository with the given owner/name slug.
-// lint:allow-no-orgid reason="pre-auth lookup in GitHub webhook handlers; no org context available"
-func (s *RepositoryStore) GetByFullName(ctx context.Context, fullName string) (models.Repository, error) {
+// GetByFullName returns the active repository with the given owner/name slug,
+// scoped to the provided org. Scoping matters because the same GitHub repo
+// can legitimately be connected to more than one org (e.g. a contractor who
+// installs the app into two separate customer orgs), and an unscoped lookup
+// would error on multiple rows or silently cross org boundaries.
+func (s *RepositoryStore) GetByFullName(ctx context.Context, orgID uuid.UUID, fullName string) (models.Repository, error) {
 	query := `
 		SELECT id, org_id, integration_id, github_id, full_name, default_branch, private, language, description, clone_url, installation_id, status, last_synced_at, context_quality, settings, created_at, updated_at
 		FROM repositories
-		WHERE full_name = @full_name AND status = 'active'`
+		WHERE org_id = @org_id AND full_name = @full_name AND status = 'active'`
 
-	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"full_name": fullName})
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID, "full_name": fullName})
 	if err != nil {
 		return models.Repository{}, fmt.Errorf("query repository by full name: %w", err)
 	}

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -115,6 +115,76 @@ func TestRepositoryStore_GetByID(t *testing.T) {
 	}
 }
 
+func TestRepositoryStore_GetByFullName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupMock func(mock pgxmock.PgxPoolIface, orgID, repoID, integrationID uuid.UUID, now time.Time)
+		expectErr bool
+	}{
+		{
+			name: "returns repository when found",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, repoID, integrationID uuid.UUID, now time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = @org_id AND full_name = @full_name").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(repoColumns).
+							AddRow(newRepoRow(repoID, orgID, integrationID, now)...),
+					)
+			},
+		},
+		{
+			name: "returns error when repository not found",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, repoID, integrationID uuid.UUID, now time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = @org_id AND full_name = @full_name").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(repoColumns))
+			},
+			expectErr: true,
+		},
+		{
+			name: "returns error when query fails",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, repoID, integrationID uuid.UUID, now time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = @org_id AND full_name = @full_name").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(context.DeadlineExceeded)
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewRepositoryStore(mock)
+			orgID := uuid.New()
+			repoID := uuid.New()
+			integrationID := uuid.New()
+			now := time.Now()
+			tt.setupMock(mock, orgID, repoID, integrationID, now)
+
+			repo, err := store.GetByFullName(context.Background(), orgID, "org/repo")
+			if tt.expectErr {
+				require.Error(t, err, "GetByFullName should return an error")
+				return
+			}
+			require.NoError(t, err, "GetByFullName should not return an error")
+			require.Equal(t, repoID, repo.ID, "should return the correct repository ID")
+			require.Equal(t, orgID, repo.OrgID, "should return the correct org ID")
+			require.Equal(t, "org/repo", repo.FullName, "should return the correct repository full name")
+			require.Equal(t, "active", repo.Status, "should return the correct repository status")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
 func TestRepositoryStore_Create(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -550,9 +550,6 @@ func (s *PRService) teardownPRPreview(ctx context.Context, pr models.PullRequest
 		}
 		return
 	}
-	if state == nil {
-		return
-	}
 
 	if state.LastPreviewInstanceID != nil {
 		if stopErr := s.previewStopper.StopPreview(ctx, pr.OrgID, *state.LastPreviewInstanceID); stopErr != nil {

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/db"
@@ -536,7 +538,19 @@ func (s *PRService) teardownPRPreview(ctx context.Context, pr models.PullRequest
 	}
 
 	state, err := s.previews.GetPRPreviewState(ctx, pr.OrgID, repo.ID, pr.GitHubPRNumber)
-	if err != nil || state == nil {
+	if err != nil {
+		// No pr_preview_state row is the common case (PR never had a
+		// preview) and not worth a warning. Anything else is an actual
+		// database error — log it so we don't silently mask ops issues.
+		if !errors.Is(err, pgx.ErrNoRows) {
+			s.logger.Warn().Err(err).
+				Str("repo", pr.GitHubRepo).
+				Int("pr_number", pr.GitHubPRNumber).
+				Msg("failed to load pr_preview_state for PR preview teardown")
+		}
+		return
+	}
+	if state == nil {
 		return
 	}
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -531,7 +531,7 @@ func (s *PRService) teardownPRPreview(ctx context.Context, pr models.PullRequest
 		return
 	}
 
-	repo, err := s.repos.GetByFullName(ctx, pr.GitHubRepo)
+	repo, err := s.repos.GetByFullName(ctx, pr.OrgID, pr.GitHubRepo)
 	if err != nil {
 		s.logger.Debug().Err(err).Str("repo", pr.GitHubRepo).Msg("no repo row for PR preview teardown")
 		return

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -29,6 +29,13 @@ const (
 	prTemplateCacheTTL = 24 * time.Hour // re-fetch repo PR template after this duration
 )
 
+// PreviewStopper stops a running preview instance. Implemented by
+// *preview.Manager; extracted as an interface here to avoid importing the
+// preview package (which depends on this package).
+type PreviewStopper interface {
+	StopPreview(ctx context.Context, orgID, previewID uuid.UUID) error
+}
+
 // PRService handles GitHub PR creation and webhook-based tracking.
 type PRService struct {
 	tokenProvider   *Service
@@ -44,6 +51,8 @@ type PRService struct {
 	users           *db.UserStore
 	orgs            *db.OrganizationStore
 	prTemplates     *db.PRTemplateStore
+	previews        *db.PreviewStore
+	previewStopper  PreviewStopper
 	llmClient       llm.Client
 	audit           *db.AuditEmitter
 	logger          zerolog.Logger
@@ -110,6 +119,14 @@ func (s *PRService) SetOrgStore(store *db.OrganizationStore) {
 // SetPRTemplateStore sets the PR template cache store.
 func (s *PRService) SetPRTemplateStore(store *db.PRTemplateStore) {
 	s.prTemplates = store
+}
+
+// SetPreviewTeardown wires the preview store and stopper used to stop any
+// active preview when a PR is closed. Both args may be nil (no-op) in
+// configurations without the preview subsystem.
+func (s *PRService) SetPreviewTeardown(previews *db.PreviewStore, stopper PreviewStopper) {
+	s.previews = previews
+	s.previewStopper = stopper
 }
 
 // tokenResolution holds the resolved token and metadata about how it was resolved.
@@ -472,6 +489,10 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 		}
 	}
 
+	// Stop any active preview for this PR. Runs in both merged and closed
+	// branches: once a PR is no longer open, the preview is obsolete.
+	s.teardownPRPreview(ctx, pr, event.PR.Merged)
+
 	// Auto-archive the linked session if the org has opted in.
 	if pr.SessionID != nil && s.orgs != nil {
 		if org, err := s.orgs.GetByID(ctx, pr.OrgID); err != nil {
@@ -498,6 +519,45 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 	}
 
 	return nil
+}
+
+// teardownPRPreview stops the running preview (if any) for a closed PR and
+// advances its pr_preview_state row to the terminal status. Best-effort: all
+// failures are logged and swallowed so webhook processing continues.
+func (s *PRService) teardownPRPreview(ctx context.Context, pr models.PullRequest, merged bool) {
+	if s.previews == nil || s.previewStopper == nil || s.repos == nil {
+		return
+	}
+
+	repo, err := s.repos.GetByFullName(ctx, pr.GitHubRepo)
+	if err != nil {
+		s.logger.Debug().Err(err).Str("repo", pr.GitHubRepo).Msg("no repo row for PR preview teardown")
+		return
+	}
+
+	state, err := s.previews.GetPRPreviewState(ctx, pr.OrgID, repo.ID, pr.GitHubPRNumber)
+	if err != nil || state == nil {
+		return
+	}
+
+	if state.LastPreviewInstanceID != nil {
+		if stopErr := s.previewStopper.StopPreview(ctx, pr.OrgID, *state.LastPreviewInstanceID); stopErr != nil {
+			s.logger.Warn().Err(stopErr).
+				Str("preview_id", state.LastPreviewInstanceID.String()).
+				Str("pr_id", pr.ID.String()).
+				Msg("failed to stop preview on PR close")
+		}
+	}
+
+	nextStatus := models.PRPreviewStatusClosed
+	if merged {
+		nextStatus = models.PRPreviewStatusMerged
+	}
+	if err := s.previews.UpdatePRPreviewStatus(ctx, pr.OrgID, state.ID, nextStatus); err != nil {
+		s.logger.Warn().Err(err).
+			Str("pr_preview_state_id", state.ID.String()).
+			Msg("failed to update pr_preview_state status")
+	}
 }
 
 // PullRequestReviewEvent represents a GitHub pull_request_review webhook event.

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -2063,3 +2063,293 @@ func TestTeardownPRPreview(t *testing.T) {
 		})
 	}
 }
+
+func TestPRService_SetPreviewTeardown(t *testing.T) {
+	t.Parallel()
+
+	previewMock := newMockPool(t)
+	store := db.NewPreviewStore(previewMock)
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{logger: zerolog.Nop()}
+	svc.SetPreviewTeardown(store, stopper)
+
+	require.Same(t, store, svc.previews, "SetPreviewTeardown should wire the preview store")
+	require.Equal(t, PreviewStopper(stopper), svc.previewStopper, "SetPreviewTeardown should wire the stopper")
+}
+
+// TestTeardownPRPreview_NilGuards exercises the early-return paths when the
+// preview subsystem is not wired. teardownPRPreview must be a silent no-op
+// in self-hosted configurations that don't construct a preview manager.
+func TestTeardownPRPreview_NilGuards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		svc  *PRService
+	}{
+		{
+			name: "previews store nil",
+			svc: &PRService{
+				previewStopper: &recordingPreviewStopper{},
+				repos:          db.NewRepositoryStore(newMockPool(t)),
+				logger:         zerolog.Nop(),
+			},
+		},
+		{
+			name: "stopper nil",
+			svc: &PRService{
+				previews: db.NewPreviewStore(newMockPool(t)),
+				repos:    db.NewRepositoryStore(newMockPool(t)),
+				logger:   zerolog.Nop(),
+			},
+		},
+		{
+			name: "repos nil",
+			svc: &PRService{
+				previews:       db.NewPreviewStore(newMockPool(t)),
+				previewStopper: &recordingPreviewStopper{},
+				logger:         zerolog.Nop(),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			pr := models.PullRequest{
+				OrgID:          uuid.New(),
+				GitHubRepo:     "testorg/testrepo",
+				GitHubPRNumber: 42,
+			}
+			require.NotPanics(t, func() {
+				tc.svc.teardownPRPreview(context.Background(), pr, false)
+			})
+		})
+	}
+}
+
+// TestTeardownPRPreview_RepoLookupError exercises the path where the
+// repository lookup fails. The function must log and return without calling
+// the preview store.
+func TestTeardownPRPreview_RepoLookupError(t *testing.T) {
+	t.Parallel()
+
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("repo not found"))
+
+	pr := models.PullRequest{
+		OrgID:          uuid.New(),
+		GitHubRepo:     "testorg/missing",
+		GitHubPRNumber: 42,
+	}
+	svc.teardownPRPreview(context.Background(), pr, false)
+
+	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when repo lookup fails")
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet(), "preview store must not be queried when repo lookup fails")
+}
+
+// TestTeardownPRPreview_NoPreviewState covers the path where the PR has
+// never had a preview created — GetPRPreviewState returns nil, no error.
+func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("no rows"))
+
+	pr := models.PullRequest{
+		OrgID:          orgID,
+		GitHubRepo:     "testorg/testrepo",
+		GitHubPRNumber: 42,
+	}
+	svc.teardownPRPreview(context.Background(), pr, false)
+
+	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when no pr_preview_state exists")
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}
+
+// TestTeardownPRPreview_NilPreviewInstanceID covers the branch where the
+// preview state row exists but never had an instance attached to it.
+// UpdatePRPreviewStatus still runs; StopPreview must not.
+func TestTeardownPRPreview_NilPreviewInstanceID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	prPreviewStateID := uuid.New()
+	now := time.Now()
+
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+				"last_preview_instance_id", "last_screenshot_blob_path",
+				"last_visual_diff_blob_path", "base_snapshot_key", "status",
+				"created_at", "updated_at",
+			}).AddRow(
+				prPreviewStateID, orgID, repoID, 42, nil,
+				(*uuid.UUID)(nil), "", "", "", "running", now, now,
+			),
+		)
+
+	previewMock.ExpectExec("UPDATE pr_preview_state SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	pr := models.PullRequest{
+		OrgID:          orgID,
+		GitHubRepo:     "testorg/testrepo",
+		GitHubPRNumber: 42,
+	}
+	svc.teardownPRPreview(context.Background(), pr, false)
+
+	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when LastPreviewInstanceID is nil")
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}
+
+// TestTeardownPRPreview_SwallowsErrors confirms that a stopper failure and
+// an UpdatePRPreviewStatus failure are both logged-and-swallowed: the
+// function returns normally so webhook processing continues.
+func TestTeardownPRPreview_SwallowsErrors(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	prPreviewStateID := uuid.New()
+	previewInstanceID := uuid.New()
+	now := time.Now()
+
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+	stopper := &recordingPreviewStopper{nextErr: fmt.Errorf("preview already gone")}
+
+	svc := &PRService{
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+				"last_preview_instance_id", "last_screenshot_blob_path",
+				"last_visual_diff_blob_path", "base_snapshot_key", "status",
+				"created_at", "updated_at",
+			}).AddRow(
+				prPreviewStateID, orgID, repoID, 42, nil,
+				&previewInstanceID, "", "", "", "running", now, now,
+			),
+		)
+
+	previewMock.ExpectExec("UPDATE pr_preview_state SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("update failed"))
+
+	pr := models.PullRequest{
+		OrgID:          orgID,
+		GitHubRepo:     "testorg/testrepo",
+		GitHubPRNumber: 42,
+	}
+	require.NotPanics(t, func() {
+		svc.teardownPRPreview(context.Background(), pr, true)
+	})
+
+	require.Equal(t, 1, stopper.calls, "StopPreview should still be invoked even though it returns an error")
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1968,3 +1968,98 @@ func TestHandlePullRequestEvent_ClosedStopsPreview(t *testing.T) {
 	require.NoError(t, repoMock.ExpectationsWereMet())
 	require.NoError(t, previewMock.ExpectationsWereMet())
 }
+
+// TestTeardownPRPreview focuses on the merged-vs-closed status decision inside
+// teardownPRPreview without exercising the rest of HandlePullRequestEvent
+// (which, on the merged branch, also writes a Deploy row and enqueues a job).
+func TestTeardownPRPreview(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		merged     bool
+		wantStatus models.PRPreviewStatus
+	}{
+		{name: "closed without merge", merged: false, wantStatus: models.PRPreviewStatusClosed},
+		{name: "closed via merge", merged: true, wantStatus: models.PRPreviewStatusMerged},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := uuid.New()
+			prID := uuid.New()
+			repoID := uuid.New()
+			integrationID := uuid.New()
+			prPreviewStateID := uuid.New()
+			previewInstanceID := uuid.New()
+			now := time.Now()
+
+			repoMock := newMockPool(t)
+			previewMock := newMockPool(t)
+
+			stopper := &recordingPreviewStopper{}
+
+			svc := &PRService{
+				repos:          db.NewRepositoryStore(repoMock),
+				previews:       db.NewPreviewStore(previewMock),
+				previewStopper: stopper,
+				logger:         zerolog.Nop(),
+			}
+
+			// Repo lookup by full name.
+			handlerRepoColumns := []string{
+				"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+				"private", "language", "description", "clone_url", "installation_id", "status",
+				"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+			}
+			repoMock.ExpectQuery("SELECT .+ FROM repositories").
+				WithArgs(pgxmock.AnyArg()).
+				WillReturnRows(
+					pgxmock.NewRows(handlerRepoColumns).
+						AddRow(repoID, orgID, integrationID, int64(12345),
+							"testorg/testrepo", "main", false, nil, nil,
+							"https://github.com/testorg/testrepo.git", int64(99),
+							"active", nil, nil, json.RawMessage(`{}`), now, now),
+				)
+
+			// GetPRPreviewState returns a state with a live instance.
+			previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(
+					pgxmock.NewRows([]string{
+						"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+						"last_preview_instance_id", "last_screenshot_blob_path",
+						"last_visual_diff_blob_path", "base_snapshot_key", "status",
+						"created_at", "updated_at",
+					}).AddRow(
+						prPreviewStateID, orgID, repoID, 42, nil,
+						&previewInstanceID, "", "", "", "running", now, now,
+					),
+				)
+
+			// UpdatePRPreviewStatus — assert the status arg matches the expected
+			// terminal value. pgx expands NamedArgs positionally in the order the
+			// @name placeholders appear in the SQL: @status, @id, @org_id.
+			previewMock.ExpectExec("UPDATE pr_preview_state SET status").
+				WithArgs(tc.wantStatus, pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+			pr := models.PullRequest{
+				ID:             prID,
+				OrgID:          orgID,
+				GitHubRepo:     "testorg/testrepo",
+				GitHubPRNumber: 42,
+			}
+			svc.teardownPRPreview(context.Background(), pr, tc.merged)
+
+			require.Equal(t, 1, stopper.calls, "StopPreview should be called exactly once")
+			require.Equal(t, previewInstanceID, stopper.prevID)
+			require.Equal(t, orgID, stopper.orgID)
+			require.NoError(t, repoMock.ExpectationsWereMet())
+			require.NoError(t, previewMock.ExpectationsWereMet())
+		})
+	}
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1927,7 +1927,7 @@ func TestHandlePullRequestEvent_ClosedStopsPreview(t *testing.T) {
 		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 	}
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerRepoColumns).
 				AddRow(repoID, orgID, integrationID, int64(12345),
@@ -1966,6 +1966,125 @@ func TestHandlePullRequestEvent_ClosedStopsPreview(t *testing.T) {
 	require.Equal(t, previewInstanceID, stopper.prevID, "StopPreview should receive the preview instance id from pr_preview_state")
 	require.Equal(t, orgID, stopper.orgID, "StopPreview should receive the PR's org id")
 	require.NoError(t, prMock.ExpectationsWereMet())
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}
+
+// TestHandlePullRequestEvent_MergedStopsPreview exercises the full merged
+// branch of HandlePullRequestEvent with preview teardown wired in: PR update,
+// deploy record, enqueued job, AND the preview stop + pr_preview_state
+// transition to "merged". SessionID is nil so we skip the session/issue path.
+func TestHandlePullRequestEvent_MergedStopsPreview(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	prPreviewStateID := uuid.New()
+	previewInstanceID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	deployMock := newMockPool(t)
+	jobMock := newMockPool(t)
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{
+		pullRequests:   db.NewPullRequestStore(prMock),
+		deploys:        db.NewDeployStore(deployMock),
+		jobs:           db.NewJobStore(jobMock),
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	// 1. GetByRepoAndNumber returns a PR with nil session_id.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, (*uuid.UUID)(nil), orgID, 42,
+					"https://github.com/testorg/testrepo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "",
+					(*time.Time)(nil), now, now),
+		)
+
+	// 2. UpdateStatus to merged.
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// 3. Create deploy row.
+	deployMock.ExpectQuery("INSERT INTO deploys").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "deployed_at", "created_at"}).
+				AddRow(uuid.New(), now, now),
+		)
+
+	// 4. Enqueue evaluate_experiment job.
+	jobMock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()),
+		)
+
+	// 5. Repo lookup (org-scoped).
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	// 6. GetPRPreviewState returns a running state with a live instance.
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+				"last_preview_instance_id", "last_screenshot_blob_path",
+				"last_visual_diff_blob_path", "base_snapshot_key", "status",
+				"created_at", "updated_at",
+			}).AddRow(
+				prPreviewStateID, orgID, repoID, 42, nil,
+				&previewInstanceID, "", "", "", "running", now, now,
+			),
+		)
+
+	// 7. UpdatePRPreviewStatus — pgx.NamedArgs bind positionally as
+	// @status, @id, @org_id. Assert status is the "merged" terminal value.
+	previewMock.ExpectExec("UPDATE pr_preview_state SET status").
+		WithArgs(models.PRPreviewStatusMerged, pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestEvent{Action: "closed", Number: 42}
+	event.PR.Merged = true
+	event.PR.Head.SHA = "abc123commit"
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err)
+	require.Equal(t, 1, stopper.calls, "StopPreview should be called exactly once on the merged branch")
+	require.Equal(t, previewInstanceID, stopper.prevID)
+	require.Equal(t, orgID, stopper.orgID)
+	require.NoError(t, prMock.ExpectationsWereMet())
+	require.NoError(t, deployMock.ExpectationsWereMet())
+	require.NoError(t, jobMock.ExpectationsWereMet())
 	require.NoError(t, repoMock.ExpectationsWereMet())
 	require.NoError(t, previewMock.ExpectationsWereMet())
 }
@@ -2017,7 +2136,7 @@ func TestTeardownPRPreview(t *testing.T) {
 				"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 			}
 			repoMock.ExpectQuery("SELECT .+ FROM repositories").
-				WithArgs(pgxmock.AnyArg()).
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnRows(
 					pgxmock.NewRows(handlerRepoColumns).
 						AddRow(repoID, orgID, integrationID, int64(12345),
@@ -2149,7 +2268,7 @@ func TestTeardownPRPreview_RepoLookupError(t *testing.T) {
 	}
 
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(fmt.Errorf("repo not found"))
 
 	pr := models.PullRequest{
@@ -2194,7 +2313,7 @@ func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
 		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 	}
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerRepoColumns).
 				AddRow(repoID, orgID, integrationID, int64(12345),
@@ -2259,7 +2378,7 @@ func TestTeardownPRPreview_PreviewStateLookupError(t *testing.T) {
 		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 	}
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerRepoColumns).
 				AddRow(repoID, orgID, integrationID, int64(12345),
@@ -2315,7 +2434,7 @@ func TestTeardownPRPreview_NilPreviewInstanceID(t *testing.T) {
 		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 	}
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerRepoColumns).
 				AddRow(repoID, orgID, integrationID, int64(12345),
@@ -2384,7 +2503,7 @@ func TestTeardownPRPreview_SwallowsErrors(t *testing.T) {
 		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
 	}
 	repoMock.ExpectQuery("SELECT .+ FROM repositories").
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(handlerRepoColumns).
 				AddRow(repoID, orgID, integrationID, int64(12345),

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1861,3 +1861,110 @@ func TestHandleCheckSuiteEvent_PRNotFound(t *testing.T) {
 	require.NoError(t, err, "should skip unknown PRs without error")
 	require.NoError(t, prMock.ExpectationsWereMet(), "all database expectations should be met")
 }
+
+// recordingPreviewStopper captures StopPreview calls for assertions.
+type recordingPreviewStopper struct {
+	calls   int
+	orgID   uuid.UUID
+	prevID  uuid.UUID
+	nextErr error
+}
+
+func (r *recordingPreviewStopper) StopPreview(_ context.Context, orgID, previewID uuid.UUID) error {
+	r.calls++
+	r.orgID = orgID
+	r.prevID = previewID
+	return r.nextErr
+}
+
+func TestHandlePullRequestEvent_ClosedStopsPreview(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	prPreviewStateID := uuid.New()
+	previewInstanceID := uuid.New()
+	now := time.Now()
+
+	prMock := newMockPool(t)
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+
+	stopper := &recordingPreviewStopper{}
+
+	svc := &PRService{
+		pullRequests:   db.NewPullRequestStore(prMock),
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.Nop(),
+	}
+
+	// 1. GetByRepoAndNumber returns the PR.
+	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE github_repo").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerPRColumns).
+				AddRow(prID, &sessionID, orgID, 42,
+					"https://github.com/testorg/testrepo/pull/42", "testorg/testrepo",
+					"Fix bug", (*string)(nil), "open", "pending", "app", "",
+					(*time.Time)(nil), now, now),
+		)
+
+	// 2. UpdateStatus to closed.
+	prMock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// 3. Repo lookup by full name.
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	// 4. GetPRPreviewState returns a state with a live instance.
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{
+				"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+				"last_preview_instance_id", "last_screenshot_blob_path",
+				"last_visual_diff_blob_path", "base_snapshot_key", "status",
+				"created_at", "updated_at",
+			}).AddRow(
+				prPreviewStateID, orgID, repoID, 42, nil,
+				&previewInstanceID, "", "", "", "running", now, now,
+			),
+		)
+
+	// 5. UpdatePRPreviewStatus to closed.
+	previewMock.ExpectExec("UPDATE pr_preview_state SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	event := PullRequestEvent{Action: "closed", Number: 42}
+	event.PR.Merged = false
+	event.Repository.FullName = "testorg/testrepo"
+
+	err := svc.HandlePullRequestEvent(context.Background(), event)
+	require.NoError(t, err)
+	require.Equal(t, 1, stopper.calls, "StopPreview should be called exactly once")
+	require.Equal(t, previewInstanceID, stopper.prevID, "StopPreview should receive the preview instance id from pr_preview_state")
+	require.Equal(t, orgID, stopper.orgID, "StopPreview should receive the PR's org id")
+	require.NoError(t, prMock.ExpectationsWereMet())
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -2163,8 +2164,10 @@ func TestTeardownPRPreview_RepoLookupError(t *testing.T) {
 	require.NoError(t, previewMock.ExpectationsWereMet(), "preview store must not be queried when repo lookup fails")
 }
 
-// TestTeardownPRPreview_NoPreviewState covers the path where the PR has
-// never had a preview created — GetPRPreviewState returns nil, no error.
+// TestTeardownPRPreview_NoPreviewState covers the common path where the PR
+// has never had a preview created — GetPRPreviewState returns pgx.ErrNoRows.
+// This must be silent (no warning log) since it's the default state for
+// every freshly-opened PR.
 func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
 	t.Parallel()
 
@@ -2177,11 +2180,77 @@ func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
 	previewMock := newMockPool(t)
 	stopper := &recordingPreviewStopper{}
 
+	var logBuf bytes.Buffer
 	svc := &PRService{
 		repos:          db.NewRepositoryStore(repoMock),
 		previews:       db.NewPreviewStore(previewMock),
 		previewStopper: stopper,
-		logger:         zerolog.Nop(),
+		logger:         zerolog.New(&logBuf),
+	}
+
+	handlerRepoColumns := []string{
+		"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+		"private", "language", "description", "clone_url", "installation_id", "status",
+		"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+	}
+	repoMock.ExpectQuery("SELECT .+ FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(handlerRepoColumns).
+				AddRow(repoID, orgID, integrationID, int64(12345),
+					"testorg/testrepo", "main", false, nil, nil,
+					"https://github.com/testorg/testrepo.git", int64(99),
+					"active", nil, nil, json.RawMessage(`{}`), now, now),
+		)
+
+	// Empty result set — CollectOneRow inside GetPRPreviewState surfaces
+	// pgx.ErrNoRows, which teardownPRPreview must treat as the benign
+	// "no preview ever created" case.
+	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "repo_id", "pr_number", "github_comment_id",
+			"last_preview_instance_id", "last_screenshot_blob_path",
+			"last_visual_diff_blob_path", "base_snapshot_key", "status",
+			"created_at", "updated_at",
+		}))
+
+	pr := models.PullRequest{
+		OrgID:          orgID,
+		GitHubRepo:     "testorg/testrepo",
+		GitHubPRNumber: 42,
+	}
+	svc.teardownPRPreview(context.Background(), pr, false)
+
+	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when no pr_preview_state exists")
+	require.NotContains(t, logBuf.String(), "failed to load pr_preview_state",
+		"no-rows must be silent — no warning log for the common case")
+	require.NoError(t, repoMock.ExpectationsWereMet())
+	require.NoError(t, previewMock.ExpectationsWereMet())
+}
+
+// TestTeardownPRPreview_PreviewStateLookupError covers the path where the
+// pr_preview_state lookup fails with a real DB error (not no-rows). The
+// function must log a warning and return without calling the stopper, so
+// ops has a breadcrumb instead of a silent swallow.
+func TestTeardownPRPreview_PreviewStateLookupError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	repoMock := newMockPool(t)
+	previewMock := newMockPool(t)
+	stopper := &recordingPreviewStopper{}
+
+	var logBuf bytes.Buffer
+	svc := &PRService{
+		repos:          db.NewRepositoryStore(repoMock),
+		previews:       db.NewPreviewStore(previewMock),
+		previewStopper: stopper,
+		logger:         zerolog.New(&logBuf),
 	}
 
 	handlerRepoColumns := []string{
@@ -2201,7 +2270,7 @@ func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
 
 	previewMock.ExpectQuery("SELECT .+ FROM pr_preview_state").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnError(fmt.Errorf("no rows"))
+		WillReturnError(fmt.Errorf("connection refused"))
 
 	pr := models.PullRequest{
 		OrgID:          orgID,
@@ -2210,7 +2279,9 @@ func TestTeardownPRPreview_NoPreviewState(t *testing.T) {
 	}
 	svc.teardownPRPreview(context.Background(), pr, false)
 
-	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when no pr_preview_state exists")
+	require.Equal(t, 0, stopper.calls, "StopPreview must not be called when preview state lookup errors")
+	require.Contains(t, logBuf.String(), "failed to load pr_preview_state",
+		"a real DB error must be logged, not silently swallowed")
 	require.NoError(t, repoMock.ExpectationsWereMet())
 	require.NoError(t, previewMock.ExpectationsWereMet())
 }


### PR DESCRIPTION
## Summary
- Rework the `.143/preview.json` + `.143/seed.sql` dogfood so a cold-click lands on a populated dashboard: binaries compiled once (not twice via `go run`), deterministic `SESSION_SECRET` across recycles, frontend `NODE_OPTIONS` bumped to 1280 MB, and seeded sessions/messages/logs/preview rows with `worker_node_id='seeded'` so the recycler skips them.
- New `DEMO_MODE` flag exposed via `/providers`: renders a login-page banner with the seeded credentials, forces `github: false`, and short-circuits all GitHub App construction in the API router so the dogfood preview does not 500 on placeholder creds. Also warn at boot when `PREVIEW_ORIGIN_TEMPLATE` still points at localhost in production.
- On `pull_request.closed`/merged webhooks, `PRService` now stops any active preview via an injected `PreviewStopper` and transitions `pr_preview_state.status` to merged/closed; wired in the router after the preview manager is built.

## Test plan
- [x] `make lint` -> 0 issues
- [x] `go test ./internal/services/github/... ./internal/api/handlers/...`
- [x] Frontend `vitest run src/app/(auth)/login/page.test.tsx` (13/13)
- [ ] Boot local stack with `DEMO_MODE=true`, verify banner + seeded dashboard renders
- [ ] Simulate a `pull_request.closed` webhook, confirm `preview_instances` stop + `pr_preview_state.status='closed'`

Generated with [Claude Code](https://claude.com/claude-code)
