### PR TITLE
Prevent long content from overflowing session and project cards

### DIFF
--- a/frontend/src/app/(dashboard)/projects/[id]/plan-tab.tsx
+++ b/frontend/src/app/(dashboard)/projects/[id]/plan-tab.tsx
@@ -218,7 +218,7 @@ export function SpecsSection({
                 {isEditing ? (
                   <Textarea value={editContent} onChange={(e) => setEditContent(e.target.value)} rows={16} className="font-mono text-xs" />
                 ) : (
-                  <pre className="whitespace-pre-wrap text-xs bg-muted/30 rounded-md p-4 font-mono">
+                  <pre className="whitespace-pre-wrap break-words text-xs bg-muted/30 rounded-md p-4 font-mono max-w-full">
                     {spec.content || "(empty)"}
                   </pre>
                 )}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -209,7 +209,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             </div>
           </CardHeader>
           <CardContent className="pt-0 space-y-3">
-            <p className="text-xs">{session.failure_explanation || session.error}</p>
+            <p className="text-xs break-words">{session.failure_explanation || session.error}</p>
             {/* Show next steps only for non-codex-auth failures (codex auth has the reauth button instead) */}
             {!isCodexAuthFailure && session.failure_next_steps && session.failure_next_steps.length > 0 && (
               <div>
@@ -316,13 +316,13 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
             {session.pm_reasoning && (
               <div>
                 <p className="text-xs font-medium text-muted-foreground">Why this was prioritized</p>
-                <p>{session.pm_reasoning}</p>
+                <p className="break-words">{session.pm_reasoning}</p>
               </div>
             )}
             {session.pm_approach && (
               <div>
                 <p className="text-xs font-medium text-muted-foreground">Suggested approach</p>
-                <p>{session.pm_approach}</p>
+                <p className="break-words">{session.pm_approach}</p>
               </div>
             )}
           </CardContent>

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -108,7 +108,7 @@ function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResu
   const inputDetail = formatToolInput(toolUse);
 
   return (
-    <div className="mx-2">
+    <div className="mx-2 min-w-0">
       <button
         onClick={() => setOpen(!open)}
         className="flex items-center gap-2 w-full text-left py-1.5 px-2 rounded-md hover:bg-muted/50 transition-colors text-xs group"
@@ -122,17 +122,17 @@ function ToolGroupEntry({ toolUse, toolResult }: { toolUse: SessionLog; toolResu
         />
       </button>
       {open && (
-        <div className="ml-7 mt-1 mb-2 space-y-1.5">
+        <div className="ml-7 mt-1 mb-2 space-y-1.5 min-w-0">
           {inputDetail && (
-            <div className="rounded-md border border-border bg-muted/30 p-2 overflow-x-auto">
-              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-foreground/80">
+            <div className="rounded-md border border-border bg-muted/30 p-2 min-w-0 max-w-full">
+              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-foreground/80 max-w-full">
                 {inputDetail}
               </pre>
             </div>
           )}
           {toolResult ? (
-            <div className="rounded-md border border-border bg-muted/30 p-2 overflow-x-auto">
-              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground">
+            <div className="rounded-md border border-border bg-muted/30 p-2 min-w-0 max-w-full">
+              <pre className="text-xs font-mono whitespace-pre-wrap break-all text-muted-foreground max-w-full">
                 {toolResult.message}
               </pre>
             </div>
@@ -155,11 +155,11 @@ function ErrorEntry({ log }: { log: SessionLog }) {
   const displayMessage = !isLong || expanded ? log.message : log.message.slice(0, 200) + "...";
 
   return (
-    <div className="mx-2 rounded-md border border-red-200 dark:border-red-900/50 bg-red-500/5 px-3 py-2">
-      <div className="flex items-start gap-2">
+    <div className="mx-2 min-w-0 max-w-full rounded-md border border-red-200 dark:border-red-900/50 bg-red-500/5 px-3 py-2">
+      <div className="flex items-start gap-2 min-w-0">
         <AlertTriangle className="h-3.5 w-3.5 text-red-600 dark:text-red-400 shrink-0 mt-0.5" />
         <div className="flex-1 min-w-0">
-          <pre className="text-xs font-mono whitespace-pre-wrap break-all text-red-700 dark:text-red-400">
+          <pre className="text-xs font-mono whitespace-pre-wrap break-all text-red-700 dark:text-red-400 max-w-full">
             {displayMessage}
           </pre>
           {isLong && (
@@ -183,7 +183,7 @@ function ErrorEntry({ log }: { log: SessionLog }) {
 
 function HiddenLogEntry({ log }: { log: SessionLog }) {
   return (
-    <div className="flex items-start gap-2 px-2 py-0.5 text-xs font-mono text-muted-foreground/70">
+    <div className="flex items-start gap-2 px-2 py-0.5 text-xs font-mono text-muted-foreground/70 min-w-0">
       <TimestampLabel
         dateStr={log.created_at}
         formatter={formatTimestamp}
@@ -195,7 +195,7 @@ function HiddenLogEntry({ log }: { log: SessionLog }) {
       >
         {log.level}
       </Badge>
-      <span className="break-all">{log.message}</span>
+      <span className="min-w-0 flex-1 break-all">{log.message}</span>
     </div>
   );
 }
@@ -206,7 +206,7 @@ function HiddenLogsGroup({ logs }: { logs: SessionLog[] }) {
   if (logs.length === 0) return null;
 
   return (
-    <div className="mx-2">
+    <div className="mx-2 min-w-0">
       <button
         onClick={() => setOpen(!open)}
         className="flex items-center gap-2 w-full text-left py-1.5 px-2 rounded-md hover:bg-muted/50 transition-colors text-xs group"
@@ -222,7 +222,7 @@ function HiddenLogsGroup({ logs }: { logs: SessionLog[] }) {
         />
       </button>
       {open && (
-        <div className="ml-7 mt-1 mb-2 rounded-md border border-border bg-muted/30 py-1 overflow-x-auto max-h-[300px] overflow-y-auto">
+        <div className="ml-7 mt-1 mb-2 min-w-0 max-w-full rounded-md border border-border bg-muted/30 py-1 max-h-[300px] overflow-y-auto">
           {logs.map((log) => (
             <HiddenLogEntry key={log.id} log={log} />
           ))}
@@ -359,7 +359,7 @@ function AttachmentGrid({ attachments }: { attachments: string[] }) {
 function AssistantBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[80%] rounded-lg px-3 py-2 text-sm bg-muted">
+      <div className="max-w-[92%] min-w-0 rounded-lg px-3 py-2 text-sm bg-muted break-words">
         {children}
       </div>
     </div>
@@ -376,14 +376,14 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
   if (msg.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[80%] rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm">
+        <div className="max-w-[92%] min-w-0 rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm break-words">
           {isPlanModeUser && (
             <div className="flex items-center gap-1.5 mb-1.5">
               <ClipboardList className="h-3 w-3 text-white/80" />
               <span className="text-xs font-medium text-white/80 uppercase tracking-wide">Plan Mode</span>
             </div>
           )}
-          {displayContent && <p className="whitespace-pre-wrap">{displayContent}</p>}
+          {displayContent && <p className="whitespace-pre-wrap break-words">{displayContent}</p>}
           {msg.attachments && msg.attachments.length > 0 && (
             <AttachmentGrid attachments={msg.attachments} />
           )}
@@ -425,7 +425,7 @@ function PlanOutputBubble({
 }) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[80%] rounded-lg text-sm bg-muted border border-amber-200 dark:border-amber-800/50">
+      <div className="max-w-[92%] min-w-0 rounded-lg text-sm bg-muted border border-amber-200 dark:border-amber-800/50 break-words">
         <div className="flex items-center gap-1.5 px-3 pt-2 pb-1">
           <ClipboardList className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
           <span className="text-xs font-medium text-amber-700 dark:text-amber-400">Implementation Plan</span>

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -17,6 +17,10 @@ import type { SessionMessage, SessionLog } from "@/lib/types";
 import { isImageURL, fileNameFromURL } from "@/lib/utils";
 import { deriveToolDisplay, formatToolInput } from "@/lib/tool-label";
 
+// Shared max-width for chat bubbles (user, assistant, plan) so they line up
+// consistently across the timeline.
+const BUBBLE_MAX_WIDTH = "max-w-[92%]";
+
 function safeDate(dateStr: string): Date | null {
   const d = new Date(dateStr);
   return isNaN(d.getTime()) ? null : d;
@@ -359,7 +363,7 @@ function AttachmentGrid({ attachments }: { attachments: string[] }) {
 function AssistantBubble({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[92%] min-w-0 rounded-lg px-3 py-2 text-sm bg-muted break-words">
+      <div className={`${BUBBLE_MAX_WIDTH} min-w-0 rounded-lg px-3 py-2 text-sm bg-muted break-words`}>
         {children}
       </div>
     </div>
@@ -376,7 +380,7 @@ function MessageBubble({ msg }: { msg: SessionMessage }) {
   if (msg.role === "user") {
     return (
       <div className="flex justify-end">
-        <div className="max-w-[92%] min-w-0 rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm break-words">
+        <div className={`${BUBBLE_MAX_WIDTH} min-w-0 rounded-lg px-3 py-2 text-sm bg-primary bg-[image:var(--gradient-primary)] text-white shadow-sm break-words`}>
           {isPlanModeUser && (
             <div className="flex items-center gap-1.5 mb-1.5">
               <ClipboardList className="h-3 w-3 text-white/80" />
@@ -425,7 +429,7 @@ function PlanOutputBubble({
 }) {
   return (
     <div className="flex justify-start">
-      <div className="max-w-[92%] min-w-0 rounded-lg text-sm bg-muted border border-amber-200 dark:border-amber-800/50 break-words">
+      <div className={`${BUBBLE_MAX_WIDTH} min-w-0 rounded-lg text-sm bg-muted border border-amber-200 dark:border-amber-800/50 break-words`}>
         <div className="flex items-center gap-1.5 px-3 pt-2 pb-1">
           <ClipboardList className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400" />
           <span className="text-xs font-medium text-amber-700 dark:text-amber-400">Implementation Plan</span>

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -45,7 +45,7 @@ const components: Components = {
   code: Code,
   // Paragraphs
   p({ children }) {
-    return <p className="mb-2 last:mb-0 leading-relaxed">{children}</p>;
+    return <p className="mb-2 last:mb-0 leading-relaxed break-words">{children}</p>;
   },
   // Headings
   h1({ children }) {


### PR DESCRIPTION
## Summary
- Widen chat bubbles (user / assistant / plan) from 80% to 92% max-width so timeline cards use more of the panel.
- Add `min-w-0` + `break-words` across chat-timeline entries, the markdown paragraph renderer, session Failure details and PM context, and project spec `<pre>` blocks so long URLs, JSON, and other unbroken strings wrap inside the card boundaries instead of escaping them.

## Test plan
- [ ] Open a failed session with a long, unbroken JSON log message and confirm the card stays within the center panel
- [ ] Verify the Failure details card in the Overview tab wraps long error strings
- [ ] Confirm project spec content with long tokens wraps inside the spec card

🤖 Generated with [Claude Code](https://claude.com/claude-code)