### PR TITLE
Fix frontend ESLint warnings and fail on lint regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         run: pip install 'diff_cover==10.2.0'
 
       - run: npm ci
+      - run: npm run lint
 
       - name: Run affected tests (PR)
         if: github.event_name == 'pull_request'

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,10 +9,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint . --max-warnings=0",
     "typecheck": "tsc --noEmit",
-    "test": "vitest",
-    "test:ci": "vitest run --reporter=dot"
+    "test": "npm run lint && vitest",
+    "test:ci": "npm run lint && vitest run --reporter=dot"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.45.0",

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -157,7 +158,7 @@ function LoginPageContent() {
                 onClick={() => api.auth.login(invitation)}
                 aria-label="Continue with GitHub"
               >
-                <img src="/integrations/github.svg" alt="" className="mr-2 h-5 w-5 dark:invert" aria-hidden="true" />
+                <Image src="/integrations/github.svg" alt="" width={20} height={20} className="mr-2 h-5 w-5 dark:invert" aria-hidden="true" />
                 Continue with GitHub
               </Button>
             )}
@@ -168,7 +169,7 @@ function LoginPageContent() {
                 onClick={() => api.auth.loginGoogle(invitation)}
                 aria-label="Continue with Google"
               >
-                <img src="/integrations/google.svg" alt="" className="mr-2 h-5 w-5" aria-hidden="true" />
+                <Image src="/integrations/google.svg" alt="" width={20} height={20} className="mr-2 h-5 w-5" aria-hidden="true" />
                 Continue with Google
               </Button>
             )}

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -151,7 +151,7 @@ export default function AutomationsPage() {
     refetchInterval: 10000,
   });
 
-  const automations = data?.data ?? [];
+  const automations = useMemo(() => data?.data ?? [], [data?.data]);
   const enabled = useMemo(() => automations.filter((a) => a.enabled), [automations]);
   const paused = useMemo(() => automations.filter((a) => !a.enabled), [automations]);
 

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -42,7 +42,7 @@ export function ProjectSidebar() {
     refetchInterval: 10000,
   });
 
