### PR TITLE
Refresh LLM model list with current OpenAI and Anthropic models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,6 @@ AWS_SECRET_ACCESS_KEY=
 # SMTP_FROM=noreply@example.com
 
 # ── LLM ──────────────────────────────────────────────────────────────
-LLM_MODEL=claude-sonnet-4-5
+LLM_MODEL=claude-sonnet-4-6
 # OPENAI_API_TYPE=                  # "chat_completions" or "responses"
 # OPENROUTER_APP_NAME=143-dev

--- a/docs/secrets/README.md
+++ b/docs/secrets/README.md
@@ -290,7 +290,7 @@ See `.env.example` for the full list. Key groups:
 
 ### LLM providers
 
-Set `LLM_MODEL` to a model name (e.g., `claude-sonnet-4-5`, `gpt-4o`) and provide at least one provider API key. The system automatically falls back through configured providers:
+Set `LLM_MODEL` to a model name (e.g., `claude-sonnet-4-6`, `gpt-5.4-mini`) and provide at least one provider API key. The system automatically falls back through configured providers:
 
 | Provider | API key variable | Notes |
 |----------|-----------------|-------|

--- a/docs/self-hosting/platform-llm.md
+++ b/docs/self-hosting/platform-llm.md
@@ -18,7 +18,7 @@ Set one of the following provider keys on the **backend** environment:
 - `OPENAI_API_KEY`
 - `OPENROUTER_API_KEY`
 
-Then pick a model with `PLATFORM_LLM_MODEL`. The default is `gpt-5-nano`, which assumes an OpenAI-compatible key. If you've only set an Anthropic key, set `PLATFORM_LLM_MODEL` to a corresponding small Anthropic model (e.g. `claude-haiku-4-5-20251001`); same idea for OpenRouter.
+Then pick a model with `PLATFORM_LLM_MODEL`. The default is `gpt-5.4-nano`, which assumes an OpenAI-compatible key. If you've only set an Anthropic key, set `PLATFORM_LLM_MODEL` to a corresponding small Anthropic model (e.g. `claude-haiku-4-5-20251001`); same idea for OpenRouter.
 
 The agent-session model (`LLM_MODEL`) is independent — the platform LLM does not use it.
 
@@ -26,7 +26,7 @@ The agent-session model (`LLM_MODEL`) is independent — the platform LLM does n
 
 ```sh
 OPENAI_API_KEY=sk-...
-# PLATFORM_LLM_MODEL is gpt-5-nano by default; no need to set it
+# PLATFORM_LLM_MODEL is gpt-5.4-nano by default; no need to set it
 ```
 
 ### Minimal example (Anthropic)

--- a/docs/self-hosting/production-deployment-checklist.md
+++ b/docs/self-hosting/production-deployment-checklist.md
@@ -53,7 +53,7 @@ Notes:
   - `ANTHROPIC_API_KEY`, or
   - `OPENAI_API_KEY`, or
   - `OPENROUTER_API_KEY`
