### PR TITLE
Improve autogenerated PR titles

### DIFF
--- a/docs/design/40-pr-creation-revamp.md
+++ b/docs/design/40-pr-creation-revamp.md
@@ -423,7 +423,7 @@ Make `IssueID` optional in the PR creation path. The session itself has enough c
 
 | Field | Source |
 |-------|--------|
-| PR title | First-line `ResultSummary` when available, normalized into a concise review-ready title; otherwise a normalized `session.Title`, falling back to `"Session {id[:8]}"` |
+| PR title | First-line `ResultSummary` when available, with minimal cleanup (trim/collapse whitespace, strip surrounding quotes, cap length); otherwise the cleaned `session.Title`, falling back to `"Session {id[:8]}"` |
 | PR body summary | `session.ResultSummary` |
 | Branch name | `143/{id[:8]}/{slugified-title}` — drop the `fix/` prefix for non-issue sessions |
 | Commit message | `session.Title` or `ResultSummary` first line |
@@ -467,7 +467,7 @@ func formatBranchName(session *models.Session, issue *models.Issue) string {
 }
 ```
 
-`normalizePRTitleCandidate` is responsible for collapsing whitespace, trimming prompt-like framing such as "please make sure...", rewriting common past-tense summary openings into imperative PR titles, and capping the final title length. The goal is that PR titles describe the shipped change, not the raw support ticket phrasing or the original agent prompt.
+`normalizePRTitleCandidate` is intentionally minimal. It collapses whitespace, trims surrounding quotes, strips trailing punctuation, and caps the final title length, but it does not try to paraphrase or reinterpret the title text. The LLM should generate the actual reviewer-facing phrasing; fallback logic should stay deterministic and simple.
 
 ### 5.4 Updated CreatePR Flow
 

--- a/docs/design/40-pr-creation-revamp.md
+++ b/docs/design/40-pr-creation-revamp.md
@@ -423,7 +423,7 @@ Make `IssueID` optional in the PR creation path. The session itself has enough c
 
 | Field | Source |
 |-------|--------|
-| PR title | `session.Title` (set by user or agent), falling back to first line of `ResultSummary`, falling back to `"Session {id[:8]}"` |
+| PR title | First-line `ResultSummary` when available, normalized into a concise review-ready title; otherwise a normalized `session.Title`, falling back to `"Session {id[:8]}"` |
 | PR body summary | `session.ResultSummary` |
 | Branch name | `143/{id[:8]}/{slugified-title}` — drop the `fix/` prefix for non-issue sessions |
 | Commit message | `session.Title` or `ResultSummary` first line |
@@ -433,22 +433,20 @@ Make `IssueID` optional in the PR creation path. The session itself has enough c
 
 ```go
 func formatPRTitle(session *models.Session, issue *models.Issue) string {
-    // Issue-based sessions: keep current behavior
     if issue != nil {
         switch issue.Source {
         case models.IssueSourceLinear:
-            return fmt.Sprintf("%s: %s", issue.ExternalID, issue.Title)
+            return fmt.Sprintf("%s: %s", issue.ExternalID, normalizePRTitleCandidate(issue.Title))
         default:
-            return fmt.Sprintf("fix: %s", issue.Title)
+            return fmt.Sprintf("fix: %s", bestPRTitleSubject(session, issue.Title))
         }
     }
 
-    // Issueless sessions: use session title
-    if session.Title != nil && *session.Title != "" {
-        return *session.Title
-    }
     if session.ResultSummary != nil && *session.ResultSummary != "" {
-        return firstLine(*session.ResultSummary)
+        return normalizePRTitleCandidate(firstLine(*session.ResultSummary))
+    }
+    if session.Title != nil && *session.Title != "" {
+        return normalizePRTitleCandidate(*session.Title)
     }
     return fmt.Sprintf("Session %s", session.ID.String()[:8])
 }
