### PR TITLE
Make deploys zero-downtime with rolling containers and SSE-safe shutdown

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -165,7 +165,10 @@ func main() {
 	// so no corruption — but don't rely on a strict happens-before between
 	// settings commit and next-read.
 	orgSettingsCache := agent.NewOrgSettingsCache(agent.DefaultOrgSettingsCacheTTL)
-	router, gwSrv, recycleWorker, inspectorCloser, previewManager, err := api.NewRouter(cfg, pool, logger, codexAuthSvc, llmClient, fileReader, cancelRegistry, pvProvider, snapshotExec, apiSandboxProvider, apiSnapshotStore, orgSettingsCache)
+	// Closed when the process receives SIGTERM so long-lived handlers (SSE
+	// streams, etc.) can end their loops cleanly during graceful shutdown.
+	shutdownCh := make(chan struct{})
+	router, gwSrv, recycleWorker, inspectorCloser, previewManager, err := api.NewRouter(cfg, pool, logger, codexAuthSvc, llmClient, fileReader, cancelRegistry, pvProvider, snapshotExec, apiSandboxProvider, apiSnapshotStore, orgSettingsCache, shutdownCh)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize API router")
 	}
@@ -305,12 +308,26 @@ func main() {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Graceful shutdown
+	// Graceful shutdown.
+	//
+	// Ordering matters here. docker-compose.app.yml sets stop_grace_period to
+	// 120s; we must finish shutting down before Docker SIGKILLs us. The total
+	// budget spent below is:
+	//   - SSE drain + http.Server.Shutdown:  up to 110s
+	//   - preview gateway.Shutdown:          up to 60s (parallel with above)
+	// leaving a safety margin under the 120s SIGKILL deadline.
 	go func() {
 		sigCh := make(chan os.Signal, 1)
 		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 		<-sigCh
 		logger.Info().Msg("shutting down server...")
+
+		// Signal long-lived SSE handlers to return before calling Shutdown.
+		// Without this, Shutdown blocks on each open SSE connection until its
+		// deadline expires; the client then sees an abrupt reset rather than
+		// a clean EOF (which EventSource retries from on its own).
+		close(shutdownCh)
+
 		cancel() // stop worker
 		if recycleWorker != nil {
 			recycleWorker.Stop()
@@ -321,20 +338,30 @@ func main() {
 			}
 		}
 		// Gateway carries long-lived WebSocket (HMR) proxies; give it a
-		// longer drain window than the main API server so in-flight preview
-		// sessions close cleanly instead of being severed mid-frame.
-		gwShutdownCtx, gwShutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer gwShutdownCancel()
-		if gwSrv != nil {
+		// generous drain window so in-flight preview sessions close cleanly
+		// instead of being severed mid-frame. Runs in parallel with the
+		// main server's Shutdown below.
+		gwDone := make(chan struct{})
+		go func() {
+			defer close(gwDone)
+			if gwSrv == nil {
+				return
+			}
+			gwShutdownCtx, gwShutdownCancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer gwShutdownCancel()
 			if err := gwSrv.Shutdown(gwShutdownCtx); err != nil {
 				logger.Error().Err(err).Msg("preview gateway shutdown failed")
 			}
-		}
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		}()
+
+		// Drain the main API server. 110s leaves ~10s of headroom before
+		// Docker SIGKILLs the container at stop_grace_period=120s.
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 110*time.Second)
 		defer shutdownCancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			logger.Error().Err(err).Msg("server shutdown failed")
 		}
+		<-gwDone
 	}()
 
 	logger.Info().Int("port", cfg.Port).Str("mode", cfg.Mode).Msg("starting server")

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -5,15 +5,109 @@
 # If your provider doesn't support env vars in Caddyfile, replace {$DOMAIN}
 # with your actual domain.
 
