### PR TITLE
Fix create PR loading state and failure handling

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -6,6 +6,17 @@ import { mockSessions, mockMembers, mockIssues } from '@/test/mocks/handlers';
 import { SessionDetailContent } from './session-detail-content';
 import type { Issue, Session, SessionLog, SessionMessage, User, SingleResponse, ListResponse } from '@/lib/types';
 
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast,
+}));
+
 // Mock EventSource (not available in jsdom)
 class MockEventSource {
   static instances: MockEventSource[] = [];
@@ -36,6 +47,9 @@ beforeAll(() => {
 
 afterEach(() => {
   MockEventSource.instances = [];
+  toast.success.mockReset();
+  toast.error.mockReset();
+  vi.useRealTimers();
 });
 
 // Mock next/link to render a plain anchor
@@ -663,8 +677,188 @@ describe('SessionDetailPage', () => {
     const user = userEvent.setup();
     await user.click(await screen.findByRole('button', { name: /Create PR/ }));
 
-    expect(await screen.findByRole('button', { name: /Pushing PR…/ })).toBeDisabled();
+    expect(await screen.findByRole('button', { name: /Creating PR…/ })).toBeDisabled();
   });
+
+  it('shows an immediate queueing state while the create PR request is still being sent', async () => {
+    let resolveCreatePR: (() => void) | undefined;
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', async () => {
+        await new Promise<void>((resolve) => {
+          resolveCreatePR = resolve;
+        });
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    expect(await screen.findByRole('button', { name: /Queueing PR…/ })).toBeDisabled();
+
+    resolveCreatePR?.();
+  });
+
+  it('keeps a creating state until the pull request exists, then swaps to View PR', async () => {
+    let sessionFetchCount = 0;
+    const queuedSession: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'queued',
+    };
+    const pushingSession: Session = {
+      ...queuedSession,
+      pr_creation_state: 'pushing',
+    };
+    const succeededSession: Session = {
+      ...queuedSession,
+      pr_creation_state: 'succeeded',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        sessionFetchCount += 1;
+        if (sessionFetchCount <= 1) {
+          return HttpResponse.json({
+            data: { ...queuedSession, pr_creation_state: 'idle' },
+          } satisfies SingleResponse<Session>);
+        }
+        if (sessionFetchCount === 2) {
+          return HttpResponse.json({ data: queuedSession } satisfies SingleResponse<Session>);
+        }
+        if (sessionFetchCount === 3) {
+          return HttpResponse.json({ data: pushingSession } satisfies SingleResponse<Session>);
+        }
+        return HttpResponse.json({ data: succeededSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        if (sessionFetchCount >= 4) {
+          return HttpResponse.json({
+            data: {
+              id: 'pr-1',
+              session_id: 'session-abcdef12-3456-7890',
+              org_id: queuedSession.org_id,
+              github_pr_number: 42,
+              github_pr_url: 'https://github.com/example/repo/pull/42',
+              github_repo: 'example/repo',
+              title: 'Fix bug',
+              status: 'open',
+              review_status: 'pending',
+              authored_by: 'app',
+              ci_status: 'pending',
+              created_at: new Date().toISOString(),
+              updated_at: new Date().toISOString(),
+            },
+          });
+        }
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    expect(await screen.findByRole('button', { name: /Creating PR…/ })).toBeDisabled();
+
+    await waitFor(
+      async () => {
+        expect(await screen.findByRole('button', { name: /View PR/ })).toBeInTheDocument();
+      },
+      { timeout: 7000 },
+    );
+    expect(screen.queryByRole('button', { name: /Create PR/ })).not.toBeInTheDocument();
+  }, 10000);
+
+  it('shows a clear toast and retry button when background PR creation fails', async () => {
+    let sessionFetchCount = 0;
+    const queuedSession: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'queued',
+    };
+    const failedSession: Session = {
+      ...queuedSession,
+      pr_creation_state: 'failed',
+      pr_creation_error: 'GitHub rejected the branch push.',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        sessionFetchCount += 1;
+        if (sessionFetchCount <= 1) {
+          return HttpResponse.json({
+            data: { ...queuedSession, pr_creation_state: 'idle' },
+          } satisfies SingleResponse<Session>);
+        }
+        return HttpResponse.json({ data: failedSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    await waitFor(
+      () => {
+        expect(toast.error).toHaveBeenCalledWith('GitHub rejected the branch push.');
+      },
+      { timeout: 5000 },
+    );
+    await waitFor(
+      () => {
+        expect(screen.getByRole('button', { name: /Retry/ })).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  }, 8000);
 
   it('shows file count badge on Changes tab when session has diff', async () => {
     const sessionWithDiff: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1207,7 +1207,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       exitReview();
     }
   }, [centerMode, exitReview, setPreviewParam]);
-  const [legacyPRRequested, setLegacyPRRequested] = useState(false);
+  const [localPRState, setLocalPRState] = useState<"idle" | "submitting" | "queued">("idle");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["session", id],
@@ -1215,13 +1215,16 @@ export function SessionDetailContent({ id }: { id: string }) {
     refetchInterval: (q) => {
       const s = q.state.data?.data;
       if (!s) return false;
+      const serverInFlight = s.pr_creation_state === "queued" || s.pr_creation_state === "pushing";
+      const waitingForServer = localPRState !== "idle" &&
+        s.pr_creation_state !== "failed" &&
+        s.pr_creation_state !== "succeeded";
+
       // Poll while PR creation is in flight so the state machine advances
-      // without waiting for the user to navigate.
-      return s.pr_creation_state === "queued" ||
-        s.pr_creation_state === "pushing" ||
-        (legacyPRRequested && s.status !== "pr_created" && s.pr_creation_state !== "failed" && s.pr_creation_state !== "succeeded")
-        ? 2000
-        : false;
+      // without waiting for the user to navigate. Keep polling during the
+      // optimistic local phases too, since the best-effort queued write can
+      // legitimately lag the 202 response.
+      return serverInFlight || waitingForServer ? 2000 : false;
     },
   });
 
@@ -1241,7 +1244,18 @@ export function SessionDetailContent({ id }: { id: string }) {
   const { data: prData } = useQuery({
     queryKey: ["session", id, "pr"],
     queryFn: () => api.sessions.getPR(id),
-    refetchInterval: (q) => (legacyPRRequested && !q.state.data?.data ? 2000 : false),
+    refetchInterval: (q) => {
+      const serverState = data?.data?.pr_creation_state;
+      const optimisticWaitingForPR =
+        localPRState !== "idle" && serverState !== "failed" && serverState !== "succeeded";
+      const waitingForPR =
+        optimisticWaitingForPR ||
+        serverState === "queued" ||
+        serverState === "pushing" ||
+        serverState === "succeeded";
+
+      return waitingForPR && !q.state.data?.data ? 2000 : false;
+    },
   });
 
   // React to pr_creation_state transitions with toast feedback. Tracks the
@@ -1249,11 +1263,16 @@ export function SessionDetailContent({ id }: { id: string }) {
   // every render.
   const prevPRStateRef = useRef<string | undefined>(undefined);
   const prUrl = prData?.data?.github_pr_url;
-  const legacyPRPending =
-    legacyPRRequested &&
+  const serverPRState = session?.pr_creation_state;
+  const localPRWaitingForServer =
+    localPRState === "queued" &&
+    serverPRState !== "failed" &&
+    serverPRState !== "succeeded";
+  const queueingPR = localPRState === "submitting";
+  const creatingPR =
     !prUrl &&
-    session?.pr_creation_state !== "failed" &&
-    session?.pr_creation_state !== "succeeded";
+    (localPRWaitingForServer || serverPRState === "queued" || serverPRState === "pushing");
+  const finalizingPR = !prUrl && serverPRState === "succeeded";
   useEffect(() => {
     const prev = prevPRStateRef.current;
     const current = session?.pr_creation_state;
@@ -1272,13 +1291,13 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [session?.pr_creation_state, session?.pr_creation_error, prUrl, queryClient, id]);
   const prevPRUrlRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    if (legacyPRRequested && prUrl && prevPRUrlRef.current !== prUrl && !session?.pr_creation_state) {
+    if (localPRState !== "idle" && prUrl && prevPRUrlRef.current !== prUrl && !session?.pr_creation_state) {
       toast.success("PR opened", {
         action: { label: "View \u2197", onClick: () => window.open(prUrl, "_blank", "noopener,noreferrer") },
       });
     }
     prevPRUrlRef.current = prUrl;
-  }, [legacyPRRequested, prUrl, session?.pr_creation_state]);
+  }, [localPRState, prUrl, session?.pr_creation_state]);
   // Record that the user has viewed this session (for unread tracking).
   useEffect(() => {
     if (id) {
@@ -1302,14 +1321,15 @@ export function SessionDetailContent({ id }: { id: string }) {
   const createPRMutation = useMutation({
     mutationFn: () => api.sessions.createPR(id),
     onMutate: () => {
-      setLegacyPRRequested(true);
+      setLocalPRState("submitting");
     },
     onSuccess: () => {
+      setLocalPRState("queued");
       queryClient.invalidateQueries({ queryKey: ["session", id] });
       queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
     },
     onError: (err) => {
-      setLegacyPRRequested(false);
+      setLocalPRState("idle");
       const msg = err instanceof Error ? err.message : "Failed to create PR";
       toast.error(msg);
     },
@@ -1537,12 +1557,11 @@ export function SessionDetailContent({ id }: { id: string }) {
                     </a>
                   );
                 }
-                if (!canCreatePR && !legacyPRPending) return null;
-
                 const prState = session.pr_creation_state;
+                const showPRAction = canCreatePR || queueingPR || creatingPR || finalizingPR || prState === "failed";
+                if (!showPRAction) return null;
                 const snapshotExpired = !session.snapshot_key;
                 const ghBlocked = ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected;
-                const inFlight = prState === "queued" || prState === "pushing" || createPRMutation.isPending || legacyPRPending;
                 const succeededButNoPR = prState === "succeeded" && !hasPR;
 
                 let label = "Create PR";
@@ -1550,11 +1569,16 @@ export function SessionDetailContent({ id }: { id: string }) {
                 let disabled = false;
                 let title: string | undefined;
 
-                if (inFlight) {
-                  label = "Pushing PR\u2026";
+                if (queueingPR) {
+                  label = "Queueing PR\u2026";
                   spinning = true;
                   disabled = true;
-                  title = "This usually takes a few seconds";
+                  title = "Sending the PR request to the queue";
+                } else if (creatingPR) {
+                  label = "Creating PR\u2026";
+                  spinning = true;
+                  disabled = true;
+                  title = "Pushing changes and opening the pull request";
                 } else if (snapshotExpired) {
                   label = "Create PR";
                   disabled = true;
@@ -1563,7 +1587,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                   // with server-side wording.
                   title = session.pr_creation_error || "Session state expired — re-run to create a PR.";
                 } else if (succeededButNoPR) {
-                  label = "Finalizing\u2026";
+                  label = "Finalizing PR\u2026";
                   spinning = true;
                   disabled = true;
                 } else if (prState === "failed") {


### PR DESCRIPTION
## Summary
- Add distinct frontend states for queueing, creating, and finalizing PR creation in the session detail view
- Keep the PR action button visible until the session reaches a terminal PR state, and surface worker failures as retryable UI with a toast
- Extend session detail tests to cover queueing, in-flight creation, success, and failure edge cases

## Testing
- `npx vitest --run src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`