### PR TITLE
Dedupe sandbox-failure error messages across job retries

### DIFF
--- a/internal/jobctx/jobctx.go
+++ b/internal/jobctx/jobctx.go
@@ -1,34 +1,81 @@
-// Package jobctx carries per-invocation job metadata (attempt counters) on
-// the context. It lives in its own package so the worker (which sets the
-// values) and downstream services like the agent orchestrator (which read
-// them) can share it without introducing an import cycle.
+// Package jobctx lets a job handler register hooks that run if — and only
+// if — the worker decides to dead-letter the job. It lives in its own
+// package so the worker (which owns the dead-letter decision) and
+// downstream services like the agent orchestrator (which know what
+// user-visible side effects to emit on terminal failure) can share it
+// without introducing an import cycle.
+//
+// The worker installs a fresh registry on the handler context per attempt
+// via WithDeadLetterHooks, then calls RunDeadLetterHooks on every
+// dead-letter code path (FatalError, retryable timeout, retries
+// exhausted, no handler registered). Handlers register side effects via
+// RegisterDeadLetterHook; direct callers without a registry drop hooks
+// silently and are expected to handle the returned error themselves.
 package jobctx
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type ctxKey int
 
-const attemptKey ctxKey = iota
+const hooksKey ctxKey = iota
 
-type attemptInfo struct {
-	current int
-	max     int
+// DeadLetterHook is invoked once if the job is dead-lettered. It receives
+// the context the handler ran under and the final error the worker is
+// recording on the job. Hooks should be idempotent and fast — they run
+// synchronously on the worker's poll goroutine.
+type DeadLetterHook func(ctx context.Context, err error)
+
+type hookRegistry struct {
+	mu    sync.Mutex
+	hooks []DeadLetterHook
+	fired bool
 }
 
-// WithAttempt annotates ctx with the current attempt number (1-indexed) and
-// the configured attempt ceiling for the running job.
-func WithAttempt(ctx context.Context, current, max int) context.Context {
-	return context.WithValue(ctx, attemptKey, attemptInfo{current: current, max: max})
+// WithDeadLetterHooks returns a context carrying a fresh, empty hook
+// registry. The worker calls this once per attempt before invoking the
+// handler, so hooks registered on attempt N do not leak into attempt N+1.
+func WithDeadLetterHooks(ctx context.Context) context.Context {
+	return context.WithValue(ctx, hooksKey, &hookRegistry{})
 }
 
-// IsFinalAttempt reports whether the job is on its last allowed attempt,
-// i.e. the next failure will dead-letter the job. Returns false when no
-// attempt metadata is present (e.g. direct callers outside the worker), so
-// callers default to treating unknown contexts as non-final.
-func IsFinalAttempt(ctx context.Context) bool {
-	info, ok := ctx.Value(attemptKey).(attemptInfo)
-	if !ok {
-		return false
+// RegisterDeadLetterHook queues a hook to run if the current job attempt
+// ends up being dead-lettered. When the context has no registry (e.g. a
+// direct caller outside the worker), the hook is dropped — the caller is
+// expected to act on the returned error directly. Safe to call from
+// multiple goroutines.
+func RegisterDeadLetterHook(ctx context.Context, hook DeadLetterHook) {
+	reg, _ := ctx.Value(hooksKey).(*hookRegistry)
+	if reg == nil || hook == nil {
+		return
 	}
-	return info.current >= info.max
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	reg.hooks = append(reg.hooks, hook)
+}
+
+// RunDeadLetterHooks invokes every registered hook in registration order,
+// passing the final error being recorded on the job. Hooks run at most
+// once per registry even if RunDeadLetterHooks is called multiple times,
+// so callers at independent dead-letter sites don't need to coordinate.
+// No-op when the context has no registry.
+func RunDeadLetterHooks(ctx context.Context, err error) {
+	reg, _ := ctx.Value(hooksKey).(*hookRegistry)
+	if reg == nil {
+		return
+	}
+	reg.mu.Lock()
+	if reg.fired {
+		reg.mu.Unlock()
+		return
+	}
+	reg.fired = true
+	hooks := make([]DeadLetterHook, len(reg.hooks))
+	copy(hooks, reg.hooks)
+	reg.mu.Unlock()
+	for _, hook := range hooks {
+		hook(ctx, err)
+	}
 }

--- a/internal/jobctx/jobctx.go
+++ b/internal/jobctx/jobctx.go
@@ -1,16 +1,6 @@
-// Package jobctx lets a job handler register hooks that run if — and only
-// if — the worker decides to dead-letter the job. It lives in its own
-// package so the worker (which owns the dead-letter decision) and
-// downstream services like the agent orchestrator (which know what
-// user-visible side effects to emit on terminal failure) can share it
-// without introducing an import cycle.
-//
-// The worker installs a fresh registry on the handler context per attempt
-// via WithDeadLetterHooks, then calls RunDeadLetterHooks on every
-// dead-letter code path (FatalError, retryable timeout, retries
-// exhausted, no handler registered). Handlers register side effects via
-// RegisterDeadLetterHook; direct callers without a registry drop hooks
-// silently and are expected to handle the returned error themselves.
+// Package jobctx lets a job handler register hooks that run only if the
+// job is dead-lettered. Split from the worker package to avoid an import
+// cycle with services that need to register hooks.
 package jobctx
 
 import (
@@ -22,10 +12,8 @@ type ctxKey int
 
 const hooksKey ctxKey = iota
 
-// DeadLetterHook is invoked once if the job is dead-lettered. It receives
-// the context the handler ran under and the final error the worker is
-// recording on the job. Hooks should be idempotent and fast — they run
-// synchronously on the worker's poll goroutine.
+// DeadLetterHook runs synchronously on the worker's poll goroutine when
+// a job is dead-lettered, receiving the final error recorded on the job.
 type DeadLetterHook func(ctx context.Context, err error)
 
 type hookRegistry struct {
@@ -35,17 +23,14 @@ type hookRegistry struct {
 }
 
 // WithDeadLetterHooks returns a context carrying a fresh, empty hook
-// registry. The worker calls this once per attempt before invoking the
-// handler, so hooks registered on attempt N do not leak into attempt N+1.
+// registry — installed once per attempt so hooks don't leak across retries.
 func WithDeadLetterHooks(ctx context.Context) context.Context {
 	return context.WithValue(ctx, hooksKey, &hookRegistry{})
 }
 
-// RegisterDeadLetterHook queues a hook to run if the current job attempt
-// ends up being dead-lettered. When the context has no registry (e.g. a
-// direct caller outside the worker), the hook is dropped — the caller is
-// expected to act on the returned error directly. Safe to call from
-// multiple goroutines.
+// RegisterDeadLetterHook queues a hook on the context's registry. When the
+// context has no registry (direct caller outside the worker), the hook is
+// dropped and the caller is expected to act on the returned error directly.
 func RegisterDeadLetterHook(ctx context.Context, hook DeadLetterHook) {
 	reg, _ := ctx.Value(hooksKey).(*hookRegistry)
 	if reg == nil || hook == nil {
@@ -56,11 +41,9 @@ func RegisterDeadLetterHook(ctx context.Context, hook DeadLetterHook) {
 	reg.hooks = append(reg.hooks, hook)
 }
 
-// RunDeadLetterHooks invokes every registered hook in registration order,
-// passing the final error being recorded on the job. Hooks run at most
-// once per registry even if RunDeadLetterHooks is called multiple times,
-// so callers at independent dead-letter sites don't need to coordinate.
-// No-op when the context has no registry.
+// RunDeadLetterHooks invokes registered hooks in registration order. Hooks
+// fire at most once per registry, so independent dead-letter sites don't
+// need to coordinate. No-op when the context has no registry.
 func RunDeadLetterHooks(ctx context.Context, err error) {
 	reg, _ := ctx.Value(hooksKey).(*hookRegistry)
 	if reg == nil {

--- a/internal/jobctx/jobctx.go
+++ b/internal/jobctx/jobctx.go
@@ -1,0 +1,34 @@
+// Package jobctx carries per-invocation job metadata (attempt counters) on
+// the context. It lives in its own package so the worker (which sets the
+// values) and downstream services like the agent orchestrator (which read
+// them) can share it without introducing an import cycle.
+package jobctx
+
+import "context"
+
+type ctxKey int
+
+const attemptKey ctxKey = iota
+
+type attemptInfo struct {
+	current int
+	max     int
+}
+
+// WithAttempt annotates ctx with the current attempt number (1-indexed) and
+// the configured attempt ceiling for the running job.
+func WithAttempt(ctx context.Context, current, max int) context.Context {
+	return context.WithValue(ctx, attemptKey, attemptInfo{current: current, max: max})
+}
+
+// IsFinalAttempt reports whether the job is on its last allowed attempt,
+// i.e. the next failure will dead-letter the job. Returns false when no
+// attempt metadata is present (e.g. direct callers outside the worker), so
+// callers default to treating unknown contexts as non-final.
+func IsFinalAttempt(ctx context.Context) bool {
+	info, ok := ctx.Value(attemptKey).(attemptInfo)
+	if !ok {
+		return false
+	}
+	return info.current >= info.max
+}

--- a/internal/jobctx/jobctx_test.go
+++ b/internal/jobctx/jobctx_test.go
@@ -1,0 +1,59 @@
+package jobctx_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/jobctx"
+)
+
+func TestIsFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		ctx  func() context.Context
+		want bool
+	}{
+		{
+			name: "missing metadata returns false",
+			ctx:  context.Background,
+			want: false,
+		},
+		{
+			name: "first attempt of three is not final",
+			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
+			want: false,
+		},
+		{
+			name: "mid attempt is not final",
+			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 2, 3) },
+			want: false,
+		},
+		{
+			name: "last attempt equals ceiling and is final",
+			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
+			want: true,
+		},
+		{
+			name: "current above ceiling is also final",
+			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 5, 3) },
+			want: true,
+		},
+		{
+			name: "single-attempt job is final on first try",
+			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 1) },
+			want: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, c.want, jobctx.IsFinalAttempt(c.ctx()))
+		})
+	}
+}

