### PR TITLE
Clarify LLM settings for app-level features

### DIFF
--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
@@ -21,6 +21,9 @@ describe("DefaultModelCard", () => {
       />,
     );
     expect(screen.getByText(/Uses your OpenAI key/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Used for organization-level LLM features, separate from the coding agents configured on the Agent settings page/i),
+    ).toBeInTheDocument();
   });
 
   it("shows an amber warning when the owner is not configured", () => {

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
@@ -76,6 +76,10 @@ export function DefaultModelCard({
                 No provider key configured for this model
               </p>
             )}
+            <p className="text-xs text-muted-foreground">
+              Used for organization-level LLM features, separate from the coding agents configured
+              on the Agent settings page.
+            </p>
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.test.tsx
@@ -87,6 +87,10 @@ describe("LLMPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /LLM/i, level: 1 })).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/Configure the app-level LLMs used for extra features like PR descriptions/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/These models are separate from the coding agents configured on the Agent page/i)).toBeInTheDocument();
   });
 
   it("renders provider keys section", async () => {
@@ -103,6 +107,9 @@ describe("LLMPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: "Default model" })).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/Choose the default model for app features like PR descriptions, titles, validation, and project generation/i),
+    ).toBeInTheDocument();
   });
 
   it("shows the platform-LLM alert when no platform provider is configured", async () => {

--- a/frontend/src/app/(dashboard)/settings/llm/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/page.tsx
@@ -213,7 +213,8 @@ export default function LLMPage() {
       <div className="space-y-6">
         <PageHeader
           title="LLM"
-          description="Configure agent credentials and the AI model for your organization."
+          description="Configure the app-level LLMs used for extra features like PR descriptions, session titles, validation, and project generation."
+          subtitle="These models are separate from the coding agents configured on the Agent page."
         />
 
         {!hasPlatformLLM && (
@@ -244,6 +245,10 @@ export default function LLMPage() {
             <h2 className="text-xs font-medium text-foreground">Default model</h2>
             <AutosaveIndicator status={autosave.status} />
           </div>
+          <p className="text-xs text-muted-foreground">
+            Choose the default model for app features like PR descriptions, titles, validation, and
+            project generation.
+          </p>
           <DefaultModelCard
             value={llmModel}
             reasoningEffort={reasoningEffort}
@@ -265,8 +270,8 @@ export default function LLMPage() {
         <section className="space-y-3">
           <h2 className="text-xs font-medium text-foreground">Provider keys</h2>
           <p className="text-xs text-muted-foreground">
-            Add API keys for this org. Keys flow to coding agent sessions and can power the default
-            model above when the matching provider is selected.
+            Add API keys for these app-level LLM features. These keys power the default model above
+            and are separate from the coding agent credentials on the Agent page.
           </p>
           <div className="space-y-2">
             {LLM_PROVIDERS.map((provider) => (


### PR DESCRIPTION
## Summary
- Clarify that the LLM settings page configures app-level models for features like PR descriptions, titles, validation, and project generation.
- Explicitly distinguish these settings from the coding agent configuration on the Agent page.
- Update the related UI tests to cover the revised copy.

## Testing
- `vitest src/app/(dashboard)/settings/llm/page.test.tsx`
- `vitest src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx`