### PR TITLE
Pass --verbose to claude --print stream-json invocations

### DIFF
--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -93,7 +93,7 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 		// The prompt is a positional argument to --print.
 		msg := shellEscapeDouble(prompt.UserMessage)
 		cmd = fmt.Sprintf(
-			"claude --print --output-format stream-json --continue \"%s\"",
+			"claude --print --output-format stream-json --verbose --continue \"%s\"",
 			msg,
 		)
 	} else {
@@ -106,7 +106,7 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"claude --print --output-format stream-json < %s",
+			"claude --print --output-format stream-json --verbose < %s",
 			promptPath,
 		)
 	}


### PR DESCRIPTION
## Summary
- The Claude Code CLI rejects `--print --output-format stream-json` unless `--verbose` is also set, so PM agent runs were aborting before producing any output and then failing downstream with `parse plan: pm plan tags not found`.
- Add `--verbose` to both the first-turn and `--continue` invocations in the Claude Code adapter.

## Test plan
- [ ] Kick off a PM agent run and confirm the CLI starts successfully and the `<pm-plan>` block parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)