-  const allProjects = data?.data ?? [];
+  const allProjects = useMemo(() => data?.data ?? [], [data?.data]);
   const currentFilter = activeFilter ?? "all";
 
   const activeCount = useMemo(

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -48,7 +48,7 @@ vi.mock('next/link', () => ({
 // Mock next/image to render a plain img
 vi.mock('next/image', () => ({
   default: ({ src, alt, className, width, height }: { src: string; alt: string; className?: string; width?: number; height?: number }) => (
-    <img src={src} alt={alt} className={className} width={width} height={height} />
+    <span data-next-image={src} aria-label={alt} className={className} data-width={width} data-height={height} />
   ),
 }));
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -420,62 +420,7 @@ function ValidationTab({ sessionId }: { sessionId: string }) {
   );
 }
 
-const prStatusColor: Record<string, string> = {
-  open: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400",
-  merged: "bg-purple-500/10 text-purple-700 dark:text-purple-400",
-  closed: "bg-red-500/10 text-red-700 dark:text-red-400",
-};
-
-function PRCard({ sessionId }: { sessionId: string }) {
-  const { data: prData, isLoading: prLoading } = useQuery({
-    queryKey: ["session", sessionId, "pr"],
-    queryFn: () => api.sessions.getPR(sessionId),
-  });
-
-  const pr = prData?.data;
-  if (prLoading) return <div className="flex items-center justify-center gap-2 py-2 text-xs text-muted-foreground"><Loader2 className="h-3.5 w-3.5 animate-spin" />Loading PR...</div>;
-  if (!pr) return null;
-
-  return (
-    <Card className="mx-4 mt-3">
-      <CardContent className="py-3 space-y-3">
-        <div className="flex items-start justify-between">
-          <div className="min-w-0">
-            <h3 className="text-xs font-medium truncate">{pr.title}</h3>
-            <p className="text-xs text-muted-foreground mt-0.5">{pr.github_repo} #{pr.github_pr_number}</p>
-          </div>
-          <a href={pr.github_pr_url} target="_blank" rel="noopener noreferrer">
-            <Button variant="outline" size="sm">
-              <ExternalLink className="mr-1.5 h-3 w-3" />
-              GitHub
-            </Button>
-          </a>
-        </div>
-        <div className="flex items-center gap-3 text-xs">
-          <div>
-            <span className="text-muted-foreground">Status: </span>
-            <Badge variant="secondary" className={`text-xs ${prStatusColor[pr.status] || "bg-muted text-muted-foreground"}`}>
-              {pr.status}
-            </Badge>
-          </div>
-          {pr.review_status && (
-            <div>
-              <span className="text-muted-foreground">Review: </span>
-              <Badge variant="secondary" className="text-xs">{pr.review_status}</Badge>
-            </div>
-          )}
-          <div className="min-w-0">
-            <span className="text-muted-foreground">Branch: </span>
-            <code className="text-xs bg-muted px-1 py-0.5 rounded">{pr.branch_name}</code>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
 function ChangesTab({
-  sessionId,
   filteredFiles,
   activeFileIndex,
   onFileSelect,
@@ -487,7 +432,6 @@ function ChangesTab({
   onPassRangeChange,
   emptyStatusText,
 }: {
-  sessionId: string;
   filteredFiles: DiffFile[];
   activeFileIndex: number;
   onFileSelect: (index: number) => void;
@@ -957,22 +901,9 @@ function ChatPanel({ session, sessionId, isActive, onDiffClick }: { session: Ses
     queryFn: () => api.sessions.getPR(sessionId),
   });
   const hasPR = !!prData?.data;
-  const hasDiff = !!session.diff_stats;
-  const canCreatePR = hasDiff && !hasPR && !isRunning;
-
   const [prQueued, setPRQueued] = useState(false);
-  const [prDraftOverride, setPRDraftOverride] = useState<boolean | null>(null);
-
-  const { data: ghStatus } = useQuery({
-    queryKey: ["github-status"],
-    queryFn: () => api.githubStatus.get(),
-    enabled: canCreatePR,
-    staleTime: 5 * 60 * 1000, // 5 min
-  });
-
-  const draftValue = prDraftOverride ?? ghStatus?.pr_draft_default ?? false;
   const createPRMutation = useMutation({
-    mutationFn: () => api.sessions.createPR(sessionId, prDraftOverride !== null ? { draft: prDraftOverride } : undefined),
+    mutationFn: () => api.sessions.createPR(sessionId),
     onSuccess: () => {
       setPRQueued(true);
       // Clear the queued banner after 30s if the PR hasn't appeared yet.
@@ -1598,7 +1529,6 @@ export function SessionDetailContent({ id }: { id: string }) {
 
             <TabsContent value="changes" className="flex-1 min-h-0">
               <ChangesTab
-                sessionId={id}
                 filteredFiles={filteredFiles}
                 activeFileIndex={activeFileIndex}
                 onFileSelect={setActiveFileIndex}

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -303,6 +303,7 @@ export function SessionsPageContent() {
 
   const columns = useMemo(() => buildColumns(members), [members]);
 
+  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table exposes unstable functions by design; this component does not memoize the table instance across boundaries.
   const table = useReactTable({
     data: filteredSessions,
     columns,

--- a/frontend/src/app/(dashboard)/settings/evals/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/[id]/page.tsx
@@ -40,7 +40,7 @@ import {
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { ArrowLeft, Play, Trash2, Loader2, AlertTriangle } from "lucide-react";
-import type { EvalTask, EvalRun, ScoringCriterion } from "@/lib/types";
+import type { EvalRun, ScoringCriterion } from "@/lib/types";
 import { evalComplexityConfig, evalRunStatusConfig, evalSourceConfig } from "@/lib/types";
 
 export default function EvalTaskDetailPage() {

--- a/frontend/src/app/(dashboard)/settings/usage/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.tsx
@@ -27,7 +27,6 @@ export default function UsagePage() {
     s.setSeconds(0, 0);
     e.setSeconds(0, 0);
     return { start: formatDateForApi(s), end: formatDateForApi(e) };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only recompute when preset changes
   }, [preset]);
 
   // If a specific day is clicked, narrow the breakdown to that day.

--- a/frontend/src/app/(dashboard)/settings/usage/usage-timeseries-chart.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-timeseries-chart.tsx
@@ -30,7 +30,6 @@ import {
   formatCost,
   metricOptions,
   type MetricKey,
-  type DailyBucket,
 } from "./usage-helpers";
 
 interface UsageTimeseriesChartProps {

--- a/frontend/src/ci-guardrails.test.ts
+++ b/frontend/src/ci-guardrails.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const frontendDir = path.resolve(import.meta.dirname, "..");
+const repoRoot = path.resolve(frontendDir, "..");
+
+describe("frontend CI guardrails", () => {
+  it("fails lint on warnings and runs lint in the CI test script", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(frontendDir, "package.json"), "utf8")
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    expect(packageJson.scripts?.lint).toContain("--max-warnings=0");
+    expect(packageJson.scripts?.test).toMatch(/^npm run lint && /);
+    expect(packageJson.scripts?.["test:ci"]).toMatch(/^npm run lint && /);
+  });
+
+  it("runs lint in the frontend test workflow before Vitest", () => {
+    const workflow = fs.readFileSync(
+      path.join(repoRoot, ".github", "workflows", "ci.yml"),
+      "utf8"
+    );
+
+    expect(workflow).toContain("frontend-test:");
+    expect(workflow).toContain("- run: npm run lint");
+  });
+});

--- a/frontend/src/components/preview/design-mode-overlay.test.tsx
+++ b/frontend/src/components/preview/design-mode-overlay.test.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { renderWithProviders, screen } from "@/test/test-utils";
 import { DesignModeOverlay } from "./design-mode-overlay";
-import { createRef } from "react";
 
 const { inspectMock, feedbackMock } = vi.hoisted(() => ({
   inspectMock: vi.fn().mockResolvedValue({
@@ -32,55 +31,27 @@ describe("DesignModeOverlay", () => {
   });
 
   it("renders the overlay with select tool button", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     expect(screen.getByTitle("Select element")).toBeInTheDocument();
   });
 
   it("select tool is active by default", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     const selectButton = screen.getByTitle("Select element");
     expect(selectButton.className).toMatch(/bg-primary/);
   });
 
   it("renders the overlay container with correct classes", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    const { container } = renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    const { container } = renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     const overlayDiv = container.querySelector(".absolute.inset-0.z-10");
     expect(overlayDiv).toBeInTheDocument();
   });
 
   it("does not show element info panel when nothing is selected", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     expect(
       screen.queryByPlaceholderText("Describe what to change...")
@@ -89,41 +60,20 @@ describe("DesignModeOverlay", () => {
   });
 
   it("does not show error banner initially", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     expect(screen.queryByText(/Failed to/)).not.toBeInTheDocument();
   });
 
   it("renders the crosshair overlay for click capture", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    const { container } = renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    const { container } = renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     const crosshairDiv = container.querySelector(".cursor-crosshair");
     expect(crosshairDiv).toBeInTheDocument();
   });
 
   it("renders SVG layer for element highlights", () => {
-    const iframeRef = createRef<HTMLIFrameElement>();
-    const { container } = renderWithProviders(
-      <DesignModeOverlay
-        sessionId="sess-1"
-        iframeRef={iframeRef}
-        previewOrigin="https://test.preview.143.dev"
-      />
-    );
+    const { container } = renderWithProviders(<DesignModeOverlay sessionId="sess-1" />);
 
     const svg = container.querySelector("svg");
     expect(svg).toBeInTheDocument();

--- a/frontend/src/components/preview/design-mode-overlay.tsx
+++ b/frontend/src/components/preview/design-mode-overlay.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -27,8 +26,6 @@ import { VisualEditingPanel } from "./visual-editing-panel";
 
 interface DesignModeOverlayProps {
   sessionId: string;
-  iframeRef: RefObject<HTMLIFrameElement | null>;
-  previewOrigin: string;
 }
 
 interface SelectedElement {
@@ -48,8 +45,6 @@ function buildSelector(info: ElementInfo): string {
 
 export function DesignModeOverlay({
   sessionId,
-  iframeRef,
-  previewOrigin,
 }: DesignModeOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -31,7 +31,6 @@ import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
 import {
   PREVIEW_ERROR_CODES,
-  type PreviewStatusResponse,
   type PreviewStatus,
 } from "@/lib/preview-types";
 import { ConsoleBadge } from "./console-badge";
@@ -669,8 +668,6 @@ export function PreviewPanel({
                 <ErrorBoundary fallback={null}>
                   <DesignModeOverlay
                     sessionId={sessionId}
-                    iframeRef={iframeRef}
-                    previewOrigin={previewOrigin}
                   />
                 </ErrorBoundary>
               )}

--- a/frontend/src/components/preview/visual-editing-panel.tsx
+++ b/frontend/src/components/preview/visual-editing-panel.tsx
@@ -14,7 +14,6 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Slider } from "@/components/ui/slider";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,7 +25,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
 import type { ElementInfo, StyleEdit } from "@/lib/preview-types";
 

--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -220,7 +220,6 @@ export function useAutosave<TVars>({
   // pass new inline closures each render — with no deps, React just re-runs
   // the assignment and we never miss an update. Do not "fix" this by adding
   // a dep array.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     mutationFnRef.current = mutationFn;
     applyOptimisticRef.current = applyOptimistic;


### PR DESCRIPTION
## Summary
- Fix the current frontend ESLint warnings and remove stale disable comments
- Make lint stricter with `--max-warnings=0` and run it from `test`/`test:ci`
- Add CI coverage so the frontend test job runs lint before Vitest

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:ci` (fails on unrelated Vitest timeouts in existing tests)