### PR TITLE
Record before/after diff in settings.updated audit entries

### DIFF
--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -7,6 +7,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/rs/zerolog"
 )
 
 type SettingsHandler struct {
@@ -14,6 +15,7 @@ type SettingsHandler struct {
 	llmDefaults   map[string]string // provider name → masked key (from server env)
 	platformModel string            // cheap model used for internal features (e.g. "gpt-5.4-nano")
 	audit         *db.AuditEmitter
+	logger        zerolog.Logger
 }
 
 // SetAuditEmitter injects the audit emitter for logging settings events.
@@ -21,8 +23,20 @@ func (h *SettingsHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 	h.audit = audit
 }
 
+// SetLogger wires a logger used by marshalAuditDetails so a failure to
+// JSON-encode the settings diff surfaces in logs instead of silently
+// dropping the audit payload.
+func (h *SettingsHandler) SetLogger(logger zerolog.Logger) {
+	h.logger = logger
+}
+
 func NewSettingsHandler(orgStore *db.OrganizationStore, llmDefaults map[string]string, platformModel string) *SettingsHandler {
-	return &SettingsHandler{orgStore: orgStore, llmDefaults: llmDefaults, platformModel: platformModel}
+	return &SettingsHandler{
+		orgStore:      orgStore,
+		llmDefaults:   llmDefaults,
+		platformModel: platformModel,
+		logger:        zerolog.Nop(),
+	}
 }
 
 func (h *SettingsHandler) Get(w http.ResponseWriter, r *http.Request) {
@@ -81,6 +95,12 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Snapshot the pre-update values so the audit entry can record a precise
+	// before/after diff. The mutations below replace these in place, so the
+	// capture has to happen up front.
+	beforeName := org.Name
+	beforeSettings := append(json.RawMessage(nil), org.Settings...)
+
 	if req.Name != nil {
 		org.Name = *req.Name
 	}
@@ -98,8 +118,23 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgIDStr := orgID.String()
-	emitUserAudit(h.audit, r, models.AuditActionSettingsUpdated, models.AuditResourceSettings, &orgIDStr, nil)
+	// Build the audit diff from what actually changed. Skip the emit entirely
+	// when nothing changed so a no-op PATCH (client re-saving the current
+	// values) doesn't pollute the timeline with empty "updated settings" rows.
+	changes := map[string]any{}
+	if req.Name != nil && org.Name != beforeName {
+		changes["name"] = map[string]any{"before": beforeName, "after": org.Name}
+	}
+	if req.Settings != nil {
+		for k, v := range settingsAuditDiff(beforeSettings, org.Settings) {
+			changes[k] = v
+		}
+	}
+	if len(changes) > 0 {
+		orgIDStr := orgID.String()
+		emitUserAudit(h.audit, r, models.AuditActionSettingsUpdated, models.AuditResourceSettings, &orgIDStr,
+			marshalAuditDetails(h.logger, map[string]any{"changes": changes}))
+	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Organization]{Data: org})
 }
 