--- a/internal/jobctx/jobctx_test.go
+++ b/internal/jobctx/jobctx_test.go
@@ -2,6 +2,8 @@ package jobctx_test
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -9,51 +11,107 @@ import (
 	"github.com/assembledhq/143/internal/jobctx"
 )
 
-func TestIsFinalAttempt(t *testing.T) {
+func TestRegisterDeadLetterHook_NoRegistryIsNoop(t *testing.T) {
 	t.Parallel()
 
-	cases := []struct {
-		name string
-		ctx  func() context.Context
-		want bool
-	}{
-		{
-			name: "missing metadata returns false",
-			ctx:  context.Background,
-			want: false,
-		},
-		{
-			name: "first attempt of three is not final",
-			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
-			want: false,
-		},
-		{
-			name: "mid attempt is not final",
-			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 2, 3) },
-			want: false,
-		},
-		{
-			name: "last attempt equals ceiling and is final",
-			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
-			want: true,
-		},
-		{
-			name: "current above ceiling is also final",
-			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 5, 3) },
-			want: true,
-		},
-		{
-			name: "single-attempt job is final on first try",
-			ctx:  func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 1) },
-			want: true,
-		},
-	}
+	// Registering on a bare context should silently drop the hook; running
+	// hooks on a bare context is also a no-op. Direct callers own their
+	// own error handling.
+	called := false
+	jobctx.RegisterDeadLetterHook(context.Background(), func(context.Context, error) {
+		called = true
+	})
+	jobctx.RunDeadLetterHooks(context.Background(), errors.New("boom"))
+	require.False(t, called, "hook must not fire when there is no registry")
+}
 
