### PR TITLE
Drop per-tool icon in chat timeline rows

### DIFF
--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect } from "react";
-import { ChevronRight, AlertTriangle, Wrench, FileCode2, X, FileText, ClipboardList, Check, PenLine, Terminal, FileSearch, Search, FolderSearch, Globe, Bot, ListTodo } from "lucide-react";
+import { ChevronRight, AlertTriangle, FileCode2, X, FileText, ClipboardList, Check, PenLine } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { MarkdownContent } from "@/components/markdown";
@@ -9,7 +9,7 @@ import { PLAN_MODE_PREFIX } from "@/lib/timeline";
 import type { TimelineEntry } from "@/lib/timeline";
 import type { SessionMessage, SessionLog } from "@/lib/types";
 import { isImageURL, fileNameFromURL } from "@/lib/utils";
-import { deriveToolDisplay, formatToolInput, type ToolIconKind } from "@/lib/tool-label";
+import { deriveToolDisplay, formatToolInput } from "@/lib/tool-label";
 
 function safeDate(dateStr: string): Date | null {
   const d = new Date(dateStr);
@@ -25,22 +25,9 @@ function formatTimestamp(dateStr: string): string {
   });
 }
 
-const TOOL_ICONS: Record<ToolIconKind, React.ComponentType<{ className?: string }>> = {
-  terminal: Terminal,
-  "file-read": FileSearch,
-  "file-edit": PenLine,
-  search: Search,
-  glob: FolderSearch,
-  web: Globe,
-  agent: Bot,
-  plan: ListTodo,
-  wrench: Wrench,
-};
-
 function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResult?: SessionLog }) {
   const [open, setOpen] = useState(false);
-  const { label, icon } = deriveToolDisplay(toolUse);
-  const Icon = TOOL_ICONS[icon];
+  const { label } = deriveToolDisplay(toolUse);
   const inputDetail = formatToolInput(toolUse);
 
   return (
@@ -50,7 +37,6 @@ function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResu
         className="flex items-center gap-2 w-full text-left py-1.5 px-2 rounded-md hover:bg-muted/50 transition-colors text-xs group"
       >
         <ChevronRight className={`h-3 w-3 text-muted-foreground shrink-0 transition-transform duration-150 ${open ? "rotate-90" : ""}`} />
-        <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
         <span className="text-foreground truncate min-w-0">{label}</span>
         <span className="ml-auto text-muted-foreground/60 text-xs tabular-nums shrink-0">
           {formatTimestamp(toolUse.created_at)}

--- a/frontend/src/lib/tool-label.test.ts
+++ b/frontend/src/lib/tool-label.test.ts
@@ -23,7 +23,6 @@ describe("deriveToolDisplay", () => {
       });
       expect(deriveToolDisplay(log)).toEqual({
         label: "Ran Check git status",
-        icon: "terminal",
         canonical: "bash",
       });
     });
@@ -61,7 +60,6 @@ describe("deriveToolDisplay", () => {
       });
       expect(deriveToolDisplay(log)).toMatchObject({
         label: "Ran `go test ./...`",
-        icon: "terminal",
         canonical: "bash",
       });
     });
@@ -75,7 +73,6 @@ describe("deriveToolDisplay", () => {
       });
       expect(deriveToolDisplay(log)).toMatchObject({
         label: "Ran `ls`",
-        icon: "terminal",
         canonical: "bash",
       });
     });
@@ -91,7 +88,6 @@ describe("deriveToolDisplay", () => {
       const log = makeLog({ tool: "read_file", input: { path: "/app/config.yaml" } });
       expect(deriveToolDisplay(log)).toMatchObject({
         label: "Read config.yaml",
-        icon: "file-read",
       });
     });
   });
@@ -106,7 +102,6 @@ describe("deriveToolDisplay", () => {
       const log = makeLog({ tool: "write_file", input: { path: "/tmp/out.txt" } });
       expect(deriveToolDisplay(log)).toMatchObject({
         label: "Edited out.txt",
-        icon: "file-edit",
       });
     });
   });
@@ -153,7 +148,6 @@ describe("deriveToolDisplay", () => {
       const log = makeLog({ tool: "frobnicate" });
       expect(deriveToolDisplay(log)).toEqual({
         label: "Ran frobnicate",
-        icon: "wrench",
         canonical: "frobnicate",
       });
     });

--- a/frontend/src/lib/tool-label.ts
+++ b/frontend/src/lib/tool-label.ts
@@ -1,25 +1,8 @@
 import type { SessionLog } from "./types";
 
-/**
- * Maps a derived tool call to one of a small set of semantic icon kinds.
- * The actual lucide-react component is resolved at the call site.
- */
-export type ToolIconKind =
-  | "terminal"
-  | "file-read"
-  | "file-edit"
-  | "search"
-  | "glob"
-  | "web"
-  | "agent"
-  | "plan"
-  | "wrench";
-
 export interface ToolDisplay {
   /** Short human-readable label like `Ran \`git log\`` or `Read models.go`. */
   label: string;
-  /** Semantic icon kind — callers map to concrete icon components. */
-  icon: ToolIconKind;
   /** Normalized canonical tool name used for the template (for debugging/analytics). */
   canonical: string;
 }
