### PR TITLE
Add per-repository disconnect for GitHub integration

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -23,13 +23,17 @@ import {
 import { useAutosave } from "@/hooks/useAutosave";
 import { useDisconnectIntegration } from "@/hooks/use-disconnect-integration";
 import { queryKeys } from "@/lib/query-keys";
+import {
+  useDisconnectRepository,
+  useReconnectRepository,
+} from "@/hooks/use-repository-connection";
 
 type SlackChannel = { id: string; name: string; selected: boolean };
 type SlackChannelsResp = { data: SlackChannel[] } | undefined;
 
 // Coalesce multi-toggle bursts: the later selection wins. Hoisted so every
 // `useAutosave` caller sharing `queryKeys.integrations.slackChannels` passes
-// the same referential identity — `useAutosave` throws in dev when two
+// the same referential identity - `useAutosave` throws in dev when two
 // callers register different coalesce fns against the same queryKey.
 const coalesceSlackChannels = (_a: string[], b: string[]): string[] => b;
 
@@ -126,11 +130,16 @@ export default function IntegrationsPage() {
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
   });
+  // Fetch disconnected repos too so the user has a "Reconnect" affordance —
+  // without this, a user-disconnected repo becomes a ghost with no discoverable
+  // path back to active.
   const { data: reposResp } = useQuery({
-    queryKey: ["repositories"],
-    queryFn: () => api.repositories.list(),
+    queryKey: ["repositories", { includeDisconnected: true }],
+    queryFn: () => api.repositories.list({ includeDisconnected: true }),
   });
   const disconnectMutation = useDisconnectIntegration();
+  const disconnectRepoMutation = useDisconnectRepository();
+  const reconnectRepoMutation = useReconnectRepository();
 
   // Notion token dialog state.
   const [notionDialogOpen, setNotionDialogOpen] = useState(false);
@@ -166,9 +175,16 @@ export default function IntegrationsPage() {
     (integration) => integration.provider === "notion" && integration.status === "active"
   );
 