-	for _, c := range cases {
-		c := c
-		t.Run(c.name, func(t *testing.T) {
-			t.Parallel()
-			require.Equal(t, c.want, jobctx.IsFinalAttempt(c.ctx()))
-		})
+func TestRegisterDeadLetterHook_NilHookIsSkipped(t *testing.T) {
+	t.Parallel()
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	require.NotPanics(t, func() {
+		jobctx.RegisterDeadLetterHook(ctx, nil)
+		jobctx.RunDeadLetterHooks(ctx, errors.New("boom"))
+	})
+}
+
+func TestRunDeadLetterHooks_InvokesInOrderWithError(t *testing.T) {
+	t.Parallel()
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+
+	var order []string
+	var gotErr error
+	jobctx.RegisterDeadLetterHook(ctx, func(_ context.Context, err error) {
+		order = append(order, "first")
+		gotErr = err
+	})
+	jobctx.RegisterDeadLetterHook(ctx, func(context.Context, error) {
+		order = append(order, "second")
+	})
+
+	want := errors.New("dead letter")
+	jobctx.RunDeadLetterHooks(ctx, want)
+
+	require.Equal(t, []string{"first", "second"}, order)
+	require.ErrorIs(t, gotErr, want)
+}
+
+func TestRunDeadLetterHooks_FiresAtMostOnce(t *testing.T) {
+	t.Parallel()
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+
+	var calls int
+	jobctx.RegisterDeadLetterHook(ctx, func(context.Context, error) {
+		calls++
+	})
+
+	jobctx.RunDeadLetterHooks(ctx, errors.New("first"))
+	jobctx.RunDeadLetterHooks(ctx, errors.New("second"))
+
+	require.Equal(t, 1, calls, "repeated RunDeadLetterHooks calls on the same registry must be idempotent")
+}
+
+func TestWithDeadLetterHooks_ProducesFreshRegistryPerCall(t *testing.T) {
+	t.Parallel()
+
+	parent := jobctx.WithDeadLetterHooks(context.Background())
+	child := jobctx.WithDeadLetterHooks(parent)
+
+	var parentCalls, childCalls int
+	jobctx.RegisterDeadLetterHook(parent, func(context.Context, error) { parentCalls++ })
+	jobctx.RegisterDeadLetterHook(child, func(context.Context, error) { childCalls++ })
+
+	jobctx.RunDeadLetterHooks(child, nil)
+	require.Equal(t, 0, parentCalls, "child registry must not leak hooks to parent")
+	require.Equal(t, 1, childCalls)
+
+	jobctx.RunDeadLetterHooks(parent, nil)
+	require.Equal(t, 1, parentCalls)
+}
+
+func TestRegisterDeadLetterHook_ConcurrentRegistrationIsSafe(t *testing.T) {
+	t.Parallel()
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	calls := 0
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			jobctx.RegisterDeadLetterHook(ctx, func(context.Context, error) {
+				mu.Lock()
+				calls++
+				mu.Unlock()
+			})
+		}()
 	}
+	wg.Wait()
+
+	jobctx.RunDeadLetterHooks(ctx, nil)
+	require.Equal(t, 32, calls)
 }

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -791,21 +791,18 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after workdir resolution failure")
 		}
-		// Only surface a user-facing message when this is the final retry —
-		// otherwise the job's automatic retries produce one duplicate message
-		// per attempt before the worker finally gives up.
-		if o.sessionMessages != nil && jobctx.IsFinalAttempt(ctx) {
-			errMsg := &models.SessionMessage{
-				SessionID:  session.ID,
-				OrgID:      session.OrgID,
-				TurnNumber: session.CurrentTurn + 1,
-				Role:       models.MessageRoleAssistant,
-				Content:    fmt.Sprintf("Failed to resolve the sandbox workspace: %s\n\nPlease try again in a moment.", slugErr),
-			}
-			if createErr := o.sessionMessages.Create(ctx, errMsg); createErr != nil {
-				log.Error().Err(createErr).Msg("failed to create error message for workdir resolution failure")
-			}
-		}
+		// Defer the user-facing message to the worker's dead-letter path so
+		// intermediate retries stay silent; when the worker gives up (for
+		// any reason — FatalError, retryable timeout, retries exhausted)
+		// the hook fires once and the user sees exactly one message.
+		// Direct callers without a worker registry drop the hook and are
+		// expected to surface the returned error themselves.
+		o.registerSandboxFailureMessage(
+			ctx,
+			session,
+			fmt.Sprintf("Failed to resolve the sandbox workspace: %s\n\nPlease try again in a moment.", slugErr),
+			"workdir resolution",
+		)
 		return fmt.Errorf("resolve workdir: %w", slugErr)
 	}
 	if slug != "" {
@@ -828,20 +825,16 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after sandbox failure")
 		}
 		// Same rationale as the workdir-resolution branch above: defer the
-		// user-visible message to the final retry so a flaky Docker daemon
-		// doesn't produce N identical assistant messages.
-		if o.sessionMessages != nil && jobctx.IsFinalAttempt(ctx) {
-			errMsg := &models.SessionMessage{
-				SessionID:  session.ID,
-				OrgID:      session.OrgID,
-				TurnNumber: session.CurrentTurn + 1,
-				Role:       models.MessageRoleAssistant,
-				Content:    fmt.Sprintf("Failed to start the sandbox environment: %s\n\nPlease try again in a moment. If this persists, check that Docker is running.", err),
-			}
-			if createErr := o.sessionMessages.Create(ctx, errMsg); createErr != nil {
-				log.Error().Err(createErr).Msg("failed to create error message for sandbox failure")
-			}
-		}
+		// user-visible message to the worker's dead-letter hook so a flaky
+		// Docker daemon doesn't produce N identical assistant messages,
+		// and so FatalError / retryable-timeout paths still surface a
+		// message rather than silently dead-lettering.
+		o.registerSandboxFailureMessage(
+			ctx,
+			session,
+			fmt.Sprintf("Failed to start the sandbox environment: %s\n\nPlease try again in a moment. If this persists, check that Docker is running.", err),
+			"sandbox creation",
+		)
 		return fmt.Errorf("create sandbox: %w", err)
 	}
 	containerStartedAt := time.Now()
@@ -1096,6 +1089,45 @@ func (o *Orchestrator) sessionRepoSlug(ctx context.Context, session *models.Sess
 		return "", fmt.Errorf("fetch repo for session workdir: %w", err)
 	}
 	return SlugForRepo(repo.FullName), nil
