### PR TITLE
Design doc: Redis as optional cache and pub/sub layer

### DIFF
--- a/docs/design/36-docker-agents-vps-architecture.md
+++ b/docs/design/36-docker-agents-vps-architecture.md
@@ -253,6 +253,7 @@ ssh -i ~/.ssh/143-deploy deploy@<vps-ip> "docker compose -f /opt/143/docker-comp
 | `deploy/cloud-init/db.yml` | Dedicated Postgres (Phase 3a) | `docker-compose.db.yml` |
 | `deploy/cloud-init/worker.yml` | Agent sandbox worker (Phase 3b) | `docker-compose.worker.yml` |
 | `deploy/cloud-init/api.yml` | API-only node behind LB (Phase 3c) | `docker-compose.api.yml` |
+| `deploy/cloud-init/redis.yml` | Redis cache + pub/sub (Phase 3d) | `docker-compose.redis.yml` |
 
 Each is a variation of the same template — only the compose file and env vars
 differ. The Docker + gVisor + kernel tuning section is identical across all roles.
@@ -509,6 +510,7 @@ services:
       NODE_ID: ${HOSTNAME:-node-1}
       BASE_URL: ${BASE_URL:-https://143.dev}
       FRONTEND_URL: ${FRONTEND_URL:-https://143.dev}
+      REDIS_URL: ${REDIS_URL:-}   # optional — leave empty to disable Redis
     env_file:
       - .env
     depends_on:
@@ -1159,6 +1161,7 @@ services:
       MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}
       SANDBOX_IMAGE: ghcr.io/assembledhq/143-agent:latest
       SANDBOX_RUNTIME: runsc
+      REDIS_URL: ${REDIS_URL:-}
     env_file:
       - .env
     volumes:
@@ -1287,6 +1290,159 @@ Add to `docker-compose.db.yml`:
 All app/worker nodes change `DATABASE_URL` to point at PgBouncer (port 6432)
 instead of Postgres directly.
 
+#### Step 3d: Add a Dedicated Redis Node
+
+Redis provides shared caching, pub/sub for real-time log streaming, distributed
+rate limiting, and job queue notifications. See
+[52-redis.md](../future/52-redis.md) for the full design. Redis is **optional** —
+all code paths fall back to current behavior (Postgres polling, per-node rate
+limiting) when Redis is unavailable.
+
+```
+┌───────────────┐     ┌───────────────┐     ┌───────────────┐
+│  VPS-1 (DB)   │     │  VPS-2 (App)  │     │  VPS-6 (Redis)│
+│               │     │  mode=all     │     │               │
+│  Postgres  ◄──┼─────┤  Caddy        ├────►│  Redis 8.6    │
+│               │  ┌──┤               │     │  :6379        │
+└───────────────┘  │  └───────────────┘     └───────▲───────┘
+                   │                                │
+        ┌──────────┼──────────┐                     │
+        │          │          │                     │
+   ┌────▼────┐ ┌──▼──────┐ ┌─▼───────┐             │
+   │ VPS-3   │ │ VPS-4   │ │ VPS-5   │─────────────┘
+   │ worker  │ │ worker  │ │ worker  │  (all nodes connect
+   │ 5 runs  │ │ 5 runs  │ │ 5 runs  │   to shared Redis)
+   └─────────┘ └─────────┘ └─────────┘
+```
+
+**New file: `docker-compose.redis.yml`** (runs on the Redis VPS):
+
+```yaml
+services:
+  redis:
+    image: redis:8.6-alpine
+    ports:
+      - "0.0.0.0:6379:6379"   # accessible from private network
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "1.0"
+    command: >-
+      redis-server
+        --save 60 1
+        --loglevel warning
+        --maxmemory 400mb
+        --maxmemory-policy allkeys-lru
+        --bind 0.0.0.0
+        --protected-mode no
+        --requirepass ${REDIS_PASSWORD}
+
+volumes:
+  redisdata:
+```
+
+**Cloud-init template: `deploy/cloud-init/redis.yml`**
+
+```yaml
+#cloud-config
+
+users:
+  - name: deploy
+    groups: docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    ssh_authorized_keys:
+      - ${SSH_PUBLIC_KEY}
+
+packages:
+  - docker.io
+  - docker-compose-plugin
+
+runcmd:
+  # No gVisor needed — Redis doesn't run sandboxes
+  - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.redis.yml up -d'
+
+write_files:
+  - path: /opt/143/.env
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      REDIS_PASSWORD=${REDIS_PASSWORD}
+
+  - path: /opt/143/docker-compose.redis.yml
+    owner: deploy:deploy
+    permissions: '0644'
+    encoding: b64
+    content: ${DOCKER_COMPOSE_REDIS_B64}
+
+  # Kernel tuning for Redis
+  - path: /etc/sysctl.d/99-redis.conf
+    content: |
+      vm.overcommit_memory = 1
+      net.core.somaxconn = 512
+```
+
+**Redis VPS sizing:** Redis is extremely lightweight for 143's workload. A
+`CX22` (2 vCPU / 4 GB, ~€4/month on Hetzner) is more than sufficient. Redis
+uses ~256MB for the expected workload (pub/sub messages are transient, rate-limit
+keys are small integers, cached tokens are <1KB each).
+
+> **`[PROVIDER-SPECIFIC]` Redis VPS sizing:**
+>
+> | Provider | Instance Type | Monthly Cost | Notes |
+> |----------|--------------|-------------|-------|
+> | Hetzner | CX22 (2 vCPU / 4 GB) | ~€4 (~$5) | More than enough for cache + pub/sub |
+> | AWS | t3.micro (2 vCPU / 1 GB) | ~$8 | Or use ElastiCache `cache.t4g.micro` (~$12/mo) for managed |
+> | GCP | e2-micro (shared 2 vCPU / 1 GB) | ~$7 | Or use Memorystore for managed |
+> | DigitalOcean | s-1vcpu-1gb | ~$6 | Simple, adequate for small-medium scale |
+
+**Connecting app/worker nodes to Redis:**
+
+All app and worker nodes need `REDIS_URL` in their environment, pointing to the
+Redis VPS's private IP:
+
+```bash
+# Add to .env on each app/worker VPS:
+REDIS_URL=redis://:${REDIS_PASSWORD}@10.0.0.X:6379/0
+```
+
+Update `docker-compose.prod.yml` (app node) to pass `REDIS_URL`:
+
+```yaml
+  api:
+    environment:
+      # ... existing vars ...
+      REDIS_URL: ${REDIS_URL}   # optional — omit or leave empty to disable Redis
+```
+
+Update `docker-compose.worker.yml` (worker nodes) similarly:
+
+```yaml
+  worker:
+    environment:
+      # ... existing vars ...
+      REDIS_URL: ${REDIS_URL}
+```
+
+**Security:** Redis listens on 0.0.0.0 but requires a password
+(`--requirepass`). The Hetzner firewall should block port 6379 from the public
+internet — only allow it from the private network CIDR (e.g., `10.0.0.0/16`).
+
+**Move to managed Redis when:** you need HA (automatic failover), or you're
+managing 10+ nodes and want one fewer thing to operate. See
+[52-redis.md Section 6](../future/52-redis.md#6-production-migrating-to-hosted-redis)
+for the migration path — it's a config change (update `REDIS_URL`), not a code
+change.
+
 ### Fleet Deployment
 
 Once you have multiple nodes, the Phase 1 single-node deploy script doesn't
@@ -1347,6 +1503,7 @@ generate the hosts file from your provider's CLI or API if you prefer.
 | Postgres CPU > 70% sustained | Separate Postgres to its own VPS (Step 3a) |
 | API p95 latency > 500ms under load | Add API nodes (Step 3c) |
 | Disk I/O wait > 20% on shared VPS | Separate Postgres (Step 3a) |
+| SSE polling > 500 QPS or rate limits need cross-node enforcement | Add Redis node (Step 3d) |
 | Need 99.9%+ uptime | Multiple API nodes + Postgres HA (Step 3c + Phase 4) |
 
 ---
@@ -1543,15 +1700,18 @@ More importantly, there's no way to enforce org-level concurrency limits on agen
 runs across the fleet.
 
 **Fix (required for Phase 3c):**
-- Move rate limiting to a shared store. Options:
-  - **Postgres-backed** (simplest): rate limit check is a single
-    `SELECT count(*) FROM requests WHERE org_id = $1 AND created_at > now() - interval '1 minute'`.
-    Adds ~1ms per request. Fine up to ~1000 req/sec.
-  - **Redis** (standard): if you're already running Redis for caching, use it.
-    Adds operational complexity (another stateful service).
-  - **Load balancer sticky sessions**: route all requests from an org to the same
-    API node. Per-node rate limiting then works correctly. Simplest if your LB
-    supports it, but limits horizontal scaling benefits.
+- **Redis sliding-window counter (recommended):** With a Redis node deployed
+  (Step 3d), use the distributed rate limiter described in
+  [52-redis.md Section 2.2](future/52-redis.md#22-distributed-rate-limiting).
+  A simple `INCR`/`EXPIRE` counter on Redis provides globally-consistent rate
+  limiting across all nodes with sub-millisecond overhead. Falls back to per-node
+  in-memory limiting if Redis is unavailable.
+- **Postgres-backed** (simpler, no Redis): rate limit check is a single
+  `SELECT count(*) FROM requests WHERE org_id = $1 AND created_at > now() - interval '1 minute'`.
+  Adds ~1ms per request. Fine up to ~1000 req/sec.
+- **Load balancer sticky sessions**: route all requests from an org to the same
+  API node. Per-node rate limiting then works correctly. Simplest if your LB
+  supports it, but limits horizontal scaling benefits.
 - For org-level agent run concurrency, the existing `maxConcurrent` check already
   queries Postgres, so it works correctly across nodes today. The concern is only
   for HTTP request rate limiting.
@@ -1571,10 +1731,17 @@ you grow.
 **When it matters:** When you regularly have 50+ concurrent streaming sessions
 across all API nodes. Monitor `session_logs` query frequency in `pg_stat_statements`.
 
-**Future fix options (not needed now):**
+**Fix options:**
+- **Redis Streams (recommended):** With a Redis node deployed (Step 3d), use
+  Redis Streams for log delivery as described in
+  [52-redis.md Section 2.1](future/52-redis.md#21-redis-streams-for-real-time-events-highest-value).
+  A fan-out goroutine per node per active session calls `XREAD BLOCK` and
+  broadcasts to local SSE clients via Go channels, reducing per-client DB
+  queries to zero. Falls back to 1s Postgres polling if Redis is unavailable.
 - **Postgres LISTEN/NOTIFY**: The orchestrator issues `NOTIFY session_log, '<run_id>'`
   on each log write. SSE handlers `LISTEN` on the channel and only query when
-  notified. Eliminates polling entirely. Medium code change.
+  notified. Eliminates polling entirely. Medium code change. No new dependency
+  but doesn't address caching or rate limiting.
 - **In-memory broadcast with cross-node pub/sub**: Each node maintains an
   in-memory channel per active session. Log writes fan out locally. Cross-node
   delivery via Postgres NOTIFY or Redis pub/sub. More complex but eliminates

--- a/docs/design/future/52-redis.md
+++ b/docs/design/future/52-redis.md
@@ -1,0 +1,802 @@
+# Design: Redis as Optional Cache and Pub/Sub Layer
+
+> **Status:** Not Started | **Last reviewed:** 2026-04-20
+
+## 1. Motivation
+
+143 currently uses PostgreSQL as the sole stateful backend for everything: job queue, session storage, auth tokens, rate limiting, real-time log streaming, and scheduler coordination. This works well at small scale but creates pressure points as node count and session volume grow:
+
+| Problem | Current approach | Bottleneck |
+|---------|-----------------|------------|
+| Real-time log streaming | SSE handler polls Postgres every 1s per connected client | O(clients) queries/sec on session_messages |
+| Rate limiting | In-memory token buckets per node | Not shared across nodes; each node allows full rate independently |
+| Job notifications | Workers poll `jobs` table every 5s | Latency floor of 5s; wasted queries when queue is empty |
+| Session status broadcasts | Each SSE client polls session row every 1s | Redundant reads for popular sessions |
+| Auth session validation | `SELECT ... FROM auth_sessions WHERE token = $1` on every request | Hot path hits Postgres on every API call |
+
+Redis addresses all of these with purpose-built primitives (pub/sub, sorted sets, expiring keys) while remaining operationally simple and horizontally familiar.
+
+---
+
+## 2. Proposed Uses
+
+### 2.1 Redis Streams for Real-Time Events (highest value)
+
+**Problem:** The SSE log-streaming endpoint (`GET /api/v1/sessions/{id}/logs`) polls Postgres every 1 second per connected client. With 50 concurrent viewers on 20 active sessions, that's up to 1,000 queries/sec of pure polling overhead (fewer if viewers cluster on popular sessions, but per-row contention is worse in that case).
+
+**Solution:** Use Redis Streams per session (not Pub/Sub — Streams provide message persistence and replay from a given ID). A single **fan-out goroutine per node per session** reads the stream at the tail and broadcasts entries to local SSE clients via bounded Go channels.
+
+**Connection and fan-out model:**
+
+- When the agent orchestrator writes a log entry to Postgres, it also `XADD`s to `stream:session:{id}:logs`.
+- One goroutine per node per active session calls `XREAD BLOCK` starting from `$` (tail). It does **not** try to serve catch-up reads — it only broadcasts newly arriving entries.
+- The goroutine maintains a small in-memory **ring buffer** of the last ~1000 entries it has seen. When a new SSE client connects with a recent `last-seen-id`, the handler first replays from the ring buffer; beyond that, it performs a one-shot `XRANGE` catch-up read (bounded by MAXLEN); beyond that still, it falls back to a Postgres backfill. Once caught up, the client registers with the live fan-out.
+- Each SSE client registers a **bounded channel** (buffer size ~256 entries) with the fan-out goroutine. When the fan-out tries to send and the channel is full, the client is considered slow: the fan-out closes the channel and removes the client. The SSE handler sees the close, sends an SSE `error: slow consumer` event, and disconnects. The client reconnects with its last-seen ID and goes through the catch-up path above.
+- The fan-out goroutine never anchors its read position on any individual client. It always reads from tail. Slow clients cannot hold back the stream position or cause unbounded buffer growth in the shared goroutine — bounded per-client channels absorb the mismatch, and drop-on-full is the back-pressure signal.
+- When no clients remain and the session is not producing entries, the fan-out goroutine exits. If new entries arrive after exit (before teardown), the next connecting client re-starts the goroutine and catches up via XRANGE.
+- Status changes use the same pattern on `stream:session:{id}:status`.
+- Streams are trimmed on every XADD with `MAXLEN ~ 10000 MINID ~ <now-60min>` for logs. MAXLEN is the hard ceiling; MINID ensures anything older than an hour gets dropped even if the session is quiet enough to not hit the count cap. Individual log entries larger than **4KB are truncated** in the Redis copy (full payload stays in Postgres) — this bounds worst-case memory for pathological entries (huge tool outputs, long compiler errors). At a ~500B-after-truncation average, MAXLEN 10000 caps per-session memory at ~5MB.
+
+**Why fan-out instead of connection-per-client:** A naive approach where each SSE client runs its own `XREAD BLOCK` would hold one Redis connection per client. With 50 clients across 10 nodes, that's 500 blocked connections just for log streaming. The fan-out pattern reduces this to one connection per node per active session — typically 10-20 connections total instead of hundreds.
+
+**Why Streams over Pub/Sub:** Plain Pub/Sub is fire-and-forget — if a subscriber disconnects and reconnects, all messages during the gap are lost. For log streaming this means users see gaps in output. Streams solve this by persisting messages and supporting replay from an arbitrary offset, which maps directly to "give me logs since entry X."
+
+**Dual-write consistency:** Log entries are written to Postgres first, then `XADD`'d to Redis. If the XADD fails, live SSE viewers miss the entry until they disconnect and the catch-up path reads from Postgres. This is acceptable — Postgres is the source of truth — but it means live viewers can briefly see "holes" in the stream. A log line that goes `"XADD failed: {stream}"` on every such failure makes this diagnosable.
+
+**Fallback:** If Redis is unavailable, fall back to the current 1s Postgres polling. The SSE handler already works this way, so Redis becomes a performance optimization, not a hard dependency. See §8.1 for the fallback-load analysis.
+
+### 2.2 Distributed Rate Limiting
+
+**Problem:** The current token-bucket rate limiter (`internal/api/middleware/ratelimit.go`) uses per-node in-memory maps. With N nodes behind a load balancer, an org can make `N * 100` requests/sec instead of 100.
+
+**Solution:** Use a simple sliding-window counter with `INCR` + `EXPIRE`. A single Redis key per org per window (`143:ratelimit:org:{id}:{window}`) ensures a global view. No Lua script needed — two standard Redis commands are sufficient for our scale:
+
+```go
+// Sliding window rate limiter using INCR + EXPIRE.
+// windowKey = fmt.Sprintf("143:ratelimit:org:%s:%d", orgID, time.Now().Unix()/windowSecs)
+func (c *Client) CheckRateLimit(ctx context.Context, windowKey string, limit int64, windowSecs int) (allowed bool, err error) {
+    count, err := c.rdb.Incr(ctx, windowKey).Result()
+    if err != nil {
+        return false, err // caller falls back to in-memory
+    }
+    if count == 1 {
+        // First request in this window — set expiry so the key self-cleans.
+        // Small race: if the process crashes between INCR and EXPIRE, the key
+        // persists without a TTL. The maxmemory-policy (allkeys-lru) handles
+        // this — orphaned keys are evicted under memory pressure. For belt-and-
+        // suspenders, the periodic cleanup goroutine (Section 2.5) could also
+        // scan for TTL-less rate limit keys, but this is not worth the complexity
+        // at our scale.
+        c.rdb.Expire(ctx, windowKey, time.Duration(windowSecs*2)*time.Second)
+    }
+    return count <= limit, nil
+}
+```
+
+**Why not a Lua script?** A GCRA (Generic Cell Rate Algorithm) Lua script would provide smoother rate limiting without fixed-window boundary bursts. But at 143's scale (tens of orgs, <1000 req/sec), the added complexity isn't justified. The simple `INCR`/`EXPIRE` approach is easy to understand, debug, and test. If boundary bursts become a problem later (an org gaming the window edge), GCRA can be swapped in without changing the middleware interface.
+
+**Boundary burst mitigation:** The worst case is 2x burst at window edges (100 requests at second 59, 100 more at second 61). For API rate limiting this is acceptable — we're protecting against sustained abuse, not microsecond-precision fairness. If needed, a two-window interpolation (count from current + previous window weighted by elapsed fraction) eliminates this with no Lua script — just two `GET` calls.
+
+**Fallback:** Redis is the authoritative limiter on every request when available. The per-node in-memory limiter is **only** used when Redis is unavailable (circuit breaker open or connection error). There is no "short-circuit-on-in-memory-first" path — that would allow a single node to silently accept above-limit traffic until its own bucket fills, defeating the point of global coordination. When Redis is down, we accept that each node independently allows up to the per-node limit (current behavior).
+
+### 2.3 Job Queue Notifications
+
+**Problem:** Workers poll the `jobs` table every 5 seconds. This means: (a) up to 5s latency before a job starts, and (b) N workers * 1 query / 5s of wasted Postgres load when the queue is empty.
+
+**Solution:** After inserting a job, `PUBLISH` to `jobs:notify`. Workers `SUBSCRIBE` and attempt to claim a job immediately on notification. Keep the 5s poll as a safety net (leader election, Redis reconnect, missed messages).
+
+**Important:** Redis pub/sub is fire-and-forget. The Postgres `FOR UPDATE SKIP LOCKED` query remains the source of truth for job claiming. Redis just reduces wake-up latency.
+
+**Thundering herd:** Every worker wakes on every `PUBLISH` and races to `FOR UPDATE SKIP LOCKED` — N-1 lose the race. At N=3 workers this is fine; at N=20+ it becomes wasted Postgres load on every job insertion. If worker count grows past ~10, revisit: either (a) use a Redis-side claim hint (`SETNX jobs:claim:{id}` before the Postgres claim, with a short TTL), or (b) move to a proper Redis-based queue (Streams with consumer groups). Not urgent today.
+
+### 2.4 Short-Lived Caches
+
+> **Status:** Deferred pending measurement. Auth session lookups are single indexed Postgres queries (typically 1–2ms). Before implementing this, measure whether auth is actually a hot path in p99 API latency. If it isn't, the complexity isn't worth it. Track `auth_session_lookup_duration_seconds` in Prometheus and revisit.
+
+**Problem (if measurement confirms it):** Auth session tokens hit Postgres on every API request. GitHub installation tokens are re-fetched frequently.
+
+**Solution:**
+- Cache auth session lookups in Redis with TTL matching `expires_at` (or shorter). Invalidate on logout/revocation by deleting the key.
+- Cache GitHub App installation tokens (TTL = token expiry - buffer).
+- Cache Codex OAuth tokens similarly.
+
+**Invalidation model:** Single-session logout and per-token revocation use `DEL 143:auth:token:{hash}`. For the rare "revoke all sessions for user X" admin operation (no product surface for this yet), run a one-off `SCAN` with a `MATCH 143:auth:token:*` filter and delete matching keys whose stored user_id equals the target. This is slow but acceptable because it's an offline maintenance path, not an every-request hot path.
+
+We intentionally do **not** introduce a per-user generation counter. Doing so would add a second Redis `GET` to every authenticated request forever — doubling the Redis cost of the hot path — to save a rare admin operation. If bulk revocation becomes a common product operation later, reconsider.
+
+**Fallback:** Cache miss falls through to Postgres. Redis unavailability = every request is a cache miss = current behavior.
+
+### 2.5 Stream Cleanup
+
+Streams expire "1h after session ends" via `EXPIREAT` (see Section 9). The session teardown path must call `EXPIREAT` on both the `:logs` and `:status` streams when a session reaches a terminal state. However, if a session crashes without clean teardown, these streams leak.
+
+**Safety net:** Run a periodic cleanup goroutine (e.g., every 10 minutes) that:
+1. Queries Postgres for sessions in a terminal state (`completed`, `failed`, `cancelled`) that ended more than 1 hour ago, **limited to 500 rows per tick** (`LIMIT 500`). This prevents a backlog from creating a single-tick spike that slams Redis and Postgres.
+2. For each, checks whether the corresponding stream keys still exist (`EXISTS`).
+3. Deletes any orphaned streams.
+
+If a tick processes the full 500-row batch, the next tick runs immediately (not after the 10-minute delay) until the backlog is drained. Track `redis_cleanup_batch_size` to detect sustained backlogs.
+
+This is cheap — it's a single Postgres query plus a few `EXISTS` + `DEL` calls per tick — and ensures streams don't accumulate indefinitely after ungraceful shutdowns.
+
+### 2.6 Future: Session Presence and Active Connections
+
+As the platform grows, Redis can track which nodes hold active sandbox connections (`SADD node:{id}:sessions {session_id}`), enabling smarter load balancing and session affinity without custom protocols.
+
+---
+
+## 3. Architecture
+
+### 3.1 Connection Model
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   Load Balancer                          │
+└────────────┬──────────────┬──────────────┬──────────────┘
+             │              │              │
+        ┌────▼────┐   ┌────▼────┐   ┌────▼────┐
+        │ Node 1  │   │ Node 2  │   │ Node 3  │
+        │ API     │   │ API     │   │ API     │
+        │ Worker  │   │ Worker  │   │ Worker  │
+        └──┬───┬──┘   └──┬───┬──┘   └──┬───┬──┘
+           │   │          │   │          │   │
+           │   └──────────┼───┼──────────┼───┘
+           │              │   │          │
+      ┌────▼────┐    ┌───▼───▼───┐  ┌──▼───────┐
+      │Postgres │    │   Redis    │  │  Docker   │
+      │ (primary│    │ (cache +   │  │  Daemon   │
+      │  store) │    │  pub/sub)  │  │ (sandbox) │
+      └─────────┘    └───────────┘  └───────────┘
+```
+
+Key principle: **Redis is an accelerator, not a source of truth.** Every piece of data in Redis is either:
+- Derivable from Postgres (caches), or
+- Ephemeral by nature (pub/sub messages, rate limit windows)
+
+If Redis disappears, the system degrades to current behavior, not to failure.
+
+### 3.2 Go Client Library
+
+Use [`github.com/redis/go-redis/v9`](https://github.com/redis/go-redis), the official Go client. It supports:
+- Connection pooling (built-in)
+- Pub/Sub with automatic reconnection
+- Sentinel and Cluster modes for HA
+- Context-aware commands (cancellation, timeouts)
+- Lua scripting for atomic operations (available if needed in the future)
+
+### 3.3 Redis Client Wrapper
+
+Create `internal/cache/redis.go`:
+
+```go
+package cache
+
+import (
+    "context"
+    "time"
+
+    "github.com/redis/go-redis/v9"
+    "github.com/rs/zerolog"
+)
+
+// Client wraps go-redis with fallback behavior and circuit breaking.
+type Client struct {
+    rdb     *redis.Client
+    breaker *CircuitBreaker
+    logger  zerolog.Logger
+}
+
+// Config holds Redis connection parameters.
+type Config struct {
+    URL      string        // REDIS_URL (redis://host:port/db or rediss:// for TLS)
+    Password string        // REDIS_PASSWORD (optional, for ACL-based auth)
+    PoolSize int           // default: 10 * GOMAXPROCS; see Section 9.1 for sizing guidance
+    Timeouts TimeoutConfig
+}
+
+type TimeoutConfig struct {
+    Dial  time.Duration // default: 5s
+    Read  time.Duration // default: 3s
+    Write time.Duration // default: 3s
+}
+
+func New(cfg Config, logger zerolog.Logger) *Client {
+    opts, err := redis.ParseURL(cfg.URL)
+    if err != nil {
+        logger.Error().Err(err).Str("url", cfg.URL).Msg("invalid Redis URL, running without Redis")
+        return nil
+    }
+    if cfg.Password != "" {
+        opts.Password = cfg.Password
+    }
+    if cfg.PoolSize > 0 {
+        opts.PoolSize = cfg.PoolSize
+    }
+    // Apply timeouts...
+    rdb := redis.NewClient(opts)
+    breaker := &CircuitBreaker{
+        threshold: 5,
+        cooldown:  30 * time.Second,
+    }
+    client := &Client{rdb: rdb, breaker: breaker, logger: logger}
+    // Ping to verify connectivity, but don't fail startup — Redis is optional.
+    if err := rdb.Ping(context.Background()).Err(); err != nil {
+        logger.Warn().Err(err).Msg("Redis ping failed on startup, will retry via circuit breaker")
+        breaker.RecordFailure()
+    } else {
+        logger.Info().Msg("Redis connected")
+    }
+    return client
+}
+
+// Available reports whether Redis is likely reachable.
+// Uses the circuit breaker state instead of issuing a PING on every call,
+// avoiding an extra network round-trip in the hot path.
+func (c *Client) Available() bool {
+    if c == nil || c.rdb == nil {
+        return false
+    }
+    return c.breaker.Allow()
+}
+```
+
+The rest of the application interacts through this wrapper. When `Client` is nil (Redis not configured), callers skip Redis paths entirely.
+
+**Circuit breaker scope:** The breaker governs **short-lived command calls only** (rate-limit INCR, auth cache GET, XADD, PUBLISH, XRANGE catch-up reads). It does **not** gate long-lived subscriber connections (fan-out `XREAD BLOCK`, job-notify `SUBSCRIBE`). Those are managed by `go-redis`'s own reconnection logic plus a per-subscriber supervisor goroutine that re-establishes the subscription on error.
+
+Rationale: treating a 30-second blocked `XREAD` as "still healthy" while a command call times out in 3s prevents one slow subscriber from tripping the breaker and cascading into an auth-cache miss storm on Postgres. Conversely, a broken subscription should not block hot-path commands from using Redis.
+
+When the breaker opens, in-flight blocked subscribers are left alone; they will naturally notice the connection failure and the supervisor will restart them once the breaker closes. Command-path callers see `Available() == false` and skip Redis for the cooldown window.
+
+---
+
+## 4. Configuration
+
+Add to `internal/config/config.go`:
+
+```go
+// Redis (optional — system degrades gracefully without it)
+RedisURL      string `env:"REDIS_URL"`                          // e.g. redis://localhost:6379/0
+RedisPassword string `env:"REDIS_PASSWORD"`                     // ACL password (if not in URL)
+RedisPoolSize int    `env:"REDIS_POOL_SIZE"    envDefault:"0"`  // 0 = library default
+```
+
+**Important:** Redis is opt-in. If `REDIS_URL` is empty, the `cache.Client` is nil and all Redis-dependent code paths fall back to existing behavior.
+
+### 4.1 Environment Files
+
+`.env` (development defaults):
+```
+REDIS_URL=redis://redis:6379/0
+```
+
+`.env.production.enc` (SOPS-encrypted, production):
+```
+REDIS_URL=rediss://clustercfg.xxx.cache.amazonaws.com:6379/0
+REDIS_PASSWORD=<encrypted>
+```
+
+---
+
+## 5. Docker Compose Integration
+
+Redis will be added to the dev `docker-compose.yml` alongside Postgres as part of Phase 2 (see §7). This section describes the intended service definition — it has **not** been applied to `docker-compose.yml` yet:
+
+```yaml
+services:
+  redis:
+    image: redis:8.6-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "0.5"
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 200mb --maxmemory-policy allkeys-lru
+
+  server:
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgres://onefortythree:dev@postgres:5432/onefortythree?sslmode=disable
+      REDIS_URL: redis://redis:6379/0
+      # ... existing env vars ...
+
+volumes:
+  redisdata:
+  # ... existing volumes ...
+```
+
+**Resource budget:** Redis is extremely memory-efficient. 256MB handles millions of keys. The alpine image is ~13MB.
+
+### 5.1 Scaling with Docker Compose
+
+For local multi-node testing:
+
+```yaml
+# docker-compose.override.yml (optional)
+services:
+  server-worker:
+    extends:
+      service: server
+    environment:
+      MODE: worker
+    ports: []  # no API port needed
+    deploy:
+      replicas: 2
+```
+
+All nodes connect to the same Redis instance. Pub/Sub and rate-limit keys are inherently shared.
+
+---
+
+## 6. Production Deployment
+
+### 6.1 Self-Hosted (Hetzner / VPS)
+
+For self-hosted deployments, Redis runs as a dedicated node alongside the existing db, app, worker, and logging nodes. The full setup — including `docker-compose.redis.yml`, `deploy/cloud-init/redis.yml`, VPS sizing, firewall rules, and how to wire `REDIS_URL` into app/worker nodes — is documented in [36-docker-agents-vps-architecture.md, Step 3d](../36-docker-agents-vps-architecture.md#step-3d-add-a-dedicated-redis-node).
+
+**Quick summary:**
+- Provision a small VPS (Hetzner CX22, 2 vCPU / 4 GB, ~€4/month)
+- Run `docker-compose.redis.yml` (Redis 8.6 with password auth)
+- Set `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` on all app/worker nodes
+- Block port 6379 from public internet via firewall (private network only)
+
+**Single-point-of-failure tradeoff:** A single Hetzner VPS means every Redis outage (crash, host reboot, network blip) triggers a platform-wide failover to Postgres. The graceful-degradation design absorbs this correctly, but the outage isn't free — see §8.1 for the fallback-load budget. Options if that becomes a problem:
+1. **Redis Sentinel on 2–3 VPSes** (~€12/month, auto-failover, still self-hosted) — moderate ops burden (quorum config, Sentinel on each app node).
+2. **Move to managed Redis with replica** (§6.3, ~$50/month) — zero ops burden, automatic failover, TLS included.
+
+At 143's current scale the single-VPS path is defensible because fallback is safe and outages are rare. Track `redis_fallback_total` in production; if it fires more than a couple times a month, it's time to upgrade.
+
+### 6.2 Migrating to Hosted/Managed Redis
+
+The design explicitly supports a zero-code-change migration from self-hosted Redis to a managed service.
+
+### 6.3 Managed Options
+
+| Provider | Service | Notes |
+|----------|---------|-------|
+| AWS | ElastiCache (Redis OSS) or MemoryDB | Cluster mode, automatic failover, encryption in transit |
+| GCP | Memorystore for Redis | Standard or Cluster tier |
+| Azure | Azure Cache for Redis | Basic through Premium tiers |
+| Render/Railway/Fly | Managed Redis add-on | Simpler, good for small scale |
+
+### 6.4 What Changes
+
+| Concern | Docker Compose | Hosted |
+|---------|---------------|--------|
+| `REDIS_URL` | `redis://redis:6379/0` | `rediss://clustercfg.xxx:6379/0` (TLS) |
+| `REDIS_PASSWORD` | (none) | Set via ACL or AUTH |
+| Persistence | RDB snapshots to volume | Managed replication + snapshots |
+| HA | Single instance | Multi-AZ replicas, auto-failover |
+| Code changes | None | None |
+
+The `go-redis` client handles TLS (`rediss://` scheme), authentication, and Sentinel/Cluster topologies via the URL and options. No application code changes required.
+
+### 6.5 Cluster Mode Considerations (future, not needed today)
+
+Redis Cluster is only relevant once we outgrow a single-master topology. At 143's current scale (tens of orgs, <1000 req/sec, <1GB working set), a single Redis instance plus optional replica covers us comfortably. The hash-tag conventions below are kept so that migrating to Cluster is a configuration change rather than a rekey exercise — but no Cluster-specific work is needed for Phases 1–6.
+
+If/when we move to Redis Cluster (multiple shards):
+- All keys for a given entity should use hash tags to ensure co-location on the same shard. The hash tag is the content between `{` and `}`: e.g., `143:stream:{ses:abc}:logs` and `143:stream:{ses:abc}:status` hash on `ses:abc`. **Note:** be careful with hash tag content — if the tagged portion is the same for many entities (e.g., a literal like `{session}`), all keys land on one shard. The entity ID must be inside the braces.
+- Pub/Sub in cluster mode broadcasts to all shards (supported since Redis 7+).
+- `go-redis` supports `NewClusterClient` as a drop-in; switch is config-only.
+
+---
+
+## 7. Implementation Plan
+
+### Phase 1: Provision Hetzner Infrastructure
+1. Provision a CX22 VPS (2 vCPU / 4 GB) on Hetzner Cloud for Redis
+2. Attach VPS to the existing private network (Hetzner Cloud Networks)
+3. Deploy `docker-compose.redis.yml` with password auth (see [36-docker-agents-vps-architecture.md, Step 3d](../36-docker-agents-vps-architecture.md#step-3d-add-a-dedicated-redis-node))
+4. Configure firewall: block port 6379 from public internet, allow from private network CIDR only
+5. Set `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` in `.env` on all app/worker VPS nodes
+6. Verify connectivity: `redis-cli -h REDIS_PRIVATE_IP -a PASSWORD ping` from an app node
+
+### Phase 2: Application Integration
+1. Add `redis:8.6-alpine` to `docker-compose.yml` (dev) — see §5 for the intended service definition
+2. Add `REDIS_URL` / `REDIS_PASSWORD` to `internal/config/config.go`
+3. Create `internal/cache/redis.go` wrapper with circuit breaker and health check
+4. Wire into `main.go` — create client on startup, pass to services
+5. Add Redis ping to `/healthz` endpoint (non-fatal: report status but don't fail health check)
+
+### Phase 3: Redis Streams for SSE
+1. Create `internal/cache/streams.go` with `StreamPublish()` (XADD) and `StreamRange()` (XRANGE for catch-up) helpers
+2. Implement fan-out manager: one goroutine per node per active session calls `XREAD BLOCK` from tail (`$`); maintains a ~1000-entry ring buffer of recently seen entries; SSE clients register bounded send channels (~256 capacity); goroutine exits when no local clients remain
+3. Modify log-writing path to `XADD` to `stream:session:{id}:logs` (with `MAXLEN ~ 10000`) after DB insert
+4. Modify SSE handler to accept `?last_event_id=...` on reconnect. On connect: (a) replay from ring buffer if last-seen is in range, (b) else `XRANGE` catch-up from stream, (c) else Postgres backfill. Then register with fan-out.
+5. Implement slow-consumer handling: if fan-out send-to-client would block, close the client channel. SSE handler sends `event: error` / `data: slow consumer` and disconnects; client reconnects via the catch-up path.
+6. Modify session status updates to `XADD` to `stream:session:{id}:status`
+7. Add `EXPIREAT` calls in session teardown path for both `:logs` and `:status` streams
+8. Add periodic cleanup goroutine (every 10 min, batched at 500 rows — see §2.5) to delete orphaned streams for terminated sessions
+
+### Phase 4: Distributed Rate Limiting
+1. Create `internal/cache/ratelimit.go` with sliding-window `INCR`/`EXPIRE` counter
+2. Modify rate-limit middleware to check Redis on every request when available
+3. When the circuit breaker reports Redis unavailable, fall back to per-node in-memory buckets (current behavior). Do not run both in parallel — one or the other, chosen by breaker state.
+
+### Phase 5: Job Notifications
+1. After job insertion, `PUBLISH` to `jobs:notify`
+2. Worker subscribes to `jobs:notify`; on message, immediately attempt job claim
+3. Keep 5s poll interval as safety net
+
+### Phase 6: Auth Token Cache (deferred — validate with metrics first)
+**Gate:** Before implementing, confirm from production metrics that auth session lookup is a meaningful p99 API latency contributor. If it's in the noise (likely, for a single indexed Postgres query), skip this phase.
+
+If implemented:
+1. On successful auth session lookup, `SET 143:auth:token:{hash} {user_json} EX {ttl}`
+2. On API request, check Redis first; cache miss falls through to Postgres and populates the cache
+3. On single logout / token revocation, `DEL 143:auth:token:{hash}`
+4. Bulk revocation ("revoke all for user X") is a `SCAN`-based maintenance path, not a request-path concern — see §2.4
+
+---
+
+## 8. Failure Modes and Graceful Degradation
+
+| Failure | Impact | Mitigation |
+|---------|--------|------------|
+| Redis down | SSE falls back to DB polling; rate limiting becomes per-node; job latency stays at 5s; auth hits Postgres | All current behavior. Zero data loss. |
+| Redis slow | Timeouts (3s read/write) trigger fallback | Circuit breaker pattern: after N consecutive failures, skip Redis for M seconds |
+| Redis full | `OOM` errors on write | Set `maxmemory-policy allkeys-lru`; all data is reconstructable from Postgres |
+| Network partition | Some nodes lose Redis, others don't | Each node independently falls back. No split-brain risk because Redis is not authoritative. |
+
+### Circuit Breaker
+
+Uses an **error-rate over a sliding window** rather than a consecutive-failure count. Consecutive counts are brittle under bursty workloads: a 5-in-a-row failure threshold can trip from a normal network blip coinciding with low-volume traffic, while high-volume traffic with 50% failure rate might never accumulate 5 consecutive failures because successes keep resetting the counter.
+
+**Parameters:**
+- **Window:** 10 seconds
+- **Min samples before opening:** 20 (don't trip the breaker on 1-of-2 failures)
+- **Error-rate threshold:** 50% over the window
+- **Cooldown:** 10 seconds (shorter than the original 30s — half-open probes are cheap, and we prefer to return to healthy Redis quickly)
+- **Half-open probe:** single request; success → closed, failure → open (cooldown restarted)
+
+```go
+// internal/cache/breaker.go
+
+// States: closed (0) = healthy, open (1) = failing, half-open (2) = probing
+const (
+    stateClosed   int32 = 0
+    stateOpen     int32 = 1
+    stateHalfOpen int32 = 2
+)
+
+type CircuitBreaker struct {
+    state    atomic.Int32
+    openedAt atomic.Int64 // unix nanos
+
+    // Sliding-window counters — bucketed by second, rolled every tick.
+    window     time.Duration // e.g. 10s
+    minSamples int32         // e.g. 20
+    errorRate  float64       // e.g. 0.5
+    cooldown   time.Duration // e.g. 10s
+
+    mu      sync.Mutex
+    buckets []bucket // ring of 1-second buckets covering `window`
+}
+
+type bucket struct {
+    ts       int64
+    attempts int32
+    failures int32
+}
+
+// Allow returns true if the caller may issue a Redis command.
+// Uses CAS so exactly one goroutine transitions open → half-open per cooldown.
+func (cb *CircuitBreaker) Allow() bool {
+    switch cb.state.Load() {
+    case stateClosed:
+        return true
+    case stateOpen:
+        if time.Since(time.Unix(0, cb.openedAt.Load())) > cb.cooldown {
+            if cb.state.CompareAndSwap(stateOpen, stateHalfOpen) {
+                return true // this goroutine is the probe
+            }
+        }
+        return false
+    case stateHalfOpen:
+        return false
+    }
+    return false
+}
+
+// RecordSuccess: in half-open, closes the breaker. Always records in the
+// current-second bucket.
+func (cb *CircuitBreaker) RecordSuccess() {
+    cb.record(false)
+    cb.state.CompareAndSwap(stateHalfOpen, stateClosed)
+}
+
+// RecordFailure: records in the current-second bucket. Opens the breaker if
+// error rate over the window exceeds threshold and we have enough samples.
+// In half-open, a single failure re-opens immediately.
+func (cb *CircuitBreaker) RecordFailure() {
+    cb.record(true)
+    if cb.state.Load() == stateHalfOpen {
+        cb.openedAt.Store(time.Now().UnixNano())
+        cb.state.Store(stateOpen)
+        return
+    }
+    attempts, failures := cb.windowStats()
+    if attempts >= cb.minSamples && float64(failures)/float64(attempts) >= cb.errorRate {
+        cb.openedAt.Store(time.Now().UnixNano())
+        cb.state.CompareAndSwap(stateClosed, stateOpen)
+    }
+}
+```
+
+Caller contract: wrap every short-lived Redis command in `breaker.Allow()` / `breaker.RecordSuccess()` / `breaker.RecordFailure()`. Context timeouts (3s read/write from `TimeoutConfig`) count as failures.
+
+### 8.1 Postgres Fallback Load Analysis
+
+When the breaker opens or Redis goes down, all four feature paths fall back to Postgres. Estimate the worst-case load so Postgres is sized for it:
+
+| Path | Peak fallback load (per node, worst case) | Notes |
+|------|--------------------------------------------|-------|
+| SSE log streaming | 1 query/sec × active sessions on that node | e.g. 20 sessions = 20 QPS/node. Existing behavior — Postgres already handles this. |
+| Rate limiting | 0 extra queries | In-memory bucket doesn't touch Postgres. |
+| Job notifications | 1 query / (5s × worker count) — i.e. current polling | Existing behavior. |
+| Auth cache (if Phase 6 lands) | 1 query per API request | Pre-cache behavior. |
+
+**Aggregate:** For a 10-node cluster with 20 active sessions per node and 100 req/s per node of authenticated API traffic, Redis-down adds:
+- 200 SSE poll QPS (already the pre-Redis baseline)
+- 1,000 auth lookup QPS (if Phase 6 is live — these were previously cache hits in Redis)
+
+Both are well within what a correctly-indexed Postgres handles, but the auth-lookup bump is worth knowing about. If Phase 6 is implemented, ensure the `auth_sessions.token` index is present and `EXPLAIN` shows an index-only scan. Track `pg_stat_statements` for `SELECT ... FROM auth_sessions` during synthetic Redis-down tests.
+
+**What isn't absorbed by graceful degradation:** A prolonged Redis outage during a traffic spike *does* put more load on Postgres than the Redis-up steady state. The design accepts this: the point of Redis is to make the common case cheap, not to create a harder failure mode. But it means "Redis-down is survivable" is not the same as "Redis-down is free."
+
+---
+
+## 9. Key Namespace and TTL Strategy
+
+All Redis keys use the `143:` prefix to avoid collisions if Redis is shared with other services in the future.
+
+**Hash tag strategy (Cluster mode — future, not needed at current scale):** Only session stream keys use hash tags (`{ses:ID}`) to co-locate the `:logs` and `:status` streams for the same session on one shard. Auth and rate-limit keys are accessed independently and don't need co-location, so they intentionally omit hash tags — this distributes them evenly across shards. Until we actually run a Redis Cluster (§6.5), the hash tags are inert (a standalone Redis ignores them).
+
+| Key pattern | Type | TTL | Size estimate | Purpose |
+|-------------|------|-----|---------------|---------|
+| `143:stream:{ses:ID}:logs` | Stream | `MAXLEN ~ 10000` + `MINID ~ now-60min` on every XADD; entries clamped to 4KB; idle streams expire via `EXPIREAT` 1h after session ends (set by teardown path; orphans cleaned by periodic goroutine — see §2.5) | ~500B per entry (~5MB max) | Log streaming |
+| `143:stream:{ses:ID}:status` | Stream | `MAXLEN ~ 100`; same idle expiry | ~200B per entry | Status broadcasts |
+| `143:ratelimit:org:{id}:{window}` | String (counter) | `EXPIRE` 2x window duration; self-cleans | ~32B | Rate limiting |
+| `143:auth:token:{hash}` | String | Matches `expires_at` (typ. 24h) | ~1KB | Auth session cache (Phase 6; deferred — see §2.4) |
+| `143:jobs:notify` | Pub/Sub channel | N/A (ephemeral) | N/A | Job wake-up signal |
+
+**MAXLEN configuration:** The default of 10000 covers typical sessions (5MB × 20 active sessions = 100MB per node's memory footprint contribution). For log-heavy agent sessions (e.g. verbose compilation output at 100+ entries/sec), operators can override via a `session_type.stream_maxlen` config — memory is cheap relative to the UX cost of a user seeing a gap when they briefly background a tab.
+
+**Read-after-write consistency (future managed deployments with replicas):** The use cases here are safe under eventual consistency: rate-limit counters are read and written on the same shard master (no replica reads involved), pub/sub is fire-and-forget, streams are typically read by different processes than the writer (and the write-then-read gap doesn't violate correctness — just adds latency), and auth cache invalidations are `DEL`s on master. If we ever add a read-replica for load-spreading, revisit cases where the same request writes and then reads within ~50ms.
+
+### 9.1 Connection Pool Sizing
+
+The `go-redis` default pool size is `10 * runtime.GOMAXPROCS`. This covers normal command traffic, but Redis Streams subscribers (`XREAD BLOCK`) and Pub/Sub subscribers each hold a dedicated connection for the lifetime of the subscription.
+
+**Formula:** `pool_size = command_concurrency + active_stream_fan_out_goroutines + pubsub_subscriptions`
+
+For a node with 20 active sessions (each with a fan-out goroutine) and subscribing to `jobs:notify`:
+- Command pool: 20 (default is fine for most workloads)
+- Stream readers: 20 (one `XREAD BLOCK` per active session per node, **not** per SSE client — see fan-out pattern in Section 2.1)
+- Pub/Sub: 1 (jobs channel)
+- **Total: ~41 connections per node**
+
+With 10 nodes, that's ~410 connections — well within Redis's default 10,000 connection limit. Monitor `redis_connection_pool_size` and `redis_connection_pool_idle` metrics (below) to validate sizing in production.
+
+**Configuration:** Set `REDIS_POOL_SIZE` to the command pool portion only. Stream/Pub/Sub connections are managed separately by `go-redis` outside the pool.
+
+### 9.2 Revisiting Stream Sizing Later
+
+The defaults above (MAXLEN 10000, MINID 60min, 4KB entry clamp) are sized for the initial rollout. If/when we need to scale well past the initial target, re-check two things: **average entry size after truncation** (the `session_log_entry_bytes` histogram — add it when Phase 3 lands), and **peak concurrent active sessions**. Rough budget per active session is `MAXLEN × avg_entry_size × 1.3 (Redis overhead)`; multiply by concurrent sessions for total working-set memory. If that exceeds ~60% of Redis memory, either lower MAXLEN for noisier session types, tighten the entry clamp, or upsize Redis. Day-one instinct is fine; measure before re-tuning.
+
+---
+
+## 10. Observability
+
+- **Metrics** (Prometheus, already in use):
+  - `redis_commands_total{command}` — command volume
+  - `redis_command_duration_seconds{command}` — latency histogram
+  - `redis_connection_pool_size` / `redis_connection_pool_idle` — pool health
+  - `redis_pubsub_channels` — active subscription count
+  - `redis_fallback_total{reason}` — how often we degrade to non-Redis path
+  - `session_log_entry_bytes` — histogram of log-entry size at XADD time (post-truncation); feeds §9.2 sizing decisions
+
+- **Logging** (zerolog, already in use):
+  - Log Redis connection/disconnection at `info` level
+  - Log fallback activations at `warn` level
+  - Log circuit breaker state changes at `error` level
+
+- **Alerting** (recommended thresholds):
+  - `redis_fallback_total` rate > 0 sustained for 5 min: warn (Redis may be degraded)
+  - `redis_fallback_total` rate > 0 sustained for 30 min: page (extended Redis outage, investigate)
+  - `redis_command_duration_seconds` p99 > 100ms: warn (Redis latency elevated)
+  - Circuit breaker state changes (`redis_circuit_breaker_state`): log at `error`, alert on open → useful for correlating with Redis infrastructure events
+
+- **Health check**:
+  - `/healthz` includes `"redis": "ok"` or `"redis": "unavailable"` (never fails the health check)
+
+---
+
+## 11. Security
+
+- **No secrets in Redis.** Auth tokens stored as hashed keys; the cached value is the session metadata, not the raw token.
+- **TLS in production.** Use `rediss://` URL scheme; `go-redis` handles TLS automatically.
+- **ACL authentication.** Use `REDIS_PASSWORD` with Redis 6+ ACL system.
+- **Network isolation.** In Docker Compose, Redis is on the internal network (no port exposure needed in production). In cloud, use VPC-internal endpoints.
+
+---
+
+## 12. Cost and Resource Estimate
+
+| Environment | Setup | Memory | HA | Cost |
+|-------------|-------|--------|----|------|
+| Development | `redis:8.6-alpine` in Docker Compose | 256MB limit | none | $0 (local) |
+| Self-hosted prod — single node | Dedicated CX22 VPS running `docker-compose.redis.yml` | 512MB limit | none (SPOF; see §6.1) | ~€4/month (~$5) |
+| Self-hosted prod — Sentinel | 2–3 CX22 VPSes with Redis Sentinel | 512MB each | auto-failover, self-managed | ~€8–12/month |
+| Small managed (1-3 nodes) | Single Redis instance (e.g., ElastiCache `cache.t4g.micro`) | 0.5GB | managed snapshots | ~$12/month (~256 max connections — well above the ~41/node estimate in §9.1) |
+| Medium managed (3-10 nodes) | Redis with replica (e.g., `cache.t4g.small` + replica) | 1.5GB x2 | multi-AZ auto-failover | ~$50/month |
+| Large managed (10+ nodes) | Redis Cluster (3 shards + replicas) | 3GB per shard | sharded + replicated | ~$200/month |
+
+Redis memory usage for 143's workload will be minimal: pub/sub messages are transient, rate-limit keys are small integers with TTLs, and cached tokens are <1KB each.
+
+---
+
+## 13. Testing Strategy
+
+Redis integration must be tested at two levels: unit tests with a mock, and integration tests with a real Redis instance.
+
+### 13.1 Unit Tests (miniredis)
+
+Use [`github.com/alicebob/miniredis/v2`](https://github.com/alicebob/miniredis) — a pure-Go in-memory Redis server that runs in-process. No external dependencies, instant startup, deterministic time control.
+
+```go
+func TestStreamPublish(t *testing.T) {
+    mr := miniredis.RunT(t)
+    rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+    client := &cache.Client{/* wrap rdb */}
+
+    client.StreamPublish(ctx, "stream:session:abc:logs", map[string]any{"msg": "hello"})
+
+    // miniredis supports XADD/XREAD — verify the stream entry exists
+    assert.True(t, mr.Exists("stream:session:abc:logs"))
+}
+```
+
+Use miniredis for: client wrapper logic, circuit breaker behavior, rate limit INCR/EXPIRE correctness, key TTL/expiry logic.
+
+### 13.2 Integration Tests (testcontainers)
+
+Use [`github.com/testcontainers/testcontainers-go`](https://github.com/testcontainers/testcontainers-go) to spin up a real `redis:8.6-alpine` container for integration tests that need full Redis behavior (stream blocking, real pub/sub timing, connection pool exhaustion).
+
+```go
+func TestSSEReconnectReplay(t *testing.T) {
+    if testing.Short() {
+        t.Skip("integration test requires Docker")
+    }
+    ctx := context.Background()
+    container, _ := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+        ContainerRequest: testcontainers.ContainerRequest{
+            Image:        "redis:8.6-alpine",
+            ExposedPorts: []string{"6379/tcp"},
+            WaitingFor:   wait.ForLog("Ready to accept connections"),
+        },
+        Started: true,
+    })
+    defer container.Terminate(ctx)
+    // ... test that SSE handler replays missed stream entries on reconnect
+}
+```
+
+### 13.3 Fallback Path Tests
+
+**Critical:** Every Redis-dependent code path has a fallback. All three states must be tested:
+
+| Code path | Redis-up | Redis-down (start) | Redis dies mid-session |
+|-----------|----------|---------------------|------------------------|
+| SSE log streaming | `XREAD BLOCK` delivers entries | 1s Postgres poll works | Client still receives entries via Postgres poll after Redis drops; no duplicate delivery once Redis recovers |
+| Rate limiting | Global INCR counter enforces limit | Per-node in-memory limiter enforces per-node limit | Switch from Redis to in-memory happens within breaker cooldown; no request is double-counted |
+| Job notifications | Instant wake on `PUBLISH` | 5s poll claims jobs | In-flight Subscribe reconnects automatically; poll continues as safety net |
+| Auth token cache (if Phase 6) | Cache hit skips Postgres | Cache miss falls through | Hot path reverts to Postgres within breaker cooldown; no stale reads served |
+
+**Testing the transition:** For each path, a testcontainers-based test should:
+1. Start with Redis up, verify Redis path is active
+2. Kill the Redis container (or block its network with `docker network disconnect`)
+3. Issue requests during the outage, verify fallback path serves them within the breaker cooldown
+4. Restart Redis, verify the breaker closes and the Redis path resumes
+
+This catches bugs that neither pure Redis-up nor pure Redis-down tests find — e.g. in-flight subscriber connections hanging, breaker oscillation, or cache invalidations being silently dropped during the outage window.
+
+For pure Redis-down tests (no transition), either pass a nil `cache.Client` or configure the circuit breaker to start in open state.
+
+---
+
+## 14. Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| **Postgres LISTEN/NOTIFY** | Built-in, no new dependency. But: no message persistence, one channel per connection, doesn't scale well with many subscribers. Would solve pub/sub but not caching or rate limiting. |
+| **KeyDB** | Redis-compatible, multithreaded. Less ecosystem support, smaller community. Could be a drop-in replacement later if needed. |
+| **Valkey** | Redis fork (Linux Foundation). API-compatible. Could be swapped in via config change. Worth watching. |
+| **In-memory + gossip** | Build our own distributed cache. High complexity, bug-prone, doesn't add enough value over Redis. |
+| **No change** | Works today. But SSE polling and per-node rate limiting will become real problems at 5-10 nodes. |
+
+**Postgres LISTEN/NOTIFY** deserves special mention: it could handle the pub/sub use case (Phase 2) without any new dependency. However, it has limitations:
+- Each LISTEN requires a dedicated Postgres connection (not from the pool)
+- No message buffering — if a listener disconnects, messages are lost
+- Payload size limited to 8KB
+- Doesn't address caching or rate limiting needs
+
+Redis is the better investment because it solves multiple problems with one dependency.
+
+---
+
+## 15. Deployment Model: Redis is a Shared Service, Not Per-Container
+
+Redis runs as a **single, separate service** — not embedded inside each application container. All app nodes (API servers, workers) connect to the same Redis instance over the network.
+
+```
+┌──────────┐  ┌──────────┐  ┌──────────┐
+│  Node 1  │  │  Node 2  │  │  Node 3  │
+│  (app)   │  │  (app)   │  │  (worker) │
+└────┬─────┘  └────┬─────┘  └────┬─────┘
+     │              │              │
+     └──────────────┼──────────────┘
+                    │
+              ┌─────▼─────┐
+              │   Redis   │   ← single instance, shared by all nodes
+              │  (6379)   │
+              └───────────┘
+```
+
+**Why not per-container?** The entire value of Redis here (shared rate limits, cross-node pub/sub, global cache) requires a single shared instance. Per-container Redis would be equivalent to the in-memory approach we already have.
+
+**Spinning up a dedicated Redis node:** To run Redis on its own dedicated host/container (e.g., for resource isolation or scaling):
+1. Deploy `redis:8.6-alpine` on a separate Docker host, VM, or as a managed service
+2. Set `REDIS_URL=redis://<redis-host>:6379/0` (or `rediss://` for TLS) on all app nodes
+3. No code changes — the `go-redis` client connects to whatever `REDIS_URL` points to
+
+**Docker Compose (dev):** Redis is defined as a top-level service in `docker-compose.yml`. It shares the Docker network with the app but runs in its own container. To move it to a separate machine in the future, just change the URL.
+
+**Production:** Use a managed service (ElastiCache, Memorystore, etc.) — see Section 6. The app containers never run Redis internally.
+
+---
+
+## 16. Redis Version Requirements
+
+This design targets **Redis 8.x** (`redis:8.6-alpine` in Docker Compose). Redis 8.6 is the latest stable release, bringing performance, memory efficiency, and observability improvements. All features used here (Streams, Pub/Sub, `INCR`/`EXPIRE`, `EXPIREAT`, cluster-mode Pub/Sub) are fully supported in Redis 8.x.
+
+Redis 7.x would also work — all APIs used here are stable since Redis 7.0. However, since 8.x is the current stable line, there's no reason to target an older version.
+
+**Valkey compatibility:** All features used here (Streams, Pub/Sub, `INCR`/`EXPIRE`, `EXPIREAT`) are part of the Redis API that Valkey preserves. Switching to Valkey is a drop-in image change.
+
+---
+
+## 17. Rolling Deployment Considerations
+
+Because Redis is optional and all code paths have fallbacks, rolling deployments are safe:
+
+- **Adding Redis (first deploy):** Old nodes without the Redis code path simply ignore Redis. New nodes start using it as they roll in. No coordination required — both old and new nodes continue to read/write Postgres as the source of truth.
+- **Redis config changes:** Changing `REDIS_URL` during a rolling deploy means some nodes briefly point to the old Redis and others to the new one. This is fine — cached data is reconstructable, and pub/sub messages on the old instance are simply missed (the Postgres polling fallback covers the gap).
+- **Removing Redis (rollback):** Set `REDIS_URL=""` and redeploy. All nodes revert to pre-Redis behavior.
+
+---
+
+## 18. Decision
+
+**Recommended approach:** Add Redis as an optional, gracefully-degrading dependency. Start with Phase 1 (Hetzner provisioning), Phase 2 (application integration), and Phase 3 (Redis Streams for SSE) — these deliver the highest value by eliminating the SSE polling floor. Phases 4 (rate limiting) and 5 (job notifications) can be added when node count or org count crosses thresholds where per-node limiting actually causes problems. Phase 6 (auth cache) is explicitly **gated on measurement** — confirm from metrics that auth is a p99 contributor before implementing.
+
+The key design constraint — Redis is never authoritative — means we get performance benefits without operational risk. The migration path from Docker Compose to hosted Redis is a config change, not a code change.
+
+**Operational decisions still open (see review notes):**
+- Self-hosted single VPS vs. Sentinel/managed HA for production Redis (see §6.1, §12)
+- Final SSE MAXLEN default (currently 10000; bump if agent logs are chattier than expected)
+- Whether to implement Phase 6 at all (may never be needed)


### PR DESCRIPTION
## Summary
- Adds `docs/design/future/46-redis.md` — full design for Redis as an optional, gracefully-degrading accelerator (SSE log streams, distributed rate limiting, job-queue notifications, short-lived caches). Redis is never authoritative; every path falls back to current Postgres behavior.
- Updates `docs/design/36-docker-agents-vps-architecture.md` with a new "Step 3d: Add a Dedicated Redis Node" deployment path and points the existing rate-limit and SSE-polling future-work notes at the new design.
- No application code or `docker-compose.yml` changes — design phase only.

## Test plan
- [ ] Review the two design docs for technical direction and any open questions called out in §18 of `46-redis.md`