-- [ ] `PLATFORM_LLM_MODEL` (small model used for background features — defaults to `gpt-5-nano`; see [platform-llm.md](platform-llm.md))
+- [ ] `PLATFORM_LLM_MODEL` (small model used for background features — defaults to `gpt-5.4-nano`; see [platform-llm.md](platform-llm.md))
 
 Optional LLM routing vars:
 - `OPENAI_API_TYPE`, `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `OPENROUTER_BASE_URL`, `OPENROUTER_APP_NAME`, `OPENROUTER_SITE_URL`

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -9,7 +9,7 @@ const mocks = vi.hoisted(() => ({
       name: "Test Org",
       settings: {
         default_agent_type: "codex",
-        default_llm_model: "gpt-4o",
+        default_llm_model: "gpt-5.4-mini",
       },
     },
   }),
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
     data: [{ name: "main", protected: true }],
   }),
   llmModelsMock: vi.fn().mockResolvedValue({
-    data: { openai: ["gpt-4o"], anthropic: ["claude-sonnet-4-20250514"] },
+    data: { openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"], anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
   }),
   createSessionMock: vi.fn().mockResolvedValue({
     data: { id: "new-sess" },

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -15,7 +15,7 @@ const {
     data: {
       name: "Test Org",
       settings: {
-        default_llm_model: "gpt-4o",
+        default_llm_model: "gpt-5.4-mini",
       },
     },
   }),
@@ -27,12 +27,12 @@ const {
   settingsUpdateMock: vi.fn().mockResolvedValue({}),
   llmModelsMock: vi.fn().mockResolvedValue({
     data: {
-      openai: ["gpt-4o", "gpt-4o-mini"],
-      anthropic: ["claude-sonnet-4-20250514"],
+      openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
+      anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
     },
   }),
   llmDefaultsMock: vi.fn().mockResolvedValue({
-    data: { default_llm_model: "gpt-4o", available_providers: ["openai"] },
+    data: { default_llm_model: "gpt-5.4-mini", available_providers: ["openai"] },
   }),
 }));
 
@@ -102,7 +102,7 @@ describe("LLMPage", () => {
   it("shows the platform-LLM alert when no platform provider is configured", async () => {
     llmDefaultsMock.mockResolvedValueOnce({
       data: {},
-      platform_model: "gpt-5-nano",
+      platform_model: "gpt-5.4-nano",
     });
 
     renderWithProviders(<LLMPage />);
@@ -119,7 +119,7 @@ describe("LLMPage", () => {
   it("hides the platform-LLM alert when a platform provider is configured", async () => {
     llmDefaultsMock.mockResolvedValueOnce({
       data: { openai: "sk-...abc" },
-      platform_model: "gpt-5-nano",
+      platform_model: "gpt-5.4-nano",
     });
 
     renderWithProviders(<LLMPage />);

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -74,7 +74,7 @@ describe("model constants", () => {
 
   it("LLM_MODELS_BY_PROVIDER maps providers to their models", () => {
     expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "openrouter"]);
-    expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toContain("claude-sonnet-4-5");
-    expect(LLM_MODELS_BY_PROVIDER.openai.models).toContain("gpt-4o");
+    expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]);
+    expect(LLM_MODELS_BY_PROVIDER.openai.models).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]);
   });
 });

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -79,9 +79,9 @@ export const AVAILABLE_PM_MODELS = [
 // from GET /api/v1/settings/llm-models (served by models.LLMModelsByProvider()
 // in internal/models/agent_model_constants.go). Keep both in sync.
 export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[] }> = {
-  anthropic: { label: "Anthropic", models: ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"] },
-  openai: { label: "OpenAI", models: ["gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"] },
-  openrouter: { label: "OpenRouter", models: ["claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"] },
+  anthropic: { label: "Anthropic", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
+  openai: { label: "OpenAI", models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
+  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
 };
 
 export const DEFAULT_LLM_MODEL = "gpt-5.4-mini";

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -12,7 +12,7 @@ import (
 type SettingsHandler struct {
 	orgStore      *db.OrganizationStore
 	llmDefaults   map[string]string // provider name → masked key (from server env)
-	platformModel string            // cheap model used for internal features (e.g. "gpt-5-nano")
+	platformModel string            // cheap model used for internal features (e.g. "gpt-5.4-nano")
 	audit         *db.AuditEmitter
 }
 

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -65,7 +65,7 @@ func TestSettingsHandler_Get(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, "gpt-5-nano")
+			handler := NewSettingsHandler(store, nil, "gpt-5.4-nano")
 
 			tt.setupMock(mock, orgID)
 
@@ -88,7 +88,7 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	defaults := map[string]string{
 		"anthropic": "sk-a••••test",
 	}
-	handler := NewSettingsHandler(nil, defaults, "gpt-5-nano")
+	handler := NewSettingsHandler(nil, defaults, "gpt-5.4-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -98,13 +98,13 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	require.Contains(t, w.Body.String(), "anthropic", "response should contain provider name")
 	require.Contains(t, w.Body.String(), "sk-a", "response should contain masked key prefix")
 	require.Contains(t, w.Body.String(), "platform_model", "response should contain platform_model")
-	require.Contains(t, w.Body.String(), "gpt-5-nano", "response should contain platform model name")
+	require.Contains(t, w.Body.String(), "gpt-5.4-nano", "response should contain platform model name")
 }
 
 func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, map[string]string{}, "gpt-5-nano")
+	handler := NewSettingsHandler(nil, map[string]string{}, "gpt-5.4-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -117,13 +117,13 @@ func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	dataMap, ok := resp["data"].(map[string]any)
 	require.True(t, ok, "data should be a map")
 	require.Empty(t, dataMap, "should return empty map when no providers configured")
-	require.Equal(t, "gpt-5-nano", resp["platform_model"], "should return platform model")
+	require.Equal(t, "gpt-5.4-nano", resp["platform_model"], "should return platform model")
 }
 
 func TestSettingsHandler_GetLLMModels(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, nil, "gpt-5-nano")
+	handler := NewSettingsHandler(nil, nil, "gpt-5.4-nano")
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-models", nil)
 	w := httptest.NewRecorder()
@@ -132,8 +132,8 @@ func TestSettingsHandler_GetLLMModels(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "should return 200 OK")
 	require.Contains(t, w.Body.String(), "anthropic", "response should contain anthropic provider")
 	require.Contains(t, w.Body.String(), "openai", "response should contain openai provider")
-	require.Contains(t, w.Body.String(), "claude-sonnet-4-5", "response should contain Claude model")
-	require.Contains(t, w.Body.String(), "gpt-4o", "response should contain OpenAI model")
+	require.Contains(t, w.Body.String(), "claude-sonnet-4-6", "response should contain Claude model")
+	require.Contains(t, w.Body.String(), "gpt-5.4-mini", "response should contain OpenAI model")
 }
 
 func TestSettingsHandler_Update(t *testing.T) {
@@ -198,7 +198,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 		},
 		{
 			name: "accepts valid llm_model",
-			body: `{"settings":{"llm_model":"gpt-4o"}}`,
+			body: `{"settings":{"llm_model":"gpt-5.4-mini"}}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 				now := time.Now()
 				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