+}
+
+// registerSandboxFailureMessage queues a user-visible assistant message to
+// be posted if — and only if — the current continue_session job attempt is
+// dead-lettered by the worker. See internal/jobctx: the worker runs
+// registered hooks from every dead-letter path (FatalError, retryable
+// timeout, retries exhausted), so the user gets exactly one message on
+// terminal failure and no message on mid-retry attempts. When there is no
+// worker registry on the context (e.g. a direct test/CLI caller), the
+// hook is dropped and the caller must act on the returned error.
+//
+// stage is a short phrase used only for the warn-level log emitted if the
+// DB insert fails inside the hook (e.g. "workdir resolution",
+// "sandbox creation").
+func (o *Orchestrator) registerSandboxFailureMessage(ctx context.Context, session *models.Session, content, stage string) {
+	if o.sessionMessages == nil {
+		return
+	}
+	sessionMessages := o.sessionMessages
+	sessionID := session.ID
+	orgID := session.OrgID
+	turnNumber := session.CurrentTurn + 1
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, _ error) {
+		errMsg := &models.SessionMessage{
+			SessionID:  sessionID,
+			OrgID:      orgID,
+			TurnNumber: turnNumber,
+			Role:       models.MessageRoleAssistant,
+			Content:    content,
+		}
+		if createErr := sessionMessages.Create(hookCtx, errMsg); createErr != nil {
+			o.logger.Error().
+				Err(createErr).
+				Str("session_id", sessionID.String()).
+				Str("org_id", orgID.String()).
+				Str("stage", stage).
+				Msg("failed to create dead-letter error message")
+		}
+	})
 }
 
 // maxDiffCharsInPrompt is the maximum number of characters from a stored diff

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -791,12 +791,6 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after workdir resolution failure")
 		}
-		// Defer the user-facing message to the worker's dead-letter path so
-		// intermediate retries stay silent; when the worker gives up (for
-		// any reason — FatalError, retryable timeout, retries exhausted)
-		// the hook fires once and the user sees exactly one message.
-		// Direct callers without a worker registry drop the hook and are
-		// expected to surface the returned error themselves.
 		o.registerSandboxFailureMessage(
 			ctx,
 			session,
@@ -824,11 +818,6 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after sandbox failure")
 		}
