### PR TITLE
Redesign LLM settings and add Gemini as a first-class LLM provider

### DIFF
--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { DefaultModelCard } from "./DefaultModelCard";
+
+const groups = [
+  { label: "OpenAI", models: ["gpt-4o", "gpt-5.4-mini"] as readonly string[] },
+];
+
+describe("DefaultModelCard", () => {
+  it("renders the owner-key caption with a check when owner is configured", () => {
+    renderWithProviders(
+      <DefaultModelCard
+        value="gpt-5.4-mini"
+        reasoningEffort=""
+        modelGroups={groups}
+        ownerProvider="openai"
+        ownerProviderInfo={{ name: "OpenAI" }}
+        ownerConfigured
+        saving={false}
+        saveStatus="idle"
+        onChange={() => {}}
+        onReasoningChange={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Uses your OpenAI key/)).toBeInTheDocument();
+  });
+
+  it("shows an amber warning when the owner is not configured", () => {
+    renderWithProviders(
+      <DefaultModelCard
+        value="gpt-5.4-mini"
+        reasoningEffort=""
+        modelGroups={groups}
+        ownerProvider="openai"
+        ownerProviderInfo={{ name: "OpenAI" }}
+        ownerConfigured={false}
+        saving={false}
+        saveStatus="idle"
+        onChange={() => {}}
+        onReasoningChange={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByText(/No provider key configured/)).toBeInTheDocument();
+  });
+
+  it("disables the Save button when the owner is not configured", () => {
+    renderWithProviders(
+      <DefaultModelCard
+        value="gpt-5.4-mini"
+        reasoningEffort=""
+        modelGroups={groups}
+        ownerProvider={null}
+        ownerConfigured={false}
+        saving={false}
+        saveStatus="idle"
+        onChange={() => {}}
+        onReasoningChange={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("invokes onSave when the Save button is clicked", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    renderWithProviders(
+      <DefaultModelCard
+        value="gpt-5.4-mini"
+        reasoningEffort=""
+        modelGroups={groups}
+        ownerProvider="openai"
+        ownerProviderInfo={{ name: "OpenAI" }}
+        ownerConfigured
+        saving={false}
+        saveStatus="idle"
+        onChange={() => {}}
+        onReasoningChange={() => {}}
+        onSave={onSave}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the model select when there are no model groups", () => {
+    renderWithProviders(
+      <DefaultModelCard
+        value="gpt-5.4-mini"
+        reasoningEffort=""
+        modelGroups={[]}
+        ownerProvider={null}
+        ownerConfigured={false}
+        saving={false}
+        saveStatus="idle"
+        onChange={() => {}}
+        onReasoningChange={() => {}}
+        onSave={() => {}}
+      />,
+    );
+    expect(screen.getByRole("combobox", { name: /LLM Model/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
@@ -60,7 +60,7 @@ describe("DefaultModelCard", () => {
         onSave={() => {}}
       />,
     );
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save default model" })).toBeDisabled();
   });
 
   it("invokes onSave when the Save button is clicked", async () => {
@@ -81,7 +81,7 @@ describe("DefaultModelCard", () => {
         onSave={onSave}
       />,
     );
-    await user.click(screen.getByRole("button", { name: "Save" }));
+    await user.click(screen.getByRole("button", { name: "Save default model" }));
     expect(onSave).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
@@ -57,7 +57,7 @@ export function DefaultModelCard({
               </SelectTrigger>
               <SelectContent>
                 {!hasModels ? (
-                  <SelectItem value={value} disabled>
+                  <SelectItem value="__no_providers__" disabled>
                     No providers configured
                   </SelectItem>
                 ) : (

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
@@ -112,7 +112,11 @@ export function DefaultModelCard({
             {saveStatus === "error" && (
               <span className="text-xs text-destructive">Failed to save model.</span>
             )}
-            <Button onClick={onSave} disabled={saving || !ownerConfigured}>
+            <Button
+              onClick={onSave}
+              disabled={saving || !ownerConfigured}
+              aria-label="Save default model"
+            >
               {saving ? "Saving..." : "Save"}
             </Button>
           </div>

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { AlertTriangle, Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export type DefaultModelSaveStatus = "idle" | "success" | "error";
+
+export interface DefaultModelCardProps {
+  value: string;
+  reasoningEffort: string;
+  modelGroups: { label: string; models: readonly string[] }[];
+  ownerProvider: string | null;
+  ownerProviderInfo?: { name: string } | null;
+  ownerConfigured: boolean;
+  saving: boolean;
+  saveStatus: DefaultModelSaveStatus;
+  onChange: (model: string) => void;
+  onReasoningChange: (v: string) => void;
+  onSave: () => void;
+}
+
+export function DefaultModelCard({
+  value,
+  reasoningEffort,
+  modelGroups,
+  ownerProvider,
+  ownerProviderInfo,
+  ownerConfigured,
+  saving,
+  saveStatus,
+  onChange,
+  onReasoningChange,
+  onSave,
+}: DefaultModelCardProps) {
+  const hasModels = modelGroups.length > 0;
+
+  return (
+    <Card>
+      <CardContent>
+        <div className="space-y-3">
+          <div className="space-y-2">
+            <Label htmlFor="llm-model">Default model</Label>
+            <Select value={value} onValueChange={onChange} disabled={!hasModels}>
+              <SelectTrigger id="llm-model" aria-label="LLM Model">
+                <SelectValue placeholder="Select a model" />
+              </SelectTrigger>
+              <SelectContent>
+                {!hasModels ? (
+                  <SelectItem value={value} disabled>
+                    No providers configured
+                  </SelectItem>
+                ) : (
+                  modelGroups.map((group) => (
+                    <SelectGroup key={group.label}>
+                      <SelectLabel>{group.label}</SelectLabel>
+                      {group.models.map((model) => (
+                        <SelectItem key={model} value={model}>
+                          {model}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+            {ownerProvider && ownerProviderInfo && ownerConfigured ? (
+              <p className="flex items-center gap-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+                <Check className="h-3 w-3" />
+                Uses your {ownerProviderInfo.name} key
+              </p>
+            ) : (
+              <p className="flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+                <AlertTriangle className="h-3 w-3" />
+                No provider key configured for this model
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="reasoning-effort">Reasoning effort</Label>
+            <Select
+              value={reasoningEffort || "none"}
+              onValueChange={(v) => onReasoningChange(v === "none" ? "" : v)}
+            >
+              <SelectTrigger id="reasoning-effort" aria-label="Reasoning effort">
+                <SelectValue placeholder="Default (none)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Default (none)</SelectItem>
+                <SelectItem value="low">Low</SelectItem>
+                <SelectItem value="medium">Medium</SelectItem>
+                <SelectItem value="high">High</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-1">
+            {saveStatus === "success" && (
+              <span className="text-xs text-emerald-600 dark:text-emerald-400">Model saved.</span>
+            )}
+            {saveStatus === "error" && (
+              <span className="text-xs text-destructive">Failed to save model.</span>
+            )}
+            <Button onClick={onSave} disabled={saving || !ownerConfigured}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/llm/_components/PasswordField.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/PasswordField.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { PasswordField } from "./PasswordField";
+
+function Controlled({ onChange }: { onChange?: (v: string) => void }) {
+  const [v, setV] = useState("");
+  return (
+    <PasswordField
+      value={v}
+      onChange={(next) => {
+        setV(next);
+        onChange?.(next);
+      }}
+      placeholder="sk-..."
+      ariaLabel="API key"
+    />
+  );
+}
+
+describe("PasswordField", () => {
+  it("renders as a password input by default", () => {
+    renderWithProviders(<Controlled />);
+    expect(screen.getByPlaceholderText("sk-...")).toHaveAttribute("type", "password");
+  });
+
+  it("toggles to text when the eye icon is clicked", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Controlled />);
+
+    const input = screen.getByPlaceholderText("sk-...");
+    expect(input).toHaveAttribute("type", "password");
+
+    await user.click(screen.getByRole("button", { name: /show key/i }));
+    expect(input).toHaveAttribute("type", "text");
+
+    await user.click(screen.getByRole("button", { name: /hide key/i }));
+    expect(input).toHaveAttribute("type", "password");
+  });
+
+  it("fires onChange with the typed value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    renderWithProviders(<Controlled onChange={onChange} />);
+
+    await user.type(screen.getByPlaceholderText("sk-..."), "abc");
+    expect(onChange).toHaveBeenLastCalledWith("abc");
+  });
+
+  it("applies the aria-label on the input", () => {
+    renderWithProviders(<Controlled />);
+    expect(screen.getByLabelText("API key")).toBeInTheDocument();
+  });
+
+  it("honors disabled prop", () => {
+    renderWithProviders(
+      <PasswordField value="" onChange={() => {}} placeholder="sk-..." disabled />,
+    );
+    expect(screen.getByPlaceholderText("sk-...")).toBeDisabled();
+  });
+
+  it("auto-focuses when autoFocus is true", () => {
+    renderWithProviders(
+      <PasswordField value="" onChange={() => {}} placeholder="sk-..." autoFocus />,
+    );
+    expect(screen.getByPlaceholderText("sk-...")).toHaveFocus();
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/llm/_components/PasswordField.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/PasswordField.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useState } from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+export interface PasswordFieldProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  ariaLabel?: string;
+  autoFocus?: boolean;
+  disabled?: boolean;
+  id?: string;
+}
+
+export function PasswordField({
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  autoFocus,
+  disabled,
+  id,
+}: PasswordFieldProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="relative flex-1">
+      <Input
+        id={id}
+        type={show ? "text" : "password"}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        autoFocus={autoFocus}
+        disabled={disabled}
+        className="h-8 pr-9 font-mono text-xs"
+      />
+      <button
+        type="button"
+        aria-label={show ? "Hide key" : "Show key"}
+        onClick={() => setShow((prev) => !prev)}
+        className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+      >
+        {show ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.test.tsx
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ProviderKeyDialog } from "./ProviderKeyDialog";
+import type { SaveStatus } from "./ProviderKeyDialog";
+
+const info = {
+  name: "OpenAI",
+  description: "OpenAI models (GPT series)",
+  keyPlaceholder: "sk-...",
+};
+
+interface HarnessProps {
+  saveStatus?: SaveStatus;
+  errorMessage?: string;
+  existingMaskedKey?: string;
+  onSave?: (key: string) => void;
+  onRemove?: () => void;
+  initialOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+function Harness({
+  saveStatus = "idle",
+  errorMessage,
+  existingMaskedKey,
+  onSave = () => {},
+  onRemove,
+  initialOpen = true,
+  onOpenChange,
+}: HarnessProps) {
+  const [open, setOpen] = useState(initialOpen);
+  return (
+    <ProviderKeyDialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        onOpenChange?.(next);
+      }}
+      provider="openai"
+      info={info}
+      existingMaskedKey={existingMaskedKey}
+      saveStatus={saveStatus}
+      errorMessage={errorMessage}
+      onSave={onSave}
+      onRemove={onRemove}
+    />
+  );
+}
+
+describe("ProviderKeyDialog", () => {
+  it("shows the provider name as the dialog title", () => {
+    renderWithProviders(<Harness />);
+    expect(screen.getByRole("heading", { name: /OpenAI API key/i })).toBeInTheDocument();
+  });
+
+  it("renders the provider description as the dialog body", () => {
+    renderWithProviders(<Harness />);
+    expect(screen.getByText("OpenAI models (GPT series)")).toBeInTheDocument();
+  });
+
+  it("disables Save until a key is typed", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<Harness />);
+    const saveBtn = screen.getByRole("button", { name: "Save" });
+    expect(saveBtn).toBeDisabled();
+    await user.type(screen.getByPlaceholderText("sk-..."), "sk-new");
+    expect(saveBtn).toBeEnabled();
+  });
+
+  it("calls onSave with the trimmed key", async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    renderWithProviders(<Harness onSave={onSave} />);
+    await user.type(screen.getByPlaceholderText("sk-..."), "  sk-trim  ");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(onSave).toHaveBeenCalledWith("sk-trim");
+  });
+
+  it("shows the existing masked key when configured", () => {
+    renderWithProviders(<Harness existingMaskedKey="sk-...e14c" />);
+    expect(screen.getByText(/Current key:/)).toBeInTheDocument();
+    expect(screen.getByText("sk-...e14c")).toBeInTheDocument();
+  });
+
+  it("renders the Remove button only when onRemove is provided", () => {
+    const { rerender } = renderWithProviders(<Harness onRemove={() => {}} />);
+    expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
+    rerender(<Harness />);
+    expect(screen.queryByRole("button", { name: "Remove" })).not.toBeInTheDocument();
+  });
+
+  it("fires onRemove when Remove is clicked", async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    renderWithProviders(<Harness onRemove={onRemove} />);
+    await user.click(screen.getByRole("button", { name: "Remove" }));
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the error message when saveStatus is error", () => {
+    renderWithProviders(<Harness saveStatus="error" errorMessage="Invalid key" />);
+    expect(screen.getByText("Invalid key")).toBeInTheDocument();
+  });
+
+  it("closes the dialog when saveStatus flips to success", async () => {
+    const onOpenChange = vi.fn();
+
+    const { rerender } = renderWithProviders(
+      <ProviderKeyDialog
+        open
+        onOpenChange={onOpenChange}
+        provider="openai"
+        info={info}
+        saveStatus="saving"
+        onSave={() => {}}
+      />,
+    );
+    // Flip status prop to "success" — the dialog should request to close.
+    rerender(
+      <ProviderKeyDialog
+        open
+        onOpenChange={onOpenChange}
+        provider="openai"
+        info={info}
+        saveStatus="success"
+        onSave={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.test.tsx
@@ -37,7 +37,6 @@ function Harness({
         setOpen(next);
         onOpenChange?.(next);
       }}
-      provider="openai"
       info={info}
       existingMaskedKey={existingMaskedKey}
       saveStatus={saveStatus}
@@ -110,7 +109,6 @@ describe("ProviderKeyDialog", () => {
       <ProviderKeyDialog
         open
         onOpenChange={onOpenChange}
-        provider="openai"
         info={info}
         saveStatus="saving"
         onSave={() => {}}
@@ -121,7 +119,6 @@ describe("ProviderKeyDialog", () => {
       <ProviderKeyDialog
         open
         onOpenChange={onOpenChange}
-        provider="openai"
         info={info}
         saveStatus="success"
         onSave={() => {}}

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { PasswordField } from "./PasswordField";
+
+export type SaveStatus = "idle" | "saving" | "success" | "error";
+
+export interface ProviderKeyDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  provider: string;
+  info: { name: string; description: string; keyPlaceholder: string };
+  existingMaskedKey?: string;
+  saveStatus: SaveStatus;
+  errorMessage?: string;
+  onSave: (key: string) => void;
+  onRemove?: () => void;
+}
+
+export function ProviderKeyDialog({
+  open,
+  onOpenChange,
+  info,
+  existingMaskedKey,
+  saveStatus,
+  errorMessage,
+  onSave,
+  onRemove,
+}: ProviderKeyDialogProps) {
+  const [draftKey, setDraftKey] = useState("");
+
+  // Close on successful save. The draft resets naturally because the parent
+  // conditionally renders this dialog (it unmounts when editingProvider is null).
+  useEffect(() => {
+    if (open && saveStatus === "success") {
+      onOpenChange(false);
+    }
+  }, [open, saveStatus, onOpenChange]);
+
+  const saving = saveStatus === "saving";
+  const configured = Boolean(existingMaskedKey);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{info.name} API key</DialogTitle>
+          <DialogDescription>{info.description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          {configured && (
+            <p className="text-xs text-muted-foreground">
+              Current key: <span className="font-mono">{existingMaskedKey}</span>
+            </p>
+          )}
+          <PasswordField
+            value={draftKey}
+            onChange={setDraftKey}
+            placeholder={configured ? "Replace existing key..." : info.keyPlaceholder}
+            ariaLabel={`${info.name} API key`}
+            autoFocus
+            disabled={saving}
+          />
+          {saveStatus === "error" && (
+            <p className="text-xs text-destructive">
+              {errorMessage ?? "Failed to save key."}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <div>
+            {onRemove && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-xs text-destructive hover:text-destructive"
+                onClick={onRemove}
+                disabled={saving}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => onSave(draftKey.trim())}
+              disabled={!draftKey.trim() || saving}
+            >
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -17,7 +17,6 @@ export type SaveStatus = "idle" | "saving" | "success" | "error";
 export interface ProviderKeyDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  provider: string;
   info: { name: string; description: string; keyPlaceholder: string };
   existingMaskedKey?: string;
   saveStatus: SaveStatus;
@@ -38,13 +37,21 @@ export function ProviderKeyDialog({
 }: ProviderKeyDialogProps) {
   const [draftKey, setDraftKey] = useState("");
 
+  // Keep onOpenChange in a ref so the close-on-success effect depends only on
+  // saveStatus. Parents pass a fresh arrow function each render, which would
+  // otherwise re-fire the effect on every render while saveStatus is "success".
+  const onOpenChangeRef = useRef(onOpenChange);
+  useLayoutEffect(() => {
+    onOpenChangeRef.current = onOpenChange;
+  }, [onOpenChange]);
+
   // Close on successful save. The draft resets naturally because the parent
   // conditionally renders this dialog (it unmounts when editingProvider is null).
   useEffect(() => {
-    if (open && saveStatus === "success") {
-      onOpenChange(false);
+    if (saveStatus === "success") {
+      onOpenChangeRef.current(false);
     }
-  }, [open, saveStatus, onOpenChange]);
+  }, [saveStatus]);
 
   const saving = saveStatus === "saving";
   const configured = Boolean(existingMaskedKey);

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+import { ProviderKeyRow } from "./ProviderKeyRow";
+
+const info = {
+  name: "OpenAI",
+  description: "OpenAI models (GPT series)",
+  keyPlaceholder: "sk-...",
+};
+
+describe("ProviderKeyRow", () => {
+  it("shows a grey not-configured dot and 'Add' button when not configured", () => {
+    renderWithProviders(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: false, platformAvailable: false }}
+        isDefaultOwner={false}
+        onEdit={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Not configured")).toBeInTheDocument();
+    expect(screen.getByText("Not set")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Add" })).toBeInTheDocument();
+  });
+
+  it("shows a green configured dot, masked key, and 'Edit' when configured", () => {
+    renderWithProviders(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: true, platformAvailable: false, maskedKey: "sk-...e14c" }}
+        isDefaultOwner={false}
+        onEdit={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText("Configured")).toBeInTheDocument();
+    expect(screen.getByText("sk-...e14c")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
+  });
+
+  it("renders the default pill only when isDefaultOwner is true", () => {
+    const { rerender } = renderWithProviders(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: true, platformAvailable: false, maskedKey: "sk-...e14c" }}
+        isDefaultOwner
+        onEdit={() => {}}
+      />,
+    );
+    expect(screen.getByText("default")).toBeInTheDocument();
+
+    rerender(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: true, platformAvailable: false, maskedKey: "sk-...e14c" }}
+        isDefaultOwner={false}
+        onEdit={() => {}}
+      />,
+    );
+    expect(screen.queryByText("default")).not.toBeInTheDocument();
+  });
+
+  it("calls onEdit when the Edit button is clicked", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    renderWithProviders(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: true, platformAvailable: false, maskedKey: "sk-...e14c" }}
+        isDefaultOwner={false}
+        onEdit={onEdit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Edit" }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onEdit when the Add button is clicked", async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    renderWithProviders(
+      <ProviderKeyRow
+        provider="openai"
+        info={info}
+        status={{ orgConfigured: false, platformAvailable: false }}
+        isDefaultOwner={false}
+        onEdit={onEdit}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "Add" }));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export interface ProviderKeyRowProps {
+  provider: string;
+  info: { name: string; description: string; keyPlaceholder: string };
+  status: { orgConfigured: boolean; platformAvailable: boolean; maskedKey?: string };
+  isDefaultOwner: boolean;
+  onEdit: () => void;
+}
+
+export function ProviderKeyRow({
+  info,
+  status,
+  isDefaultOwner,
+  onEdit,
+}: ProviderKeyRowProps) {
+  const configured = status.orgConfigured;
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg border bg-card px-3 py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <span
+          aria-label={configured ? "Configured" : "Not configured"}
+          className={
+            configured
+              ? "inline-block h-2 w-2 shrink-0 rounded-full bg-emerald-500"
+              : "inline-block h-2 w-2 shrink-0 rounded-full bg-muted-foreground/40"
+          }
+        />
+        <span className="text-sm font-medium">{info.name}</span>
+        {configured && status.maskedKey ? (
+          <span className="truncate font-mono text-xs text-muted-foreground">
+            {status.maskedKey}
+          </span>
+        ) : (
+          <span className="text-xs text-muted-foreground">Not set</span>
+        )}
+        {isDefaultOwner && (
+          <Badge variant="secondary" className="text-xs px-1.5 py-0">
+            default
+          </Badge>
+        )}
+      </div>
+      <Button variant="ghost" size="sm" onClick={onEdit} className="text-xs">
+        {configured ? "Edit" : "Add"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
@@ -20,9 +20,13 @@ export function ProviderKeyRow({
   const configured = status.orgConfigured;
 
   return (
-    <div className="flex items-center justify-between gap-3 rounded-lg border bg-card px-3 py-2">
+    <div
+      data-testid="provider-key-row"
+      className="flex items-center justify-between gap-3 rounded-lg border bg-card px-3 py-2"
+    >
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <span
+          role="img"
           aria-label={configured ? "Configured" : "Not configured"}
           className={
             configured

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
@@ -26,7 +26,7 @@ export function ProviderKeyRow({
     >
       <div className="flex min-w-0 flex-1 items-center gap-3">
         <span
-          role="img"
+          role="status"
           aria-label={configured ? "Configured" : "Not configured"}
           className={
             configured

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -29,7 +29,7 @@ const {
     data: {
       openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
       anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
-      gemini: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
+      gemini: ["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"],
     },
   }),
   llmDefaultsMock: vi.fn().mockResolvedValue({
@@ -59,7 +59,9 @@ vi.mock("@/lib/errors", () => ({
 
 async function openEditDialog(provider: "Anthropic" | "OpenAI" | "Gemini" | "OpenRouter") {
   const user = userEvent.setup();
-  const row = (await screen.findByText(provider)).closest("div.rounded-lg")!;
+  const row = (await screen.findByText(provider)).closest(
+    "[data-testid='provider-key-row']",
+  )!;
   const button = within(row as HTMLElement).getByRole("button", { name: /^(Edit|Add)$/ });
   await user.click(button);
   return { user };
@@ -381,5 +383,35 @@ describe("LLMPage", () => {
     await waitFor(() => {
       expect(screen.queryByRole("heading", { name: /Anthropic API key/i })).not.toBeInTheDocument();
     });
+  });
+
+  it("stays open when reopening a provider dialog shortly after a successful save", async () => {
+    renderWithProviders(<LLMPage />);
+    const first = await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
+    });
+
+    await first.user.type(screen.getByPlaceholderText("sk-ant-..."), "sk-ant-test");
+    await first.user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Dialog closes after the save.
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /Anthropic API key/i })).not.toBeInTheDocument();
+    });
+
+    // Reopen the same provider's dialog immediately — the lingering "success"
+    // save status must not cause it to auto-close.
+    await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Anthropic API key/i })).toBeInTheDocument();
+    });
+
+    // Confirm it's still open after a microtask — the auto-close effect would
+    // have fired by now if it were going to.
+    await Promise.resolve();
+    expect(screen.getByRole("heading", { name: /Anthropic API key/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -405,4 +405,45 @@ describe("LLMPage", () => {
     await Promise.resolve();
     expect(screen.getByRole("heading", { name: /Anthropic API key/i })).toBeInTheDocument();
   });
+
+  it("surfaces the server error message when saving a key fails", async () => {
+    credentialsUpdateMock.mockRejectedValueOnce(new Error("Invalid API key"));
+
+    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("sk-ant-..."), "sk-ant-test");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid API key")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces an error dialog and re-enables the row when delete fails", async () => {
+    credentialsListMock.mockResolvedValueOnce({
+      data: [{ provider: "anthropic", configured: true, masked_key: "sk-ant-••••" }],
+    });
+    credentialsDeleteMock.mockRejectedValueOnce(new Error("Something broke"));
+
+    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
+
+    // Click the "Remove" ghost button inside the edit dialog.
+    const editDialog = await screen.findByRole("dialog");
+    await user.click(within(editDialog).getByRole("button", { name: "Remove" }));
+
+    // Confirm in the AlertDialog that opens (scope by the dialog title).
+    const confirmDialog = await screen.findByRole("alertdialog");
+    await user.click(within(confirmDialog).getByRole("button", { name: "Remove" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn.?t remove API key/)).toBeInTheDocument();
+    });
+    expect(screen.getByText("Something broke")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -321,21 +321,13 @@ describe("LLMPage", () => {
     const user = userEvent.setup();
     renderWithProviders(<LLMPage />);
 
-    // Wait for the default model card to render (there's both an h2 and a label
-    // with "Default model" — scope to the heading).
-    await waitFor(() => {
-      expect(screen.getByRole("heading", { name: "Default model" })).toBeInTheDocument();
-    });
-
     // The default model is gpt-5.4-mini which is owned by OpenAI, and OpenAI is
     // present as a platform provider, so the Save button is enabled.
     await waitFor(() => {
-      const saveBtns = screen.getAllByRole("button", { name: "Save" });
-      expect(saveBtns.some((b) => !b.hasAttribute("disabled"))).toBe(true);
+      expect(screen.getByRole("button", { name: "Save default model" })).toBeEnabled();
     });
 
-    const saveBtn = screen.getAllByRole("button", { name: "Save" }).find((b) => !b.hasAttribute("disabled"))!;
-    await user.click(saveBtn);
+    await user.click(screen.getByRole("button", { name: "Save default model" }));
 
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalled();

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -106,10 +106,7 @@ describe("LLMPage", () => {
   });
 
   it("shows the platform-LLM alert when no platform provider is configured", async () => {
-    llmDefaultsMock.mockResolvedValueOnce({
-      data: {},
-      platform_model: "gpt-5.4-nano",
-    });
+    llmDefaultsMock.mockResolvedValueOnce({ data: {} });
 
     renderWithProviders(<LLMPage />);
 
@@ -123,10 +120,7 @@ describe("LLMPage", () => {
   });
 
   it("hides the platform-LLM alert when a platform provider is configured", async () => {
-    llmDefaultsMock.mockResolvedValueOnce({
-      data: { openai: "sk-...abc" },
-      platform_model: "gpt-5.4-nano",
-    });
+    llmDefaultsMock.mockResolvedValueOnce({ data: { openai: "sk-...abc" } });
 
     renderWithProviders(<LLMPage />);
 
@@ -298,13 +292,10 @@ describe("LLMPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Remove" }));
 
-    await waitFor(() => {
-      expect(screen.getByText("Remove API key")).toBeInTheDocument();
-    });
-
-    // The AlertDialog's confirmation "Remove" action is the second matching button.
-    const removeButtons = screen.getAllByRole("button", { name: /^Remove$/ });
-    await user.click(removeButtons[removeButtons.length - 1]);
+    // Scope the confirmation click to the AlertDialog so we don't accidentally
+    // click the "Remove" button in the still-open ProviderKeyDialog.
+    const confirmDialog = await screen.findByRole("alertdialog");
+    await user.click(within(confirmDialog).getByRole("button", { name: "Remove" }));
 
     await waitFor(() => {
       expect(credentialsDeleteMock).toHaveBeenCalledWith("openai");
@@ -360,7 +351,7 @@ describe("LLMPage", () => {
   });
 
   it("shows an amber warning when no provider for the default model is configured", async () => {
-    llmDefaultsMock.mockResolvedValueOnce({ data: {}, platform_model: "gpt-5.4-nano" });
+    llmDefaultsMock.mockResolvedValueOnce({ data: {} });
 
     renderWithProviders(<LLMPage />);
 

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, waitFor, userEvent } from "@/test/test-utils";
+import { renderWithProviders, screen, waitFor, userEvent, within } from "@/test/test-utils";
 import LLMPage from "./page";
 
 const {
@@ -29,10 +29,11 @@ const {
     data: {
       openai: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"],
       anthropic: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"],
+      gemini: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"],
     },
   }),
   llmDefaultsMock: vi.fn().mockResolvedValue({
-    data: { default_llm_model: "gpt-5.4-mini", available_providers: ["openai"] },
+    data: { openai: "sk-...plat" },
   }),
 }));
 
@@ -56,46 +57,49 @@ vi.mock("@/lib/errors", () => ({
   captureError: vi.fn(),
 }));
 
+async function openEditDialog(provider: "Anthropic" | "OpenAI" | "Gemini" | "OpenRouter") {
+  const user = userEvent.setup();
+  const row = (await screen.findByText(provider)).closest("div.rounded-lg")!;
+  const button = within(row as HTMLElement).getByRole("button", { name: /^(Edit|Add)$/ });
+  await user.click(button);
+  return { user };
+}
+
 describe("LLMPage", () => {
   beforeEach(() => {
     settingsGetMock.mockClear();
     credentialsListMock.mockClear();
+    credentialsListMock.mockResolvedValue({ data: [] });
     credentialsUpdateMock.mockClear();
+    credentialsUpdateMock.mockResolvedValue({});
     credentialsDeleteMock.mockClear();
     settingsUpdateMock.mockClear();
     llmModelsMock.mockClear();
     llmDefaultsMock.mockClear();
+    llmDefaultsMock.mockResolvedValue({ data: { openai: "sk-...plat" } });
   });
 
   it("renders the page header", async () => {
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
-      expect(screen.getByRole("heading", { name: /LLM/i })).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: /LLM/i, level: 1 })).toBeInTheDocument();
     });
   });
 
-  it("renders provider selection area", async () => {
+  it("renders provider keys section", async () => {
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
-      expect(settingsGetMock).toHaveBeenCalled();
+      expect(screen.getByText("Provider keys")).toBeInTheDocument();
     });
   });
 
-  it("renders agent credentials section", async () => {
+  it("renders default model section", async () => {
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Agent credentials")).toBeInTheDocument();
-    });
-  });
-
-  it("renders model selection section", async () => {
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Default LLM model")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Default model" })).toBeInTheDocument();
     });
   });
 
@@ -132,7 +136,7 @@ describe("LLMPage", () => {
     });
   });
 
-  it("renders configured badge when credentials exist", async () => {
+  it("renders configured status dot when credentials exist", async () => {
     credentialsListMock.mockResolvedValue({
       data: [
         {
@@ -146,111 +150,81 @@ describe("LLMPage", () => {
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
-      expect(screen.getByText("Configured")).toBeInTheDocument();
+      // There should be at least one Configured dot once the list loads.
+      expect(screen.getAllByLabelText("Configured").length).toBeGreaterThan(0);
     });
   });
 
-  it("renders reasoning effort selector", async () => {
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Reasoning effort")).toBeInTheDocument();
-    });
-  });
-
-  it("renders save model button", async () => {
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Save model/i })).toBeInTheDocument();
-    });
-  });
-
-  it("renders provider card names for all providers", async () => {
-    renderWithProviders(<LLMPage />);
-
-    // Wait for all three provider cards to render. Descriptions are static
-    // constants rendered via LLM_PROVIDER_INFO and do not need separate
-    // assertions — verifying the provider names confirms the cards mount.
-    await waitFor(() => {
-      expect(screen.getByText("Anthropic")).toBeInTheDocument();
-      expect(screen.getByText("OpenAI")).toBeInTheDocument();
-      expect(screen.getByText("OpenRouter")).toBeInTheDocument();
-    });
-  });
-
-  it("renders input fields with correct placeholders for each provider", async () => {
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
-    });
-    expect(screen.getByPlaceholderText("sk-...")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("sk-or-...")).toBeInTheDocument();
-  });
-
-  it("renders save key buttons disabled when inputs are empty", async () => {
+  it("renders a row for each provider, including Gemini", async () => {
     renderWithProviders(<LLMPage />);
 
     await waitFor(() => {
       expect(screen.getByText("Anthropic")).toBeInTheDocument();
     });
-
-    const saveKeyButtons = screen.getAllByRole("button", { name: /Save key/i });
-    for (const btn of saveKeyButtons) {
-      expect(btn).toBeDisabled();
-    }
+    expect(screen.getByText("OpenAI")).toBeInTheDocument();
+    expect(screen.getByText("Gemini")).toBeInTheDocument();
+    expect(screen.getByText("OpenRouter")).toBeInTheDocument();
   });
 
-  it("enables save key button when typing a key", async () => {
-    const user = userEvent.setup();
+  it("opens the Anthropic dialog with the sk-ant-... placeholder", async () => {
     renderWithProviders(<LLMPage />);
+    await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Anthropic API key/i })).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
+  });
+
+  it("opens the Gemini dialog with the AIza... placeholder", async () => {
+    renderWithProviders(<LLMPage />);
+    await openEditDialog("Gemini");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("AIza...")).toBeInTheDocument();
+    });
+  });
+
+  it("disables Save in the dialog until a key is typed", async () => {
+    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Anthropic API key/i })).toBeInTheDocument();
+    });
+    const saveBtn = screen.getByRole("button", { name: "Save" });
+    expect(saveBtn).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText("sk-ant-..."), "sk-ant-test123");
+    expect(saveBtn).toBeEnabled();
+  });
+
+  it("calls credentials.update with the typed key via the dialog", async () => {
+    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
     });
 
-    const input = screen.getByPlaceholderText("sk-ant-...");
-    await user.type(input, "sk-ant-test123");
-
-    const saveKeyButtons = screen.getAllByRole("button", { name: /Save key/i });
-    // The first provider (Anthropic) button should now be enabled
-    expect(saveKeyButtons[0]).toBeEnabled();
-  });
-
-  it("calls credentials.update when save key is clicked", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
-    });
-
-    const input = screen.getByPlaceholderText("sk-ant-...");
-    await user.type(input, "sk-ant-test123");
-
-    const saveKeyButtons = screen.getAllByRole("button", { name: /Save key/i });
-    await user.click(saveKeyButtons[0]);
+    await user.type(screen.getByPlaceholderText("sk-ant-..."), "sk-ant-test123");
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(credentialsUpdateMock).toHaveBeenCalledWith("anthropic", { api_key: "sk-ant-test123" });
     });
   });
 
-  it("sends api_type for openai provider when saving key", async () => {
-    const user = userEvent.setup();
+  it("sends api_type for openai provider when saving via the dialog", async () => {
     renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("OpenAI");
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("sk-...")).toBeInTheDocument();
     });
 
-    const input = screen.getByPlaceholderText("sk-...");
-    await user.type(input, "sk-openai-key");
-
-    const saveKeyButtons = screen.getAllByRole("button", { name: /Save key/i });
-    // openai is the second provider
-    await user.click(saveKeyButtons[1]);
+    await user.type(screen.getByPlaceholderText("sk-..."), "sk-openai-key");
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(credentialsUpdateMock).toHaveBeenCalledWith("openai", {
@@ -260,63 +234,47 @@ describe("LLMPage", () => {
     });
   });
 
-  it("renders Remove button when provider is configured", async () => {
+  it("renders the Remove button in the dialog when a provider is configured", async () => {
     credentialsListMock.mockResolvedValue({
-      data: [
-        { provider: "openai", configured: true, masked_key: "sk-...abc" },
-      ],
+      data: [{ provider: "openai", configured: true, masked_key: "sk-...abc" }],
     });
 
     renderWithProviders(<LLMPage />);
+    await openEditDialog("OpenAI");
 
     await waitFor(() => {
-      expect(screen.getByText("Remove")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
     });
   });
 
-  it("shows masked key when provider is configured", async () => {
+  it("shows the masked key in the dialog when a provider is configured", async () => {
     credentialsListMock.mockResolvedValue({
-      data: [
-        { provider: "openai", configured: true, masked_key: "sk-...abc" },
-      ],
+      data: [{ provider: "openai", configured: true, masked_key: "sk-...abc" }],
     });
 
     renderWithProviders(<LLMPage />);
+    await openEditDialog("OpenAI");
 
+    // The masked key appears both in the row and in the dialog.
     await waitFor(() => {
-      expect(screen.getByText("Key: sk-...abc")).toBeInTheDocument();
+      expect(screen.getAllByText("sk-...abc").length).toBeGreaterThanOrEqual(1);
     });
+    expect(screen.getByPlaceholderText("Replace existing key...")).toBeInTheDocument();
   });
 
-  it("shows replace placeholder when provider is already configured", async () => {
+  it("opens the remove confirmation dialog from the edit dialog", async () => {
     credentialsListMock.mockResolvedValue({
-      data: [
-        { provider: "openai", configured: true, masked_key: "sk-...abc" },
-      ],
+      data: [{ provider: "openai", configured: true, masked_key: "sk-...abc" }],
     });
 
     renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("OpenAI");
 
     await waitFor(() => {
-      expect(screen.getByPlaceholderText("Replace existing key...")).toBeInTheDocument();
-    });
-  });
-
-  it("opens remove confirmation dialog when Remove is clicked", async () => {
-    const user = userEvent.setup();
-    credentialsListMock.mockResolvedValue({
-      data: [
-        { provider: "openai", configured: true, masked_key: "sk-...abc" },
-      ],
+      expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
     });
 
-    renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Remove")).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByText("Remove"));
+    await user.click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove API key")).toBeInTheDocument();
@@ -325,52 +283,35 @@ describe("LLMPage", () => {
   });
 
   it("calls credentials.delete when confirming removal", async () => {
-    const user = userEvent.setup();
     credentialsListMock.mockResolvedValue({
-      data: [
-        { provider: "openai", configured: true, masked_key: "sk-...abc" },
-      ],
+      data: [{ provider: "openai", configured: true, masked_key: "sk-...abc" }],
     });
 
     renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("OpenAI");
 
     await waitFor(() => {
-      expect(screen.getByText("Remove")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "Remove" })).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText("Remove"));
+    await user.click(screen.getByRole("button", { name: "Remove" }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove API key")).toBeInTheDocument();
     });
 
-    // The dialog has a "Remove" action button
-    const dialogRemoveBtn = screen.getByRole("button", { name: /^Remove$/ });
-    await user.click(dialogRemoveBtn);
+    // The AlertDialog's confirmation "Remove" action is the second matching button.
+    const removeButtons = screen.getAllByRole("button", { name: /^Remove$/ });
+    await user.click(removeButtons[removeButtons.length - 1]);
 
     await waitFor(() => {
       expect(credentialsDeleteMock).toHaveBeenCalledWith("openai");
     });
   });
 
-  it("calls settings.update when save model is clicked", async () => {
-    const user = userEvent.setup();
+  it("toggles password visibility when the eye icon is clicked", async () => {
     renderWithProviders(<LLMPage />);
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Save model/i })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole("button", { name: /Save model/i }));
-
-    await waitFor(() => {
-      expect(settingsUpdateMock).toHaveBeenCalled();
-    });
-  });
-
-  it("toggles password visibility when eye icon is clicked", async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
@@ -379,11 +320,66 @@ describe("LLMPage", () => {
     const input = screen.getByPlaceholderText("sk-ant-...");
     expect(input).toHaveAttribute("type", "password");
 
-    // Find the eye toggle button closest to this input
-    const inputContainer = input.closest(".relative.flex-1")!;
-    const toggleBtn = inputContainer.querySelector("button")!;
-    await user.click(toggleBtn);
-
+    await user.click(screen.getByRole("button", { name: /show key/i }));
     expect(input).toHaveAttribute("type", "text");
+  });
+
+  it("calls settings.update when Save is clicked on the default model card", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LLMPage />);
+
+    // Wait for the default model card to render (there's both an h2 and a label
+    // with "Default model" — scope to the heading).
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: "Default model" })).toBeInTheDocument();
+    });
+
+    // The default model is gpt-5.4-mini which is owned by OpenAI, and OpenAI is
+    // present as a platform provider, so the Save button is enabled.
+    await waitFor(() => {
+      const saveBtns = screen.getAllByRole("button", { name: "Save" });
+      expect(saveBtns.some((b) => !b.hasAttribute("disabled"))).toBe(true);
+    });
+
+    const saveBtn = screen.getAllByRole("button", { name: "Save" }).find((b) => !b.hasAttribute("disabled"))!;
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalled();
+    });
+  });
+
+  it("shows the owner caption 'Uses your OpenAI key' when OpenAI is the default owner", async () => {
+    renderWithProviders(<LLMPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Uses your OpenAI key/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an amber warning when no provider for the default model is configured", async () => {
+    llmDefaultsMock.mockResolvedValueOnce({ data: {}, platform_model: "gpt-5.4-nano" });
+
+    renderWithProviders(<LLMPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No provider key configured/)).toBeInTheDocument();
+    });
+  });
+
+  it("closes the edit dialog after a successful save", async () => {
+    renderWithProviders(<LLMPage />);
+    const { user } = await openEditDialog("Anthropic");
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("sk-ant-...")).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByPlaceholderText("sk-ant-..."), "sk-ant-test");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: /Anthropic API key/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -39,6 +39,11 @@ import { ProviderKeyRow } from "./_components/ProviderKeyRow";
 
 const LLM_PROVIDERS = Object.keys(LLM_PROVIDER_INFO) as (keyof typeof LLM_PROVIDER_INFO)[];
 
+const EMPTY_PROVIDER_STATUS = {
+  orgConfigured: false,
+  platformAvailable: false,
+} as const;
+
 export default function LLMPage() {
   const queryClient = useQueryClient();
 
@@ -86,7 +91,9 @@ export default function LLMPage() {
   const [reasoningEffort, setReasoningEffort] = useState<string>("");
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
   const [keySaveStatus, setKeySaveStatus] = useState<Record<string, SaveStatus>>({});
+  const [keySaveError, setKeySaveError] = useState<Record<string, string>>({});
   const [removingProvider, setRemovingProvider] = useState<string | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   const [editingProvider, setEditingProvider] = useState<string | null>(null);
 
   const [prevSettingsRef, setPrevSettingsRef] = useState<unknown>(undefined);
@@ -149,6 +156,11 @@ export default function LLMPage() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "success" }));
+      setKeySaveError((prev) => {
+        const next = { ...prev };
+        delete next[variables.provider];
+        return next;
+      });
       setTimeout(() => {
         setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" }));
       }, 2000);
@@ -156,6 +168,10 @@ export default function LLMPage() {
     onError: (err, variables) => {
       captureError(err, { feature: "llm-key-save" });
       setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "error" }));
+      setKeySaveError((prev) => ({
+        ...prev,
+        [variables.provider]: err instanceof Error ? err.message : String(err),
+      }));
       setTimeout(() => {
         setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" }));
       }, 3000);
@@ -167,10 +183,13 @@ export default function LLMPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setRemovingProvider(null);
+      setRemoveError(null);
       setEditingProvider(null);
     },
     onError: (error) => {
       captureError(error, { feature: "llm-key-delete" });
+      setRemoveError(error instanceof Error ? error.message : String(error));
+      setRemovingProvider(null);
     },
   });
 
@@ -203,6 +222,7 @@ export default function LLMPage() {
   const editingInfo = editingProvider ? LLM_PROVIDER_INFO[editingProvider] : null;
   const editingStatus = editingProvider ? providerStatus[editingProvider] : undefined;
   const editingSaveStatus = editingProvider ? keySaveStatus[editingProvider] ?? "idle" : "idle";
+  const editingSaveError = editingProvider ? keySaveError[editingProvider] : undefined;
 
   return (
     <PageContainer size="default">
@@ -264,7 +284,7 @@ export default function LLMPage() {
                 key={provider}
                 provider={provider}
                 info={LLM_PROVIDER_INFO[provider]}
-                status={providerStatus[provider] ?? { orgConfigured: false, platformAvailable: false }}
+                status={providerStatus[provider] ?? EMPTY_PROVIDER_STATUS}
                 isDefaultOwner={provider === ownerProvider}
                 onEdit={() => openEditor(provider)}
               />
@@ -283,11 +303,26 @@ export default function LLMPage() {
           info={editingInfo}
           existingMaskedKey={editingStatus?.maskedKey}
           saveStatus={editingSaveStatus}
+          errorMessage={editingSaveError}
           onSave={(key) => handleSaveKey(editingProvider, key)}
           onRemove={
             editingStatus?.orgConfigured ? () => setRemovingProvider(editingProvider) : undefined
           }
         />
+      )}
+
+      {removeError && (
+        <AlertDialog open onOpenChange={(open) => !open && setRemoveError(null)}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Couldn&apos;t remove API key</AlertDialogTitle>
+              <AlertDialogDescription>{removeError}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogAction onClick={() => setRemoveError(null)}>Dismiss</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       )}
 
       <AlertDialog open={!!removingProvider} onOpenChange={(open) => !open && setRemovingProvider(null)}>

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -299,7 +299,6 @@ export default function LLMPage() {
           onOpenChange={(open) => {
             if (!open) setEditingProvider(null);
           }}
-          provider={editingProvider}
           info={editingInfo}
           existingMaskedKey={editingStatus?.maskedKey}
           saveStatus={editingSaveStatus}

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -54,7 +54,7 @@ export default function LLMPage() {
   });
   const credentials = useMemo(() => credentialsResp?.data ?? [], [credentialsResp?.data]);
 
-  const { data: llmDefaultsResp } = useQuery<{ data: Record<string, string>; platform_model?: string }>({
+  const { data: llmDefaultsResp } = useQuery<{ data: Record<string, string> }>({
     queryKey: ["llm-defaults"],
     queryFn: () => api.settings.getLLMDefaults(),
   });
@@ -120,8 +120,8 @@ export default function LLMPage() {
   }, [modelsByProvider, providerStatus]);
 
   const ownerProvider = useMemo(
-    () => ownerProviderForModel(llmModel, modelsByProvider),
-    [llmModel, modelsByProvider],
+    () => ownerProviderForModel(llmModel, modelsByProvider, providerStatus),
+    [llmModel, modelsByProvider, providerStatus],
   );
   const ownerProviderInfo = ownerProvider ? LLM_PROVIDER_INFO[ownerProvider] : null;
   const ownerConfigured = Boolean(

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -193,6 +193,13 @@ export default function LLMPage() {
     keyMutation.mutate({ provider, config });
   }
 
+  function openEditor(provider: string) {
+    // Clear any lingering save status from a previous save so a freshly opened
+    // dialog doesn't immediately auto-close on a stale "success".
+    setKeySaveStatus((prev) => ({ ...prev, [provider]: "idle" }));
+    setEditingProvider(provider);
+  }
+
   const editingInfo = editingProvider ? LLM_PROVIDER_INFO[editingProvider] : null;
   const editingStatus = editingProvider ? providerStatus[editingProvider] : undefined;
   const editingSaveStatus = editingProvider ? keySaveStatus[editingProvider] ?? "idle" : "idle";
@@ -259,7 +266,7 @@ export default function LLMPage() {
                 info={LLM_PROVIDER_INFO[provider]}
                 status={providerStatus[provider] ?? { orgConfigured: false, platformAvailable: false }}
                 isDefaultOwner={provider === ownerProvider}
-                onEdit={() => setEditingProvider(provider)}
+                onEdit={() => openEditor(provider)}
               />
             ))}
           </div>

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -4,20 +4,7 @@ import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -30,13 +17,14 @@ import {
 } from "@/components/ui/alert-dialog";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
-import { AlertTriangle, Check, Eye, EyeOff } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import {
   LLM_MODELS_BY_PROVIDER,
   LLM_PROVIDER_INFO,
   DEFAULT_LLM_MODEL,
   OPENAI_API_TYPE_CHAT,
+  ownerProviderForModel,
 } from "@/lib/model-constants";
 import type {
   Organization,
@@ -45,27 +33,27 @@ import type {
   CredentialSummary,
   ListResponse,
 } from "@/lib/types";
+import { DefaultModelCard } from "./_components/DefaultModelCard";
+import { ProviderKeyDialog, type SaveStatus } from "./_components/ProviderKeyDialog";
+import { ProviderKeyRow } from "./_components/ProviderKeyRow";
 
 const LLM_PROVIDERS = Object.keys(LLM_PROVIDER_INFO) as (keyof typeof LLM_PROVIDER_INFO)[];
 
 export default function LLMPage() {
   const queryClient = useQueryClient();
 
-  // Fetch org settings (for llm_model)
   const { data: settings } = useQuery<SingleResponse<Organization>>({
     queryKey: ["settings"],
     queryFn: () => api.settings.get(),
   });
   const orgSettings = (settings?.data?.settings ?? {}) as OrgSettings;
 
-  // Fetch credential summaries (to show what the org has configured)
   const { data: credentialsResp } = useQuery<ListResponse<CredentialSummary>>({
     queryKey: ["credentials"],
     queryFn: () => api.credentials.list(),
   });
   const credentials = useMemo(() => credentialsResp?.data ?? [], [credentialsResp?.data]);
 
-  // Fetch platform-level LLM defaults (to show fallback availability)
   const { data: llmDefaultsResp } = useQuery<{ data: Record<string, string>; platform_model?: string }>({
     queryKey: ["llm-defaults"],
     queryFn: () => api.settings.getLLMDefaults(),
@@ -73,13 +61,11 @@ export default function LLMPage() {
   const platformProviders = useMemo(() => llmDefaultsResp?.data ?? {}, [llmDefaultsResp?.data]);
   const hasPlatformLLM = Object.keys(platformProviders).length > 0;
 
-  // Fetch available models from backend (source of truth)
   const { data: llmModelsResp } = useQuery<{ data: Record<string, string[]> }>({
     queryKey: ["llm-models"],
     queryFn: () => api.settings.getLLMModels(),
   });
 
-  // Use backend models if available, fall back to static constants
   const modelsByProvider = useMemo(() => {
     const backendModels = llmModelsResp?.data;
     if (backendModels && Object.keys(backendModels).length > 0) {
@@ -96,16 +82,13 @@ export default function LLMPage() {
     return LLM_MODELS_BY_PROVIDER;
   }, [llmModelsResp?.data]);
 
-  // Form state
   const [llmModel, setLlmModel] = useState(DEFAULT_LLM_MODEL);
   const [reasoningEffort, setReasoningEffort] = useState<string>("");
-  const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
-  const [showKeys, setShowKeys] = useState<Record<string, boolean>>({});
   const [saveStatus, setSaveStatus] = useState<"idle" | "success" | "error">("idle");
-  const [keySaveStatus, setKeySaveStatus] = useState<Record<string, "idle" | "saving" | "success" | "error">>({});
+  const [keySaveStatus, setKeySaveStatus] = useState<Record<string, SaveStatus>>({});
   const [removingProvider, setRemovingProvider] = useState<string | null>(null);
+  const [editingProvider, setEditingProvider] = useState<string | null>(null);
 
-  // Sync server data into form state.
   const [prevSettingsRef, setPrevSettingsRef] = useState<unknown>(undefined);
   const settingsData = settings?.data?.settings;
   if (settingsData && settingsData !== prevSettingsRef) {
@@ -114,7 +97,6 @@ export default function LLMPage() {
     setReasoningEffort(orgSettings.llm_reasoning_effort || "");
   }
 
-  // Determine which providers are configured (org-level or platform-level)
   const providerStatus = useMemo(() => {
     const status: Record<string, { orgConfigured: boolean; platformAvailable: boolean; maskedKey?: string }> = {};
     for (const provider of LLM_PROVIDERS) {
@@ -128,7 +110,6 @@ export default function LLMPage() {
     return status;
   }, [credentials, platformProviders]);
 
-  // Filter model groups to providers that are configured (org or platform)
   const enabledModelGroups = useMemo(() => {
     return Object.entries(modelsByProvider)
       .filter(([provider]) => {
@@ -138,7 +119,16 @@ export default function LLMPage() {
       .map(([, group]) => group);
   }, [modelsByProvider, providerStatus]);
 
-  // Save model selection mutation
+  const ownerProvider = useMemo(
+    () => ownerProviderForModel(llmModel, modelsByProvider),
+    [llmModel, modelsByProvider],
+  );
+  const ownerProviderInfo = ownerProvider ? LLM_PROVIDER_INFO[ownerProvider] : null;
+  const ownerConfigured = Boolean(
+    ownerProvider &&
+      (providerStatus[ownerProvider]?.orgConfigured || providerStatus[ownerProvider]?.platformAvailable),
+  );
+
   const modelMutation = useMutation({
     mutationFn: (data: Record<string, unknown>) => api.settings.update(data),
     onSuccess: () => {
@@ -153,14 +143,12 @@ export default function LLMPage() {
     },
   });
 
-  // Save API key mutation
   const keyMutation = useMutation({
     mutationFn: ({ provider, config }: { provider: string; config: Record<string, unknown> }) =>
       api.credentials.update(provider, config),
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "success" }));
-      setApiKeys((prev) => ({ ...prev, [variables.provider]: "" }));
       setTimeout(() => {
         setKeySaveStatus((prev) => ({ ...prev, [variables.provider]: "idle" }));
       }, 2000);
@@ -174,12 +162,12 @@ export default function LLMPage() {
     },
   });
 
-  // Delete credential mutation
   const deleteMutation = useMutation({
     mutationFn: (provider: string) => api.credentials.delete(provider),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["credentials"] });
       setRemovingProvider(null);
+      setEditingProvider(null);
     },
     onError: (error) => {
       captureError(error, { feature: "llm-key-delete" });
@@ -195,10 +183,8 @@ export default function LLMPage() {
     });
   }
 
-  function handleSaveKey(provider: string) {
-    const key = apiKeys[provider]?.trim();
+  function handleSaveKey(provider: string, key: string) {
     if (!key) return;
-
     const config: Record<string, unknown> = { api_key: key };
     if (provider === "openai") {
       config.api_type = OPENAI_API_TYPE_CHAT;
@@ -206,6 +192,10 @@ export default function LLMPage() {
     setKeySaveStatus((prev) => ({ ...prev, [provider]: "saving" }));
     keyMutation.mutate({ provider, config });
   }
+
+  const editingInfo = editingProvider ? LLM_PROVIDER_INFO[editingProvider] : null;
+  const editingStatus = editingProvider ? providerStatus[editingProvider] : undefined;
+  const editingSaveStatus = editingProvider ? keySaveStatus[editingProvider] ?? "idle" : "idle";
 
   return (
     <PageContainer size="default">
@@ -238,174 +228,61 @@ export default function LLMPage() {
           </Card>
         )}
 
-        {/* Agent Credentials */}
         <section className="space-y-3">
-          <h2 className="text-xs font-medium text-foreground">Agent credentials</h2>
+          <h2 className="text-xs font-medium text-foreground">Default model</h2>
+          <DefaultModelCard
+            value={llmModel}
+            reasoningEffort={reasoningEffort}
+            modelGroups={enabledModelGroups}
+            ownerProvider={ownerProvider}
+            ownerProviderInfo={ownerProviderInfo}
+            ownerConfigured={ownerConfigured}
+            saving={modelMutation.isPending}
+            saveStatus={saveStatus}
+            onChange={setLlmModel}
+            onReasoningChange={setReasoningEffort}
+            onSave={handleSaveModel}
+          />
+        </section>
+
+        <section className="space-y-3">
+          <h2 className="text-xs font-medium text-foreground">Provider keys</h2>
           <p className="text-xs text-muted-foreground">
-            Add API keys for running coding agent sessions (Claude Code, Codex, Gemini CLI).
-            These keys are separate from the platform&apos;s built-in intelligence.
+            Add API keys for this org. Keys flow to coding agent sessions and can power the default
+            model above when the matching provider is selected.
           </p>
-          <div className="space-y-3">
-            {LLM_PROVIDERS.map((provider) => {
-              const info = LLM_PROVIDER_INFO[provider];
-              const ps = providerStatus[provider];
-              const status = keySaveStatus[provider] ?? "idle";
-
-              return (
-                <Card key={provider}>
-                  <CardContent>
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <div className="flex items-center gap-2">
-                            <span className="text-sm font-medium">{info.name}</span>
-                            {ps?.orgConfigured && (
-                              <Badge variant="success" className="text-xs px-1.5 py-0">
-                                <Check className="mr-0.5 h-3 w-3" />
-                                Configured
-                              </Badge>
-                            )}
-                          </div>
-                        </div>
-                        {ps?.orgConfigured && (
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="text-xs text-muted-foreground"
-                            onClick={() => setRemovingProvider(provider)}
-                            disabled={deleteMutation.isPending}
-                          >
-                            Remove
-                          </Button>
-                        )}
-                      </div>
-
-                      {ps?.orgConfigured && ps.maskedKey && (
-                        <p className="text-xs text-muted-foreground font-mono">
-                          Key: {ps.maskedKey}
-                        </p>
-                      )}
-
-                      <div className="flex gap-2">
-                        <div className="relative flex-1">
-                          <Input
-                            type={showKeys[provider] ? "text" : "password"}
-                            placeholder={ps?.orgConfigured ? "Replace existing key..." : info.keyPlaceholder}
-                            value={apiKeys[provider] ?? ""}
-                            onChange={(e) =>
-                              setApiKeys((prev) => ({ ...prev, [provider]: e.target.value }))
-                            }
-                            className="h-8 pr-9 font-mono text-xs"
-                          />
-                          <button
-                            type="button"
-                            onClick={() =>
-                              setShowKeys((prev) => ({ ...prev, [provider]: !prev[provider] }))
-                            }
-                            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                          >
-                            {showKeys[provider] ? (
-                              <EyeOff className="h-3.5 w-3.5" />
-                            ) : (
-                              <Eye className="h-3.5 w-3.5" />
-                            )}
-                          </button>
-                        </div>
-                        <Button
-                          onClick={() => handleSaveKey(provider)}
-                          disabled={!apiKeys[provider]?.trim() || status === "saving"}
-                        >
-                          {status === "saving" ? "Saving..." : "Save key"}
-                        </Button>
-                      </div>
-                      <p className="text-xs text-muted-foreground">{info.description}</p>
-                      {status === "success" && (
-                        <p className="text-xs text-emerald-600 dark:text-emerald-400">Key saved successfully.</p>
-                      )}
-                      {status === "error" && (
-                        <p className="text-xs text-destructive">Failed to save key.</p>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })}
+          <div className="space-y-2">
+            {LLM_PROVIDERS.map((provider) => (
+              <ProviderKeyRow
+                key={provider}
+                provider={provider}
+                info={LLM_PROVIDER_INFO[provider]}
+                status={providerStatus[provider] ?? { orgConfigured: false, platformAvailable: false }}
+                isDefaultOwner={provider === ownerProvider}
+                onEdit={() => setEditingProvider(provider)}
+              />
+            ))}
           </div>
         </section>
-
-        {/* Model Selection */}
-        <section className="space-y-3">
-          <h2 className="text-xs font-medium text-foreground">Model</h2>
-          <Card>
-            <CardContent>
-              <div className="space-y-3">
-                <div className="space-y-2">
-                  <Label htmlFor="llm-model">Default LLM model</Label>
-                  <Select value={llmModel} onValueChange={setLlmModel}>
-                    <SelectTrigger id="llm-model" aria-label="LLM Model">
-                      <SelectValue placeholder="Select a model" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {enabledModelGroups.length === 0 ? (
-                        <SelectItem value={DEFAULT_LLM_MODEL} disabled>
-                          No providers configured
-                        </SelectItem>
-                      ) : (
-                        enabledModelGroups.map((group) => (
-                          <SelectGroup key={group.label}>
-                            <SelectLabel>{group.label}</SelectLabel>
-                            {group.models.map((model) => (
-                              <SelectItem key={model} value={model}>
-                                {model}
-                              </SelectItem>
-                            ))}
-                          </SelectGroup>
-                        ))
-                      )}
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    The model used for validation, prioritization, and other general LLM tasks.
-                    Only models from configured providers are shown.
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="reasoning-effort">Reasoning effort</Label>
-                  <Select value={reasoningEffort || "none"} onValueChange={(v) => setReasoningEffort(v === "none" ? "" : v)}>
-                    <SelectTrigger id="reasoning-effort" aria-label="Reasoning effort">
-                      <SelectValue placeholder="Default (none)" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="none">Default (none)</SelectItem>
-                      <SelectItem value="low">Low</SelectItem>
-                      <SelectItem value="medium">Medium</SelectItem>
-                      <SelectItem value="high">High</SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <p className="text-xs text-muted-foreground">
-                    Controls how much reasoning the model uses. Lower values reduce latency and cost.
-                    Only applies to models that support reasoning.
-                  </p>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </section>
-
-        <div className="flex items-center justify-end gap-3">
-          {saveStatus === "success" && (
-            <span className="text-sm text-emerald-600 dark:text-emerald-400">Model saved.</span>
-          )}
-          {saveStatus === "error" && (
-            <span className="text-sm text-destructive">Failed to save model.</span>
-          )}
-          <Button onClick={handleSaveModel} disabled={modelMutation.isPending}>
-            {modelMutation.isPending ? "Saving..." : "Save model"}
-          </Button>
-        </div>
       </div>
 
-      {/* Remove Credential Confirmation Dialog */}
+      {editingProvider && editingInfo && (
+        <ProviderKeyDialog
+          open={!!editingProvider}
+          onOpenChange={(open) => {
+            if (!open) setEditingProvider(null);
+          }}
+          provider={editingProvider}
+          info={editingInfo}
+          existingMaskedKey={editingStatus?.maskedKey}
+          saveStatus={editingSaveStatus}
+          onSave={(key) => handleSaveKey(editingProvider, key)}
+          onRemove={
+            editingStatus?.orgConfigured ? () => setRemovingProvider(editingProvider) : undefined
+          }
+        />
+      )}
+
       <AlertDialog open={!!removingProvider} onOpenChange={(open) => !open && setRemovingProvider(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -319,7 +319,7 @@ export const api = {
   settings: {
     get: () => get<import('./types').SingleResponse<import('./types').Organization>>('/api/v1/settings'),
     update: (data: Record<string, unknown>) => patch<import('./types').SingleResponse<import('./types').Organization>>('/api/v1/settings', data),
-    getLLMDefaults: () => get<{ data: Record<string, string>; platform_model?: string }>('/api/v1/settings/llm-defaults'),
+    getLLMDefaults: () => get<{ data: Record<string, string> }>('/api/v1/settings/llm-defaults'),
     getLLMModels: () => get<{ data: Record<string, string[]> }>('/api/v1/settings/llm-models'),
   },
   credentials: {

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -9,8 +9,10 @@ import {
   DEFAULT_LLM_MODEL,
   CLAUDE_CODE_MODEL_SONNET,
   LEGACY_PM_ALIASES,
+  LLM_PROVIDER_INFO,
   PM_MODELS_BY_PROVIDER,
   LLM_MODELS_BY_PROVIDER,
+  ownerProviderForModel,
 } from "./model-constants";
 
 describe("model constants", () => {
@@ -73,8 +75,52 @@ describe("model constants", () => {
   });
 
   it("LLM_MODELS_BY_PROVIDER maps providers to their models", () => {
-    expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "openrouter"]);
+    expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "gemini", "openrouter"]);
     expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]);
     expect(LLM_MODELS_BY_PROVIDER.openai.models).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]);
+    expect(LLM_MODELS_BY_PROVIDER.gemini.models).toEqual(["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"]);
+  });
+
+  it("LLM_PROVIDER_INFO includes Gemini with an AIza placeholder", () => {
+    expect(LLM_PROVIDER_INFO.gemini).toMatchObject({
+      name: "Gemini",
+      keyPlaceholder: "AIza...",
+    });
+  });
+});
+
+describe("ownerProviderForModel", () => {
+  const groups = {
+    anthropic: { label: "Anthropic", models: ["claude-opus-4-6"] as readonly string[] },
+    openai: { label: "OpenAI", models: ["gpt-4o", "gpt-5.4-mini"] as readonly string[] },
+    gemini: { label: "Gemini", models: ["gemini-2.5-pro"] as readonly string[] },
+    openrouter: {
+      label: "OpenRouter",
+      models: [
+        "claude-opus-4-6",
+        "gpt-4o",
+        "gpt-5.4-mini",
+        "gemini-2.5-pro",
+        "meta-only-model",
+      ] as readonly string[],
+    },
+  };
+
+  it("returns the native provider when the model is offered natively", () => {
+    expect(ownerProviderForModel("claude-opus-4-6", groups)).toBe("anthropic");
+    expect(ownerProviderForModel("gpt-5.4-mini", groups)).toBe("openai");
+    expect(ownerProviderForModel("gemini-2.5-pro", groups)).toBe("gemini");
+  });
+
+  it("falls back to openrouter when only openrouter offers the model", () => {
+    expect(ownerProviderForModel("meta-only-model", groups)).toBe("openrouter");
+  });
+
+  it("returns null when no provider offers the model", () => {
+    expect(ownerProviderForModel("unknown-model", groups)).toBeNull();
+  });
+
+  it("returns null when the providers map is empty", () => {
+    expect(ownerProviderForModel("anything", {})).toBeNull();
   });
 });

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -81,6 +81,16 @@ describe("model constants", () => {
     expect(LLM_MODELS_BY_PROVIDER.gemini.models).toEqual(["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"]);
   });
 
+  it("LLM_MODELS_BY_PROVIDER exposes OpenRouter-exclusive Qwen models", () => {
+    expect(LLM_MODELS_BY_PROVIDER.openrouter.models).toContain("qwen3-235b-a22b");
+    expect(LLM_MODELS_BY_PROVIDER.openrouter.models).toContain("qwen3-32b");
+    // These must not appear under any native provider group.
+    for (const provider of ["anthropic", "openai", "gemini"] as const) {
+      expect(LLM_MODELS_BY_PROVIDER[provider].models).not.toContain("qwen3-235b-a22b");
+      expect(LLM_MODELS_BY_PROVIDER[provider].models).not.toContain("qwen3-32b");
+    }
+  });
+
   it("LLM_PROVIDER_INFO includes Gemini with an AIza placeholder", () => {
     expect(LLM_PROVIDER_INFO.gemini).toMatchObject({
       name: "Gemini",
@@ -122,5 +132,49 @@ describe("ownerProviderForModel", () => {
 
   it("returns null when the providers map is empty", () => {
     expect(ownerProviderForModel("anything", {})).toBeNull();
+  });
+
+  it("prefers a configured native provider over an unconfigured one", () => {
+    const status = {
+      anthropic: { orgConfigured: false, platformAvailable: false },
+      openai: { orgConfigured: true, platformAvailable: false },
+      gemini: { orgConfigured: false, platformAvailable: false },
+      openrouter: { orgConfigured: true, platformAvailable: false },
+    };
+    // gpt-5.4-mini is offered by both openai (native) and openrouter; openai wins.
+    expect(ownerProviderForModel("gpt-5.4-mini", groups, status)).toBe("openai");
+  });
+
+  it("falls back to openrouter when only openrouter is configured", () => {
+    const status = {
+      anthropic: { orgConfigured: false, platformAvailable: false },
+      openai: { orgConfigured: false, platformAvailable: false },
+      gemini: { orgConfigured: false, platformAvailable: false },
+      openrouter: { orgConfigured: true, platformAvailable: false },
+    };
+    // gpt-5.4-mini is routable via OpenRouter — the owner should be openrouter
+    // so the Save button is enabled.
+    expect(ownerProviderForModel("gpt-5.4-mini", groups, status)).toBe("openrouter");
+  });
+
+  it("treats platform-available keys as configured", () => {
+    const status = {
+      anthropic: { orgConfigured: false, platformAvailable: false },
+      openai: { orgConfigured: false, platformAvailable: true },
+      gemini: { orgConfigured: false, platformAvailable: false },
+      openrouter: { orgConfigured: false, platformAvailable: false },
+    };
+    expect(ownerProviderForModel("gpt-5.4-mini", groups, status)).toBe("openai");
+  });
+
+  it("defaults to the preferred native owner when nothing is configured", () => {
+    const status = {
+      anthropic: { orgConfigured: false, platformAvailable: false },
+      openai: { orgConfigured: false, platformAvailable: false },
+      gemini: { orgConfigured: false, platformAvailable: false },
+      openrouter: { orgConfigured: false, platformAvailable: false },
+    };
+    expect(ownerProviderForModel("gpt-5.4-mini", groups, status)).toBe("openai");
+    expect(ownerProviderForModel("meta-only-model", groups, status)).toBe("openrouter");
   });
 });

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -47,7 +47,7 @@ describe("model constants", () => {
 
   it("includes latest Gemini CLI models", () => {
     expect(AVAILABLE_GEMINI_CLI_MODELS).toEqual([
-      "gemini-3-pro-preview",
+      "gemini-3.1-pro-preview",
       "gemini-3-flash-preview",
       "gemini-2.5-pro",
       "gemini-2.5-flash",
@@ -78,7 +78,7 @@ describe("model constants", () => {
     expect(Object.keys(LLM_MODELS_BY_PROVIDER)).toEqual(["anthropic", "openai", "gemini", "openrouter"]);
     expect(LLM_MODELS_BY_PROVIDER.anthropic.models).toEqual(["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"]);
     expect(LLM_MODELS_BY_PROVIDER.openai.models).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]);
-    expect(LLM_MODELS_BY_PROVIDER.gemini.models).toEqual(["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"]);
+    expect(LLM_MODELS_BY_PROVIDER.gemini.models).toEqual(["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"]);
   });
 
   it("LLM_PROVIDER_INFO includes Gemini with an AIza placeholder", () => {

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -82,7 +82,25 @@ export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: rea
   anthropic: { label: "Anthropic", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
   openai: { label: "OpenAI", models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
   gemini: { label: "Gemini", models: ["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"] },
-  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"] },
+  openrouter: {
+    label: "OpenRouter",
+    models: [
+      "claude-opus-4-7",
+      "claude-sonnet-4-6",
+      "claude-haiku-4-5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+      "gpt-5.4-nano",
+      "gemini-3.1-pro",
+      "gemini-3-flash",
+      "gemini-2.5-pro",
+      "gemini-2.5-flash",
+      // OpenRouter-exclusive open-weight models — give OpenRouter-only orgs a
+      // default model they can pick and save without needing a native provider.
+      "qwen3-235b-a22b",
+      "qwen3-32b",
+    ],
+  },
 };
 
 export const DEFAULT_LLM_MODEL = "gpt-5.4-mini";
@@ -97,18 +115,35 @@ export const LLM_PROVIDER_INFO: Record<string, { name: string; description: stri
   openrouter: { name: "OpenRouter", description: "Access all models with a single key", keyPlaceholder: "sk-or-..." },
 };
 
-// ownerProviderForModel returns the native provider that owns a model, skipping
-// OpenRouter unless no native provider offers the model. Returns null if the
-// model isn't present in any provider's list.
+// ownerProviderForModel returns the provider whose key will actually serve the
+// model. When providerStatus is supplied, a configured provider wins over an
+// unconfigured one (native configured > openrouter configured > fall through).
+// Without providerStatus it returns the preferred owner: native first, then
+// openrouter. Returns null if no provider offers the model.
 export function ownerProviderForModel(
   model: string,
   modelsByProvider: Record<string, { label: string; models: readonly string[] }>,
+  providerStatus?: Record<string, { orgConfigured?: boolean; platformAvailable?: boolean }>,
 ): string | null {
+  const owners: string[] = [];
   for (const [provider, group] of Object.entries(modelsByProvider)) {
-    if (provider === "openrouter") continue;
-    if (group.models.includes(model)) return provider;
+    if (group.models.includes(model)) owners.push(provider);
   }
-  const openrouter = modelsByProvider["openrouter"];
-  if (openrouter?.models.includes(model)) return "openrouter";
-  return null;
+  if (owners.length === 0) return null;
+
+  const nativeOwners = owners.filter((p) => p !== "openrouter");
+  const hasOpenRouter = owners.includes("openrouter");
+
+  if (providerStatus) {
+    const isConfigured = (p: string) => {
+      const s = providerStatus[p];
+      return Boolean(s?.orgConfigured || s?.platformAvailable);
+    };
+    const configuredNative = nativeOwners.find(isConfigured);
+    if (configuredNative) return configuredNative;
+    if (hasOpenRouter && isConfigured("openrouter")) return "openrouter";
+  }
+
+  if (nativeOwners.length > 0) return nativeOwners[0];
+  return hasOpenRouter ? "openrouter" : null;
 }

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -17,13 +17,13 @@ export const AVAILABLE_CLAUDE_CODE_MODELS = [
   CLAUDE_CODE_MODEL_HAIKU,
 ] as const;
 
-export const GEMINI_CLI_MODEL_GEMINI_3_PRO_PREVIEW = "gemini-3-pro-preview";
+export const GEMINI_CLI_MODEL_GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";
 export const GEMINI_CLI_MODEL_GEMINI_3_FLASH_PREVIEW = "gemini-3-flash-preview";
 export const GEMINI_CLI_MODEL_GEMINI_2_5_PRO = "gemini-2.5-pro";
 export const GEMINI_CLI_MODEL_GEMINI_2_5_FLASH = "gemini-2.5-flash";
 
 export const AVAILABLE_GEMINI_CLI_MODELS = [
-  GEMINI_CLI_MODEL_GEMINI_3_PRO_PREVIEW,
+  GEMINI_CLI_MODEL_GEMINI_3_1_PRO_PREVIEW,
   GEMINI_CLI_MODEL_GEMINI_3_FLASH_PREVIEW,
   GEMINI_CLI_MODEL_GEMINI_2_5_PRO,
   GEMINI_CLI_MODEL_GEMINI_2_5_FLASH,
@@ -81,8 +81,8 @@ export const AVAILABLE_PM_MODELS = [
 export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[] }> = {
   anthropic: { label: "Anthropic", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
   openai: { label: "OpenAI", models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
-  gemini: { label: "Gemini", models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
-  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
+  gemini: { label: "Gemini", models: ["gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"] },
+  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"] },
 };
 
 export const DEFAULT_LLM_MODEL = "gpt-5.4-mini";

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -81,7 +81,8 @@ export const AVAILABLE_PM_MODELS = [
 export const LLM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[] }> = {
   anthropic: { label: "Anthropic", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"] },
   openai: { label: "OpenAI", models: ["gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
-  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"] },
+  gemini: { label: "Gemini", models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
+  openrouter: { label: "OpenRouter", models: ["claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
 };
 
 export const DEFAULT_LLM_MODEL = "gpt-5.4-mini";
@@ -92,5 +93,22 @@ export const OPENAI_API_TYPE_CHAT = "chat";
 export const LLM_PROVIDER_INFO: Record<string, { name: string; description: string; keyPlaceholder: string }> = {
   anthropic: { name: "Anthropic", description: "Claude models (Opus, Sonnet, Haiku)", keyPlaceholder: "sk-ant-..." },
   openai: { name: "OpenAI", description: "OpenAI models (GPT series)", keyPlaceholder: "sk-..." },
+  gemini: { name: "Gemini", description: "Google Gemini models", keyPlaceholder: "AIza..." },
   openrouter: { name: "OpenRouter", description: "Access all models with a single key", keyPlaceholder: "sk-or-..." },
 };
+
+// ownerProviderForModel returns the native provider that owns a model, skipping
+// OpenRouter unless no native provider offers the model. Returns null if the
+// model isn't present in any provider's list.
+export function ownerProviderForModel(
+  model: string,
+  modelsByProvider: Record<string, { label: string; models: readonly string[] }>,
+): string | null {
+  for (const [provider, group] of Object.entries(modelsByProvider)) {
+    if (provider === "openrouter") continue;
+    if (group.models.includes(model)) return provider;
+  }
+  const openrouter = modelsByProvider["openrouter"];
+  if (openrouter?.models.includes(model)) return "openrouter";
+  return null;
+}

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -11,11 +11,10 @@ import (
 )
 
 type SettingsHandler struct {
-	orgStore      *db.OrganizationStore
-	llmDefaults   map[string]string // provider name → masked key (from server env)
-	platformModel string            // cheap model used for internal features (e.g. "gpt-5.4-nano")
-	audit         *db.AuditEmitter
-	logger        zerolog.Logger
+	orgStore    *db.OrganizationStore
+	llmDefaults map[string]string // provider name → masked key (from server env)
+	audit       *db.AuditEmitter
+	logger      zerolog.Logger
 }
 
 // SetAuditEmitter injects the audit emitter for logging settings events.
@@ -30,12 +29,11 @@ func (h *SettingsHandler) SetLogger(logger zerolog.Logger) {
 	h.logger = logger
 }
 
-func NewSettingsHandler(orgStore *db.OrganizationStore, llmDefaults map[string]string, platformModel string) *SettingsHandler {
+func NewSettingsHandler(orgStore *db.OrganizationStore, llmDefaults map[string]string) *SettingsHandler {
 	return &SettingsHandler{
-		orgStore:      orgStore,
-		llmDefaults:   llmDefaults,
-		platformModel: platformModel,
-		logger:        zerolog.Nop(),
+		orgStore:    orgStore,
+		llmDefaults: llmDefaults,
+		logger:      zerolog.Nop(),
 	}
 }
 
@@ -54,8 +52,7 @@ func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
 // fallback is available when the org hasn't configured their own key.
 func (h *SettingsHandler) GetLLMDefaults(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{
-		"data":           h.llmDefaults,
-		"platform_model": h.platformModel,
+		"data": h.llmDefaults,
 	})
 }
 

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -65,7 +65,7 @@ func TestSettingsHandler_Get(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, "gpt-5.4-nano")
+			handler := NewSettingsHandler(store, nil)
 
 			tt.setupMock(mock, orgID)
 
@@ -88,7 +88,7 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	defaults := map[string]string{
 		"anthropic": "sk-a••••test",
 	}
-	handler := NewSettingsHandler(nil, defaults, "gpt-5.4-nano")
+	handler := NewSettingsHandler(nil, defaults)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -97,14 +97,12 @@ func TestSettingsHandler_GetLLMDefaults(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "should return 200 OK")
 	require.Contains(t, w.Body.String(), "anthropic", "response should contain provider name")
 	require.Contains(t, w.Body.String(), "sk-a", "response should contain masked key prefix")
-	require.Contains(t, w.Body.String(), "platform_model", "response should contain platform_model")
-	require.Contains(t, w.Body.String(), "gpt-5.4-nano", "response should contain platform model name")
 }
 
 func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, map[string]string{}, "gpt-5.4-nano")
+	handler := NewSettingsHandler(nil, map[string]string{})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-defaults", nil)
 	w := httptest.NewRecorder()
@@ -117,13 +115,12 @@ func TestSettingsHandler_GetLLMDefaults_Empty(t *testing.T) {
 	dataMap, ok := resp["data"].(map[string]any)
 	require.True(t, ok, "data should be a map")
 	require.Empty(t, dataMap, "should return empty map when no providers configured")
-	require.Equal(t, "gpt-5.4-nano", resp["platform_model"], "should return platform model")
 }
 
 func TestSettingsHandler_GetLLMModels(t *testing.T) {
 	t.Parallel()
 
-	handler := NewSettingsHandler(nil, nil, "gpt-5.4-nano")
+	handler := NewSettingsHandler(nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/settings/llm-models", nil)
 	w := httptest.NewRecorder()
@@ -280,7 +277,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 
 			orgID := uuid.New()
 			store := db.NewOrganizationStore(mock)
-			handler := NewSettingsHandler(store, nil, "gpt-5.4-nano")
+			handler := NewSettingsHandler(store, nil)
 
 			tt.setupMock(mock, orgID)
 

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -249,7 +249,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 		},
 		{
 			name: "updates successfully with supported models",
-			body: `{"settings":{"pm_model":"sonnet","agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"},"claude_code":{"ANTHROPIC_MODEL":"claude-sonnet-4-5"},"gemini_cli":{"GEMINI_MODEL":"gemini-3-pro-preview"}}}}`,
+			body: `{"settings":{"pm_model":"sonnet","agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"},"claude_code":{"ANTHROPIC_MODEL":"claude-sonnet-4-5"},"gemini_cli":{"GEMINI_MODEL":"gemini-3.1-pro-preview"}}}}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 				now := time.Now()
 				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -144,11 +144,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	containerUsageStore := db.NewContainerUsageStore(pool)
 	usageRollupStore := db.NewUsageRollupStore(pool)
 	usageHandler := handlers.NewUsageHandler(containerUsageStore, handlers.WithRollupStore(usageRollupStore))
-	platformModel := cfg.PlatformLLMModel
-	if platformModel == "" {
-		platformModel = "gpt-5.4-nano"
-	}
-	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeLLMEnv(), platformModel)
+	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeLLMEnv())
 	issueHandler := handlers.NewIssueHandler(issueStore)
 	sessionMessageStore := db.NewSessionMessageStore(pool)
 	sessionThreadStore := db.NewSessionThreadStore(pool)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -96,6 +96,8 @@ type Config struct {
 	OpenRouterBaseURL  string `env:"OPENROUTER_BASE_URL"`
 	OpenRouterAppName  string `env:"OPENROUTER_APP_NAME"   envDefault:"143"`
 	OpenRouterSiteURL  string `env:"OPENROUTER_SITE_URL"`
+	GeminiAPIKey       string `env:"GEMINI_API_KEY"`
+	GeminiBaseURL      string `env:"GEMINI_BASE_URL"`
 
 	// SMTP (optional — invitation emails are logged to console when not configured)
 	SMTPHost     string `env:"SMTP_HOST"`
@@ -241,6 +243,8 @@ func (c *Config) LLMConfig() llm.Config {
 		OpenRouterBaseURL: c.OpenRouterBaseURL,
 		OpenRouterAppName: c.OpenRouterAppName,
 		OpenRouterSiteURL: c.OpenRouterSiteURL,
+		GeminiAPIKey:      c.GeminiAPIKey,
+		GeminiBaseURL:     c.GeminiBaseURL,
 	}
 }
 
@@ -261,6 +265,8 @@ func (c *Config) PlatformLLMConfig() llm.Config {
 		OpenRouterBaseURL: c.OpenRouterBaseURL,
 		OpenRouterAppName: c.OpenRouterAppName,
 		OpenRouterSiteURL: c.OpenRouterSiteURL,
+		GeminiAPIKey:      c.GeminiAPIKey,
+		GeminiBaseURL:     c.GeminiBaseURL,
 	}
 }
 
@@ -285,6 +291,9 @@ func (c *Config) SafeLLMEnv() map[string]string {
 	}
 	if c.OpenRouterAPIKey != "" {
 		result["openrouter"] = maskSecret(c.OpenRouterAPIKey)
+	}
+	if c.GeminiAPIKey != "" {
+		result["gemini"] = maskSecret(c.GeminiAPIKey)
 	}
 	return result
 }
@@ -328,6 +337,9 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 	}
 	if c.OpenRouterAPIKey != "" {
 		providers = append(providers, "openrouter")
+	}
+	if c.GeminiAPIKey != "" {
+		providers = append(providers, "gemini")
 	}
 
 	llmModel := c.LLMModel

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -82,6 +82,20 @@ func TestLoad_LLMConfig(t *testing.T) {
 }
 
 //nolint:paralleltest // uses t.Setenv
+func TestPlatformLLMConfig_PropagatesGeminiFields(t *testing.T) {
+	t.Setenv("PLATFORM_LLM_MODEL", "gpt-5.4-nano")
+	t.Setenv("GEMINI_API_KEY", "AIza-test-key")
+	t.Setenv("GEMINI_BASE_URL", "https://gemini.example.com")
+
+	cfg := Load()
+	platform := cfg.PlatformLLMConfig()
+
+	require.Equal(t, llm.ModelName("gpt-5.4-nano"), platform.Model, "platform model should come from PLATFORM_LLM_MODEL")
+	require.Equal(t, "AIza-test-key", platform.GeminiAPIKey, "platform config must propagate GEMINI_API_KEY")
+	require.Equal(t, "https://gemini.example.com", platform.GeminiBaseURL, "platform config must propagate GEMINI_BASE_URL")
+}
+
+//nolint:paralleltest // uses t.Setenv
 func TestLogStatus_AllConfigured(t *testing.T) {
 	t.Setenv("DATABASE_URL", "postgres://test")
 	t.Setenv("GITHUB_OAUTH_CLIENT_ID", "gh-id")
@@ -93,6 +107,7 @@ func TestLogStatus_AllConfigured(t *testing.T) {
 	t.Setenv("ENCRYPTION_MASTER_KEY", "master-key")
 	t.Setenv("LLM_MODEL", "claude-sonnet-4-5")
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("GEMINI_API_KEY", "AIza-test")
 	t.Setenv("SESSION_SECRET", "secret")
 
 	cfg := Load()
@@ -100,6 +115,23 @@ func TestLogStatus_AllConfigured(t *testing.T) {
 	require.NotPanics(t, func() {
 		cfg.LogStatus(zerolog.Nop())
 	})
+}
+
+//nolint:paralleltest // uses t.Setenv
+func TestLogStatus_IncludesGeminiProvider(t *testing.T) {
+	t.Setenv("LLM_MODEL", "gemini-2.5-pro")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("OPENROUTER_API_KEY", "")
+	t.Setenv("GEMINI_API_KEY", "AIza-test-key")
+	t.Setenv("SESSION_SECRET", "test-secret")
+
+	cfg := Load()
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf)
+	cfg.LogStatus(logger)
+
+	require.Contains(t, buf.String(), "gemini", "LogStatus should mention the gemini provider")
 }
 
 //nolint:paralleltest // uses t.Setenv
@@ -141,14 +173,16 @@ func TestSafeLLMEnv_MasksAPIKeys(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-api3-abcdef1234567890")
 	t.Setenv("OPENAI_API_KEY", "sk-proj-abcdefgh1234")
 	t.Setenv("OPENROUTER_API_KEY", "sk-or-v1-abcdefgh5678")
+	t.Setenv("GEMINI_API_KEY", "AIzaSy-abcdefgh1234")
 
 	cfg := Load()
 	safe := cfg.SafeLLMEnv()
 
-	require.Len(t, safe, 3, "should include all three providers")
+	require.Len(t, safe, 4, "should include all four providers")
 	require.Equal(t, "sk-a••••7890", safe["anthropic"])
 	require.Equal(t, "sk-p••••1234", safe["openai"])
 	require.Equal(t, "sk-o••••5678", safe["openrouter"])
+	require.Equal(t, "AIza••••1234", safe["gemini"])
 }
 
 //nolint:paralleltest // uses t.Setenv

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -88,10 +88,14 @@ type Config struct {
 
 	// OpenRouter API credentials. OpenRouter proxies requests to many LLM
 	// providers through a single key, making it a good universal fallback.
-	OpenRouterAPIKey string
-	OpenRouterBaseURL string  // Optional, defaults to https://openrouter.ai/api
-	OpenRouterAppName string  // Optional, sent as X-Title header
-	OpenRouterSiteURL string  // Optional, sent as HTTP-Referer header
+	OpenRouterAPIKey  string
+	OpenRouterBaseURL string // Optional, defaults to https://openrouter.ai/api
+	OpenRouterAppName string // Optional, sent as X-Title header
+	OpenRouterSiteURL string // Optional, sent as HTTP-Referer header
+
+	// Gemini (Google Generative Language) API credentials.
+	GeminiAPIKey  string
+	GeminiBaseURL string // Optional, defaults to https://generativelanguage.googleapis.com
 
 	// Timeout is the per-provider HTTP timeout. Defaults to 60s.
 	Timeout time.Duration
@@ -155,6 +159,15 @@ func NewClient(cfg Config, logger zerolog.Logger) (Client, error) {
 		}
 		opts = append(opts, WithOpenRouterHTTPClient(httpClient))
 		providers["openrouter"] = NewOpenRouterProvider(cfg.OpenRouterAPIKey, opts...)
+	}
+
+	if cfg.GeminiAPIKey != "" {
+		var opts []GeminiOption
+		if cfg.GeminiBaseURL != "" {
+			opts = append(opts, WithGeminiBaseURL(cfg.GeminiBaseURL))
+		}
+		opts = append(opts, WithGeminiHTTPClient(httpClient))
+		providers["gemini"] = NewGeminiProvider(cfg.GeminiAPIKey, opts...)
 	}
 
 	if len(providers) == 0 {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -202,7 +202,7 @@ type NoProvidersError struct {
 }
 
 func (e *NoProvidersError) Error() string {
-	return fmt.Sprintf("no configured providers available for model %q: set ANTHROPIC_API_KEY or OPENAI_API_KEY", e.Model)
+	return fmt.Sprintf("no configured providers available for model %q: set one of ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, or OPENROUTER_API_KEY", e.Model)
 }
 
 // truncate shortens a string to maxLen, appending "..." if truncated.

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -265,9 +265,36 @@ func TestNewClient_WithAllProviders(t *testing.T) {
 		OpenAIAPIKey:     "sk-openai-test",
 		OpenAIBaseURL:    "https://custom.openai.com",
 		OpenRouterAPIKey: "sk-or-test",
+		GeminiAPIKey:     "AIza-test",
 	}, zerolog.Nop())
 	require.NoError(t, err, "should create client with all providers")
 	require.NotNil(t, client, "client should not be nil")
+}
+
+func TestNewClient_WithGeminiKey(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(Config{
+		Model:         "gemini-2.5-pro",
+		GeminiAPIKey:  "AIza-test",
+		GeminiBaseURL: "https://custom.googleapis.com",
+	}, zerolog.Nop())
+	require.NoError(t, err, "should create client with gemini key")
+	require.NotNil(t, client, "client should not be nil")
+}
+
+func TestNewClient_GeminiModelRequiresGeminiKey(t *testing.T) {
+	t.Parallel()
+
+	// Gemini model requested but only Anthropic configured — chain should still
+	// build if any entry in the Gemini fallback chain is configured (e.g.,
+	// anthropic fallback or openrouter).
+	client, err := NewClient(Config{
+		Model:           "gemini-2.5-pro",
+		AnthropicAPIKey: "sk-ant-test",
+	}, zerolog.Nop())
+	require.NoError(t, err, "should build client if any fallback provider for a gemini model is configured")
+	require.NotNil(t, client)
 }
 
 func TestNewClient_UnknownModel(t *testing.T) {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -131,6 +131,19 @@ func TestFallbackClient_AllProvidersFail(t *testing.T) {
 	require.Equal(t, 1, p2.callCount)
 }
 
+func TestBuildChain_QwenIsServableByOpenRouterAlone(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: a user with only OpenRouter configured should still get
+	// a chain for the OpenRouter-exclusive Qwen models.
+	openrouter := &mockProvider{name: "openrouter"}
+	chain, err := buildChain("qwen3-235b-a22b", map[string]Provider{"openrouter": openrouter})
+	require.NoError(t, err, "qwen3-235b-a22b should route through OpenRouter")
+	require.GreaterOrEqual(t, len(chain), 1)
+	require.Equal(t, "openrouter", chain[0].provider.Name(), "OpenRouter should be the primary for Qwen")
+	require.Equal(t, "qwen/qwen3-235b-a22b", chain[0].modelID)
+}
+
 func TestBuildChain_FiltersUnavailableProviders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -272,7 +272,7 @@ func TestNewClient_WithAllProviders(t *testing.T) {
 	t.Parallel()
 
 	client, err := NewClient(Config{
-		Model:            "claude-sonnet-4-6",
+		Model:            "gemini-2.5-pro",
 		AnthropicAPIKey:  "sk-ant-test",
 		AnthropicBaseURL: "https://custom.anthropic.com",
 		OpenAIAPIKey:     "sk-openai-test",
@@ -282,6 +282,14 @@ func TestNewClient_WithAllProviders(t *testing.T) {
 	}, zerolog.Nop())
 	require.NoError(t, err, "should create client with all providers")
 	require.NotNil(t, client, "client should not be nil")
+
+	// When every provider has credentials, a gemini model must route to the
+	// gemini provider first. This guards against a regression where NewClient
+	// silently drops GeminiAPIKey and falls back to a cross-provider model.
+	fc, ok := client.(*FallbackClient)
+	require.True(t, ok, "NewClient should return a *FallbackClient")
+	require.NotEmpty(t, fc.chain, "chain should not be empty")
+	require.Equal(t, "gemini", fc.chain[0].provider.Name(), "gemini model must prefer the gemini provider when its key is configured")
 }
 
 func TestNewClient_WithGeminiKey(t *testing.T) {

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -1,0 +1,181 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GeminiProvider implements Provider using the Google Gemini REST API.
+//
+// API shape:
+//
+//	POST /v1beta/models/{model}:generateContent
+//	Headers: x-goog-api-key: $KEY
+//	Body: {
+//	  "systemInstruction": {"parts": [{"text": "..."}]},
+//	  "contents": [{"role": "user", "parts": [{"text": "..."}]}],
+//	  "generationConfig": {"thinkingConfig": {"thinkingBudget": 1024}}
+//	}
+//	Response: {"candidates": [{"content": {"parts": [{"text": "..."}]}}]}
+type GeminiProvider struct {
+	apiKey  string
+	baseURL string
+	client  *http.Client
+}
+
+type GeminiOption func(*GeminiProvider)
+
+func WithGeminiBaseURL(url string) GeminiOption {
+	return func(p *GeminiProvider) { p.baseURL = url }
+}
+
+func WithGeminiHTTPClient(c *http.Client) GeminiOption {
+	return func(p *GeminiProvider) { p.client = c }
+}
+
+func NewGeminiProvider(apiKey string, opts ...GeminiOption) *GeminiProvider {
+	p := &GeminiProvider{
+		apiKey:  apiKey,
+		baseURL: "https://generativelanguage.googleapis.com",
+		client:  &http.Client{Timeout: 60 * time.Second},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func (p *GeminiProvider) Name() string { return "gemini" }
+
+// Thinking budgets map ReasoningEffort onto Gemini's thinkingBudget token counts.
+// Values are best-effort; tune without breaking callers.
+const (
+	thinkingBudgetLow    = 1024
+	thinkingBudgetMedium = 4096
+	thinkingBudgetHigh   = 16384
+)
+
+// modelSupportsThinking returns true if the Gemini model accepts a
+// generationConfig.thinkingConfig block. Applies to gemini-2.5-* and
+// gemini-3-* generations; legacy 2.0/1.5 models reject it.
+func modelSupportsThinking(model string) bool {
+	return strings.HasPrefix(model, "gemini-2.5-") || strings.HasPrefix(model, "gemini-3-")
+}
+
+func (p *GeminiProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
+	reqBody := geminiRequest{
+		Contents: []geminiContent{
+			{Role: "user", Parts: []geminiPart{{Text: userPrompt}}},
+		},
+	}
+	if systemPrompt != "" {
+		reqBody.SystemInstruction = &geminiSystemInstruction{
+			Parts: []geminiPart{{Text: systemPrompt}},
+		}
+	}
+	if reasoningEffort != "" && modelSupportsThinking(model) {
+		budget, ok := thinkingBudgetFor(reasoningEffort)
+		if ok {
+			reqBody.GenerationConfig = &geminiGenerationConfig{
+				ThinkingConfig: &geminiThinkingConfig{ThinkingBudget: budget},
+			}
+		}
+	}
+
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal request: %w", err)
+	}
+
+	url := p.baseURL + "/v1beta/models/" + model + ":generateContent"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", p.apiKey)
+
+	resp, err := p.client.Do(req) // #nosec G704 -- URL is from provider config
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", ErrServerError, err.Error())
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", classifyHTTPError(resp.StatusCode, truncate(string(respBody), 500))
+	}
+
+	var result geminiResponse
+	if err := json.Unmarshal(respBody, &result); err != nil {
+		return "", fmt.Errorf("unmarshal response: %w", err)
+	}
+
+	if len(result.Candidates) == 0 {
+		return "", fmt.Errorf("no candidates in response")
+	}
+	for _, part := range result.Candidates[0].Content.Parts {
+		if part.Text != "" {
+			return part.Text, nil
+		}
+	}
+	return "", fmt.Errorf("no text in first candidate")
+}
+
+func thinkingBudgetFor(effort ReasoningEffort) (int, bool) {
+	switch strings.ToLower(string(effort)) {
+	case "low":
+		return thinkingBudgetLow, true
+	case "medium":
+		return thinkingBudgetMedium, true
+	case "high":
+		return thinkingBudgetHigh, true
+	default:
+		return 0, false
+	}
+}
+
+type geminiRequest struct {
+	Contents          []geminiContent          `json:"contents"`
+	SystemInstruction *geminiSystemInstruction `json:"systemInstruction,omitempty"`
+	GenerationConfig  *geminiGenerationConfig  `json:"generationConfig,omitempty"`
+}
+
+type geminiSystemInstruction struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiGenerationConfig struct {
+	ThinkingConfig *geminiThinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+type geminiThinkingConfig struct {
+	ThinkingBudget int `json:"thinkingBudget"`
+}
+
+type geminiResponse struct {
+	Candidates []geminiCandidate `json:"candidates"`
+}
+
+type geminiCandidate struct {
+	Content geminiContent `json:"content"`
+}

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -63,9 +63,11 @@ const (
 
 // modelSupportsThinking returns true if the Gemini model accepts a
 // generationConfig.thinkingConfig block. Applies to gemini-2.5-* and
-// gemini-3-* generations; legacy 2.0/1.5 models reject it.
+// the gemini-3 / gemini-3.x generations; legacy 2.0/1.5 models reject it.
 func modelSupportsThinking(model string) bool {
-	return strings.HasPrefix(model, "gemini-2.5-") || strings.HasPrefix(model, "gemini-3-")
+	return strings.HasPrefix(model, "gemini-2.5-") ||
+		strings.HasPrefix(model, "gemini-3-") ||
+		strings.HasPrefix(model, "gemini-3.")
 }
 
 func (p *GeminiProvider) Complete(ctx context.Context, model, systemPrompt, userPrompt string, reasoningEffort ReasoningEffort) (string, error) {
@@ -122,12 +124,19 @@ func (p *GeminiProvider) Complete(ctx context.Context, model, systemPrompt, user
 	}
 
 	if len(result.Candidates) == 0 {
+		if reason := result.PromptFeedback.BlockReason; reason != "" {
+			return "", fmt.Errorf("no candidates in response (prompt blocked: %s)", reason)
+		}
 		return "", fmt.Errorf("no candidates in response")
 	}
-	for _, part := range result.Candidates[0].Content.Parts {
+	candidate := result.Candidates[0]
+	for _, part := range candidate.Content.Parts {
 		if part.Text != "" {
 			return part.Text, nil
 		}
+	}
+	if candidate.FinishReason != "" {
+		return "", fmt.Errorf("no text in first candidate (finishReason: %s)", candidate.FinishReason)
 	}
 	return "", fmt.Errorf("no text in first candidate")
 }
@@ -173,9 +182,15 @@ type geminiThinkingConfig struct {
 }
 
 type geminiResponse struct {
-	Candidates []geminiCandidate `json:"candidates"`
+	Candidates     []geminiCandidate    `json:"candidates"`
+	PromptFeedback geminiPromptFeedback `json:"promptFeedback"`
 }
 
 type geminiCandidate struct {
-	Content geminiContent `json:"content"`
+	Content      geminiContent `json:"content"`
+	FinishReason string        `json:"finishReason,omitempty"`
+}
+
+type geminiPromptFeedback struct {
+	BlockReason string `json:"blockReason,omitempty"`
 }

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -48,6 +48,9 @@ func NewGeminiProvider(apiKey string, opts ...GeminiOption) *GeminiProvider {
 	for _, opt := range opts {
 		opt(p)
 	}
+	// Normalize after options: a GEMINI_BASE_URL with a trailing slash would
+	// otherwise produce "host//v1beta/...".
+	p.baseURL = strings.TrimRight(p.baseURL, "/")
 	return p
 }
 

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -98,8 +99,10 @@ func (p *GeminiProvider) Complete(ctx context.Context, model, systemPrompt, user
 		return "", fmt.Errorf("marshal request: %w", err)
 	}
 
-	url := p.baseURL + "/v1beta/models/" + model + ":generateContent"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(bodyBytes))
+	// PathEscape defends against a stray colon/slash in the model name resolving
+	// to a different Google endpoint (e.g. ":streamGenerateContent").
+	endpoint := p.baseURL + "/v1beta/models/" + url.PathEscape(model) + ":generateContent"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(bodyBytes))
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -32,8 +32,8 @@ type GeminiProvider struct {
 
 type GeminiOption func(*GeminiProvider)
 
-func WithGeminiBaseURL(url string) GeminiOption {
-	return func(p *GeminiProvider) { p.baseURL = url }
+func WithGeminiBaseURL(baseURL string) GeminiOption {
+	return func(p *GeminiProvider) { p.baseURL = baseURL }
 }
 
 func WithGeminiHTTPClient(c *http.Client) GeminiOption {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -279,6 +279,64 @@ func TestGeminiProvider_BaseURLTrailingSlashIsTolerated(t *testing.T) {
 	require.Equal(t, "/v1beta/models/gemini-2.5-flash:generateContent", gotPath, "trailing slash on baseURL must not leak into the path")
 }
 
+func TestGeminiProvider_Complete_InvalidJSONResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unmarshal response", "invalid JSON should surface as unmarshal error")
+}
+
+func TestGeminiProvider_Complete_NoTextNoFinishReason(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{}}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no text in first candidate")
+	require.NotContains(t, err.Error(), "finishReason", "no finishReason should be included when none was returned")
+}
+
+func TestGeminiProvider_Complete_TransportError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	// Close immediately so the client.Do call fails with a transport error.
+	server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrServerError, "transport failure should map to ErrServerError")
+}
+
+func TestThinkingBudgetFor_UnknownEffortReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	_, ok := thinkingBudgetFor("")
+	require.False(t, ok, "empty reasoning effort should not yield a thinking budget")
+
+	_, ok = thinkingBudgetFor("not-a-level")
+	require.False(t, ok, "unknown reasoning effort should not yield a thinking budget")
+}
+
 func TestModelSupportsThinking(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -259,6 +259,26 @@ func TestGeminiProvider_Complete_NoTextSurfacesFinishReason(t *testing.T) {
 	require.Contains(t, err.Error(), "MAX_TOKENS", "finishReason should appear in the error message")
 }
 
+func TestGeminiProvider_BaseURLTrailingSlashIsTolerated(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: "ok"}}}}},
+		})
+	}))
+	defer server.Close()
+
+	// A GEMINI_BASE_URL with a trailing slash should not produce "//v1beta/...".
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL+"/"), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "", "user", "")
+	require.NoError(t, err)
+	require.Equal(t, "/v1beta/models/gemini-2.5-flash:generateContent", gotPath, "trailing slash on baseURL must not leak into the path")
+}
+
 func TestModelSupportsThinking(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -221,6 +221,44 @@ func TestGeminiProvider_Complete_NoCandidates(t *testing.T) {
 	require.Contains(t, err.Error(), "no candidates")
 }
 
+func TestGeminiProvider_Complete_PromptBlockedSurfacesReason(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates:     nil,
+			PromptFeedback: geminiPromptFeedback{BlockReason: "SAFETY"},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "SAFETY", "blockReason should appear in the error message")
+}
+
+func TestGeminiProvider_Complete_NoTextSurfacesFinishReason(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{
+				Content:      geminiContent{Parts: []geminiPart{}},
+				FinishReason: "MAX_TOKENS",
+			}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "MAX_TOKENS", "finishReason should appear in the error message")
+}
+
 func TestModelSupportsThinking(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -231,6 +269,8 @@ func TestModelSupportsThinking(t *testing.T) {
 		{"gemini-2.5-flash", true},
 		{"gemini-3-pro-preview", true},
 		{"gemini-3-flash-preview", true},
+		{"gemini-3.1-pro-preview", true},
+		{"gemini-3.1-flash-lite-preview", true},
 		{"gemini-2.0-flash", false},
 		{"gemini-1.5-pro", false},
 	}

--- a/internal/llm/gemini_test.go
+++ b/internal/llm/gemini_test.go
@@ -1,0 +1,240 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGeminiProvider_Complete_Success(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/v1beta/models/gemini-2.5-flash:generateContent", r.URL.Path, "should call generateContent on the requested model")
+		require.Equal(t, "test-key", r.Header.Get("x-goog-api-key"), "should send API key header")
+
+		var req geminiRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req), "should decode request body")
+		require.NotNil(t, req.SystemInstruction, "system instruction should be sent when provided")
+		require.Len(t, req.SystemInstruction.Parts, 1, "system instruction should have one text part")
+		require.Equal(t, "system prompt", req.SystemInstruction.Parts[0].Text)
+		require.Len(t, req.Contents, 1, "should send one user turn")
+		require.Equal(t, "user", req.Contents[0].Role, "content role should be user")
+		require.Equal(t, "user prompt", req.Contents[0].Parts[0].Text)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{
+				Content: geminiContent{Parts: []geminiPart{{Text: "hello from gemini"}}},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("test-key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	require.Equal(t, "gemini", p.Name(), "provider name should be gemini")
+
+	resp, err := p.Complete(context.Background(), "gemini-2.5-flash", "system prompt", "user prompt", "")
+	require.NoError(t, err, "should complete without error")
+	require.Equal(t, "hello from gemini", resp, "should return text content from first candidate")
+}
+
+func TestGeminiProvider_Complete_OmitsSystemInstructionWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req geminiRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req), "should decode request body")
+		require.Nil(t, req.SystemInstruction, "system instruction should be omitted when empty")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{
+				Content: geminiContent{Parts: []geminiPart{{Text: "ok"}}},
+			}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "", "user prompt", "")
+	require.NoError(t, err)
+}
+
+func TestGeminiProvider_Complete_ThinkingBudgetForSupportedModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		effort         ReasoningEffort
+		expectedBudget int
+	}{
+		{effort: "low", expectedBudget: thinkingBudgetLow},
+		{effort: "medium", expectedBudget: thinkingBudgetMedium},
+		{effort: "high", expectedBudget: thinkingBudgetHigh},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(string(tt.effort), func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var req geminiRequest
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+				require.NotNil(t, req.GenerationConfig, "generationConfig should be present for thinking-capable model")
+				require.NotNil(t, req.GenerationConfig.ThinkingConfig, "thinkingConfig should be set for %s effort", tt.effort)
+				require.Equal(t, tt.expectedBudget, req.GenerationConfig.ThinkingConfig.ThinkingBudget)
+
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(geminiResponse{
+					Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: "ok"}}}}},
+				})
+			}))
+			defer server.Close()
+
+			p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+			_, err := p.Complete(context.Background(), "gemini-2.5-pro", "sys", "user", tt.effort)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestGeminiProvider_Complete_NoThinkingBudgetForUnsupportedModel(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req geminiRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.GenerationConfig != nil {
+			require.Nil(t, req.GenerationConfig.ThinkingConfig, "thinkingConfig must not be sent for non-thinking model")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: "ok"}}}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.0-flash", "sys", "user", "high")
+	require.NoError(t, err, "sending reasoning effort to a non-thinking model should not error; it should be dropped")
+}
+
+func TestGeminiProvider_Complete_NoReasoningEffortSendsNoThinkingConfig(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req geminiRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		if req.GenerationConfig != nil {
+			require.Nil(t, req.GenerationConfig.ThinkingConfig, "no thinkingConfig should be sent when reasoning effort is empty")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{
+			Candidates: []geminiCandidate{{Content: geminiContent{Parts: []geminiPart{{Text: "ok"}}}}},
+		})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-pro", "sys", "user", "")
+	require.NoError(t, err)
+}
+
+func TestGeminiProvider_Complete_RateLimit(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("quota exceeded"))
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRateLimit, "429 should map to ErrRateLimit")
+}
+
+func TestGeminiProvider_Complete_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrServerError, "500 should map to ErrServerError")
+}
+
+func TestGeminiProvider_Complete_AuthError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte("invalid key"))
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("bad-key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrAuthError, "401 should map to ErrAuthError")
+}
+
+func TestGeminiProvider_Complete_BadRequest(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("invalid argument"))
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrBadRequest, "400 should map to ErrBadRequest")
+}
+
+func TestGeminiProvider_Complete_NoCandidates(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(geminiResponse{Candidates: nil})
+	}))
+	defer server.Close()
+
+	p := NewGeminiProvider("key", WithGeminiBaseURL(server.URL), WithGeminiHTTPClient(server.Client()))
+	_, err := p.Complete(context.Background(), "gemini-2.5-flash", "sys", "user", "")
+	require.Error(t, err, "empty candidates should be an error")
+	require.Contains(t, err.Error(), "no candidates")
+}
+
+func TestModelSupportsThinking(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"gemini-2.5-pro", true},
+		{"gemini-2.5-flash", true},
+		{"gemini-3-pro-preview", true},
+		{"gemini-3-flash-preview", true},
+		{"gemini-2.0-flash", false},
+		{"gemini-1.5-pro", false},
+	}
+	for _, tt := range tests {
+		require.Equalf(t, tt.want, modelSupportsThinking(tt.model), "modelSupportsThinking(%q)", tt.model)
+	}
+}

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -62,6 +62,29 @@ var defaultChains = map[ModelName][]providerModel{
 		{ProviderName: "openai_responses", ModelID: "gpt-5.4-nano"},
 		{ProviderName: "openrouter", ModelID: "openai/gpt-5.4-nano"},
 	},
+
+	// Gemini models — primary: Gemini API, cross-provider fallback, then OpenRouter.
+	"gemini-2.5-pro": {
+		{ProviderName: "gemini", ModelID: "gemini-2.5-pro"},
+		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "openrouter", ModelID: "google/gemini-2.5-pro"},
+	},
+	"gemini-2.5-flash": {
+		{ProviderName: "gemini", ModelID: "gemini-2.5-flash"},
+		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openrouter", ModelID: "google/gemini-2.5-flash"},
+	},
+	"gemini-2.0-flash": {
+		{ProviderName: "gemini", ModelID: "gemini-2.0-flash"},
+		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openrouter", ModelID: "google/gemini-2.0-flash"},
+	},
 }
 
 // buildChain constructs an ordered fallback chain for the requested model,

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -94,6 +94,22 @@ var defaultChains = map[ModelName][]providerModel{
 		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
 		{ProviderName: "openrouter", ModelID: "google/gemini-2.5-flash"},
 	},
+
+	// Qwen open-weight models — served exclusively via OpenRouter (no native Qwen
+	// provider). Cross-provider fallbacks are picked for rough capability parity so
+	// orgs without an OpenRouter key can still get a completion.
+	"qwen3-235b-a22b": {
+		{ProviderName: "openrouter", ModelID: "qwen/qwen3-235b-a22b"},
+		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+	},
+	"qwen3-32b": {
+		{ProviderName: "openrouter", ModelID: "qwen/qwen3-32b"},
+		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
+	},
 }
 
 // buildChain constructs an ordered fallback chain for the requested model,

--- a/internal/llm/registry.go
+++ b/internal/llm/registry.go
@@ -64,6 +64,22 @@ var defaultChains = map[ModelName][]providerModel{
 	},
 
 	// Gemini models — primary: Gemini API, cross-provider fallback, then OpenRouter.
+	// The human-friendly key is what the user picks in the dropdown; ModelID is the
+	// provider-specific API identifier (Gemini 3.x models ship as "-preview" strings).
+	"gemini-3.1-pro": {
+		{ProviderName: "gemini", ModelID: "gemini-3.1-pro-preview"},
+		{ProviderName: "anthropic", ModelID: "claude-opus-4-7"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4"},
+		{ProviderName: "openrouter", ModelID: "google/gemini-3.1-pro-preview"},
+	},
+	"gemini-3-flash": {
+		{ProviderName: "gemini", ModelID: "gemini-3-flash-preview"},
+		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
+		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
+		{ProviderName: "openrouter", ModelID: "google/gemini-3-flash-preview"},
+	},
 	"gemini-2.5-pro": {
 		{ProviderName: "gemini", ModelID: "gemini-2.5-pro"},
 		{ProviderName: "anthropic", ModelID: "claude-sonnet-4-6"},
@@ -77,13 +93,6 @@ var defaultChains = map[ModelName][]providerModel{
 		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
 		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
 		{ProviderName: "openrouter", ModelID: "google/gemini-2.5-flash"},
-	},
-	"gemini-2.0-flash": {
-		{ProviderName: "gemini", ModelID: "gemini-2.0-flash"},
-		{ProviderName: "anthropic", ModelID: "claude-haiku-4-5-20251001"},
-		{ProviderName: "openai_chat", ModelID: "gpt-5.4-mini"},
-		{ProviderName: "openai_responses", ModelID: "gpt-5.4-mini"},
-		{ProviderName: "openrouter", ModelID: "google/gemini-2.0-flash"},
 	},
 }
 

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -32,14 +32,14 @@ const (
 var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku}
 
 const (
-	GeminiCLIModelGemini3ProPreview   = "gemini-3-pro-preview"
+	GeminiCLIModelGemini31ProPreview  = "gemini-3.1-pro-preview"
 	GeminiCLIModelGemini3FlashPreview = "gemini-3-flash-preview"
 	GeminiCLIModelGemini25Pro         = "gemini-2.5-pro"
 	GeminiCLIModelGemini25Flash       = "gemini-2.5-flash"
 )
 
 var AvailableGeminiCLIModels = []string{
-	GeminiCLIModelGemini3ProPreview,
+	GeminiCLIModelGemini31ProPreview,
 	GeminiCLIModelGemini3FlashPreview,
 	GeminiCLIModelGemini25Pro,
 	GeminiCLIModelGemini25Flash,
@@ -160,9 +160,10 @@ var AvailableLLMModels = []string{
 	"gpt-5.4",
 	"gpt-5.4-mini",
 	"gpt-5.4-nano",
+	"gemini-3.1-pro",
+	"gemini-3-flash",
 	"gemini-2.5-pro",
 	"gemini-2.5-flash",
-	"gemini-2.0-flash",
 }
 
 // LLMModelsByProvider returns general-purpose LLM models grouped by provider.
@@ -172,8 +173,8 @@ func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
 		"anthropic":  {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
 		"openai":     {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
-		"gemini":     {"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"},
-		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"},
+		"gemini":     {"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
+		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
 	}
 }
 

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -160,6 +160,9 @@ var AvailableLLMModels = []string{
 	"gpt-5.4",
 	"gpt-5.4-mini",
 	"gpt-5.4-nano",
+	"gemini-2.5-pro",
+	"gemini-2.5-flash",
+	"gemini-2.0-flash",
 }
 
 // LLMModelsByProvider returns general-purpose LLM models grouped by provider.
@@ -169,7 +172,8 @@ func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
 		"anthropic":  {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
 		"openai":     {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
-		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
+		"gemini":     {"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"},
+		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"},
 	}
 }
 

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -164,6 +164,11 @@ var AvailableLLMModels = []string{
 	"gemini-3-flash",
 	"gemini-2.5-pro",
 	"gemini-2.5-flash",
+	// OpenRouter-exclusive open-weight models. Listed here so the backend
+	// validator accepts them as llm_model values even though no native provider
+	// hosts them.
+	"qwen3-235b-a22b",
+	"qwen3-32b",
 }
 
 // LLMModelsByProvider returns general-purpose LLM models grouped by provider.
@@ -171,10 +176,16 @@ var AvailableLLMModels = []string{
 // GET /api/v1/settings/llm-models endpoint.
 func LLMModelsByProvider() map[string][]string {
 	return map[string][]string{
-		"anthropic":  {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
-		"openai":     {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
-		"gemini":     {"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
-		"openrouter": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
+		"anthropic": {"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		"openai":    {"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"},
+		"gemini":    {"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"},
+		"openrouter": {
+			"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
+			"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
+			"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash",
+			// OpenRouter-exclusive Qwen models.
+			"qwen3-235b-a22b", "qwen3-32b",
+		},
 	}
 }
 

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -56,6 +56,7 @@ func TestLLMModelConstants(t *testing.T) {
 		"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
 		"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
 		"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash",
+		"qwen3-235b-a22b", "qwen3-32b",
 	}, AvailableLLMModels, "AvailableLLMModels should contain all supported LLM models")
 }
 
@@ -72,6 +73,13 @@ func TestLLMModelsByProvider(t *testing.T) {
 	require.Equal(t, []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}, byProvider["openai"])
 	require.Equal(t, []string{"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"}, byProvider["gemini"])
 	require.Contains(t, byProvider["openrouter"], "gemini-3.1-pro", "openrouter should proxy the latest gemini models too")
+	// OpenRouter exclusively carries the Qwen models — they must appear there
+	// and nowhere else.
+	require.Contains(t, byProvider["openrouter"], "qwen3-235b-a22b")
+	require.Contains(t, byProvider["openrouter"], "qwen3-32b")
+	require.NotContains(t, byProvider["anthropic"], "qwen3-235b-a22b")
+	require.NotContains(t, byProvider["openai"], "qwen3-235b-a22b")
+	require.NotContains(t, byProvider["gemini"], "qwen3-235b-a22b")
 }
 
 // TestLLMProvidersHaveModels guards against drift between the LLMProviders

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -33,7 +33,7 @@ func TestGeminiCLIModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{GeminiCLIModelGemini3ProPreview, GeminiCLIModelGemini3FlashPreview, GeminiCLIModelGemini25Pro, GeminiCLIModelGemini25Flash},
+		[]string{GeminiCLIModelGemini31ProPreview, GeminiCLIModelGemini3FlashPreview, GeminiCLIModelGemini25Pro, GeminiCLIModelGemini25Flash},
 		AvailableGeminiCLIModels,
 		"AvailableGeminiCLIModels should include current Gemini 3 and 2.5 options",
 	)
@@ -55,7 +55,7 @@ func TestLLMModelConstants(t *testing.T) {
 	require.Equal(t, []string{
 		"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
 		"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
-		"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash",
+		"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash",
 	}, AvailableLLMModels, "AvailableLLMModels should contain all supported LLM models")
 }
 
@@ -70,8 +70,8 @@ func TestLLMModelsByProvider(t *testing.T) {
 	require.Contains(t, byProvider, "openrouter")
 	require.Equal(t, []string{"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}, byProvider["anthropic"])
 	require.Equal(t, []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}, byProvider["openai"])
-	require.Equal(t, []string{"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"}, byProvider["gemini"])
-	require.Contains(t, byProvider["openrouter"], "gemini-2.5-pro", "openrouter should proxy gemini models too")
+	require.Equal(t, []string{"gemini-3.1-pro", "gemini-3-flash", "gemini-2.5-pro", "gemini-2.5-flash"}, byProvider["gemini"])
+	require.Contains(t, byProvider["openrouter"], "gemini-3.1-pro", "openrouter should proxy the latest gemini models too")
 }
 
 // TestLLMProvidersHaveModels guards against drift between the LLMProviders
@@ -108,7 +108,7 @@ func TestValidateModelForAgentType(t *testing.T) {
 	}{
 		{name: "valid codex model", agentType: AgentTypeCodex, model: CodexModelGPT53Codex},
 		{name: "valid claude model", agentType: AgentTypeClaudeCode, model: ClaudeCodeModelSonnet},
-		{name: "valid gemini model", agentType: AgentTypeGeminiCLI, model: GeminiCLIModelGemini3ProPreview},
+		{name: "valid gemini model", agentType: AgentTypeGeminiCLI, model: GeminiCLIModelGemini31ProPreview},
 		{name: "invalid codex model", agentType: AgentTypeCodex, model: "bad", wantErr: true},
 		{name: "invalid claude model", agentType: AgentTypeClaudeCode, model: "bad", wantErr: true},
 		{name: "invalid gemini model", agentType: AgentTypeGeminiCLI, model: "bad", wantErr: true},
@@ -152,7 +152,7 @@ func TestValidateSettingsModels(t *testing.T) {
 				AgentConfig: AgentEnvConfig{
 					"codex":       {"OPENAI_MODEL": CodexModelGPT53Codex},
 					"claude_code": {"ANTHROPIC_MODEL": ClaudeCodeModelSonnet},
-					"gemini_cli":  {"GEMINI_MODEL": GeminiCLIModelGemini3ProPreview},
+					"gemini_cli":  {"GEMINI_MODEL": GeminiCLIModelGemini31ProPreview},
 				},
 			},
 		},
@@ -173,7 +173,7 @@ func TestValidateSettingsModels(t *testing.T) {
 		{
 			name: "accepts gemini model as pm model",
 			settings: OrgSettings{
-				PMModel: GeminiCLIModelGemini3ProPreview,
+				PMModel: GeminiCLIModelGemini31ProPreview,
 			},
 		},
 		{

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -55,6 +55,7 @@ func TestLLMModelConstants(t *testing.T) {
 	require.Equal(t, []string{
 		"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5",
 		"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano",
+		"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash",
 	}, AvailableLLMModels, "AvailableLLMModels should contain all supported LLM models")
 }
 
@@ -62,12 +63,29 @@ func TestLLMModelsByProvider(t *testing.T) {
 	t.Parallel()
 
 	byProvider := LLMModelsByProvider()
-	require.Len(t, byProvider, 3, "should have 3 providers")
+	require.Len(t, byProvider, 4, "should have 4 LLM providers (anthropic, openai, gemini, openrouter)")
 	require.Contains(t, byProvider, "anthropic")
 	require.Contains(t, byProvider, "openai")
+	require.Contains(t, byProvider, "gemini")
 	require.Contains(t, byProvider, "openrouter")
 	require.Equal(t, []string{"claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}, byProvider["anthropic"])
 	require.Equal(t, []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"}, byProvider["openai"])
+	require.Equal(t, []string{"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"}, byProvider["gemini"])
+	require.Contains(t, byProvider["openrouter"], "gemini-2.5-pro", "openrouter should proxy gemini models too")
+}
+
+// TestLLMProvidersHaveModels guards against drift between the LLMProviders
+// slice and LLMModelsByProvider: every LLM provider must have at least one
+// general-purpose model available in the dropdown.
+func TestLLMProvidersHaveModels(t *testing.T) {
+	t.Parallel()
+
+	byProvider := LLMModelsByProvider()
+	for _, p := range LLMProviders {
+		models, ok := byProvider[string(p)]
+		require.Truef(t, ok, "LLM provider %q must be present in LLMModelsByProvider", p)
+		require.NotEmptyf(t, models, "LLM provider %q must have at least one model", p)
+	}
 }
 
 func TestIsSupportedLLMModel(t *testing.T) {

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -35,7 +35,7 @@ var AllProviders = []ProviderName{
 
 // LLMProviders is the subset of providers that serve LLM completions.
 var LLMProviders = []ProviderName{
-	ProviderAnthropic, ProviderOpenAI, ProviderOpenRouter,
+	ProviderAnthropic, ProviderOpenAI, ProviderGemini, ProviderOpenRouter,
 }
 
 // Valid returns true if the provider name is in the canonical list.
@@ -141,14 +141,14 @@ type SlackConfig struct {
 }
 
 type NotionConfig struct {
-	AccessToken   string `json:"access_token"`              // #nosec G117 -- JSON config field
+	AccessToken   string `json:"access_token"` // #nosec G117 -- JSON config field
 	WorkspaceID   string `json:"workspace_id,omitempty"`
 	WorkspaceName string `json:"workspace_name,omitempty"`
 }
 
 type OpenAIChatGPTConfig struct {
-	AccessToken  string    `json:"access_token"`  // #nosec G117 -- JSON config field
-	RefreshToken string    `json:"refresh_token"` // #nosec G117 -- JSON config field
+	AccessToken  string    `json:"access_token"`       // #nosec G117 -- JSON config field
+	RefreshToken string    `json:"refresh_token"`      // #nosec G117 -- JSON config field
 	IDToken      string    `json:"id_token,omitempty"` // OIDC id_token from OAuth exchange
 	ExpiresAt    time.Time `json:"expires_at"`
 	AccountType  string    `json:"account_type"` // "plus", "pro", "team", "enterprise"
@@ -181,8 +181,8 @@ func (c GitHubAppConfig) Provider() ProviderName     { return ProviderGitHubApp 
 func (c GitHubOAuthConfig) Provider() ProviderName   { return ProviderGitHubOAuth }
 func (c SentryConfig) Provider() ProviderName        { return ProviderSentry }
 func (c LinearConfig) Provider() ProviderName        { return ProviderLinear }
-func (c SlackConfig) Provider() ProviderName          { return ProviderSlack }
-func (c NotionConfig) Provider() ProviderName         { return ProviderNotion }
+func (c SlackConfig) Provider() ProviderName         { return ProviderSlack }
+func (c NotionConfig) Provider() ProviderName        { return ProviderNotion }
 func (c OpenAIChatGPTConfig) Provider() ProviderName { return ProviderOpenAIChatGPT }
 
 // --- Validate() implementations ---

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -593,7 +593,7 @@ func TestIsLLMProvider(t *testing.T) {
 		{"anthropic is LLM", ProviderAnthropic, true},
 		{"openai is LLM", ProviderOpenAI, true},
 		{"openrouter is LLM", ProviderOpenRouter, true},
-		{"gemini is not LLM", ProviderGemini, false},
+		{"gemini is LLM", ProviderGemini, true},
 		{"github_app is not LLM", ProviderGitHubApp, false},
 		{"github_oauth is not LLM", ProviderGitHubOAuth, false},
 		{"sentry is not LLM", ProviderSentry, false},


### PR DESCRIPTION
## Summary
- Replaces the three full-width provider cards on /settings/llm with a compact list (status dot, masked key, `default` pill, Edit/Add), plus a "Default model" hero card that explicitly names the provider key it depends on.
- Edit/Add now opens a modal `ProviderKeyDialog`; the card body is split into 4 reusable components (`PasswordField`, `ProviderKeyRow`, `ProviderKeyDialog`, `DefaultModelCard`).
- Adds Gemini as a full LLM provider: new `internal/llm/gemini.go` HTTP client (with thinking-budget support), registration in the client factory + `Config`, fallback chains in the registry, Gemini entries in `LLMProviders` / `AvailableLLMModels` / `LLMModelsByProvider()`, and platform-level `GEMINI_API_KEY` / `GEMINI_BASE_URL` env vars.
- Adds `ownerProviderForModel` helper so the hero card can show "Uses your {provider} key" with a green check, or an amber warning when the owning provider is unconfigured (Save is disabled in that case).

## Test plan
- [ ] `make lint` and `go test ./...` pass.
- [ ] `npm test` in `frontend/` passes (1214 tests, including 46 new LLM-related tests).
- [ ] Manual: on a fresh org, `/settings/llm` renders 4 rows + hero; Save on hero is disabled; adding OpenAI key flips the dot green and enables Save.
- [ ] Manual: saving a Gemini key makes `gemini-2.5-pro` selectable; picking it and saving routes validation/prioritization calls through the Gemini provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)