### PR TITLE
Fix frontend deploy healthcheck bind

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -18,6 +18,7 @@ COPY --from=builder /app/public ./public
 
 ENV NODE_ENV=production
 ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
 EXPOSE 3000
 
 CMD ["node", "server.js"]

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -1,0 +1,20 @@
+package deploy_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrontendContainerBindsAllInterfaces(t *testing.T) {
+	t.Parallel()
+
+	compose, err := os.ReadFile("../docker-compose.app.yml")
+	require.NoError(t, err, "test should read the app compose file")
+	require.Contains(t, string(compose), `HOSTNAME: "0.0.0.0"`, "frontend compose config should override Docker's container-id HOSTNAME so Next binds all interfaces")
+
+	dockerfile, err := os.ReadFile("../Dockerfile.frontend")
+	require.NoError(t, err, "test should read the frontend Dockerfile")
+	require.Contains(t, string(dockerfile), "ENV HOSTNAME=0.0.0.0", "frontend image should default Next standalone to bind all interfaces")
+}

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -54,6 +54,7 @@ services:
     image: ghcr.io/assembledhq/143-frontend:${IMAGE_TAG:-latest}
     environment:
       API_PROXY_TARGET: http://api:8080
+      HOSTNAME: "0.0.0.0"
       NODE_ENV: production
     depends_on:
       - api

--- a/docs/design/10-infrastructure.md
+++ b/docs/design/10-infrastructure.md
@@ -543,6 +543,12 @@ The server exposes:
 - `GET /healthz` — basic liveness check (returns 200)
 - `GET /readyz` — readiness check (verifies DB connection, sandbox provider connectivity, gVisor availability, secret validation)
 
+The production frontend image runs Next.js standalone on port 3000 and sets
+`HOSTNAME=0.0.0.0`. Docker injects `HOSTNAME` as the container ID by default;
+overriding it keeps the Next server bound to all interfaces so both Docker
+health checks on `127.0.0.1:3000/healthz` and other compose services can reach
+the process.
+
 ## Logging: Mezmo
 
 All application logs are structured JSON via zerolog. Mezmo is the primary log aggregation platform.


### PR DESCRIPTION
## Summary
Fix the production frontend container so Next standalone binds to all interfaces instead of Docker's container-id hostname. This lets the existing Docker healthcheck reach /healthz on 127.0.0.1 and prevents frontend deploy rollbacks. Adds a regression test for the deployment config and documents the frontend healthcheck binding behavior.

## Verification
- go vet ./...
- go build ./...
- go test ./...
- npm run typecheck
- npm run lint
- npm run build