### PR TITLE
Inject Anthropic credentials into PM sandboxes and surface auth failures

### DIFF
--- a/internal/services/pm/bootstrap.go
+++ b/internal/services/pm/bootstrap.go
@@ -58,6 +58,7 @@ func (s *Service) runAgentInSandbox(ctx context.Context, params sandboxRunParams
 
 	sbCfg := bootstrapSandboxConfig()
 	sbCfg.Env = resolveBootstrapEnv(&creds, ghToken, &repo)
+	s.applyClaudeCodeEnv(ctx, params.orgID, sbCfg.Env)
 	sb, err := s.sandbox.Create(ctx, sbCfg)
 	if err != nil {
 		return nil, noop, fmt.Errorf("create sandbox: %w", err)

--- a/internal/services/pm/plan.go
+++ b/internal/services/pm/plan.go
@@ -10,7 +10,20 @@ func parsePlan(output string) (*Plan, error) {
 	start := strings.Index(output, "<pm-plan>")
 	end := strings.Index(output, "</pm-plan>")
 	if start == -1 || end == -1 || end <= start {
-		return nil, fmt.Errorf("pm plan tags not found")
+		// Surface common upstream failures (e.g. Claude Code CLI auth errors)
+		// so they don't get buried behind a generic "tags not found".
+		trimmed := strings.TrimSpace(output)
+		if trimmed == "" {
+			return nil, fmt.Errorf("pm plan tags not found: agent produced no output")
+		}
+		if strings.Contains(output, "Not logged in") ||
+			strings.Contains(output, "Please run /login") ||
+			strings.Contains(output, "authentication_failed") ||
+			strings.Contains(output, "invalid api key") ||
+			strings.Contains(output, "invalid_api_key") {
+			return nil, fmt.Errorf("pm agent not authenticated — configure an Anthropic API key for this org: %s", excerpt(output, 200))
+		}
+		return nil, fmt.Errorf("pm plan tags not found in agent output: %s", excerpt(output, 500))
 	}
 
 	content := strings.TrimSpace(output[start+len("<pm-plan>") : end])
@@ -19,13 +32,13 @@ func parsePlan(output string) (*Plan, error) {
 	}
 
 	var payload struct {
-		Analysis       string           `json:"analysis"`
-		Tasks          []Task           `json:"tasks"`
-		Clusters       []Cluster        `json:"clusters"`
-		Skip           []SkipEntry      `json:"skip"`
-		ProjectPlans   []ProjectPlan    `json:"project_plans,omitempty"`
-		LinearActions  []LinearAction   `json:"linear_actions,omitempty"`
-		SlotAllocation *SlotAllocation  `json:"slot_allocation,omitempty"`
+		Analysis       string          `json:"analysis"`
+		Tasks          []Task          `json:"tasks"`
+		Clusters       []Cluster       `json:"clusters"`
+		Skip           []SkipEntry     `json:"skip"`
+		ProjectPlans   []ProjectPlan   `json:"project_plans,omitempty"`
+		LinearActions  []LinearAction  `json:"linear_actions,omitempty"`
+		SlotAllocation *SlotAllocation `json:"slot_allocation,omitempty"`
 	}
 
 	if err := json.Unmarshal([]byte(content), &payload); err != nil {
@@ -55,4 +68,15 @@ func parsePlan(output string) (*Plan, error) {
 		LinearActions:  payload.LinearActions,
 		SlotAllocation: payload.SlotAllocation,
 	}, nil
+}
+
+// excerpt returns a trimmed, single-line preview of s capped at max runes so
+// error messages don't dump megabytes of CLI output into logs.
+func excerpt(s string, max int) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len([]rune(s)) > max {
+		return string([]rune(s)[:max]) + "…"
+	}
+	return s
 }

--- a/internal/services/pm/plan_test.go
+++ b/internal/services/pm/plan_test.go
@@ -159,6 +159,20 @@ func TestParsePlan_MissingTagsIncludesExcerpt(t *testing.T) {
 	require.Contains(t, err.Error(), "decided not to emit", "error should embed output excerpt")
 }
 
+func TestExcerpt_TruncatesAndCollapsesNewlines(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "hello world", excerpt("  hello\nworld  ", 100),
+		"excerpt should trim edges and collapse newlines into spaces")
+
+	long := "abcdefghijklmnop"
+	got := excerpt(long, 5)
+	require.Equal(t, "abcde…", got, "excerpt should cap at max runes and append ellipsis")
+
+	require.Equal(t, "fits", excerpt("fits", 10),
+		"excerpt should leave short input unchanged")
+}
+
 func TestParsePlan_InvalidEnums(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/pm/plan_test.go
+++ b/internal/services/pm/plan_test.go
@@ -127,6 +127,38 @@ func TestParsePlan_WithLinearActions(t *testing.T) {
 	require.Equal(t, "re_prioritize", plan.LinearActions[0].Action, "should parse linear action type")
 }
 
+func TestParsePlan_AuthFailureSurface(t *testing.T) {
+	t.Parallel()
+
+	// Claude Code CLI prints this when ANTHROPIC_API_KEY is missing.
+	output := `{"type":"assistant","content":[{"type":"text","text":"Not logged in · Please run /login"}],"error":"authentication_failed"}`
+
+	_, err := parsePlan(output)
+	require.Error(t, err, "missing auth should produce an error")
+	require.Contains(t, err.Error(), "not authenticated", "error should identify auth root cause, not tag parsing")
+}
+
+func TestParsePlan_EmptyOutput(t *testing.T) {
+	t.Parallel()
+
+	_, err := parsePlan("   \n\n   ")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no output", "empty output should produce a descriptive error")
+}
+
+func TestParsePlan_MissingTagsIncludesExcerpt(t *testing.T) {
+	t.Parallel()
+
+	// Non-auth output without tags should still surface a snippet so the
+	// operator can diagnose why the agent didn't emit a plan.
+	output := "I thought about this for a while but decided not to emit a plan."
+
+	_, err := parsePlan(output)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pm plan tags not found")
+	require.Contains(t, err.Error(), "decided not to emit", "error should embed output excerpt")
+}
+
 func TestParsePlan_InvalidEnums(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/pm/project_analyze.go
+++ b/internal/services/pm/project_analyze.go
@@ -69,6 +69,10 @@ func (s *Service) AnalyzeProject(ctx context.Context, orgID, projectID uuid.UUID
 
 	// Create sandbox and clone repo.
 	sbCfg := pmSandboxConfig()
+	if sbCfg.Env == nil {
+		sbCfg.Env = make(map[string]string)
+	}
+	s.applyClaudeCodeEnv(ctx, orgID, sbCfg.Env)
 	sb, err := s.sandbox.Create(ctx, sbCfg)
 	if err != nil {
 		return fmt.Errorf("create sandbox: %w", err)

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -302,6 +302,14 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	}
 
 	sbCfg := pmSandboxConfig()
+	if sbCfg.Env == nil {
+		sbCfg.Env = make(map[string]string)
+	}
+
+	// Inject Anthropic credentials so the Claude Code CLI inside the sandbox
+	// can authenticate. Without this the CLI prints "Not logged in · Please
+	// run /login" and the agent produces no plan.
+	s.applyClaudeCodeEnv(ctx, orgID, sbCfg.Env)
 
 	// Inject internal API credentials so the PM agent can create issues.
 	if s.internalAPIURL != "" && s.internalAPISecret != "" {
@@ -311,9 +319,6 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 		if tokenErr != nil {
 			s.logger.Warn().Err(tokenErr).Msg("failed to generate internal API token — issue creation will be unavailable")
 		} else {
-			if sbCfg.Env == nil {
-				sbCfg.Env = make(map[string]string)
-			}
 			sbCfg.Env["INTERNAL_API_TOKEN"] = internalToken
 			sbCfg.Env["INTERNAL_API_URL"] = s.internalAPIURL
 		}
@@ -524,6 +529,32 @@ func (s *Service) streamPMLogs(ctx context.Context, pmSession *models.Session, l
 		if err := s.sessionLogs.Create(ctx, log); err != nil {
 			s.logger.Error().Err(err).Msg("failed to persist PM log entry")
 		}
+	}
+}
+
+// applyClaudeCodeEnv fetches Anthropic credentials from the org credential
+// store and writes ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL into env. Safe to
+// call when no credential store is configured or no credential is set — the
+// env map is left unchanged and the caller surfaces the downstream failure.
+func (s *Service) applyClaudeCodeEnv(ctx context.Context, orgID uuid.UUID, env map[string]string) {
+	if s.credentials == nil || env == nil {
+		return
+	}
+	cred, err := s.credentials.Get(ctx, orgID, models.ProviderAnthropic)
+	if err != nil || cred == nil {
+		s.logger.Warn().Err(err).Msg("no Anthropic credential configured for PM agent — Claude Code CLI will fail to authenticate")
+		return
+	}
+	cfg, ok := cred.Config.(models.AnthropicConfig)
+	if !ok {
+		s.logger.Warn().Msg("Anthropic credential has unexpected config type")
+		return
+	}
+	if cfg.APIKey != "" {
+		env["ANTHROPIC_API_KEY"] = cfg.APIKey
+	}
+	if cfg.BaseURL != "" {
+		env["ANTHROPIC_BASE_URL"] = cfg.BaseURL
 	}
 }
 

--- a/internal/services/pm/service_helpers_test.go
+++ b/internal/services/pm/service_helpers_test.go
@@ -1,6 +1,7 @@
 package pm
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -76,4 +77,86 @@ func TestPlanToModelAndTokenMode(t *testing.T) {
 	require.Equal(t, "low", tokenModeFromComplexity(models.PMTaskComplexitySimple), "tokenModeFromComplexity should use low tokens for simple tasks")
 	require.Equal(t, "high", tokenModeFromComplexity(models.PMTaskComplexityModerate), "tokenModeFromComplexity should use high tokens for moderate tasks")
 	require.Equal(t, "high", tokenModeFromComplexity(models.PMTaskComplexityComplex), "tokenModeFromComplexity should use high tokens for complex tasks")
+}
+
+func TestApplyClaudeCodeEnv(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+
+	t.Run("no credential store leaves env unchanged", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{logger: zerolog.Nop()}
+		env := map[string]string{"EXISTING": "value"}
+		svc.applyClaudeCodeEnv(context.Background(), orgID, env)
+		require.Equal(t, map[string]string{"EXISTING": "value"}, env)
+	})
+
+	t.Run("nil env map is a no-op", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{
+			credentials: &mockCredStore{creds: map[models.ProviderName]*models.DecryptedCredential{
+				models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant-test"}},
+			}},
+			logger: zerolog.Nop(),
+		}
+		// Should not panic despite nil env.
+		svc.applyClaudeCodeEnv(context.Background(), orgID, nil)
+	})
+
+	t.Run("missing credential leaves env unchanged", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{
+			credentials: &mockCredStore{creds: map[models.ProviderName]*models.DecryptedCredential{}},
+			logger:      zerolog.Nop(),
+		}
+		env := map[string]string{}
+		svc.applyClaudeCodeEnv(context.Background(), orgID, env)
+		require.Empty(t, env, "missing Anthropic credential should leave env empty")
+	})
+
+	t.Run("wrong config type leaves env unchanged", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{
+			credentials: &mockCredStore{creds: map[models.ProviderName]*models.DecryptedCredential{
+				models.ProviderAnthropic: {Config: models.OpenAIConfig{APIKey: "sk-openai"}},
+			}},
+			logger: zerolog.Nop(),
+		}
+		env := map[string]string{}
+		svc.applyClaudeCodeEnv(context.Background(), orgID, env)
+		require.Empty(t, env, "unexpected config type should leave env untouched")
+	})
+
+	t.Run("injects api key and base url when present", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{
+			credentials: &mockCredStore{creds: map[models.ProviderName]*models.DecryptedCredential{
+				models.ProviderAnthropic: {Config: models.AnthropicConfig{
+					APIKey:  "sk-ant-real",
+					BaseURL: "https://anthropic.example.com",
+				}},
+			}},
+			logger: zerolog.Nop(),
+		}
+		env := map[string]string{}
+		svc.applyClaudeCodeEnv(context.Background(), orgID, env)
+		require.Equal(t, "sk-ant-real", env["ANTHROPIC_API_KEY"])
+		require.Equal(t, "https://anthropic.example.com", env["ANTHROPIC_BASE_URL"])
+	})
+
+	t.Run("omits base url when not set", func(t *testing.T) {
+		t.Parallel()
+		svc := &Service{
+			credentials: &mockCredStore{creds: map[models.ProviderName]*models.DecryptedCredential{
+				models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant-only"}},
+			}},
+			logger: zerolog.Nop(),
+		}
+		env := map[string]string{}
+		svc.applyClaudeCodeEnv(context.Background(), orgID, env)
+		require.Equal(t, "sk-ant-only", env["ANTHROPIC_API_KEY"])
+		_, hasBase := env["ANTHROPIC_BASE_URL"]
+		require.False(t, hasBase, "base URL should not be set when empty")
+	})
 }


### PR DESCRIPTION
## Summary
- The PM agent's sandboxes (Analyze, AnalyzeProject, bootstrap/refresh) never had \`ANTHROPIC_API_KEY\` injected, so the Claude Code CLI inside failed with \`Not logged in · Please run /login\` and produced no plan — which then surfaced as the opaque \`parse plan: pm plan tags not found\`.
- Added \`Service.applyClaudeCodeEnv\` that pulls the org's Anthropic credential from the credential store and writes \`ANTHROPIC_API_KEY\` / \`ANTHROPIC_BASE_URL\` into the sandbox env, and wired it into all three PM sandbox entry points.
- Taught \`parsePlan\` to recognize common auth-failure output (\`Not logged in\`, \`Please run /login\`, \`authentication_failed\`, \`invalid api key\`) and return a descriptive error that names the root cause; non-auth tagless outputs now include a bounded excerpt so operators can diagnose without fishing through logs.

## Test plan
- [x] \`go test ./...\` passes
- [x] \`make lint\` passes
- [ ] Run a PM cycle against an org with an Anthropic credential configured and confirm the plan parses
- [ ] Remove the credential and confirm the failure now reads \"pm agent not authenticated\" instead of \"pm plan tags not found\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)