### PR TITLE
Fix legacy PR polling for session PR creation

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -632,6 +632,40 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('keeps the button in a pending state after create PR starts without server PR state fields', async () => {
+    const legacySession: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: undefined,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: legacySession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    expect(await screen.findByRole('button', { name: /Pushing PR…/ })).toBeDisabled();
+  });
+
   it('shows file count badge on Changes tab when session has diff', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1207,6 +1207,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       exitReview();
     }
   }, [centerMode, exitReview, setPreviewParam]);
+  const [legacyPRRequested, setLegacyPRRequested] = useState(false);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["session", id],
@@ -1216,7 +1217,9 @@ export function SessionDetailContent({ id }: { id: string }) {
       if (!s) return false;
       // Poll while PR creation is in flight so the state machine advances
       // without waiting for the user to navigate.
-      return s.pr_creation_state === "queued" || s.pr_creation_state === "pushing"
+      return s.pr_creation_state === "queued" ||
+        s.pr_creation_state === "pushing" ||
+        (legacyPRRequested && s.status !== "pr_created" && s.pr_creation_state !== "failed" && s.pr_creation_state !== "succeeded")
         ? 2000
         : false;
     },
@@ -1238,6 +1241,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const { data: prData } = useQuery({
     queryKey: ["session", id, "pr"],
     queryFn: () => api.sessions.getPR(id),
+    refetchInterval: (q) => (legacyPRRequested && !q.state.data?.data ? 2000 : false),
   });
 
   // React to pr_creation_state transitions with toast feedback. Tracks the
@@ -1245,6 +1249,11 @@ export function SessionDetailContent({ id }: { id: string }) {
   // every render.
   const prevPRStateRef = useRef<string | undefined>(undefined);
   const prUrl = prData?.data?.github_pr_url;
+  const legacyPRPending =
+    legacyPRRequested &&
+    !prUrl &&
+    session?.pr_creation_state !== "failed" &&
+    session?.pr_creation_state !== "succeeded";
   useEffect(() => {
     const prev = prevPRStateRef.current;
     const current = session?.pr_creation_state;
@@ -1261,6 +1270,15 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRStateRef.current = current;
   }, [session?.pr_creation_state, session?.pr_creation_error, prUrl, queryClient, id]);
+  const prevPRUrlRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    if (legacyPRRequested && prUrl && prevPRUrlRef.current !== prUrl && !session?.pr_creation_state) {
+      toast.success("PR opened", {
+        action: { label: "View \u2197", onClick: () => window.open(prUrl, "_blank", "noopener,noreferrer") },
+      });
+    }
+    prevPRUrlRef.current = prUrl;
+  }, [legacyPRRequested, prUrl, session?.pr_creation_state]);
   // Record that the user has viewed this session (for unread tracking).
   useEffect(() => {
     if (id) {
@@ -1283,11 +1301,15 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const createPRMutation = useMutation({
     mutationFn: () => api.sessions.createPR(id),
+    onMutate: () => {
+      setLegacyPRRequested(true);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["session", id] });
       queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
     },
     onError: (err) => {
+      setLegacyPRRequested(false);
       const msg = err instanceof Error ? err.message : "Failed to create PR";
       toast.error(msg);
     },
@@ -1515,12 +1537,12 @@ export function SessionDetailContent({ id }: { id: string }) {
                     </a>
                   );
                 }
-                if (!canCreatePR) return null;
+                if (!canCreatePR && !legacyPRPending) return null;
 
                 const prState = session.pr_creation_state;
                 const snapshotExpired = !session.snapshot_key;
                 const ghBlocked = ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected;
-                const inFlight = prState === "queued" || prState === "pushing" || createPRMutation.isPending;
+                const inFlight = prState === "queued" || prState === "pushing" || createPRMutation.isPending || legacyPRPending;
                 const succeededButNoPR = prState === "succeeded" && !hasPR;
 
                 let label = "Create PR";
@@ -1528,18 +1550,18 @@ export function SessionDetailContent({ id }: { id: string }) {
                 let disabled = false;
                 let title: string | undefined;
 
-                if (snapshotExpired) {
+                if (inFlight) {
+                  label = "Pushing PR\u2026";
+                  spinning = true;
+                  disabled = true;
+                  title = "This usually takes a few seconds";
+                } else if (snapshotExpired) {
                   label = "Create PR";
                   disabled = true;
                   // Prefer the server-produced message (e.g. from the last
                   // failed attempt) when available so the UI stays aligned
                   // with server-side wording.
                   title = session.pr_creation_error || "Session state expired — re-run to create a PR.";
-                } else if (inFlight) {
-                  label = "Pushing PR\u2026";
-                  spinning = true;
-                  disabled = true;
-                  title = "This usually takes a few seconds";
                 } else if (succeededButNoPR) {
                   label = "Finalizing\u2026";
                   spinning = true;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -133,7 +133,7 @@ export interface Session {
   last_activity_at: string;
   sandbox_state: string;
   snapshot_key?: string;
-  pr_creation_state: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  pr_creation_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
   pr_creation_error?: string;
   target_branch?: string;
   repository_id?: string;


### PR DESCRIPTION
## Summary
- Keep the Create PR button in a pending state after submit for legacy sessions that do not expose `pr_creation_state`
- Poll the session and PR endpoints only while PR creation is actually in flight or the PR row is still missing
- Add a UI regression test for the legacy pending-state flow

## Testing
- `npx vitest run src/app/'(dashboard)'/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`