+# Shared reverse-proxy defaults. Snippets are imported with `import <name>`
+# and expand inline, which lets the api/frontend blocks stay DRY without
+# hiding per-upstream configuration behind indirection.
+(upstream_defaults) {
+	# Request-level retry window. lb_try_duration keeps the request alive
+	# while Caddy re-dials a different/healthy instance; lb_try_interval is
+	# the gap between attempts.
+	lb_try_duration 10s
+	lb_try_interval 250ms
+	lb_policy first
+
+	# Active upstream health checking. Caddy probes /healthz every 2s and
+	# removes the backend from rotation until it recovers, so traffic isn't
+	# sent to a container that's still starting or already draining.
+	health_uri /healthz
+	health_interval 2s
+	health_timeout 2s
+
+	# Passive health: mark the upstream unhealthy for 10s after any failed
+	# request, so retries target a different/healthy instance immediately
+	# instead of hammering the bad one.
+	fail_duration 10s
+	max_fails 1
+	unhealthy_status 502 503 504
+
+	# SSE streams and other long-lived responses must not be buffered.
+	# flush_interval -1 flushes every write immediately; without it, Caddy
+	# buffers the response and the browser sees no events until close.
+	flush_interval -1
+
+	# Keep a small idle pool so TLS/TCP handshakes don't re-negotiate on
+	# every request, but cap it so connections to a killed old container
+	# age out quickly.
+	transport http {
+		keepalive 30s
+		keepalive_idle_conns 32
+		dial_timeout 5s
+	}
+}
+
 www.{$DOMAIN:143.dev} {
 	redir https://{$DOMAIN:143.dev}{uri} permanent
 }
 
 {$DOMAIN:143.dev} {
+	# Retries are gated by HTTP method. For idempotent requests (GET/HEAD/
+	# OPTIONS), Caddy retries transient 5xx against a different/healthy
+	# instance; for mutating methods, a retry after the backend partially
+	# executed would duplicate the write. Those fall through to the second
+	# handler with lb_retries 0 and rely on active/passive health checks
+	# alone to keep bad upstreams out of rotation.
+	@safe method GET HEAD OPTIONS
+
 	handle /api/* {
-		reverse_proxy api:8080
+		handle @safe {
+			reverse_proxy {
+				# dynamic a re-resolves the service name every `refresh`,
+				# so new replicas from `docker compose up --scale api=2`
+				# appear in the upstream pool within seconds instead of
+				# being cached as a single static IP.
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 5
+				import upstream_defaults
+			}
+		}
+		handle {
+			reverse_proxy {
+				dynamic a {
+					name api
+					port 8080
+					refresh 2s
+				}
+				lb_retries 0
+				import upstream_defaults
+			}
+		}
 	}
 	handle {
-		reverse_proxy frontend:3000
+		handle @safe {
+			reverse_proxy {
+				dynamic a {
+					name frontend
+					port 3000
+					refresh 2s
+				}
+				lb_retries 5
+				import upstream_defaults
+			}
+		}
+		handle {
+			reverse_proxy {
+				dynamic a {
+					name frontend
+					port 3000
+					refresh 2s
+				}
+				lb_retries 0
+				import upstream_defaults
+			}
+		}
 	}
 }

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -104,6 +104,12 @@ if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy /opt/143/deploy/scripts"
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
 fi
+if [ "$ROLE" = "app" ]; then
+  # Sync Caddyfile so the remote always has the latest reverse-proxy config.
+  # The remote compares the new hash against the currently running copy to
+  # decide whether to restart Caddy (see `stage_caddy_config_if_changed` below).
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/Caddyfile" deploy@"$HOST":/opt/143/deploy/Caddyfile.new
+fi
 if [ "$ROLE" = "worker" ]; then
   # Keep the sandbox firewall script in sync so every deploy can re-apply
   # the egress rules (they read the sandbox network's current subnet).
@@ -135,13 +141,134 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   set -euo pipefail
   cd /opt/143
 
+  # Clean up the staged Caddyfile on any exit path.
+  # stage_caddy_config_if_changed normally consumes it (mv or rm), but this
+  # guards against a failure between the scp and that call leaving it on disk.
+  trap 'rm -f /opt/143/deploy/Caddyfile.new' EXIT
+
+  # recreate_other_services SKIP_SVCS — force-recreate every compose service
+  # except the space-separated list in SKIP_SVCS. Used to update out-of-band
+  # services (vector, etc.) without touching services that are being rolled.
   recreate_other_services() {
-    local skip="$1"
-    local others
-    others="$(docker compose -f "$COMPOSE_FILE" config --services | grep -v "^${skip}$" || true)"
-    if [ -n "$others" ]; then
-      echo "$others" | xargs docker compose -f "$COMPOSE_FILE" up -d --force-recreate --no-deps --remove-orphans
+    local skip_list="$1"
+    local all filtered=""
+    all="$(docker compose -f "$COMPOSE_FILE" config --services)"
+    for svc in $all; do
+      local match=0
+      for skip in $skip_list; do
+        if [ "$svc" = "$skip" ]; then match=1; break; fi
+      done
+      [ "$match" -eq 0 ] && filtered="$filtered $svc"
+    done
+    # shellcheck disable=SC2086
+    if [ -n "$(echo $filtered | tr -d ' ')" ]; then
+      echo $filtered | xargs docker compose -f "$COMPOSE_FILE" up -d --force-recreate --no-deps --remove-orphans
     fi
+  }
+
+  # stage_caddy_config_if_changed — returns 0 if deploy/Caddyfile.new differs
+  # from the currently deployed deploy/Caddyfile, and when it does, promotes
+  # the staged file into place (mv). Returns 1 (and removes the staged file)
+  # when contents match. Used to avoid restarting Caddy on code-only deploys;
+  # Caddy restarts briefly unbind ports 80/443 and surface as 502s through
+  # any upstream proxy (Cloudflare, etc.).
+  stage_caddy_config_if_changed() {
+    local new_file="/opt/143/deploy/Caddyfile.new"
+    local cur_file="/opt/143/deploy/Caddyfile"
+    [ -f "$new_file" ] || return 1
+    if [ ! -f "$cur_file" ]; then
+      mv "$new_file" "$cur_file"
+      return 0
+    fi
+    if ! cmp -s "$new_file" "$cur_file"; then
+      mv "$new_file" "$cur_file"
+      return 0
+    fi
+    rm -f "$new_file"
+    return 1
+  }
+
+  # rolling_deploy_service SERVICE — roll a single service with zero-downtime:
+  #   1. scale up by 1 alongside the existing container(s)
+  #   2. wait for the new container's health check
+  #   3. stop & remove the old container(s)
+  #   4. reconcile scale back to 1
+  # Handles the case where a prior failed roll left >1 container running by
+  # scaling to old_count+1 and treating every pre-existing container as old.
+  # Requires the service to have a HEALTHCHECK defined; falls back to
+  # treating "running" as healthy when no healthcheck is configured.
+  rolling_deploy_service() {
+    local service="$1"
+    local old_containers new_container
+
+    # Capture ALL existing containers so leftovers from a failed prior roll
+    # don't get orphaned when we stop "the" old container below.
+    old_containers="$(docker compose -f "$COMPOSE_FILE" ps -q "$service" || true)"
+    local old_count=0
+    if [ -n "$old_containers" ]; then
+      old_count="$(printf '%s\n' "$old_containers" | wc -l | tr -d ' ')"
+    fi
+    local target_scale=$((old_count + 1))
+
+    echo "Starting new $service container (scale=$target_scale, old=$old_count)..."
+    docker compose -f "$COMPOSE_FILE" up -d --no-deps --scale "$service=$target_scale" --no-recreate "$service"
+
+    # The new container is the one in all_containers but not in old_containers.
+    local all_containers
+    all_containers="$(docker compose -f "$COMPOSE_FILE" ps -q "$service")"
+    new_container=""
+    for c in $all_containers; do
+      local is_old=0
+      for o in $old_containers; do
+        if [ "$c" = "$o" ]; then is_old=1; break; fi
+      done
+      if [ "$is_old" -eq 0 ]; then new_container="$c"; break; fi
+    done
+    if [ -z "$new_container" ]; then
+      echo "ERROR: could not identify new $service container"
+      return 1
+    fi
+
+    # Short IDs make the post-mortem easier when a roll misbehaves — you can
+    # pick either ID out of the logs and dig with `docker inspect` / `logs`.
+    local old_short=""
+    for oc in $old_containers; do
+      if [ -n "$old_short" ]; then old_short="$old_short,"; fi
+      old_short="$old_short${oc:0:12}"
+    done
+    echo "Rolling $service: new=${new_container:0:12} old=${old_short:-none}"
+
+    if ! wait_container_healthy "$new_container" 180; then
+      echo "Rolling back $service — removing failed container..."
+      docker stop "$new_container" >/dev/null 2>&1 || true
+      docker rm "$new_container" >/dev/null 2>&1 || true
+      # Verify at least one old container is still serving. If every old
+      # container has died, bring the service back up from compose.
+      local any_running=0
+      for oc in $old_containers; do
+        local s
+        s="$(docker inspect --format '{{.State.Status}}' "$oc" 2>/dev/null || echo "missing")"
+        if [ "$s" = "running" ]; then any_running=1; break; fi
+      done
+      if [ "$any_running" -eq 0 ]; then
+        echo "WARNING: no old $service containers are running — restarting service..."
+        docker compose -f "$COMPOSE_FILE" up -d --no-deps "$service"
+      fi
+      return 1
+    fi
+
+    if [ -n "$old_containers" ]; then
+      # Stop each old container with a long timeout so in-flight requests and
+      # SSE streams have time to drain. Docker sends SIGTERM and only falls
+      # back to SIGKILL once stop_grace_period (compose) / -t (CLI) expires.
+      echo "Draining $old_count old $service container(s) (up to 120s each)..."
+      for oc in $old_containers; do
+        docker stop -t 120 "$oc" >/dev/null 2>&1 || true
+        docker rm "$oc" >/dev/null 2>&1 || true
+      done
+    fi
+    docker compose -f "$COMPOSE_FILE" up -d --no-deps --scale "$service=1" "$service"
+    echo "$service rolled over successfully."
   }
 
   dump_diagnostics() {
@@ -247,66 +374,45 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps api /bin/migrate up < /dev/null
   fi
 
-  # Recreate non-health-service containers (vector, caddy, frontend, etc.)
-  # BEFORE the rolling deploy. These services don't depend on the health
-  # service version, and updating them first ensures config fixes (e.g.
-  # vector.yaml, Caddyfile) are applied even if the health service roll fails.
-  if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+  # Recreate out-of-band containers (vector, etc.) BEFORE the rolling deploy.
+  # Skip services that we roll explicitly (api, frontend) so they don't get
+  # force-recreated into downtime. Also skip caddy: we only restart it when
+  # the Caddyfile has actually changed (see below), since restarting caddy
+  # briefly unbinds ports 80/443 and surfaces as 502s to any proxy in front.
+  if [ "$ROLE" = "app" ]; then
+    echo "Updating supporting services..."
+    recreate_other_services "api frontend caddy"
+  elif [ "$ROLE" = "worker" ]; then
     echo "Updating supporting services..."
     recreate_other_services "$HEALTH_SERVICE"
   fi
 
-  # Rolling deploy for the app service:
-  #   1. Scale up a new container alongside the old one (both share the network
-  #      so the new container can reach Postgres during startup)
-  #   2. Wait for the new container's health check to pass
-  #   3. Stop the old container
-  # NOTE: --no-recreate keeps the old container as-is. If you change compose
-  # config (env vars, ports, etc.) alongside a code deploy, the old container
-  # will still run the stale config during the health-check window.
+  # Rolling deploy for both api and frontend on the app role. Order matters:
+  # api first so the new code and any new DB columns are live before the
+  # frontend that references them starts serving. --no-recreate keeps old
+  # containers as-is during the health-check window.
   if [ "$ROLE" = "app" ]; then
-    OLD_CONTAINER="$(docker compose -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE" | head -1 || true)"
+    rolling_deploy_service api
+    rolling_deploy_service frontend
 
-    echo "Starting new $HEALTH_SERVICE container..."
-    docker compose -f "$COMPOSE_FILE" up -d --no-deps --scale "$HEALTH_SERVICE=2" --no-recreate "$HEALTH_SERVICE"
-
-    # Identify the new container
-    if [ -n "$OLD_CONTAINER" ]; then
-      NEW_CONTAINER="$(docker compose -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE" | grep -v "$OLD_CONTAINER" | head -1)"
-    else
-      NEW_CONTAINER="$(docker compose -f "$COMPOSE_FILE" ps -q "$HEALTH_SERVICE" | head -1)"
-    fi
-    if [ -z "$NEW_CONTAINER" ]; then
-      echo "ERROR: could not identify new container"
-      exit 1
-    fi
-
-    if ! wait_container_healthy "$NEW_CONTAINER" 120; then
-      echo "Rolling back — removing failed container..."
-      docker stop "$NEW_CONTAINER" >/dev/null 2>&1 || true
-      docker rm "$NEW_CONTAINER" >/dev/null 2>&1 || true
-      # Ensure the old container is still serving after rollback.
-      if [ -n "$OLD_CONTAINER" ]; then
-        OLD_STATUS="$(docker inspect --format '{{.State.Status}}' "$OLD_CONTAINER" 2>/dev/null || echo "missing")"
-        if [ "$OLD_STATUS" != "running" ]; then
-          echo "WARNING: old container is $OLD_STATUS — restarting service..."
-          docker compose -f "$COMPOSE_FILE" up -d --no-deps "$HEALTH_SERVICE"
+    # Caddy: only restart when the Caddyfile contents actually changed. This
+    # keeps deploys invisible at the edge for the common case (code-only
+    # change). When the config changed, we prefer an in-place SIGUSR1 reload
+    # over a container restart so ports 80/443 stay bound throughout.
+    if stage_caddy_config_if_changed; then
+      CADDY_ID="$(docker compose -f "$COMPOSE_FILE" ps -q caddy | head -1 || true)"
+      if [ -n "$CADDY_ID" ]; then
+        echo "Caddyfile changed — reloading caddy in place..."
+        if ! docker exec "$CADDY_ID" caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile; then
+          echo "In-place reload failed — falling back to container recreate."
+          docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate caddy
         fi
       else
-        docker compose -f "$COMPOSE_FILE" up -d --no-deps "$HEALTH_SERVICE"
+        docker compose -f "$COMPOSE_FILE" up -d --no-deps caddy
       fi
-      exit 1
+    else
+      echo "Caddyfile unchanged — leaving caddy running."
     fi
-
-    # New container is healthy — remove the old one.
-    if [ -n "$OLD_CONTAINER" ]; then
-      echo "Removing old container..."
-      docker stop "$OLD_CONTAINER" >/dev/null 2>&1 || true
-      docker rm "$OLD_CONTAINER" >/dev/null 2>&1 || true
-    fi
-    # Reconcile Compose state back to scale=1 now that only one container remains.
-    docker compose -f "$COMPOSE_FILE" up -d --no-deps --scale "$HEALTH_SERVICE=1" "$HEALTH_SERVICE"
-    echo "$HEALTH_SERVICE rolled over successfully."
 
   elif [ "$ROLE" = "worker" ]; then
     # Workers poll for jobs, so running two simultaneously would double the

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -8,6 +8,9 @@ include:
 
 services:
   caddy:
+    # caddy:2-alpine floats to latest Caddy 2.x. The Caddyfile uses
+    # `dynamic a`, which requires Caddy >= 2.6 — do not downgrade below that
+    # without also removing the dynamic upstream blocks in deploy/Caddyfile.
     image: caddy:2-alpine
     ports:
       - "80:80"
@@ -37,6 +40,10 @@ services:
       retries: 5
       start_period: 60s
     restart: unless-stopped
+    # Give in-flight requests and SSE streams up to 2 minutes to drain before
+    # Docker sends SIGKILL. Must be >= the server's Shutdown deadline in
+    # cmd/server/main.go so the process exits cleanly on its own.
+    stop_grace_period: 120s
     deploy:
       resources:
         limits:
@@ -50,7 +57,17 @@ services:
       NODE_ENV: production
     depends_on:
       - api
+    healthcheck:
+      # node -e avoids needing wget/curl in the minimal node:22-alpine image.
+      test:
+        - "CMD-SHELL"
+        - "node -e \"require('http').get('http://127.0.0.1:3000/healthz', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     restart: unless-stopped
+    stop_grace_period: 120s
     deploy:
       resources:
         limits:

--- a/frontend/src/app/healthz/route.ts
+++ b/frontend/src/app/healthz/route.ts
@@ -1,0 +1,9 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export function GET() {
+  return new Response("ok", {
+    status: 200,
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -47,6 +47,8 @@ type SessionHandler struct {
 	logger           zerolog.Logger
 	audit            *db.AuditEmitter
 	canceller        SessionCanceller // optional — enables cancelling running sessions
+	// shutdownCh is closed on SIGTERM; see SetShutdownSignal.
+	shutdownCh <-chan struct{}
 }
 
 // SetAuditEmitter injects the audit emitter for logging session events.
@@ -62,6 +64,14 @@ func (h *SessionHandler) SetCanceller(c SessionCanceller) {
 // SetViewStore injects the session view store for tracking unread sessions.
 func (h *SessionHandler) SetViewStore(vs *db.SessionViewStore) {
 	h.viewStore = vs
+}
+
+// SetShutdownSignal wires a channel that is closed when the server is
+// shutting down. SSE stream handlers listen on it so they return promptly
+// during graceful shutdown instead of blocking Server.Shutdown until its
+// deadline expires.
+func (h *SessionHandler) SetShutdownSignal(ch <-chan struct{}) {
+	h.shutdownCh = ch
 }
 
 func NewSessionHandler(
@@ -582,9 +592,23 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	heartbeat := time.NewTicker(15 * time.Second)
 	defer heartbeat.Stop()
 
+	// Local shutdown channel so we can safely `select` even when no signal
+	// has been wired up. A nil channel blocks forever, which is what we want
+	// as a default.
+	shutdownCh := h.shutdownCh
+
 	for {
 		select {
 		case <-r.Context().Done():
+			return
+		case <-shutdownCh:
+			// Server is shutting down — close the stream cleanly. The
+			// EventSource client sees an EOF, fires onerror, and reconnects
+			// to the new container via Caddy. Sending a final heartbeat
+			// triggers a flush so the browser isn't blocked reading a
+			// half-buffered chunk.
+			_ = sw.WriteHeartbeat()
+			sw.Flush()
 			return
 		case <-heartbeat.C:
 			if err := sw.WriteHeartbeat(); err != nil {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -1605,6 +1605,89 @@ func TestSessionHandler_StreamLogs_InvalidID(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_ID")
 }
 
+// TestSessionHandler_StreamLogs_ShutdownSignal verifies that the SSE loop
+// returns promptly when shutdownCh is closed, instead of blocking
+// Server.Shutdown until its deadline expires.
+func TestSessionHandler_StreamLogs_ShutdownSignal(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	now := time.Now()
+	issueID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+	shutdownCh := make(chan struct{})
+	handler.SetShutdownSignal(shutdownCh)
+
+	// Non-terminal ("running") status triggers the SSE streaming path.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				runID, issueID, orgID, "claude-code", "running", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, false, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,                      // triggered_by_user_id
+				nil, 0, now, "none", nil, // agent_session_id, current_turn, last_activity_at, sandbox_state, snapshot_key
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
+				nil, // automation_run_id
+				nil, // deleted_at
+				now,
+			),
+		)
+
+	// Empty logs list so the initial write loop is a no-op.
+	mock.ExpectQuery("SELECT .+ FROM session_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number"}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/"+runID.String()+"/logs/stream", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", runID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.StreamLogs(w, req)
+	}()
+
+	// Close the shutdown channel; whether the handler has reached its select
+	// yet or not, the for-select will pick the shutdownCh case on its first
+	// iteration and return.
+	close(shutdownCh)
+
+	select {
+	case <-done:
+		// Expected: handler exited within deadline.
+	case <-time.After(2 * time.Second):
+		t.Fatal("StreamLogs did not return within 2s of shutdownCh close")
+	}
+
+	// A heartbeat is written on the shutdown path so the browser sees a
+	// flush before EOF; check for its SSE comment marker.
+	require.Contains(t, w.Body.String(), ": ping", "expected heartbeat on shutdown")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestSessionHandler_CreateManual(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -35,7 +35,7 @@ import (
 	threadservice "github.com/assembledhq/143/internal/services/thread"
 )
 
-func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, codexAuthSvc *codexauth.Service, llmClient llm.Client, fileReader sandbox.FileReader, canceller handlers.SessionCanceller, previewProvider preview.PreviewCapableProvider, snapshotExecutor preview.SnapshotExecutor, sandboxProvider agent.SandboxProvider, snapshotStore storage.SnapshotStore, orgSettingsInvalidator handlers.OrgSettingsInvalidator) (*chi.Mux, *http.Server, *preview.RecycleWorker, io.Closer, *preview.Manager, error) {
+func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, codexAuthSvc *codexauth.Service, llmClient llm.Client, fileReader sandbox.FileReader, canceller handlers.SessionCanceller, previewProvider preview.PreviewCapableProvider, snapshotExecutor preview.SnapshotExecutor, sandboxProvider agent.SandboxProvider, snapshotStore storage.SnapshotStore, orgSettingsInvalidator handlers.OrgSettingsInvalidator, shutdownCh <-chan struct{}) (*chi.Mux, *http.Server, *preview.RecycleWorker, io.Closer, *preview.Manager, error) {
 	// Create stores
 	orgStore := db.NewOrganizationStore(pool)
 	userStore := db.NewUserStore(pool)
@@ -161,6 +161,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger,
 	)
 	sessionHandler.SetViewStore(sessionViewStore)
+	sessionHandler.SetShutdownSignal(shutdownCh)
 	threadSvc := threadservice.NewService(
 		sessionThreadStore,
 		sessionStore,

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -36,7 +36,7 @@ func TestNewRouter_EncryptionKeyValidation(t *testing.T) {
 
 			cfg := &config.Config{EncryptionMasterKey: tt.masterKey}
 			codexSvc := codexauth.NewService(nil, zerolog.Nop())
-			router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), codexSvc, nil, nil, nil, nil, nil, nil, nil, nil)
+			router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), codexSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			if tt.expectErr {
 				require.Error(t, err, "NewRouter should return an error when encryption key is invalid")
 				require.Nil(t, router, "NewRouter should not construct a router with an invalid encryption key")


### PR DESCRIPTION
## Summary
- Roll `api` and `frontend` one-at-a-time via a new `rolling_deploy_service` helper in `deploy/scripts/deploy.sh`: scale up +1, wait for container health, drain old containers with a 120s stop timeout, then reconcile to scale=1. Caddy is reloaded in place only when `deploy/Caddyfile` actually changed.
- Upgrade Caddy config: dynamic DNS re-resolution of `api`/`frontend` (so new replicas appear in the pool), active+passive health checks on `/healthz`, retries gated by HTTP method (GETs retry, writes do not), and `flush_interval -1` so SSE streams aren't buffered.
- Harden server shutdown in `cmd/server/main.go`: pass a `shutdownCh` into the router so long-lived SSE handlers (`SessionHandler.StreamLogs`) return promptly on SIGTERM; run preview gateway `Shutdown` in parallel with the main server; raise the API drain deadline to 110s under Docker's new `stop_grace_period: 120s`.
- Add a `/healthz` endpoint to the Next.js frontend and wire a matching container healthcheck so Caddy can use it for active load-balancing.

## Test plan
- [ ] `go test ./internal/api/...` passes (verified locally)
- [ ] Staging deploy: confirm `api` and `frontend` roll one-at-a-time without 5xx at the edge
- [ ] Staging deploy: confirm open SSE session-log stream reconnects cleanly across a roll
- [ ] Staging deploy: confirm `caddy` is left untouched on a code-only deploy, and reloads in place when `Caddyfile` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)