@@ -132,74 +115,51 @@ export function deriveToolDisplay(toolUse: SessionLog): ToolDisplay {
   //    not for Agent/Task where `description` is the subagent task name.
   const description = input && asString(input.description);
   if (description && canonical !== "agent") {
-    return { label: `Ran ${description}`, icon: iconFor(canonical), canonical };
+    return { label: `Ran ${description}`, canonical };
   }
 
   // 2. Per-canonical-tool templates.
   switch (canonical) {
     case "bash": {
       const cmd = input && asString(input.command);
-      if (cmd) return { label: `Ran \`${shortCommand(cmd)}\``, icon: "terminal", canonical };
-      return { label: "Ran shell command", icon: "terminal", canonical };
+      if (cmd) return { label: `Ran \`${shortCommand(cmd)}\``, canonical };
+      return { label: "Ran shell command", canonical };
     }
     case "read": {
       const path = input && (asString(input.path) ?? asString(input.file_path) ?? asString(input.absolute_path));
-      if (path) return { label: `Read ${basename(path)}`, icon: "file-read", canonical };
-      return { label: "Read file", icon: "file-read", canonical };
+      if (path) return { label: `Read ${basename(path)}`, canonical };
+      return { label: "Read file", canonical };
     }
     case "edit": {
       const path = input && (asString(input.path) ?? asString(input.file_path) ?? asString(input.absolute_path));
-      if (path) return { label: `Edited ${basename(path)}`, icon: "file-edit", canonical };
-      return { label: "Edited file", icon: "file-edit", canonical };
+      if (path) return { label: `Edited ${basename(path)}`, canonical };
+      return { label: "Edited file", canonical };
     }
     case "grep": {
       const pattern = input && asString(input.pattern);
-      if (pattern) return { label: `Searched for \`${truncate(pattern, MAX_PATTERN_LEN)}\``, icon: "search", canonical };
-      return { label: "Searched files", icon: "search", canonical };
+      if (pattern) return { label: `Searched for \`${truncate(pattern, MAX_PATTERN_LEN)}\``, canonical };
+      return { label: "Searched files", canonical };
     }
     case "glob": {
       const pattern = input && asString(input.pattern);
-      if (pattern) return { label: `Found files matching \`${truncate(pattern, MAX_PATTERN_LEN)}\``, icon: "glob", canonical };
-      return { label: "Listed files", icon: "glob", canonical };
+      if (pattern) return { label: `Found files matching \`${truncate(pattern, MAX_PATTERN_LEN)}\``, canonical };
+      return { label: "Listed files", canonical };
     }
     case "web_fetch": {
       const url = input && asString(input.url);
-      if (url) return { label: `Fetched ${hostname(url)}`, icon: "web", canonical };
-      return { label: "Fetched URL", icon: "web", canonical };
+      if (url) return { label: `Fetched ${hostname(url)}`, canonical };
+      return { label: "Fetched URL", canonical };
     }
     case "agent": {
       const desc = input && (asString(input.description) ?? asString(input.prompt));
-      if (desc) return { label: `Ran agent: ${truncate(desc, 50)}`, icon: "agent", canonical };
-      return { label: "Ran subagent", icon: "agent", canonical };
+      if (desc) return { label: `Ran agent: ${truncate(desc, 50)}`, canonical };
+      return { label: "Ran subagent", canonical };
     }
     case "plan": {
-      return { label: "Updated plan", icon: "plan", canonical };
+      return { label: "Updated plan", canonical };
     }
     default:
-      return { label: `Ran ${rawTool}`, icon: "wrench", canonical: rawTool };
-  }
-}
-
-function iconFor(canonical: string): ToolIconKind {
-  switch (canonical) {
-    case "bash":
-      return "terminal";
-    case "read":
-      return "file-read";
-    case "edit":
-      return "file-edit";
-    case "grep":
-      return "search";
-    case "glob":
-      return "glob";
-    case "web_fetch":
-      return "web";
-    case "agent":
-      return "agent";
-    case "plan":
-      return "plan";
-    default:
-      return "wrench";
+      return { label: `Ran ${rawTool}`, canonical: rawTool };
   }
 }
 


### PR DESCRIPTION
## Summary
- The `Terminal` lucide icon rendered next to the expand/collapse `ChevronRight` in tool-call rows looked like a second caret (`>_`), making bash rows appear to have duplicate carets.
- Removes the per-tool icon column in `ToolGroupEntry`; the row label (e.g. `Ran \`git log\``, `Read main.go`) already identifies the tool.
- Cleans up the now-unused `ToolIconKind` type, the `icon` field on `ToolDisplay`, the `iconFor` helper, and the `TOOL_ICONS` map. Tests updated to drop `icon:` expectations; all 23 still pass.

## Test plan
- [ ] Load a session with bash, read, edit, grep tool calls and confirm each row shows a single caret + label
- [ ] Verify expand/collapse still rotates the caret correctly
- [ ] `npm run test` and `npm run typecheck` in `frontend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)