-		// Same rationale as the workdir-resolution branch above: defer the
-		// user-visible message to the worker's dead-letter hook so a flaky
-		// Docker daemon doesn't produce N identical assistant messages,
-		// and so FatalError / retryable-timeout paths still surface a
-		// message rather than silently dead-lettering.
 		o.registerSandboxFailureMessage(
 			ctx,
 			session,
@@ -1091,18 +1080,11 @@ func (o *Orchestrator) sessionRepoSlug(ctx context.Context, session *models.Sess
 	return SlugForRepo(repo.FullName), nil
 }
 
-// registerSandboxFailureMessage queues a user-visible assistant message to
-// be posted if — and only if — the current continue_session job attempt is
-// dead-lettered by the worker. See internal/jobctx: the worker runs
-// registered hooks from every dead-letter path (FatalError, retryable
-// timeout, retries exhausted), so the user gets exactly one message on
-// terminal failure and no message on mid-retry attempts. When there is no
-// worker registry on the context (e.g. a direct test/CLI caller), the
-// hook is dropped and the caller must act on the returned error.
-//
-// stage is a short phrase used only for the warn-level log emitted if the
-// DB insert fails inside the hook (e.g. "workdir resolution",
-// "sandbox creation").
+// registerSandboxFailureMessage queues a user-visible assistant message
+// to post only if the current continue_session job is dead-lettered —
+// posting inline would fire once per retry. Direct callers without a
+// jobctx registry drop the hook and must handle the returned error
+// themselves. stage labels the warn log emitted if the DB insert fails.
 func (o *Orchestrator) registerSandboxFailureMessage(ctx context.Context, session *models.Session, content, stage string) {
 	if o.sessionMessages == nil {
 		return
@@ -1119,7 +1101,14 @@ func (o *Orchestrator) registerSandboxFailureMessage(ctx context.Context, sessio
 			Role:       models.MessageRoleAssistant,
 			Content:    content,
 		}
-		if createErr := sessionMessages.Create(hookCtx, errMsg); createErr != nil {
+		// The retryable-timeout dead-letter path fires this hook with a
+		// handler context whose deadline has just expired; detach so the
+		// terminal-message write isn't racing the very timeout that
+		// triggered it, but keep a short bound so we can't hang the poll
+		// goroutine on a wedged DB.
+		writeCtx, cancel := context.WithTimeout(context.WithoutCancel(hookCtx), 5*time.Second)
+		defer cancel()
+		if createErr := sessionMessages.Create(writeCtx, errMsg); createErr != nil {
 			o.logger.Error().
 				Err(createErr).
 				Str("session_id", sessionID.String()).

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/integration"
 	"github.com/assembledhq/143/internal/services/mcp"
@@ -790,7 +791,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after workdir resolution failure")
 		}
-		if o.sessionMessages != nil {
+		// Only surface a user-facing message when this is the final retry —
+		// otherwise the job's automatic retries produce one duplicate message
+		// per attempt before the worker finally gives up.
+		if o.sessionMessages != nil && jobctx.IsFinalAttempt(ctx) {
 			errMsg := &models.SessionMessage{
 				SessionID:  session.ID,
 				OrgID:      session.OrgID,
@@ -823,7 +827,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if revertErr := o.sessions.UpdateSandboxState(ctx, session.OrgID, session.ID, string(models.SandboxStateSnapshotted)); revertErr != nil {
 			log.Warn().Err(revertErr).Msg("failed to revert sandbox state after sandbox failure")
 		}
-		if o.sessionMessages != nil {
+		// Same rationale as the workdir-resolution branch above: defer the
+		// user-visible message to the final retry so a flaky Docker daemon
+		// doesn't produce N identical assistant messages.
+		if o.sessionMessages != nil && jobctx.IsFinalAttempt(ctx) {
 			errMsg := &models.SessionMessage{
 				SessionID:  session.ID,
 				OrgID:      session.OrgID,

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1530,13 +1530,16 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 	}
 }
 
-// TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt locks in the
-// behavior that when sandbox preparation fails, ContinueSession posts the
-// user-visible assistant message only on the final retry attempt.
-// Intermediate attempts must stay silent so the worker's automatic retry
-// loop doesn't flood the session with duplicates. Exercised for both the
-// sandbox-creation branch and the sibling workdir-resolution branch.
-func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
+// TestContinueSession_ErrorMessageDeferredToDeadLetterHook locks in the
+// behavior that when sandbox preparation fails, ContinueSession does NOT
+// post the user-visible assistant message inline. Instead it registers a
+// dead-letter hook that the worker runs only when it decides to stop
+// retrying — so a mid-retry attempt stays silent, but a dead-lettered job
+// (for any reason: FatalError, retryable timeout, retries exhausted)
+// produces exactly one message. Exercised for both the sandbox-creation
+// branch and the sibling workdir-resolution branch, plus the direct
+// caller case (no registry on ctx).
+func TestContinueSession_ErrorMessageDeferredToDeadLetterHook(t *testing.T) {
 	t.Parallel()
 
 	type failureMode int
@@ -1546,46 +1549,57 @@ func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
 	)
 
 	cases := []struct {
-		name            string
-		failure         failureMode
-		ctx             func() context.Context
-		wantErrorPosted bool
-		wantErrMatch    string
+		name              string
+		failure           failureMode
+		withRegistry      bool
+		runHooks          bool
+		wantMessageInline bool
+		wantMessageAfter  bool
+		wantErrMatch      string
 	}{
 		{
-			name:            "sandbox-create: no attempt metadata does not post",
-			failure:         sandboxCreateFailure,
-			ctx:             context.Background,
-			wantErrorPosted: false,
-			wantErrMatch:    "create sandbox",
+			name:              "sandbox-create: direct caller without registry posts nothing",
+			failure:           sandboxCreateFailure,
+			withRegistry:      false,
+			wantMessageInline: false,
+			wantMessageAfter:  false,
+			wantErrMatch:      "create sandbox",
 		},
 		{
-			name:            "sandbox-create: mid-retry attempt does not post",
-			failure:         sandboxCreateFailure,
-			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
-			wantErrorPosted: false,
-			wantErrMatch:    "create sandbox",
+			name:              "sandbox-create: mid-retry (registry present, hooks not fired) stays silent",
+			failure:           sandboxCreateFailure,
+			withRegistry:      true,
+			runHooks:          false,
+			wantMessageInline: false,
+			wantMessageAfter:  false,
+			wantErrMatch:      "create sandbox",
 		},
 		{
-			name:            "sandbox-create: final attempt posts",
-			failure:         sandboxCreateFailure,
-			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
-			wantErrorPosted: true,
-			wantErrMatch:    "create sandbox",
+			name:              "sandbox-create: dead-letter (hooks fired) posts exactly one message",
+			failure:           sandboxCreateFailure,
+			withRegistry:      true,
+			runHooks:          true,
+			wantMessageInline: false,
+			wantMessageAfter:  true,
+			wantErrMatch:      "create sandbox",
 		},
 		{
-			name:            "workdir-resolve: mid-retry attempt does not post",
-			failure:         workdirResolveFailure,
-			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
-			wantErrorPosted: false,
-			wantErrMatch:    "resolve workdir",
+			name:              "workdir-resolve: mid-retry stays silent",
+			failure:           workdirResolveFailure,
+			withRegistry:      true,
+			runHooks:          false,
+			wantMessageInline: false,
+			wantMessageAfter:  false,
+			wantErrMatch:      "resolve workdir",
 		},
 		{
-			name:            "workdir-resolve: final attempt posts",
-			failure:         workdirResolveFailure,
-			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
-			wantErrorPosted: true,
-			wantErrMatch:    "resolve workdir",
+			name:              "workdir-resolve: dead-letter posts exactly one message",
+			failure:           workdirResolveFailure,
+			withRegistry:      true,
+			runHooks:          true,
+			wantMessageInline: false,
+			wantMessageAfter:  true,
+			wantErrMatch:      "resolve workdir",
 		},
 	}
 
@@ -1626,25 +1640,83 @@ func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
 				d.issues.err = errors.New("db flaky")
 			}
 
+			ctx := context.Background()
+			if c.withRegistry {
+				ctx = jobctx.WithDeadLetterHooks(ctx)
+			}
+
 			orch := buildOrchestrator(d)
-			err := orch.ContinueSession(c.ctx(), session)
+			err := orch.ContinueSession(ctx, session)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), c.wantErrMatch)
 
-			var errorMessages int
-			for _, m := range d.messages.getMessages() {
-				if m.Role == models.MessageRoleAssistant &&
-					m.SessionID == session.ID {
-					errorMessages++
+			countAssistantMessages := func() int {
+				var n int
+				for _, m := range d.messages.getMessages() {
+					if m.Role == models.MessageRoleAssistant && m.SessionID == session.ID {
+						n++
+					}
 				}
+				return n
 			}
-			if c.wantErrorPosted {
-				require.Equal(t, 1, errorMessages, "final attempt should post exactly one error message")
+
+			if c.wantMessageInline {
+				require.Equal(t, 1, countAssistantMessages(), "inline assistant message expected before hook runs")
 			} else {
-				require.Zero(t, errorMessages, "non-final attempts must not post error messages")
+				require.Zero(t, countAssistantMessages(), "no assistant message should be posted inline")
+			}
+
+			if c.runHooks {
+				jobctx.RunDeadLetterHooks(ctx, err)
+			}
+
+			if c.wantMessageAfter {
+				require.Equal(t, 1, countAssistantMessages(), "dead-letter hook should post exactly one assistant message")
+			} else {
+				require.Zero(t, countAssistantMessages(), "no assistant message should be posted when hook does not fire")
 			}
 		})
 	}
+}
+
+// TestContinueSession_DeadLetterHookIdempotent ensures repeated invocations
+// of the hook registry — which can happen if multiple worker dead-letter
+// branches coordinate or tests drive it defensively — still produce only
+// one user-visible message.
+func TestContinueSession_DeadLetterHookIdempotent(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{{
+		ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2,
+		Role: models.MessageRoleUser, Content: "continue please",
+	}}
+	d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+		return nil, errForcedCreateFailure
+	}
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(ctx, session)
+	require.Error(t, err)
+
+	jobctx.RunDeadLetterHooks(ctx, err)
+	jobctx.RunDeadLetterHooks(ctx, err)
+
+	var assistantMessages int
+	for _, m := range d.messages.getMessages() {
+		if m.Role == models.MessageRoleAssistant && m.SessionID == session.ID {
+			assistantMessages++
+		}
+	}
+	require.Equal(t, 1, assistantMessages, "repeated RunDeadLetterHooks must not produce duplicate messages")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/testutil"
@@ -1525,6 +1526,86 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 			}
 			require.Equal(t, 1, createCalls, "Create should be called exactly once when workdir resolution succeeds")
 			require.Equal(t, c.wantWorkDir, gotWorkDir, "sessionRepoSlug should drive WorkDir selection")
+		})
+	}
+}
+
+// TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt locks in the
+// behavior that when sandbox creation fails, ContinueSession posts the
+// user-visible "Failed to start..." assistant message only on the final
+// retry attempt. Intermediate attempts must stay silent so the worker's
+// automatic retry loop doesn't flood the session with duplicates.
+func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		ctx             func() context.Context
+		wantErrorPosted bool
+	}{
+		{
+			name:            "no attempt metadata does not post",
+			ctx:             context.Background,
+			wantErrorPosted: false,
+		},
+		{
+			name:            "mid-retry attempt does not post",
+			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
+			wantErrorPosted: false,
+		},
+		{
+			name:            "final attempt posts",
+			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
+			wantErrorPosted: true,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			orgID := testOrg()
+			issue := testIssue(orgID)
+			session := testRun(orgID, issue.ID)
+			session.Status = string(models.SessionStatusIdle)
+			session.CurrentTurn = 1
+
+			d := defaultDeps()
+			d.issues.issue = issue
+
+			// Pre-populate a user message so ContinueSession reaches the
+			// provider.Create call that we'll force to fail.
+			d.messages.messages = []models.SessionMessage{{
+				ID:         1,
+				SessionID:  session.ID,
+				OrgID:      orgID,
+				TurnNumber: 2,
+				Role:       models.MessageRoleUser,
+				Content:    "continue please",
+			}}
+
+			d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+				return nil, errForcedCreateFailure
+			}
+
+			orch := buildOrchestrator(d)
+			err := orch.ContinueSession(c.ctx(), session)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "create sandbox")
+
+			var errorMessages int
+			for _, m := range d.messages.getMessages() {
+				if m.Role == models.MessageRoleAssistant &&
+					m.SessionID == session.ID {
+					errorMessages++
+				}
+			}
+			if c.wantErrorPosted {
+				require.Equal(t, 1, errorMessages, "final attempt should post exactly one error message")
+			} else {
+				require.Zero(t, errorMessages, "non-final attempts must not post error messages")
+			}
 		})
 	}
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1531,32 +1531,61 @@ func TestContinueSession_SessionRepoSlug(t *testing.T) {
 }
 
 // TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt locks in the
