### PR TITLE
Add org switcher UI and create-org endpoint

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -191,14 +191,14 @@ describe("AuthenticatedLayout", () => {
 
   // --- New nav header tests ---
 
-  it("displays the organization name from settings", async () => {
+  it("displays the active organization name from memberships", async () => {
     renderWithProviders(
       <AuthenticatedLayout>
         <div>content</div>
       </AuthenticatedLayout>
     );
 
-    // The default mock returns "Test Org" from /api/v1/settings
+    // Default mock: /api/v1/auth/memberships returns "Test Org"
     await waitFor(() => {
       expect(screen.getByText("Test Org")).toBeInTheDocument();
     });
@@ -214,29 +214,6 @@ describe("AuthenticatedLayout", () => {
     await waitFor(() => {
       expect(screen.getByText("T")).toBeInTheDocument();
     });
-  });
-
-  it("falls back to 143.dev when org name is not available", async () => {
-    server.use(
-      http.get("/api/v1/settings", () => {
-        return HttpResponse.json({
-          data: {
-            id: "org-1",
-            name: "",
-            settings: {},
-          },
-        });
-      }),
-    );
-
-    renderWithProviders(
-      <AuthenticatedLayout>
-        <div>content</div>
-      </AuthenticatedLayout>
-    );
-
-    // Should initially show "143.dev" as the fallback before API responds
-    expect(screen.getByText("143.dev")).toBeInTheDocument();
   });
 
   it("has a search button that opens the command palette", async () => {
@@ -276,7 +253,7 @@ describe("AuthenticatedLayout", () => {
     });
   });
 
-  it("org name links to /sessions", async () => {
+  it("org name is an org-switcher dropdown trigger", async () => {
     renderWithProviders(
       <AuthenticatedLayout>
         <div>content</div>
@@ -284,8 +261,9 @@ describe("AuthenticatedLayout", () => {
     );
 
     await waitFor(() => {
-      const orgLink = screen.getByText("Test Org").closest("a");
-      expect(orgLink).toHaveAttribute("href", "/sessions");
+      const trigger = screen.getByTestId("org-switcher");
+      expect(trigger).toHaveTextContent("Test Org");
+      expect(trigger.getAttribute("aria-haspopup")).not.toBeNull();
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -35,12 +35,11 @@ import { useAuth } from "@/hooks/use-auth";
 import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
-import { queryKeys } from "@/lib/query-keys";
 import { RepoContextSwitcher } from "@/components/repo-context-switcher";
+import { OrgSwitcher } from "@/components/org-switcher";
 import { CommandPalette } from "@/components/command-palette/command-palette";
 import { SidebarSettingsSection } from "@/components/sidebar-settings-section";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
-import type { Organization, SingleResponse } from "@/lib/types";
 
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "dev";
 const shortSha = buildSha === "dev" ? "dev" : buildSha.slice(0, 7);
@@ -107,13 +106,6 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     enabled: isAuthenticated,
   });
   const proposalCount = proposalSummary?.data?.count ?? 0;
-
-  const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
-    queryKey: queryKeys.settings.all,
-    queryFn: () => api.settings.get(),
-    enabled: isAuthenticated,
-  });
-  const orgName = settingsResponse?.data?.name ?? "143.dev";
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
@@ -225,20 +217,10 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   return (
     <div className="flex h-screen">
       <aside className="w-[260px] border-r border-border/50 bg-sidebar flex flex-col relative">
-        {/* Header: org name + actions */}
+        {/* Header: org switcher + actions */}
         <div className="relative flex items-center justify-between px-4 py-3.5">
-          <div className="flex items-center gap-1.5 min-w-0">
-            <Link
-              href="/sessions"
-              className="flex items-center gap-1.5 min-w-0 rounded-md px-1.5 py-1 -ml-1.5 hover:bg-sidebar-accent transition-colors"
-            >
-              <div className="flex h-5 w-5 items-center justify-center rounded bg-foreground text-background text-xs font-semibold shrink-0">
-                {orgName[0]?.toUpperCase() ?? "1"}
-              </div>
-              <span className="text-sm font-semibold text-sidebar-foreground truncate">
-                {orgName}
-              </span>
-            </Link>
+          <div className="flex items-center min-w-0 flex-1">
+            <OrgSwitcher userEmail={user?.email} />
           </div>
           <TooltipProvider>
             <div className="flex items-center gap-0.5">

--- a/frontend/src/components/create-org-dialog.test.tsx
+++ b/frontend/src/components/create-org-dialog.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import { CreateOrgDialog } from "./create-org-dialog";
+import { getActiveOrgId } from "@/lib/active-org";
+
+const { pushMock, toastSuccess, toastInfo } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastInfo: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: toastSuccess, info: toastInfo, error: vi.fn() },
+}));
+
+beforeEach(() => {
+  pushMock.mockReset();
+  toastSuccess.mockReset();
+  toastInfo.mockReset();
+  window.sessionStorage.clear();
+});
+
+describe("CreateOrgDialog", () => {
+  it("on success: sets active org, pushes /sessions, closes, toasts", async () => {
+    server.use(
+      http.post("/api/v1/organizations", async () => {
+        return HttpResponse.json(
+          {
+            data: {
+              id: "org-new",
+              name: "Acme",
+              role: "admin",
+              created_at: "2026-04-21T00:00:00Z",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+    );
+
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />);
+
+    await user.type(screen.getByLabelText("Name"), "Acme");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/sessions");
+    });
+    expect(getActiveOrgId()).toBe("org-new");
+    expect(toastSuccess).toHaveBeenCalledWith("Created Acme");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("maps CREATE_ORG_RATE_LIMITED to the human-readable copy", async () => {
+    server.use(
+      http.post("/api/v1/organizations", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "CREATE_ORG_RATE_LIMITED",
+              message: "too many organization-creation attempts; try again later",
+            },
+          },
+          { status: 429 },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<CreateOrgDialog open={true} onOpenChange={vi.fn()} />);
+
+    await user.type(screen.getByLabelText("Name"), "Acme");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/too many organizations/i);
+    // Active org must not change on failure.
+    expect(getActiveOrgId()).toBeNull();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("maps NAME_TOO_LONG from the server to a length-specific message", async () => {
+    server.use(
+      http.post("/api/v1/organizations", () =>
+        HttpResponse.json(
+          {
+            error: { code: "NAME_TOO_LONG", message: "Name must be 120 characters or fewer." },
+          },
+          { status: 400 },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<CreateOrgDialog open={true} onOpenChange={vi.fn()} />);
+
+    await user.type(screen.getByLabelText("Name"), "Acme");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/120 characters or fewer/i);
+  });
+
+  it("disables Create while the name is empty or whitespace-only", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreateOrgDialog open={true} onOpenChange={vi.fn()} />);
+
+    const createButton = screen.getByRole("button", { name: "Create" });
+    expect(createButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Name"), "   ");
+    expect(createButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Name"), "Acme");
+    expect(createButton).not.toBeDisabled();
+  });
+});

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { api } from "@/lib/api";
+import { setActiveOrgId } from "@/lib/active-org";
+import { queryKeys } from "@/lib/query-keys";
+
+const MAX_NAME_LEN = 120;
+
+export interface CreateOrgDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setName("");
+    setError(null);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const mutation = useMutation({
+    mutationFn: (trimmed: string) => api.organizations.create(trimmed),
+    onSuccess: async (response) => {
+      const created = response.data;
+      setActiveOrgId(created.id);
+      // Refresh the memberships list immediately so the switcher renders the
+      // new org without waiting for the next focus/interval refetch.
+      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.memberships });
+      // Everything else is scoped to the previous org; nuke the cache so the
+      // next render fetches fresh data for the new workspace.
+      await queryClient.invalidateQueries();
+      toast.success(`Created ${created.name}`);
+      handleOpenChange(false);
+      router.push("/sessions");
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : "Failed to create organization";
+      setError(msg);
+    },
+  });
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError("Name is required.");
+      return;
+    }
+    if ([...trimmed].length > MAX_NAME_LEN) {
+      setError(`Name must be ${MAX_NAME_LEN} characters or fewer.`);
+      return;
+    }
+    setError(null);
+    mutation.mutate(trimmed);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md" data-testid="create-org-dialog">
+        <DialogHeader>
+          <DialogTitle>Create organization</DialogTitle>
+          <DialogDescription>
+            A new workspace with its own sessions, projects, and members. You&apos;ll be added as an admin.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="create-org-name">Name</Label>
+            <Input
+              id="create-org-name"
+              type="text"
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Acme Inc."
+              maxLength={MAX_NAME_LEN}
+              disabled={mutation.isPending}
+            />
+            {error && (
+              <p className="text-xs text-destructive" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={mutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={mutation.isPending || name.trim().length === 0}>
+              {mutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+              Create
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -23,6 +23,27 @@ import { queryKeys } from "@/lib/query-keys";
 
 const MAX_NAME_LEN = 120;
 
+// Duck-typed ApiError.code lookup — see hooks/use-auth.ts for rationale. The
+// codes below mirror writeError calls in internal/api/handlers/organizations.go
+// and the rate-limit middleware, so the user sees human copy instead of raw
+// SCREAMING_SNAKE error codes.
+function messageForError(err: unknown): string {
+  const code = typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
+  switch (code) {
+    case "CREATE_ORG_RATE_LIMITED":
+      return "You've created too many organizations in a short time. Please wait a bit and try again.";
+    case "NAME_TOO_LONG":
+      return `Name must be ${MAX_NAME_LEN} characters or fewer.`;
+    case "MISSING_NAME":
+      return "Name is required.";
+    case "UNAUTHORIZED":
+      return "Your session expired. Please sign in again.";
+    default:
+      if (err instanceof Error && err.message) return err.message;
+      return "Failed to create organization.";
+  }
+}
+
 export interface CreateOrgDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -61,8 +82,7 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
       router.push("/sessions");
     },
     onError: (err: unknown) => {
-      const msg = err instanceof Error ? err.message : "Failed to create organization";
-      setError(msg);
+      setError(messageForError(err));
     },
   });
 

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -22,10 +22,8 @@ import { setActiveOrgId } from "@/lib/active-org";
 
 const MAX_NAME_LEN = 120;
 
-// Duck-typed ApiError.code lookup — see hooks/use-auth.ts for rationale. The
-// codes below mirror writeError calls in internal/api/handlers/organizations.go
-// and the rate-limit middleware, so the user sees human copy instead of raw
-// SCREAMING_SNAKE error codes.
+// Codes must stay in sync with writeError calls in
+// internal/api/handlers/organizations.go and CreateOrgRateLimit.
 function messageForError(err: unknown): string {
   const code = typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
   switch (code) {
@@ -67,13 +65,14 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
 
   const mutation = useMutation({
     mutationFn: (trimmed: string) => api.organizations.create(trimmed),
-    onSuccess: async (response) => {
+    onSuccess: (response) => {
       const created = response.data;
       setActiveOrgId(created.id);
-      // Everything (including memberships) is scoped to the previous org; nuke
-      // the whole cache so the next render fetches fresh data for the new
-      // workspace. The unqualified invalidate subsumes the memberships key.
-      await queryClient.invalidateQueries();
+      // clear() over invalidateQueries(): invalidating would fire refetches
+      // against the current page right before navigation unmounts it.
+      // Clearing drops cached data so the next page's queries fetch fresh
+      // under the new active-org header.
+      queryClient.clear();
       toast.success(`Created ${created.name}`);
       handleOpenChange(false);
       router.push("/sessions");

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -19,7 +19,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
 import { setActiveOrgId } from "@/lib/active-org";
-import { queryKeys } from "@/lib/query-keys";
 
 const MAX_NAME_LEN = 120;
 
@@ -71,11 +70,9 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
     onSuccess: async (response) => {
       const created = response.data;
       setActiveOrgId(created.id);
-      // Refresh the memberships list immediately so the switcher renders the
-      // new org without waiting for the next focus/interval refetch.
-      await queryClient.invalidateQueries({ queryKey: queryKeys.auth.memberships });
-      // Everything else is scoped to the previous org; nuke the cache so the
-      // next render fetches fresh data for the new workspace.
+      // Everything (including memberships) is scoped to the previous org; nuke
+      // the whole cache so the next render fetches fresh data for the new
+      // workspace. The unqualified invalidate subsumes the memberships key.
       await queryClient.invalidateQueries();
       toast.success(`Created ${created.name}`);
       handleOpenChange(false);

--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -151,6 +151,23 @@ describe("OrgSwitcher", () => {
     });
   });
 
+  it("clears the stale tab-local org id on revocation so the next request cannot re-trigger it", async () => {
+    setActiveOrgId("org-revoked");
+
+    mockMemberships(
+      [{ org_id: "org-1", org_name: "Acme", role: "admin" }],
+      "org-1",
+    );
+
+    renderWithProviders(<OrgSwitcher />);
+
+    window.dispatchEvent(new CustomEvent(ORG_MEMBERSHIP_REVOKED_EVENT));
+
+    await waitFor(() => {
+      expect(getActiveOrgId()).toBeNull();
+    });
+  });
+
   it("syncs with active-org-changed events from elsewhere in the tab", async () => {
     mockMemberships(
       [

--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import { OrgSwitcher } from "./org-switcher";
+import {
+  ACTIVE_ORG_CHANGED_EVENT,
+  ORG_MEMBERSHIP_REVOKED_EVENT,
+  getActiveOrgId,
+  setActiveOrgId,
+} from "@/lib/active-org";
+
+const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+beforeEach(() => {
+  pushMock.mockReset();
+  window.sessionStorage.clear();
+});
+
+function mockMemberships(memberships: Array<{ org_id: string; org_name: string; role: string }>, activeOrgId = memberships[0]?.org_id ?? "") {
+  server.use(
+    http.get("/api/v1/auth/memberships", () =>
+      HttpResponse.json({
+        data: {
+          active_org_id: activeOrgId,
+          active_role: memberships.find((m) => m.org_id === activeOrgId)?.role ?? "",
+          memberships,
+        },
+      }),
+    ),
+  );
+}
+
+describe("OrgSwitcher", () => {
+  it("renders the active org label from the server response", async () => {
+    mockMemberships([
+      { org_id: "org-1", org_name: "Acme", role: "admin" },
+    ]);
+
+    renderWithProviders(<OrgSwitcher userEmail="alex@example.com" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher")).toHaveTextContent("Acme");
+    });
+  });
+
+  it("shows all memberships in the dropdown with a check on the active one", async () => {
+    mockMemberships(
+      [
+        { org_id: "org-1", org_name: "Acme", role: "admin" },
+        { org_id: "org-2", org_name: "Globex", role: "member" },
+      ],
+      "org-1",
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher")).toHaveTextContent("Acme");
+    });
+
+    await user.click(screen.getByTestId("org-switcher"));
+
+    expect(await screen.findByTestId("org-switcher-item-org-1")).toBeInTheDocument();
+    expect(screen.getByTestId("org-switcher-item-org-2")).toBeInTheDocument();
+  });
+
+  it("switching orgs writes sessionStorage and pushes /sessions", async () => {
+    mockMemberships(
+      [
+        { org_id: "org-1", org_name: "Acme", role: "admin" },
+        { org_id: "org-2", org_name: "Globex", role: "member" },
+      ],
+      "org-1",
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("org-switcher-item-org-2"));
+
+    expect(getActiveOrgId()).toBe("org-2");
+    expect(pushMock).toHaveBeenCalledWith("/sessions");
+  });
+
+  it("clicking the already-active org is a no-op", async () => {
+    mockMemberships(
+      [{ org_id: "org-1", org_name: "Acme", role: "admin" }],
+      "org-1",
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("org-switcher-item-org-1"));
+
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers the tab-local active org when sessionStorage is set", async () => {
+    setActiveOrgId("org-2");
+
+    mockMemberships(
+      [
+        { org_id: "org-1", org_name: "Acme", role: "admin" },
+        { org_id: "org-2", org_name: "Globex", role: "member" },
+      ],
+      "org-1",
+    );
+
+    renderWithProviders(<OrgSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher")).toHaveTextContent("Globex");
+    });
+  });
+
+  it("revoked-membership event refetches and shows a toast-like info message", async () => {
+    let callCount = 0;
+    server.use(
+      http.get("/api/v1/auth/memberships", () => {
+        callCount += 1;
+        return HttpResponse.json({
+          data: {
+            active_org_id: "org-1",
+            active_role: "admin",
+            memberships: [{ org_id: "org-1", org_name: "Acme", role: "admin" }],
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<OrgSwitcher />);
+
+    await waitFor(() => {
+      expect(callCount).toBeGreaterThanOrEqual(1);
+    });
+
+    const before = callCount;
+    window.dispatchEvent(new CustomEvent(ORG_MEMBERSHIP_REVOKED_EVENT));
+
+    await waitFor(() => {
+      expect(callCount).toBeGreaterThan(before);
+    });
+  });
+
+  it("syncs with active-org-changed events from elsewhere in the tab", async () => {
+    mockMemberships(
+      [
+        { org_id: "org-1", org_name: "Acme", role: "admin" },
+        { org_id: "org-2", org_name: "Globex", role: "member" },
+      ],
+      "org-1",
+    );
+
+    renderWithProviders(<OrgSwitcher />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher")).toHaveTextContent("Acme");
+    });
+
+    window.sessionStorage.setItem("active_org_id", "org-2");
+    window.dispatchEvent(new CustomEvent(ACTIVE_ORG_CHANGED_EVENT));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher")).toHaveTextContent("Globex");
+    });
+  });
+});

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -83,6 +83,11 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   useEffect(() => {
     const handler = () => {
       const previousLabel = activeMembershipRef.current?.org_name;
+      // Drop the stale tab selection so the next request doesn't resend the
+      // revoked org id and trip the same response header in a loop. Falling
+      // back to null lets effectiveActiveOrgId pick up whatever org the
+      // server resolves for this user on the refetch below.
+      setActiveOrgId(null);
       void queryClient.invalidateQueries();
       toast.info(
         previousLabel

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -86,13 +86,17 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
       // Drop the stale tab selection so the next request doesn't resend the
       // revoked org id and trip the same response header in a loop. Falling
       // back to null lets effectiveActiveOrgId pick up whatever org the
-      // server resolves for this user on the refetch below.
+      // server resolves for this user on the next fetch.
       setActiveOrgId(null);
-      void queryClient.invalidateQueries();
+      // clear() drops cached data without kicking off refetches against the
+      // current page. Mounted queries will fetch fresh data with the new
+      // active-org resolution; unmounted queries won't waste a request.
+      queryClient.clear();
       toast.info(
         previousLabel
           ? `Your access to ${previousLabel} changed. Switched to your next available workspace.`
           : "Your access to an organization changed. Switched to your next available workspace.",
+        { id: "org-membership-revoked" },
       );
     };
     window.addEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
@@ -109,7 +113,11 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   const handleSwitch = (membership: MembershipSummary) => {
     if (membership.org_id === effectiveActiveOrgId) return;
     setActiveOrgId(membership.org_id);
-    void queryClient.invalidateQueries();
+    // clear() over invalidateQueries(): invalidating here would refetch every
+    // cached query against the *current* page right before it unmounts on
+    // navigation — doubling request volume. Clearing drops the cache so the
+    // destination page fetches fresh under the new active-org header.
+    queryClient.clear();
     router.push("/sessions");
   };
 

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { Check, ChevronsUpDown, Plus, Settings } from "lucide-react";
@@ -37,7 +37,7 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
 
-  const { data: membershipsResponse, refetch } = useQuery<SingleResponse<MembershipsResponse>>({
+  const { data: membershipsResponse } = useQuery<SingleResponse<MembershipsResponse>>({
     queryKey: queryKeys.auth.memberships,
     queryFn: () => api.auth.memberships(),
   });
@@ -45,26 +45,6 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   const [tabOrgId, setTabOrgId] = useState<string | null>(() => getActiveOrgId());
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
-
-  // Keep tabOrgId in sync with sessionStorage changes from other code paths
-  // in the same tab (e.g. Create Org finishing, another component calling
-  // setActiveOrgId). Cross-tab sync is intentionally not wired up — per-tab
-  // org is the whole point.
-  useEffect(() => {
-    const handler = () => setTabOrgId(getActiveOrgId());
-    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
-    return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
-  }, []);
-
-  useEffect(() => {
-    const handler = () => {
-      void refetch();
-      void queryClient.invalidateQueries();
-      toast.info("Your access to an organization changed. Switched to your next available workspace.");
-    };
-    window.addEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
-    return () => window.removeEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
-  }, [refetch, queryClient]);
 
   const memberships = useMemo(
     () => membershipsResponse?.data?.memberships ?? [],
@@ -82,6 +62,38 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     [memberships, effectiveActiveOrgId],
   );
 
+  // Keep tabOrgId in sync with sessionStorage changes from other code paths
+  // in the same tab (e.g. Create Org finishing, another component calling
+  // setActiveOrgId). Cross-tab sync is intentionally not wired up — per-tab
+  // org is the whole point.
+  useEffect(() => {
+    const handler = () => setTabOrgId(getActiveOrgId());
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+  }, []);
+
+  // Name the currently-active org in the revocation toast. Capturing via ref
+  // lets us read the label the user *had* right before the server signaled
+  // revocation without making invalidateQueries race our own read of it.
+  const activeMembershipRef = useRef(activeMembership);
+  useEffect(() => {
+    activeMembershipRef.current = activeMembership;
+  }, [activeMembership]);
+
+  useEffect(() => {
+    const handler = () => {
+      const previousLabel = activeMembershipRef.current?.org_name;
+      void queryClient.invalidateQueries();
+      toast.info(
+        previousLabel
+          ? `Your access to ${previousLabel} changed. Switched to your next available workspace.`
+          : "Your access to an organization changed. Switched to your next available workspace.",
+      );
+    };
+    window.addEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
+    return () => window.removeEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
+  }, [queryClient]);
+
   const showSearch = memberships.length >= SEARCH_THRESHOLD;
   const filtered = useMemo(() => {
     if (!search) return memberships;
@@ -97,7 +109,9 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   };
 
   const orgLabel = activeMembership?.org_name ?? "Workspace";
-  const initial = orgLabel[0]?.toUpperCase() ?? "?";
+  // Index by code points, not UTF-16 code units: "🏢 Acme"[0] is a lone high
+  // surrogate that renders as a replacement char. Array.from splits correctly.
+  const initial = Array.from(orgLabel)[0]?.toUpperCase() ?? "?";
 
   return (
     <>
@@ -151,7 +165,7 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
                 data-testid={`org-switcher-item-${m.org_id}`}
               >
                 <div className="flex h-5 w-5 items-center justify-center rounded bg-muted text-xs font-semibold shrink-0">
-                  {m.org_name[0]?.toUpperCase() ?? "?"}
+                  {Array.from(m.org_name)[0]?.toUpperCase() ?? "?"}
                 </div>
                 <span className="truncate flex-1" title={m.org_name}>
                   {m.org_name}

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { Check, ChevronsUpDown, Plus, Settings } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { api } from "@/lib/api";
+import {
+  ACTIVE_ORG_CHANGED_EVENT,
+  ORG_MEMBERSHIP_REVOKED_EVENT,
+  getActiveOrgId,
+  setActiveOrgId,
+} from "@/lib/active-org";
+import { cn } from "@/lib/utils";
+import { queryKeys } from "@/lib/query-keys";
+import { CreateOrgDialog } from "@/components/create-org-dialog";
+import type { MembershipSummary, SingleResponse, MembershipsResponse } from "@/lib/types";
+
+const SEARCH_THRESHOLD = 5;
+
+export interface OrgSwitcherProps {
+  userEmail?: string;
+}
+
+export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const { data: membershipsResponse, refetch } = useQuery<SingleResponse<MembershipsResponse>>({
+    queryKey: queryKeys.auth.memberships,
+    queryFn: () => api.auth.memberships(),
+  });
+
+  const [tabOrgId, setTabOrgId] = useState<string | null>(() => getActiveOrgId());
+  const [search, setSearch] = useState("");
+  const [createOpen, setCreateOpen] = useState(false);
+
+  // Keep tabOrgId in sync with sessionStorage changes from other code paths
+  // in the same tab (e.g. Create Org finishing, another component calling
+  // setActiveOrgId). Cross-tab sync is intentionally not wired up — per-tab
+  // org is the whole point.
+  useEffect(() => {
+    const handler = () => setTabOrgId(getActiveOrgId());
+    window.addEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+    return () => window.removeEventListener(ACTIVE_ORG_CHANGED_EVENT, handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = () => {
+      void refetch();
+      void queryClient.invalidateQueries();
+      toast.info("Your access to an organization changed. Switched to your next available workspace.");
+    };
+    window.addEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
+    return () => window.removeEventListener(ORG_MEMBERSHIP_REVOKED_EVENT, handler);
+  }, [refetch, queryClient]);
+
+  const memberships = useMemo(
+    () => membershipsResponse?.data?.memberships ?? [],
+    [membershipsResponse],
+  );
+  const serverActiveOrgId = membershipsResponse?.data?.active_org_id ?? "";
+
+  // Prefer the tab-local selection; fall back to the server-resolved active
+  // org until the user picks one explicitly. Using the server value here keeps
+  // the switcher showing the same org the backend will scope requests to on
+  // the very first page load of a fresh tab (no X-Active-Org-ID sent yet).
+  const effectiveActiveOrgId = tabOrgId ?? serverActiveOrgId;
+  const activeMembership = useMemo(
+    () => memberships.find((m) => m.org_id === effectiveActiveOrgId) ?? memberships[0],
+    [memberships, effectiveActiveOrgId],
+  );
+
+  const showSearch = memberships.length >= SEARCH_THRESHOLD;
+  const filtered = useMemo(() => {
+    if (!search) return memberships;
+    const q = search.toLowerCase();
+    return memberships.filter((m) => m.org_name.toLowerCase().includes(q));
+  }, [memberships, search]);
+
+  const handleSwitch = (membership: MembershipSummary) => {
+    if (membership.org_id === effectiveActiveOrgId) return;
+    setActiveOrgId(membership.org_id);
+    void queryClient.invalidateQueries();
+    router.push("/sessions");
+  };
+
+  const orgLabel = activeMembership?.org_name ?? "Workspace";
+  const initial = orgLabel[0]?.toUpperCase() ?? "?";
+
+  return (
+    <>
+      <DropdownMenu onOpenChange={(open) => { if (!open) setSearch(""); }}>
+        <DropdownMenuTrigger
+          className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 -ml-1.5 hover:bg-sidebar-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="org-switcher"
+          aria-label="Switch organization"
+        >
+          <div className="flex h-5 w-5 items-center justify-center rounded bg-foreground text-background text-xs font-semibold shrink-0">
+            {initial}
+          </div>
+          <span className="text-sm font-semibold text-sidebar-foreground truncate flex-1 text-left">
+            {orgLabel}
+          </span>
+          <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" side="bottom" className="w-64">
+          {userEmail && (
+            <>
+              <DropdownMenuLabel className="text-xs font-normal text-muted-foreground truncate">
+                {userEmail}
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {showSearch && (
+            <div className="px-2 pb-1.5">
+              <Input
+                type="text"
+                placeholder="Search workspaces..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </div>
+          )}
+          {filtered.length === 0 && (
+            <div className="px-2 py-4 text-center text-xs text-muted-foreground">
+              No matching workspaces
+            </div>
+          )}
+          {filtered.map((m) => {
+            const isActive = m.org_id === effectiveActiveOrgId;
+            return (
+              <DropdownMenuItem
+                key={m.org_id}
+                onClick={() => handleSwitch(m)}
+                className={cn("flex items-center gap-2", isActive && "font-medium")}
+                data-testid={`org-switcher-item-${m.org_id}`}
+              >
+                <div className="flex h-5 w-5 items-center justify-center rounded bg-muted text-xs font-semibold shrink-0">
+                  {m.org_name[0]?.toUpperCase() ?? "?"}
+                </div>
+                <span className="truncate flex-1" title={m.org_name}>
+                  {m.org_name}
+                </span>
+                <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                  {m.role}
+                </span>
+                {isActive && <Check className="h-3.5 w-3.5 text-foreground shrink-0" />}
+              </DropdownMenuItem>
+            );
+          })}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              setCreateOpen(true);
+            }}
+          >
+            <Plus className="h-4 w-4" />
+            Create organization
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => router.push("/settings")}>
+            <Settings className="h-4 w-4" />
+            Organization settings
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <CreateOrgDialog open={createOpen} onOpenChange={setCreateOpen} />
+    </>
+  );
+}

--- a/frontend/src/lib/active-org.ts
+++ b/frontend/src/lib/active-org.ts
@@ -1,0 +1,33 @@
+// Per-tab active org selection. Stored in sessionStorage so each browser tab
+// can independently focus a different org without stomping its siblings; the
+// backend's X-Active-Org-ID header cascade makes this cheap (no server-side
+// session churn). The key name is load-bearing — the API request interceptor
+// in ./api.ts reads the same key.
+
+const ACTIVE_ORG_KEY = 'active_org_id';
+
+export const ACTIVE_ORG_CHANGED_EVENT = 'active-org-changed';
+export const ORG_MEMBERSHIP_REVOKED_EVENT = 'org-membership-revoked';
+
+export function getActiveOrgId(): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.sessionStorage.getItem(ACTIVE_ORG_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function setActiveOrgId(id: string | null): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (id) {
+      window.sessionStorage.setItem(ACTIVE_ORG_KEY, id);
+    } else {
+      window.sessionStorage.removeItem(ACTIVE_ORG_KEY);
+    }
+  } catch {
+    return;
+  }
+  window.dispatchEvent(new CustomEvent(ACTIVE_ORG_CHANGED_EVENT, { detail: { id } }));
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,6 +31,19 @@ function getCSRFToken(): string {
   return match ? decodeURIComponent(match.substring('csrf_token='.length)) : '';
 }
 
+// N parallel requests after a membership revocation all see the header, and
+// without a guard each one would fire a fresh event → fresh toast. Collapse
+// bursts into a single dispatch per short window; listeners still get woken
+// up for any later revocation that lands after the window closes.
+let lastRevokedDispatchAt = 0;
+const REVOKED_DISPATCH_MIN_INTERVAL_MS = 1000;
+function maybeDispatchRevoked(): void {
+  const now = Date.now();
+  if (now - lastRevokedDispatchAt < REVOKED_DISPATCH_MIN_INTERVAL_MS) return;
+  lastRevokedDispatchAt = now;
+  window.dispatchEvent(new CustomEvent(ORG_MEMBERSHIP_REVOKED_EVENT));
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -47,9 +60,16 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   // (login, register, logout, me, memberships) are user-scoped — they operate
   // on session/user state regardless of the selected workspace, so sending a
   // stale org id here would only give the server a way to misattribute the
-  // request or echo back an irrelevant header.
+  // request or echo back an irrelevant header. Creating a new org (POST
+  // /api/v1/organizations) is also user-scoped: the handler runs outside
+  // OrgContext, and forwarding a just-revoked active-org id would trip the
+  // upstream auth middleware into emitting X-Org-Membership-Revoked *during*
+  // the create flow, firing a confusing "your access changed" toast.
   const activeOrgId = getActiveOrgId();
-  if (activeOrgId && !path.startsWith('/api/v1/auth/')) {
+  const isUserScopedRoute =
+    path.startsWith('/api/v1/auth/') ||
+    (method === 'POST' && path === '/api/v1/organizations');
+  if (activeOrgId && !isUserScopedRoute) {
     headers['X-Active-Org-ID'] = activeOrgId;
   }
 
@@ -60,7 +80,7 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   });
 
   if (typeof window !== 'undefined' && res.headers.get('X-Org-Membership-Revoked') === '1') {
-    window.dispatchEvent(new CustomEvent(ORG_MEMBERSHIP_REVOKED_EVENT));
+    maybeDispatchRevoked();
   }
 
   if (!res.ok) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,8 +43,13 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     headers['X-CSRF-Token'] = getCSRFToken();
   }
 
+  // Only attach the active-org header on org-scoped routes. Auth endpoints
+  // (login, register, logout, me, memberships) are user-scoped — they operate
+  // on session/user state regardless of the selected workspace, so sending a
+  // stale org id here would only give the server a way to misattribute the
+  // request or echo back an irrelevant header.
   const activeOrgId = getActiveOrgId();
-  if (activeOrgId) {
+  if (activeOrgId && !path.startsWith('/api/v1/auth/')) {
     headers['X-Active-Org-ID'] = activeOrgId;
   }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { getActiveOrgId, ORG_MEMBERSHIP_REVOKED_EVENT } from './active-org';
+
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
 const SENTRY_REDIRECT_URI = process.env.NEXT_PUBLIC_SENTRY_REDIRECT_URI || '';
@@ -41,11 +43,20 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     headers['X-CSRF-Token'] = getCSRFToken();
   }
 
+  const activeOrgId = getActiveOrgId();
+  if (activeOrgId) {
+    headers['X-Active-Org-ID'] = activeOrgId;
+  }
+
   const res = await fetch(`${API_BASE}${path}`, {
     ...options,
     credentials: 'include',
     headers,
   });
+
+  if (typeof window !== 'undefined' && res.headers.get('X-Org-Membership-Revoked') === '1') {
+    window.dispatchEvent(new CustomEvent(ORG_MEMBERSHIP_REVOKED_EVENT));
+  }
 
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
@@ -143,6 +154,12 @@ export const api = {
     register: (email: string, password: string, name: string, invitation?: string) =>
       post<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/register', { email, password, name, ...(invitation && { invitation }) }),
     logout: () => post('/api/v1/auth/logout'),
+    memberships: () =>
+      get<import('./types').SingleResponse<import('./types').MembershipsResponse>>('/api/v1/auth/memberships'),
+  },
+  organizations: {
+    create: (name: string) =>
+      post<import('./types').SingleResponse<import('./types').OrganizationCreated>>('/api/v1/organizations', { name }),
   },
   repositories: {
     list: () => get<import('./types').ListResponse<import('./types').Repository>>('/api/v1/repositories'),

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -52,6 +52,9 @@ export const queryKeys = {
   team: {
     members: ["team", "members"] as const,
   },
+  auth: {
+    memberships: ["auth", "memberships"] as const,
+  },
   usage: {
     summary: (params: { start: string; end: string }) =>
       ["usage", "summary", params] as const,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,25 @@ export interface Organization {
   updated_at: string;
 }
 
+export interface MembershipSummary {
+  org_id: string;
+  org_name: string;
+  role: string;
+}
+
+export interface MembershipsResponse {
+  active_org_id: string;
+  active_role: string;
+  memberships: MembershipSummary[];
+}
+
+export interface OrganizationCreated {
+  id: string;
+  name: string;
+  role: string;
+  created_at: string;
+}
+
 export interface User {
   id: string;
   org_id: string;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -430,6 +430,18 @@ export const handlers = [
     });
   }),
 
+  http.get('/api/v1/auth/memberships', () => {
+    return HttpResponse.json({
+      data: {
+        active_org_id: 'org-1',
+        active_role: 'admin',
+        memberships: [
+          { org_id: 'org-1', org_name: 'Test Org', role: 'admin' },
+        ],
+      },
+    });
+  }),
+
   http.patch('/api/v1/settings', () => {
     return HttpResponse.json({
       data: {

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -51,6 +51,7 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"AuthHandler.Me":                   "returns user from context only",
 		"AuthHandler.Logout":               "deletes session by cookie token only",
 		"AuthHandler.ClaimInvitation":      "grants membership in a different org than the active one; target org comes from the invitation token, not the request context",
+		"OrganizationsHandler.Create":      "creates a new org; runs outside OrgContext, no pre-existing org to scope against",
 		"SettingsHandler.GetLLMDefaults":   "returns static server config",
 		"SettingsHandler.GetLLMModels":     "returns static server config",
 		"ProjectGenerateHandler.Generate":  "calls LLM only, no org-scoped data",

--- a/internal/api/handlers/organizations.go
+++ b/internal/api/handlers/organizations.go
@@ -1,0 +1,153 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// maxOrgNameLen bounds the display name for a newly-created org. 120 chars
+// matches the bound enforced by the frontend CreateOrgDialog and leaves
+// plenty of headroom for real team names without allowing paragraph-length
+// junk that would break the switcher dropdown layout.
+const maxOrgNameLen = 120
+
+// OrganizationsHandler owns routes that act on organizations the authenticated
+// user may not yet belong to — most notably POST /api/v1/organizations, which
+// is how a signed-in user provisions an additional org for themselves without
+// going through the signup flow.
+type OrganizationsHandler struct {
+	pool  db.TxStarter
+	audit *db.AuditEmitter
+}
+
+func NewOrganizationsHandler(pool db.TxStarter) *OrganizationsHandler {
+	return &OrganizationsHandler{pool: pool}
+}
+
+// SetAuditEmitter injects the audit emitter for logging organization events.
+func (h *OrganizationsHandler) SetAuditEmitter(audit *db.AuditEmitter) {
+	h.audit = audit
+}
+
+// Create provisions a new organization with the authenticated user as its
+// first admin. The org row and the initial admin membership are inserted in
+// a single transaction so no org is ever persisted without at least one admin.
+//
+// This route is deliberately mounted OUTSIDE OrgContext: a zero-membership
+// user (removed from their last org) must still be able to create a fresh org
+// to escape that state, and OrgContext would 403 them before they ever reach
+// this handler. Authentication is still required via UserFromContext.
+//
+// The response echoes the new org's id, name, the caller's role ("admin"), and
+// the server-generated created_at. The frontend uses id to switch into the
+// new org by setting the X-Active-Org-ID header on the very next request; no
+// server-side session mutation happens here, which keeps the create step
+// independent of the switch step.
+//
+// lint:allow-no-orgid reason="creates a new org; no pre-existing org context to scope against"
+func (h *OrganizationsHandler) Create(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+	if h.pool == nil {
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "organizations handler pool is not configured")
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+	name := strings.TrimSpace(body.Name)
+	if name == "" {
+		writeError(w, r, http.StatusBadRequest, "MISSING_NAME", "Name is required.")
+		return
+	}
+	if len([]rune(name)) > maxOrgNameLen {
+		writeError(w, r, http.StatusBadRequest, "NAME_TOO_LONG", fmt.Sprintf("Name must be %d characters or fewer.", maxOrgNameLen))
+		return
+	}
+
+	org, err := h.createOrgWithAdmin(r.Context(), name, user.ID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "ORG_CREATE_FAILED", "failed to create organization", err)
+		return
+	}
+
+	h.emitOrgCreated(r, user.ID, org)
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"data": map[string]any{
+			"id":         org.ID,
+			"name":       org.Name,
+			"role":       models.RoleAdmin,
+			"created_at": org.CreatedAt,
+		},
+	})
+}
+
+func (h *OrganizationsHandler) createOrgWithAdmin(ctx context.Context, name string, userID uuid.UUID) (*models.Organization, error) {
+	tx, err := h.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin org tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	org := &models.Organization{Name: name, Settings: json.RawMessage(`{}`)}
+	if err := db.NewOrganizationStore(tx).Create(ctx, org); err != nil {
+		return nil, fmt.Errorf("create organization: %w", err)
+	}
+	// Plain Insert (not GrantAtLeast): the org was just created inside this
+	// tx, so a pre-existing membership would indicate a bug. Loud failure is
+	// better than GrantAtLeast's silent no-op.
+	if err := db.NewOrganizationMembershipStore(tx).Insert(ctx, userID, org.ID, models.RoleAdmin); err != nil {
+		return nil, fmt.Errorf("grant admin membership: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit org tx: %w", err)
+	}
+	return org, nil
+}
+
+// emitOrgCreated writes the audit row against the newly-created org. The route
+// runs outside OrgContext so OrgIDFromContext is uuid.Nil here — we set
+// params.OrgID explicitly to the new org, matching auth.register's attribution
+// pattern where the audit row belongs to the org the user just entered.
+func (h *OrganizationsHandler) emitOrgCreated(r *http.Request, userID uuid.UUID, org *models.Organization) {
+	if h.audit == nil || org == nil {
+		return
+	}
+	resID := org.ID.String()
+	params := db.UserActionParams{
+		OrgID:        org.ID,
+		UserID:       userID,
+		Action:       models.AuditActionOrganizationCreated,
+		ResourceType: models.AuditResourceOrganization,
+		ResourceID:   &resID,
+	}
+	if reqID := chiMiddleware.GetReqID(r.Context()); reqID != "" {
+		params.RequestID = &reqID
+	}
+	if ip := parseClientIP(r); ip != nil {
+		params.IPAddress = ip
+	}
+	if ua := r.UserAgent(); ua != "" {
+		params.UserAgent = &ua
+	}
+	h.audit.EmitUserAction(r.Context(), params)
+}

--- a/internal/api/handlers/organizations_test.go
+++ b/internal/api/handlers/organizations_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -147,6 +149,50 @@ func TestOrganizationsHandler_Create_HappyPath(t *testing.T) {
 	require.Equal(t, orgID, resp.Data.ID)
 	require.Equal(t, "Acme", resp.Data.Name, "whitespace should be trimmed before persistence")
 	require.Equal(t, models.RoleAdmin, resp.Data.Role)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Happy path with an audit emitter attached — the handler must write an
+// organization.created row keyed on the NEW org (not the caller's previous
+// active org, since the route runs outside OrgContext).
+func TestOrganizationsHandler_Create_EmitsAudit(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	createdAt := time.Now()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(orgID, createdAt, createdAt))
+	mock.ExpectExec("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+	// Audit row fires post-commit via the emitter. AuditLogStore.Create binds
+	// 13 named args which pgxmock sees as 13 positional args.
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	handler := NewOrganizationsHandler(mock)
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+
+	req := authedRequestAs(t, userID, `{"name":"Acme"}`)
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/api/handlers/organizations_test.go
+++ b/internal/api/handlers/organizations_test.go
@@ -1,0 +1,217 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestOrganizationsHandler_Create_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	handler := NewOrganizationsHandler(nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", bytes.NewBufferString(`{"name":"Acme"}`))
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestOrganizationsHandler_Create_PoolNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	handler := NewOrganizationsHandler(nil)
+	req := authedRequest(t, `{"name":"Acme"}`)
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestOrganizationsHandler_Create_InvalidBody(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewOrganizationsHandler(mock)
+	req := authedRequest(t, "not json")
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_BODY")
+}
+
+func TestOrganizationsHandler_Create_MissingName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty", `{"name":""}`},
+		{"whitespace only", `{"name":"   "}`},
+		{"no field", `{}`},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			handler := NewOrganizationsHandler(mock)
+			req := authedRequest(t, tc.body)
+			w := httptest.NewRecorder()
+
+			handler.Create(w, req)
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "MISSING_NAME")
+		})
+	}
+}
+
+func TestOrganizationsHandler_Create_NameTooLong(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewOrganizationsHandler(mock)
+	body, err := json.Marshal(map[string]string{"name": strings.Repeat("a", maxOrgNameLen+1)})
+	require.NoError(t, err)
+
+	req := authedRequest(t, string(body))
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "NAME_TOO_LONG")
+}
+
+func TestOrganizationsHandler_Create_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	userID := uuid.New()
+	orgID := uuid.New()
+	createdAt := time.Now()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(orgID, createdAt, createdAt))
+	mock.ExpectExec("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+
+	handler := NewOrganizationsHandler(mock)
+
+	req := authedRequestAs(t, userID, `{"name":"  Acme  "}`)
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp struct {
+		Data struct {
+			ID   uuid.UUID `json:"id"`
+			Name string    `json:"name"`
+			Role string    `json:"role"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, orgID, resp.Data.ID)
+	require.Equal(t, "Acme", resp.Data.Name, "whitespace should be trimmed before persistence")
+	require.Equal(t, models.RoleAdmin, resp.Data.Role)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOrganizationsHandler_Create_OrgInsertFails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("boom"))
+	mock.ExpectRollback()
+
+	handler := NewOrganizationsHandler(mock)
+	req := authedRequest(t, `{"name":"Acme"}`)
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "ORG_CREATE_FAILED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOrganizationsHandler_Create_MembershipInsertFails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	createdAt := time.Now()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(orgID, createdAt, createdAt))
+	mock.ExpectExec("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("boom"))
+	mock.ExpectRollback()
+
+	handler := NewOrganizationsHandler(mock)
+	req := authedRequest(t, `{"name":"Acme"}`)
+	w := httptest.NewRecorder()
+
+	handler.Create(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "ORG_CREATE_FAILED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// authedRequest builds a POST request with a fresh authenticated user on the
+// context. Use authedRequestAs when the test needs a known user ID.
+func authedRequest(t *testing.T, body string) *http.Request {
+	t.Helper()
+	return authedRequestAs(t, uuid.New(), body)
+}
+
+func authedRequestAs(t *testing.T, userID uuid.UUID, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", bytes.NewBufferString(body))
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, Email: "u@example.com"})
+	return req.WithContext(ctx)
+}

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -237,6 +237,60 @@ func ClaimRateLimit(perMinute int) func(http.Handler) http.Handler {
 	}
 }
 
+// CreateOrgRateLimit returns a per-hour rate limiter for POST /organizations.
+// Sized much tighter than ClaimRateLimit: a legitimate user creates an org
+// maybe once per onboarding and then never again, so any bucket that refills
+// faster than once every few minutes is room for spam. 5/hour per user and
+// per IP keeps the door open for the rare genuine multi-org case (a user
+// creating two workspaces in the same session) while closing it on scripted
+// creation from a single credential or host.
+//
+// Requires authentication: the user bucket is the primary defense and
+// anonymous callers should already have been rejected by the auth middleware
+// upstream; the IP bucket is a backstop for any future unauthenticated path.
+func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
+	ipBuckets := &sync.Map{}
+	userBuckets := &sync.Map{}
+	refillPerSecond := float64(perHour) / 3600.0
+
+	getBucket := func(m *sync.Map, key string) *tokenBucket {
+		if existing, ok := m.Load(key); ok {
+			return existing.(*tokenBucket)
+		}
+		fresh := &tokenBucket{
+			tokens:     float64(perHour),
+			maxTokens:  float64(perHour),
+			refillRate: refillPerSecond,
+			lastRefill: time.Now(),
+		}
+		actual, _ := m.LoadOrStore(key, fresh)
+		return actual.(*tokenBucket)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := remoteAddrIP(r)
+			if !getBucket(ipBuckets, ip).allow() {
+				zerolog.Ctx(r.Context()).Warn().Str("ip", ip).Msg("create-org rate limit exceeded (IP)")
+				w.Header().Set("Retry-After", "3600")
+				http.Error(w, `{"error":{"code":"CREATE_ORG_RATE_LIMITED","message":"too many organization-creation attempts; try again later"}}`, http.StatusTooManyRequests)
+				return
+			}
+
+			if user := UserFromContext(r.Context()); user != nil {
+				if !getBucket(userBuckets, user.ID.String()).allow() {
+					zerolog.Ctx(r.Context()).Warn().Str("user_id", user.ID.String()).Msg("create-org rate limit exceeded (user)")
+					w.Header().Set("Retry-After", "3600")
+					http.Error(w, `{"error":{"code":"CREATE_ORG_RATE_LIMITED","message":"too many organization-creation attempts; try again later"}}`, http.StatusTooManyRequests)
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // extractIP returns the client's IP for rate-limit bucketing. Prefers the
 // first entry in X-Forwarded-For when present (reverse-proxy deployments) and
 // otherwise falls back to the TCP peer address. The XFF path trusts its input

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"strings"
@@ -218,16 +219,14 @@ func ClaimRateLimit(perMinute int) func(http.Handler) http.Handler {
 			ip := remoteAddrIP(r)
 			if !getBucket(ipBuckets, ip).allow() {
 				zerolog.Ctx(r.Context()).Warn().Str("ip", ip).Msg("invitation claim rate limit exceeded (IP)")
-				w.Header().Set("Retry-After", "60")
-				http.Error(w, `{"error":{"code":"CLAIM_RATE_LIMITED","message":"too many invitation claim attempts; try again in a minute"}}`, http.StatusTooManyRequests)
+				writeRateLimited(w, "CLAIM_RATE_LIMITED", "too many invitation claim attempts; try again in a minute", "60")
 				return
 			}
 
 			if user := UserFromContext(r.Context()); user != nil {
 				if !getBucket(userBuckets, user.ID.String()).allow() {
 					zerolog.Ctx(r.Context()).Warn().Str("user_id", user.ID.String()).Msg("invitation claim rate limit exceeded (user)")
-					w.Header().Set("Retry-After", "60")
-					http.Error(w, `{"error":{"code":"CLAIM_RATE_LIMITED","message":"too many invitation claim attempts; try again in a minute"}}`, http.StatusTooManyRequests)
+					writeRateLimited(w, "CLAIM_RATE_LIMITED", "too many invitation claim attempts; try again in a minute", "60")
 					return
 				}
 			}
@@ -252,8 +251,11 @@ func ClaimRateLimit(perMinute int) func(http.Handler) http.Handler {
 // Bucket maps are pruned in the background to prevent unbounded memory growth
 // over process lifetime — entries idle for more than 2h (twice the refill
 // window) are discarded because a bucket that's been untouched that long is
-// indistinguishable from a fresh one anyway.
-func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
+// indistinguishable from a fresh one anyway. The prune goroutine exits when
+// ctx is cancelled; in production this is the server lifetime, in tests it
+// should be t.Context() so each test does not leak a goroutine for the life
+// of the test binary.
+func CreateOrgRateLimit(ctx context.Context, perHour int) func(http.Handler) http.Handler {
 	ipBuckets := &sync.Map{}
 	userBuckets := &sync.Map{}
 	refillPerSecond := float64(perHour) / 3600.0
@@ -272,7 +274,7 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 		return actual.(*tokenBucket)
 	}
 
-	startPruneLoop(ipBuckets, userBuckets, 10*time.Minute, 2*time.Hour)
+	startPruneLoop(ctx, ipBuckets, userBuckets, 10*time.Minute, 2*time.Hour)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -287,16 +289,14 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 			ip := remoteAddrIP(r)
 			if !getBucket(ipBuckets, ip).allow() {
 				zerolog.Ctx(r.Context()).Warn().Str("ip", ip).Msg("create-org rate limit exceeded (IP)")
-				w.Header().Set("Retry-After", "3600")
-				http.Error(w, `{"error":{"code":"CREATE_ORG_RATE_LIMITED","message":"too many organization-creation attempts; try again later"}}`, http.StatusTooManyRequests)
+				writeRateLimited(w, "CREATE_ORG_RATE_LIMITED", "too many organization-creation attempts; try again later", "3600")
 				return
 			}
 
 			if user := UserFromContext(r.Context()); user != nil {
 				if !getBucket(userBuckets, user.ID.String()).allow() {
 					zerolog.Ctx(r.Context()).Warn().Str("user_id", user.ID.String()).Msg("create-org rate limit exceeded (user)")
-					w.Header().Set("Retry-After", "3600")
-					http.Error(w, `{"error":{"code":"CREATE_ORG_RATE_LIMITED","message":"too many organization-creation attempts; try again later"}}`, http.StatusTooManyRequests)
+					writeRateLimited(w, "CREATE_ORG_RATE_LIMITED", "too many organization-creation attempts; try again later", "3600")
 					return
 				}
 			}
@@ -307,17 +307,33 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 }
 
 // startPruneLoop runs a background goroutine that evicts bucket-map entries
-// whose lastRefill is older than staleAfter. Exported as an internal helper
-// so tests can drive pruning synchronously via pruneStaleBuckets.
-func startPruneLoop(ipBuckets, userBuckets *sync.Map, interval, staleAfter time.Duration) {
+// whose lastRefill is older than staleAfter. Exits when ctx is cancelled.
+// Exported as an internal helper so tests can drive pruning synchronously
+// via pruneStaleBuckets.
+func startPruneLoop(ctx context.Context, ipBuckets, userBuckets *sync.Map, interval, staleAfter time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		for range ticker.C {
-			pruneStaleBuckets(ipBuckets, staleAfter)
-			pruneStaleBuckets(userBuckets, staleAfter)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				pruneStaleBuckets(ipBuckets, staleAfter)
+				pruneStaleBuckets(userBuckets, staleAfter)
+			}
 		}
 	}()
+}
+
+// writeRateLimited writes a 429 response with a JSON error body and a
+// Retry-After header. Use instead of http.Error for rate-limit rejections so
+// the Content-Type is application/json (http.Error would set text/plain and
+// append a trailing newline, leaving a body that looks like JSON but is
+// served as text).
+func writeRateLimited(w http.ResponseWriter, code, message, retryAfterSeconds string) {
+	w.Header().Set("Retry-After", retryAfterSeconds)
+	writeError(w, http.StatusTooManyRequests, code, message)
 }
 
 // pruneStaleBuckets removes entries whose bucket has not refilled within the

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -276,6 +276,14 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Order matters: IP first, user second. A request that passes IP
+			// but fails the user check still consumes an IP token. That is
+			// deliberate — we want scripted abuse from a single host to count
+			// against the host even when the per-user cap already rejected
+			// it, so rotating fresh user IDs on the same IP cannot dodge the
+			// IP backstop. The practical cost is that legitimate users
+			// sharing a NAT with a flooder may see IP rejections sooner; at
+			// 5/hour across any shared egress, that tradeoff favors the cap.
 			ip := remoteAddrIP(r)
 			if !getBucket(ipBuckets, ip).allow() {
 				zerolog.Ctx(r.Context()).Warn().Str("ip", ip).Msg("create-org rate limit exceeded (IP)")

--- a/internal/api/middleware/ratelimit.go
+++ b/internal/api/middleware/ratelimit.go
@@ -248,6 +248,11 @@ func ClaimRateLimit(perMinute int) func(http.Handler) http.Handler {
 // Requires authentication: the user bucket is the primary defense and
 // anonymous callers should already have been rejected by the auth middleware
 // upstream; the IP bucket is a backstop for any future unauthenticated path.
+//
+// Bucket maps are pruned in the background to prevent unbounded memory growth
+// over process lifetime — entries idle for more than 2h (twice the refill
+// window) are discarded because a bucket that's been untouched that long is
+// indistinguishable from a fresh one anyway.
 func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 	ipBuckets := &sync.Map{}
 	userBuckets := &sync.Map{}
@@ -266,6 +271,8 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 		actual, _ := m.LoadOrStore(key, fresh)
 		return actual.(*tokenBucket)
 	}
+
+	startPruneLoop(ipBuckets, userBuckets, 10*time.Minute, 2*time.Hour)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -289,6 +296,40 @@ func CreateOrgRateLimit(perHour int) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// startPruneLoop runs a background goroutine that evicts bucket-map entries
+// whose lastRefill is older than staleAfter. Exported as an internal helper
+// so tests can drive pruning synchronously via pruneStaleBuckets.
+func startPruneLoop(ipBuckets, userBuckets *sync.Map, interval, staleAfter time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for range ticker.C {
+			pruneStaleBuckets(ipBuckets, staleAfter)
+			pruneStaleBuckets(userBuckets, staleAfter)
+		}
+	}()
+}
+
+// pruneStaleBuckets removes entries whose bucket has not refilled within the
+// last staleAfter window. Safe to call concurrently with allow() because the
+// bucket's own mutex guards lastRefill.
+func pruneStaleBuckets(m *sync.Map, staleAfter time.Duration) {
+	cutoff := time.Now().Add(-staleAfter)
+	m.Range(func(key, value any) bool {
+		bucket, ok := value.(*tokenBucket)
+		if !ok {
+			return true
+		}
+		bucket.mu.Lock()
+		stale := bucket.lastRefill.Before(cutoff)
+		bucket.mu.Unlock()
+		if stale {
+			m.Delete(key)
+		}
+		return true
+	})
 }
 
 // extractIP returns the client's IP for rate-limit bucketing. Prefers the

--- a/internal/api/middleware/ratelimit_test.go
+++ b/internal/api/middleware/ratelimit_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
@@ -295,6 +297,88 @@ func TestClaimRateLimit(t *testing.T) {
 		require.Equal(t, http.StatusTooManyRequests, w.Code)
 		require.Contains(t, w.Body.String(), "CLAIM_RATE_LIMITED")
 	})
+}
+
+func TestCreateOrgRateLimit(t *testing.T) {
+	t.Parallel()
+
+	// Silent "OK" handler that the middleware wraps; we only care about whether
+	// the middleware admits or rejects the request.
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("allows the first N requests and blocks the N+1th with 429 + Retry-After", func(t *testing.T) {
+		t.Parallel()
+
+		const perHour = 3
+		handler := CreateOrgRateLimit(perHour)(okHandler)
+		user := &models.User{ID: uuid.New()}
+
+		for i := 0; i < perHour; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", nil)
+			req.RemoteAddr = "10.0.4.1:1234"
+			req = req.WithContext(WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			require.Equalf(t, http.StatusOK, w.Code, "request %d/%d inside the bucket should pass", i+1, perHour)
+		}
+
+		// First over-budget request.
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", nil)
+		req.RemoteAddr = "10.0.4.1:1234"
+		req = req.WithContext(WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		require.Equal(t, "3600", w.Header().Get("Retry-After"))
+		require.Contains(t, w.Body.String(), "CREATE_ORG_RATE_LIMITED")
+	})
+
+	t.Run("per-user bucket trips even when IP bucket is fresh", func(t *testing.T) {
+		t.Parallel()
+
+		const perHour = 2
+		handler := CreateOrgRateLimit(perHour)(okHandler)
+		user := &models.User{ID: uuid.New()}
+
+		// Exhaust the user bucket by cycling IP addresses, so the IP bucket
+		// never becomes the blocker.
+		for i := 0; i < perHour; i++ {
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", nil)
+			req.RemoteAddr = fmt.Sprintf("10.0.5.%d:1234", i+1)
+			req = req.WithContext(WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+		}
+
+		// Fresh IP, same user → user bucket should still reject.
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/organizations", nil)
+		req.RemoteAddr = "10.0.5.99:1234"
+		req = req.WithContext(WithUser(req.Context(), user))
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+		require.Contains(t, w.Body.String(), "CREATE_ORG_RATE_LIMITED")
+	})
+}
+
+func TestPruneStaleBuckets(t *testing.T) {
+	t.Parallel()
+
+	m := &sync.Map{}
+	fresh := &tokenBucket{lastRefill: time.Now()}
+	stale := &tokenBucket{lastRefill: time.Now().Add(-3 * time.Hour)}
+	m.Store("fresh", fresh)
+	m.Store("stale", stale)
+
+	pruneStaleBuckets(m, 2*time.Hour)
+
+	_, freshOK := m.Load("fresh")
+	_, staleOK := m.Load("stale")
+	require.True(t, freshOK, "fresh bucket should survive pruning")
+	require.False(t, staleOK, "stale bucket should be evicted")
 }
 
 func TestDefaultRateLimitConfig(t *testing.T) {

--- a/internal/api/middleware/ratelimit_test.go
+++ b/internal/api/middleware/ratelimit_test.go
@@ -312,7 +312,7 @@ func TestCreateOrgRateLimit(t *testing.T) {
 		t.Parallel()
 
 		const perHour = 3
-		handler := CreateOrgRateLimit(perHour)(okHandler)
+		handler := CreateOrgRateLimit(t.Context(), perHour)(okHandler)
 		user := &models.User{ID: uuid.New()}
 
 		for i := 0; i < perHour; i++ {
@@ -339,7 +339,7 @@ func TestCreateOrgRateLimit(t *testing.T) {
 		t.Parallel()
 
 		const perHour = 2
-		handler := CreateOrgRateLimit(perHour)(okHandler)
+		handler := CreateOrgRateLimit(t.Context(), perHour)(okHandler)
 		user := &models.User{ID: uuid.New()}
 
 		// Exhaust the user bucket by cycling IP addresses, so the IP bucket

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -108,6 +108,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 	// Create handlers
 	healthHandler := handlers.NewHealthHandler(pool)
 	authHandler := handlers.NewAuthHandler(cfg, pool, userStore, authSessionStore, invitationStore, membershipStore)
+	organizationsHandler := handlers.NewOrganizationsHandler(pool)
 	repoHandler := handlers.NewRepositoryHandler(repoStore)
 	if prService != nil {
 		repoHandler.SetPRService(prService)
@@ -228,6 +229,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 
 	// Wire audit emitter into all handlers that perform state changes.
 	authHandler.SetAuditEmitter(auditEmitter)
+	organizationsHandler.SetAuditEmitter(auditEmitter)
 	sessionHandler.SetAuditEmitter(auditEmitter)
 	if canceller != nil {
 		sessionHandler.SetCanceller(canceller)
@@ -454,6 +456,14 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		// token the server looks up, so tightening beyond the default 20 rps
 		// IP limit forces any enumeration attempt into detectable territory.
 		r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/invitations/claim", authHandler.ClaimInvitation)
+
+		// Creating a new org is zero-membership-safe for the same reason the
+		// other routes in this block are: a user whose only membership was
+		// just revoked must be able to create a fresh org to recover, and
+		// OrgContext would 403 them before they could. Rate-limited 5/hour
+		// per user and per IP to cap spam: a human creates maybe one org per
+		// onboarding, so a bucket any larger is just room for scripted abuse.
+		r.With(middleware.CreateOrgRateLimit(5)).Post("/api/v1/organizations", organizationsHandler.Create)
 
 		// Read-only routes (all roles: admin, member, viewer)
 		r.Group(func(r chi.Router) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -463,7 +463,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		// OrgContext would 403 them before they could. Rate-limited 5/hour
 		// per user and per IP to cap spam: a human creates maybe one org per
 		// onboarding, so a bucket any larger is just room for scripted abuse.
-		r.With(middleware.CreateOrgRateLimit(5)).Post("/api/v1/organizations", organizationsHandler.Create)
+		// The prune goroutine inside the limiter runs for the life of the
+		// process; context.Background() is the right lifetime here.
+		r.With(middleware.CreateOrgRateLimit(context.Background(), 5)).Post("/api/v1/organizations", organizationsHandler.Create)
 
 		// Read-only routes (all roles: admin, member, viewer)
 		r.Group(func(r chi.Router) {

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -90,6 +90,9 @@ const (
 	AuditActionTeamInvitationAccepted    AuditAction = "team.invitation_accepted"
 	AuditActionTeamInvitationClaimFailed AuditAction = "team.invitation_claim_failed"
 
+	// Organization actions
+	AuditActionOrganizationCreated AuditAction = "organization.created"
+
 	// Integration & credential actions
 	AuditActionIntegrationConnected AuditAction = "integration.connected"
 	AuditActionCredentialUpdated    AuditAction = "credential.updated" // #nosec G101 -- not a credential
@@ -132,6 +135,7 @@ func (a AuditAction) Validate() error {
 		AuditActionSettingsUpdated, AuditActionTeamMemberInvited, AuditActionTeamMemberRoleChanged,
 		AuditActionTeamMemberRemoved, AuditActionTeamInvitationRevoked, AuditActionTeamInvitationAccepted,
 		AuditActionTeamInvitationClaimFailed,
+		AuditActionOrganizationCreated,
 		AuditActionIntegrationConnected, AuditActionCredentialUpdated, AuditActionCredentialDeleted,
 		AuditActionAuthLogin, AuditActionAuthLogout, AuditActionAuthRegister,
 		AuditActionEvalTaskCreated, AuditActionEvalTaskUpdated, AuditActionEvalTaskArchived,
@@ -165,6 +169,7 @@ const (
 	AuditResourceEvalRun              AuditResourceType = "eval_run"
 	AuditResourceEvalBatch            AuditResourceType = "eval_batch"
 	AuditResourceAutomation           AuditResourceType = "automation"
+	AuditResourceOrganization         AuditResourceType = "organization"
 )
 
 func (t AuditResourceType) Validate() error {
@@ -175,7 +180,7 @@ func (t AuditResourceType) Validate() error {
 		AuditResourceIntegration, AuditResourceCredential, AuditResourceUser,
 		AuditResourceSessionReviewComment, AuditResourcePMDocument, AuditResourcePMDocumentSet,
 		AuditResourceEvalTask, AuditResourceEvalRun, AuditResourceEvalBatch,
-		AuditResourceAutomation:
+		AuditResourceAutomation, AuditResourceOrganization:
 		return nil
 	default:
 		return fmt.Errorf("invalid AuditResourceType: %q", t)


### PR DESCRIPTION
## Summary
- Replaces the static org-name header with an `OrgSwitcher` dropdown fed by a new `GET /auth/memberships` response, plus a `CreateOrgDialog` for provisioning additional orgs from the switcher.
- Adds `POST /api/v1/organizations` (outside `OrgContext`, so zero-membership users can recover), wraps it in a new `CreateOrgRateLimit` (5/hour per user and per IP), and records an `organization.created` audit event.
- Plumbs per-tab active org selection through `sessionStorage` and an `X-Active-Org-ID` request header in `api.ts`; the client also listens for an `X-Org-Membership-Revoked` response header to clear stale selections.

## Test plan
- [ ] `make lint` and frontend/backend test suites pass
- [ ] Switcher lists memberships, switches active org, and persists per-tab
- [ ] Create-org dialog provisions a new org and switches into it
- [ ] `POST /organizations` rejects past the 5/hour user/IP limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)