@@ -215,7 +215,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 					)
 			},
 			expectedCode: http.StatusOK,
-			expectedBody: "gpt-4o",
+			expectedBody: "gpt-5.4-mini",
 		},
 		{
 			name: "returns bad request for invalid codex model in agent_config",
@@ -280,7 +280,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, "gpt-5-nano")
+			handler := NewSettingsHandler(store, nil, "gpt-5.4-nano")
 
 			tt.setupMock(mock, orgID)
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -140,7 +140,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	usageHandler := handlers.NewUsageHandler(containerUsageStore, handlers.WithRollupStore(usageRollupStore))
 	platformModel := cfg.PlatformLLMModel
 	if platformModel == "" {
-		platformModel = "gpt-5-nano"
+		platformModel = "gpt-5.4-nano"
 	}
 	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeLLMEnv(), platformModel)
 	issueHandler := handlers.NewIssueHandler(issueStore)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	// Slack OAuth
 	SlackOAuthClientID     string `env:"SLACK_OAUTH_CLIENT_ID"`
 	SlackOAuthClientSecret string `env:"SLACK_OAUTH_CLIENT_SECRET"`
-	SlackSummaryModel      string `env:"SLACK_SUMMARY_MODEL" envDefault:"gpt-5-nano"`
+	SlackSummaryModel      string `env:"SLACK_SUMMARY_MODEL" envDefault:"gpt-5.4-nano"`
 
 	// GitHub App
 	GitHubAppID         int64  `env:"GITHUB_APP_ID"`
