### PR TITLE
Keep session cookie alive on transient DB errors

### DIFF
--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 )
 
@@ -74,19 +76,35 @@ func Auth(sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []
 func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, sessionStore *db.AuthSessionStore, userStore *db.UserStore, csrfKey []byte, logger zerolog.Logger, token string, cookieBased bool) {
 	session, err := sessionStore.GetByToken(r.Context(), token)
 	if err != nil {
-		if cookieBased {
-			clearSessionCookie(w, r)
+		// Only treat ErrNoRows as a genuinely invalid session. Other errors
+		// (pool exhaustion, connection reset, query timeout during a rolling
+		// deploy) must NOT clear the cookie or return 401, otherwise the
+		// browser loses its session and the frontend — which treats 401 as
+		// terminal — logs the user out. Surface transient errors as 503 so
+		// the useAuth retry path handles them.
+		if errors.Is(err, pgx.ErrNoRows) {
+			if cookieBased {
+				clearSessionCookie(w, r)
+			}
+			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid session")
+			return
 		}
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "invalid session")
+		logger.Warn().Err(err).Msg("auth: session lookup failed")
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "session lookup failed")
 		return
 	}
 
 	user, err := userStore.GetByID(r.Context(), session.OrgID, session.UserID)
 	if err != nil {
-		if cookieBased {
-			clearSessionCookie(w, r)
+		if errors.Is(err, pgx.ErrNoRows) {
+			if cookieBased {
+				clearSessionCookie(w, r)
+			}
+			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+			return
 		}
-		writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "user not found")
+		logger.Warn().Err(err).Msg("auth: user lookup failed")
+		writeError(w, http.StatusServiceUnavailable, "SERVICE_UNAVAILABLE", "user lookup failed")
 		return
 	}
 

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -535,6 +535,70 @@ func TestAuth(t *testing.T) {
 			checkContext:  nil,
 			checkResponse: nil,
 		},
+		{
+			name: "returns 503 without clearing cookie when session lookup hits a transient DB error",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnError(fmt.Errorf("connection reset by peer"))
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: "valid-token"})
+				return req
+			},
+			expectedCode: http.StatusServiceUnavailable,
+			checkContext: nil,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName {
+						t.Fatalf("transient DB error must not clear session cookie, got %+v", c)
+					}
+				}
+				require.Contains(t, w.Body.String(), "SERVICE_UNAVAILABLE",
+					"transient failures should return SERVICE_UNAVAILABLE so useAuth retries")
+			},
+		},
+		{
+			name: "returns 503 without clearing cookie when user lookup hits a transient DB error",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				now := time.Now()
+				sessionRows := pgxmock.NewRows([]string{"id", "user_id", "org_id", "token", "expires_at", "created_at"}).
+					AddRow(
+						uuid.MustParse("99999999-0000-0000-0000-000000000001"),
+						uuid.MustParse("99999999-0000-0000-0000-000000000002"),
+						uuid.MustParse("99999999-0000-0000-0000-000000000003"),
+						"valid-token",
+						now.Add(29*24*time.Hour),
+						now,
+					)
+				mock.ExpectQuery("SELECT .+ FROM auth_sessions").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(sessionRows)
+
+				mock.ExpectQuery("SELECT .+ FROM users").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(fmt.Errorf("connection reset by peer"))
+			},
+			setupRequest: func(req *http.Request) *http.Request {
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: "valid-token"})
+				return req
+			},
+			expectedCode: http.StatusServiceUnavailable,
+			checkContext: nil,
+			checkResponse: func(t *testing.T, w *httptest.ResponseRecorder) {
+				t.Helper()
+				resp := w.Result()
+				defer resp.Body.Close()
+				for _, c := range resp.Cookies() {
+					if c.Name == SessionCookieName {
+						t.Fatalf("transient DB error must not clear session cookie, got %+v", c)
+					}
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Auth middleware cleared `session_token` on *any* error from `GetByToken` / `GetByID`, including transient DB errors (pool exhaustion, connection reset, query timeout during a rolling deploy). The browser dropped the cookie, subsequent requests returned 401 "missing session", and `useAuth` (which treats 401 as terminal) logged the user out despite their session still being valid in Postgres.
- Distinguish `pgx.ErrNoRows` (genuinely invalid → clear cookie + 401) from other errors (transient → 503 `SERVICE_UNAVAILABLE` without clearing the cookie, so useAuth's retry path handles it).

## Evidence
- Prod logs: cascade of 401s at 2026-04-20 23:53:20–36 UTC on `143-api-39` (commit `11bd121a`), immediately after a rolling deploy finished at 23:51:34.
- DB: 7 recent non-expired `auth_sessions` rows for my user with pairs minutes apart — the pattern of re-logins despite fresh server-side sessions is consistent with the browser losing the cookie, not server-side revocation.

## Test plan
- [x] `go test ./internal/api/middleware/ -run TestAuth` — added two cases covering the transient-error branch (session lookup and user lookup) asserting 503 + cookie preserved
- [x] `make lint` — clean
- [ ] Watch the next rolling deploy: confirm `auth: session lookup failed` warn logs appear if there are transient errors, and that the user does not get bounced to /login

Generated with [Claude Code](https://claude.com/claude-code)
