### PR TITLE
Fix stuck session setup job claims

### DIFF
--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -215,7 +215,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
-				mock.ExpectQuery("WITH next_job AS").
+				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
@@ -235,7 +235,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				orgID := uuid.New()
 				now := time.Now()
 				completedAt := now.Add(time.Minute)
-				mock.ExpectQuery("WITH next_job AS").
+				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
@@ -251,7 +251,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 		{
 			name: "returns nil when no pending job exists",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH next_job AS").
+				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(pgx.ErrNoRows)
 			},
@@ -260,7 +260,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 		{
 			name: "returns query errors",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH next_job AS").
+				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
 					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(errors.New("db down"))
 			},

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -101,10 +101,10 @@ func (s *JobStore) DeleteExpiredCompleted(ctx context.Context, retentionDays int
 	return deleted, err
 }
 
-const claimedJobColumns = `id, org_id, queue, job_type, payload, priority, status,
-	attempts, max_attempts, run_at, locked_by_node_id, locked_at,
-	lease_expires_at, lock_token, run_owner_id, last_error,
-	dedupe_key, created_at, updated_at, completed_at`
+const claimedJobColumns = `j.id, j.org_id, j.queue, j.job_type, j.payload, j.priority, j.status,
+	j.attempts, j.max_attempts, j.run_at, j.locked_by_node_id, j.locked_at,
+	j.lease_expires_at, j.lock_token, j.run_owner_id, j.last_error,
+	j.dedupe_key, j.created_at, j.updated_at, j.completed_at`
 
 type jobExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)


### PR DESCRIPTION
## Summary
- Qualify the `ClaimNextRunnable` return columns with the `jobs j` alias to avoid the ambiguous `id` error in production.
- Tighten the job store regression test so it asserts the qualified SQL shape.

## Testing
- `go test ./internal/db -run TestJobStore_ClaimNextRunnable`
- `go test ./...`
- `go vet ./...`
- `go build ./...`