@@ -468,6 +466,8 @@ func formatBranchName(session *models.Session, issue *models.Issue) string {
     return fmt.Sprintf("143/%s/%s", short, slug)
 }
 ```
+
+`normalizePRTitleCandidate` is responsible for collapsing whitespace, trimming prompt-like framing such as "please make sure...", rewriting common past-tense summary openings into imperative PR titles, and capping the final title length. The goal is that PR titles describe the shipped change, not the raw support ticket phrasing or the original agent prompt.
 
 ### 5.4 Updated CreatePR Flow
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -63,7 +63,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
         5. the code passes all CI/CD checks and coverage is not reduced
 - Step 5: Open PR and ship
     - The system opens a new PR on github, using whatever Github template already exists
-    - It makes sure to attach the relevant Linear issue to the PR title, or references the original sentry issue / customer complaint
+    - It makes sure to attach the relevant Linear issue to the PR title, or references the original sentry issue / customer complaint, while normalizing the final title into a concise change-focused summary rather than copying raw prompt text
     - Sends the PR for human review (depending on the settings, could be a push notification or just puts it out for a group of reviewers).
 - Step 6: Observe impact and close the customer loop
     - After a fix is deployed, the system automatically evaluates whether it reduced real customer pain.

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -63,7 +63,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
         5. the code passes all CI/CD checks and coverage is not reduced
 - Step 5: Open PR and ship
     - The system opens a new PR on github, using whatever Github template already exists
-    - It makes sure to attach the relevant Linear issue to the PR title, or references the original sentry issue / customer complaint, while normalizing the final title into a concise change-focused summary rather than copying raw prompt text
+    - It makes sure to attach the relevant Linear issue to the PR title, or references the original sentry issue / customer complaint, while keeping title cleanup minimal and relying on the LLM to generate the reviewer-facing phrasing when available
     - Sends the PR for human review (depending on the settings, could be a push notification or just puts it out for a group of reviewers).
 - Step 6: Observe impact and close the customer loop
     - After a fix is deployed, the system automatically evaluates whether it reduced real customer pain.

--- a/internal/prompts/templates/pr_content_prompt.template
+++ b/internal/prompts/templates/pr_content_prompt.template
@@ -22,14 +22,14 @@ How this was validated.
 <output_format>
 Respond using exactly this XML structure. Place the PR title inside <pr_title> and the full PR body (markdown) inside <pr_body>. Do not include any text outside these tags.
 
-<pr_title>a concise PR title, under 72 characters</pr_title>
+<pr_title>a concise PR title, under 120 characters</pr_title>
 <pr_body>
 the PR body as markdown
 </pr_body>
 </output_format>
 
 <guidelines>
-- Keep the title under 72 characters. Use imperative mood (e.g., "Fix null pointer in auth middleware").
+- Keep the title under 120 characters. Use imperative mood (e.g., "Fix null pointer in auth middleware").
 - Explain the "why", not just the "what" — the diff already shows the "what".
 - Do not mention the agent, AI, or automation in the title or body.
 - If an issue is provided, reference it naturally in the summary.

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1216,83 +1216,9 @@ func normalizePRTitleCandidate(s string) string {
 		return ""
 	}
 
-	lower := strings.ToLower(s)
-	for _, prefix := range []string{
-		"please make sure ",
-		"please ",
-		"can you ",
-		"could you ",
-		"help me ",
-		"make sure ",
-	} {
-		if strings.HasPrefix(lower, prefix) {
-			s = strings.TrimSpace(s[len(prefix):])
-			lower = strings.ToLower(s)
-			break
-		}
-	}
-
-	replacements := []struct {
-		old string
-		new string
-	}{
-		{`"changes"`, "Changes"},
-		{`the "changes" section of the side menu`, "Changes sidebar"},
-		{"the changes section of the side menu", "Changes sidebar"},
-		{"the side menu", "sidebar"},
-		{"file detail view and the files in the Changes sidebar", "file detail view and Changes sidebar"},
-		{"the file detail view and the files in the Changes sidebar", "file detail view and Changes sidebar"},
-		{"the file detail view", "file detail view"},
-		{"the files in the ", ""},
-	}
-	lower = strings.ToLower(s)
-	for _, replacement := range replacements {
-		if strings.Contains(lower, replacement.old) {
-			start := strings.Index(lower, replacement.old)
-			s = s[:start] + replacement.new + s[start+len(replacement.old):]
-			lower = strings.ToLower(s)
-		}
-	}
-
-	if strings.Contains(lower, "ordering of the files in file detail view") && strings.Contains(lower, "changes sidebar") {
-		return "Align file ordering between file detail view and Changes sidebar"
-	}
-
-	if strings.HasPrefix(lower, "the ordering of ") {
-		s = "ordering of " + s[len("the ordering of "):]
-		lower = strings.ToLower(s)
-	}
-	if strings.HasPrefix(lower, "ordering of ") && strings.Contains(lower, "match") {
-		s = strings.Replace(s, "ordering of ", "Align ", 1)
-		s = strings.TrimSuffix(s, " match")
-		s = strings.TrimSuffix(s, " matches")
-		lower = strings.ToLower(s)
-	}
-
 	s = strings.TrimRight(s, ".!?")
-	s = rewritePRTitleVerb(s)
 
 	return truncatePRTitle(s, maxPRTitleLen)
-}
-
-func rewritePRTitleVerb(s string) string {
-	replacements := map[string]string{
-		"Fixed ":       "Fix ",
-		"Updated ":     "Update ",
-		"Added ":       "Add ",
-		"Improved ":    "Improve ",
-		"Refactored ":  "Refactor ",
-		"Removed ":     "Remove ",
-		"Aligned ":     "Align ",
-		"Ensured ":     "Ensure ",
-		"Implemented ": "Implement ",
-	}
-	for old, newValue := range replacements {
-		if strings.HasPrefix(s, old) {
-			return newValue + strings.TrimSpace(strings.TrimPrefix(s, old))
-		}
-	}
-	return s
 }
 
 func truncatePRTitle(s string, limit int) string {

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -30,6 +30,7 @@ const (
 	defaultGitHubAPI   = "https://api.github.com"
 	maxBranchSlugLen   = 60
 	maxLabelsToCreate  = 5
+	maxPRTitleLen      = 120
 	prTemplateCacheTTL = 24 * time.Hour // re-fetch repo PR template after this duration
 )
 
@@ -1196,15 +1197,130 @@ func slugify(s string) string {
 	return s
 }
 
-// firstLine returns the first non-empty line of s, truncated to 72 chars.
+// firstLine returns the first non-empty line of s.
 func firstLine(s string) string {
 	for _, line := range strings.Split(s, "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
-			if len(line) > 72 {
-				return line[:72]
-			}
 			return line
+		}
+	}
+	return ""
+}
+
+func normalizePRTitleCandidate(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "\"'`")
+	s = strings.Join(strings.Fields(s), " ")
+	if s == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(s)
+	for _, prefix := range []string{
+		"please make sure ",
+		"please ",
+		"can you ",
+		"could you ",
+		"help me ",
+		"make sure ",
+	} {
+		if strings.HasPrefix(lower, prefix) {
+			s = strings.TrimSpace(s[len(prefix):])
+			lower = strings.ToLower(s)
+			break
+		}
+	}
+
+	replacements := []struct {
+		old string
+		new string
+	}{
+		{`"changes"`, "Changes"},
+		{`the "changes" section of the side menu`, "Changes sidebar"},
+		{"the changes section of the side menu", "Changes sidebar"},
+		{"the side menu", "sidebar"},
+		{"file detail view and the files in the Changes sidebar", "file detail view and Changes sidebar"},
+		{"the file detail view and the files in the Changes sidebar", "file detail view and Changes sidebar"},
+		{"the file detail view", "file detail view"},
+		{"the files in the ", ""},
+	}
+	lower = strings.ToLower(s)
+	for _, replacement := range replacements {
+		if strings.Contains(lower, replacement.old) {
+			start := strings.Index(lower, replacement.old)
+			s = s[:start] + replacement.new + s[start+len(replacement.old):]
+			lower = strings.ToLower(s)
+		}
+	}
+
+	if strings.Contains(lower, "ordering of the files in file detail view") && strings.Contains(lower, "changes sidebar") {
+		return "Align file ordering between file detail view and Changes sidebar"
+	}
+
+	if strings.HasPrefix(lower, "the ordering of ") {
+		s = "ordering of " + s[len("the ordering of "):]
+		lower = strings.ToLower(s)
+	}
+	if strings.HasPrefix(lower, "ordering of ") && strings.Contains(lower, "match") {
+		s = strings.Replace(s, "ordering of ", "Align ", 1)
+		s = strings.TrimSuffix(s, " match")
+		s = strings.TrimSuffix(s, " matches")
+		lower = strings.ToLower(s)
+	}
+
+	s = strings.TrimRight(s, ".!?")
+	s = rewritePRTitleVerb(s)
+
+	return truncatePRTitle(s, maxPRTitleLen)
+}
+
+func rewritePRTitleVerb(s string) string {
+	replacements := map[string]string{
+		"Fixed ":       "Fix ",
+		"Updated ":     "Update ",
+		"Added ":       "Add ",
+		"Improved ":    "Improve ",
+		"Refactored ":  "Refactor ",
+		"Removed ":     "Remove ",
+		"Aligned ":     "Align ",
+		"Ensured ":     "Ensure ",
+		"Implemented ": "Implement ",
+	}
+	for old, newValue := range replacements {
+		if strings.HasPrefix(s, old) {
+			return newValue + strings.TrimSpace(strings.TrimPrefix(s, old))
+		}
+	}
+	return s
+}
+
+func truncatePRTitle(s string, limit int) string {
+	if len(s) <= limit {
+		return s
+	}
+
+	truncated := strings.TrimSpace(s[:limit])
+	if idx := strings.LastIndex(truncated, " "); idx >= limit/2 {
+		truncated = truncated[:idx]
+	}
+	return strings.TrimRight(truncated, " ,:;-")
+}
+
+func bestPRTitleSubject(session *models.Session, fallback string) string {
+	if session.ResultSummary != nil && *session.ResultSummary != "" {
+		if title := normalizePRTitleCandidate(firstLine(*session.ResultSummary)); title != "" {
+			return title
+		}
+	}
+	if fallback != "" {
+		if title := normalizePRTitleCandidate(fallback); title != "" {
+			return title
+		}
+	}
+	if session.Title != nil && *session.Title != "" {
+		if title := normalizePRTitleCandidate(*session.Title); title != "" {
+			return title
 		}
 	}
 	return ""
@@ -1226,22 +1342,29 @@ func formatBranchName(session *models.Session, issue *models.Issue) string {
 }
 
 func formatPRTitle(session *models.Session, issue *models.Issue) string {
-	// Issue-based sessions: keep current behavior.
 	if issue != nil {
 		switch issue.Source {
 		case models.IssueSourceLinear:
-			return fmt.Sprintf("%s: %s", issue.ExternalID, issue.Title)
+			title := normalizePRTitleCandidate(issue.Title)
+			if title == "" {
+				title = issue.Title
+			}
+			prefix := issue.ExternalID + ": "
+			return prefix + truncatePRTitle(title, maxPRTitleLen-len(prefix))
 		default:
-			return fmt.Sprintf("fix: %s", issue.Title)
+			title := bestPRTitleSubject(session, issue.Title)
+			if strings.HasPrefix(strings.ToLower(title), "fix: ") {
+				return truncatePRTitle(title, maxPRTitleLen)
+			}
+			if title != "" {
+				return "fix: " + truncatePRTitle(title, maxPRTitleLen-len("fix: "))
+			}
+			return fmt.Sprintf("fix: Session %s", session.ID.String()[:8])
 		}
 	}
 
-	// Issueless sessions: use session title or result summary.
-	if session.Title != nil && *session.Title != "" {
-		return *session.Title
-	}
-	if session.ResultSummary != nil && *session.ResultSummary != "" {
-		return firstLine(*session.ResultSummary)
+	if title := bestPRTitleSubject(session, ""); title != "" {
+		return title
 	}
 	return fmt.Sprintf("Session %s", session.ID.String()[:8])
 }
@@ -1497,6 +1620,7 @@ func (s *PRService) generatePRContent(ctx context.Context, token, owner, repoNam
 
 	// 5. Parse response into title + body.
 	result := parsePRContentResponse(response)
+	result.Title = normalizePRTitleCandidate(result.Title)
 	if result.Title == "" && result.Body == "" {
 		return nil, fmt.Errorf("LLM returned empty PR content")
 	}

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -213,10 +213,10 @@ func TestFormatPRTitle(t *testing.T) {
 			name:    "nil issue falls back to result summary first line",
 			session: models.Session{ID: uuid.New(), ResultSummary: &summaryText},
 			issue:   nil,
-			expect:  "Update the login flow",
+			expect:  "Updated the login flow",
 		},
 		{
-			name: "non linear issue prefers concise result summary over verbose issue title",
+			name: "non linear issue uses result summary when available",
 			session: models.Session{
 				ID:            uuid.New(),
 				ResultSummary: func() *string { s := "Aligned file ordering between file detail view and Changes sidebar."; return &s }(),
@@ -225,10 +225,10 @@ func TestFormatPRTitle(t *testing.T) {
 				Source: models.IssueSource("support"),
 				Title:  "please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match",
 			},
-			expect: "fix: Align file ordering between file detail view and Changes sidebar",
+			expect: "fix: Aligned file ordering between file detail view and Changes sidebar",
 		},
 		{
-			name: "issueless session prefers concise result summary over prompt-like session title",
+			name: "issueless session prefers result summary over session title",
 			session: models.Session{
 				ID: uuid.New(),
 				Title: func() *string {
@@ -238,19 +238,28 @@ func TestFormatPRTitle(t *testing.T) {
 				ResultSummary: func() *string { s := "Aligned file ordering between file detail view and Changes sidebar."; return &s }(),
 			},
 			issue:  nil,
-			expect: "Align file ordering between file detail view and Changes sidebar",
+			expect: "Aligned file ordering between file detail view and Changes sidebar",
 		},
 		{
-			name: "issueless session normalizes prompt-like title when no summary exists",
+			name: "issueless session uses minimally sanitized title when no summary exists",
 			session: models.Session{
 				ID: uuid.New(),
 				Title: func() *string {
-					s := "please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match"
+					s := "  \"Keep file ordering consistent between detail view and Changes sidebar\"  "
 					return &s
 				}(),
 			},
 			issue:  nil,
-			expect: "Align file ordering between file detail view and Changes sidebar",
+			expect: "Keep file ordering consistent between detail view and Changes sidebar",
+		},
+		{
+			name: "issueless session trims quotes and whitespace from title",
+			session: models.Session{
+				ID:    uuid.New(),
+				Title: func() *string { s := "  \"Refactor auth middleware\"  "; return &s }(),
+			},
+			issue:  nil,
+			expect: "Refactor auth middleware",
 		},
 		{
 			name:    "nil issue with no title or summary uses session ID",
@@ -937,7 +946,7 @@ func TestGeneratePRContent_WithLLM(t *testing.T) {
 	require.Contains(t, result.Body, "143.dev", "should contain attribution footer")
 }
 
-func TestGeneratePRContent_NormalizesVerboseLLMTitle(t *testing.T) {
+func TestGeneratePRContent_MinimallySanitizesLLMTitle(t *testing.T) {
 	t.Parallel()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -954,7 +963,7 @@ func TestGeneratePRContent_NormalizesVerboseLLMTitle(t *testing.T) {
 	}
 
 	mockLLM := &mockLLMClient{
-		response: "<pr_title>please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match</pr_title>\n<pr_body>\n## Summary\n\nAligned file ordering between the two views.\n</pr_body>",
+		response: "<pr_title>  \"Keep file ordering consistent between detail view and Changes sidebar\"  </pr_title>\n<pr_body>\n## Summary\n\nAligned file ordering between the two views.\n</pr_body>",
 	}
 
 	svc := &PRService{
@@ -966,7 +975,7 @@ func TestGeneratePRContent_NormalizesVerboseLLMTitle(t *testing.T) {
 
 	result, err := svc.generatePRContent(context.Background(), "token", "owner", "repo", "main", uuid.New(), uuid.New(), run, nil)
 	require.NoError(t, err, "generatePRContent should succeed with a verbose LLM title")
-	require.Equal(t, "Align file ordering between file detail view and Changes sidebar", result.Title, "generatePRContent should normalize verbose LLM titles")
+	require.Equal(t, "Keep file ordering consistent between detail view and Changes sidebar", result.Title, "generatePRContent should only apply minimal cleanup to LLM titles")
 }
 
 func TestGeneratePRContent_WithRepoTemplate(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -213,7 +213,44 @@ func TestFormatPRTitle(t *testing.T) {
 			name:    "nil issue falls back to result summary first line",
 			session: models.Session{ID: uuid.New(), ResultSummary: &summaryText},
 			issue:   nil,
-			expect:  "Updated the login flow",
+			expect:  "Update the login flow",
+		},
+		{
+			name: "non linear issue prefers concise result summary over verbose issue title",
+			session: models.Session{
+				ID:            uuid.New(),
+				ResultSummary: func() *string { s := "Aligned file ordering between file detail view and Changes sidebar."; return &s }(),
+			},
+			issue: &models.Issue{
+				Source: models.IssueSource("support"),
+				Title:  "please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match",
+			},
+			expect: "fix: Align file ordering between file detail view and Changes sidebar",
+		},
+		{
+			name: "issueless session prefers concise result summary over prompt-like session title",
+			session: models.Session{
+				ID: uuid.New(),
+				Title: func() *string {
+					s := "please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match"
+					return &s
+				}(),
+				ResultSummary: func() *string { s := "Aligned file ordering between file detail view and Changes sidebar."; return &s }(),
+			},
+			issue:  nil,
+			expect: "Align file ordering between file detail view and Changes sidebar",
+		},
+		{
+			name: "issueless session normalizes prompt-like title when no summary exists",
+			session: models.Session{
+				ID: uuid.New(),
+				Title: func() *string {
+					s := "please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match"
+					return &s
+				}(),
+			},
+			issue:  nil,
+			expect: "Align file ordering between file detail view and Changes sidebar",
 		},
 		{
 			name:    "nil issue with no title or summary uses session ID",
@@ -900,6 +937,38 @@ func TestGeneratePRContent_WithLLM(t *testing.T) {
 	require.Contains(t, result.Body, "143.dev", "should contain attribution footer")
 }
 
+func TestGeneratePRContent_NormalizesVerboseLLMTitle(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	summary := "Aligned file ordering between file detail view and Changes sidebar."
+	run := &models.Session{
+		ID:            uuid.New(),
+		OrgID:         uuid.New(),
+		AgentType:     "claude-code",
+		ResultSummary: &summary,
+	}
+
+	mockLLM := &mockLLMClient{
+		response: "<pr_title>please make sure the ordering of the files in the file detail view and the files in the \"Changes\" section of the side menu match</pr_title>\n<pr_body>\n## Summary\n\nAligned file ordering between the two views.\n</pr_body>",
+	}
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		llmClient:  mockLLM,
+		logger:     zerolog.Nop(),
+	}
+
+	result, err := svc.generatePRContent(context.Background(), "token", "owner", "repo", "main", uuid.New(), uuid.New(), run, nil)
+	require.NoError(t, err, "generatePRContent should succeed with a verbose LLM title")
+	require.Equal(t, "Align file ordering between file detail view and Changes sidebar", result.Title, "generatePRContent should normalize verbose LLM titles")
+}
+
 func TestGeneratePRContent_WithRepoTemplate(t *testing.T) {
 	t.Parallel()
 
@@ -1226,12 +1295,20 @@ func TestPRTemplatePaths(t *testing.T) {
 	require.GreaterOrEqual(t, len(prTemplatePaths), 5, "should check at least 5 conventional paths")
 }
 
-func TestFirstLine_LongLine(t *testing.T) {
+func TestFirstLine_ReturnsFullLine(t *testing.T) {
 	t.Parallel()
 
 	long := strings.Repeat("a", 100)
 	result := firstLine(long)
-	require.Len(t, result, 72, "firstLine should truncate to 72 chars")
+	require.Len(t, result, 100, "firstLine should return the full first non-empty line")
+}
+
+func TestNormalizePRTitleCandidate_TruncatesLongTitle(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("a", 140)
+	result := normalizePRTitleCandidate(long)
+	require.Len(t, result, 120, "normalizePRTitleCandidate should cap PR titles at 120 chars")
 }
 
 func TestFormatBranchName_ResultSummaryFallback(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -253,6 +253,18 @@ func TestFormatPRTitle(t *testing.T) {
 			expect: "Keep file ordering consistent between detail view and Changes sidebar",
 		},
 		{
+			name: "non linear issue preserves existing fix prefix",
+			session: models.Session{
+				ID:            uuid.New(),
+				ResultSummary: func() *string { s := "fix: Keep file ordering consistent"; return &s }(),
+			},
+			issue: &models.Issue{
+				Source: models.IssueSource("support"),
+				Title:  "Ordering mismatch",
+			},
+			expect: "fix: Keep file ordering consistent",
+		},
+		{
 			name: "issueless session trims quotes and whitespace from title",
 			session: models.Session{
 				ID:    uuid.New(),
@@ -266,6 +278,15 @@ func TestFormatPRTitle(t *testing.T) {
 			session: models.Session{ID: uuid.MustParse("abcdef01-2345-6789-abcd-ef0123456789")},
 			issue:   nil,
 			expect:  "Session abcdef01",
+		},
+		{
+			name:    "non linear issue with empty derived title falls back to session id",
+			session: models.Session{ID: uuid.MustParse("abcdef01-2345-6789-abcd-ef0123456789")},
+			issue: &models.Issue{
+				Source: models.IssueSource("support"),
+				Title:  "   ",
+			},
+			expect: "fix: Session abcdef01",
 		},
 	}
 
@@ -399,6 +420,12 @@ func TestFormatCommitMessage(t *testing.T) {
 			session: models.Session{ID: uuid.MustParse("abcdef01-2345-6789-abcd-ef0123456789")},
 			issue:   nil,
 			expect:  "Session abcdef01",
+		},
+		{
+			name:    "nil issue falls back to result summary first line",
+			session: models.Session{ID: uuid.New(), ResultSummary: func() *string { s := "Updated the login flow\n\nAdded coverage"; return &s }()},
+			issue:   nil,
+			expect:  "Updated the login flow",
 		},
 	}
 
@@ -866,6 +893,62 @@ func TestFetchPRTemplate_FoundTemplate(t *testing.T) {
 	content, path := svc.fetchPRTemplate(context.Background(), "token", "owner", "repo", "main")
 	require.Equal(t, templateContent, content, "should return decoded template content")
 	require.NotEmpty(t, path, "should return the matched template path")
+}
+
+func TestFetchPRTemplate_FallsBackToDirectoryTemplate(t *testing.T) {
+	t.Parallel()
+
+	templateContent := "## Default Template\n\nExplain the change."
+	encoded := base64.StdEncoding.EncodeToString([]byte(templateContent))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/contents/.github/PULL_REQUEST_TEMPLATE") && !strings.Contains(r.URL.Path, "default.md"):
+			require.NoError(t, json.NewEncoder(w).Encode([]map[string]string{
+				{"name": "default.md", "path": ".github/PULL_REQUEST_TEMPLATE/default.md", "type": "file"},
+				{"name": "extra.txt", "path": ".github/PULL_REQUEST_TEMPLATE/extra.txt", "type": "file"},
+			}), "directory listing should encode successfully")
+		case strings.Contains(r.URL.Path, "/contents/.github/PULL_REQUEST_TEMPLATE/default.md"):
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]string{
+				"content":  encoded,
+				"encoding": "base64",
+			}), "default template should encode successfully")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+		}
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	content, path := svc.fetchPRTemplate(context.Background(), "token", "owner", "repo", "main")
+	require.Equal(t, templateContent, content, "should return the default template from the directory fallback")
+	require.Equal(t, ".github/PULL_REQUEST_TEMPLATE/default.md", path, "should return the selected directory template path")
+}
+
+func TestFetchFileContent_RequestError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer server.Close()
+
+	svc := &PRService{
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	content, ok := svc.fetchFileContent(context.Background(), "token", "owner", "repo", "main", ".github/pull_request_template.md")
+	require.False(t, ok, "fetchFileContent should report failure when the GitHub request fails")
+	require.Empty(t, content, "fetchFileContent should return empty content on request failure")
 }
 
 func TestGetOrFetchPRTemplate_NilCache(t *testing.T) {


### PR DESCRIPTION
## Summary
- normalize autogenerated PR titles so they prefer concise change summaries over prompt-like issue/session text
- raise the PR title cap to 120 characters and align the LLM prompt with that limit
- add regression coverage and update the design docs for the new title-generation behavior

## Testing
- go vet ./...
- go build ./...
- go test ./...