### PR TITLE
Update organization rename autosave behavior

### DIFF
--- a/frontend/src/app/(dashboard)/settings/AGENTS.md
+++ b/frontend/src/app/(dashboard)/settings/AGENTS.md
@@ -13,6 +13,13 @@ colored status text, no sticky bottom footer.
 Exceptions that still use explicit buttons are enumerated below. If your field
 is not on that list, autosave it.
 
+Short rule:
+
+- **Edits configuration state** for future behavior and is easy to undo →
+  autosave it.
+- **Performs an operation** (connect, disconnect, create, delete, rotate,
+  promote, archive) or handles a secret → use an explicit button/dialog.
+
 ## The hook
 
 See `@/hooks/useAutosave.ts`.

--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderWithProviders, screen, waitFor } from '@/test/test-utils';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderWithProviders, screen, waitFor, userEvent } from '@/test/test-utils';
 import SettingsPage from './page';
 
 const {
   settingsGetMock,
+  settingsUpdateMock,
+  useAuthMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
@@ -11,25 +13,48 @@ const {
       settings: {},
     },
   }),
+  settingsUpdateMock: vi.fn().mockResolvedValue({
+    data: {
+      name: 'Updated Org',
+      settings: {},
+    },
+  }),
+  useAuthMock: vi.fn(() => ({
+    user: { role: 'admin' },
+  })),
 }));
 
 vi.mock('@/lib/api', () => ({
   api: {
     settings: {
       get: settingsGetMock,
+      update: settingsUpdateMock,
     },
   },
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: useAuthMock,
 }));
 
 describe('SettingsPage', () => {
   beforeEach(() => {
     settingsGetMock.mockClear();
+    settingsUpdateMock.mockClear();
+    useAuthMock.mockReset();
+    useAuthMock.mockReturnValue({
+      user: { role: 'admin' },
+    });
     settingsGetMock.mockResolvedValue({
       data: {
         name: 'Test Org',
         settings: {},
       },
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('renders the Organization section with organization name', async () => {
@@ -57,7 +82,26 @@ describe('SettingsPage', () => {
     });
   });
 
-  it('has the organization name field disabled', async () => {
+  it('lets admins edit the organization name', async () => {
+    renderWithProviders(<SettingsPage />);
+
+    const input = await screen.findByLabelText('Organization name');
+    expect(input).not.toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(input);
+    await user.keyboard('{Control>}a{/Control}Updated Org');
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledWith({ name: 'Updated Org' });
+    });
+  });
+
+  it('keeps the organization name field disabled for non-admins', async () => {
+    useAuthMock.mockReturnValue({
+      user: { role: 'member' },
+    });
+
     renderWithProviders(<SettingsPage />);
 
     await waitFor(() => {

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { Card, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
+import { DebouncedInput } from "@/components/debounced-fields";
 import { useAuth } from "@/hooks/use-auth";
 import { useAutosave } from "@/hooks/useAutosave";
 import {
@@ -17,7 +17,7 @@ import {
   coalesceSettingsPatch,
   type SettingsPatch,
 } from "@/lib/settings-autosave";
-import type { Organization, OrgSettings, SingleResponse } from "@/lib/types";
+import type { MembershipsResponse, Organization, OrgSettings, SingleResponse } from "@/lib/types";
 
 const PR_AUTHORSHIP_OPTIONS = [
   { value: "user_preferred", label: "User preferred", description: "Use the user's GitHub token when available, fall back to the 143 app" },
@@ -119,9 +119,38 @@ function PRAuthorshipSettings() {
 
 export default function SettingsPage() {
   const { user } = useAuth();
+  const queryClient = useQueryClient();
   const { data: settings } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
+  });
+  const autosave = useAutosave<SettingsPatch>({
+    queryKey: queryKeys.settings.all,
+    mutationFn: async (payload) => {
+      const response = await api.settings.update(payload);
+      if (payload.name !== undefined) {
+        queryClient.setQueryData<SingleResponse<MembershipsResponse> | undefined>(
+          queryKeys.auth.memberships,
+          (previous) => {
+            if (!previous?.data) return previous;
+            return {
+              ...previous,
+              data: {
+                ...previous.data,
+                memberships: previous.data.memberships.map((membership) =>
+                  membership.org_id === response.data.id
+                    ? { ...membership, org_name: response.data.name }
+                    : membership,
+                ),
+              },
+            };
+          },
+        );
+      }
+      return response;
+    },
+    applyOptimistic: applyOrgSettingsPatch,
+    coalesce: coalesceSettingsPatch,
   });
 
   return (
@@ -137,16 +166,20 @@ export default function SettingsPage() {
         />
 
         <section className="space-y-3">
-          <h2 className="text-xs font-medium text-foreground">Organization</h2>
+          <div className="flex items-center justify-between">
+            <h2 className="text-xs font-medium text-foreground">Organization</h2>
+            {user?.role === "admin" && <AutosaveIndicator status={autosave.status} />}
+          </div>
           <Card>
             <CardContent>
               <div className="max-w-[560px] space-y-2">
                 <Label htmlFor="org-name">Organization name</Label>
-                <Input
+                <DebouncedInput
                   id="org-name"
-                  value={settings?.data?.name ?? ""}
-                  disabled
-                  className="bg-muted"
+                  serverValue={settings?.data?.name ?? ""}
+                  onCommit={(name) => autosave.save({ name })}
+                  disabled={user?.role !== "admin"}
+                  className={user?.role !== "admin" ? "bg-muted" : undefined}
                 />
               </div>
             </CardContent>

--- a/frontend/src/lib/settings-autosave.ts
+++ b/frontend/src/lib/settings-autosave.ts
@@ -3,7 +3,10 @@ import type { Organization, OrgSettings, SingleResponse } from "@/lib/types";
 /**
  * Patch shape used by every `api.settings.update(...)` autosave call.
  */
-export type SettingsPatch = { settings: Partial<OrgSettings> };
+export type SettingsPatch = {
+  name?: string;
+  settings?: Partial<OrgSettings>;
+};
 
 /**
  * Keys inside `OrgSettings` whose values are nested objects. Patching any of
@@ -48,6 +51,7 @@ export function applyOrgSettingsPatch(prev: unknown, patch: SettingsPatch): unkn
     ...previous,
     data: {
       ...previous.data,
+      ...(patch.name !== undefined ? { name: patch.name } : {}),
       settings: { ...previous.data.settings, ...patch.settings },
     },
   };
@@ -57,6 +61,7 @@ function warnIfPartialNestedPatch(
   previous: SingleResponse<Organization> | undefined,
   patch: SettingsPatch,
 ): void {
+  if (!patch.settings) return;
   const existing = previous?.data?.settings ?? ({} as Partial<OrgSettings>);
   for (const key of Object.keys(patch.settings) as (keyof OrgSettings)[]) {
     if (!NESTED_OBJECT_KEYS.has(key)) continue;
@@ -84,5 +89,9 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
  * when a single page may emit multiple in-flight saves.
  */
 export function coalesceSettingsPatch(a: SettingsPatch, b: SettingsPatch): SettingsPatch {
-  return { settings: { ...a.settings, ...b.settings } };
+  return {
+    ...(a.name !== undefined ? { name: a.name } : {}),
+    ...(b.name !== undefined ? { name: b.name } : {}),
+    settings: { ...a.settings, ...b.settings },
+  };
 }

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -105,6 +106,18 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, http.StatusBadRequest, "INVALID_SETTINGS", err.Error())
 			return
 		}
+	}
+	if req.Name != nil {
+		trimmed := strings.TrimSpace(*req.Name)
+		if trimmed == "" {
+			writeError(w, r, http.StatusBadRequest, "MISSING_NAME", "Name is required.")
+			return
+		}
+		if len([]rune(trimmed)) > maxOrgNameLen {
+			writeError(w, r, http.StatusBadRequest, "NAME_TOO_LONG", "Name must be 120 characters or fewer.")
+			return
+		}
+		req.Name = &trimmed
 	}
 
 	org, err := h.orgStore.GetByID(r.Context(), orgID)

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -167,6 +167,45 @@ func TestSettingsHandler_Update(t *testing.T) {
 			expectedBody: "Updated Org",
 		},
 		{
+			name: "trims organization name before saving",
+			body: `{"name":"  Updated Org  "}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				now := time.Now()
+				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(orgColumns()).AddRow(
+							orgID, "Test Org", json.RawMessage(`{}`), now, now,
+						),
+					)
+				mock.ExpectQuery("UPDATE organizations").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows([]string{"updated_at"}).AddRow(now),
+					)
+			},
+			expectedCode: http.StatusOK,
+			expectedBody: "Updated Org",
+		},
+		{
+			name: "rejects empty organization name",
+			body: `{"name":"   "}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				// no DB calls expected
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "MISSING_NAME",
+		},
+		{
+			name: "rejects organization name that is too long",
+			body: `{"name":"` + strings.Repeat("a", maxOrgNameLen+1) + `"}`,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				// no DB calls expected
+			},
+			expectedCode: http.StatusBadRequest,
+			expectedBody: "NAME_TOO_LONG",
+		},
+		{
 			name: "returns bad request for invalid JSON body",
 			body: `not json`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {


### PR DESCRIPTION
## Summary
- Enable organization name editing in settings with the existing autosave flow for admins.
- Keep the field read-only for non-admins.
- Update org-switcher cache state after a rename so the new name is reflected immediately.
- Tighten the settings guidance to distinguish autosaved configuration edits from explicit action flows.

## Testing
- Go unit tests for settings handler and org store behavior.
- Frontend unit test for the settings page rename flow.
- Not run (not requested): broader manual UI verification.