### PR TITLE
Add optional Grafana webhook fallbacks for logging deploys

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -13,6 +13,8 @@ SSH_KEY="$3"
 TAG="${4:-latest}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISABLED_WARNING_WEBHOOK_URL="http://localhost:65535/disabled-warning"
+DISABLED_CRITICAL_WEBHOOK_URL="http://localhost:65535/disabled-critical"
 
 case "$ROLE" in
   app)
@@ -67,8 +69,8 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
   if [ "$ROLE" = "logging" ]; then
     : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for logging role (set it or add to .env.production.enc)}"
-    : "${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:?GRAFANA_ALERTS_WARNING_WEBHOOK_URL is required for logging role (set it or add to .env.production.enc)}"
-    : "${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:?GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL is required for logging role (set it or add to .env.production.enc)}"
+    GRAFANA_ALERTS_WARNING_WEBHOOK_URL="${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:-$DISABLED_WARNING_WEBHOOK_URL}"
+    GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL="${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:-$DISABLED_CRITICAL_WEBHOOK_URL}"
     printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
       "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'

--- a/deploy/scripts/logging_webhook_optional_test.sh
+++ b/deploy/scripts/logging_webhook_optional_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+STUB_DIR="$TMP_DIR/stubs"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/sops" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${SOPS_STUB_OUTPUT:-}"
+EOF
+chmod +x "$STUB_DIR/sops"
+
+cat >"$STUB_DIR/scp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+chmod +x "$STUB_DIR/scp"
+
+cat >"$STUB_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+capture_file="${SSH_CAPTURE_FILE:?}"
+counter_file="${SSH_COUNTER_FILE:?}"
+call_number="$(cat "$counter_file")"
+next_call_number=$((call_number + 1))
+printf '%s\n' "$next_call_number" >"$counter_file"
+
+printf 'ARGS:'
+printf ' %q' "$@"
+printf '\n' >>"$capture_file"
+
+stdin_file="${SSH_STDIN_DIR:?}/call-${call_number}.stdin"
+cat >"$stdin_file"
+printf 'STDIN:%s\n' "$stdin_file" >>"$capture_file"
+
+if printf '%s\n' "$@" | grep -q "docker compose -f"; then
+  exit 0
+fi
+
+exit 0
+EOF
+chmod +x "$STUB_DIR/ssh"
+
+run_case() {
+  local script_path="$1"
+  local expected_warning_url="$2"
+  local expected_critical_url="$3"
+
+  local home_dir="$TMP_DIR/home"
+  mkdir -p "$home_dir/.config/sops/age"
+  printf 'AGE-SECRET-KEY-test\n' >"$home_dir/.config/sops/age/keys.txt"
+
+  local capture_file="$TMP_DIR/$(basename "$script_path").capture"
+  : >"$capture_file"
+  local stdin_dir="$TMP_DIR/$(basename "$script_path").stdin"
+  mkdir -p "$stdin_dir"
+  local counter_file="$TMP_DIR/$(basename "$script_path").counter"
+  printf '1\n' >"$counter_file"
+
+  local output_file="$TMP_DIR/$(basename "$script_path").out"
+
+  (
+    export HOME="$home_dir"
+    export PATH="$STUB_DIR:$PATH"
+    export SOPS_STUB_OUTPUT=$'GRAFANA_ADMIN_PASSWORD=admin-secret\nVICTORIALOGS_HOST=10.0.0.9'
+    export SSH_CAPTURE_FILE="$capture_file"
+    export SSH_STDIN_DIR="$stdin_dir"
+    export SSH_COUNTER_FILE="$counter_file"
+    export GRAFANA_ADMIN_PASSWORD="admin-secret"
+    export VICTORIALOGS_HOST="10.0.0.9"
+    unset GRAFANA_ALERTS_WARNING_WEBHOOK_URL
+    unset GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL
+
+    bash "$script_path" logging 127.0.0.1 "$TMP_DIR/fake-key" >"$output_file" 2>&1
+  )
+
+  grep -R -q "GRAFANA_ALERTS_WARNING_WEBHOOK_URL=${expected_warning_url}" "$stdin_dir"
+  grep -R -q "GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=${expected_critical_url}" "$stdin_dir"
+}
+
+run_case \
+  "$ROOT_DIR/deploy/scripts/deploy.sh" \
+  "http://localhost:65535/disabled-warning" \
+  "http://localhost:65535/disabled-critical"
+
+grep -q 'GRAFANA_ALERTS_WARNING_WEBHOOK_URL="${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:-\$DISABLED_WARNING_WEBHOOK_URL}"' \
+  "$ROOT_DIR/deploy/scripts/provision.sh"
+grep -q 'GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL="${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:-\$DISABLED_CRITICAL_WEBHOOK_URL}"' \
+  "$ROOT_DIR/deploy/scripts/provision.sh"
+
+printf 'logging webhook fallback test passed\n'

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -28,6 +28,8 @@ SSH_KEY="$3"
 REPROVISION="${4:-}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DISABLED_WARNING_WEBHOOK_URL="http://localhost:65535/disabled-warning"
+DISABLED_CRITICAL_WEBHOOK_URL="http://localhost:65535/disabled-critical"
 
 # Validate role
 case "$ROLE" in
@@ -87,8 +89,8 @@ if [ "$ROLE" != "db" ] && [ "$ROLE" != "logging" ]; then
 fi
 if [ "$ROLE" = "logging" ]; then
   : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