-  const connectedRepoNames = (reposResp?.data ?? [])
-    .filter((r) => r.status === "active")
-    .map((r) => r.full_name);
+  const githubRepos = (reposResp?.data ?? []).map((r) => ({
+    id: r.id,
+    full_name: r.full_name,
+    status: r.status,
+  }));
+  const pendingRepoID = disconnectRepoMutation.isPending
+    ? (disconnectRepoMutation.variables ?? null)
+    : reconnectRepoMutation.isPending
+      ? (reconnectRepoMutation.variables ?? null)
+      : null;
 
   return (
     <PageContainer size="default">
@@ -179,7 +195,10 @@ export default function IntegrationsPage() {
         />
       <AllIntegrationCards
         githubConnected={Boolean(githubIntegration)}
-        githubRepoNames={connectedRepoNames}
+        githubRepos={githubRepos}
+        onDisconnectRepo={(id) => disconnectRepoMutation.mutate(id)}
+        onReconnectRepo={(id) => reconnectRepoMutation.mutate(id)}
+        pendingRepoID={pendingRepoID}
         sentryConnected={Boolean(sentryIntegration)}
         linearConnected={Boolean(linearIntegration)}
         linearLoading={false}

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -56,7 +56,10 @@ describe("integration connection cards", () => {
     renderWithProviders(
       <SourceControlIntegrationCard
         githubConnected
-        githubRepoNames={["acme/api", "acme/web"]}
+        githubRepos={[
+          { id: "r1", full_name: "acme/api", status: "active" },
+          { id: "r2", full_name: "acme/web", status: "active" },
+        ]}
         onConnectGitHub={vi.fn()}
       />
     );
@@ -69,12 +72,49 @@ describe("integration connection cards", () => {
     renderWithProviders(
       <SourceControlIntegrationCard
         githubConnected={false}
-        githubRepoNames={["acme/api"]}
+        githubRepos={[{ id: "r1", full_name: "acme/api", status: "active" }]}
         onConnectGitHub={vi.fn()}
       />
     );
 
     expect(screen.queryByText("acme/api")).not.toBeInTheDocument();
+  });
+
+  it("shows per-repo disconnect button and calls onDisconnectRepo on confirm", async () => {
+    const user = userEvent.setup();
+    const onDisconnectRepo = vi.fn();
+
+    renderWithProviders(
+      <SourceControlIntegrationCard
+        githubConnected
+        githubRepos={[{ id: "r1", full_name: "acme/api", status: "active" }]}
+        onConnectGitHub={vi.fn()}
+        onDisconnectRepo={onDisconnectRepo}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Disconnect acme/api" }));
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(onDisconnectRepo).toHaveBeenCalledWith("r1");
+  });
+
+  it("renders Reconnect button for disconnected repos and calls onReconnectRepo", async () => {
+    const user = userEvent.setup();
+    const onReconnectRepo = vi.fn();
+
+    renderWithProviders(
+      <SourceControlIntegrationCard
+        githubConnected
+        githubRepos={[{ id: "r1", full_name: "acme/api", status: "disconnected" }]}
+        onConnectGitHub={vi.fn()}
+        onReconnectRepo={onReconnectRepo}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reconnect acme/api" }));
+
+    expect(onReconnectRepo).toHaveBeenCalledWith("r1");
   });
 
   it("disables Linear connect when already connected and no disconnect handler", () => {

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
@@ -23,9 +23,21 @@ type IntegrationCallbacks = {
   disconnectError?: string | null;
 };
 
-type SourceControlIntegrationCardProps = IntegrationCallbacks & {
+export type GithubRepoChip = {
+  id: string;
+  full_name: string;
+  status: string;
+};
+
+type RepoCallbacks = {
+  onDisconnectRepo?: (repoID: string) => void;
+  onReconnectRepo?: (repoID: string) => void;
+  pendingRepoID?: string | null;
+};
+
+type SourceControlIntegrationCardProps = IntegrationCallbacks & RepoCallbacks & {
   githubConnected: boolean;
-  githubRepoNames?: string[];
+  githubRepos?: GithubRepoChip[];
   onConnectGitHub: () => void;
   onSyncRepos?: () => void;
   isSyncing?: boolean;
@@ -46,18 +58,132 @@ type AdditionalIntegrationCardsProps = IntegrationCallbacks & {
 
 type AllIntegrationCardsProps = SourceControlIntegrationCardProps & AdditionalIntegrationCardsProps;
 
-function ConnectedReposList({ repoNames }: { repoNames: string[] }) {
-  if (repoNames.length === 0) return null;
+// ActiveRepoChip renders one active repo with a trailing × button that opens a
+// confirmation dialog before disconnecting. The × is only shown when a handler
+// is provided so read-only callers (e.g. the GitHub card rendered before the
+// user has the disconnect wiring) still display cleanly.
+function ActiveRepoChip({
+  repo,
+  onDisconnect,
+  pending,
+}: {
+  repo: GithubRepoChip;
+  onDisconnect?: (id: string) => void;
+  pending: boolean;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
   return (
-    <div className="mt-1.5 flex flex-wrap gap-1.5">
-      {repoNames.map((name) => (
-        <span
-          key={name}
-          className="inline-flex items-center rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+    <>
+      <span
+        className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+      >
+        {repo.full_name}
+        {onDisconnect && (
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            disabled={pending}
+            aria-label={`Disconnect ${repo.full_name}`}
+            className="ml-0.5 rounded-sm p-0.5 text-muted-foreground/70 transition hover:bg-destructive/10 hover:text-destructive disabled:opacity-50"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        )}
+      </span>
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Disconnect {repo.full_name}?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Existing sessions and runs for this repo will remain visible, but
+              you won&rsquo;t be able to start new ones. You can reconnect at
+              any time from this page.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                setConfirmOpen(false);
+                onDisconnect?.(repo.id);
+              }}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Disconnect
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function DisconnectedRepoChip({
+  repo,
+  onReconnect,
+  pending,
+}: {
+  repo: GithubRepoChip;
+  onReconnect?: (id: string) => void;
+  pending: boolean;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border border-dashed border-muted-foreground/30 bg-transparent px-2 py-0.5 text-xs font-medium text-muted-foreground/70 line-through">
+      {repo.full_name}
+      {onReconnect && (
+        <button
+          type="button"
+          onClick={() => onReconnect(repo.id)}
+          disabled={pending}
+          aria-label={`Reconnect ${repo.full_name}`}
+          className="ml-0.5 rounded-sm px-1 py-0 text-xs font-semibold uppercase tracking-wide text-primary no-underline hover:bg-primary/10 disabled:opacity-50"
         >
-          {name}
-        </span>
-      ))}
+          Reconnect
+        </button>
+      )}
+    </span>
+  );
+}
+
+function ConnectedReposList({
+  repos,
+  onDisconnectRepo,
+  onReconnectRepo,
+  pendingRepoID,
+}: {
+  repos: GithubRepoChip[];
+} & RepoCallbacks) {
+  if (repos.length === 0) return null;
+  const active = repos.filter((r) => r.status === "active");
+  const disconnected = repos.filter((r) => r.status !== "active");
+
+  return (
+    <div className="mt-1.5 space-y-1.5">
+      {active.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {active.map((repo) => (
+            <ActiveRepoChip
+              key={repo.id}
+              repo={repo}
+              onDisconnect={onDisconnectRepo}
+              pending={pendingRepoID === repo.id}
+            />
+          ))}
+        </div>
+      )}
+      {disconnected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {disconnected.map((repo) => (
+            <DisconnectedRepoChip
+              key={repo.id}
+              repo={repo}
+              onReconnect={onReconnectRepo}
+              pending={pendingRepoID === repo.id}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -166,7 +292,7 @@ function IntegrationAction({
 
 export function SourceControlIntegrationCard({
   githubConnected,
-  githubRepoNames = [],
+  githubRepos = [],
   onConnectGitHub,
   onDisconnect,
   disconnectingProvider,
@@ -174,6 +300,9 @@ export function SourceControlIntegrationCard({
   disconnectError,
   onSyncRepos,
   isSyncing,
+  onDisconnectRepo,
+  onReconnectRepo,
+  pendingRepoID,
 }: SourceControlIntegrationCardProps) {
   const github = getIntegrationByKey("github");
 
@@ -186,7 +315,14 @@ export function SourceControlIntegrationCard({
           description: github.description,
           logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
-          extra: githubConnected ? <ConnectedReposList repoNames={githubRepoNames} /> : undefined,
+          extra: githubConnected ? (
+            <ConnectedReposList
+              repos={githubRepos}
+              onDisconnectRepo={onDisconnectRepo}
+              onReconnectRepo={onReconnectRepo}
+              pendingRepoID={pendingRepoID}
+            />
+          ) : undefined,
           action: (
             <div className="flex items-center gap-1.5">
               {githubConnected && onSyncRepos && (
@@ -332,13 +468,16 @@ export function AllIntegrationCards({
   disconnectErrorProvider,
   disconnectError,
   githubConnected,
-  githubRepoNames = [],
+  githubRepos = [],
   sentryConnected,
   linearConnected,
   linearLoading,
   slackConnected,
   notionConnected,
   notionLoading,
+  onDisconnectRepo,
+  onReconnectRepo,
+  pendingRepoID,
 }: AllIntegrationCardsProps) {
   const github = getIntegrationByKey("github");
   const sentry = getIntegrationByKey("sentry");
@@ -355,7 +494,14 @@ export function AllIntegrationCards({
           description: github.description,
           logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
-          extra: githubConnected ? <ConnectedReposList repoNames={githubRepoNames} /> : undefined,
+          extra: githubConnected ? (
+            <ConnectedReposList
+              repos={githubRepos}
+              onDisconnectRepo={onDisconnectRepo}
+              onReconnectRepo={onReconnectRepo}
+              pendingRepoID={pendingRepoID}
+            />
+          ) : undefined,
           action: (
             <IntegrationAction
               connected={githubConnected}

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -198,7 +198,11 @@ export function SetupChecklist() {
 
   const integrations = integrationsResponse?.data ?? [];
   const repositories = repositoriesResponse?.data ?? [];
-  const githubRepoNames = repositories.map((repository) => repository.full_name);
+  const githubRepos = repositories.map((r) => ({
+    id: r.id,
+    full_name: r.full_name,
+    status: r.status,
+  }));
   const githubIntegration = integrations.find((integration) => integration.provider === "github" && integration.status === "active");
   const sentryIntegration = integrations.find((integration) => integration.provider === "sentry" && integration.status === "active");
   const linearIntegration = integrations.find((integration) => integration.provider === "linear" && integration.status === "active");
@@ -217,7 +221,7 @@ export function SetupChecklist() {
         <div className="space-y-3">
           <SourceControlIntegrationCard
             githubConnected={Boolean(githubIntegration)}
-            githubRepoNames={githubRepoNames}
+            githubRepos={githubRepos}
             onConnectGitHub={() => api.integrations.loginGitHub()}
             onDisconnect={(provider) => disconnectMutation.mutate(provider)}
             disconnectingProvider={disconnectMutation.isPending ? disconnectMutation.variables : null}

--- a/frontend/src/hooks/use-repository-connection.ts
+++ b/frontend/src/hooks/use-repository-connection.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+// Shared cache invalidations for connect/disconnect: the repo picker, the
+// integrations page (renders chips + counts), and the repo context switcher
+// summary all reflect status changes.
+function invalidateRepositoryQueries(queryClient: ReturnType<typeof useQueryClient>) {
+  queryClient.invalidateQueries({ queryKey: ["repositories"] });
+  queryClient.invalidateQueries({ queryKey: ["integrations"] });
+  queryClient.invalidateQueries({ queryKey: ["repositories", "summary"] });
+}
+
+export function useDisconnectRepository() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.repositories.disconnect(id),
+    onSuccess: () => invalidateRepositoryQueries(queryClient),
+  });
+}
+
+export function useReconnectRepository() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.repositories.reconnect(id),
+    onSuccess: () => invalidateRepositoryQueries(queryClient),
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -187,11 +187,18 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').OrganizationCreated>>('/api/v1/organizations', { name }),
   },
   repositories: {
-    list: () => get<import('./types').ListResponse<import('./types').Repository>>('/api/v1/repositories'),
+    list: (opts?: { includeDisconnected?: boolean }) => {
+      const qs = opts?.includeDisconnected ? '?include_disconnected=true' : '';
+      return get<import('./types').ListResponse<import('./types').Repository>>(`/api/v1/repositories${qs}`);
+    },
     get: (id: string) => get<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}`),
     update: (id: string, data: Record<string, unknown>) =>
       patch<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}`, data),
     delete: (id: string) => del(`/api/v1/repositories/${id}`),
+    disconnect: (id: string) =>
+      post<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}/disconnect`),
+    reconnect: (id: string) =>
+      post<import('./types').SingleResponse<import('./types').Repository>>(`/api/v1/repositories/${id}/reconnect`),
     summary: () => get<import('./types').ListResponse<import('./types').RepoSummary>>('/api/v1/repositories/summary'),
     branches: (id: string) => get<import('./types').ListResponse<{ name: string; protected: boolean }>>(`/api/v1/repositories/${id}/branches`),
     detectPreview: (owner: string, repo: string) => get<import('./preview-types').PreviewDetectionResult>(`/api/v1/repos/${owner}/${repo}/preview/detect`),

--- a/internal/api/handlers/automations.go
+++ b/internal/api/handlers/automations.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -177,6 +178,10 @@ func (h *AutomationHandler) Create(w http.ResponseWriter, r *http.Request) {
 
 	repoID, err := h.resolveRepositoryID(r.Context(), orgID, req.RepositoryID)
 	if err != nil {
+		if errors.Is(err, errRepoDisconnected) {
+			writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to create automations")
+			return
+		}
 		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", err.Error())
 		return
 	}
@@ -406,6 +411,10 @@ func (h *AutomationHandler) Update(w http.ResponseWriter, r *http.Request) {
 	if req.RepositoryID != nil {
 		repoID, err := h.resolveRepositoryID(r.Context(), orgID, *req.RepositoryID)
 		if err != nil {
+			if errors.Is(err, errRepoDisconnected) {
+				writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to assign automations")
+				return
+			}
 			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", err.Error())
 			return
 		}

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -23,16 +23,22 @@ import (
 )
 
 // stubRepoLookup satisfies automationRepoLookup for Create/Update tests that
-// supply a repository_id.
+// supply a repository_id. Status defaults to active so existing tests that
+// exercise the happy path don't need to opt in.
 type stubRepoLookup struct {
-	err error
+	err    error
+	status string
 }
 
 func (s *stubRepoLookup) GetByID(_ context.Context, _, repoID uuid.UUID) (models.Repository, error) {
 	if s.err != nil {
 		return models.Repository{}, s.err
 	}
-	return models.Repository{ID: repoID}, nil
+	status := s.status
+	if status == "" {
+		status = models.RepositoryStatusActive
+	}
+	return models.Repository{ID: repoID, Status: status}, nil
 }
 
 func automationTestColumns() []string {
@@ -322,6 +328,24 @@ func TestAutomationHandler_Create_RepoIDNotFoundInOrg(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+func TestAutomationHandler_Create_RejectsDisconnectedRepo(t *testing.T) {
+	t.Parallel()
+
+	h := NewAutomationHandler(nil, nil)
+	h.SetRepositoryStore(&stubRepoLookup{status: models.RepositoryStatusDisconnected})
+
+	body := map[string]any{
+		"name":          "n",
+		"goal":          "g",
+		"repository_id": uuid.New().String(),
+	}
+	req := newAutomationRequest(t, http.MethodPost, "/api/v1/automations", body, uuid.New(), uuid.New(), nil)
+	rr := httptest.NewRecorder()
+	h.Create(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "REPO_DISCONNECTED")
+}
+
 func TestAutomationHandler_Create_RepoIDFailsClosedWhenNoStore(t *testing.T) {
 	t.Parallel()
 
@@ -559,6 +583,39 @@ func TestAutomationHandler_Update_InvalidID(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.Update(rr, req)
 	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestAutomationHandler_Update_RejectsDisconnectedRepo(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	id := uuid.New()
+	now := time.Now()
+	iv := 1
+	unit := "days"
+	a := models.Automation{
+		ID: id, OrgID: orgID, Name: "a", Goal: "g",
+		ExecutionMode: "sequential", BaseBranch: "main", ScheduleType: "interval",
+		Timezone: "UTC", Enabled: true, IntervalValue: &iv, IntervalUnit: &unit,
+		CreatedAt: now, UpdatedAt: now,
+	}
+	mock.ExpectQuery("SELECT .+ FROM automations WHERE id =").
+		WithArgs(testAnyArgs(2)...).
+		WillReturnRows(newAutomationRow(mock, a))
+
+	h := NewAutomationHandler(db.NewAutomationStore(mock), db.NewAutomationRunStore(mock))
+	h.SetRepositoryStore(&stubRepoLookup{status: models.RepositoryStatusDisconnected})
+
+	body := map[string]any{"repository_id": uuid.New().String()}
+	req := newAutomationRequest(t, http.MethodPatch, "/api/v1/automations/"+id.String(), body, orgID, uuid.New(), map[string]string{"id": id.String()})
+	rr := httptest.NewRecorder()
+	h.Update(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "REPO_DISCONNECTED")
 }
 
 // --- Delete ---

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -27,7 +27,7 @@ import (
 // exercise the happy path don't need to opt in.
 type stubRepoLookup struct {
 	err    error
-	status string
+	status models.RepositoryStatus
 }
 
 func (s *stubRepoLookup) GetByID(_ context.Context, _, repoID uuid.UUID) (models.Repository, error) {
@@ -38,7 +38,7 @@ func (s *stubRepoLookup) GetByID(_ context.Context, _, repoID uuid.UUID) (models
 	if status == "" {
 		status = models.RepositoryStatusActive
 	}
-	return models.Repository{ID: repoID, Status: status}, nil
+	return models.Repository{ID: repoID, Status: string(status)}, nil
 }
 
 func automationTestColumns() []string {

--- a/internal/api/handlers/automations_validation.go
+++ b/internal/api/handlers/automations_validation.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -73,18 +74,11 @@ func validateTimezone(tz string) error {
 	return nil
 }
 
-// errRepoDisconnected is returned by resolveRepositoryID when the repo exists
-// but is user-disconnected. Callers should surface this as REPO_DISCONNECTED so
-// the UI can show a reconnect affordance instead of a generic validation error.
-var errRepoDisconnected = fmt.Errorf("repository is disconnected")
-
 // resolveRepositoryID parses a repository_id from a request and verifies it
 // belongs to orgID and is still active. Returns nil + nil for empty input.
-// Errors are user-safe and can be returned directly from handlers.
-//
-// Fails closed when no repo store is configured: the router always calls
-// SetRepositoryStore so a missing store means a wiring bug, not a
-// less-secure-but-usable path.
+// Errors are user-safe and can be returned directly from handlers; the
+// errRepoDisconnected sentinel (defined in repo_active.go) lets handlers
+// distinguish disconnected repos so they can return REPO_DISCONNECTED.
 func (h *AutomationHandler) resolveRepositoryID(ctx context.Context, orgID uuid.UUID, raw string) (*uuid.UUID, error) {
 	if raw == "" {
 		return nil, nil
@@ -93,15 +87,15 @@ func (h *AutomationHandler) resolveRepositoryID(ctx context.Context, orgID uuid.
 	if err != nil {
 		return nil, fmt.Errorf("invalid repository_id")
 	}
-	if h.repoStore == nil {
-		return nil, fmt.Errorf("repository lookup not configured")
-	}
-	repo, err := h.repoStore.GetByID(ctx, orgID, parsed)
-	if err != nil {
-		return nil, fmt.Errorf("repository not found in this org")
-	}
-	if !repo.IsActive() {
-		return nil, errRepoDisconnected
+	if _, err := requireActiveRepo(ctx, h.repoStore, orgID, parsed); err != nil {
+		switch {
+		case errors.Is(err, errRepoDisconnected):
+			return nil, errRepoDisconnected
+		case errors.Is(err, errRepoStoreUnconfigured):
+			return nil, fmt.Errorf("repository lookup not configured")
+		default:
+			return nil, fmt.Errorf("repository not found in this org")
+		}
 	}
 	return &parsed, nil
 }

--- a/internal/api/handlers/automations_validation.go
+++ b/internal/api/handlers/automations_validation.go
@@ -73,9 +73,14 @@ func validateTimezone(tz string) error {
 	return nil
 }
 
+// errRepoDisconnected is returned by resolveRepositoryID when the repo exists
+// but is user-disconnected. Callers should surface this as REPO_DISCONNECTED so
+// the UI can show a reconnect affordance instead of a generic validation error.
+var errRepoDisconnected = fmt.Errorf("repository is disconnected")
+
 // resolveRepositoryID parses a repository_id from a request and verifies it
-// belongs to orgID. Returns nil + nil for empty input. The error is one a
-// handler can return directly (already user-safe).
+// belongs to orgID and is still active. Returns nil + nil for empty input.
+// Errors are user-safe and can be returned directly from handlers.
 //
 // Fails closed when no repo store is configured: the router always calls
 // SetRepositoryStore so a missing store means a wiring bug, not a
@@ -91,8 +96,12 @@ func (h *AutomationHandler) resolveRepositoryID(ctx context.Context, orgID uuid.
 	if h.repoStore == nil {
 		return nil, fmt.Errorf("repository lookup not configured")
 	}
-	if _, err := h.repoStore.GetByID(ctx, orgID, parsed); err != nil {
+	repo, err := h.repoStore.GetByID(ctx, orgID, parsed)
+	if err != nil {
 		return nil, fmt.Errorf("repository not found in this org")
+	}
+	if !repo.IsActive() {
+		return nil, errRepoDisconnected
 	}
 	return &parsed, nil
 }

--- a/internal/api/handlers/internal_projects.go
+++ b/internal/api/handlers/internal_projects.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -153,13 +154,15 @@ func (h *InternalProjectHandler) Propose(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	repo, err := h.repoStore.GetByID(r.Context(), claims.OrgID, repoID)
-	if err != nil || repo.OrgID != claims.OrgID {
-		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY", "repository not found in this organization")
-		return
-	}
-	if !repo.IsActive() {
-		writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to propose projects")
+	if _, err := requireActiveRepo(r.Context(), h.repoStore, claims.OrgID, repoID); err != nil {
+		switch {
+		case errors.Is(err, errRepoDisconnected):
+			writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to propose projects")
+		case errors.Is(err, errRepoStoreUnconfigured):
+			writeError(w, r, http.StatusInternalServerError, "REPO_STORE_UNCONFIGURED", "repository lookup not configured")
+		default:
+			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY", "repository not found in this organization")
+		}
 		return
 	}
 

--- a/internal/api/handlers/internal_projects.go
+++ b/internal/api/handlers/internal_projects.go
@@ -30,12 +30,12 @@ const maxOpenProposalsPerRepo = 3
 // InternalProjectHandler handles project proposal creation from sandbox agents
 // via internal API tokens.
 type InternalProjectHandler struct {
-	txStarter         db.TxStarter
-	projectStore      *db.ProjectStore
-	projectTaskStore  *db.ProjectTaskStore
-	repoStore         *db.RepositoryStore
-	signingSecret     string
-	logger            zerolog.Logger
+	txStarter        db.TxStarter
+	projectStore     *db.ProjectStore
+	projectTaskStore *db.ProjectTaskStore
+	repoStore        *db.RepositoryStore
+	signingSecret    string
+	logger           zerolog.Logger
 
 	// perTokenRepoCount tracks how many proposals each token has created per repo.
 	// Keyed by hash(token):repoID. This is intentionally in-memory: counters
@@ -156,6 +156,10 @@ func (h *InternalProjectHandler) Propose(w http.ResponseWriter, r *http.Request)
 	repo, err := h.repoStore.GetByID(r.Context(), claims.OrgID, repoID)
 	if err != nil || repo.OrgID != claims.OrgID {
 		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY", "repository not found in this organization")
+		return
+	}
+	if !repo.IsActive() {
+		writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to propose projects")
 		return
 	}
 

--- a/internal/api/handlers/internal_projects_test.go
+++ b/internal/api/handlers/internal_projects_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/auth"
+	"github.com/assembledhq/143/internal/db"
+)
+
+func TestInternalProjectHandler_Propose_RejectsDisconnectedRepo(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	secret := "test-secret-32-chars-long-enough-xxx"
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	// Return an org-matching repo with disconnected status so the IsActive
+	// guard fires — the whole point of this test.
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "org/repo", "main",
+				false, nil, nil, "https://github.com/org/repo.git", int64(12345), "disconnected",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+
+	handler := NewInternalProjectHandler(
+		nil,
+		db.NewProjectStore(mock),
+		db.NewProjectTaskStore(mock),
+		db.NewRepositoryStore(mock),
+		secret,
+		zerolog.Nop(),
+	)
+
+	token, err := auth.GenerateInternalToken(secret, orgID, repoID, 5*time.Minute)
+	require.NoError(t, err)
+
+	body, err := json.Marshal(map[string]any{
+		"repository_id": repoID.String(),
+		"title":         "T",
+		"goal":          "G",
+		"reasoning":     "R",
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/internal/projects/propose", bytes.NewBuffer(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+	handler.Propose(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "REPO_DISCONNECTED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -67,6 +67,8 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"PMHandler.Bootstrap":               "delegates to enqueueAndRespond which uses OrgIDFromContext",
 		"PMHandler.Refresh":                 "delegates to enqueueAndRespond which uses OrgIDFromContext",
 		"ProjectHandler.Start":              "delegates to transitionStatus which uses OrgIDFromContext",
+		"RepositoryHandler.Disconnect":      "delegates to setRepoStatus which uses OrgIDFromContext",
+		"RepositoryHandler.Reconnect":       "delegates to setRepoStatus which uses OrgIDFromContext",
 		"SessionFileHandler.ListFiles":      "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionFileHandler.GetFileContent": "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionFileHandler.GetFileContext": "delegates to getSessionContainer which uses OrgIDFromContext",

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -20,6 +20,7 @@ type ProjectHandler struct {
 	attachmentStore   *db.ProjectAttachmentStore
 	specStore         *db.ProjectSpecStore
 	jobStore          *db.JobStore
+	repoStore         *db.RepositoryStore
 	audit             *db.AuditEmitter
 }
 
@@ -47,6 +48,13 @@ func NewProjectHandler(
 // SetJobStore injects the job store for enqueuing project_cycle jobs.
 func (h *ProjectHandler) SetJobStore(jobStore *db.JobStore) {
 	h.jobStore = jobStore
+}
+
+// SetRepositoryStore injects the repository store so create flows can reject
+// disconnected repos. Missing store is treated as a wiring bug — handlers that
+// need it will fail closed with a clear error.
+func (h *ProjectHandler) SetRepositoryStore(repoStore *db.RepositoryStore) {
+	h.repoStore = repoStore
 }
 
 // ProjectDetailResponse combines a project with its tasks, cycles, attachments, and specs.
@@ -216,6 +224,20 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 	repoID, err := uuid.Parse(req.RepositoryID)
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
+		return
+	}
+
+	if h.repoStore == nil {
+		writeError(w, r, http.StatusInternalServerError, "REPO_STORE_UNCONFIGURED", "repository lookup not configured")
+		return
+	}
+	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "repository not found in this org")
+		return
+	}
+	if !repo.IsActive() {
+		writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to create projects")
 		return
 	}
 

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -227,17 +228,15 @@ func (h *ProjectHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.repoStore == nil {
-		writeError(w, r, http.StatusInternalServerError, "REPO_STORE_UNCONFIGURED", "repository lookup not configured")
-		return
-	}
-	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
-	if err != nil {
-		writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "repository not found in this org")
-		return
-	}
-	if !repo.IsActive() {
-		writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to create projects")
+	if _, err := requireActiveRepo(r.Context(), h.repoStore, orgID, repoID); err != nil {
+		switch {
+		case errors.Is(err, errRepoDisconnected):
+			writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to create projects")
+		case errors.Is(err, errRepoStoreUnconfigured):
+			writeError(w, r, http.StatusInternalServerError, "REPO_STORE_UNCONFIGURED", "repository lookup not configured")
+		default:
+			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "repository not found in this org")
+		}
 		return
 	}
 

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -388,11 +388,22 @@ func TestProjectHandler_Create(t *testing.T) {
 	defer mock.Close()
 
 	handler := NewProjectHandler(db.NewProjectStore(mock), nil, nil, nil, nil)
+	handler.SetRepositoryStore(db.NewRepositoryStore(mock))
 	orgID := uuid.New()
 	userID := uuid.New()
 	repoID := uuid.New()
+	integrationID := uuid.New()
 	now := time.Now()
 
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+				false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "active",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
 	mock.ExpectBegin()
 	mock.ExpectQuery("INSERT INTO projects").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -491,6 +492,105 @@ func TestProjectHandler_Create_InvalidRepoID(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rr.Code)
 	require.Contains(t, rr.Body.String(), "INVALID_REPOSITORY_ID")
+}
+
+func TestProjectHandler_Create_RejectsDisconnectedRepo(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewProjectHandler(db.NewProjectStore(mock), nil, nil, nil, nil)
+	handler.SetRepositoryStore(db.NewRepositoryStore(mock))
+	orgID := uuid.New()
+	userID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+				false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "disconnected",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+
+	body, _ := json.Marshal(map[string]string{
+		"title":         "New Project",
+		"goal":          "Build something",
+		"repository_id": repoID.String(),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewBuffer(body))
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "REPO_DISCONNECTED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestProjectHandler_Create_RepoNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewProjectHandler(db.NewProjectStore(mock), nil, nil, nil, nil)
+	handler.SetRepositoryStore(db.NewRepositoryStore(mock))
+
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	body, _ := json.Marshal(map[string]string{
+		"title":         "New Project",
+		"goal":          "Build something",
+		"repository_id": uuid.New().String(),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewBuffer(body))
+	ctx := middleware.WithOrgID(req.Context(), uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: uuid.New()})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "INVALID_REPOSITORY_ID")
+}
+
+func TestProjectHandler_Create_RepoStoreUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	handler := NewProjectHandler(nil, nil, nil, nil, nil)
+
+	body, _ := json.Marshal(map[string]string{
+		"title":         "New Project",
+		"goal":          "Build something",
+		"repository_id": uuid.New().String(),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/projects", bytes.NewBuffer(body))
+	ctx := middleware.WithOrgID(req.Context(), uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: uuid.New()})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Create(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.Contains(t, rr.Body.String(), "REPO_STORE_UNCONFIGURED")
 }
 
 // --- Delete handler tests ---

--- a/internal/api/handlers/repo_active.go
+++ b/internal/api/handlers/repo_active.go
@@ -1,0 +1,62 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// Sentinels returned by requireActiveRepo. Callers map them to the HTTP shape
+// that fits their endpoint — some 404 the missing case, others 400 it.
+var (
+	errRepoStoreUnconfigured = errors.New("repository lookup not configured")
+	errRepoNotFound          = errors.New("repository not found")
+	errRepoDisconnected      = errors.New("repository is disconnected")
+)
+
+// repoLookup is the slim interface requireActiveRepo needs from the repository
+// store. Defined here (instead of taking *db.RepositoryStore) so that handlers
+// that already inject a narrower interface — like AutomationHandler's
+// automationRepoLookup — can share the same helper without an adapter.
+type repoLookup interface {
+	GetByID(ctx context.Context, orgID, repoID uuid.UUID) (models.Repository, error)
+}
+
+// requireActiveRepo fetches a repo scoped to orgID and verifies it is active.
+// Centralises the three-step check (store wired? row exists? still active?)
+// that every creation path (sessions, projects, automations, internal proposals)
+// needs to run before accepting new work against a repository.
+func requireActiveRepo(ctx context.Context, store repoLookup, orgID, repoID uuid.UUID) (models.Repository, error) {
+	if isNilLookup(store) {
+		return models.Repository{}, errRepoStoreUnconfigured
+	}
+	repo, err := store.GetByID(ctx, orgID, repoID)
+	if err != nil {
+		return models.Repository{}, errRepoNotFound
+	}
+	if !repo.IsActive() {
+		return models.Repository{}, errRepoDisconnected
+	}
+	return repo, nil
+}
+
+// isNilLookup catches the typed-nil-interface trap: handlers store the lookup
+// as a concrete pointer (e.g. *db.RepositoryStore), and a nil pointer wrapped
+// in an interface compares != nil. Without this check, an unconfigured store
+// would slip past the guard and panic on the GetByID call.
+func isNilLookup(store repoLookup) bool {
+	if store == nil {
+		return true
+	}
+	v := reflect.ValueOf(store)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func:
+		return v.IsNil()
+	default:
+		return false
+	}
+}

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
@@ -11,6 +12,7 @@ import (
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 type RepositoryHandler struct {
@@ -28,7 +30,13 @@ func (h *RepositoryHandler) SetPRService(svc *ghservice.PRService) {
 
 func (h *RepositoryHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
-	repos, err := h.repoStore.ListByOrg(r.Context(), orgID)
+	// Pickers (session/project/automation creation) are the dominant caller and
+	// always want active repos only; the integrations settings page opts in with
+	// ?include_disconnected=true so the user can still see and reconnect them.
+	filters := db.RepositoryFilters{
+		IncludeDisconnected: r.URL.Query().Get("include_disconnected") == "true",
+	}
+	repos, err := h.repoStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list repositories", err)
 		return
@@ -124,6 +132,41 @@ func (h *RepositoryHandler) Update(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Repository]{Data: repo})
 }
 
+// Disconnect marks a single repository as disconnected without tearing down the
+// parent GitHub integration. Existing sessions/runs/projects referencing the
+// repo remain readable; new work is blocked by the guards in session/automation
+// /project creation paths. The op is idempotent — calling it twice is a no-op.
+func (h *RepositoryHandler) Disconnect(w http.ResponseWriter, r *http.Request) {
+	h.setRepoStatus(w, r, models.RepositoryStatusDisconnected)
+}
+
+// Reconnect flips a user-disconnected repo back to active. Requires an explicit
+// user action — an integration Sync does NOT silently revive disconnected repos
+// (UpsertFromGitHub deliberately omits status from the ON CONFLICT SET clause).
+func (h *RepositoryHandler) Reconnect(w http.ResponseWriter, r *http.Request) {
+	h.setRepoStatus(w, r, models.RepositoryStatusActive)
+}
+
+func (h *RepositoryHandler) setRepoStatus(w http.ResponseWriter, r *http.Request, status string) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid repository ID")
+		return
+	}
+
+	repo, err := h.repoStore.SetStatus(r.Context(), orgID, repoID, status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "repository not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update repository status", err)
+		return
+	}
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.Repository]{Data: repo})
+}
+
 func (h *RepositoryHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
@@ -160,6 +203,10 @@ func (h *RepositoryHandler) ListBranches(w http.ResponseWriter, r *http.Request)
 	repo, err := h.repoStore.GetByID(r.Context(), orgID, repoID)
 	if err != nil {
 		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "repository not found")
+		return
+	}
+	if !repo.IsActive() {
+		writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to fetch branches")
 		return
 	}
 

--- a/internal/api/handlers/repositories.go
+++ b/internal/api/handlers/repositories.go
@@ -147,7 +147,7 @@ func (h *RepositoryHandler) Reconnect(w http.ResponseWriter, r *http.Request) {
 	h.setRepoStatus(w, r, models.RepositoryStatusActive)
 }
 
-func (h *RepositoryHandler) setRepoStatus(w http.ResponseWriter, r *http.Request, status string) {
+func (h *RepositoryHandler) setRepoStatus(w http.ResponseWriter, r *http.Request, status models.RepositoryStatus) {
 	orgID := middleware.OrgIDFromContext(r.Context())
 	repoID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -414,6 +414,124 @@ func TestRepositoryHandler_ListBranches_RepoNotFound(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestRepositoryHandler_Disconnect_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+				false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "disconnected",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/"+repoID.String()+"/disconnect", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.Disconnect(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "disconnect should return 200")
+	require.Contains(t, w.Body.String(), "disconnected", "response should echo new status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryHandler_Reconnect_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+				false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "active",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/"+repoID.String()+"/reconnect", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.Reconnect(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "reconnect should return 200")
+	require.Contains(t, w.Body.String(), "active", "response should echo new status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryHandler_ListBranches_RejectsDisconnected(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repoColumns()).AddRow(
+				repoID, orgID, integrationID, int64(1001), "test-org/repo1", "main",
+				false, nil, nil, "https://github.com/test-org/repo1.git", int64(12345), "disconnected",
+				nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+	handler.prService = &ghservice.PRService{}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/repositories/"+repoID.String()+"/branches", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.ListBranches(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "branches on a disconnected repo should 400")
+	require.Contains(t, w.Body.String(), "REPO_DISCONNECTED", "error code should flag disconnected state")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestRepositoryHandler_Delete_Success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/repositories_test.go
+++ b/internal/api/handlers/repositories_test.go
@@ -16,6 +16,7 @@ import (
 	ghservice "github.com/assembledhq/143/internal/services/github"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -489,6 +490,91 @@ func TestRepositoryHandler_Reconnect_Success(t *testing.T) {
 	handler.Reconnect(w, req)
 	require.Equal(t, http.StatusOK, w.Code, "reconnect should return 200")
 	require.Contains(t, w.Body.String(), "active", "response should echo new status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryHandler_Disconnect_InvalidID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/not-a-uuid/disconnect", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", "not-a-uuid")
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.Disconnect(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code, "invalid UUID should 400")
+	require.Contains(t, w.Body.String(), "INVALID_ID", "error code should flag invalid ID")
+}
+
+func TestRepositoryHandler_Disconnect_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/"+repoID.String()+"/disconnect", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.Disconnect(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code, "missing repo should 404")
+	require.Contains(t, w.Body.String(), "NOT_FOUND", "error code should flag not found")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryHandler_Disconnect_UpdateFails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	store := db.NewRepositoryStore(mock)
+	handler := NewRepositoryHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/repositories/"+repoID.String()+"/disconnect", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", repoID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.Disconnect(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code, "db error should 500")
+	require.Contains(t, w.Body.String(), "UPDATE_FAILED", "error code should flag update failure")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1126,13 +1126,15 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return
 		}
-		repo, err := h.repoStore.GetByID(r.Context(), orgID, parsed)
-		if err != nil {
-			writeError(w, r, http.StatusNotFound, "REPOSITORY_NOT_FOUND", "repository not found")
-			return
-		}
-		if !repo.IsActive() {
-			writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to start new sessions")
+		if _, err := requireActiveRepo(r.Context(), h.repoStore, orgID, parsed); err != nil {
+			switch {
+			case errors.Is(err, errRepoDisconnected):
+				writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to start new sessions")
+			case errors.Is(err, errRepoStoreUnconfigured):
+				writeError(w, r, http.StatusInternalServerError, "REPO_STORE_UNCONFIGURED", "repository lookup not configured")
+			default:
+				writeError(w, r, http.StatusNotFound, "REPOSITORY_NOT_FOUND", "repository not found")
+			}
 			return
 		}
 		repoID = &parsed

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1126,8 +1126,13 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, http.StatusBadRequest, "INVALID_REPOSITORY_ID", "invalid repository_id")
 			return
 		}
-		if _, err := h.repoStore.GetByID(r.Context(), orgID, parsed); err != nil {
+		repo, err := h.repoStore.GetByID(r.Context(), orgID, parsed)
+		if err != nil {
 			writeError(w, r, http.StatusNotFound, "REPOSITORY_NOT_FOUND", "repository not found")
+			return
+		}
+		if !repo.IsActive() {
+			writeError(w, r, http.StatusBadRequest, "REPO_DISCONNECTED", "repository is disconnected; reconnect it to start new sessions")
 			return
 		}
 		repoID = &parsed

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1873,6 +1873,27 @@ func TestSessionHandler_CreateManual(t *testing.T) {
 			expectedCode: http.StatusNotFound,
 			expectedBody: "REPOSITORY_NOT_FOUND",
 		},
+		{
+			name: "rejects creation against a disconnected repository",
+			body: `{"message":"Fix bug","agent_type":"claude_code","repository_id":"` + uuid.New().String() + `"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				cols := []string{
+					"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+					"private", "language", "description", "clone_url", "installation_id", "status",
+					"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+				}
+				mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(cols).AddRow(
+						uuid.New(), orgID, uuid.New(), int64(1), "org/repo", "main",
+						false, nil, nil, "https://github.com/org/repo.git", int64(1),
+						"disconnected", nil, nil, json.RawMessage(`{}`), now, now,
+					))
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "REPO_DISCONNECTED",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -199,6 +199,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 
 	projectHandler := handlers.NewProjectHandler(projectStore, projectTaskStore, projectCycleStore, projectAttachmentStore, projectSpecStore)
 	projectHandler.SetJobStore(jobStore)
+	projectHandler.SetRepositoryStore(repoStore)
 
 	automationStore := db.NewAutomationStore(pool)
 	automationRunStore := db.NewAutomationRunStore(pool)
@@ -567,6 +568,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 			r.Use(middleware.RequireRole("admin", "member"))
 
 			r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
+			r.Post("/api/v1/repositories/{id}/disconnect", repoHandler.Disconnect)
+			r.Post("/api/v1/repositories/{id}/reconnect", repoHandler.Reconnect)
 			r.Get("/api/v1/integrations/linear/login", integrationHandler.StartLinearOAuth)
 			r.Get("/api/v1/integrations/linear/callback", integrationHandler.HandleLinearOAuthCallback)
 			r.Post("/api/v1/integrations/linear/connect", integrationHandler.ConnectLinear)

--- a/internal/cluster/runtime_test.go
+++ b/internal/cluster/runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -97,7 +98,7 @@ type schedulerRuntimeRepoStoreMock struct {
 	err   error
 }
 
-func (m *schedulerRuntimeRepoStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error) {
+func (m *schedulerRuntimeRepoStoreMock) ListByOrg(ctx context.Context, orgID uuid.UUID, _ db.RepositoryFilters) ([]models.Repository, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/internal/cluster/scheduler.go
+++ b/internal/cluster/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -32,7 +33,7 @@ type schedulerPlanStore interface {
 }
 
 type schedulerRepoStore interface {
-	ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error)
+	ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.RepositoryFilters) ([]models.Repository, error)
 }
 
 type schedulerAutomationStore interface {
@@ -191,7 +192,7 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 		}
 
 		// Check if any repos have custom PM settings; if so, enqueue per-repo jobs.
-		repos, err := s.repos.ListByOrg(ctx, orgID)
+		repos, err := s.repos.ListByOrg(ctx, orgID, db.RepositoryFilters{})
 		if err != nil {
 			s.logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("scheduler failed to list repos")
 			repos = nil

--- a/internal/cluster/scheduler_test.go
+++ b/internal/cluster/scheduler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -64,7 +65,7 @@ type mockRepos struct {
 	repos []models.Repository
 }
 
-func (m *mockRepos) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error) {
+func (m *mockRepos) ListByOrg(ctx context.Context, orgID uuid.UUID, _ db.RepositoryFilters) ([]models.Repository, error) {
 	return m.repos, nil
 }
 

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -44,12 +44,23 @@ func (s *RepositoryStore) Create(ctx context.Context, repo *models.Repository) e
 	return row.Scan(&repo.ID, &repo.CreatedAt, &repo.UpdatedAt)
 }
 
-func (s *RepositoryStore) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error) {
+// RepositoryFilters controls optional predicates on ListByOrg. Default behavior
+// (zero value) returns only active repos, which is what every picker UI wants;
+// set IncludeDisconnected to surface user-disconnected repos for the settings
+// page's "Reconnect" affordance.
+type RepositoryFilters struct {
+	IncludeDisconnected bool
+}
+
+func (s *RepositoryStore) ListByOrg(ctx context.Context, orgID uuid.UUID, filters RepositoryFilters) ([]models.Repository, error) {
 	query := `
 		SELECT id, org_id, integration_id, github_id, full_name, default_branch, private, language, description, clone_url, installation_id, status, last_synced_at, context_quality, settings, created_at, updated_at
 		FROM repositories
-		WHERE org_id = @org_id
-		ORDER BY full_name ASC`
+		WHERE org_id = @org_id`
+	if !filters.IncludeDisconnected {
+		query += ` AND status = 'active'`
+	}
+	query += ` ORDER BY full_name ASC`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
 	if err != nil {
@@ -90,6 +101,28 @@ func (s *RepositoryStore) Update(ctx context.Context, repo *models.Repository) e
 
 	row := s.db.QueryRow(ctx, query, args)
 	return row.Scan(&repo.UpdatedAt)
+}
+
+// SetStatus flips a repo's status within an org. Returns the refreshed row so
+// callers can echo it back to the client without an extra round-trip. The
+// caller is responsible for validating that status is one of the known values
+// via models.RepositoryStatus* constants.
+func (s *RepositoryStore) SetStatus(ctx context.Context, orgID, repoID uuid.UUID, status string) (models.Repository, error) {
+	query := `
+		UPDATE repositories
+		SET status = @status, updated_at = now()
+		WHERE id = @id AND org_id = @org_id
+		RETURNING id, org_id, integration_id, github_id, full_name, default_branch, private, language, description, clone_url, installation_id, status, last_synced_at, context_quality, settings, created_at, updated_at`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"id":     repoID,
+		"org_id": orgID,
+		"status": status,
+	})
+	if err != nil {
+		return models.Repository{}, fmt.Errorf("update repository status: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Repository])
 }
 
 func (s *RepositoryStore) Delete(ctx context.Context, orgID, repoID uuid.UUID) error {

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -105,9 +105,9 @@ func (s *RepositoryStore) Update(ctx context.Context, repo *models.Repository) e
 
 // SetStatus flips a repo's status within an org. Returns the refreshed row so
 // callers can echo it back to the client without an extra round-trip. The
-// caller is responsible for validating that status is one of the known values
-// via models.RepositoryStatus* constants.
-func (s *RepositoryStore) SetStatus(ctx context.Context, orgID, repoID uuid.UUID, status string) (models.Repository, error) {
+// status parameter is typed (models.RepositoryStatus) so callers must pass one
+// of the named constants — a stray string literal won't compile.
+func (s *RepositoryStore) SetStatus(ctx context.Context, orgID, repoID uuid.UUID, status models.RepositoryStatus) (models.Repository, error) {
 	query := `
 		UPDATE repositories
 		SET status = @status, updated_at = now()
@@ -117,7 +117,7 @@ func (s *RepositoryStore) SetStatus(ctx context.Context, orgID, repoID uuid.UUID
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"id":     repoID,
 		"org_id": orgID,
-		"status": status,
+		"status": string(status),
 	})
 	if err != nil {
 		return models.Repository{}, fmt.Errorf("update repository status: %w", err)

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -191,24 +192,72 @@ func TestRepositoryStore_UpsertFromGitHub_OmitsStatusFromSetClause(t *testing.T)
 	// user-disconnected repo. UpsertFromGitHub deliberately omits `status`
 	// from the ON CONFLICT ... DO UPDATE SET clause; if it ever gets added,
 	// this test catches it at the source level.
+	//
+	// The check parses the SET clause's column names rather than substring-
+	// matching the word "status", so reformatting the SQL (lowercasing
+	// keywords, reordering columns, changing whitespace) won't trip it.
 	t.Parallel()
 
 	src, err := os.ReadFile("repositories.go")
 	require.NoError(t, err, "reading repositories.go source should succeed")
 
-	i := strings.Index(string(src), "UpsertFromGitHub")
-	require.NotEqual(t, -1, i, "UpsertFromGitHub must exist in repositories.go")
+	setClause := extractUpsertFromGitHubSetClause(t, string(src))
+	cols := setClauseColumns(setClause)
+	require.NotContains(t, cols, "status",
+		"UpsertFromGitHub's DO UPDATE SET clause must not include status — would silently revive user-disconnected repos on sync (SET columns: %v)", cols)
+}
 
-	// Scan the SET clause only — an INSERT line referencing `status` is fine.
-	tail := string(src)[i:]
-	setStart := strings.Index(tail, "DO UPDATE")
-	returnEnd := strings.Index(tail, "RETURNING")
-	require.NotEqual(t, -1, setStart, "expected DO UPDATE clause in UpsertFromGitHub")
-	require.NotEqual(t, -1, returnEnd, "expected RETURNING clause in UpsertFromGitHub")
-	setClause := tail[setStart:returnEnd]
+// extractUpsertFromGitHubSetClause returns the contents of the DO UPDATE SET
+// clause from the UpsertFromGitHub function in repositories.go. Case-insensitive
+// keyword matching keeps the test robust to SQL reformatting.
+func extractUpsertFromGitHubSetClause(t *testing.T, src string) string {
+	t.Helper()
+	fnIdx := strings.Index(src, "UpsertFromGitHub")
+	require.NotEqual(t, -1, fnIdx, "UpsertFromGitHub must exist in repositories.go")
+	tail := src[fnIdx:]
 
-	require.NotContains(t, setClause, "status",
-		"UpsertFromGitHub's DO UPDATE SET clause must not touch status — would silently revive user-disconnected repos on sync")
+	// (?is) = case-insensitive + dotall so we can match across newlines.
+	re := regexp.MustCompile(`(?is)do\s+update\s+set\s+(.*?)\s+returning\b`)
+	matches := re.FindStringSubmatch(tail)
+	require.Len(t, matches, 2, "expected DO UPDATE SET ... RETURNING block in UpsertFromGitHub")
+	return matches[1]
+}
+
+// setClauseColumns returns the lowercased LHS column names from a SET clause's
+// `col = expr, col = expr` list. Splits at the top level only, so commas inside
+// function calls (e.g., COALESCE(a, b)) don't fool the parser.
+func setClauseColumns(clause string) []string {
+	var (
+		cols  []string
+		depth int
+		buf   strings.Builder
+	)
+	flush := func() {
+		assignment := strings.TrimSpace(buf.String())
+		buf.Reset()
+		if assignment == "" {
+			return
+		}
+		if eq := strings.Index(assignment, "="); eq >= 0 {
+			cols = append(cols, strings.ToLower(strings.TrimSpace(assignment[:eq])))
+		}
+	}
+	for _, ch := range clause {
+		switch {
+		case ch == '(':
+			depth++
+			buf.WriteRune(ch)
+		case ch == ')':
+			depth--
+			buf.WriteRune(ch)
+		case ch == ',' && depth == 0:
+			flush()
+		default:
+			buf.WriteRune(ch)
+		}
+	}
+	flush()
+	return cols
 }
 
 func TestRepositoryStore_GetByFullName(t *testing.T) {

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -3,6 +3,8 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,7 +50,7 @@ func TestRepositoryStore_ListByOrg(t *testing.T) {
 				AddRow(newRepoRow(repoID2, orgID, integrationID, now)...),
 		)
 
-	repos, err := store.ListByOrg(context.Background(), orgID)
+	repos, err := store.ListByOrg(context.Background(), orgID, RepositoryFilters{IncludeDisconnected: true})
 	require.NoError(t, err, "ListByOrg should not return an error")
 	require.Len(t, repos, 2, "should return both repositories for the org")
 	require.Equal(t, repoID1, repos[0].ID, "should return the first repository ID")
@@ -113,6 +115,58 @@ func TestRepositoryStore_GetByID(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestRepositoryStore_SetStatus(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+	orgID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	row := newRepoRow(repoID, orgID, integrationID, now)
+	// Override the status column (index 11) to reflect the new value.
+	row[11] = "disconnected"
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(repoColumns).AddRow(row...))
+
+	repo, err := store.SetStatus(context.Background(), orgID, repoID, models.RepositoryStatusDisconnected)
+	require.NoError(t, err, "SetStatus should not error on happy path")
+	require.Equal(t, "disconnected", repo.Status, "should return the refreshed row with new status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryStore_UpsertFromGitHub_OmitsStatusFromSetClause(t *testing.T) {
+	// Regression guard: a GitHub sync must never silently re-activate a
+	// user-disconnected repo. UpsertFromGitHub deliberately omits `status`
+	// from the ON CONFLICT ... DO UPDATE SET clause; if it ever gets added,
+	// this test catches it at the source level.
+	t.Parallel()
+
+	src, err := os.ReadFile("repositories.go")
+	require.NoError(t, err, "reading repositories.go source should succeed")
+
+	i := strings.Index(string(src), "UpsertFromGitHub")
+	require.NotEqual(t, -1, i, "UpsertFromGitHub must exist in repositories.go")
+
+	// Scan the SET clause only — an INSERT line referencing `status` is fine.
+	tail := string(src)[i:]
+	setStart := strings.Index(tail, "DO UPDATE")
+	returnEnd := strings.Index(tail, "RETURNING")
+	require.NotEqual(t, -1, setStart, "expected DO UPDATE clause in UpsertFromGitHub")
+	require.NotEqual(t, -1, returnEnd, "expected RETURNING clause in UpsertFromGitHub")
+	setClause := tail[setStart:returnEnd]
+
+	require.NotContains(t, setClause, "status",
+		"UpsertFromGitHub's DO UPDATE SET clause must not touch status — would silently revive user-disconnected repos on sync")
 }
 
 func TestRepositoryStore_GetByFullName(t *testing.T) {

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -58,6 +58,29 @@ func TestRepositoryStore_ListByOrg(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestRepositoryStore_ListByOrg_DefaultFiltersDisconnected(t *testing.T) {
+	// Default filter path: the SQL picked up by pgxmock must restrict to
+	// status = 'active'. Regression guard against a refactor that drops the
+	// WHERE clause and silently surfaces disconnected repos in pickers.
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+	orgID := uuid.New()
+
+	mock.ExpectQuery(`status = 'active'`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(repoColumns))
+
+	repos, err := store.ListByOrg(context.Background(), orgID, RepositoryFilters{})
+	require.NoError(t, err, "ListByOrg should not return an error with default filters")
+	require.Empty(t, repos, "no repos expected")
+	require.NoError(t, mock.ExpectationsWereMet(), "default filter must emit the status = 'active' predicate")
+}
+
 func TestRepositoryStore_GetByID(t *testing.T) {
 	t.Parallel()
 
@@ -141,6 +164,25 @@ func TestRepositoryStore_SetStatus(t *testing.T) {
 	repo, err := store.SetStatus(context.Background(), orgID, repoID, models.RepositoryStatusDisconnected)
 	require.NoError(t, err, "SetStatus should not error on happy path")
 	require.Equal(t, "disconnected", repo.Status, "should return the refreshed row with new status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryStore_SetStatus_QueryError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+
+	mock.ExpectQuery("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(context.DeadlineExceeded)
+
+	_, err = store.SetStatus(context.Background(), uuid.New(), uuid.New(), models.RepositoryStatusActive)
+	require.Error(t, err, "SetStatus should propagate query errors")
+	require.Contains(t, err.Error(), "update repository status", "error should be wrapped with context")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -74,6 +74,18 @@ type Repository struct {
 	UpdatedAt      time.Time       `db:"updated_at" json:"updated_at"`
 }
 
+const (
+	RepositoryStatusActive       = "active"
+	RepositoryStatusDisconnected = "disconnected"
+)
+
+// IsActive reports whether the repo is currently usable for new work. Disconnected
+// repos remain readable (existing sessions still load) but must be rejected from
+// any code path that creates new sessions, runs, projects, or automations.
+func (r Repository) IsActive() bool {
+	return r.Status == RepositoryStatusActive
+}
+
 // RepoSummary is the API model for repository summary data in the context switcher.
 type RepoSummary struct {
 	RepositoryID        uuid.UUID `json:"repository_id"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -74,16 +74,22 @@ type Repository struct {
 	UpdatedAt      time.Time       `db:"updated_at" json:"updated_at"`
 }
 
+// RepositoryStatus is a typed string for the `repositories.status` column.
+// Defined as a distinct type (not a plain string alias) so that boundary-layer
+// APIs like RepositoryStore.SetStatus reject arbitrary callers passing raw
+// strings and require one of the known constants below.
+type RepositoryStatus string
+
 const (
-	RepositoryStatusActive       = "active"
-	RepositoryStatusDisconnected = "disconnected"
+	RepositoryStatusActive       RepositoryStatus = "active"
+	RepositoryStatusDisconnected RepositoryStatus = "disconnected"
 )
 
 // IsActive reports whether the repo is currently usable for new work. Disconnected
 // repos remain readable (existing sessions still load) but must be rejected from
 // any code path that creates new sessions, runs, projects, or automations.
 func (r Repository) IsActive() bool {
-	return r.Status == RepositoryStatusActive
+	return RepositoryStatus(r.Status) == RepositoryStatusActive
 }
 
 // RepoSummary is the API model for repository summary data in the context switcher.

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -6,7 +6,7 @@ func TestRepository_IsActive(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
-		status string
+		status RepositoryStatus
 		want   bool
 	}{
 		{RepositoryStatusActive, true},
@@ -17,9 +17,9 @@ func TestRepository_IsActive(t *testing.T) {
 
 	for _, tc := range cases {
 		tc := tc
-		t.Run(tc.status, func(t *testing.T) {
+		t.Run(string(tc.status), func(t *testing.T) {
 			t.Parallel()
-			repo := Repository{Status: tc.status}
+			repo := Repository{Status: string(tc.status)}
 			if got := repo.IsActive(); got != tc.want {
 				t.Fatalf("IsActive() = %v, want %v (status %q)", got, tc.want, tc.status)
 			}

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,0 +1,28 @@
+package models
+
+import "testing"
+
+func TestRepository_IsActive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{RepositoryStatusActive, true},
+		{RepositoryStatusDisconnected, false},
+		{"", false},
+		{"unknown", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.status, func(t *testing.T) {
+			t.Parallel()
+			repo := Repository{Status: tc.status}
+			if got := repo.IsActive(); got != tc.want {
+				t.Fatalf("IsActive() = %v, want %v (status %q)", got, tc.want, tc.status)
+			}
+		})
+	}
+}

--- a/internal/services/pm/coverage_boost_test.go
+++ b/internal/services/pm/coverage_boost_test.go
@@ -943,7 +943,7 @@ type mockRepoStore struct {
 	err   error
 }
 
-func (m *mockRepoStore) ListByOrg(_ context.Context, _ uuid.UUID) ([]models.Repository, error) {
+func (m *mockRepoStore) ListByOrg(_ context.Context, _ uuid.UUID, _ db.RepositoryFilters) ([]models.Repository, error) {
 	if m.err != nil {
 		return nil, m.err
 	}

--- a/internal/services/pm/project_analyze_test.go
+++ b/internal/services/pm/project_analyze_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 )
@@ -166,7 +167,7 @@ func (m *successOrgStore) GetByID(ctx context.Context, orgID uuid.UUID) (models.
 
 type failingRepoStore struct{}
 
-func (m *failingRepoStore) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error) {
+func (m *failingRepoStore) ListByOrg(ctx context.Context, orgID uuid.UUID, _ db.RepositoryFilters) ([]models.Repository, error) {
 	return nil, nil
 }
 

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -42,7 +42,7 @@ type orgStore interface {
 }
 
 type repoStore interface {
-	ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Repository, error)
+	ListByOrg(ctx context.Context, orgID uuid.UUID, filters db.RepositoryFilters) ([]models.Repository, error)
 	GetByID(ctx context.Context, orgID, repoID uuid.UUID) (models.Repository, error)
 }
 
@@ -212,7 +212,7 @@ func (s *Service) SetSkillsBuilder(sb SkillsBuilder) {
 // Note: for multi-repo orgs, this only returns one repo. Bootstrap/refresh will
 // only cover that single repo's codebase.
 func (s *Service) selectRepo(ctx context.Context, orgID uuid.UUID, repoID *uuid.UUID) (models.Repository, error) {
-	repos, err := s.repos.ListByOrg(ctx, orgID)
+	repos, err := s.repos.ListByOrg(ctx, orgID, db.RepositoryFilters{})
 	if err != nil {
 		return models.Repository{}, fmt.Errorf("list repositories: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds per-repo Disconnect/Reconnect affordances on the GitHub integration card so users can drop a single repo without tearing down the whole integration.
- New \`POST /repositories/{id}/disconnect\` and \`/reconnect\` endpoints flip \`repositories.status\`; session, project, automation create paths and \`ListBranches\` reject disconnected repos with \`REPO_DISCONNECTED\`.
- \`ListByOrg\` defaults to active-only with an opt-in \`?include_disconnected=true\` for the settings page; \`UpsertFromGitHub\` already omits \`status\` from its ON CONFLICT SET so Sync leaves user-disconnected repos alone (now covered by a regression test).
- Frontend: confirmation dialog on the × button, a dimmed "Disconnected" row with Reconnect buttons, and \`useDisconnectRepository\`/\`useReconnectRepository\` hooks mirroring the existing integration hooks.

## Test plan
- [x] \`make lint\` and \`go test ./...\` green
- [x] \`npm run lint\` and vitest suites green
- [ ] Manually verify disconnect → repo disappears from session picker, existing sessions still load, Sync does not revive it, Reconnect restores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)