--- a/internal/api/handlers/settings_audit.go
+++ b/internal/api/handlers/settings_audit.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+)
+
+// settingsAuditDiff reports every leaf key whose value differs between the
+// previous and the merged settings JSON blobs. Nested objects are walked
+// recursively and reported via dotted paths ("context_limits.max_open_issues",
+// "agent_config.codex.OPENAI_MODEL") so the audit viewer's ChangesBlock can
+// render one row per real change instead of one giant JSON diff.
+//
+// The returned map has the shape {"field.path": {"before": X, "after": Y}}
+// and uses nil on the absent side for keys that were added or removed, so a
+// value→null transition is distinguishable from a no-op in the audit UI.
+// Unchanged keys are omitted; if nothing changed the map is empty and the
+// caller should skip emitting the audit row.
+//
+// We diff raw JSON maps (not the strongly-typed OrgSettings struct) on
+// purpose: ParseOrgSettings applies size-aware defaults that are not
+// persisted to the DB, so parsing both sides would surface a flood of
+// "changes" on the first write to a previously-empty settings blob even
+// though the user only touched one field.
+func settingsAuditDiff(old, new_ json.RawMessage) map[string]any {
+	changes := map[string]any{}
+	diffJSONMaps("", rawSettingsToMap(old), rawSettingsToMap(new_), changes)
+	return changes
+}
+
+// rawSettingsToMap unmarshals a settings JSON blob into a generic map.
+// Empty or malformed input yields an empty map — malformed DB state is rare
+// and the handler validates incoming JSON before calling this, so we swallow
+// the unmarshal error rather than propagate it and block audit emission.
+func rawSettingsToMap(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return map[string]any{}
+	}
+	m := map[string]any{}
+	_ = json.Unmarshal(raw, &m)
+	return m
+}
+
+// diffJSONMaps walks two JSON objects in lockstep and appends every leaf
+// difference to changes. When both sides hold an object at the same key we
+// recurse so nested edits report as dotted paths; otherwise we compare with
+// reflect.DeepEqual (correct for scalars, arrays, and mixed type/null cases
+// that == cannot handle).
+//
+// Keys are walked in sorted order so the emitted diff is deterministic —
+// this keeps audit entries byte-stable across replays and makes the
+// side-by-side UI render in a predictable order.
+func diffJSONMaps(prefix string, old, new_ map[string]any, changes map[string]any) {
+	keys := make(map[string]struct{}, len(old)+len(new_))
+	for k := range old {
+		keys[k] = struct{}{}
+	}
+	for k := range new_ {
+		keys[k] = struct{}{}
+	}
+	sorted := make([]string, 0, len(keys))
+	for k := range keys {
+		sorted = append(sorted, k)
+	}
+	sort.Strings(sorted)
+
+	for _, k := range sorted {
+		oldV, hasOld := old[k]
+		newV, hasNew := new_[k]
+		path := k
+		if prefix != "" {
+			path = prefix + "." + k
+		}
+
+		oldSub, oldIsObj := oldV.(map[string]any)
+		newSub, newIsObj := newV.(map[string]any)
+		if hasOld && hasNew && oldIsObj && newIsObj {
+			diffJSONMaps(path, oldSub, newSub, changes)
+			continue
+		}
+
+		if reflect.DeepEqual(oldV, newV) {
+			continue
+		}
+
+		var before, after any
+		if hasOld {
+			before = oldV
+		}
+		if hasNew {
+			after = newV
+		}
+		changes[path] = map[string]any{"before": before, "after": after}
+	}
+}

