### PR TITLE
Fix deploy migration path resolution

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database"
@@ -31,7 +32,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	m, err := migrate.New("file://migrations", dbURL)
+	migrationSource, err := resolveMigrationSource(pathExists)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to resolve migrations directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	m, err := migrate.New(migrationSource, dbURL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to create migrator: %v\n", err)
 		os.Exit(1)
@@ -57,6 +64,41 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1]) // #nosec G705 -- writing to stderr, not HTTP response
 		os.Exit(1)
 	}
+}
+
+func resolveMigrationSource(exists func(string) bool) (string, error) {
+	candidates := []struct {
+		path   string
+		source string
+	}{
+		{path: "migrations", source: "file://migrations"},
+		{path: "/migrations", source: "file:///migrations"},
+	}
+
+	execPath, err := os.Executable()
+	if err == nil {
+		execDir := filepath.Dir(execPath)
+		candidates = append(candidates, struct {
+			path   string
+			source string
+		}{
+			path:   filepath.Join(execDir, "migrations"),
+			source: fmt.Sprintf("file://%s", filepath.Join(execDir, "migrations")),
+		})
+	}
+
+	for _, candidate := range candidates {
+		if exists(candidate.path) {
+			return candidate.source, nil
+		}
+	}
+
+	return "", fmt.Errorf("searched %q, %q, and executable-adjacent migrations", "migrations", "/migrations")
+}
+
+func pathExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // logMigrationError prints detailed diagnostics for a failed migration.

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMigrationSource(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		paths    map[string]bool
+		expected string
+	}{
+		{
+			name: "prefers repo relative migrations directory",
+			paths: map[string]bool{
+				"migrations":  true,
+				"/migrations": true,
+			},
+			expected: "file://migrations",
+		},
+		{
+			name: "falls back to container absolute migrations directory",
+			paths: map[string]bool{
+				"/migrations": true,
+			},
+			expected: "file:///migrations",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual, err := resolveMigrationSource(func(path string) bool {
+				return tt.paths[path]
+			})
+
+			require.NoError(t, err, "resolveMigrationSource should find an available migrations directory")
+			require.Equal(t, tt.expected, actual, "resolveMigrationSource should return the expected source URL")
+		})
+	}
+}
+
+func TestResolveMigrationSourceReturnsErrorWhenNoDirectoryExists(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveMigrationSource(func(path string) bool {
+		return false
+	})
+
+	require.Error(t, err, "resolveMigrationSource should fail when no migrations directory is available")
+}


### PR DESCRIPTION
## Summary
- Resolve the migrations source dynamically so the migrator works both from the repo checkout and the production container image.
- Add unit tests covering the repo-relative path, the container `/migrations` path, and the failure case when no migrations directory exists.

## Testing
- `go test ./cmd/migrate`
- `go vet ./...`
- `go build ./...`
- `go test ./...`