### PR TITLE
Update Redis design for topology-agnostic migration

### DIFF
--- a/docs/design/future/52-redis.md
+++ b/docs/design/future/52-redis.md
@@ -35,13 +35,21 @@ Redis addresses all of these with purpose-built primitives (pub/sub, sorted sets
 - The fan-out goroutine never anchors its read position on any individual client. It always reads from tail. Slow clients cannot hold back the stream position or cause unbounded buffer growth in the shared goroutine — bounded per-client channels absorb the mismatch, and drop-on-full is the back-pressure signal.
 - When no clients remain and the session is not producing entries, the fan-out goroutine exits. If new entries arrive after exit (before teardown), the next connecting client re-starts the goroutine and catches up via XRANGE.
 - Status changes use the same pattern on `stream:session:{id}:status`.
-- Streams are trimmed on every XADD with `MAXLEN ~ 10000 MINID ~ <now-60min>` for logs. MAXLEN is the hard ceiling; MINID ensures anything older than an hour gets dropped even if the session is quiet enough to not hit the count cap. Individual log entries larger than **4KB are truncated** in the Redis copy (full payload stays in Postgres) — this bounds worst-case memory for pathological entries (huge tool outputs, long compiler errors). At a ~500B-after-truncation average, MAXLEN 10000 caps per-session memory at ~5MB.
+- Streams are trimmed on every `XADD` with `MAXLEN ~ 10000` for logs. We intentionally choose a **count-based write-path trim only** because Redis `XADD` supports either `MAXLEN` or `MINID` trim, not both in one call. `MAXLEN` is the important invariant because it gives a hard memory ceiling. Individual log entries larger than **4KB are truncated** in the Redis copy (full payload stays in Postgres) — this bounds worst-case memory for pathological entries (huge tool outputs, long compiler errors). At a ~500B-after-truncation average, MAXLEN 10000 caps per-session memory at ~5MB.
+- We do **not** guarantee that active but quiet sessions lose entries older than 60 minutes while still running. That is acceptable for v1 because Postgres remains the source of truth and `MAXLEN` is the stronger operational guardrail. After a session reaches a terminal state, `EXPIREAT` removes the whole stream 1 hour later. If active-session age-based trimming becomes necessary later, add a periodic `XTRIM MINID` maintenance pass rather than trying to overload the write path.
+
+**Live failover model:** Existing SSE connections do not hot-swap from Redis fan-out into Postgres polling on the same socket. When the fan-out reader detects a Redis read error or subscription teardown, it closes all registered client channels with a retryable reason. Each SSE handler emits an `event: error` / `data: retry` frame if possible and closes the HTTP stream. The browser reconnects with its `Last-Event-ID` (or `?last_event_id=`), and the normal connect path chooses the best available catch-up source:
+1. ring buffer replay if the watermark is still local,
+2. `XRANGE` from Redis if Redis is reachable,
+3. Postgres backfill if Redis is unavailable or the watermark is older than the stream window.
+
+This keeps the server-side state machine simple: reconnect is the failover boundary, and the durable watermark is always the last event ID already delivered to the client.
 
 **Why fan-out instead of connection-per-client:** A naive approach where each SSE client runs its own `XREAD BLOCK` would hold one Redis connection per client. With 50 clients across 10 nodes, that's 500 blocked connections just for log streaming. The fan-out pattern reduces this to one connection per node per active session — typically 10-20 connections total instead of hundreds.
 
 **Why Streams over Pub/Sub:** Plain Pub/Sub is fire-and-forget — if a subscriber disconnects and reconnects, all messages during the gap are lost. For log streaming this means users see gaps in output. Streams solve this by persisting messages and supporting replay from an arbitrary offset, which maps directly to "give me logs since entry X."
 
-**Dual-write consistency:** Log entries are written to Postgres first, then `XADD`'d to Redis. If the XADD fails, live SSE viewers miss the entry until they disconnect and the catch-up path reads from Postgres. This is acceptable — Postgres is the source of truth — but it means live viewers can briefly see "holes" in the stream. A log line that goes `"XADD failed: {stream}"` on every such failure makes this diagnosable.
+**Dual-write consistency:** Log entries are written to Postgres first, then `XADD`'d to Redis. If the XADD fails, already-connected viewers may miss the entry until their next reconnect and catch-up pass reads from Postgres. This is acceptable — Postgres is the source of truth — but it means live viewers can briefly see "holes" in the stream. A log line that goes `"XADD failed: {stream}"` on every such failure makes this diagnosable.
 
 **Fallback:** If Redis is unavailable, fall back to the current 1s Postgres polling. The SSE handler already works this way, so Redis becomes a performance optimization, not a hard dependency. See §8.1 for the fallback-load analysis.
 
@@ -49,10 +57,14 @@ Redis addresses all of these with purpose-built primitives (pub/sub, sorted sets
 
 **Problem:** The current token-bucket rate limiter (`internal/api/middleware/ratelimit.go`) uses per-node in-memory maps. With N nodes behind a load balancer, an org can make `N * 100` requests/sec instead of 100.
 
-**Solution:** Use a simple sliding-window counter with `INCR` + `EXPIRE`. A single Redis key per org per window (`143:ratelimit:org:{id}:{window}`) ensures a global view. No Lua script needed — two standard Redis commands are sufficient for our scale:
+> **Status:** Gated. We should not enable distributed rate limiting on the same eviction domain as large session streams. If Redis is configured with `allkeys-lru` and the same instance holds both stream data and limiter keys, memory pressure can evict active limiter counters and silently relax limits for the busiest orgs. That is acceptable for an accelerator, but not for a control-plane safeguard.
+
+**Enablement rule:** Phase 4 only turns on once rate-limit keys are isolated from stream eviction risk, typically via a **small dedicated Redis instance for control-plane keys**. Until then, keep the existing per-node in-memory limiter.
+
+**Solution (when the gate is met):** Use a simple **fixed-window** counter with `INCR` + TTL. A single Redis key per org per window (`143:ratelimit:org:{id}:{window}`) ensures a global view. No Lua script needed — standard Redis commands are sufficient for our scale:
 
 ```go
-// Sliding window rate limiter using INCR + EXPIRE.
+// Fixed-window rate limiter using INCR + TTL.
 // windowKey = fmt.Sprintf("143:ratelimit:org:%s:%d", orgID, time.Now().Unix()/windowSecs)
 func (c *Client) CheckRateLimit(ctx context.Context, windowKey string, limit int64, windowSecs int) (allowed bool, err error) {
     count, err := c.rdb.Incr(ctx, windowKey).Result()
@@ -61,13 +73,13 @@ func (c *Client) CheckRateLimit(ctx context.Context, windowKey string, limit int
     }
     if count == 1 {
         // First request in this window — set expiry so the key self-cleans.
-        // Small race: if the process crashes between INCR and EXPIRE, the key
-        // persists without a TTL. The maxmemory-policy (allkeys-lru) handles
-        // this — orphaned keys are evicted under memory pressure. For belt-and-
-        // suspenders, the periodic cleanup goroutine (Section 2.5) could also
-        // scan for TTL-less rate limit keys, but this is not worth the complexity
-        // at our scale.
-        c.rdb.Expire(ctx, windowKey, time.Duration(windowSecs*2)*time.Second)
+        // If EXPIRE fails after INCR succeeds, log and count it: correctness
+        // for this request is still preserved, but the key may outlive the
+        // window. A lightweight periodic cleanup can scan for ttl-less
+        // ratelimit keys if this ever shows up in metrics.
+        if err := c.rdb.Expire(ctx, windowKey, time.Duration(windowSecs*2)*time.Second).Err(); err != nil {
+            c.logger.Warn().Err(err).Str("key", windowKey).Msg("rate limit TTL set failed")
+        }
     }
     return count <= limit, nil
 }
@@ -75,9 +87,11 @@ func (c *Client) CheckRateLimit(ctx context.Context, windowKey string, limit int
 
 **Why not a Lua script?** A GCRA (Generic Cell Rate Algorithm) Lua script would provide smoother rate limiting without fixed-window boundary bursts. But at 143's scale (tens of orgs, <1000 req/sec), the added complexity isn't justified. The simple `INCR`/`EXPIRE` approach is easy to understand, debug, and test. If boundary bursts become a problem later (an org gaming the window edge), GCRA can be swapped in without changing the middleware interface.
 
-**Boundary burst mitigation:** The worst case is 2x burst at window edges (100 requests at second 59, 100 more at second 61). For API rate limiting this is acceptable — we're protecting against sustained abuse, not microsecond-precision fairness. If needed, a two-window interpolation (count from current + previous window weighted by elapsed fraction) eliminates this with no Lua script — just two `GET` calls.
+**Boundary burst mitigation:** The worst case is 2x burst at window edges (100 requests at second 59, 100 more at second 61). For API rate limiting this is acceptable — we're protecting against sustained abuse, not microsecond-precision fairness. If needed, a two-window interpolation (count from current + previous window weighted by elapsed fraction) eliminates most of this without introducing Lua.
 
-**Fallback:** Redis is the authoritative limiter on every request when available. The per-node in-memory limiter is **only** used when Redis is unavailable (circuit breaker open or connection error). There is no "short-circuit-on-in-memory-first" path — that would allow a single node to silently accept above-limit traffic until its own bucket fills, defeating the point of global coordination. When Redis is down, we accept that each node independently allows up to the per-node limit (current behavior).
+**Failure semantics:** Redis is the authoritative limiter on every request when available. The per-node in-memory limiter is **only** used when Redis is unavailable (circuit breaker open or connection error). There is no "short-circuit-on-in-memory-first" path — that would allow a single node to silently accept above-limit traffic until its own bucket fills, defeating the point of global coordination. When Redis is down, we accept that each node independently allows up to the per-node limit (current behavior).
+
+**TTL orphan handling:** If `INCR` succeeds but TTL application does not, the request may still be evaluated using the returned count, but the event must be logged and counted with a dedicated metric. If this shows up in production, add a periodic cleanup for `143:ratelimit:*` keys with no TTL. We should not silently rely on key eviction for limiter correctness.
 
 ### 2.3 Job Queue Notifications
 
@@ -155,6 +169,10 @@ Key principle: **Redis is an accelerator, not a source of truth.** Every piece o
 
 If Redis disappears, the system degrades to current behavior, not to failure.
 
+For rollout purposes, treat the features in two classes:
+- **Safe accelerator features:** session streams and job notifications. These improve latency and efficiency but do not weaken correctness if Redis degrades.
+- **Control-plane features:** distributed rate limiting. These only ship once their eviction and failure semantics are explicitly acceptable.
+
 ### 3.2 Go Client Library
 
 Use [`github.com/redis/go-redis/v9`](https://github.com/redis/go-redis), the official Go client. It supports:
@@ -163,6 +181,8 @@ Use [`github.com/redis/go-redis/v9`](https://github.com/redis/go-redis), the off
 - Sentinel and Cluster modes for HA
 - Context-aware commands (cancellation, timeouts)
 - Lua scripting for atomic operations (available if needed in the future)
+
+**Topology choice:** Use `go-redis` through its `redis.UniversalClient` abstraction from day 1, not a concrete `*redis.Client`. `UniversalClient` can represent a standalone server, Failover/Sentinel deployment, or Cluster deployment behind the same interface. That keeps the application wrapper stable even if infrastructure changes later.
 
 ### 3.3 Redis Client Wrapper
 
@@ -181,16 +201,27 @@ import (
 
 // Client wraps go-redis with fallback behavior and circuit breaking.
 type Client struct {
-    rdb     *redis.Client
+    rdb     redis.UniversalClient
     breaker *CircuitBreaker
     logger  zerolog.Logger
 }
 
 // Config holds Redis connection parameters.
 type Config struct {
-    URL      string        // REDIS_URL (redis://host:port/db or rediss:// for TLS)
-    Password string        // REDIS_PASSWORD (optional, for ACL-based auth)
-    PoolSize int           // default: 10 * GOMAXPROCS; see Section 9.1 for sizing guidance
+    // Topology: standalone | sentinel | cluster
+    Topology string `env:"REDIS_TOPOLOGY" envDefault:"standalone"`
+
+    // Standalone / single-endpoint managed Redis.
+    URL string // REDIS_URL (redis://host:port/db or rediss:// for TLS)
+
+    // Sentinel / Cluster can provide multiple seed addresses.
+    Addrs []string // REDIS_ADDRS=host1:6379,host2:6379
+
+    // Sentinel-specific settings.
+    MasterName string // REDIS_MASTER_NAME
+
+    Password string // REDIS_PASSWORD (optional, for ACL-based auth)
+    PoolSize int    // command pool size only; see Section 9.1
     Timeouts TimeoutConfig
 }
 
@@ -201,28 +232,51 @@ type TimeoutConfig struct {
 }
 
 func New(cfg Config, logger zerolog.Logger) *Client {
-    opts, err := redis.ParseURL(cfg.URL)
-    if err != nil {
-        logger.Error().Err(err).Str("url", cfg.URL).Msg("invalid Redis URL, running without Redis")
+    var rdb redis.UniversalClient
+    switch cfg.Topology {
+    case "", "standalone":
+        opts, err := redis.ParseURL(cfg.URL)
+        if err != nil {
+            logger.Error().Err(err).Str("url", cfg.URL).Msg("invalid Redis URL, running without Redis")
+            return nil
+        }
+        if cfg.Password != "" {
+            opts.Password = cfg.Password
+        }
+        if cfg.PoolSize > 0 {
+            opts.PoolSize = cfg.PoolSize
+        }
+        // Apply timeouts...
+        rdb = redis.NewClient(opts)
+    case "sentinel":
+        opts := &redis.FailoverOptions{
+            MasterName:    cfg.MasterName,
+            SentinelAddrs: cfg.Addrs,
+            Password:      cfg.Password,
+            PoolSize:      cfg.PoolSize,
+            // Apply timeouts...
+        }
+        rdb = redis.NewFailoverClient(opts)
+    case "cluster":
+        opts := &redis.ClusterOptions{
+            Addrs:    cfg.Addrs,
+            Password: cfg.Password,
+            PoolSize: cfg.PoolSize,
+            // Apply timeouts...
+        }
+        rdb = redis.NewClusterClient(opts)
+    default:
+        logger.Error().Str("topology", cfg.Topology).Msg("invalid Redis topology, running without Redis")
         return nil
     }
-    if cfg.Password != "" {
-        opts.Password = cfg.Password
-    }
-    if cfg.PoolSize > 0 {
-        opts.PoolSize = cfg.PoolSize
-    }
-    // Apply timeouts...
-    rdb := redis.NewClient(opts)
-    breaker := &CircuitBreaker{
-        threshold: 5,
-        cooldown:  30 * time.Second,
-    }
+    breaker := NewCircuitBreaker()
     client := &Client{rdb: rdb, breaker: breaker, logger: logger}
     // Ping to verify connectivity, but don't fail startup — Redis is optional.
+    // A startup ping failure forces the breaker open immediately so command-path
+    // callers cleanly skip Redis until the first half-open probe window.
     if err := rdb.Ping(context.Background()).Err(); err != nil {
         logger.Warn().Err(err).Msg("Redis ping failed on startup, will retry via circuit breaker")
-        breaker.RecordFailure()
+        breaker.ForceOpen()
     } else {
         logger.Info().Msg("Redis connected")
     }
@@ -242,6 +296,8 @@ func (c *Client) Available() bool {
 
 The rest of the application interacts through this wrapper. When `Client` is nil (Redis not configured), callers skip Redis paths entirely.
 
+**Why this preserves zero-code-change migration:** The application code only depends on the wrapper plus `redis.UniversalClient` operations. Moving from a single VPS Redis to managed standalone Redis, Sentinel, or Cluster is then a configuration change in `REDIS_TOPOLOGY` and connection settings, not an application refactor.
+
 **Circuit breaker scope:** The breaker governs **short-lived command calls only** (rate-limit INCR, auth cache GET, XADD, PUBLISH, XRANGE catch-up reads). It does **not** gate long-lived subscriber connections (fan-out `XREAD BLOCK`, job-notify `SUBSCRIBE`). Those are managed by `go-redis`'s own reconnection logic plus a per-subscriber supervisor goroutine that re-establishes the subscription on error.
 
 Rationale: treating a 30-second blocked `XREAD` as "still healthy" while a command call times out in 3s prevents one slow subscriber from tripping the breaker and cascading into an auth-cache miss storm on Postgres. Conversely, a broken subscription should not block hot-path commands from using Redis.
@@ -256,22 +312,27 @@ Add to `internal/config/config.go`:
 
 ```go
 // Redis (optional — system degrades gracefully without it)
-RedisURL      string `env:"REDIS_URL"`                          // e.g. redis://localhost:6379/0
-RedisPassword string `env:"REDIS_PASSWORD"`                     // ACL password (if not in URL)
-RedisPoolSize int    `env:"REDIS_POOL_SIZE"    envDefault:"0"`  // 0 = library default
+RedisTopology   string `env:"REDIS_TOPOLOGY"   envDefault:"standalone"` // standalone | sentinel | cluster
+RedisURL        string `env:"REDIS_URL"`                               // standalone endpoint, e.g. redis://localhost:6379/0
+RedisAddrs      string `env:"REDIS_ADDRS"`                             // comma-separated host:port list for sentinel/cluster
+RedisMasterName string `env:"REDIS_MASTER_NAME"`                       // sentinel master name
+RedisPassword   string `env:"REDIS_PASSWORD"`                          // ACL password (if not in URL)
+RedisPoolSize   int    `env:"REDIS_POOL_SIZE"    envDefault:"0"`       // command pool size only; 0 = library default
 ```
 
-**Important:** Redis is opt-in. If `REDIS_URL` is empty, the `cache.Client` is nil and all Redis-dependent code paths fall back to existing behavior.
+**Important:** Redis is opt-in. For `standalone`, `REDIS_URL` is required. For `sentinel` and `cluster`, `REDIS_ADDRS` is required (and `REDIS_MASTER_NAME` is also required for `sentinel`). If the required settings for the selected topology are missing, the `cache.Client` is nil and all Redis-dependent code paths fall back to existing behavior.
 
 ### 4.1 Environment Files
 
 `.env` (development defaults):
 ```
+REDIS_TOPOLOGY=standalone
 REDIS_URL=redis://redis:6379/0
 ```
 
 `.env.production.enc` (SOPS-encrypted, production):
 ```
+REDIS_TOPOLOGY=standalone
 REDIS_URL=rediss://clustercfg.xxx.cache.amazonaws.com:6379/0
 REDIS_PASSWORD=<encrypted>
 ```
@@ -318,11 +379,11 @@ volumes:
   # ... existing volumes ...
 ```
 
-**Resource budget:** Redis is extremely memory-efficient. 256MB handles millions of keys. The alpine image is ~13MB.
+**Resource budget:** Redis is extremely memory-efficient. 256MB handles millions of small keys, but stream entries dominate this workload. In the shared-instance rollout, `allkeys-lru` is acceptable only because the first phases are stream and pub/sub acceleration, not authoritative control-plane decisions. The alpine image is ~13MB.
 
 ### 5.1 Scaling with Docker Compose
 
-For local multi-node testing:
+For local multi-node testing, use ordinary Compose scaling rather than the `deploy.replicas` Swarm field:
 
 ```yaml
 # docker-compose.override.yml (optional)
@@ -333,8 +394,12 @@ services:
     environment:
       MODE: worker
     ports: []  # no API port needed
-    deploy:
-      replicas: 2
+```
+
+Then start multiple workers with:
+
+```bash
+docker compose up --scale server-worker=2
 ```
 
 All nodes connect to the same Redis instance. Pub/Sub and rate-limit keys are inherently shared.
@@ -350,7 +415,7 @@ For self-hosted deployments, Redis runs as a dedicated node alongside the existi
 **Quick summary:**
 - Provision a small VPS (Hetzner CX22, 2 vCPU / 4 GB, ~€4/month)
 - Run `docker-compose.redis.yml` (Redis 8.6 with password auth)
-- Set `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` on all app/worker nodes
+- Set `REDIS_TOPOLOGY=standalone` and `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` on all app/worker nodes
 - Block port 6379 from public internet via firewall (private network only)
 
 **Single-point-of-failure tradeoff:** A single Hetzner VPS means every Redis outage (crash, host reboot, network blip) triggers a platform-wide failover to Postgres. The graceful-degradation design absorbs this correctly, but the outage isn't free — see §8.1 for the fallback-load budget. Options if that becomes a problem:
@@ -361,7 +426,7 @@ At 143's current scale the single-VPS path is defensible because fallback is saf
 
 ### 6.2 Migrating to Hosted/Managed Redis
 
-The design explicitly supports a zero-code-change migration from self-hosted Redis to a managed service.
+The design explicitly supports a zero-code-change migration from self-hosted Redis to a managed service **because the wrapper is topology-agnostic from day 1**.
 
 ### 6.3 Managed Options
 
@@ -376,13 +441,16 @@ The design explicitly supports a zero-code-change migration from self-hosted Red
 
 | Concern | Docker Compose | Hosted |
 |---------|---------------|--------|
-| `REDIS_URL` | `redis://redis:6379/0` | `rediss://clustercfg.xxx:6379/0` (TLS) |
+| `REDIS_TOPOLOGY` | `standalone` | `standalone`, `sentinel`, or `cluster` |
+| `REDIS_URL` | `redis://redis:6379/0` | `rediss://host:6379/0` for standalone managed Redis |
+| `REDIS_ADDRS` | (unused) | `host1:6379,host2:6379,...` for Sentinel or Cluster |
+| `REDIS_MASTER_NAME` | (unused) | required for Sentinel |
 | `REDIS_PASSWORD` | (none) | Set via ACL or AUTH |
 | Persistence | RDB snapshots to volume | Managed replication + snapshots |
 | HA | Single instance | Multi-AZ replicas, auto-failover |
 | Code changes | None | None |
 
-The `go-redis` client handles TLS (`rediss://` scheme), authentication, and Sentinel/Cluster topologies via the URL and options. No application code changes required.
+The wrapper handles TLS (`rediss://` scheme), authentication, and topology selection through configuration. No application code changes are required when changing Redis deployment mode.
 
 ### 6.5 Cluster Mode Considerations (future, not needed today)
 
@@ -402,12 +470,12 @@ If/when we move to Redis Cluster (multiple shards):
 2. Attach VPS to the existing private network (Hetzner Cloud Networks)
 3. Deploy `docker-compose.redis.yml` with password auth (see [36-docker-agents-vps-architecture.md, Step 3d](../36-docker-agents-vps-architecture.md#step-3d-add-a-dedicated-redis-node))
 4. Configure firewall: block port 6379 from public internet, allow from private network CIDR only
-5. Set `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` in `.env` on all app/worker VPS nodes
+5. Set `REDIS_TOPOLOGY=standalone` and `REDIS_URL=redis://:PASSWORD@REDIS_PRIVATE_IP:6379/0` in `.env` on all app/worker VPS nodes
 6. Verify connectivity: `redis-cli -h REDIS_PRIVATE_IP -a PASSWORD ping` from an app node
 
 ### Phase 2: Application Integration
 1. Add `redis:8.6-alpine` to `docker-compose.yml` (dev) — see §5 for the intended service definition
-2. Add `REDIS_URL` / `REDIS_PASSWORD` to `internal/config/config.go`
+2. Add `REDIS_TOPOLOGY`, `REDIS_URL`, `REDIS_ADDRS`, `REDIS_MASTER_NAME`, and `REDIS_PASSWORD` to `internal/config/config.go`
 3. Create `internal/cache/redis.go` wrapper with circuit breaker and health check
 4. Wire into `main.go` — create client on startup, pass to services
 5. Add Redis ping to `/healthz` endpoint (non-fatal: report status but don't fail health check)
@@ -422,10 +490,11 @@ If/when we move to Redis Cluster (multiple shards):
 7. Add `EXPIREAT` calls in session teardown path for both `:logs` and `:status` streams
 8. Add periodic cleanup goroutine (every 10 min, batched at 500 rows — see §2.5) to delete orphaned streams for terminated sessions
 
-### Phase 4: Distributed Rate Limiting
-1. Create `internal/cache/ratelimit.go` with sliding-window `INCR`/`EXPIRE` counter
-2. Modify rate-limit middleware to check Redis on every request when available
-3. When the circuit breaker reports Redis unavailable, fall back to per-node in-memory buckets (current behavior). Do not run both in parallel — one or the other, chosen by breaker state.
+### Phase 4: Distributed Rate Limiting (gated)
+1. Create `internal/cache/ratelimit.go` with fixed-window `INCR`/`EXPIRE` counter
+2. Provision a small dedicated Redis deployment for control-plane keys, or explicitly defer the phase
+3. Modify rate-limit middleware to check Redis on every request when available
+4. When the circuit breaker reports Redis unavailable, fall back to per-node in-memory buckets (current behavior). Do not run both in parallel — one or the other, chosen by breaker state.
 
 ### Phase 5: Job Notifications
 1. After job insertion, `PUBLISH` to `jobs:notify`
@@ -447,9 +516,9 @@ If implemented:
 
 | Failure | Impact | Mitigation |
 |---------|--------|------------|
-| Redis down | SSE falls back to DB polling; rate limiting becomes per-node; job latency stays at 5s; auth hits Postgres | All current behavior. Zero data loss. |
-| Redis slow | Timeouts (3s read/write) trigger fallback | Circuit breaker pattern: after N consecutive failures, skip Redis for M seconds |
-| Redis full | `OOM` errors on write | Set `maxmemory-policy allkeys-lru`; all data is reconstructable from Postgres |
+| Redis down | New SSE connections fall back to Postgres catch-up/polling after reconnect; rate limiting becomes per-node; job latency stays at 5s; auth hits Postgres | All current behavior. Zero data loss. |
+| Redis slow | Timeouts (3s read/write) trigger fallback | Circuit breaker opens on sustained error rate and skips Redis for a short cooldown |
+| Redis full | `OOM` errors on write or eviction pressure on shared-instance data | Shared-instance rollout only covers accelerator features; distributed rate limiting stays disabled until its keys are isolated from stream eviction risk |
 | Network partition | Some nodes lose Redis, others don't | Each node independently falls back. No split-brain risk because Redis is not authoritative. |
 
 ### Circuit Breaker
@@ -535,13 +604,21 @@ func (cb *CircuitBreaker) RecordFailure() {
         cb.state.CompareAndSwap(stateClosed, stateOpen)
     }
 }
+
+// ForceOpen is used at startup when the initial connectivity probe fails.
+// This bypasses the sliding-window sample threshold so the command path
+// immediately falls back instead of burning requests until the breaker trips.
+func (cb *CircuitBreaker) ForceOpen() {
+    cb.openedAt.Store(time.Now().UnixNano())
+    cb.state.Store(stateOpen)
+}
 ```
 
 Caller contract: wrap every short-lived Redis command in `breaker.Allow()` / `breaker.RecordSuccess()` / `breaker.RecordFailure()`. Context timeouts (3s read/write from `TimeoutConfig`) count as failures.
 
 ### 8.1 Postgres Fallback Load Analysis
 
-When the breaker opens or Redis goes down, all four feature paths fall back to Postgres. Estimate the worst-case load so Postgres is sized for it:
+When the breaker opens or Redis goes down, all Redis-backed paths fall back to their non-Redis behavior. Estimate the worst-case Postgres load so the primary store is sized for it:
 
 | Path | Peak fallback load (per node, worst case) | Notes |
 |------|--------------------------------------------|-------|
@@ -568,9 +645,9 @@ All Redis keys use the `143:` prefix to avoid collisions if Redis is shared with
 
 | Key pattern | Type | TTL | Size estimate | Purpose |
 |-------------|------|-----|---------------|---------|
-| `143:stream:{ses:ID}:logs` | Stream | `MAXLEN ~ 10000` + `MINID ~ now-60min` on every XADD; entries clamped to 4KB; idle streams expire via `EXPIREAT` 1h after session ends (set by teardown path; orphans cleaned by periodic goroutine — see §2.5) | ~500B per entry (~5MB max) | Log streaming |
+| `143:stream:{ses:ID}:logs` | Stream | `MAXLEN ~ 10000` on every `XADD`; entries clamped to 4KB; whole stream expires via `EXPIREAT` 1h after session ends (set by teardown path; orphans cleaned by periodic goroutine — see §2.5) | ~500B per entry (~5MB max) | Log streaming |
 | `143:stream:{ses:ID}:status` | Stream | `MAXLEN ~ 100`; same idle expiry | ~200B per entry | Status broadcasts |
-| `143:ratelimit:org:{id}:{window}` | String (counter) | `EXPIRE` 2x window duration; self-cleans | ~32B | Rate limiting |
+| `143:ratelimit:org:{id}:{window}` | String (counter) | `EXPIRE` 2x window duration; self-cleans; only used once limiter keys are isolated from stream eviction | ~32B | Rate limiting |
 | `143:auth:token:{hash}` | String | Matches `expires_at` (typ. 24h) | ~1KB | Auth session cache (Phase 6; deferred — see §2.4) |
 | `143:jobs:notify` | Pub/Sub channel | N/A (ephemeral) | N/A | Job wake-up signal |
 
@@ -582,21 +659,28 @@ All Redis keys use the `143:` prefix to avoid collisions if Redis is shared with
 
 The `go-redis` default pool size is `10 * runtime.GOMAXPROCS`. This covers normal command traffic, but Redis Streams subscribers (`XREAD BLOCK`) and Pub/Sub subscribers each hold a dedicated connection for the lifetime of the subscription.
 
-**Formula:** `pool_size = command_concurrency + active_stream_fan_out_goroutines + pubsub_subscriptions`
+This section needs two separate numbers:
+
+- **Command pool size:** how many concurrent short-lived command calls (`GET`, `INCR`, `XADD`, `XRANGE`, `PUBLISH`) the node should support.
+- **Total expected Redis connections per node:** command pool size plus long-lived stream-reader and Pub/Sub connections.
+
+**Formulas:**
+- `command_pool_size = expected_peak_concurrent_command_calls`
+- `total_connections_per_node = command_pool_size + active_stream_fan_out_goroutines + pubsub_subscriptions`
 
 For a node with 20 active sessions (each with a fan-out goroutine) and subscribing to `jobs:notify`:
-- Command pool: 20 (default is fine for most workloads)
+- Command pool size: 20
 - Stream readers: 20 (one `XREAD BLOCK` per active session per node, **not** per SSE client — see fan-out pattern in Section 2.1)
-- Pub/Sub: 1 (jobs channel)
-- **Total: ~41 connections per node**
+- Pub/Sub subscriptions: 1 (jobs channel)
+- **Total expected connections per node: ~41**
 
-With 10 nodes, that's ~410 connections — well within Redis's default 10,000 connection limit. Monitor `redis_connection_pool_size` and `redis_connection_pool_idle` metrics (below) to validate sizing in production.
+With 10 nodes, that's ~410 total connections — well within Redis's default 10,000 connection limit. Monitor both the command pool metrics and the total connection count in production to validate sizing.
 
-**Configuration:** Set `REDIS_POOL_SIZE` to the command pool portion only. Stream/Pub/Sub connections are managed separately by `go-redis` outside the pool.
+**Configuration:** Set `REDIS_POOL_SIZE` to the **command pool size only**. Stream-reader and Pub/Sub connections are separate long-lived connections and should be budgeted in capacity planning, not folded into the configured pool size.
 
 ### 9.2 Revisiting Stream Sizing Later
 
-The defaults above (MAXLEN 10000, MINID 60min, 4KB entry clamp) are sized for the initial rollout. If/when we need to scale well past the initial target, re-check two things: **average entry size after truncation** (the `session_log_entry_bytes` histogram — add it when Phase 3 lands), and **peak concurrent active sessions**. Rough budget per active session is `MAXLEN × avg_entry_size × 1.3 (Redis overhead)`; multiply by concurrent sessions for total working-set memory. If that exceeds ~60% of Redis memory, either lower MAXLEN for noisier session types, tighten the entry clamp, or upsize Redis. Day-one instinct is fine; measure before re-tuning.
+The defaults above (MAXLEN 10000, 4KB entry clamp) are sized for the initial rollout. If/when we need to scale well past the initial target, re-check two things: **average entry size after truncation** (the `session_log_entry_bytes` histogram — add it when Phase 3 lands), and **peak concurrent active sessions**. Rough budget per active session is `MAXLEN × avg_entry_size × 1.3 (Redis overhead)`; multiply by concurrent sessions for total working-set memory. If that exceeds ~60% of Redis memory, either lower MAXLEN for noisier session types, tighten the entry clamp, or upsize Redis. If active-session age-based trimming becomes important later, add an explicit periodic `XTRIM MINID` pass rather than changing the write path. Day-one instinct is fine; measure before re-tuning.
 
 ---
 
@@ -642,7 +726,7 @@ The defaults above (MAXLEN 10000, MINID 60min, 4KB entry clamp) are sized for th
 | Development | `redis:8.6-alpine` in Docker Compose | 256MB limit | none | $0 (local) |
 | Self-hosted prod — single node | Dedicated CX22 VPS running `docker-compose.redis.yml` | 512MB limit | none (SPOF; see §6.1) | ~€4/month (~$5) |
 | Self-hosted prod — Sentinel | 2–3 CX22 VPSes with Redis Sentinel | 512MB each | auto-failover, self-managed | ~€8–12/month |
-| Small managed (1-3 nodes) | Single Redis instance (e.g., ElastiCache `cache.t4g.micro`) | 0.5GB | managed snapshots | ~$12/month (~256 max connections — well above the ~41/node estimate in §9.1) |
+| Small managed (1-3 nodes) | Single Redis instance (e.g., ElastiCache `cache.t4g.micro`) | 0.5GB | managed snapshots | ~$12/month (~256 max connections — fine for small rollouts, but re-check before roughly 6+ nodes at the §9.1 connection budget) |
 | Medium managed (3-10 nodes) | Redis with replica (e.g., `cache.t4g.small` + replica) | 1.5GB x2 | multi-AZ auto-failover | ~$50/month |
 | Large managed (10+ nodes) | Redis Cluster (3 shards + replicas) | 3GB per shard | sharded + replicated | ~$200/month |
 
@@ -660,6 +744,8 @@ Use [`github.com/alicebob/miniredis/v2`](https://github.com/alicebob/miniredis) 
 
 ```go
 func TestStreamPublish(t *testing.T) {
+    t.Parallel()
+
     mr := miniredis.RunT(t)
     rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
     client := &cache.Client{/* wrap rdb */}
@@ -667,7 +753,7 @@ func TestStreamPublish(t *testing.T) {
     client.StreamPublish(ctx, "stream:session:abc:logs", map[string]any{"msg": "hello"})
 
     // miniredis supports XADD/XREAD — verify the stream entry exists
-    assert.True(t, mr.Exists("stream:session:abc:logs"))
+    require.True(t, mr.Exists("stream:session:abc:logs"), "stream publish should create the Redis stream key")
 }
 ```
 
@@ -702,8 +788,8 @@ func TestSSEReconnectReplay(t *testing.T) {
 
 | Code path | Redis-up | Redis-down (start) | Redis dies mid-session |
 |-----------|----------|---------------------|------------------------|
-| SSE log streaming | `XREAD BLOCK` delivers entries | 1s Postgres poll works | Client still receives entries via Postgres poll after Redis drops; no duplicate delivery once Redis recovers |
-| Rate limiting | Global INCR counter enforces limit | Per-node in-memory limiter enforces per-node limit | Switch from Redis to in-memory happens within breaker cooldown; no request is double-counted |
+| SSE log streaming | `XREAD BLOCK` delivers entries | 1s Postgres poll works for new connections | Existing connection is closed with retryable error; reconnect uses `Last-Event-ID`, catches up from Redis or Postgres, and resumes without duplicate delivery |
+| Rate limiting | Global fixed-window counter enforces limit | Per-node in-memory limiter enforces per-node limit | Switch from Redis to in-memory happens within breaker cooldown; no request is double-counted |
 | Job notifications | Instant wake on `PUBLISH` | 5s poll claims jobs | In-flight Subscribe reconnects automatically; poll continues as safety net |
 | Auth token cache (if Phase 6) | Cache hit skips Postgres | Cache miss falls through | Hot path reverts to Postgres within breaker cooldown; no stale reads served |
 
@@ -761,10 +847,10 @@ Redis runs as a **single, separate service** — not embedded inside each applic
 
 **Spinning up a dedicated Redis node:** To run Redis on its own dedicated host/container (e.g., for resource isolation or scaling):
 1. Deploy `redis:8.6-alpine` on a separate Docker host, VM, or as a managed service
-2. Set `REDIS_URL=redis://<redis-host>:6379/0` (or `rediss://` for TLS) on all app nodes
-3. No code changes — the `go-redis` client connects to whatever `REDIS_URL` points to
+2. Set the topology-appropriate Redis connection settings on all app nodes (`REDIS_URL` for standalone, or `REDIS_ADDRS`/`REDIS_MASTER_NAME` for Sentinel or Cluster; use `rediss://` where TLS is available)
+3. No code changes — the wrapper connects using whatever topology-specific settings are configured
 
-**Docker Compose (dev):** Redis is defined as a top-level service in `docker-compose.yml`. It shares the Docker network with the app but runs in its own container. To move it to a separate machine in the future, just change the URL.
+**Docker Compose (dev):** Redis is defined as a top-level service in `docker-compose.yml`. It shares the Docker network with the app but runs in its own container. To move it to a separate machine in the future, just change the topology-specific connection settings.
 
 **Production:** Use a managed service (ElastiCache, Memorystore, etc.) — see Section 6. The app containers never run Redis internally.
 
@@ -785,14 +871,14 @@ Redis 7.x would also work — all APIs used here are stable since Redis 7.0. How
 Because Redis is optional and all code paths have fallbacks, rolling deployments are safe:
 
 - **Adding Redis (first deploy):** Old nodes without the Redis code path simply ignore Redis. New nodes start using it as they roll in. No coordination required — both old and new nodes continue to read/write Postgres as the source of truth.
-- **Redis config changes:** Changing `REDIS_URL` during a rolling deploy means some nodes briefly point to the old Redis and others to the new one. This is fine — cached data is reconstructable, and pub/sub messages on the old instance are simply missed (the Postgres polling fallback covers the gap).
-- **Removing Redis (rollback):** Set `REDIS_URL=""` and redeploy. All nodes revert to pre-Redis behavior.
+- **Redis config changes:** Changing the selected Redis connection settings during a rolling deploy means some nodes briefly point to the old Redis and others to the new one. This is fine — cached data is reconstructable, and pub/sub/stream messages on the old instance are simply missed until reconnect or fallback catch-up closes the gap.
+- **Removing Redis (rollback):** Clear the required connection settings for the selected topology (for example `REDIS_URL=""` in standalone mode) and redeploy. All nodes revert to pre-Redis behavior.
 
 ---
 
 ## 18. Decision
 
-**Recommended approach:** Add Redis as an optional, gracefully-degrading dependency. Start with Phase 1 (Hetzner provisioning), Phase 2 (application integration), and Phase 3 (Redis Streams for SSE) — these deliver the highest value by eliminating the SSE polling floor. Phases 4 (rate limiting) and 5 (job notifications) can be added when node count or org count crosses thresholds where per-node limiting actually causes problems. Phase 6 (auth cache) is explicitly **gated on measurement** — confirm from metrics that auth is a p99 contributor before implementing.
+**Recommended approach:** Add Redis as an optional, gracefully-degrading dependency. Start with Phase 1 (Hetzner provisioning), Phase 2 (application integration), and Phase 3 (Redis Streams for SSE) — these deliver the highest value by eliminating the SSE polling floor. Phase 5 (job notifications) can follow once worker wake-up latency matters, and Phase 4 (distributed rate limiting) only lands once control-plane keys are isolated from stream eviction risk. Phase 6 (auth cache) is explicitly **gated on measurement** — confirm from metrics that auth is a p99 contributor before implementing.
 
 The key design constraint — Redis is never authoritative — means we get performance benefits without operational risk. The migration path from Docker Compose to hosted Redis is a config change, not a code change.
 


### PR DESCRIPTION
## Summary
- Tightened the Redis design to make stream retention, SSE failover, and rate limiting internally consistent.
- Switched the client wrapper to a topology-agnostic `UniversalClient` model so standalone, Sentinel, and Cluster remain config-only changes.
- Clarified startup breaker behavior, local Compose scaling, connection sizing, and rolling/rollback guidance.

## Testing
- Not run (not requested)