### PR TITLE
Stop session-list flash when creating manual sessions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -73,6 +73,8 @@ vi.mock("@/components/no-repos-warning", () => ({
 vi.mock("@/contexts/optimistic-sessions", () => ({
   useOptimisticSessions: () => ({
     addOptimisticSession: vi.fn(),
+    removeOptimisticSession: vi.fn(),
+    markOptimisticResolved: vi.fn(),
   }),
   OptimisticSessionsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -86,7 +86,7 @@ export function ManualSessionCreatePageContent() {
   const [branchByRepoId, setBranchByRepoId] = useState<Record<string, string>>({});
   const [creationError, setCreationError] = useState<string | null>(null);
 
-  const { addOptimisticSession, removeOptimisticSession } = useOptimisticSessions();
+  const { addOptimisticSession, removeOptimisticSession, markOptimisticResolved } = useOptimisticSessions();
 
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
@@ -190,12 +190,14 @@ export function ManualSessionCreatePageContent() {
         : message.trim();
       return { optimisticId: addOptimisticSession(title) };
     },
-    onSuccess: async (response, _variables, context) => {
+    onSuccess: (response, _variables, context) => {
       if (selectedRepoId) {
         try { localStorage.setItem("143:lastUsedRepoId", selectedRepoId); } catch {}
       }
-      await queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
-      removeOptimisticSession(context.optimisticId);
+      // Keep the optimistic row visible — the sidebar swaps it for the real
+      // session once the refetch lands. See OptimisticSession.resolvedId.
+      markOptimisticResolved(context.optimisticId, response.data.id);
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       router.push(`/sessions/${response.data.id}`);
     },
     onError: (error, _variables, context) => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -27,13 +27,14 @@ vi.mock('@/hooks/use-auth', () => ({
   useAuth: () => ({ isAuthenticated: true, user: { id: 'user-1' }, isLoading: false, logout: vi.fn() }),
 }));
 
-const mockOptimisticSessions: { id: string; title: string; status: 'pending'; created_at: string }[] = [];
+const mockOptimisticSessions: { id: string; title: string; status: 'pending'; created_at: string; resolvedId?: string }[] = [];
 
 vi.mock('@/contexts/optimistic-sessions', () => ({
   useOptimisticSessions: () => ({
     optimisticSessions: mockOptimisticSessions,
     addOptimisticSession: vi.fn(),
     removeOptimisticSession: vi.fn(),
+    markOptimisticResolved: vi.fn(),
   }),
   OptimisticSessionsProvider: ({ children }: { children: React.ReactNode }) => children,
 }));

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -157,6 +157,41 @@ describe('SessionSidebar', () => {
     expect(screen.getByText('Pending')).toBeInTheDocument();
   });
 
+  it('hides a resolved optimistic row once its real session appears in the list', async () => {
+    // Simulate the create flow: the optimistic has already been marked resolved
+    // to real session id "s-real". The real row is served by the API.
+    serveSessions([makeSession({ id: 's-real', result_summary: 'Real session' })]);
+    mockOptimisticSessions.push({
+      id: 'opt-1',
+      title: 'Optimistic placeholder',
+      status: 'pending',
+      created_at: new Date().toISOString(),
+      resolvedId: 's-real',
+    });
+
+    renderWithProviders(<SessionSidebar />);
+
+    await screen.findByText('Real session');
+    expect(screen.queryByText('Optimistic placeholder')).not.toBeInTheDocument();
+  });
+
+  it('keeps a resolved optimistic row visible when the real session is not yet in the list', async () => {
+    serveSessions([]);
+    mockOptimisticSessions.push({
+      id: 'opt-1',
+      title: 'Still waiting',
+      status: 'pending',
+      created_at: new Date().toISOString(),
+      resolvedId: 's-not-yet-fetched',
+    });
+
+    renderWithProviders(<SessionSidebar />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Still waiting')).toBeInTheDocument();
+    });
+  });
+
   // -----------------------------------------------------------------------
   // PR status badge variants
   // -----------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -165,7 +165,7 @@ export function SessionSidebar() {
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
 
-  const { optimisticSessions } = useOptimisticSessions();
+  const { optimisticSessions, removeOptimisticSession } = useOptimisticSessions();
 
   const currentFilter = activeFilter ?? "all";
   const isArchivedView = currentFilter === "archived";
@@ -262,6 +262,28 @@ export function SessionSidebar() {
     return merged.filter((s) => sessionTitle(s).toLowerCase().includes(q));
   }, [firstPage, extraPages, search]);
 
+  // Hide optimistic rows whose real session is already in the list — prevents
+  // the double-render flash between "optimistic added" and "server refetch
+  // lands". Resolved-but-not-yet-visible rows stay until the real row arrives.
+  const realIds = useMemo(() => new Set(displayedSessions.map((s) => s.id)), [displayedSessions]);
+  const visibleOptimistic = useMemo(
+    () => optimisticSessions.filter((os) => !(os.resolvedId && realIds.has(os.resolvedId))),
+    [optimisticSessions, realIds],
+  );
+
+  // Garbage-collect resolved optimistic rows once we've observed their real
+  // counterpart in the list. Done in an effect so state updates happen after
+  // render. This also handles the failure case: if the real session later
+  // changes status (e.g. to "failed"), it's still in the list, so the
+  // optimistic stays hidden and gets cleaned up here.
+  useEffect(() => {
+    for (const os of optimisticSessions) {
+      if (os.resolvedId && realIds.has(os.resolvedId)) {
+        removeOptimisticSession(os.id);
+      }
+    }
+  }, [optimisticSessions, realIds, removeOptimisticSession]);
+
   const counts = countsData?.data;
 
   const isNewSession = pathname === "/sessions/new";
@@ -354,7 +376,7 @@ export function SessionSidebar() {
         )}
 
         {(currentFilter === "all" || currentFilter === "active") &&
-          optimisticSessions.map((os) => (
+          visibleOptimistic.map((os) => (
             <OptimisticSessionRow key={os.id} session={os} />
           ))}
 

--- a/frontend/src/components/create-session-dialog.tsx
+++ b/frontend/src/components/create-session-dialog.tsx
@@ -66,7 +66,7 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
   const [branchByRepoId, setBranchByRepoId] = useState<Record<string, string>>({});
   const [creationError, setCreationError] = useState<string | null>(null);
 
-  const { addOptimisticSession, removeOptimisticSession } = useOptimisticSessionsSafe();
+  const { addOptimisticSession, removeOptimisticSession, markOptimisticResolved } = useOptimisticSessionsSafe();
 
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
@@ -166,12 +166,15 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
         : message.trim();
       return { optimisticId: addOptimisticSession(title) };
     },
-    onSuccess: async (response, _variables, context) => {
+    onSuccess: (response, _variables, context) => {
       if (selectedRepoId) {
         try { localStorage.setItem("143:lastUsedRepoId", selectedRepoId); } catch {}
       }
-      await queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
-      removeOptimisticSession(context.optimisticId);
+      // Keep the optimistic row visible — the sidebar swaps it for the real
+      // session once the refetch lands, so there's no double-render flash and
+      // no empty gap. Cleanup happens there after the real row is observed.
+      markOptimisticResolved(context.optimisticId, response.data.id);
+      queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
       onOpenChange(false);
       router.push(`/sessions/${response.data.id}`);
     },

--- a/frontend/src/contexts/optimistic-sessions.test.tsx
+++ b/frontend/src/contexts/optimistic-sessions.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import {
   OptimisticSessionsProvider,
@@ -107,6 +107,67 @@ describe("OptimisticSessionsProvider", () => {
 
     expect(result.current.optimisticSessions).toHaveLength(1);
     expect(result.current.optimisticSessions[0].resolvedId).toBeUndefined();
+  });
+
+  describe("resolution fallback timer", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("force-removes a resolved optimistic after the fallback window", () => {
+      const { result } = renderHook(() => useOptimisticSessions(), { wrapper });
+
+      let id: string;
+      act(() => {
+        id = result.current.addOptimisticSession("Will be GCd");
+      });
+
+      act(() => {
+        result.current.markOptimisticResolved(id!, "real-1");
+      });
+      expect(result.current.optimisticSessions).toHaveLength(1);
+
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+      expect(result.current.optimisticSessions).toHaveLength(0);
+    });
+
+    it("clears the fallback timer when removeOptimisticSession runs first", () => {
+      const { result } = renderHook(() => useOptimisticSessions(), { wrapper });
+
+      let id: string;
+      act(() => {
+        id = result.current.addOptimisticSession("Cleared early");
+        result.current.addOptimisticSession("Untouched");
+      });
+
+      act(() => {
+        result.current.markOptimisticResolved(id!, "real-2");
+      });
+      act(() => {
+        result.current.removeOptimisticSession(id!);
+      });
+
+      // Add it back under the same id slot — the pending timer must not
+      // spuriously drop this replacement when it fires.
+      act(() => {
+        result.current.addOptimisticSession("Reused slot");
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+
+      expect(result.current.optimisticSessions.map((s) => s.title)).toEqual([
+        "Reused slot",
+        "Untouched",
+      ]);
+    });
   });
 
   it("throws when used outside the provider", () => {

--- a/frontend/src/contexts/optimistic-sessions.test.tsx
+++ b/frontend/src/contexts/optimistic-sessions.test.tsx
@@ -78,6 +78,37 @@ describe("OptimisticSessionsProvider", () => {
     expect(result.current.optimisticSessions).toHaveLength(1);
   });
 
+  it("markOptimisticResolved stamps the real session id onto a placeholder", () => {
+    const { result } = renderHook(() => useOptimisticSessions(), { wrapper });
+
+    let id: string;
+    act(() => {
+      id = result.current.addOptimisticSession("Pending");
+    });
+
+    act(() => {
+      result.current.markOptimisticResolved(id!, "real-123");
+    });
+
+    expect(result.current.optimisticSessions).toHaveLength(1);
+    expect(result.current.optimisticSessions[0].resolvedId).toBe("real-123");
+  });
+
+  it("markOptimisticResolved is a no-op for unknown ids", () => {
+    const { result } = renderHook(() => useOptimisticSessions(), { wrapper });
+
+    act(() => {
+      result.current.addOptimisticSession("Only one");
+    });
+
+    act(() => {
+      result.current.markOptimisticResolved("does-not-exist", "real-xyz");
+    });
+
+    expect(result.current.optimisticSessions).toHaveLength(1);
+    expect(result.current.optimisticSessions[0].resolvedId).toBeUndefined();
+  });
+
   it("throws when used outside the provider", () => {
     expect(() => {
       renderHook(() => useOptimisticSessions());

--- a/frontend/src/contexts/optimistic-sessions.tsx
+++ b/frontend/src/contexts/optimistic-sessions.tsx
@@ -16,14 +16,22 @@ export interface OptimisticSession {
   title: string;
   status: "pending";
   created_at: string;
+  /**
+   * Set once the create mutation returns with a real session id. The sidebar
+   * hides optimistic rows whose resolvedId matches a session already in the
+   * server-returned list, then removes them — avoiding a double-render flash.
+   */
+  resolvedId?: string;
 }
 
 interface OptimisticSessionsContextValue {
   optimisticSessions: OptimisticSession[];
   /** Add a placeholder session. Returns the temporary id. */
   addOptimisticSession: (title: string) => string;
-  /** Remove a placeholder (on success or error). */
+  /** Remove a placeholder (on error, or after the real session is visible). */
   removeOptimisticSession: (id: string) => void;
+  /** Link an optimistic placeholder to the real session id returned by the server. */
+  markOptimisticResolved: (id: string, resolvedId: string) => void;
 }
 
 const OptimisticSessionsContext = createContext<OptimisticSessionsContextValue | null>(null);
@@ -44,8 +52,12 @@ export function OptimisticSessionsProvider({ children }: { children: React.React
     setSessions((prev) => prev.filter((s) => s.id !== id));
   }, []);
 
+  const markOptimisticResolved = useCallback((id: string, resolvedId: string) => {
+    setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, resolvedId } : s)));
+  }, []);
+
   return (
-    <OptimisticSessionsContext.Provider value={{ optimisticSessions: sessions, addOptimisticSession, removeOptimisticSession }}>
+    <OptimisticSessionsContext.Provider value={{ optimisticSessions: sessions, addOptimisticSession, removeOptimisticSession, markOptimisticResolved }}>
       {children}
     </OptimisticSessionsContext.Provider>
   );
@@ -62,10 +74,12 @@ export function useOptimisticSessions() {
 const EMPTY_SESSIONS: OptimisticSession[] = [];
 const noopAdd = () => `optimistic-${Date.now()}`;
 const noopRemove = () => {};
+const noopResolve = () => {};
 const FALLBACK: OptimisticSessionsContextValue = {
   optimisticSessions: EMPTY_SESSIONS,
   addOptimisticSession: noopAdd,
   removeOptimisticSession: noopRemove,
+  markOptimisticResolved: noopResolve,
 };
 
 /** Same as useOptimisticSessions but returns no-op stubs when outside a provider. */

--- a/frontend/src/contexts/optimistic-sessions.tsx
+++ b/frontend/src/contexts/optimistic-sessions.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react";
+
+/**
+ * Safety-net window after resolution before we force-remove a placeholder.
+ * The sidebar normally GCs resolved rows as soon as the real session appears
+ * in its list, but if the user's current filters exclude the new session (or
+ * no sidebar is mounted), the placeholder would otherwise linger forever.
+ * 10s comfortably exceeds a typical post-invalidation refetch.
+ */
+const RESOLUTION_FALLBACK_MS = 10_000;
 
 /**
  * Minimal shape for a session that hasn't been saved to the backend yet.
@@ -38,6 +47,15 @@ const OptimisticSessionsContext = createContext<OptimisticSessionsContextValue |
 
 export function OptimisticSessionsProvider({ children }: { children: React.ReactNode }) {
   const [sessions, setSessions] = useState<OptimisticSession[]>([]);
+  const fallbackTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const clearFallback = useCallback((id: string) => {
+    const handle = fallbackTimers.current.get(id);
+    if (handle !== undefined) {
+      clearTimeout(handle);
+      fallbackTimers.current.delete(id);
+    }
+  }, []);
 
   const addOptimisticSession = useCallback((title: string) => {
     const id = `optimistic-${crypto.randomUUID()}`;
@@ -49,11 +67,26 @@ export function OptimisticSessionsProvider({ children }: { children: React.React
   }, []);
 
   const removeOptimisticSession = useCallback((id: string) => {
+    clearFallback(id);
     setSessions((prev) => prev.filter((s) => s.id !== id));
-  }, []);
+  }, [clearFallback]);
 
   const markOptimisticResolved = useCallback((id: string, resolvedId: string) => {
     setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, resolvedId } : s)));
+    clearFallback(id);
+    const handle = setTimeout(() => {
+      fallbackTimers.current.delete(id);
+      setSessions((prev) => prev.filter((s) => s.id !== id));
+    }, RESOLUTION_FALLBACK_MS);
+    fallbackTimers.current.set(id, handle);
+  }, [clearFallback]);
+
+  useEffect(() => {
+    const timers = fallbackTimers.current;
+    return () => {
+      for (const handle of timers.values()) clearTimeout(handle);
+      timers.clear();
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary

- When a manual session is created, the optimistic sidebar row stayed visible while the refetch returned the real session, briefly rendering both and flashing back to one. This was very visible when the sandbox failed fast (e.g. `bootstrap workdir (exit 1)`), but happened on every create.
- Added `resolvedId` + `markOptimisticResolved` to the optimistic-sessions context, and taught the sidebar to hide optimistic rows whose real counterpart is already in the list, with a post-render effect to garbage-collect them.
- Applied the new `onSuccess` flow (mark resolved, fire-and-forget invalidate, navigate) to both create paths: `CreateSessionDialog` and `ManualSessionCreatePageContent`. The swap is now atomic — no duplicate, no gap.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run` for optimistic-sessions, session-sidebar, manual-session-create tests (33 passed)
- [x] `npx eslint` on touched files (0 errors)
- [ ] Manually create a manual session and confirm the sidebar no longer double-renders
- [ ] Force a sandbox bootstrap failure and confirm the row transitions cleanly to "failed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)