--- a/internal/api/handlers/settings_audit_test.go
+++ b/internal/api/handlers/settings_audit_test.go
@@ -1,0 +1,103 @@
+package handlers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSettingsAuditDiff_NoChange(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"pm_model":"sonnet","max_concurrent_runs":10}`)
+	changes := settingsAuditDiff(raw, raw)
+	require.Empty(t, changes, "identical blobs must not produce changes")
+}
+
+func TestSettingsAuditDiff_ScalarChange(t *testing.T) {
+	t.Parallel()
+
+	old := json.RawMessage(`{"pm_model":"sonnet"}`)
+	new_ := json.RawMessage(`{"pm_model":"opus"}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	require.Equal(t, map[string]any{"before": "sonnet", "after": "opus"}, changes["pm_model"])
+}
+
+func TestSettingsAuditDiff_NestedChangeFlattened(t *testing.T) {
+	t.Parallel()
+
+	old := json.RawMessage(`{"context_limits":{"max_open_issues":100,"pm_max_tokens":50000}}`)
+	new_ := json.RawMessage(`{"context_limits":{"max_open_issues":300,"pm_max_tokens":50000}}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1, "only the leaf that differs should be reported")
+	require.Equal(t,
+		map[string]any{"before": float64(100), "after": float64(300)},
+		changes["context_limits.max_open_issues"],
+		"nested changes must report as dotted paths so the UI renders one row per leaf")
+}
+
+func TestSettingsAuditDiff_KeyAdded(t *testing.T) {
+	t.Parallel()
+
+	old := json.RawMessage(`{"pm_model":"sonnet"}`)
+	new_ := json.RawMessage(`{"pm_model":"sonnet","llm_model":"gpt-5.4-mini"}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	entry, ok := changes["llm_model"].(map[string]any)
+	require.True(t, ok)
+	require.Nil(t, entry["before"], "absent-on-old must surface as nil so the UI renders an added-field row")
+	require.Equal(t, "gpt-5.4-mini", entry["after"])
+}
+
+func TestSettingsAuditDiff_KeyRemoved(t *testing.T) {
+	t.Parallel()
+
+	old := json.RawMessage(`{"pm_model":"sonnet","llm_model":"gpt-5.4-mini"}`)
+	new_ := json.RawMessage(`{"pm_model":"sonnet"}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	entry, ok := changes["llm_model"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "gpt-5.4-mini", entry["before"])
+	require.Nil(t, entry["after"])
+}
+
+func TestSettingsAuditDiff_EmptyOldBlob(t *testing.T) {
+	t.Parallel()
+
+	// First-ever settings write: every incoming key is a change.
+	old := json.RawMessage(nil)
+	new_ := json.RawMessage(`{"pm_model":"sonnet"}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	entry := changes["pm_model"].(map[string]any)
+	require.Nil(t, entry["before"])
+	require.Equal(t, "sonnet", entry["after"])
+}
+
+func TestSettingsAuditDiff_DeeplyNestedAgentConfig(t *testing.T) {
+	t.Parallel()
+
+	old := json.RawMessage(`{"agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.4"}}}`)
+	new_ := json.RawMessage(`{"agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"}}}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	require.Equal(t,
+		map[string]any{"before": "gpt-5.4", "after": "gpt-5.3-codex"},
+		changes["agent_config.codex.OPENAI_MODEL"],
+		"multi-level nesting must flatten to a single dotted path")
+}
+
+func TestSettingsAuditDiff_ObjectToScalarTreatedAsReplacement(t *testing.T) {
+	t.Parallel()
+
+	// If one side is a scalar and the other is an object at the same key, the
+	// diff must not recurse — the whole value is the change.
+	old := json.RawMessage(`{"product_context":null}`)
+	new_ := json.RawMessage(`{"product_context":{"direction":"ship faster"}}`)
+	changes := settingsAuditDiff(old, new_)
+	require.Len(t, changes, 1)
+	require.Contains(t, changes, "product_context")
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -239,6 +239,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	}
 	teamHandler.SetAuditEmitter(auditEmitter)
 	settingsHandler.SetAuditEmitter(auditEmitter)
+	settingsHandler.SetLogger(logger)
 	credentialHandler.SetAuditEmitter(auditEmitter)
 	projectHandler.SetAuditEmitter(auditEmitter)
 	automationHandler.SetAuditEmitter(auditEmitter)


### PR DESCRIPTION
## Summary
- `settings.updated` audit rows previously stored no details, so the UI showed "X updated settings" with no indication of what changed.
- Adds a recursive JSON diff of the org settings blob (plus org name) and stores it as `{"changes": {"field.path": {"before", "after"}}}` — the existing `ChangesBlock` in the audit drawer already renders that shape as one row per leaf edit (e.g. `context_limits.max_open_issues: 100 → 300`, `agent_config.codex.OPENAI_MODEL: gpt-5.4 → gpt-5.3-codex`).
- Nested objects are walked recursively and reported via dotted paths; added/removed keys surface as `nil` on the absent side; no-op PATCHes no longer emit an audit row at all.

## Test plan
- [x] `go test ./internal/api/handlers/...` — new `settings_audit_test.go` covers no-op, scalar change, nested flattening, add, remove, empty-old blob, deep agent_config, object↔scalar replacement
- [x] `golangci-lint run ./...` clean
- [ ] Change an org setting in the UI and confirm the audit drawer shows the before → after diff
