### PR TITLE
Update session header title size

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -70,6 +70,18 @@ describe('SessionDetailPage', () => {
     expect(screen.getAllByText(/Claude Code/).length).toBeGreaterThanOrEqual(1);
   });
 
+  it('renders the session header title at text-sm size', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const headerTitle = await screen.findByRole('heading', {
+      level: 1,
+      name: 'Fixed TypeError by adding null check',
+    });
+
+    expect(headerTitle.className).toContain('text-sm');
+    expect(headerTitle.className).not.toContain('text-xs');
+  });
+
   it('shows overview tab with status in detail panel', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1493,7 +1493,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         {/* Session header bar */}
         <div className="border-b border-border px-4 py-3 bg-background flex items-center justify-between shrink-0">
           <div className="min-w-0 flex-1 flex items-center gap-2">
-            <h1 className="text-xs font-medium text-foreground truncate">
+            <h1 className="text-sm font-medium text-foreground truncate">
               {sessionTitle(session)}
             </h1>
             <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shrink-0 ${status.color}`}>


### PR DESCRIPTION
## Summary
- Increase the session detail page header title from `text-xs` to `text-sm`
- Add a UI test that locks in the new header text size

## Testing
- UI test: `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`