### PR TITLE
Fix billing usage page display and capacity tier formatting

### DIFF
--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -384,7 +384,7 @@ describe('UsageSummaryCards', () => {
     renderWithProviders(
       <UsageSummaryCards start="2026-04-01T00:00:00Z" end="2026-04-30T00:00:00Z" />
     );
-    expect(screen.getByText('Container Minutes')).toBeInTheDocument();
+    expect(screen.getByText('Container Hours')).toBeInTheDocument();
     expect(screen.getByText('Total Sessions')).toBeInTheDocument();
     expect(screen.getByText('Peak Concurrent')).toBeInTheDocument();
     expect(screen.getByText('LLM Tokens')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -12,6 +12,7 @@ import {
   formatNumber,
   getDateRangePreset,
   groupByLocalDay,
+  fillMissingDays,
   formatDayLabel,
   formatDateForApi,
   nextDayIso,
@@ -251,6 +252,48 @@ describe('groupByLocalDay', () => {
     const result = groupByLocalDay(buckets);
     const totalCost = result.reduce((s, d) => s + d.total_llm_cost_usd, 0);
     expect(totalCost).toBeCloseTo(4.0);
+  });
+});
+
+describe('fillMissingDays', () => {
+  // Use midday UTC so local day matches across timezones up to UTC-10.
+  const start = '2026-04-01T12:00:00Z';
+  const end = '2026-04-03T12:00:00Z';
+
+  it('returns a zero-filled day for every day in the inclusive range', () => {
+    const result = fillMissingDays([], start, end);
+    expect(result.map((d) => d.day)).toEqual([
+      '2026-04-01',
+      '2026-04-02',
+      '2026-04-03',
+    ]);
+    for (const d of result) {
+      expect(d.total_container_minutes).toBe(0);
+      expect(d.total_sessions).toBe(0);
+      expect(d.total_input_tokens).toBe(0);
+    }
+  });
+
+  it('preserves existing days and zero-fills the gaps', () => {
+    const existing = groupByLocalDay([
+      makeBucket({
+        hour_utc: '2026-04-02T12:00:00Z',
+        total_container_minutes: 45,
+        total_sessions: 2,
+      }),
+    ]);
+    const result = fillMissingDays(existing, start, end);
+    expect(result).toHaveLength(3);
+    expect(result[0].total_container_minutes).toBe(0);
+    expect(result[1].total_container_minutes).toBe(45);
+    expect(result[1].total_sessions).toBe(2);
+    expect(result[2].total_container_minutes).toBe(0);
+  });
+
+  it('returns a single day when start and end fall on the same day', () => {
+    const result = fillMissingDays([], start, start);
+    expect(result).toHaveLength(1);
+    expect(result[0].day).toBe('2026-04-01');
   });
 });
 

--- a/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
@@ -98,7 +98,7 @@ export function UsageBreakdownTable({
                   <TableHead className="pl-4 text-xs">
                     {dimension === "user" ? "User" : "Capacity Tier"}
                   </TableHead>
-                  <TableHead className="text-xs text-right">Minutes</TableHead>
+                  <TableHead className="text-xs text-right">Hours</TableHead>
                   <TableHead className="text-xs text-right">Sessions</TableHead>
                   {dimension === "user" && (
                     <>

--- a/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
@@ -122,7 +122,7 @@ export type MetricKey =
   | "total_llm_cost_usd";
 
 export const metricOptions: { value: MetricKey; label: string }[] = [
-  { value: "total_container_minutes", label: "Container Minutes" },
+  { value: "total_container_minutes", label: "Container Hours" },
   { value: "total_sessions", label: "Peak Hourly Sessions" },
   { value: "total_container_starts", label: "Container Starts" },
   { value: "peak_concurrent", label: "Peak Concurrent" },

--- a/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
@@ -39,6 +39,43 @@ export function groupByLocalDay(buckets: UsageTimeseriesBucket[]): DailyBucket[]
   }));
 }
 
+// Fill any missing local-days between start and end (inclusive) with a
+// zero-value bucket so the chart renders a continuous x-axis even when
+// no activity was recorded on some days.
+export function fillMissingDays(
+  buckets: DailyBucket[],
+  start: string,
+  end: string,
+): DailyBucket[] {
+  const byDay = new Map(buckets.map((b) => [b.day, b]));
+  const startLocal = startOfLocalDay(new Date(start));
+  const endLocal = startOfLocalDay(new Date(end));
+
+  const result: DailyBucket[] = [];
+  const cursor = new Date(startLocal);
+  while (cursor <= endLocal) {
+    const dayKey = cursor.toLocaleDateString("en-CA");
+    result.push(
+      byDay.get(dayKey) ?? {
+        day: dayKey,
+        total_container_minutes: 0,
+        total_sessions: 0,
+        total_container_starts: 0,
+        peak_concurrent: 0,
+        total_input_tokens: 0,
+        total_output_tokens: 0,
+        total_llm_cost_usd: 0,
+      },
+    );
+    cursor.setDate(cursor.getDate() + 1);
+  }
+  return result;
+}
+
+function startOfLocalDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
 function sum(items: UsageTimeseriesBucket[], key: keyof UsageTimeseriesBucket): number {
   return items.reduce((acc, item) => acc + (Number(item[key]) || 0), 0);
 }

--- a/frontend/src/app/(dashboard)/settings/usage/usage-summary-cards.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-summary-cards.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { Card, CardContent } from "@/components/ui/card";
-import { Activity, Layers, Gauge, Cpu } from "lucide-react";
-import { formatMinutes, formatNumber, formatTokenCount, formatCost } from "./usage-helpers";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Activity, Layers, Gauge, Cpu, Info } from "lucide-react";
+import { formatNumber, formatTokenCount, formatCost } from "./usage-helpers";
 import type { LucideIcon } from "lucide-react";
 
 interface UsageSummaryCardsProps {
@@ -19,15 +21,26 @@ interface KPICardProps {
   value: string;
   subtitle?: string;
   loading?: boolean;
+  labelTooltip?: ReactNode;
 }
 
-function KPICard({ icon: Icon, label, value, subtitle, loading }: KPICardProps) {
+function KPICard({ icon: Icon, label, value, subtitle, loading, labelTooltip }: KPICardProps) {
   return (
     <Card>
       <CardContent className="p-4">
         <div className="flex items-center gap-2 text-muted-foreground mb-2">
           <Icon className="h-4 w-4" />
           <span className="text-xs font-medium">{label}</span>
+          {labelTooltip && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="h-3 w-3 cursor-help" aria-label="More info" />
+                </TooltipTrigger>
+                <TooltipContent>{labelTooltip}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
         </div>
         {loading ? (
           <div className="space-y-2">
@@ -77,9 +90,8 @@ export function UsageSummaryCards({ start, end }: UsageSummaryCardsProps) {
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <KPICard
         icon={Activity}
-        label="Container Minutes"
-        value={isLoading ? "" : formatMinutes(summary?.total_container_minutes ?? 0)}
-        subtitle={`${formatNumber(summary?.total_container_minutes ?? 0)} total min`}
+        label="Container Hours"
+        value={isLoading ? "" : `${((summary?.total_container_minutes ?? 0) / 60).toFixed(1)}h`}
         loading={isLoading}
       />
       <KPICard
@@ -97,9 +109,17 @@ export function UsageSummaryCards({ start, end }: UsageSummaryCardsProps) {
       <KPICard
         icon={Cpu}
         label="LLM Tokens"
-        value={isLoading ? "" : `${formatTokenCount(tokenTotals.input)} / ${formatTokenCount(tokenTotals.output)}`}
+        value={isLoading ? "" : formatTokenCount(tokenTotals.input + tokenTotals.output)}
         subtitle={`~${formatCost(tokenTotals.cost)} est. cost`}
         loading={isLoading}
+        labelTooltip={
+          isLoading ? null : (
+            <div className="space-y-0.5">
+              <div>Input: {formatTokenCount(tokenTotals.input)}</div>
+              <div>Output: {formatTokenCount(tokenTotals.output)}</div>
+            </div>
+          )
+        }
       />
     </div>
   );

--- a/frontend/src/app/(dashboard)/settings/usage/usage-timeseries-chart.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-timeseries-chart.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/select";
 import {
   groupByLocalDay,
+  fillMissingDays,
   formatDayLabel,
   formatMinutes,
   formatTokenCount,
@@ -117,12 +118,13 @@ export function UsageTimeseriesChart({
   });
 
   const dailyData = useMemo(() => {
-    if (!data?.data?.buckets) return [];
-    return groupByLocalDay(data.data.buckets).map((d) => ({
+    const grouped = data?.data?.buckets ? groupByLocalDay(data.data.buckets) : [];
+    if (grouped.length === 0) return [];
+    return fillMissingDays(grouped, start, end).map((d) => ({
       ...d,
       label: formatDayLabel(d.day),
     }));
-  }, [data]);
+  }, [data, start, end]);
 
   const metricLabel = metricOptions.find((o) => o.value === metric)?.label ?? metric;
 
@@ -193,7 +195,7 @@ export function UsageTimeseriesChart({
                     metric={metric}
                   />
                 )}
-                cursor={{ fill: "hsl(var(--muted))", opacity: 0.3 }}
+                cursor={false}
               />
               <Bar
                 dataKey={metric}
@@ -201,6 +203,7 @@ export function UsageTimeseriesChart({
                 radius={[3, 3, 0, 0]}
                 maxBarSize={40}
                 name={metricLabel}
+                activeBar={{ fill: getBarColor(metric), fillOpacity: 0.75 }}
                 style={{ cursor: onDayClick ? "pointer" : "default" }}
               />
             </BarChart>

--- a/internal/db/usage_rollup_store.go
+++ b/internal/db/usage_rollup_store.go
@@ -669,19 +669,21 @@ func (s *UsageRollupStore) GetBreakdown(ctx context.Context, orgID uuid.UUID, st
 	// container_usage_events) and then joined, instead of per-row LATERAL
 	// subqueries which would re-scan the events table for every group.
 	// NOTE: '%%' in format() calls below is Go's fmt.Sprintf escaping — Postgres
-	// receives single '%' and interprets '%0.0f'/'%s' as format verbs.
+	// receives single '%'. Postgres format() only accepts %s/%I/%L, so the
+	// cpu_limit is rounded+cast to int before formatting with %s to match the
+	// Go-side rollup's "Ncpu_Mmb" string.
 	switch dimension {
 	case "capacity":
 		query = fmt.Sprintf(`
 			WITH session_counts AS (
 				SELECT
-					format('%%0.0fcpu_%%smb', e.cpu_limit, e.memory_limit_mb) AS capacity_tier,
+					format('%%scpu_%%smb', round(e.cpu_limit)::int, e.memory_limit_mb) AS capacity_tier,
 					COUNT(DISTINCT e.session_id) AS distinct_sessions
 				FROM container_usage_events e
 				WHERE e.org_id = @org_id
 				  AND e.started_at < @end
 				  AND COALESCE(e.stopped_at, @now) > @start
-				GROUP BY format('%%0.0fcpu_%%smb', e.cpu_limit, e.memory_limit_mb)
+				GROUP BY format('%%scpu_%%smb', round(e.cpu_limit)::int, e.memory_limit_mb)
 			)
 			SELECT
 				uh.capacity_tier AS key,
@@ -865,7 +867,7 @@ func (s *UsageRollupStore) GetDailySessionCounts(ctx context.Context, orgID uuid
 			SELECT
 				to_char(days.local_day::date, 'YYYY-MM-DD') AS local_date,
 				'' AS user_email,
-				format('%0.0fcpu_%smb', e.cpu_limit, e.memory_limit_mb) AS capacity_tier,
+				format('%scpu_%smb', round(e.cpu_limit)::int, e.memory_limit_mb) AS capacity_tier,
 				COUNT(DISTINCT e.session_id) AS sessions
 			FROM days
 			JOIN container_usage_events e

--- a/internal/db/usage_rollup_store_test.go
+++ b/internal/db/usage_rollup_store_test.go
@@ -350,7 +350,9 @@ func TestGetDailySessionCounts_Capacity(t *testing.T) {
 	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
 	end := time.Date(2026, 4, 2, 0, 0, 0, 0, time.UTC)
 
-	mock.ExpectQuery("WITH days AS").
+	// Regression guard (same as GetBreakdown capacity test): format() must use
+	// '%scpu_%smb' after casting, not '%0.0fcpu_%smb'.
+	mock.ExpectQuery(`format\('%scpu_%smb', round\(e\.cpu_limit\)::int, e\.memory_limit_mb\)`).
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "start": start, "end": end, "tz": "UTC"}).
 		WillReturnRows(pgxmock.NewRows([]string{"local_date", "user_email", "capacity_tier", "sessions"}).
 			AddRow("2026-04-01", "", "2cpu_4096mb", 2))
@@ -773,7 +775,11 @@ func TestGetBreakdown_CapacityDimension(t *testing.T) {
 		"total_container_minutes", "total_sessions", "total_container_starts",
 		"peak_concurrent", "total_input_tokens", "total_output_tokens", "total_llm_cost_usd",
 	}
-	mock.ExpectQuery("WITH session_counts").
+	// Regression guard: Postgres format() only accepts %s/%I/%L specifiers, so
+	// the capacity_tier CTE must use '%scpu_%smb' (not '%0.0fcpu_%smb'). This
+	// regex only matches the fixed form; if someone reintroduces %f the test
+	// will fail with an unexpected-query error from pgxmock.
+	mock.ExpectQuery(`format\('%scpu_%smb', round\(e\.cpu_limit\)::int, e\.memory_limit_mb\)`).
 		WithArgs(args).
 		WillReturnRows(pgxmock.NewRows(cols).
 			AddRow("2cpu_4096mb", "2cpu_4096mb", 100.0, 5, 5, 2, int64(2000), int64(1000), 1.0))


### PR DESCRIPTION
## Summary
- Switch summary cards from container minutes to hours; combine LLM input/output tokens into a single card with a tooltip breakdown
- Fill gaps in the usage timeseries chart so missing days render as zero bars for a continuous x-axis; replace hover cursor fill with an active-bar highlight
- Fix Postgres `format()` in the capacity-tier rollup queries: `%0.0f` isn't a supported verb, so round `cpu_limit` to an int and format with `%s` to match the Go-side `Ncpu_Mmb` string

## Test plan
- [ ] Usage settings page renders summary cards and timeseries chart correctly with gaps filled
- [ ] Capacity breakdown query returns tiers without Postgres format errors