-// behavior that when sandbox creation fails, ContinueSession posts the
-// user-visible "Failed to start..." assistant message only on the final
-// retry attempt. Intermediate attempts must stay silent so the worker's
-// automatic retry loop doesn't flood the session with duplicates.
+// behavior that when sandbox preparation fails, ContinueSession posts the
+// user-visible assistant message only on the final retry attempt.
+// Intermediate attempts must stay silent so the worker's automatic retry
+// loop doesn't flood the session with duplicates. Exercised for both the
+// sandbox-creation branch and the sibling workdir-resolution branch.
 func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
 	t.Parallel()
 
+	type failureMode int
+	const (
+		sandboxCreateFailure failureMode = iota
+		workdirResolveFailure
+	)
+
 	cases := []struct {
 		name            string
+		failure         failureMode
 		ctx             func() context.Context
 		wantErrorPosted bool
+		wantErrMatch    string
 	}{
 		{
-			name:            "no attempt metadata does not post",
+			name:            "sandbox-create: no attempt metadata does not post",
+			failure:         sandboxCreateFailure,
 			ctx:             context.Background,
 			wantErrorPosted: false,
+			wantErrMatch:    "create sandbox",
 		},
 		{
-			name:            "mid-retry attempt does not post",
+			name:            "sandbox-create: mid-retry attempt does not post",
+			failure:         sandboxCreateFailure,
 			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
 			wantErrorPosted: false,
+			wantErrMatch:    "create sandbox",
 		},
 		{
-			name:            "final attempt posts",
+			name:            "sandbox-create: final attempt posts",
+			failure:         sandboxCreateFailure,
 			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
 			wantErrorPosted: true,
+			wantErrMatch:    "create sandbox",
+		},
+		{
+			name:            "workdir-resolve: mid-retry attempt does not post",
+			failure:         workdirResolveFailure,
+			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 1, 3) },
+			wantErrorPosted: false,
+			wantErrMatch:    "resolve workdir",
+		},
+		{
+			name:            "workdir-resolve: final attempt posts",
+			failure:         workdirResolveFailure,
+			ctx:             func() context.Context { return jobctx.WithAttempt(context.Background(), 3, 3) },
+			wantErrorPosted: true,
+			wantErrMatch:    "resolve workdir",
 		},
 	}
 
@@ -1575,7 +1604,7 @@ func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
 			d.issues.issue = issue
 
 			// Pre-populate a user message so ContinueSession reaches the