@@ -62,7 +62,7 @@ type Config struct {
 	// LLM
 	LLMModel           string `env:"LLM_MODEL"`
 	LLMReasoningEffort string `env:"LLM_REASONING_EFFORT"`
-	PlatformLLMModel   string `env:"PLATFORM_LLM_MODEL"    envDefault:"gpt-5-nano"`
+	PlatformLLMModel   string `env:"PLATFORM_LLM_MODEL"    envDefault:"gpt-5.4-nano"`
 	AnthropicAPIKey    string `env:"ANTHROPIC_API_KEY"`
 	AnthropicBaseURL   string `env:"ANTHROPIC_BASE_URL"`
 	OpenAIAPIKey       string `env:"OPENAI_API_KEY"`
@@ -188,7 +188,7 @@ func (c *Config) LLMConfig() llm.Config {
 
 // PlatformLLMConfig returns the llm.Config for platform-internal features
 // (titles, PR descriptions, project generation, validation, prioritization).
-// Uses the cheap PLATFORM_LLM_MODEL (default: gpt-5-nano) regardless of what
+// Uses the cheap PLATFORM_LLM_MODEL (default: gpt-5.4-nano) regardless of what
 // LLM_MODEL is set to, keeping internal feature costs low.
 func (c *Config) PlatformLLMConfig() llm.Config {
 	return llm.Config{

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -140,11 +140,11 @@ func TestBuildChain_FiltersUnavailableProviders(t *testing.T) {
 		// openai_chat is NOT configured
 	}
 
-	chain, err := buildChain("claude-sonnet-4-5", available)
+	chain, err := buildChain("claude-sonnet-4-6", available)
 	require.NoError(t, err)
 	require.Len(t, chain, 1, "chain should only include configured providers")
 	require.Equal(t, "anthropic", chain[0].provider.Name())
-	require.Equal(t, "claude-sonnet-4-5-20250929", chain[0].modelID)
+	require.Equal(t, "claude-sonnet-4-6", chain[0].modelID)
 }
 
 func TestBuildChain_UnknownModel(t *testing.T) {
@@ -160,7 +160,7 @@ func TestBuildChain_NoConfiguredProviders(t *testing.T) {
 	t.Parallel()
 
 	// Model exists in registry but no matching providers configured.
-	_, err := buildChain("claude-sonnet-4-5", map[string]Provider{})
+	_, err := buildChain("claude-sonnet-4-6", map[string]Provider{})
 	require.Error(t, err)
 	var noProvidersErr *NoProvidersError
 	require.ErrorAs(t, err, &noProvidersErr)
@@ -190,7 +190,7 @@ func TestNewClient_DefaultsModelWhenEmpty(t *testing.T) {
 func TestNewClient_ErrorWhenNoProviders(t *testing.T) {
 	t.Parallel()
 
-	_, err := NewClient(Config{Model: "claude-sonnet-4-5"}, zerolog.Nop())
+	_, err := NewClient(Config{Model: "claude-sonnet-4-6"}, zerolog.Nop())
 	require.Error(t, err)
 }
 
@@ -198,7 +198,7 @@ func TestNewClient_WithAnthropicKey(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:           "claude-sonnet-4-5",
+		Model:           "claude-sonnet-4-6",
 		AnthropicAPIKey: "sk-ant-test",
 	}, zerolog.Nop())
 	require.NoError(t, err, "should create client with anthropic key")
@@ -209,7 +209,7 @@ func TestNewClient_WithOpenAIChatKey(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:         "gpt-4o",
+		Model:         "gpt-5.4-mini",
 		OpenAIAPIKey:  "sk-test",
 		OpenAIAPIType: "chat",
 	}, zerolog.Nop())
@@ -221,7 +221,7 @@ func TestNewClient_WithOpenAIResponsesKey(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:         "gpt-4o",
+		Model:         "gpt-5.4-mini",
 		OpenAIAPIKey:  "sk-test",
 		OpenAIAPIType: "responses",
 	}, zerolog.Nop())
@@ -233,7 +233,7 @@ func TestNewClient_WithOpenRouterKey(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:             "claude-sonnet-4-5",
+		Model:             "claude-sonnet-4-6",
 		OpenRouterAPIKey:  "sk-or-test",
 		OpenRouterBaseURL: "https://custom.openrouter.ai",
 		OpenRouterAppName: "test-app",
@@ -247,7 +247,7 @@ func TestNewClient_WithCustomTimeout(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:           "claude-sonnet-4-5",
+		Model:           "claude-sonnet-4-6",
 		AnthropicAPIKey: "sk-ant-test",
 		Timeout:         30 * time.Second,
 	}, zerolog.Nop())
@@ -259,7 +259,7 @@ func TestNewClient_WithAllProviders(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:            "claude-sonnet-4-5",
+		Model:            "claude-sonnet-4-6",
 		AnthropicAPIKey:  "sk-ant-test",
 		AnthropicBaseURL: "https://custom.anthropic.com",
 		OpenAIAPIKey:     "sk-openai-test",

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -26,11 +26,10 @@ type Provider interface {
 }
 
 // modelSupportsReasoningEffort returns true if the given model ID is known to
-// support the reasoning_effort parameter. Unsupported models (e.g. gpt-4o)
-// may reject the parameter with a 400 error.
+// support the reasoning_effort parameter. Unsupported models (e.g. legacy
+// gpt-4o) may reject the parameter with a 400 error.
 func modelSupportsReasoningEffort(model string) bool {
 	// o-series reasoning models and gpt-5+ models support reasoning_effort.
-	// Legacy models (gpt-4o, gpt-4o-mini) do not.
 	return strings.HasPrefix(model, "o") || strings.HasPrefix(model, "gpt-5")
 }
 

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -23,43 +23,33 @@ type providerModel struct {
 // so it serves as a useful last-resort fallback.
 var defaultChains = map[ModelName][]providerModel{
 	// Anthropic models — primary: Anthropic API, cross-provider fallback, then OpenRouter.
-	"claude-opus-4-6": {
-		{ProviderName: "anthropic", ModelID: "claude-opus-4-6"},
-		{ProviderName: "openai_chat", ModelID: "gpt-4o"},
-		{ProviderName: "openai_responses", ModelID: "gpt-4o"},
-		{ProviderName: "openrouter", ModelID: "anthropic/claude-opus-4-6"},
+	// Ordered most-capable → least-capable within the Claude 4 family.
+	"claude-opus-4-7": {
+		{ProviderName: "anthropic", ModelID: "claude-opus-4-7"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "openrouter", ModelID: "anthropic/claude-opus-4-7"},
 	},
-	"claude-sonnet-4-5": {
-		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-5-20250929"},
-		{ProviderName: "openai_chat", ModelID: "gpt-4o"},
-		{ProviderName: "openai_responses", ModelID: "gpt-4o"},
-		{ProviderName: "openrouter", ModelID: "anthropic/claude-sonnet-4-5"},
+	"claude-sonnet-4-6": {
+		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "openrouter", ModelID: "anthropic/claude-sonnet-4-6"},
 	},
 	"claude-haiku-4-5": {
 		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
-		{ProviderName: "openai_chat", ModelID: "gpt-4o-mini"},
-		{ProviderName: "openai_responses", ModelID: "gpt-4o-mini"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
 		{ProviderName: "openrouter", ModelID: "anthropic/claude-haiku-4-5"},
 	},
 
 	// OpenAI models — primary: OpenAI (chat or responses), cross-provider fallback, then OpenRouter.
-	"gpt-4o": {
-		{ProviderName: "openai_chat", ModelID: "gpt-4o"},
-		{ProviderName: "openai_responses", ModelID: "gpt-4o"},
-		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-5-20250929"},
-		{ProviderName: "openrouter", ModelID: "openai/gpt-4o"},
-	},
-	"gpt-4o-mini": {
-		{ProviderName: "openai_chat", ModelID: "gpt-4o-mini"},
-		{ProviderName: "openai_responses", ModelID: "gpt-4o-mini"},
-		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
-		{ProviderName: "openrouter", ModelID: "openai/gpt-4o-mini"},
-	},
-	"o3-mini": {
-		{ProviderName: "openai_chat", ModelID: "o3-mini"},
-		{ProviderName: "openai_responses", ModelID: "o3-mini"},
-		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-5-20250929"},
-		{ProviderName: "openrouter", ModelID: "openai/o3-mini"},
+	// Ordered most-capable → least-capable within the gpt-5.4 family.
+	"gpt-5.4": {
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
+		{ProviderName: "openrouter", ModelID: "openai/gpt-5.4"},
 	},
 	"gpt-5.4-mini": {
 		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
@@ -67,10 +57,10 @@ var defaultChains = map[ModelName][]providerModel{
 		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
 		{ProviderName: "openrouter", ModelID: "openai/gpt-5.4-mini"},
 	},
-	"gpt-5-nano": {
-		{ProviderName: "openai_chat", ModelID: "gpt-5-nano"},
-		{ProviderName: "openai_responses", ModelID: "gpt-5-nano"},
-		{ProviderName: "openrouter", ModelID: "openai/gpt-5-nano"},
+	"gpt-5.4-nano": {
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-nano"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-nano"},
+		{ProviderName: "openrouter", ModelID: "openai/gpt-5.4-nano"},
 	},
 }
 

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -23,10 +23,10 @@ func init() {
 }
 
 const (
-	ClaudeCodeModelOpus      = "claude-opus-4-6"
-	ClaudeCodeModelSonnet46  = "claude-sonnet-4-6"
-	ClaudeCodeModelSonnet    = "claude-sonnet-4-5"
-	ClaudeCodeModelHaiku     = "claude-haiku-4-5"
+	ClaudeCodeModelOpus     = "claude-opus-4-6"
+	ClaudeCodeModelSonnet46 = "claude-sonnet-4-6"
+	ClaudeCodeModelSonnet   = "claude-sonnet-4-5"
+	ClaudeCodeModelHaiku    = "claude-haiku-4-5"
 )
 
 var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku}
@@ -152,15 +152,14 @@ const DefaultLLMModel = "gpt-5.4-mini"
 
 // AvailableLLMModels lists all models supported by the general-purpose LLM system.
 // Keep in sync with frontend/src/lib/model-constants.ts (LLM_MODELS_BY_PROVIDER).
+// Models are listed most-capable → least-capable within each provider family.
 var AvailableLLMModels = []string{
-	"claude-opus-4-6",
-	"claude-sonnet-4-5",
+	"claude-opus-4-7",
+	"claude-sonnet-4-6",
 	"claude-haiku-4-5",
-	"gpt-4o",
-	"gpt-4o-mini",
+	"gpt-5.4",
 	"gpt-5.4-mini",
-	"gpt-5-nano",
-	"o3-mini",
+	"gpt-5.4-nano",
 }
 
 // LLMModelsByProvider returns general-purpose LLM models grouped by provider.
@@ -168,9 +167,9 @@ var AvailableLLMModels = []string{
 // GET /api/v1/settings/llm-models endpoint.
 func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
-		"anthropic":  {"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"},
-		"openai":     {"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"},
-		"openrouter": {"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5", "gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"},
+		"anthropic":  {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		"openai":     {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
+		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
 	}
 }
 

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -53,8 +53,8 @@ func TestLLMModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, []string{
-		"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5",
-		"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini",
+		"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
+		"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
 	}, AvailableLLMModels, "AvailableLLMModels should contain all supported LLM models")
 }
 
@@ -66,15 +66,15 @@ func TestLLMModelsByProvider(t *testing.T) {
 	require.Contains(t, byProvider, "anthropic")
 	require.Contains(t, byProvider, "openai")
 	require.Contains(t, byProvider, "openrouter")
-	require.Equal(t, []string{"claude-opus-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"}, byProvider["anthropic"])
-	require.Equal(t, []string{"gpt-4o", "gpt-4o-mini", "gpt-5.4-mini", "gpt-5-nano", "o3-mini"}, byProvider["openai"])
+	require.Equal(t, []string{"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}, byProvider["anthropic"])
+	require.Equal(t, []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}, byProvider["openai"])
 }
 
 func TestIsSupportedLLMModel(t *testing.T) {
 	t.Parallel()
 
-	require.True(t, IsSupportedLLMModel("claude-sonnet-4-5"), "should accept valid LLM model")
-	require.True(t, IsSupportedLLMModel("gpt-4o"), "should accept valid OpenAI model")
+	require.True(t, IsSupportedLLMModel("claude-sonnet-4-6"), "should accept valid LLM model")
+	require.True(t, IsSupportedLLMModel("gpt-5.4-mini"), "should accept valid OpenAI model")
 	require.False(t, IsSupportedLLMModel("invalid-model"), "should reject invalid model")
 	require.False(t, IsSupportedLLMModel(""), "should reject empty string")
 }
@@ -167,7 +167,7 @@ func TestValidateSettingsModels(t *testing.T) {
 		{
 			name: "accepts valid llm model",
 			settings: OrgSettings{
-				LLMModel: "gpt-4o",
+				LLMModel: "gpt-5.4-mini",
 			},
 		},
 		{

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -59,7 +59,7 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 			"focus_areas": ["billing", "api"],
 			"avoid_areas": ["legacy-auth"]
 		},
-		"llm_model": "gpt-4o",
+		"llm_model": "gpt-5.4-mini",
 		"priority_weights": {
 			"customer_impact": 0.40,
 			"severity": 0.30,
@@ -83,7 +83,7 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 	require.Equal(t, "Harden billing", s.ProductContext.Direction, "should parse product_context.direction")
 	require.Equal(t, []string{"billing", "api"}, s.ProductContext.FocusAreas, "should parse product_context.focus_areas")
 	require.Equal(t, []string{"legacy-auth"}, s.ProductContext.AvoidAreas, "should parse product_context.avoid_areas")
-	require.Equal(t, "gpt-4o", s.LLMModel, "should override llm_model")
+	require.Equal(t, "gpt-5.4-mini", s.LLMModel, "should override llm_model")
 	require.Equal(t, "conservative", s.AgentAutonomy, "should override agent_autonomy")
 	require.Equal(t, 1.0, s.ConfidenceThresholds.AutoProceed, "should derive auto_proceed from conservative autonomy")
 	require.Equal(t, 0.8, s.ConfidenceThresholds.HumanReview, "should derive human_review from conservative autonomy")

--- a/render.yaml
+++ b/render.yaml
@@ -61,7 +61,7 @@ services:
         sync: false
       # ── LLM ──
       - key: LLM_MODEL
-        value: claude-sonnet-4-5
+        value: claude-sonnet-4-6
       - key: ANTHROPIC_API_KEY
         sync: false
 


### PR DESCRIPTION
## Summary
- Replaces the stale user-selectable LLM models (`gpt-4o`, `o3-mini`, `claude-sonnet-4-5`, etc.) with the current gpt-5.4 and claude-4 series, reordered most→least capable.
- Updates provider fallback chains in `internal/llm/registry.go` (Anthropic chains fall back to gpt-5.4/gpt-5.4-mini; OpenAI chains fall back to claude-sonnet-4-6/claude-haiku-4-5) and bumps the `PLATFORM_LLM_MODEL` default from `gpt-5-nano` → `gpt-5.4-nano`.
- Refreshes all tests, fixtures, and docs (`.env.example`, `render.yaml`, self-hosting guides, secrets README) to reference the new model IDs.

## Test plan
- [ ] `make lint` passes
- [ ] Go test suite passes
- [ ] Frontend `npm test` + typecheck pass
- [ ] Verify `/settings/llm` shows the new model list and a working default selection