### PR TITLE
Clarify evals settings page as coding-agent benchmarks

### DIFF
--- a/frontend/src/app/(dashboard)/settings/evals/new/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/new/page.tsx
@@ -128,7 +128,7 @@ export default function CreateEvalTaskPage() {
               Back to evals
             </Link>
           </Button>
-          <PageHeader title="Create eval task" description="Define a reproducible challenge to measure agent quality." />
+          <PageHeader title="Create eval task" description="Pin a base commit and task to benchmark how well a coding agent handles real work from your repo." />
         </div>
 
         {/* Step indicator */}

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -157,7 +157,10 @@ export default function EvalsSettingsPage() {
   return (
     <PageContainer size="default">
       <div className="space-y-6">
-        <PageHeader title="Evals" description="Create, manage, and run eval tasks to measure agent quality." />
+        <PageHeader
+          title="Coding agent evals"
+          description="Benchmark coding agents on real tasks from your repo. Each eval pins a base commit and task setup to measure end-to-end coding ability."
+        />
       {/* Actions */}
       <div className="flex items-center gap-3">
         <Button size="sm" asChild>
@@ -263,8 +266,8 @@ export default function EvalsSettingsPage() {
       ) : tasks.length === 0 ? (
         <EmptyState
           icon={FlaskConical}
-          title="No eval tasks yet"
-          description="Create eval tasks manually or bootstrap them from your PR history to start measuring agent quality."
+          title="No coding agent evals yet"
+          description="Create eval tasks manually or bootstrap from your PR history. Each pins a base commit and setup to benchmark different coding agents."
           action={{ label: "Create eval task", href: "/settings/evals/new" }}
         />
       ) : (


### PR DESCRIPTION
## Summary
- Renames the /settings/evals page to "Coding agent evals" and rewrites the header, empty-state, and create-task descriptions to make clear these evals benchmark coding agents on real tasks (pinned base commit + task setup), not raw LLM quality.

## Test plan
- [ ] Visit /settings/evals and confirm the new header/empty-state copy renders
- [ ] Visit /settings/evals/new and confirm the updated description renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)