-  : "${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:?GRAFANA_ALERTS_WARNING_WEBHOOK_URL is required for logging role (set it or add to .env.production.enc)}"
-  : "${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:?GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL is required for logging role (set it or add to .env.production.enc)}"
+  GRAFANA_ALERTS_WARNING_WEBHOOK_URL="${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:-$DISABLED_WARNING_WEBHOOK_URL}"
+  GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL="${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:-$DISABLED_CRITICAL_WEBHOOK_URL}"
 fi
 if [ "$ROLE" != "db" ]; then
   : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for $ROLE role (logging server private IP)}"

--- a/deploy/vmalert/README.md
+++ b/deploy/vmalert/README.md
@@ -14,3 +14,5 @@ The logging compose stack now includes both `vmalert` and `Alertmanager`. Notifi
 
 - `GRAFANA_ALERTS_WARNING_WEBHOOK_URL`
 - `GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL`
+
+If either webhook URL is omitted, logging deploys now fall back to a disabled localhost endpoint instead of failing provisioning or rollout. Alerts for that severity will be dropped until a real webhook URL is configured.

--- a/docs/design/47-logging-victorialogs.md
+++ b/docs/design/47-logging-victorialogs.md
@@ -316,7 +316,7 @@ Vector will still collect and ship logs without this change, but all fields will
 The logging server follows the same provisioning pattern as app, worker, and db nodes. This requires changes to:
 
 - **Makefile**: Add `provision-logging` and `deploy-logging` targets
-- **`deploy/scripts/provision.sh`**: Add `logging` role — lightweight bootstrap (Docker only, no gVisor, no kernel tuning), `GRAFANA_ADMIN_PASSWORD` as the only secret (no DB credentials or age key)
+- **`deploy/scripts/provision.sh`**: Add `logging` role — lightweight bootstrap (Docker only, no gVisor, no kernel tuning), `GRAFANA_ADMIN_PASSWORD` as the only required secret (no DB credentials or age key). Alert webhook URLs are optional and default to disabled local sinks.
 - **`deploy/scripts/deploy.sh`**: Add `logging` role with `grafana` as the health service
 - **`deploy/scripts/bootstrap.sh`**: Accept `logging` as a valid role
 - **`deploy/cloud-init/logging.yml`**: Cloud-init template for automated provisioning
@@ -326,7 +326,8 @@ Key differences from other roles:
 - **No gVisor** — logging server doesn't run sandboxes
 - **No DB credentials** — logging server doesn't connect to Postgres
 - **No GHCR login needed** — VictoriaLogs and Grafana are public Docker Hub images
-- **Minimal secrets** — only `GRAFANA_ADMIN_PASSWORD`
+- **Minimal required secrets** — only `GRAFANA_ADMIN_PASSWORD`
+- **Optional alert webhooks** — missing warning/critical webhook URLs fall back to disabled localhost endpoints so logging deploys still succeed
 
 Provisioning workflow:
 
@@ -485,7 +486,8 @@ if [ "$ROLE" != "db" ] && [ "$ROLE" != "logging" ]; then
 fi
 if [ "$ROLE" = "logging" ]; then
   : "${GRAFANA_ADMIN_PASSWORD:?GRAFANA_ADMIN_PASSWORD is required for logging role (set it or add to .env.production.enc)}"
-  : "${PRIVATE_IP:?PRIVATE_IP is required for logging role (set it or add to .env.production.enc)}"
+  GRAFANA_ALERTS_WARNING_WEBHOOK_URL="${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:-http://localhost:65535/disabled-warning}"
+  GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL="${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:-http://localhost:65535/disabled-critical}"
 fi
 if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
   : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for $ROLE role (logging server private IP)}"
@@ -514,9 +516,9 @@ Add secrets block (before the `db` block):
 
 ```bash
 if [ "$ROLE" = "logging" ]; then
-  # Logging nodes need the Grafana admin password and the private IP for binding VictoriaLogs
-  : "${PRIVATE_IP:?PRIVATE_IP is required for logging role (set it or add to .env.production.enc)}"
-  printf 'GRAFANA_ADMIN_PASSWORD=%s\nPRIVATE_IP=%s\n' "$GRAFANA_ADMIN_PASSWORD" "$PRIVATE_IP" \
+  # Logging nodes need the Grafana admin password, VictoriaLogs bind IP, and optional alert webhooks
+  printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
+    "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 elif [ "$ROLE" = "db" ]; then
 ```

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -293,7 +293,7 @@ Single system of record. Bundled in Docker Compose for local dev, swappable to m
 
 ## Logging & Monitoring
 
-- **VictoriaLogs + Grafana**: Primary centralized logging and operational alerting. Structured JSON logs are shipped by Vector and queried in Grafana. This is the current production observability backbone.
+- **VictoriaLogs + Grafana**: Primary centralized logging and operational alerting. Structured JSON logs are shipped by Vector and queried in Grafana. The logging stack tolerates missing warning/critical webhook URLs by falling back to disabled local sinks so observability deploys do not block on notification wiring. This is the current production observability backbone.
 - **Sentry**: Primary exception monitoring and developer-facing error triage. Frontend SDKs are already configured; backend exception capture should be added so Sentry becomes the system of record for application errors.
 - **Alerting model**: Page on aggregated service symptoms in Grafana; send exception issues from Sentry primarily to Slack unless they meet a paging threshold. See [54-production-alerting.md](54-production-alerting.md).
 


### PR DESCRIPTION
## Summary
- Make `GRAFANA_ALERTS_WARNING_WEBHOOK_URL` and `GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL` optional for logging deploys/provisions
- Fall back to disabled localhost sinks so Grafana/Alertmanager can boot without notification wiring
- Update logging docs and add a regression test for the fallback behavior

## Testing
- `bash deploy/scripts/logging_webhook_optional_test.sh`
- `bash -n deploy/scripts/deploy.sh deploy/scripts/provision.sh deploy/scripts/logging_webhook_optional_test.sh`