### PR TITLE
Fix image preview centering and sizing

### DIFF
--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -232,11 +232,11 @@ describe("ChatTimeline", () => {
     // Click thumbnail to open lightbox.
     await userEvent.click(screen.getByAltText("Attached image"));
     // Lightbox shows a larger image with close button.
-    expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close image preview" })).toBeInTheDocument();
 
     // Close via button.
-    await userEvent.click(screen.getByRole("button", { name: "Close" }));
-    expect(screen.queryByRole("button", { name: "Close" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Close image preview" }));
+    expect(screen.queryByRole("button", { name: "Close image preview" })).not.toBeInTheDocument();
   });
 
   it("renders attachments on assistant messages", () => {

--- a/frontend/src/components/image-lightbox.test.tsx
+++ b/frontend/src/components/image-lightbox.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { ImageLightbox } from "./image-lightbox";
+
+describe("ImageLightbox", () => {
+  it("renders a full-screen centered stage with a viewport-anchored close button", () => {
+    const onOpenChange = vi.fn();
+
+    renderWithProviders(
+      <ImageLightbox
+        open
+        src="/api/v1/uploads/files/org-1/2026-04/screenshot.png"
+        alt="screenshot.png"
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Image preview" });
+    expect(dialog).toHaveClass("inset-0");
+    expect(dialog).toHaveClass("flex");
+    expect(dialog).toHaveClass("items-center");
+    expect(dialog).toHaveClass("justify-center");
+
+    const image = screen.getByRole("img", { name: "screenshot.png" });
+    expect(image).toHaveClass("max-h-[88vh]");
+    expect(image).toHaveClass("max-w-[92vw]");
+
+    const closeButton = screen.getByRole("button", { name: "Close image preview" });
+    expect(closeButton).toHaveClass("fixed");
+    expect(closeButton).toHaveClass("right-4");
+    expect(closeButton).toHaveClass("top-4");
+  });
+
+  it("closes when the backdrop is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    renderWithProviders(
+      <ImageLightbox
+        open
+        src="/api/v1/uploads/files/org-1/2026-04/screenshot.png"
+        alt="screenshot.png"
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    const backdrop = document.querySelector("[data-slot='dialog-overlay']");
+    expect(backdrop).not.toBeNull();
+
+    await user.click(backdrop as Element);
+
+    await waitFor(() => {
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+});

--- a/frontend/src/components/image-lightbox.tsx
+++ b/frontend/src/components/image-lightbox.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { X } from "lucide-react";
 import Image from "next/image";
-import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 
 type ImageLightboxProps = {
   open: boolean;
@@ -15,20 +17,34 @@ export function ImageLightbox({ open, src, alt, onOpenChange }: ImageLightboxPro
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         aria-label="Image preview"
-        className="max-w-[90vw] border-none bg-transparent p-0 shadow-none"
+        showCloseButton={false}
+        className="pointer-events-none inset-0 flex max-w-none translate-x-0 translate-y-0 items-center justify-center border-none bg-transparent p-4 shadow-none sm:p-6"
       >
         <DialogTitle className="sr-only">Image preview</DialogTitle>
         <DialogDescription className="sr-only">
           Enlarged preview of {alt}
         </DialogDescription>
-        <Image
-          src={src}
-          alt={alt}
-          width={1600}
-          height={1200}
-          unoptimized
-          className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
-        />
+        <DialogClose asChild>
+          <Button
+            type="button"
+            variant="secondary"
+            size="icon"
+            aria-label="Close image preview"
+            className="pointer-events-auto fixed right-4 top-4 z-10 rounded-full bg-background/90 shadow-lg backdrop-blur-sm hover:bg-background sm:right-6 sm:top-6"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </DialogClose>
+        <div className="pointer-events-auto flex max-h-full max-w-full items-center justify-center">
+          <Image
+            src={src}
+            alt={alt}
+            width={1600}
+            height={1200}
+            unoptimized
+            className="max-h-[88vh] max-w-[92vw] rounded-xl object-contain shadow-2xl"
+          />
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/pending-attachment-strip.test.tsx
+++ b/frontend/src/components/pending-attachment-strip.test.tsx
@@ -19,6 +19,9 @@ describe("PendingAttachmentStrip", () => {
     await waitFor(() => {
       expect(screen.getByAltText("Preview of screenshot.png")).toBeInTheDocument();
     });
+
+    expect(screen.getByAltText("Preview of screenshot.png")).toHaveClass("max-h-[70vh]");
+    expect(screen.getByAltText("Preview of screenshot.png")).toHaveClass("max-w-[min(70vw,56rem)]");
   });
 
   it("opens a lightbox when clicking an image attachment", async () => {

--- a/frontend/src/components/pending-attachment-strip.tsx
+++ b/frontend/src/components/pending-attachment-strip.tsx
@@ -77,14 +77,18 @@ function AttachmentImageTile({
             />
           </Button>
         </HoverCardTrigger>
-        <HoverCardContent side="top" align="start">
+        <HoverCardContent
+          side="top"
+          align="center"
+          className="w-auto max-w-[min(72vw,58rem)] border-border/80 bg-popover/95 p-2 shadow-xl backdrop-blur-sm"
+        >
           <Image
             src={url}
             alt={`Preview of ${fileName}`}
             width={1200}
             height={900}
             unoptimized
-            className="max-h-80 max-w-80 rounded-md object-contain"
+            className="max-h-[70vh] max-w-[min(70vw,56rem)] rounded-lg object-contain"
           />
         </HoverCardContent>
       </HoverCard>


### PR DESCRIPTION
## Summary
- enlarge hover previews for pending image attachments
- rework the image lightbox into a centered full-screen stage with an explicit close button
- add UI tests for hover preview sizing and lightbox dismissal

## Testing
- `npm exec vitest run src/components/image-lightbox.test.tsx src/components/pending-attachment-strip.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`