### PR TITLE
Fix Create PR 500 on dedupe conflict and show error toast in UI

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -25,6 +25,7 @@ import {
   X,
 } from "lucide-react";
 import Image from "next/image";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
@@ -986,6 +987,10 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
       queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
       queryClient.invalidateQueries({ queryKey: ["session", sessionId, "pr"] });
     },
+    onError: (err) => {
+      const msg = err instanceof Error ? err.message : "Failed to create PR";
+      toast.error(msg);
+    },
   });
 
   // Auto-resize textarea
@@ -1379,6 +1384,10 @@ export function SessionDetailContent({ id }: { id: string }) {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["session", id] });
       queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
+    },
+    onError: (err) => {
+      const msg = err instanceof Error ? err.message : "Failed to create PR";
+      toast.error(msg);
     },
   });
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -2832,6 +2833,74 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 
 	require.Equal(t, http.StatusAccepted, w.Code, "should return 202 Accepted")
 	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should indicate job was queued")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_DedupeConflict(t *testing.T) {
+	t.Parallel()
+
+	// Regression: an in-flight open_pr job for the same session must not cause
+	// a 500 ENQUEUE_FAILED response. The dedupe conflict means a PR job is
+	// already queued, so the request is effectively a success.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	diff := "--- a/file.go\n+++ b/file.go\n@@ -1 +1 @@\n-old\n+new"
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, &diff,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", nil,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				nil,
+				now,
+			),
+		)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+
+	// ON CONFLICT DO NOTHING fires because the dedupe_key already matches a
+	// pending job — pgx surfaces this as ErrNoRows.
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "dedupe conflict should be a success — the existing job satisfies the request")
+	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should still indicate queued status")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -15,14 +15,15 @@ func TestJobStore_Enqueue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		queue     string
-		jobType   string
-		payload   any
-		priority  int
-		dedupeKey *string
-		setupMock func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID)
-		expectErr bool
+		name        string
+		queue       string
+		jobType     string
+		payload     any
+		priority    int
+		dedupeKey   *string
+		setupMock   func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID)
+		expectErr   bool
+		expectNilID bool
 	}{
 		{
 			name:      "enqueues job without dedupe key",
@@ -70,6 +71,21 @@ func TestJobStore_Enqueue(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name:      "treats dedupe conflict as a no-op success",
+			queue:     "agent",
+			jobType:   "open_pr",
+			payload:   map[string]string{"session_id": "abc-123"},
+			priority:  5,
+			dedupeKey: jobDedupeKeyPtr("open_pr:abc-123"),
+			setupMock: func(mock pgxmock.PgxPoolIface, _ uuid.UUID) {
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+			},
+			expectNilID: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -92,7 +108,11 @@ func TestJobStore_Enqueue(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "Enqueue should not return an error")
-			require.Equal(t, generatedID, id, "should return the generated job ID")
+			if tt.expectNilID {
+				require.Equal(t, uuid.Nil, id, "dedupe conflict should return nil UUID with no error")
+			} else {
+				require.Equal(t, generatedID, id, "should return the generated job ID")
+			}
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -78,6 +78,12 @@ func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, queue, jobTyp
 		"priority":   priority,
 		"dedupe_key": dedupeKey,
 	}).Scan(&id)
+	// ON CONFLICT DO NOTHING returns no row when a pending/running job with the
+	// same (queue, dedupe_key) already exists. Treat that as a successful no-op:
+	// the existing job will satisfy the caller's intent.
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, nil
+	}
 	return id, err
 }
 


### PR DESCRIPTION
## Summary
- Clicking Create PR while a prior `open_pr` job was still pending/running returned `500 ENQUEUE_FAILED`. The insert uses `ON CONFLICT DO NOTHING RETURNING id`, so a dedupe hit produced `pgx.ErrNoRows` on `Scan`. `Enqueue`/`EnqueueInTx` now collapse that to `(uuid.Nil, nil)` — the existing job satisfies the request, so callers get a clean `202 Accepted`.
- Both `createPRMutation` callsites in the session detail page now surface failures via `toast.error(...)`; previously the detail-panel header button swallowed errors silently.
- Regression tests added: `TestJobStore_Enqueue` dedupe-conflict case and `TestSessionHandler_CreatePR_DedupeConflict`.

## Test plan
- [x] `go test ./internal/db/ ./internal/api/handlers/`
- [x] `go build ./...`
- [x] `tsc --noEmit` (frontend)
- [x] `vitest run sessions/[id]/page.test.tsx` — 85/85 passing
- [ ] Manually click Create PR twice in quick succession on a session — second click should no-op (still `202`) rather than showing an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)