### PR TITLE
Bootstrap sandbox workdir unprivileged to avoid CapDrop=ALL failures

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -251,9 +251,10 @@ func (d *DockerProvider) configLogger(cfg agent.SandboxConfig) zerolog.Logger {
 // Create spins up a new Docker container with the given resource limits and
 // security hardening (dropped capabilities, gVisor runtime, non-root user).
 // The rootfs is writable so the orchestrator can seed per-session state via
-// docker exec User="root" (see bootstrap below). Runtime apt-get is not
-// supported — every dependency is baked into the sandbox image — because
-// sudo's setuid bit is stripped under gVisor / nosuid mounts.
+// unprivileged docker exec as the sandbox user (see bootstrap below).
+// Runtime apt-get is not supported — every dependency is baked into the
+// sandbox image — because sudo's setuid bit is stripped under gVisor /
+// nosuid mounts and the provider runs with CapDrop=ALL.
 func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*agent.Sandbox, error) {
 	log := d.configLogger(cfg)
 	log.Info().
@@ -281,9 +282,19 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		envSlice = append(envSlice, "GOTMPDIR="+defaultScratchDir)
 	}
 
+	// Anchor the container's WorkingDir at HomeDir (baked into the image by
+	// `useradd -m sandbox`, owned by sandbox:sandbox) rather than cfg.WorkDir.
+	// If WorkingDir doesn't exist, the OCI runtime auto-creates it as root —
+	// which then makes the dir unwritable by the sandbox user without a
+	// privileged chown. Pointing at an always-present, sandbox-owned dir
+	// sidesteps that entirely so bootstrap can run as the sandbox user.
+	bootstrapCwd := cfg.HomeDir
+	if bootstrapCwd == "" {
+		bootstrapCwd = "/"
+	}
 	containerCfg := &container.Config{
 		Image:      cfg.Image,
-		WorkingDir: cfg.WorkDir,
+		WorkingDir: bootstrapCwd,
 		User:       "sandbox",
 		Tty:        false,
 		Env:        envSlice,
@@ -302,9 +313,10 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		CapDrop:     []string{"ALL"},
 		// No CapAdd: sudo was removed from the sandbox image (setuid bits
 		// are stripped under gVisor / nosuid), and bootstrap provisioning
-		// runs via docker exec User="root", which doesn't need container
-		// capabilities. Keeping the cap set empty shrinks the attack
-		// surface for any agent code that escapes into the sandbox.
+		// runs as the sandbox user under its own home directory, which
+		// needs no container capabilities. Keeping the cap set empty
+		// shrinks the attack surface for any agent code that escapes into
+		// the sandbox.
 		ReadonlyRootfs: false,
 		Tmpfs: map[string]string{
 			// /tmp is hardened (noexec,nosuid) so exploits can't drop a binary
@@ -384,25 +396,18 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		Purpose:   cfg.Purpose,
 	}
 
-	// Bootstrap WorkDir: Docker creates a missing WorkingDir as root, so the
-	// sandbox user can't write to it (e.g. git clone). We mkdir -p + chown
-	// idempotently so the case where WorkDir already exists (e.g. /workspace
-	// baked into the image) is a harmless no-op too. Run with WorkDir="/" so
-	// the exec's own cwd doesn't race with creation.
-	//
-	// Invoke docker exec with User="root" rather than prefixing `sudo`: sudo
-	// relies on its setuid bit, which the kernel strips under gVisor (and
-	// under no-new-privileges, userns-remap, or any nosuid mount), yielding
-	// "sudo: effective uid is not 0, is /usr/bin/sudo on a file system with
-	// the 'nosuid' option set". The exec API sets the uid via the runtime's
-	// control plane, so no setuid is involved.
+	// Bootstrap WorkDir as the sandbox user. cfg.WorkDir is always either the
+	// image's baked-in /workspace (a no-op for mkdir -p) or a HomeDir subdir
+	// like /home/sandbox/<repo>; in the latter case /home/sandbox already
+	// exists and is sandbox-owned (from `useradd -m`), so sandbox can create
+	// the per-session subdir without any privileged exec. Running this as
+	// root would require CAP_DAC_OVERRIDE / CAP_CHOWN to be preserved under
+	// CapDrop=ALL, which gVisor and some Docker runtimes do not honor —
+	// hence the non-root approach.
 	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
-	bootstrapCmd := fmt.Sprintf(
-		"mkdir -p '%s' && chown sandbox:sandbox '%s'",
-		shellEscape(cfg.WorkDir), shellEscape(cfg.WorkDir),
-	)
+	bootstrapCmd := fmt.Sprintf("mkdir -p '%s'", shellEscape(cfg.WorkDir))
 	var bootErr bytes.Buffer
-	if code, err := d.execAs(ctx, bootstrapSB, "root", bootstrapCmd, io.Discard, &bootErr); err != nil || code != 0 {
+	if code, err := d.Exec(ctx, bootstrapSB, bootstrapCmd, io.Discard, &bootErr); err != nil || code != 0 {
 		removeErr := d.client.ContainerRemove(ctx, resp.ID, container.RemoveOptions{Force: true})
 		if removeErr != nil {
 			log.Error().Err(removeErr).Str("container_id", resp.ID).Msg("failed to remove container after bootstrap failure")
@@ -472,25 +477,13 @@ func (d *DockerProvider) CloneRepo(ctx context.Context, sb *agent.Sandbox, repoU
 }
 
 // Exec runs a command inside the sandbox container and streams output to the
-// provided writers. Returns the command's exit code.
+// provided writers. Returns the command's exit code. Leaves ExecOptions.User
+// empty so the exec runs as the container's default user (sandbox).
 func (d *DockerProvider) Exec(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
-	return d.execAs(ctx, sb, "", cmd, stdout, stderr)
-}
-
-// execAs runs a command in the container as a specific user. An empty user
-// means "use the container's default" (sandbox, per containerCfg.User).
-// Bootstrap uses user="root" to mkdir/chown without relying on sudo's setuid
-// bit, which the kernel strips under gVisor / no-new-privileges / userns.
-func (d *DockerProvider) execAs(ctx context.Context, sb *agent.Sandbox, user, cmd string, stdout, stderr io.Writer) (int, error) {
 	log := d.scopedLogger(sb)
-	logEvent := log.Debug().Str("cmd", cmd)
-	if user != "" {
-		logEvent = logEvent.Str("user", user)
-	}
-	logEvent.Msg("executing command in sandbox")
+	log.Debug().Str("cmd", cmd).Msg("executing command in sandbox")
 
 	execCfg := container.ExecOptions{
-		User:         user,
 		Cmd:          []string{"sh", "-c", cmd},
 		AttachStdout: true,
 		AttachStderr: true,

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -290,8 +290,6 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// sidesteps that entirely so bootstrap can run as the sandbox user.
 	bootstrapCwd := cfg.HomeDir
 	if bootstrapCwd == "" {
-		// Fallback for unusual callers that don't set HomeDir. Bootstrap can
-		// still succeed as long as cfg.WorkDir is writable by sandbox.
 		bootstrapCwd = "/"
 	}
 	containerCfg := &container.Config{
@@ -402,11 +400,10 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// image's baked-in /workspace (a no-op for mkdir -p) or a HomeDir subdir
 	// like /home/sandbox/<repo>; in the latter case /home/sandbox already
 	// exists and is sandbox-owned (from `useradd -m`), so sandbox can create
-	// the per-session subdir without any privileged exec. The previous
-	// root-exec bootstrap chown'd the dir to sandbox, which requires
-	// CAP_CHOWN — and that cap is stripped by CapDrop=ALL under gVisor and
-	// some Docker runtimes. Owning the dir from creation sidesteps the cap
-	// requirement entirely.
+	// the per-session subdir without any privileged exec. Running this as
+	// root would require CAP_DAC_OVERRIDE / CAP_CHOWN to be preserved under
+	// CapDrop=ALL, which gVisor and some Docker runtimes do not honor —
+	// hence the non-root approach.
 	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
 	bootstrapCmd := fmt.Sprintf("mkdir -p '%s'", shellEscape(cfg.WorkDir))
 	var bootErr bytes.Buffer

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -290,6 +290,8 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// sidesteps that entirely so bootstrap can run as the sandbox user.
 	bootstrapCwd := cfg.HomeDir
 	if bootstrapCwd == "" {
+		// Fallback for unusual callers that don't set HomeDir. Bootstrap can
+		// still succeed as long as cfg.WorkDir is writable by sandbox.
 		bootstrapCwd = "/"
 	}
 	containerCfg := &container.Config{
@@ -400,10 +402,11 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	// image's baked-in /workspace (a no-op for mkdir -p) or a HomeDir subdir
 	// like /home/sandbox/<repo>; in the latter case /home/sandbox already
 	// exists and is sandbox-owned (from `useradd -m`), so sandbox can create
-	// the per-session subdir without any privileged exec. Running this as
-	// root would require CAP_DAC_OVERRIDE / CAP_CHOWN to be preserved under
-	// CapDrop=ALL, which gVisor and some Docker runtimes do not honor —
-	// hence the non-root approach.
+	// the per-session subdir without any privileged exec. The previous
+	// root-exec bootstrap chown'd the dir to sandbox, which requires
+	// CAP_CHOWN — and that cap is stripped by CapDrop=ALL under gVisor and
+	// some Docker runtimes. Owning the dir from creation sidesteps the cap
+	// requirement entirely.
 	bootstrapSB := &agent.Sandbox{ID: resp.ID, Provider: "docker", WorkDir: "/"}
 	bootstrapCmd := fmt.Sprintf("mkdir -p '%s'", shellEscape(cfg.WorkDir))
 	var bootErr bytes.Buffer

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -706,6 +706,25 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Contains(t, boot.Cmd[2], "mkdir -p", "bootstrap must still create the workdir idempotently")
 	})
 
+	t.Run("falls back to / when HomeDir is unset", func(t *testing.T) {
+		t.Parallel()
+
+		var createdCfg *container.Config
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			createdCfg = config
+			return container.CreateResponse{ID: "no-home"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		cfg := agent.DefaultSandboxConfig()
+		cfg.HomeDir = ""
+		_, err := p.Create(context.Background(), cfg)
+		require.NoError(t, err)
+
+		require.Equal(t, "/", createdCfg.WorkingDir, "callers that omit HomeDir should anchor at / rather than an empty WorkingDir (which the OCI runtime would reject)")
+	})
+
 	t.Run("cleans up on bootstrap workdir failure", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -408,12 +408,12 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		// Verify container config
 		require.Equal(t, "sandbox", capturedConfig.User, "container should run as non-root user")
-		require.Equal(t, "/workspace", capturedConfig.WorkingDir, "container should use /workspace as working dir")
+		require.Equal(t, "/home/sandbox", capturedConfig.WorkingDir, "container WorkingDir should be HomeDir (sandbox-owned, always present) so the OCI runtime doesn't auto-create cfg.WorkDir as root")
 
 		// Verify security hardening
 		require.Equal(t, "runsc", capturedHostConfig.Runtime, "container should use gVisor runtime")
 		require.Equal(t, []string(capturedHostConfig.CapDrop), []string{"ALL"}, "container should drop all capabilities")
-		require.Empty(t, capturedHostConfig.CapAdd, "container should not add back any caps — sudo is gone from the image and bootstrap uses docker exec User=root")
+		require.Empty(t, capturedHostConfig.CapAdd, "container should not add back any caps — sudo is gone from the image and bootstrap runs unprivileged as the sandbox user")
 		require.Empty(t, capturedHostConfig.SecurityOpt, "container should not set security options — no-new-privileges is moot without sudo, keep it unset for parity with the pre-sudo-removal behavior")
 		require.False(t, capturedHostConfig.ReadonlyRootfs, "container should have writable rootfs for package installation")
 		require.Contains(t, capturedHostConfig.Tmpfs, "/tmp", "container should have tmpfs at /tmp")
@@ -669,20 +669,22 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, "agent_run", sb.Purpose, "Purpose should be copied from config")
 	})
 
-	t.Run("bootstrap runs as root without sudo", func(t *testing.T) {
+	t.Run("bootstrap runs as sandbox user with no sudo or chown", func(t *testing.T) {
 		t.Parallel()
 
-		// The bootstrap mkdir/chown must NOT shell out to `sudo`: under gVisor
-		// (and no-new-privileges / userns-remap / any nosuid mount) the setuid
-		// bit on /usr/bin/sudo is stripped, producing "sudo: effective uid is
-		// not 0 ... nosuid" and failing session startup. Running the exec with
-		// ExecOptions.User="root" goes through Docker's control plane instead,
-		// so it works under every runtime and security profile we support.
+		// Bootstrap must NOT require root: sudo's setuid bit is stripped under
+		// gVisor/nosuid, and Docker exec with User="root" + CapDrop=ALL has
+		// been observed to fail `mkdir -p /home/sandbox` with Permission
+		// denied on some runtimes. Anchoring the container's WorkingDir at
+		// HomeDir (baked in by `useradd -m sandbox`, owned by sandbox:sandbox)
+		// lets the sandbox user create the per-session workdir itself.
 		var execCfgs []container.ExecOptions
+		var createdCfg *container.Config
 
 		mock := &mockDockerClient{}
 		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
-			return container.CreateResponse{ID: "bootstrap-root"}, nil
+			createdCfg = config
+			return container.CreateResponse{ID: "bootstrap-sandbox"}, nil
 		}
 		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
 			execCfgs = append(execCfgs, config)
@@ -693,13 +695,15 @@ func TestDockerProvider_Create(t *testing.T) {
 		_, err := p.Create(context.Background(), agent.DefaultSandboxConfig())
 		require.NoError(t, err)
 
+		require.Equal(t, "/home/sandbox", createdCfg.WorkingDir, "container WorkingDir must be HomeDir so the OCI runtime doesn't auto-create a root-owned cfg.WorkDir")
+
 		require.Len(t, execCfgs, 1, "Create should issue exactly one bootstrap exec")
 		boot := execCfgs[0]
-		require.Equal(t, "root", boot.User, "bootstrap exec must run as root via ExecOptions.User (not via sudo)")
+		require.Empty(t, boot.User, "bootstrap exec must run as the container's default user (sandbox), not root")
 		require.Len(t, boot.Cmd, 3, "bootstrap cmd should be wrapped by sh -c")
 		require.NotContains(t, boot.Cmd[2], "sudo", "bootstrap shell cmd must not invoke sudo — the setuid bit is stripped under gVisor/no-new-privileges")
+		require.NotContains(t, boot.Cmd[2], "chown", "bootstrap shell cmd must not invoke chown — sandbox already owns the created dir and chown under CapDrop=ALL fails without CAP_CHOWN")
 		require.Contains(t, boot.Cmd[2], "mkdir -p", "bootstrap must still create the workdir idempotently")
-		require.Contains(t, boot.Cmd[2], "chown sandbox:sandbox", "bootstrap must chown the workdir to the sandbox user")
 	})
 
 	t.Run("cleans up on bootstrap workdir failure", func(t *testing.T) {
@@ -933,7 +937,7 @@ func TestDockerProvider_Exec(t *testing.T) {
 		require.NoError(t, err, "Exec should not return an error")
 		require.Equal(t, 0, code, "exit code should be 0")
 		require.Equal(t, []string{"sh", "-c", "echo hello"}, capturedCmd, "command should be wrapped in sh -c")
-		require.Empty(t, capturedUser, "public Exec must leave User empty so the exec runs as the container's default (sandbox); only bootstrap opts in to root")
+		require.Empty(t, capturedUser, "Exec must leave User empty so the exec runs as the container's default (sandbox); bootstrap also runs as sandbox now")
 		require.True(t, capturedAttachStdout, "should attach stdout")
 		require.True(t, capturedAttachStderr, "should attach stderr")
 	})

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -706,25 +706,6 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Contains(t, boot.Cmd[2], "mkdir -p", "bootstrap must still create the workdir idempotently")
 	})
 
-	t.Run("falls back to / when HomeDir is unset", func(t *testing.T) {
-		t.Parallel()
-
-		var createdCfg *container.Config
-		mock := &mockDockerClient{}
-		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
-			createdCfg = config
-			return container.CreateResponse{ID: "no-home"}, nil
-		}
-		p := NewDockerProvider(mock, newTestLogger())
-
-		cfg := agent.DefaultSandboxConfig()
-		cfg.HomeDir = ""
-		_, err := p.Create(context.Background(), cfg)
-		require.NoError(t, err)
-
-		require.Equal(t, "/", createdCfg.WorkingDir, "callers that omit HomeDir should anchor at / rather than an empty WorkingDir (which the OCI runtime would reject)")
-	})
-
 	t.Run("cleans up on bootstrap workdir failure", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- Session startup failed with `create sandbox: bootstrap workdir (exit 1): mkdir: cannot create directory '/home/sandbox': Permission denied`. `docker exec User=root` under `CapDrop=ALL` has no `CAP_DAC_OVERRIDE`/`CAP_CHOWN`, so the root-side chown from #424 can't succeed — and the pre-#424 `sudo` path failed under gVisor's nosuid setuid stripping.
- Root cause: `containerCfg.WorkingDir` was `cfg.WorkDir` (e.g. `/home/sandbox/<slug>`), which the OCI runtime auto-creates as root. Point it at `cfg.HomeDir` instead — that path already exists and is sandbox-owned from `useradd -m` — and the sandbox user can then `mkdir -p cfg.WorkDir` itself with no chown and no privileged exec.
- Drops the `execAs` helper (no caller needed the user override) and tightens the bootstrap tests to pin "no sudo, no chown, no root".

## Test plan
- [x] `go test ./internal/services/agent/providers/...` passes, including updated `bootstrap runs as sandbox user with no sudo or chown` assertions.
- [ ] Deploy and create a manual session to confirm the bootstrap no longer errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)