### PR TITLE
PM: fail-fast adapter resolve + pluralize error copy

### DIFF
--- a/internal/services/pm/bootstrap.go
+++ b/internal/services/pm/bootstrap.go
@@ -126,7 +126,7 @@ func (s *Service) runAgentInSandbox(ctx context.Context, params sandboxRunParams
 // The output is extracted from the sandbox and stored in pm_documents.
 func (s *Service) RunBootstrap(ctx context.Context, orgID uuid.UUID) error {
 	if len(s.adapters) == 0 || s.sandbox == nil {
-		return fmt.Errorf("pm adapter or sandbox not configured")
+		return fmt.Errorf("pm adapters or sandbox not configured")
 	}
 	if s.pmDocuments == nil {
 		return fmt.Errorf("pm document store not configured")

--- a/internal/services/pm/project_analyze.go
+++ b/internal/services/pm/project_analyze.go
@@ -20,7 +20,7 @@ import (
 // and dispatch runs. This is the entry point for the project_cycle job.
 func (s *Service) AnalyzeProject(ctx context.Context, orgID, projectID uuid.UUID) error {
 	if len(s.adapters) == 0 || s.sandbox == nil {
-		return fmt.Errorf("pm adapter or sandbox not configured")
+		return fmt.Errorf("pm adapters or sandbox not configured")
 	}
 	if s.projects == nil || s.projectTasks == nil || s.projectCycles == nil {
 		return fmt.Errorf("project stores not configured")

--- a/internal/services/pm/refresh.go
+++ b/internal/services/pm/refresh.go
@@ -19,7 +19,7 @@ const refreshSuggestionsPath = "/workspace/.pm-context/SUGGESTIONS.md"
 // to update it, and stores the result as a pending refresh for operator review.
 func (s *Service) RunRefresh(ctx context.Context, orgID uuid.UUID) error {
 	if len(s.adapters) == 0 || s.sandbox == nil {
-		return fmt.Errorf("pm adapter or sandbox not configured")
+		return fmt.Errorf("pm adapters or sandbox not configured")
 	}
 	if s.pmDocuments == nil {
 		return fmt.Errorf("pm document store not configured")

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -281,7 +281,7 @@ func (s *Service) selectRepo(ctx context.Context, orgID uuid.UUID, repoID *uuid.
 
 func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.PMTrigger, repoID *uuid.UUID) (*Plan, error) {
 	if len(s.adapters) == 0 || s.sandbox == nil {
-		return nil, fmt.Errorf("pm adapter or sandbox not configured")
+		return nil, fmt.Errorf("pm adapters or sandbox not configured")
 	}
 	if err := trigger.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid trigger: %w", err)
@@ -339,6 +339,13 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	ctxBundle, err := s.gatherContext(ctx, orgID, &repo)
 	if err != nil {
 		return nil, failSession("gather context", err)
+	}
+
+	// Resolve the agent adapter up front so a misconfigured org fails fast
+	// before we pay for sandbox create/clone.
+	adapter, err := s.resolveAgentAdapter(ctxBundle.settings)
+	if err != nil {
+		return nil, failSession("resolve adapter", err)
 	}
 
 	sbCfg := pmSandboxConfig()
@@ -432,13 +439,6 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		defer logWg.Done()
 		s.streamPMLogs(ctx, pmSession, logCh)
 	}()
-
-	adapter, err := s.resolveAgentAdapter(ctxBundle.settings)
-	if err != nil {
-		close(logCh)
-		logWg.Wait()
-		return nil, failSession("resolve adapter", err)
-	}
 
 	execCtx := adapters.WithSandboxProvider(ctx, s.sandbox)
 	result, err := adapter.Execute(execCtx, sb, prompt, logCh)

--- a/internal/services/pm/service_setters_test.go
+++ b/internal/services/pm/service_setters_test.go
@@ -103,7 +103,7 @@ func TestRunBootstrap_NoAdapter(t *testing.T) {
 	svc := &Service{logger: zerolog.Nop()}
 	err := svc.RunBootstrap(context.Background(), uuid.New())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "pm adapter or sandbox not configured")
+	require.Contains(t, err.Error(), "pm adapters or sandbox not configured")
 }
 
 func TestRunBootstrap_NoPMDocStore(t *testing.T) {
@@ -125,7 +125,7 @@ func TestRunRefresh_NoAdapter(t *testing.T) {
 	svc := &Service{logger: zerolog.Nop()}
 	err := svc.RunRefresh(context.Background(), uuid.New())
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "pm adapter or sandbox not configured")
+	require.Contains(t, err.Error(), "pm adapters or sandbox not configured")
 }
 
 func TestRunRefresh_NoPMDocStore(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stacked on #425. Addresses two review items from the adapter-resolution refactor:
  1. **Fail-fast in `Analyze`**: moves `resolveAgentAdapter(ctxBundle.settings)` above `sandbox.Create` / `CloneRepo` / log-goroutine spawn. A misconfigured org now fails before paying for sandbox setup, matching the pattern already used by `AnalyzeProject` / `RunBootstrap` / `RunRefresh`.
  2. **Error copy**: pluralizes the precondition message from "pm adapter or sandbox not configured" to "pm adapters …" (the field is now a map). Updates the two tests that pinned the old string.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/services/pm/...` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)