### PR TITLE
Fix GitHub integration status and disconnect handling

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -162,6 +162,7 @@ export default function IntegrationsPage() {
   const githubIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "github" && integration.status === "active"
   );
+  const githubConnected = Boolean(githubIntegration);
   const sentryIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "sentry" && integration.status === "active"
   );
@@ -194,7 +195,7 @@ export default function IntegrationsPage() {
           description="Connect external services to your organization."
         />
       <AllIntegrationCards
-        githubConnected={Boolean(githubIntegration)}
+        githubConnected={githubConnected}
         githubRepos={githubRepos}
         onDisconnectRepo={(id) => disconnectRepoMutation.mutate(id)}
         onReconnectRepo={(id) => reconnectRepoMutation.mutate(id)}

--- a/frontend/src/components/no-repos-warning.test.tsx
+++ b/frontend/src/components/no-repos-warning.test.tsx
@@ -32,7 +32,7 @@ describe("NoReposWarning", () => {
     server.use(
       http.get("/api/v1/integrations", () => {
         return HttpResponse.json({
-          data: [{ id: "int-1", provider: "github", status: "active" }],
+          data: [{ id: "int-1", provider: "github", status: "active", github_app_installed: true }],
           meta: {},
         });
       }),
@@ -63,7 +63,7 @@ describe("NoReposWarning", () => {
     server.use(
       http.get("/api/v1/integrations", () => {
         return HttpResponse.json({
-          data: [{ id: "int-1", provider: "github", status: "active" }],
+          data: [{ id: "int-1", provider: "github", status: "active", github_app_installed: true }],
           meta: {},
         });
       }),
@@ -88,7 +88,7 @@ describe("NoReposWarning", () => {
     server.use(
       http.get("/api/v1/integrations", () => {
         return HttpResponse.json({
-          data: [{ id: "int-1", provider: "github", status: "active" }],
+          data: [{ id: "int-1", provider: "github", status: "active", github_app_installed: true }],
           meta: {},
         });
       }),
@@ -105,6 +105,28 @@ describe("NoReposWarning", () => {
     await waitFor(() => {
       expect(
         screen.getByText(/no repositories are synced/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("keeps neutral copy when github integration exists without an app installation", async () => {
+    server.use(
+      http.get("/api/v1/integrations", () => {
+        return HttpResponse.json({
+          data: [{ id: "int-1", provider: "github", status: "active", github_app_installed: false }],
+          meta: {},
+        });
+      }),
+      http.get("/api/v1/repositories", () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    renderWithProviders(<NoReposWarning />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/github is connected but no repositories are synced/i)
       ).toBeInTheDocument();
     });
   });

--- a/frontend/src/components/no-repos-warning.tsx
+++ b/frontend/src/components/no-repos-warning.tsx
@@ -41,6 +41,10 @@ export function NoReposWarning() {
       (i) => i.provider === "github" && i.status === "active"
     )
   );
+  const githubIntegration = integrationsResp?.data?.find(
+    (i) => i.provider === "github" && i.status === "active"
+  );
+  const githubAppInstalled = Boolean(githubIntegration?.github_app_installed);
   const repos = reposResp?.data ?? [];
   const hasRepos = repos.length > 0;
 
@@ -50,11 +54,11 @@ export function NoReposWarning() {
   const needsReinstall = isReinstallError(syncError);
 
   useEffect(() => {
-    autoSyncIfNeeded(hasGitHub, hasRepos);
-  }, [hasGitHub, hasRepos, autoSyncIfNeeded]);
+    autoSyncIfNeeded(githubAppInstalled, hasRepos);
+  }, [githubAppInstalled, hasRepos, autoSyncIfNeeded]);
 
   // Don't render if GitHub isn't connected or repos exist (and no recent sync result to show)
-  if (!hasGitHub || (hasRepos && !syncResult)) return null;
+  if (!hasGitHub || (hasRepos && !syncResult && githubAppInstalled)) return null;
 
   // After a successful sync that found repos, show success briefly then hide
   if (syncResult && syncResult.repos_synced > 0 && hasRepos) {

--- a/frontend/src/components/setup-checklist.test.tsx
+++ b/frontend/src/components/setup-checklist.test.tsx
@@ -15,6 +15,10 @@ const mocks = vi.hoisted(() => ({
   codexAuthMock: vi.fn().mockResolvedValue({ data: { status: "pending" } }),
   integrationsListMock: vi.fn().mockResolvedValue({ data: [] }),
   repositoriesListMock: vi.fn().mockResolvedValue({ data: [] }),
+  sourceControlCardMock: vi.fn((props: unknown) => {
+    void props;
+    return <div data-testid="source-control-card" />;
+  }),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -59,7 +63,7 @@ vi.mock("@/components/no-repos-warning", () => ({
 }));
 
 vi.mock("@/components/integration-connection-cards", () => ({
-  SourceControlIntegrationCard: () => <div data-testid="source-control-card" />,
+  SourceControlIntegrationCard: (props: unknown) => mocks.sourceControlCardMock(props),
   AdditionalIntegrationCards: () => <div data-testid="additional-cards" />,
 }));
 
@@ -92,6 +96,20 @@ describe("SetupChecklist", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Codex")).toBeInTheDocument();
+    });
+  });
+
+  it("treats oauth-only github integrations as connected", async () => {
+    mocks.integrationsListMock.mockResolvedValueOnce({
+      data: [{ id: "int-1", provider: "github", status: "active", github_app_installed: false }],
+    });
+
+    renderWithProviders(<SetupChecklist />);
+
+    await waitFor(() => {
+      expect(mocks.sourceControlCardMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ githubConnected: true })
+      );
     });
   });
 });

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -209,7 +209,8 @@ export function SetupChecklist() {
   const slackIntegration = integrations.find((integration) => integration.provider === "slack" && integration.status === "active");
   const notionIntegration = integrations.find((integration) => integration.provider === "notion" && integration.status === "active");
 
-  const githubReady = Boolean(githubIntegration) && repositories.length > 0;
+  const githubConnected = Boolean(githubIntegration);
+  const githubReady = githubConnected && repositories.length > 0;
 
   return (
     <div id="autopilot-setup" className="space-y-6">
@@ -220,7 +221,7 @@ export function SetupChecklist() {
       <StepSection step={2} title="Connect integrations" completed={githubReady}>
         <div className="space-y-3">
           <SourceControlIntegrationCard
-            githubConnected={Boolean(githubIntegration)}
+            githubConnected={githubConnected}
             githubRepos={githubRepos}
             onConnectGitHub={() => api.integrations.loginGitHub()}
             onDisconnect={(provider) => disconnectMutation.mutate(provider)}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -71,6 +71,7 @@ export interface Integration {
   id: string;
   org_id: string;
   provider: string;
+  github_app_installed?: boolean;
   status: string;
   last_synced_at?: string;
   created_at: string;

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -269,7 +269,30 @@ func (h *IntegrationHandler) ListIntegrations(w http.ResponseWriter, r *http.Req
 	if integrations == nil {
 		integrations = []models.Integration{}
 	}
+	for i := range integrations {
+		h.deriveIntegrationStatus(r.Context(), &integrations[i])
+	}
 	writeJSON(w, http.StatusOK, models.ListResponse[models.Integration]{Data: integrations})
+}
+
+func (h *IntegrationHandler) deriveIntegrationStatus(ctx context.Context, integration *models.Integration) {
+	if integration == nil || integration.Provider != models.IntegrationProviderGitHub {
+		return
+	}
+
+	var cfg struct {
+		InstallationID int64 `json:"installation_id"`
+	}
+	installed := false
+	if len(integration.Config) > 0 && json.Unmarshal(integration.Config, &cfg) == nil && cfg.InstallationID > 0 {
+		installed = true
+	}
+	if !installed && h.repoStore != nil {
+		if installationID, err := h.repoStore.GetAnyInstallationIDByOrg(ctx, integration.OrgID); err == nil && installationID > 0 {
+			installed = true
+		}
+	}
+	integration.GitHubAppInstalled = &installed
 }
 
 // DisconnectIntegration sets the integration status to inactive for a given provider.
@@ -309,6 +332,12 @@ func (h *IntegrationHandler) DisconnectIntegration(w http.ResponseWriter, r *htt
 		if err := h.integrationStore.UpdateStatus(r.Context(), orgID, integration.ID, string(models.IntegrationStatusInactive)); err != nil {
 			writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disconnect integration", err)
 			return
+		}
+		if provider == models.IntegrationProviderGitHub && h.repoStore != nil {
+			if err := h.repoStore.DisconnectByIntegration(r.Context(), orgID, integration.ID); err != nil {
+				writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to disconnect github repositories", err)
+				return
+			}
 		}
 	}
 

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -92,6 +92,50 @@ func TestIntegrationHandler_ListIntegrations_Success(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestIntegrationHandler_ListIntegrations_DerivesGitHubAppInstalled(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(uuid.New(), orgID, "github", []byte(`{}`), "active", nil, now).
+		AddRow(uuid.New(), orgID, "github", []byte(`{"installation_id":12345}`), "active", nil, now).
+		AddRow(uuid.New(), orgID, "linear", []byte(`{}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ListIntegrations(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "list integrations should succeed")
+
+	var resp struct {
+		Data []struct {
+			Provider           string `json:"provider"`
+			GitHubAppInstalled *bool  `json:"github_app_installed,omitempty"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "list integrations response should decode")
+	require.Len(t, resp.Data, 3, "list integrations should return every integration row")
+	require.NotNil(t, resp.Data[0].GitHubAppInstalled, "github integrations should include derived app-installed status")
+	require.Equal(t, false, *resp.Data[0].GitHubAppInstalled, "github integration without installation_id should report not installed")
+	require.NotNil(t, resp.Data[1].GitHubAppInstalled, "github integrations with installation_id should include derived app-installed status")
+	require.Equal(t, true, *resp.Data[1].GitHubAppInstalled, "github integration with installation_id should report installed")
+	require.Nil(t, resp.Data[2].GitHubAppInstalled, "non-github integrations should not include github app status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
+}
+
 func TestIntegrationHandler_ListIntegrations_DBError(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +160,42 @@ func TestIntegrationHandler_ListIntegrations_DBError(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, w.Code, "should return 500 on DB error")
 	require.Contains(t, w.Body.String(), "LIST_FAILED")
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIntegrationHandler_DisconnectIntegration_DisconnectsGitHubRepos(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.repoStore = db.NewRepositoryStore(mock)
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(integrationID, orgID, "github", []byte(`{"installation_id":12345}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectExec("UPDATE integrations SET status = @status WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE repositories SET status = 'disconnected', updated_at = now\\(\\) WHERE org_id = @org_id AND integration_id = @integration_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/github/disconnect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.DisconnectIntegration(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code, "disconnect integration should succeed")
+	require.NoError(t, mock.ExpectationsWereMet(), "disconnect integration should also disconnect github repos")
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -136,6 +137,48 @@ func TestIntegrationHandler_ListIntegrations_DerivesGitHubAppInstalled(t *testin
 	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
 }
 
+func TestIntegrationHandler_ListIntegrations_DerivesGitHubAppInstalled_FromRepoFallback(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.repoStore = db.NewRepositoryStore(mock)
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(uuid.New(), orgID, "github", []byte(`{}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectQuery("SELECT installation_id FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(12345)))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ListIntegrations(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "list integrations should succeed")
+
+	var resp struct {
+		Data []struct {
+			GitHubAppInstalled *bool `json:"github_app_installed,omitempty"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "list integrations response should decode")
+	require.Len(t, resp.Data, 1, "list integrations should return the github integration")
+	require.NotNil(t, resp.Data[0].GitHubAppInstalled, "github integration should include derived app-installed status")
+	require.Equal(t, true, *resp.Data[0].GitHubAppInstalled, "repo fallback should mark the github app as installed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
+}
+
 func TestIntegrationHandler_ListIntegrations_DBError(t *testing.T) {
 	t.Parallel()
 
@@ -196,6 +239,43 @@ func TestIntegrationHandler_DisconnectIntegration_DisconnectsGitHubRepos(t *test
 
 	require.Equal(t, http.StatusNoContent, w.Code, "disconnect integration should succeed")
 	require.NoError(t, mock.ExpectationsWereMet(), "disconnect integration should also disconnect github repos")
+}
+
+func TestIntegrationHandler_DisconnectIntegration_GitHubRepoDisconnectError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+	handler.repoStore = db.NewRepositoryStore(mock)
+
+	rows := pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+		AddRow(integrationID, orgID, "github", []byte(`{"installation_id":12345}`), "active", nil, now)
+	mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(rows)
+	mock.ExpectExec("UPDATE integrations SET status = @status WHERE id = @id AND org_id = @org_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE repositories SET status = 'disconnected', updated_at = now\\(\\) WHERE org_id = @org_id AND integration_id = @integration_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(context.DeadlineExceeded)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/github/disconnect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.DisconnectIntegration(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "disconnect integration should surface github repo disconnect failures")
+	require.Contains(t, w.Body.String(), "UPDATE_FAILED", "disconnect integration should return update failed on github repo disconnect errors")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration-store expectations should be met")
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -80,6 +80,14 @@ type teamGitHubService interface {
 	GetInstallationToken(ctx context.Context, installationID int64) (string, error)
 }
 
+// teamRepositoryStore supplies repo-scoped fallbacks for GitHub App metadata.
+// Some orgs predate integration.config.installation_id but already have active
+// repo rows populated from a prior install sync; those repos still carry the
+// installation id we need for invite search.
+type teamRepositoryStore interface {
+	GetAnyInstallationIDByOrg(ctx context.Context, orgID uuid.UUID) (int64, error)
+}
+
 // TeamHandler serves the /api/v1/team/* endpoints.
 type TeamHandler struct {
 	users        teamUserStore
@@ -87,6 +95,7 @@ type TeamHandler struct {
 	sessions     teamSessionStore
 	invitations  teamInvitationStore
 	orgs         teamOrgStore
+	repositories teamRepositoryStore
 	integrations teamIntegrationStore
 	githubSvc    teamGitHubService
 	httpClient   *http.Client
@@ -101,6 +110,10 @@ type TeamHandler struct {
 func (h *TeamHandler) SetGitHubIntegration(integrations teamIntegrationStore, ghSvc teamGitHubService) {
 	h.integrations = integrations
 	h.githubSvc = ghSvc
+}
+
+func (h *TeamHandler) SetRepositoryStore(repositories teamRepositoryStore) {
+	h.repositories = repositories
 }
 
 // SetAuditEmitter injects the audit emitter for logging team events.
@@ -730,7 +743,7 @@ func (h *TeamHandler) SearchGitHubUsers(w http.ResponseWriter, r *http.Request) 
 // GitHub integration, or 0 if no usable integration exists.
 func (h *TeamHandler) getGitHubInstallationID(ctx context.Context, orgID uuid.UUID) (int64, error) {
 	if h.integrations == nil {
-		return 0, nil
+		return h.fallbackGitHubInstallationID(ctx, orgID)
 	}
 	integrations, err := h.integrations.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
 	if err != nil {
@@ -750,7 +763,21 @@ func (h *TeamHandler) getGitHubInstallationID(ctx context.Context, orgID uuid.UU
 			return cfg.InstallationID, nil
 		}
 	}
-	return 0, nil
+	return h.fallbackGitHubInstallationID(ctx, orgID)
+}
+
+func (h *TeamHandler) fallbackGitHubInstallationID(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	if h.repositories == nil {
+		return 0, nil
+	}
+	installationID, err := h.repositories.GetAnyInstallationIDByOrg(ctx, orgID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return installationID, nil
 }
 
 // searchGitHubUsers calls GitHub's REST user search and returns up to 10

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -105,6 +105,39 @@ type mockTeamInvitationStore struct {
 	revokeFn                      func(ctx context.Context, orgID, id uuid.UUID) error
 }
 
+type mockTeamRepositoryStore struct {
+	getAnyInstallationIDByOrgFn func(ctx context.Context, orgID uuid.UUID) (int64, error)
+}
+
+func (m *mockTeamRepositoryStore) GetAnyInstallationIDByOrg(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	if m.getAnyInstallationIDByOrgFn != nil {
+		return m.getAnyInstallationIDByOrgFn(ctx, orgID)
+	}
+	return 0, pgx.ErrNoRows
+}
+
+type mockTeamIntegrationStore struct {
+	listByOrgAndProviderFn func(ctx context.Context, orgID uuid.UUID, provider string) ([]models.Integration, error)
+}
+
+func (m *mockTeamIntegrationStore) ListByOrgAndProvider(ctx context.Context, orgID uuid.UUID, provider string) ([]models.Integration, error) {
+	if m.listByOrgAndProviderFn != nil {
+		return m.listByOrgAndProviderFn(ctx, orgID, provider)
+	}
+	return nil, nil
+}
+
+type mockTeamGitHubService struct {
+	getInstallationTokenFn func(ctx context.Context, installationID int64) (string, error)
+}
+
+func (m *mockTeamGitHubService) GetInstallationToken(ctx context.Context, installationID int64) (string, error) {
+	if m.getInstallationTokenFn != nil {
+		return m.getInstallationTokenFn(ctx, installationID)
+	}
+	return "token", nil
+}
+
 func (m *mockTeamInvitationStore) Create(ctx context.Context, inv *models.Invitation) error {
 	if m.createFn != nil {
 		return m.createFn(ctx, inv)
@@ -169,6 +202,43 @@ func newTeamHandler(users *mockTeamUserStore, memberships *mockTeamMembershipSto
 		orgs = &mockTeamOrgStore{}
 	}
 	return NewTeamHandler(users, memberships, sessions, invitations, orgs, "http://localhost:3000", nil)
+}
+
+func TestTeamHandler_GitHubInviteStatus_FallsBackToRepositoryInstallationID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	h := newTeamHandler(nil, nil, nil, nil, nil)
+	h.integrations = &mockTeamIntegrationStore{
+		listByOrgAndProviderFn: func(ctx context.Context, gotOrgID uuid.UUID, provider string) ([]models.Integration, error) {
+			return []models.Integration{{
+				ID:       uuid.New(),
+				OrgID:    gotOrgID,
+				Provider: models.IntegrationProviderGitHub,
+				Config:   []byte(`{}`),
+				Status:   models.IntegrationStatusActive,
+			}}, nil
+		},
+	}
+	h.githubSvc = &mockTeamGitHubService{}
+	h.repositories = &mockTeamRepositoryStore{
+		getAnyInstallationIDByOrgFn: func(ctx context.Context, gotOrgID uuid.UUID) (int64, error) {
+			require.Equal(t, orgID, gotOrgID, "fallback repo installation lookup should stay org-scoped")
+			return 12345, nil
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/team/github/status", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	h.GitHubInviteStatus(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "github invite status should succeed")
+
+	var resp models.SingleResponse[GitHubInviteStatus]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "github invite status response should decode")
+	require.True(t, resp.Data.Connected, "repo installation id fallback should mark github invite search connected")
 }
 
 func teamCtx(orgID uuid.UUID, user *models.User) context.Context {

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -241,6 +241,97 @@ func TestTeamHandler_GitHubInviteStatus_FallsBackToRepositoryInstallationID(t *t
 	require.True(t, resp.Data.Connected, "repo installation id fallback should mark github invite search connected")
 }
 
+func TestTeamHandler_SetRepositoryStore(t *testing.T) {
+	t.Parallel()
+
+	h := newTeamHandler(nil, nil, nil, nil, nil)
+	repositories := &mockTeamRepositoryStore{}
+
+	h.SetRepositoryStore(repositories)
+
+	require.Same(t, repositories, h.repositories, "SetRepositoryStore should store the repository dependency")
+}
+
+func TestTeamHandler_GetGitHubInstallationID_FallbackCases(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+
+	tests := []struct {
+		name         string
+		integrations teamIntegrationStore
+		repositories teamRepositoryStore
+		expected     int64
+		expectErr    bool
+	}{
+		{
+			name:         "returns zero when neither integrations nor repositories are configured",
+			integrations: nil,
+			repositories: nil,
+			expected:     0,
+		},
+		{
+			name:         "returns zero when repository fallback has no rows",
+			integrations: nil,
+			repositories: &mockTeamRepositoryStore{},
+			expected:     0,
+		},
+		{
+			name:         "returns repository fallback error",
+			integrations: nil,
+			repositories: &mockTeamRepositoryStore{
+				getAnyInstallationIDByOrgFn: func(ctx context.Context, gotOrgID uuid.UUID) (int64, error) {
+					require.Equal(t, orgID, gotOrgID, "repository fallback should stay org-scoped")
+					return 0, context.DeadlineExceeded
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name: "falls back after integrations without installation id",
+			integrations: &mockTeamIntegrationStore{
+				listByOrgAndProviderFn: func(ctx context.Context, gotOrgID uuid.UUID, provider string) ([]models.Integration, error) {
+					require.Equal(t, orgID, gotOrgID, "integration lookup should stay org-scoped")
+					require.Equal(t, string(models.IntegrationProviderGitHub), provider, "integration lookup should target github")
+					return []models.Integration{{
+						ID:       uuid.New(),
+						OrgID:    gotOrgID,
+						Provider: models.IntegrationProviderGitHub,
+						Config:   []byte(`{}`),
+						Status:   models.IntegrationStatusActive,
+					}}, nil
+				},
+			},
+			repositories: &mockTeamRepositoryStore{
+				getAnyInstallationIDByOrgFn: func(ctx context.Context, gotOrgID uuid.UUID) (int64, error) {
+					require.Equal(t, orgID, gotOrgID, "repository fallback should stay org-scoped")
+					return 67890, nil
+				},
+			},
+			expected: 67890,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newTeamHandler(nil, nil, nil, nil, nil)
+			h.integrations = tt.integrations
+			h.repositories = tt.repositories
+
+			installationID, err := h.getGitHubInstallationID(context.Background(), orgID)
+			if tt.expectErr {
+				require.Error(t, err, "getGitHubInstallationID should return an error for repository fallback failures")
+				return
+			}
+			require.NoError(t, err, "getGitHubInstallationID should not return an error")
+			require.Equal(t, tt.expected, installationID, "getGitHubInstallationID should return the expected installation id")
+		})
+	}
+}
+
 func teamCtx(orgID uuid.UUID, user *models.User) context.Context {
 	ctx := context.Background()
 	ctx = middleware.WithOrgID(ctx, orgID)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -191,6 +191,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, co
 		logger.Info().Str("smtp_host", cfg.SMTPHost).Msg("SMTP email sender configured")
 	}
 	teamHandler := handlers.NewTeamHandler(userStore, membershipStore, authSessionStore, invitationStore, orgStore, cfg.FrontendURL, emailSender)
+	teamHandler.SetRepositoryStore(repoStore)
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err == nil {

--- a/internal/db/repositories.go
+++ b/internal/db/repositories.go
@@ -191,6 +191,43 @@ func (s *RepositoryStore) GetByFullName(ctx context.Context, orgID uuid.UUID, fu
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Repository])
 }
 
+// GetAnyInstallationIDByOrg returns one non-zero GitHub installation_id for an
+// active repo in the org. This is a repair-path fallback for orgs whose
+// integrations.github config is missing installation_id even though repo sync
+// already populated repository rows with the correct installation.
+func (s *RepositoryStore) GetAnyInstallationIDByOrg(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	query := `
+		SELECT installation_id
+		FROM repositories
+		WHERE org_id = @org_id
+		  AND status = 'active'
+		  AND installation_id > 0
+		ORDER BY full_name ASC
+		LIMIT 1`
+
+	var installationID int64
+	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{"org_id": orgID}).Scan(&installationID)
+	if err != nil {
+		return 0, err
+	}
+	return installationID, nil
+}
+
+// DisconnectByIntegration marks every repo under the given integration as
+// disconnected within the org. This keeps repo state aligned with an explicit
+// user disconnect of the parent GitHub integration.
+func (s *RepositoryStore) DisconnectByIntegration(ctx context.Context, orgID, integrationID uuid.UUID) error {
+	query := `
+		UPDATE repositories
+		SET status = 'disconnected', updated_at = now()
+		WHERE org_id = @org_id AND integration_id = @integration_id`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"org_id":         orgID,
+		"integration_id": integrationID,
+	})
+	return err
+}
+
 // DisconnectByInstallationID marks every repo under the given GitHub
 // installation as disconnected (cascades on app uninstall).
 // lint:allow-no-orgid reason="cross-org cascade when a GitHub app installation is uninstalled"

--- a/internal/db/repository_store_test.go
+++ b/internal/db/repository_store_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -538,5 +539,79 @@ func TestRepositoryStore_DisconnectByInstallationID(t *testing.T) {
 
 	err = store.DisconnectByInstallationID(context.Background(), int64(99))
 	require.NoError(t, err, "DisconnectByInstallationID should not return an error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRepositoryStore_GetAnyInstallationIDByOrg(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		setupMock func(mock pgxmock.PgxPoolIface, orgID uuid.UUID)
+		expected  int64
+		expectErr bool
+	}{
+		{
+			name: "returns installation id for active repo",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				mock.ExpectQuery("SELECT installation_id FROM repositories").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(12345)))
+			},
+			expected: 12345,
+		},
+		{
+			name: "returns error when no active repo installation exists",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
+				mock.ExpectQuery("SELECT installation_id FROM repositories").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewRepositoryStore(mock)
+			orgID := uuid.New()
+			tt.setupMock(mock, orgID)
+
+			installationID, err := store.GetAnyInstallationIDByOrg(context.Background(), orgID)
+			if tt.expectErr {
+				require.Error(t, err, "GetAnyInstallationIDByOrg should return an error when no installation id is available")
+			} else {
+				require.NoError(t, err, "GetAnyInstallationIDByOrg should not return an error")
+				require.Equal(t, tt.expected, installationID, "GetAnyInstallationIDByOrg should return the expected installation id")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestRepositoryStore_DisconnectByIntegration(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewRepositoryStore(mock)
+	orgID := uuid.New()
+	integrationID := uuid.New()
+
+	mock.ExpectExec("UPDATE repositories").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	err = store.DisconnectByIntegration(context.Background(), orgID, integrationID)
+	require.NoError(t, err, "DisconnectByIntegration should not return an error")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -45,13 +45,14 @@ type AuthSession struct {
 }
 
 type Integration struct {
-	ID           uuid.UUID           `db:"id" json:"id"`
-	OrgID        uuid.UUID           `db:"org_id" json:"org_id"`
-	Provider     IntegrationProvider `db:"provider" json:"provider"`
-	Config       json.RawMessage     `db:"config" json:"-"` // never expose config in JSON (contains secrets)
-	Status       IntegrationStatus   `db:"status" json:"status"`
-	LastSyncedAt *time.Time          `db:"last_synced_at" json:"last_synced_at,omitempty"`
-	CreatedAt    time.Time           `db:"created_at" json:"created_at"`
+	ID                 uuid.UUID           `db:"id" json:"id"`
+	OrgID              uuid.UUID           `db:"org_id" json:"org_id"`
+	Provider           IntegrationProvider `db:"provider" json:"provider"`
+	Config             json.RawMessage     `db:"config" json:"-"` // never expose config in JSON (contains secrets)
+	GitHubAppInstalled *bool               `db:"-" json:"github_app_installed,omitempty"`
+	Status             IntegrationStatus   `db:"status" json:"status"`
+	LastSyncedAt       *time.Time          `db:"last_synced_at" json:"last_synced_at,omitempty"`
+	CreatedAt          time.Time           `db:"created_at" json:"created_at"`
 }
 
 type Repository struct {


### PR DESCRIPTION
## Summary
- fall back to repo installation IDs when team GitHub invite search and integration status need to recover from stale GitHub App metadata
- preserve OAuth-only GitHub connected state in the integrations UI and setup checklist
- disconnect GitHub repo rows when the parent GitHub integration is disconnected to avoid stale app-installed state

## Testing
- go vet ./...
- go build ./...
- go test ./...
- cd frontend && npm test -- --run src/components/setup-checklist.test.tsx src/components/no-repos-warning.test.tsx
- cd frontend && npm run typecheck
- cd frontend && npm run lint
- cd frontend && npm run build