### PR TITLE
Reject empty Claude Code refresh tokens

### DIFF
--- a/internal/services/claudecodeauth/service.go
+++ b/internal/services/claudecodeauth/service.go
@@ -670,6 +670,9 @@ func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID 
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
 		return nil, fmt.Errorf("parse refresh response: %w", err)
 	}
+	if tokenResp.AccessToken == "" {
+		return nil, fmt.Errorf("refresh response returned empty access_token")
+	}
 
 	newSub := &models.AnthropicSubscription{
 		AccessToken:   tokenResp.AccessToken,

--- a/internal/services/claudecodeauth/service_test.go
+++ b/internal/services/claudecodeauth/service_test.go
@@ -556,6 +556,38 @@ func TestRefreshTokenByID_PreservesRefreshTokenWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestRefreshTokenByID_RejectsEmptyAccessToken(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"","refresh_token":"new-refresh","expires_in":3600,"scope":"user:profile"}`))
+	}))
+	defer ts.Close()
+
+	svc := NewService(store, zerolog.Nop())
+	svc.SetTokenURL(ts.URL)
+	svc.SetProfileURL("")
+
+	orgID := uuid.New()
+	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
+
+	newSub, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	require.Nil(t, newSub, "RefreshTokenByID should not return a subscription when the refresh response omits access_token")
+	require.Error(t, err, "RefreshTokenByID should fail closed when the refresh response omits access_token")
+	require.Contains(t, err.Error(), "empty access_token", "RefreshTokenByID should surface the empty access_token error")
+
+	storedCred, getErr := store.GetByID(context.Background(), orgID, credID)
+	require.NoError(t, getErr, "GetByID should return the seeded credential after a failed refresh")
+
+	storedCfg, ok := storedCred.Config.(models.AnthropicConfig)
+	require.True(t, ok, "stored credential should remain an AnthropicConfig after a failed refresh")
+	require.NotNil(t, storedCfg.Subscription, "stored credential should still include its subscription after a failed refresh")
+	require.Equal(t, "old-access", storedCfg.Subscription.AccessToken, "failed refresh should preserve the previously stored access token")
+	require.Equal(t, "old-refresh", storedCfg.Subscription.RefreshToken, "failed refresh should preserve the previously stored refresh token")
+}
+
 func TestRefreshTokenByID_RefreshTokenReused(t *testing.T) {
 	t.Parallel()
 	store := newMockCredentialStore()


### PR DESCRIPTION
## Summary
- fail Claude Code OAuth refreshes that return HTTP 200 without an `access_token` instead of persisting an empty active token
- add a regression test covering the malformed refresh response and verifying the stored credential is left unchanged

## Verification
- `go vet ./...`
- `go build ./...`
- `go test ./...`