-			// provider.Create call that we'll force to fail.
+			// failure point we're exercising.
 			d.messages.messages = []models.SessionMessage{{
 				ID:         1,
 				SessionID:  session.ID,
@@ -1585,14 +1614,22 @@ func TestContinueSession_ErrorMessagePostedOnlyOnFinalAttempt(t *testing.T) {
 				Content:    "continue please",
 			}}
 
-			d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
-				return nil, errForcedCreateFailure
+			switch c.failure {
+			case sandboxCreateFailure:
+				d.provider.CreateFn = func(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
+					return nil, errForcedCreateFailure
+				}
+			case workdirResolveFailure:
+				// Force sessionRepoSlug to fail: drop the session's repo and
+				// make the fallback issue-repo lookup error out.
+				session.RepositoryID = nil
+				d.issues.err = errors.New("db flaky")
 			}
 
 			orch := buildOrchestrator(d)
 			err := orch.ContinueSession(c.ctx(), session)
 			require.Error(t, err)
-			require.Contains(t, err.Error(), "create sandbox")
+			require.Contains(t, err.Error(), c.wantErrMatch)
 
 			var errorMessages int
 			for _, m := range d.messages.getMessages() {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -163,11 +163,6 @@ func (w *Worker) poll(ctx context.Context) {
 	}
 
 	handlerCtx := withJobOrgID(ctx, orgID)
-	// Install a fresh per-attempt dead-letter hook registry so handlers can
-	// defer user-visible side effects (error messages, status transitions)
-	// until the worker actually decides to dead-letter the job — covering
-	// FatalError, retryable timeout, and retries-exhausted uniformly
-	// instead of forcing each handler to guess which branch it's on.
 	handlerCtx = jobctx.WithDeadLetterHooks(handlerCtx)
 	w.logger.Info().Str("job_id", jobID.String()).Str("job_type", jobType).Msg("processing job")
 	if err := handler(handlerCtx, jobType, payload); err != nil {
@@ -176,8 +171,8 @@ func (w *Worker) poll(ctx context.Context) {
 		var fatal *FatalError
 		if errors.As(err, &fatal) {
 			w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed (fatal, skipping retries)")
-			jobctx.RunDeadLetterHooks(handlerCtx, err)
 			w.deadLetterJob(ctx, jobID, err.Error())
+			jobctx.RunDeadLetterHooks(handlerCtx, err)
 			return
 		}
 		// RetryableError means we should retry without consuming an attempt
@@ -192,8 +187,8 @@ func (w *Worker) poll(ctx context.Context) {
 					Dur("age", time.Since(jobCreatedAt)).
 					Msg("retryable job exceeded max duration, dead-lettering")
 				timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", maxRetryableDuration, err)
-				jobctx.RunDeadLetterHooks(handlerCtx, timeoutErr)
 				w.deadLetterJob(ctx, jobID, timeoutErr.Error())
+				jobctx.RunDeadLetterHooks(handlerCtx, timeoutErr)
 				return
 			}
 			w.logger.Info().Err(err).Str("job_id", jobID.String()).Msg("job deferred (retryable)")
@@ -202,8 +197,8 @@ func (w *Worker) poll(ctx context.Context) {
 		}
 		w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed")
 		if attempts+1 >= maxAttempts {
-			jobctx.RunDeadLetterHooks(handlerCtx, err)
 			w.deadLetterJob(ctx, jobID, err.Error())
+			jobctx.RunDeadLetterHooks(handlerCtx, err)
 		} else {
 			w.retryJob(ctx, jobID, err.Error(), attempts+1)
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/jobctx"
 )
 
 type JobHandler func(ctx context.Context, jobType string, payload json.RawMessage) error
@@ -161,6 +163,9 @@ func (w *Worker) poll(ctx context.Context) {
 	}
 
 	handlerCtx := withJobOrgID(ctx, orgID)
+	// attempts is the pre-UPDATE count; the DB row was just incremented to
+	// attempts+1, so that's the attempt number the handler is running as.
+	handlerCtx = jobctx.WithAttempt(handlerCtx, attempts+1, maxAttempts)
 	w.logger.Info().Str("job_id", jobID.String()).Str("job_type", jobType).Msg("processing job")
 	if err := handler(handlerCtx, jobType, payload); err != nil {
 		// FatalError means the failure is persistent — dead-letter immediately

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -163,9 +163,12 @@ func (w *Worker) poll(ctx context.Context) {
 	}
 
 	handlerCtx := withJobOrgID(ctx, orgID)
-	// attempts is the pre-UPDATE count; the DB row was just incremented to
-	// attempts+1, so that's the attempt number the handler is running as.
-	handlerCtx = jobctx.WithAttempt(handlerCtx, attempts+1, maxAttempts)
+	// Install a fresh per-attempt dead-letter hook registry so handlers can
+	// defer user-visible side effects (error messages, status transitions)
+	// until the worker actually decides to dead-letter the job — covering
+	// FatalError, retryable timeout, and retries-exhausted uniformly
+	// instead of forcing each handler to guess which branch it's on.
+	handlerCtx = jobctx.WithDeadLetterHooks(handlerCtx)
 	w.logger.Info().Str("job_id", jobID.String()).Str("job_type", jobType).Msg("processing job")
 	if err := handler(handlerCtx, jobType, payload); err != nil {
 		// FatalError means the failure is persistent — dead-letter immediately
@@ -173,6 +176,7 @@ func (w *Worker) poll(ctx context.Context) {
 		var fatal *FatalError
 		if errors.As(err, &fatal) {
 			w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed (fatal, skipping retries)")
+			jobctx.RunDeadLetterHooks(handlerCtx, err)
 			w.deadLetterJob(ctx, jobID, err.Error())
 			return
 		}
@@ -187,7 +191,9 @@ func (w *Worker) poll(ctx context.Context) {
 					Str("job_id", jobID.String()).
 					Dur("age", time.Since(jobCreatedAt)).
 					Msg("retryable job exceeded max duration, dead-lettering")
-				w.deadLetterJob(ctx, jobID, fmt.Sprintf("retryable job timed out after %s: %s", maxRetryableDuration, err.Error()))
+				timeoutErr := fmt.Errorf("retryable job timed out after %s: %w", maxRetryableDuration, err)
+				jobctx.RunDeadLetterHooks(handlerCtx, timeoutErr)
+				w.deadLetterJob(ctx, jobID, timeoutErr.Error())
 				return
 			}
 			w.logger.Info().Err(err).Str("job_id", jobID.String()).Msg("job deferred (retryable)")
@@ -196,6 +202,7 @@ func (w *Worker) poll(ctx context.Context) {
 		}
 		w.logger.Error().Err(err).Str("job_id", jobID.String()).Msg("job failed")
 		if attempts+1 >= maxAttempts {
+			jobctx.RunDeadLetterHooks(handlerCtx, err)
 			w.deadLetterJob(ctx, jobID, err.Error())
 		} else {
 			w.retryJob(ctx, jobID, err.Error(), attempts+1)

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/jobctx"
 )
 
 func newTestWorker(t *testing.T) (*Worker, pgxmock.PgxPoolIface) {
@@ -131,10 +133,10 @@ func TestWorker_LifecycleMethodsLogWarningOnExecFailure(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		expectSQL     string
-		invoke        func(w *Worker, ctx context.Context, jobID uuid.UUID)
-		expectedArg1  string
+		name         string
+		expectSQL    string
+		invoke       func(w *Worker, ctx context.Context, jobID uuid.UUID)
+		expectedArg1 string
 	}{
 		{
 			name:      "succeedJob logs warning when update fails",
@@ -525,6 +527,136 @@ func TestWorker_Poll(t *testing.T) {
 			}, "poll should not panic")
 
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+// TestWorker_Poll_RunsDeadLetterHooksOnAllTerminalPaths verifies that
+// handlers can rely on jobctx.RegisterDeadLetterHook to fire exactly once
+// on every dead-letter branch (FatalError, retryable timeout, retries
+// exhausted) and to stay silent when the worker retries without
+// dead-lettering. This is the invariant that lets downstream services
+// (e.g. the agent orchestrator) defer user-visible side effects until the
+// worker actually gives up.
+func TestWorker_Poll_RunsDeadLetterHooksOnAllTerminalPaths(t *testing.T) {
+	t.Parallel()
+
+	type branch int
+	const (
+		branchDeadLetter branch = iota // deadLetterJob: WithArgs(errMsg, jobID)
+		branchRetry                    // retryJob:      WithArgs(errMsg, interval, jobID)
+	)
+
+	tests := []struct {
+		name        string
+		handlerErr  func() error
+		attempts    int
+		maxAttempts int
+		createdAt   time.Time
+		branch      branch
+		finalSQL    string
+		expectFires int
+	}{
+		{
+			name:        "fatal error fires hook before dead-letter",
+			handlerErr:  func() error { return &FatalError{Err: errors.New("docker daemon unreachable")} },
+			attempts:    0,
+			maxAttempts: 3,
+			createdAt:   time.Now(),
+			branch:      branchDeadLetter,
+			finalSQL:    "UPDATE jobs SET status = 'dead_letter'",
+			expectFires: 1,
+		},
+		{
+			name:        "retryable timeout fires hook before dead-letter",
+			handlerErr:  func() error { return &RetryableError{Err: errors.New("concurrency limit")} },
+			attempts:    0,
+			maxAttempts: 3,
+			createdAt:   time.Now().Add(-10 * time.Minute),
+			branch:      branchDeadLetter,
+			finalSQL:    "UPDATE jobs SET status = 'dead_letter'",
+			expectFires: 1,
+		},
+		{
+			name:        "retries exhausted fires hook before dead-letter",
+			handlerErr:  func() error { return errors.New("permanent failure") },
+			attempts:    2,
+			maxAttempts: 3,
+			createdAt:   time.Now(),
+			branch:      branchDeadLetter,
+			finalSQL:    "UPDATE jobs SET status = 'dead_letter'",
+			expectFires: 1,
+		},
+		{
+			name:        "plain error under the retry cap does not fire hook",
+			handlerErr:  func() error { return errors.New("transient failure") },
+			attempts:    0,
+			maxAttempts: 3,
+			createdAt:   time.Now(),
+			branch:      branchRetry,
+			finalSQL:    "UPDATE jobs SET status = 'pending'",
+			expectFires: 0,
+		},
+		{
+			name:        "retryable error within time budget does not fire hook",
+			handlerErr:  func() error { return &RetryableError{Err: errors.New("concurrency limit")} },
+			attempts:    0,
+			maxAttempts: 3,
+			createdAt:   time.Now(),
+			branch:      branchRetry,
+			finalSQL:    "UPDATE jobs SET status = 'pending'",
+			expectFires: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w, mock := newTestWorker(t)
+			defer mock.Close()
+
+			jobID := uuid.New()
+			orgID := uuid.New()
+			payload := json.RawMessage(`{}`)
+
+			var fires int
+			var gotErr error
+			handlerErr := tt.handlerErr()
+			w.Register("hook_job", func(ctx context.Context, jobType string, p json.RawMessage) error {
+				jobctx.RegisterDeadLetterHook(ctx, func(_ context.Context, err error) {
+					fires++
+					gotErr = err
+				})
+				return handlerErr
+			})
+
+			mock.ExpectBegin()
+			rows := pgxmock.NewRows([]string{"id", "org_id", "job_type", "payload", "attempts", "max_attempts", "created_at"}).
+				AddRow(jobID, orgID, "hook_job", payload, tt.attempts, tt.maxAttempts, tt.createdAt)
+			mock.ExpectQuery("SELECT .+ FROM jobs").WillReturnRows(rows)
+			mock.ExpectExec("UPDATE jobs SET status = 'running'").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			mock.ExpectCommit()
+			switch tt.branch {
+			case branchDeadLetter:
+				mock.ExpectExec(tt.finalSQL).
+					WithArgs(pgxmock.AnyArg(), jobID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			case branchRetry:
+				mock.ExpectExec(tt.finalSQL).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), jobID).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			}
+
+			w.poll(context.Background())
+
+			require.NoError(t, mock.ExpectationsWereMet())
+			require.Equal(t, tt.expectFires, fires, "hook fire count mismatch for %s", tt.name)
+			if tt.expectFires > 0 {
+				require.Error(t, gotErr, "hook must receive the error being recorded on the job")
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- `ContinueSession` posted a user-visible assistant message on every worker retry of a failing `continue_session` job, so a single failure produced up to `max_attempts` (default 3) identical "Failed to start the sandbox environment" messages within a few seconds.
- Added `internal/jobctx`, a dead-letter hook registry the worker installs on the handler context per attempt. Handlers call `jobctx.RegisterDeadLetterHook` to defer user-visible side effects; the worker fires those hooks exactly once from every terminal branch (`FatalError`, retryable timeout, retries exhausted) and leaves them untouched on mid-retry attempts.
- `ContinueSession` now registers the assistant-message create as such a hook on both the sandbox-creation and workdir-resolution failure paths. Status/sandbox-state reverts still run inline on every attempt (idempotent). The hook's DB write runs under a detached, 5s-bounded context so the retryable-timeout path does not race the very deadline that fired it.
- Hooks fire *after* `deadLetterJob` updates the job row, so a worker crash between the two cannot leave the job reclaimable while the user has already seen the terminal message.

## Test plan

- [x] `internal/jobctx/jobctx_test.go` covers no-registry no-op, nil-hook, ordered invocation, at-most-once firing, per-context isolation, concurrent registration
- [x] `TestWorker_Poll_RunsDeadLetterHooksOnAllTerminalPaths` covers FatalError, retryable timeout, retries-exhausted (all fire once) and plain/retryable within budget (never fire)
- [x] `TestContinueSession_ErrorMessageDeferredToDeadLetterHook` covers both failure sites x {no registry, mid-retry, dead-letter} and `TestContinueSession_DeadLetterHookIdempotent` locks in single-message-on-repeat-fire
- [x] `make lint` clean; `go test ./internal/jobctx/ ./internal/worker/ ./internal/services/agent/` passes
- [ ] Manual: trigger a sandbox-creation failure in a real session and confirm only one error message appears after retries exhaust

Generated with [Claude Code](https://claude.com/claude-code)
