### PR TITLE
Add GitHub App user-authored PR creation flow

### DIFF
--- a/docs/design/40-pr-creation-revamp.md
+++ b/docs/design/40-pr-creation-revamp.md
@@ -1,8 +1,8 @@
 # Design: PR Creation Revamp — User-Authored PRs, Template Support, and Issueless Sessions
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-04-21
+> **Status:** Partially Implemented | **Last reviewed:** 2026-04-22
 >
-> **Implementation notes:** PR template detection and caching implemented (`pr_templates` store). Missing: GitHub App user-to-server token storage/refresh, user-authored PR creation flow via GitHub App authorization, issueless session support.
+> **Implementation notes:** PR template detection and caching implemented (`pr_templates` store). The on-demand `Create PR` authorization flow now uses encrypted `github_app_user` credentials with refresh-aware validation, app fallback, and frontend auto-resume after callback. The implementation reuses `/api/v1/users/me/github/*` routes for PR authorship instead of introducing separate `/github-app/*` endpoints. Remaining work: issueless session support and any future reconnect/error-taxonomy tightening.
 
 **Depends on**: [08-pr-and-ship.md](implemented/08-pr-and-ship.md), [13-repository-onboarding.md](implemented/13-repository-onboarding.md), [34-personal-team-coding-agents.md](implemented/34-personal-team-coding-agents.md)
 
@@ -116,12 +116,12 @@ Provider split:
 
 Add a dedicated GitHub App authorization flow for PR authorship. This is separate from `/api/v1/auth/github/*`.
 
-New endpoints:
+Routes used for PR authorship:
 
 ```text
-GET  /api/v1/users/me/github-app/connect
-GET  /api/v1/users/me/github-app/callback
-POST /api/v1/users/me/github-app/disconnect
+GET  /api/v1/users/me/github/connect
+GET  /api/v1/users/me/github/callback
+POST /api/v1/users/me/github/disconnect
 GET  /api/v1/users/me/github-status
 ```
 
@@ -136,6 +136,7 @@ Flow:
 7. 143 exchanges the code for a GitHub App user access token and stores it under `provider = github_app_user`
 8. 143 redirects the user back to the same session page with enough state to auto-resume PR creation
 9. Future PR creation attempts reuse the stored credential and refresh it silently when possible
+10. Concurrent auth flows in multiple tabs must bind the PR `resume_token` to the OAuth `state` so callbacks resume the correct session
 
 Handler shape:
 
@@ -177,11 +178,13 @@ func (h *GitHubAppUserHandler) HandleConnectCallback(w http.ResponseWriter, r *h
 
 Unlike login OAuth, GitHub App user tokens may expire and require refresh. We therefore need a small token manager in `internal/services/github/`.
 
-Interface:
+Concrete service shape:
 
 ```go
-type GitHubAppUserTokenManager interface {
-    GetValidToken(ctx context.Context, orgID, userID uuid.UUID) (string, *models.User, error)
+type AppUserAuthService interface {
+    ExchangeCode(ctx context.Context, code string) (*models.GitHubAppUserConfig, error)
+    HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
+    GetValidCredential(ctx context.Context, orgID, userID uuid.UUID) (*models.GitHubAppUserConfig, error)
 }
 ```
 
@@ -369,7 +372,7 @@ When the org is `user_preferred` or `user_required`, the request wants a user-au
   },
   "details": {
     "session_id": "session-123",
-    "connect_url": "/api/v1/users/me/github-app/connect?flow=pr_authorship",
+    "connect_url": "/api/v1/users/me/github/connect?flow=pr_authorship",
     "resume_token": "opaque-short-lived-token",
     "can_fallback_to_app": true,
     "suggested_author_mode": "user"
@@ -403,7 +406,7 @@ If the modal offers `Create as 143`, the frontend should retry:
 
 That makes the fallback explicit and avoids backend ambiguity about whether the second attempt should still try user auth.
 
-##### `GET /api/v1/users/me/github-app/connect`
+##### `GET /api/v1/users/me/github/connect`
 
 This endpoint starts GitHub App user authorization.
 
@@ -419,10 +422,10 @@ Behavior:
 - validate the current authenticated user matches the intended flow owner
 - validate the `resume_token` is still active
 - store a short-lived CSRF state cookie
-- store or bind the `resume_token` to the auth state
+- bind the `resume_token` to the OAuth `state` (for example via a state-scoped cookie name) so concurrent tabs cannot overwrite one another
 - redirect to GitHub's user authorization URL
 
-##### `GET /api/v1/users/me/github-app/callback`
+##### `GET /api/v1/users/me/github/callback`
 
 Behavior after GitHub redirects back:
 
@@ -853,9 +856,9 @@ Low-risk changes to unblock manually created sessions.
 |--------|----------|--------|
 | `POST /api/v1/sessions/{id}/pr` | Add optional `draft`, `author_mode`, and `resume_token`; may return typed auth-intercept responses |
 | `GET /api/v1/users/me/github-status` | New — returns whether user has a valid GitHub App user token for PR creation |
-| `GET /api/v1/users/me/github-app/connect` | New — starts GitHub App user authorization for PR authorship |
-| `GET /api/v1/users/me/github-app/callback` | New — stores GitHub App user token after authorization |
-| `POST /api/v1/users/me/github-app/disconnect` | New — removes stored GitHub App user credential |
+| `GET /api/v1/users/me/github/connect` | Starts GitHub App user authorization for PR authorship |
+| `GET /api/v1/users/me/github/callback` | Stores GitHub App user token after authorization |
+| `POST /api/v1/users/me/github/disconnect` | Removes stored GitHub App user credential |
 
 ### New Org Settings Fields
 

--- a/docs/self-hosting/github-app-setup.md
+++ b/docs/self-hosting/github-app-setup.md
@@ -69,6 +69,7 @@ This is the main integration that lets 143 create branches, push commits, open P
 
 | Field | Value |
 |-------|-------|
+| User authorization callback URL | `{BASE_URL}/api/v1/users/me/github/callback` |
 | Setup URL | `{BASE_URL}/settings/integrations/github/setup` |
 | Webhook URL | `{BASE_URL}/api/v1/webhooks/github` |
 | Webhook secret | Generate a strong random string (save it — you'll need it for the env var) |
@@ -80,6 +81,8 @@ openssl rand -hex 32
 ```
 
 Make sure **Active** is checked under the Webhook section.
+
+If you are upgrading an existing GitHub App, keep any existing callback URLs that your current install/connect flow still uses, and add the new user authorization callback URL alongside them. The PR-authorship flow uses the user callback URL above; the GitHub App install flow still uses the Setup URL.
 
 ### Step 3: Set permissions
 
@@ -116,13 +119,15 @@ Click **Create GitHub App**. You'll be taken to the app's settings page.
 
 Note the **App ID** displayed near the top of the page.
 
-### Step 7: Generate a private key
+### Step 7: Generate a private key and client secret
 
 1. Scroll down to **Private keys**
 2. Click **Generate a private key**
 3. A `.pem` file will download — this is your RSA private key
+4. In the app settings, note the **Client ID**
+5. Under **Client secrets**, click **Generate a new client secret** and copy it immediately
 
-Keep this file secure. You'll need its contents for the environment variable.
+Keep both the private key and client secret secure. You'll need them for the environment variables.
 
 ### Step 8: Configure 143
 
@@ -130,9 +135,13 @@ Add to your `.env` (or `.env.local`):
 
 ```env
 GITHUB_APP_ID=123456
+GITHUB_APP_CLIENT_ID=Iv1.0123456789abcdef
+GITHUB_APP_CLIENT_SECRET=your_github_app_client_secret
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBA...\n-----END RSA PRIVATE KEY-----"
 GITHUB_WEBHOOK_SECRET=your_webhook_secret_from_step_2
 ```
+
+The client ID and client secret are used for the on-demand "Create PR as me" flow. They are separate from the private key used to mint installation tokens.
 
 **Private key formatting:** The key must be the full PEM contents. You have two options:
 
@@ -167,7 +176,8 @@ Once configured, the flow is:
 1. **User logs in** via GitHub OAuth — 143 creates a user record with their GitHub profile
 2. **Admin installs the GitHub App** on their org — 143 receives the `installation` webhook and stores the installation ID + repo list
 3. **When 143 needs to act** (create a PR, push a commit), it signs a JWT with the App's private key, exchanges it for a short-lived installation token (valid 1 hour), and uses that token for API calls
-4. **GitHub sends webhooks** when PRs are reviewed, merged, or closed — 143 updates its records and triggers follow-up actions (deploy detection, review feedback loops, etc.)
+4. **When a user wants a PR created as themselves**, 143 sends them through the GitHub App user authorization flow at `/api/v1/users/me/github/callback`, stores a GitHub App user token, and then reuses or refreshes that token for future PRs
+5. **GitHub sends webhooks** when PRs are reviewed, merged, or closed — 143 updates its records and triggers follow-up actions (deploy detection, review feedback loops, etc.)
 
 ## Local development tips
 
@@ -184,7 +194,7 @@ ngrok http 8080
 cloudflared tunnel --url http://localhost:8080
 ```
 
-Update both the OAuth callback URL and the GitHub App webhook URL to use the tunnel URL. Remember to update these when the tunnel URL changes.
+Update the GitHub OAuth callback URL, the GitHub App user authorization callback URL, and the GitHub App webhook URL to use the tunnel URL. Remember to update these when the tunnel URL changes.
 
 ### Testing webhooks
 
@@ -199,9 +209,10 @@ Create separate GitHub OAuth Apps and GitHub Apps for development and production
 | Problem | Fix |
 |---------|-----|
 | `configured=false` for GitHub App at startup | Check that `GITHUB_APP_ID` is a number (not empty) and `GITHUB_APP_PRIVATE_KEY` is set |
+| First-time `Create PR` fails with `GITHUB_APP_USER_AUTH_NOT_CONFIGURED` | Check that `GITHUB_APP_CLIENT_ID` and `GITHUB_APP_CLIENT_SECRET` are set and that the GitHub App has a user authorization callback URL pointing to `{BASE_URL}/api/v1/users/me/github/callback` |
 | Webhook signature verification fails (401) | Make sure `GITHUB_WEBHOOK_SECRET` matches what you entered in the GitHub App settings |
 | "Resource not accessible by integration" on API calls | The app is missing a required permission — check the permissions table above and update in GitHub App settings |
 | PRs aren't being created | Verify the app is installed on the target repo and has Contents + Pull Requests write access |
 | Webhooks not arriving | Check that the webhook URL is correct and reachable. Use the Recent Deliveries tab in GitHub App settings to debug |
-| "redirect_uri is not associated with this application" | Your `BASE_URL` doesn't match the callback URL in GitHub OAuth App settings. Either update the callback URL in GitHub, or set `GITHUB_OAUTH_REDIRECT_URI` to match what's registered |
+| "redirect_uri is not associated with this application" | Your `BASE_URL` doesn't match the callback URL registered in GitHub. For login, update the GitHub OAuth App callback URL or set `GITHUB_OAUTH_REDIRECT_URI`. For PR authorship, update the GitHub App user authorization callback URL to `{BASE_URL}/api/v1/users/me/github/callback` |
 | Private key parse error | Make sure the full PEM is included, including `-----BEGIN RSA PRIVATE KEY-----` and `-----END RSA PRIVATE KEY-----` |

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1006,6 +1006,119 @@ describe('SessionDetailPage', () => {
     expect(screen.getByText('GitHub rejected the branch push.')).toBeInTheDocument();
   });
 
+  it('shows the PR authorship modal and falls back to app mode when requested', async () => {
+    const requestBodies: Array<Record<string, unknown> | undefined> = [];
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.get('/api/v1/users/me/github-status', () => {
+        return HttpResponse.json({
+          connected: false,
+          has_repo_scope: false,
+          pr_authorship_mode: 'user_preferred',
+          pr_draft_default: false,
+        });
+      }),
+      http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
+        requestBodies.push(await request.json().catch(() => undefined));
+        if (requestBodies.length === 1) {
+          return HttpResponse.json(
+            {
+              error: {
+                code: 'GITHUB_PR_AUTHORSHIP_REQUIRED',
+                message: 'Authorize GitHub to create this pull request as you.',
+                details: {
+                  connect_url: '/api/v1/users/me/github/connect?flow=pr_authorship',
+                  resume_token: 'resume-123',
+                  can_fallback_to_app: true,
+                },
+              },
+            },
+            { status: 409 },
+          );
+        }
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    expect(await screen.findByText('Open this pull request as yourself?')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Create as 143' }));
+
+    await waitFor(() => {
+      expect(requestBodies).toEqual([undefined, { author_mode: 'app' }]);
+    });
+  });
+
+  it('auto-resumes PR creation after GitHub auth callback', async () => {
+    const requestBodies: Array<Record<string, unknown> | undefined> = [];
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.get('/api/v1/users/me/github-status', () => {
+        return HttpResponse.json({
+          connected: true,
+          has_repo_scope: true,
+          github_login: 'alice',
+          pr_authorship_mode: 'user_preferred',
+          pr_draft_default: false,
+        });
+      }),
+      http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
+        requestBodies.push(await request.json().catch(() => undefined));
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />, {
+      searchParams: { github_pr: 'connected', resume_pr: 'resume-123' },
+    });
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    await waitFor(() => {
+      expect(requestBodies).toEqual([{ author_mode: 'user', resume_token: 'resume-123' }]);
+    });
+  });
+
   it('keeps a creating state until the pull request exists, then swaps to View PR', async () => {
     let sessionFetchCount = 0;
     const queuedSession: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1007,7 +1007,7 @@ describe('SessionDetailPage', () => {
   });
 
   it('shows the PR authorship modal and falls back to app mode when requested', async () => {
-    const requestBodies: Array<Record<string, unknown> | undefined> = [];
+    const requestBodies: unknown[] = [];
 
     const sessionWithDiff: Session = {
       ...mockSessions[0],
@@ -1073,7 +1073,7 @@ describe('SessionDetailPage', () => {
   });
 
   it('auto-resumes PR creation after GitHub auth callback', async () => {
-    const requestBodies: Array<Record<string, unknown> | undefined> = [];
+    const requestBodies: unknown[] = [];
 
     const sessionWithDiff: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -28,6 +28,16 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from "@/components/ui/table";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -40,7 +50,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { ChatTimeline } from "@/components/chat-timeline";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 import { AGENTS, AGENTS_BY_KEY } from "@/lib/agents";
 import { SSE_EVENT, addSSEListener } from "@/lib/sse";
 import { buildTimeline, buildTimelineFromResponse } from "@/lib/timeline";
@@ -141,8 +151,23 @@ function checkResultBadge(result: string | null) {
 // ---------------------------------------------------------------------------
 
 type DetailTab = "overview" | "changes" | "validation" | "preview";
+type PRAuthorMode = "auto" | "user" | "app";
+
+type PRAuthInterceptDetails = {
+  connect_url: string;
+  resume_token: string;
+  can_fallback_to_app: boolean;
+};
 
 const terminalSessionStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
+
+function isPRAuthInterceptDetails(value: unknown): value is PRAuthInterceptDetails {
+  if (!value || typeof value !== "object") return false;
+  const details = value as Partial<PRAuthInterceptDetails>;
+  return typeof details.connect_url === "string" &&
+    typeof details.resume_token === "string" &&
+    typeof details.can_fallback_to_app === "boolean";
+}
 
 function OverviewTab({ session, members }: { session: Session; members: User[] }) {
   const queryClient = useQueryClient();
@@ -1320,6 +1345,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   const terminalStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
   const [reviewParam, setReviewParam] = useQueryState("review");
   const [previewParam, setPreviewParam] = useQueryState("preview");
+  const [resumePRParam, setResumePRParam] = useQueryState("resume_pr");
+  const [githubPRParam, setGithubPRParam] = useQueryState("github_pr");
   const centerMode = reviewParam === "active" ? "review" : "chat";
   const [detailTab, setDetailTab] = useState<DetailTab>(
     previewParam === "1" ? "preview" : "overview"
@@ -1356,6 +1383,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [centerMode, exitReview, setPreviewParam]);
   const [localPRState, setLocalPRState] = useState<"idle" | "submitting" | "queued">("idle");
   const [localPRActionError, setLocalPRActionError] = useState<string | null>(null);
+  const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthInterceptDetails | null>(null);
+  const resumeAttemptRef = useRef<string | null>(null);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["session", id],
@@ -1465,8 +1494,16 @@ export function SessionDetailContent({ id }: { id: string }) {
     staleTime: 5 * 60 * 1000,
   });
 
+  const clearPRResumeParams = useCallback(() => {
+    void setResumePRParam(null);
+    if (githubPRParam === "connected") {
+      void setGithubPRParam(null);
+    }
+  }, [githubPRParam, setGithubPRParam, setResumePRParam]);
+
   const createPRMutation = useMutation({
-    mutationFn: () => api.sessions.createPR(id),
+    mutationFn: (options?: { draft?: boolean; authorMode?: PRAuthorMode; resumeToken?: string }) =>
+      api.sessions.createPR(id, options),
     onMutate: () => {
       setLocalPRActionError(null);
       setLocalPRState("submitting");
@@ -1478,12 +1515,28 @@ export function SessionDetailContent({ id }: { id: string }) {
       queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
     },
     onError: (err) => {
+      if (err instanceof ApiError &&
+        (err.code === "GITHUB_PR_AUTHORSHIP_REQUIRED" || err.code === "GITHUB_PR_AUTHORSHIP_REAUTH_REQUIRED") &&
+        isPRAuthInterceptDetails(err.details)) {
+        setLocalPRState("idle");
+        setLocalPRActionError(null);
+        setPRAuthPrompt(err.details);
+        clearPRResumeParams();
+        return;
+      }
       setLocalPRState("idle");
       const msg = err instanceof Error ? err.message : PR_ERROR_TOAST_MESSAGE;
       setLocalPRActionError(msg);
       toast.error(PR_ERROR_TOAST_MESSAGE, { duration: PR_ERROR_TOAST_DURATION_MS });
     },
   });
+
+  useEffect(() => {
+    if (!canCreatePR || !resumePRParam) return;
+    if (resumeAttemptRef.current === resumePRParam) return;
+    resumeAttemptRef.current = resumePRParam;
+    createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
+  }, [canCreatePR, createPRMutation, resumePRParam]);
 
   const sessionDiff = session?.diff;
   const diffStats = useMemo(() => {
@@ -1816,6 +1869,43 @@ export function SessionDetailContent({ id }: { id: string }) {
         </div>
         </>
       )}
+      <AlertDialog
+        open={!!prAuthPrompt}
+        onOpenChange={(open) => {
+          if (!open) setPRAuthPrompt(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Open this pull request as yourself?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Authorize GitHub once to open PRs as you. If you skip this, 143 can still open the PR as the app.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            {prAuthPrompt?.can_fallback_to_app ? (
+              <AlertDialogCancel
+                onClick={(event) => {
+                  event.preventDefault();
+                  setPRAuthPrompt(null);
+                  createPRMutation.mutate({ authorMode: "app" });
+                }}
+              >
+                Create as 143
+              </AlertDialogCancel>
+            ) : null}
+            <AlertDialogAction
+              onClick={(event) => {
+                event.preventDefault();
+                if (!prAuthPrompt) return;
+                api.githubStatus.connect(prAuthPrompt.resume_token);
+              }}
+            >
+              Continue with GitHub
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1812,7 +1812,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                       className="h-7 text-xs gap-1.5"
                       disabled={disabled}
                       title={title}
-                      onClick={() => createPRMutation.mutate()}
+                      onClick={() => createPRMutation.mutate(undefined)}
                     >
                       {spinning ? (
                         <Loader2 className="h-3 w-3 animate-spin" />

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -698,17 +698,20 @@ describe('api client', () => {
   describe('sessions - createPR', () => {
     it('creates PR and returns queued status', async () => {
       let capturedUrl: string | undefined;
+      let capturedBody: unknown;
 
       server.use(
-        http.post('/api/v1/sessions/:id/pr', ({ request }) => {
+        http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
           capturedUrl = request.url;
+          capturedBody = await request.json();
           return HttpResponse.json({ status: 'queued' }, { status: 202 });
         }),
       );
 
-      const result = await api.sessions.createPR('session-abc');
+      const result = await api.sessions.createPR('session-abc', { draft: true, authorMode: 'user', resumeToken: 'resume-123' });
       expect(result.status).toBe('queued');
       expect(capturedUrl).toContain('/api/v1/sessions/session-abc/pr');
+      expect(capturedBody).toEqual({ draft: true, author_mode: 'user', resume_token: 'resume-123' });
     });
 
     it('throws on conflict when PR already exists', async () => {
@@ -722,6 +725,35 @@ describe('api client', () => {
       );
 
       await expect(api.sessions.createPR('session-abc')).rejects.toThrow('a pull request already exists for this session');
+    });
+
+    it('surfaces auth intercept details', async () => {
+      server.use(
+        http.post('/api/v1/sessions/:id/pr', () => {
+          return HttpResponse.json(
+            {
+              error: {
+                code: 'GITHUB_PR_AUTHORSHIP_REQUIRED',
+                message: 'Authorize GitHub to create this pull request as you.',
+                details: {
+                  connect_url: '/api/v1/users/me/github/connect?flow=pr_authorship',
+                  resume_token: 'resume-123',
+                  can_fallback_to_app: true,
+                },
+              },
+            },
+            { status: 409 },
+          );
+        }),
+      );
+
+      await expect(api.sessions.createPR('session-abc')).rejects.toMatchObject({
+        code: 'GITHUB_PR_AUTHORSHIP_REQUIRED',
+        details: expect.objectContaining({
+          connect_url: '/api/v1/users/me/github/connect?flow=pr_authorship',
+          resume_token: 'resume-123',
+        }),
+      });
     });
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,7 +4,7 @@ const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const SENTRY_CLIENT_ID = process.env.NEXT_PUBLIC_SENTRY_CLIENT_ID || '';
 const SENTRY_REDIRECT_URI = process.env.NEXT_PUBLIC_SENTRY_REDIRECT_URI || '';
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(public code: string, message: string, public details?: unknown) {
     super(message);
     this.name = 'ApiError';
@@ -298,8 +298,12 @@ export const api = {
     getTimeline: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionTimelineEntry>>(`/api/v1/sessions/${sessionId}/timeline`),
     getValidation: (sessionId: string) => get<import('./types').SingleResponse<import('./types').Validation>>(`/api/v1/sessions/${sessionId}/validation`),
     getPR: (sessionId: string) => get<import('./types').SingleResponse<import('./types').PullRequest | null>>(`/api/v1/sessions/${sessionId}/pr`),
-    createPR: (sessionId: string, options?: { draft?: boolean }) =>
-      post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr`, options),
+    createPR: (sessionId: string, options?: { draft?: boolean; authorMode?: 'auto' | 'user' | 'app'; resumeToken?: string }) =>
+      post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr`, options ? {
+        ...(options.draft !== undefined ? { draft: options.draft } : {}),
+        ...(options.authorMode ? { author_mode: options.authorMode } : {}),
+        ...(options.resumeToken ? { resume_token: options.resumeToken } : {}),
+      } : undefined),
     getQuestions: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions`),
     answerQuestion: (sessionId: string, questionId: string, answer: string) =>
       post<import('./types').SingleResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions/${questionId}/answer`, { answer }),
@@ -466,7 +470,12 @@ export const api = {
   },
   githubStatus: {
     get: () => get<{ connected: boolean; has_repo_scope: boolean; github_login?: string; pr_authorship_mode: string; pr_draft_default: boolean }>('/api/v1/users/me/github-status'),
-    connect: () => { window.location.href = `${API_BASE}/api/v1/users/me/github/connect`; },
+    connect: (resumeToken?: string) => {
+      const searchParams = new URLSearchParams();
+      if (resumeToken) searchParams.set('resume_token', resumeToken);
+      const qs = searchParams.toString();
+      window.location.href = `${API_BASE}/api/v1/users/me/github/connect${qs ? `?${qs}` : ''}`;
+    },
     disconnect: () => post('/api/v1/users/me/github/disconnect'),
   },
   priority: {

--- a/internal/api/handlers/github_status.go
+++ b/internal/api/handlers/github_status.go
@@ -3,9 +3,10 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -15,7 +16,6 @@ import (
 
 const (
 	githubPRConnectStateCookie = "github_pr_connect_state"
-	githubPRConnectScope       = "repo read:user user:email"
 )
 
 // githubStatusCredentialStore is the interface for checking GitHub credential status.
@@ -30,6 +30,11 @@ type githubStatusOrgReader interface {
 	GetByID(ctx context.Context, id uuid.UUID) (models.Organization, error)
 }
 
+type githubAppUserAuth interface {
+	HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
+	ExchangeCode(ctx context.Context, code string) (*models.GitHubAppUserConfig, error)
+}
+
 // GitHubStatusHandler serves the user's GitHub connection status for PR creation.
 type GitHubStatusHandler struct {
 	credentials    githubStatusCredentialStore
@@ -38,6 +43,8 @@ type GitHubStatusHandler struct {
 	githubSecret   string
 	baseURL        string // e.g. "https://app.143.dev"
 	frontendURL    string // e.g. "https://app.143.dev"
+	signingKey     []byte
+	appUserAuth    githubAppUserAuth
 }
 
 // NewGitHubStatusHandler creates a new GitHub status handler.
@@ -54,6 +61,17 @@ func NewGitHubStatusHandler(
 		baseURL:        baseURL,
 		frontendURL:    frontendURL,
 	}
+}
+
+// SetPRAuthFlow wires the signing key used for signed PR resume tokens.
+func (h *GitHubStatusHandler) SetPRAuthFlow(signingKey string) {
+	h.signingKey = []byte(signingKey)
+}
+
+// SetAppUserAuth wires the refresh-aware GitHub App user auth service used by
+// the on-demand Create PR flow.
+func (h *GitHubStatusHandler) SetAppUserAuth(auth githubAppUserAuth) {
+	h.appUserAuth = auth
 }
 
 // GitHubStatusResponse is the response for GET /api/v1/users/me/github-status.
@@ -88,15 +106,30 @@ func (h *GitHubStatusHandler) GetStatus(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Check if the user has a GitHub OAuth credential.
-	cred, err := h.credentials.GetForUser(r.Context(), orgID, user.ID, models.ProviderGitHubOAuth)
-	if err == nil && cred != nil {
-		cfg, ok := cred.Config.(models.GitHubOAuthConfig)
-		if ok && cfg.AccessToken != "" {
+	if h.appUserAuth != nil {
+		ok, authErr := h.appUserAuth.HasValidCredential(r.Context(), orgID, user.ID)
+		if authErr != nil {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to determine GitHub PR auth status", authErr)
+			return
+		}
+		if ok {
 			resp.Connected = true
-			resp.HasRepoScope = hasRepoScope(cfg.Scope)
+			resp.HasRepoScope = true
 			if user.GitHubLogin != nil {
 				resp.GitHubLogin = *user.GitHubLogin
+			}
+		}
+	} else {
+		// Fallback for tests/wiring without the refresh-aware auth service.
+		cred, err := h.credentials.GetForUser(r.Context(), orgID, user.ID, models.ProviderGitHubAppUser)
+		if err == nil && cred != nil {
+			cfg, ok := cred.Config.(models.GitHubAppUserConfig)
+			if ok && cfg.AccessToken != "" && !cfg.IsExpired() {
+				resp.Connected = true
+				resp.HasRepoScope = true
+				if user.GitHubLogin != nil {
+					resp.GitHubLogin = *user.GitHubLogin
+				}
 			}
 		}
 	}
@@ -105,11 +138,34 @@ func (h *GitHubStatusHandler) GetStatus(w http.ResponseWriter, r *http.Request) 
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-// StartConnect initiates a GitHub OAuth flow with repo scope for PR authorship.
+// StartConnect initiates a GitHub App user authorization flow for PR authorship.
 func (h *GitHubStatusHandler) StartConnect(w http.ResponseWriter, r *http.Request) {
 	if h.githubClientID == "" || h.githubSecret == "" {
-		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_OAUTH_NOT_CONFIGURED", "github oauth is not configured")
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
 		return
+	}
+	var resumeCookieName string
+	if resumeToken := r.URL.Query().Get("resume_token"); resumeToken != "" {
+		user := middleware.UserFromContext(r.Context())
+		orgID := middleware.OrgIDFromContext(r.Context())
+		if user == nil {
+			writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+			return
+		}
+		if len(h.signingKey) == 0 {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
+			return
+		}
+		claims, err := parsePRAuthResumeToken(h.signingKey, resumeToken, time.Now())
+		if err != nil || claims.UserID != user.ID || claims.OrgID != orgID {
+			writeJSON(w, http.StatusConflict, models.ErrorResponse{
+				Error: models.ErrorDetail{
+					Code:    "PR_RESUME_EXPIRED",
+					Message: "GitHub authorization completed, but the PR resume request expired. Please click Create PR again.",
+				},
+			})
+			return
+		}
 	}
 
 	state, err := setOAuthState(w, githubPRConnectStateCookie)
@@ -118,17 +174,29 @@ func (h *GitHubStatusHandler) StartConnect(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	if resumeToken := r.URL.Query().Get("resume_token"); resumeToken != "" {
+		resumeCookieName = githubPRResumeCookiePrefix + state
+		http.SetCookie(w, &http.Cookie{
+			Name:     resumeCookieName,
+			Value:    resumeToken,
+			Path:     "/",
+			MaxAge:   int(prAuthResumeTokenTTL.Seconds()),
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   isSecureRequest(r),
+		})
+	}
+
 	params := url.Values{
 		"client_id":    {h.githubClientID},
 		"redirect_uri": {h.baseURL + "/api/v1/users/me/github/callback"},
-		"scope":        {githubPRConnectScope},
 		"state":        {state},
 	}
 
 	http.Redirect(w, r, "https://github.com/login/oauth/authorize?"+params.Encode(), http.StatusTemporaryRedirect)
 }
 
-// HandleConnectCallback handles the GitHub OAuth callback for PR authorship.
+// HandleConnectCallback handles the GitHub App user auth callback for PR authorship.
 func (h *GitHubStatusHandler) HandleConnectCallback(w http.ResponseWriter, r *http.Request) {
 	code, ok := validateOAuthCallback(w, r, githubPRConnectStateCookie)
 	if !ok {
@@ -142,38 +210,34 @@ func (h *GitHubStatusHandler) HandleConnectCallback(w http.ResponseWriter, r *ht
 	}
 	orgID := middleware.OrgIDFromContext(r.Context())
 
-	// Exchange code for token using the shared helper.
-	tokenResp, err := exchangeGitHubOAuthCode(h.githubClientID, h.githubSecret, code)
+	if h.appUserAuth == nil {
+		writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
+		return
+	}
+
+	cfg, err := h.appUserAuth.ExchangeCode(r.Context(), code)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "TOKEN_EXCHANGE_FAILED", "failed to exchange code", err)
 		return
 	}
 
-	// Store user credential with repo scope.
-	cfg := models.GitHubOAuthConfig{
-		AccessToken: tokenResp.AccessToken,
-		TokenType:   tokenResp.TokenType,
-		Scope:       tokenResp.Scope,
-	}
 	if err := h.credentials.Upsert(r.Context(), user.ID, orgID, cfg, false); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store credential", err)
 		return
 	}
 
-	http.Redirect(w, r, h.frontendURL+"/settings?github_pr=connected", http.StatusTemporaryRedirect)
-}
-
-// hasRepoScope returns true if the comma/space-separated scope string includes "repo".
-func hasRepoScope(scope string) bool {
-	for _, s := range strings.FieldsFunc(scope, func(r rune) bool { return r == ',' || r == ' ' }) {
-		if s == "repo" {
-			return true
+	redirectURL := h.frontendURL + "/settings?github_pr=connected"
+	resumeCookieName := githubPRResumeCookiePrefix + r.URL.Query().Get("state")
+	if resumeCookie, err := r.Cookie(resumeCookieName); err == nil && resumeCookie.Value != "" && len(h.signingKey) > 0 {
+		if claims, tokenErr := parsePRAuthResumeToken(h.signingKey, resumeCookie.Value, time.Now()); tokenErr == nil {
+			redirectURL = fmt.Sprintf("%s/sessions/%s?github_pr=connected&resume_pr=%s", h.frontendURL, claims.SessionID, url.QueryEscape(resumeCookie.Value))
 		}
 	}
-	return false
+	clearCookie(w, r, resumeCookieName)
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
 }
 
-// Disconnect removes the user's stored GitHub OAuth credential.
+// Disconnect removes the user's stored GitHub App user credential.
 func (h *GitHubStatusHandler) Disconnect(w http.ResponseWriter, r *http.Request) {
 	user := middleware.UserFromContext(r.Context())
 	if user == nil {
@@ -182,7 +246,7 @@ func (h *GitHubStatusHandler) Disconnect(w http.ResponseWriter, r *http.Request)
 	}
 	orgID := middleware.OrgIDFromContext(r.Context())
 
-	if err := h.credentials.Disable(r.Context(), orgID, user.ID, models.ProviderGitHubOAuth); err != nil {
+	if err := h.credentials.Disable(r.Context(), orgID, user.ID, models.ProviderGitHubAppUser); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "DISCONNECT_FAILED", "failed to disconnect GitHub", err)
 		return
 	}

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -19,17 +19,25 @@ import (
 // --- test doubles ---
 
 type stubGHCredentialStore struct {
-	cred *models.DecryptedUserCredential
-	err  error
+	cred        *models.DecryptedUserCredential
+	err         error
+	upsertFunc  func(context.Context, uuid.UUID, uuid.UUID, models.ProviderConfig, bool) error
+	disableFunc func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) error
 }
 
 func (s *stubGHCredentialStore) GetForUser(_ context.Context, _, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedUserCredential, error) {
 	return s.cred, s.err
 }
-func (s *stubGHCredentialStore) Upsert(_ context.Context, _, _ uuid.UUID, _ models.ProviderConfig, _ bool) error {
+func (s *stubGHCredentialStore) Upsert(ctx context.Context, userID, orgID uuid.UUID, cfg models.ProviderConfig, isTeamDefault bool) error {
+	if s.upsertFunc != nil {
+		return s.upsertFunc(ctx, userID, orgID, cfg, isTeamDefault)
+	}
 	return nil
 }
-func (s *stubGHCredentialStore) Disable(_ context.Context, _, _ uuid.UUID, _ models.ProviderName) error {
+func (s *stubGHCredentialStore) Disable(ctx context.Context, orgID, userID uuid.UUID, provider models.ProviderName) error {
+	if s.disableFunc != nil {
+		return s.disableFunc(ctx, orgID, userID, provider)
+	}
 	return nil
 }
 
@@ -369,4 +377,213 @@ func TestGitHubStatusHandler_HandleConnectCallback_UsesStateScopedResumeCookie(t
 	require.NoError(t, parseErr, "redirect location should parse")
 	require.Equal(t, "/sessions/"+secondSessionID.String(), parsed.Path, "callback should resume the flow bound to the callback state")
 	require.Equal(t, secondResumeToken, parsed.Query().Get("resume_pr"), "callback should return the state-scoped resume token")
+}
+
+func TestGitHubStatusHandler_GetStatus_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "", "", "", "")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+	rr := httptest.NewRecorder()
+
+	handler.GetStatus(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "GetStatus should reject unauthenticated requests")
+}
+
+func TestGitHubStatusHandler_GetStatus_AppUserAuthError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "", "", "", "")
+	handler.SetAppUserAuth(&stubGitHubAppUserAuthService{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, context.DeadlineExceeded
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.GetStatus(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "GetStatus should surface app-user auth check failures")
+}
+
+func TestGitHubStatusHandler_GetStatus_UsesAppUserAuthService(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	login := "octocat"
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "", "", "", "")
+	handler.SetAppUserAuth(&stubGitHubAppUserAuthService{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return true, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github-status", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID, GitHubLogin: &login})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.GetStatus(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "GetStatus should succeed")
+	var resp GitHubStatusResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response body should decode")
+	require.True(t, resp.Connected, "valid app user auth should mark the user connected")
+	require.True(t, resp.HasRepoScope, "valid app user auth should mark repo scope")
+	require.Equal(t, login, resp.GitHubLogin, "GetStatus should include the GitHub login when connected")
+}
+
+func TestGitHubStatusHandler_StartConnect_ResumeTokenRequiresAuthContext(t *testing.T) {
+	t.Parallel()
+
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev")
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/connect?resume_token=token", nil)
+	rr := httptest.NewRecorder()
+
+	handler.StartConnect(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "StartConnect should reject resume flows without an authenticated user")
+}
+
+func TestGitHubStatusHandler_StartConnect_ResumeTokenRequiresSigningKey(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/connect?resume_token=token", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.StartConnect(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "StartConnect should reject resume flows when PR auth signing is not configured")
+}
+
+func TestGitHubStatusHandler_StartConnect_InvalidResumeToken(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev")
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/connect?resume_token=bad-token", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.StartConnect(rr, req)
+
+	require.Equal(t, http.StatusConflict, rr.Code, "StartConnect should reject expired or invalid resume tokens")
+}
+
+func TestGitHubStatusHandler_HandleConnectCallback_NotConfigured(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=ok&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "ok"})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, rr.Code, "callback should fail fast when app user auth is unavailable")
+}
+
+func TestGitHubStatusHandler_HandleConnectCallback_ExchangeFailure(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	handler := NewGitHubStatusHandler(&stubGHCredentialStore{}, &stubGHOrgReader{}, "test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev")
+	handler.SetAppUserAuth(&stubGitHubAppUserAuthService{
+		exchangeCodeFunc: func(context.Context, string) (*models.GitHubAppUserConfig, error) {
+			return nil, context.DeadlineExceeded
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=ok&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "ok"})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "callback should surface exchange failures")
+}
+
+func TestGitHubStatusHandler_Disconnect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		user       *models.User
+		disableErr error
+		wantCode   int
+	}{
+		{
+			name:     "unauthorized",
+			wantCode: http.StatusUnauthorized,
+		},
+		{
+			name:       "disable failure",
+			user:       &models.User{ID: uuid.New(), OrgID: uuid.New()},
+			disableErr: context.DeadlineExceeded,
+			wantCode:   http.StatusInternalServerError,
+		},
+		{
+			name:     "success",
+			user:     &models.User{ID: uuid.New(), OrgID: uuid.New()},
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			handler := NewGitHubStatusHandler(&stubGHCredentialStore{
+				disableFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) error {
+					return tt.disableErr
+				},
+			}, &stubGHOrgReader{}, "", "", "", "")
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/users/me/github/disconnect", nil)
+			if tt.user != nil {
+				ctx := middleware.WithUser(req.Context(), tt.user)
+				ctx = middleware.WithOrgID(ctx, tt.user.OrgID)
+				req = req.WithContext(ctx)
+			}
+			rr := httptest.NewRecorder()
+
+			handler.Disconnect(rr, req)
+
+			require.Equal(t, tt.wantCode, rr.Code, "Disconnect should return the expected status")
+		})
+	}
 }

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -31,6 +33,25 @@ func (s *stubGHCredentialStore) Disable(_ context.Context, _, _ uuid.UUID, _ mod
 	return nil
 }
 
+type stubGitHubAppUserAuthService struct {
+	hasValidCredentialFunc func(context.Context, uuid.UUID, uuid.UUID) (bool, error)
+	exchangeCodeFunc       func(context.Context, string) (*models.GitHubAppUserConfig, error)
+}
+
+func (s *stubGitHubAppUserAuthService) HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error) {
+	if s.hasValidCredentialFunc != nil {
+		return s.hasValidCredentialFunc(ctx, orgID, userID)
+	}
+	return false, nil
+}
+
+func (s *stubGitHubAppUserAuthService) ExchangeCode(ctx context.Context, code string) (*models.GitHubAppUserConfig, error) {
+	if s.exchangeCodeFunc != nil {
+		return s.exchangeCodeFunc(ctx, code)
+	}
+	return nil, nil
+}
+
 type stubGHOrgReader struct {
 	org models.Organization
 	err error
@@ -51,9 +72,12 @@ func TestGitHubStatusHandler_GetStatus_Connected(t *testing.T) {
 
 	credStore := &stubGHCredentialStore{
 		cred: &models.DecryptedUserCredential{
-			Config: models.GitHubOAuthConfig{
-				AccessToken: "gho_test",
-				Scope:       "repo,read:org",
+			Config: models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 			},
 		},
 	}
@@ -76,11 +100,11 @@ func TestGitHubStatusHandler_GetStatus_Connected(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	var resp GitHubStatusResponse
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	require.True(t, resp.Connected)
-	require.True(t, resp.HasRepoScope)
-	require.Equal(t, "testuser", resp.GitHubLogin)
-	require.Equal(t, "user_preferred", resp.PRAuthorshipMode)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response body should decode")
+	require.True(t, resp.Connected, "connected app-user credential should mark GitHub as connected")
+	require.True(t, resp.HasRepoScope, "app-user credential should be treated as PR-capable")
+	require.Equal(t, "testuser", resp.GitHubLogin, "response should include the user's GitHub login")
+	require.Equal(t, "user_preferred", resp.PRAuthorshipMode, "response should echo org PR authorship mode")
 }
 
 func TestGitHubStatusHandler_GetStatus_NotConnected(t *testing.T) {
@@ -111,13 +135,13 @@ func TestGitHubStatusHandler_GetStatus_NotConnected(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	var resp GitHubStatusResponse
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	require.False(t, resp.Connected)
-	require.False(t, resp.HasRepoScope)
-	require.Equal(t, "app_only", resp.PRAuthorshipMode)
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response body should decode")
+	require.False(t, resp.Connected, "missing app-user credential should report disconnected")
+	require.False(t, resp.HasRepoScope, "missing app-user credential should not report PR capability")
+	require.Equal(t, "app_only", resp.PRAuthorshipMode, "response should echo app_only mode")
 }
 
-func TestGitHubStatusHandler_GetStatus_ConnectedWithoutRepoScope(t *testing.T) {
+func TestGitHubStatusHandler_GetStatus_IgnoresExpiredCredential(t *testing.T) {
 	t.Parallel()
 
 	orgID := uuid.New()
@@ -126,9 +150,12 @@ func TestGitHubStatusHandler_GetStatus_ConnectedWithoutRepoScope(t *testing.T) {
 
 	credStore := &stubGHCredentialStore{
 		cred: &models.DecryptedUserCredential{
-			Config: models.GitHubOAuthConfig{
-				AccessToken: "gho_test",
-				Scope:       "read:user,user:email", // no repo scope
+			Config: models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(-time.Minute),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
 			},
 		},
 	}
@@ -151,21 +178,10 @@ func TestGitHubStatusHandler_GetStatus_ConnectedWithoutRepoScope(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 
 	var resp GitHubStatusResponse
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
-	require.True(t, resp.Connected)
-	require.False(t, resp.HasRepoScope, "should not have repo scope with read:user,user:email")
-	require.Equal(t, "testuser", resp.GitHubLogin)
-}
-
-func TestHasRepoScope_Handler(t *testing.T) {
-	t.Parallel()
-
-	require.True(t, hasRepoScope("repo"))
-	require.True(t, hasRepoScope("repo read:org"))
-	require.True(t, hasRepoScope("read:user,repo,user:email"))
-	require.False(t, hasRepoScope("read:user,user:email"))
-	require.False(t, hasRepoScope(""))
-	require.False(t, hasRepoScope("public_repo"))
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response body should decode")
+	require.False(t, resp.Connected, "expired app-user credential should not be treated as connected")
+	require.False(t, resp.HasRepoScope, "expired app-user credential should not be treated as PR-capable")
+	require.Empty(t, resp.GitHubLogin, "disconnected response should not promise authorship as the user")
 }
 
 func TestGitHubStatusHandler_StartConnect_NotConfigured(t *testing.T) {
@@ -195,7 +211,162 @@ func TestGitHubStatusHandler_StartConnect_Redirects(t *testing.T) {
 	require.Equal(t, http.StatusTemporaryRedirect, rr.Code)
 	loc := rr.Header().Get("Location")
 	require.Contains(t, loc, "github.com/login/oauth/authorize")
-	require.Contains(t, loc, "scope=repo")
 	require.Contains(t, loc, "client_id=test-client-id")
 	require.Contains(t, loc, "redirect_uri=")
+}
+
+func TestGitHubStatusHandler_StartConnect_StoresResumeCookie(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	handler := NewGitHubStatusHandler(
+		&stubGHCredentialStore{}, &stubGHOrgReader{},
+		"test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev",
+	)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+
+	resumeToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  sessionID,
+		UserID:     userID,
+		OrgID:      orgID,
+		AuthorMode: "user",
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+	})
+	require.NoError(t, err, "resume token should sign")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/connect?resume_token="+url.QueryEscape(resumeToken), nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID}))
+	rr := httptest.NewRecorder()
+
+	handler.StartConnect(rr, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, rr.Code, "connect should redirect to GitHub")
+	loc := rr.Header().Get("Location")
+	parsed, parseErr := url.Parse(loc)
+	require.NoError(t, parseErr, "redirect location should parse")
+	state := parsed.Query().Get("state")
+	require.NotEmpty(t, state, "redirect should include oauth state")
+	cookies := rr.Result().Cookies()
+	found := false
+	for _, cookie := range cookies {
+		if cookie.Name == githubPRResumeCookiePrefix+state {
+			found = true
+			require.Equal(t, resumeToken, cookie.Value, "resume cookie should preserve resume token")
+		}
+	}
+	require.True(t, found, "connect should set a resume cookie when resume_token is provided")
+}
+
+func TestGitHubStatusHandler_HandleConnectCallback_RedirectsBackToSessionResume(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	handler := NewGitHubStatusHandler(
+		&stubGHCredentialStore{}, &stubGHOrgReader{},
+		"test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev",
+	)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		exchangeCodeFunc: func(context.Context, string) (*models.GitHubAppUserConfig, error) {
+			return &models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	resumeToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  sessionID,
+		UserID:     userID,
+		OrgID:      orgID,
+		AuthorMode: "user",
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+	})
+	require.NoError(t, err, "resume token should sign")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=ok&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "ok"})
+	req.AddCookie(&http.Cookie{Name: githubPRResumeCookiePrefix + "ok", Value: resumeToken})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, rr.Code, "callback should redirect back to the session page")
+	loc := rr.Header().Get("Location")
+	parsed, parseErr := url.Parse(loc)
+	require.NoError(t, parseErr, "redirect location should parse")
+	require.Equal(t, "/sessions/"+sessionID.String(), parsed.Path, "callback should return to the originating session page")
+	require.Equal(t, "connected", parsed.Query().Get("github_pr"), "redirect should note successful GitHub PR auth")
+	require.NotEmpty(t, parsed.Query().Get("resume_pr"), "redirect should carry resume token back to the frontend")
+}
+
+func TestGitHubStatusHandler_HandleConnectCallback_UsesStateScopedResumeCookie(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	firstSessionID := uuid.New()
+	secondSessionID := uuid.New()
+	handler := NewGitHubStatusHandler(
+		&stubGHCredentialStore{}, &stubGHOrgReader{},
+		"test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev",
+	)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		exchangeCodeFunc: func(context.Context, string) (*models.GitHubAppUserConfig, error) {
+			return &models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	firstResumeToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  firstSessionID,
+		UserID:     userID,
+		OrgID:      orgID,
+		AuthorMode: "user",
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+	})
+	require.NoError(t, err, "first resume token should sign")
+	secondResumeToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  secondSessionID,
+		UserID:     userID,
+		OrgID:      orgID,
+		AuthorMode: "user",
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+	})
+	require.NoError(t, err, "second resume token should sign")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=second-state&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "second-state"})
+	req.AddCookie(&http.Cookie{Name: githubPRResumeCookiePrefix + "first-state", Value: firstResumeToken})
+	req.AddCookie(&http.Cookie{Name: githubPRResumeCookiePrefix + "second-state", Value: secondResumeToken})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, rr.Code, "callback should redirect after successful auth")
+	loc := rr.Header().Get("Location")
+	parsed, parseErr := url.Parse(loc)
+	require.NoError(t, parseErr, "redirect location should parse")
+	require.Equal(t, "/sessions/"+secondSessionID.String(), parsed.Path, "callback should resume the flow bound to the callback state")
+	require.Equal(t, secondResumeToken, parsed.Query().Get("resume_pr"), "callback should return the state-scoped resume token")
 }

--- a/internal/api/handlers/pr_auth_flow.go
+++ b/internal/api/handlers/pr_auth_flow.go
@@ -1,0 +1,125 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+const (
+	githubPRResumeCookiePrefix  = "github_pr_resume_"
+	prAuthResumeTokenTTL        = 10 * time.Minute
+	prAuthResumeTokenSkewWindow = 30 * time.Second
+)
+
+type prAuthorMode string
+
+const (
+	prAuthorModeAuto prAuthorMode = "auto"
+	prAuthorModeUser prAuthorMode = "user"
+	prAuthorModeApp  prAuthorMode = "app"
+)
+
+type prAuthResumeClaims struct {
+	SessionID  uuid.UUID `json:"session_id"`
+	UserID     uuid.UUID `json:"user_id"`
+	OrgID      uuid.UUID `json:"org_id"`
+	Draft      *bool     `json:"draft,omitempty"`
+	AuthorMode string    `json:"author_mode"`
+	ExpiresAt  int64     `json:"exp"`
+}
+
+func parsePRAuthorMode(raw string) (prAuthorMode, error) {
+	switch strings.TrimSpace(strings.ToLower(raw)) {
+	case "", string(prAuthorModeAuto):
+		return prAuthorModeAuto, nil
+	case string(prAuthorModeUser):
+		return prAuthorModeUser, nil
+	case string(prAuthorModeApp):
+		return prAuthorModeApp, nil
+	default:
+		return "", fmt.Errorf("invalid author mode %q", raw)
+	}
+}
+
+func shouldPromptForPRAuth(mode prAuthorMode, policy models.PRAuthorship) bool {
+	if mode == prAuthorModeApp || policy == models.PRAuthorshipAppOnly {
+		return false
+	}
+	if mode == prAuthorModeUser {
+		return true
+	}
+	return policy == models.PRAuthorshipUserPreferred || policy == models.PRAuthorshipUserRequired
+}
+
+func signPRAuthResumeToken(key []byte, claims prAuthResumeClaims) (string, error) {
+	if len(key) == 0 {
+		return "", errors.New("missing signing key")
+	}
+	raw, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	payload := base64.RawURLEncoding.EncodeToString(raw)
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(payload))
+	return payload + "." + hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func parsePRAuthResumeToken(key []byte, token string, now time.Time) (prAuthResumeClaims, error) {
+	var claims prAuthResumeClaims
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return claims, errors.New("invalid token format")
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write([]byte(parts[0]))
+	expectedSig := hex.EncodeToString(mac.Sum(nil))
+	if !hmac.Equal([]byte(expectedSig), []byte(parts[1])) {
+		return claims, errors.New("invalid token signature")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return claims, fmt.Errorf("decode payload: %w", err)
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return claims, fmt.Errorf("decode claims: %w", err)
+	}
+	if claims.ExpiresAt == 0 {
+		return claims, errors.New("token missing expiry")
+	}
+	if now.After(time.Unix(claims.ExpiresAt, 0).Add(prAuthResumeTokenSkewWindow)) {
+		return claims, errors.New("token expired")
+	}
+	return claims, nil
+}
+
+func clearCookie(w http.ResponseWriter, r *http.Request, name string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   isSecureRequest(r),
+	})
+}
+
+func isSecureRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	return strings.EqualFold(r.URL.Scheme, "https") || r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+}

--- a/internal/api/handlers/pr_auth_flow_test.go
+++ b/internal/api/handlers/pr_auth_flow_test.go
@@ -1,0 +1,127 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestParsePRAuthorMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		expected  prAuthorMode
+		expectErr bool
+	}{
+		{name: "empty defaults to auto", raw: "", expected: prAuthorModeAuto},
+		{name: "user", raw: "user", expected: prAuthorModeUser},
+		{name: "app", raw: " app ", expected: prAuthorModeApp},
+		{name: "invalid", raw: "bogus", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parsePRAuthorMode(tt.raw)
+			if tt.expectErr {
+				require.Error(t, err, "parsePRAuthorMode should reject invalid values")
+				return
+			}
+			require.NoError(t, err, "parsePRAuthorMode should accept valid values")
+			require.Equal(t, tt.expected, got, "parsePRAuthorMode should normalize the expected mode")
+		})
+	}
+}
+
+func TestShouldPromptForPRAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		mode     prAuthorMode
+		policy   models.PRAuthorship
+		expected bool
+	}{
+		{name: "app mode never prompts", mode: prAuthorModeApp, policy: models.PRAuthorshipUserRequired, expected: false},
+		{name: "app only policy never prompts", mode: prAuthorModeAuto, policy: models.PRAuthorshipAppOnly, expected: false},
+		{name: "explicit user prompts when org allows user auth", mode: prAuthorModeUser, policy: models.PRAuthorshipUserRequired, expected: true},
+		{name: "auto prompts for preferred", mode: prAuthorModeAuto, policy: models.PRAuthorshipUserPreferred, expected: true},
+		{name: "auto prompts for required", mode: prAuthorModeAuto, policy: models.PRAuthorshipUserRequired, expected: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, shouldPromptForPRAuth(tt.mode, tt.policy), "shouldPromptForPRAuth should respect author mode and org policy")
+		})
+	}
+}
+
+func TestPRAuthResumeTokenRoundTripAndFailures(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	claims := prAuthResumeClaims{
+		SessionID:  uuid.New(),
+		UserID:     uuid.New(),
+		OrgID:      uuid.New(),
+		AuthorMode: string(prAuthorModeUser),
+		ExpiresAt:  now.Add(time.Minute).Unix(),
+	}
+
+	token, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), claims)
+	require.NoError(t, err, "signPRAuthResumeToken should sign valid claims")
+
+	parsed, err := parsePRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), token, now)
+	require.NoError(t, err, "parsePRAuthResumeToken should accept a valid token")
+	require.Equal(t, claims.SessionID, parsed.SessionID, "parsed token should preserve the session id")
+
+	_, err = signPRAuthResumeToken(nil, claims)
+	require.Error(t, err, "signPRAuthResumeToken should reject missing signing keys")
+
+	_, err = parsePRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), "invalid", now)
+	require.Error(t, err, "parsePRAuthResumeToken should reject malformed tokens")
+
+	_, err = parsePRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), token+"x", now)
+	require.Error(t, err, "parsePRAuthResumeToken should reject bad signatures")
+
+	expiredToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  uuid.New(),
+		UserID:     uuid.New(),
+		OrgID:      uuid.New(),
+		AuthorMode: string(prAuthorModeUser),
+		ExpiresAt:  now.Add(-time.Hour).Unix(),
+	})
+	require.NoError(t, err, "signPRAuthResumeToken should sign expired claims for parse-time validation")
+
+	_, err = parsePRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), expiredToken, now)
+	require.Error(t, err, "parsePRAuthResumeToken should reject expired tokens")
+}
+
+func TestClearCookieAndIsSecureRequest(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "https://app.143.dev/callback", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := httptest.NewRecorder()
+
+	clearCookie(rr, req, "github_pr_resume_state")
+
+	result := rr.Result()
+	require.True(t, isSecureRequest(req), "isSecureRequest should treat https and forwarded https requests as secure")
+	require.Len(t, result.Cookies(), 1, "clearCookie should emit one clearing cookie")
+	require.Equal(t, -1, result.Cookies()[0].MaxAge, "clearCookie should expire the cookie immediately")
+	require.True(t, result.Cookies()[0].Secure, "clearCookie should preserve secure semantics for secure requests")
+
+	require.False(t, isSecureRequest(nil), "isSecureRequest should treat nil requests as insecure")
+}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -45,11 +45,17 @@ type SessionHandler struct {
 	messageStore     *db.SessionMessageStore
 	threadStore      *db.SessionThreadStore
 	viewStore        *db.SessionViewStore
+	prCredentials    githubStatusCredentialStore
+	prAuthChecker    interface {
+		HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
+	}
 	snapshotStore    storage.SnapshotStore // optional — enables snapshot cleanup on archive
 	llmClient        llm.Client            // optional, used for generating manual session titles
 	logger           zerolog.Logger
 	audit            *db.AuditEmitter
 	canceller        SessionCanceller // optional — enables cancelling running sessions
+	prAuthSigningKey []byte
+	frontendURL      string
 	// shutdownCh is closed on SIGTERM; see SetShutdownSignal.
 	shutdownCh <-chan struct{}
 }
@@ -82,6 +88,27 @@ func (h *SessionHandler) SetShutdownSignal(ch <-chan struct{}) {
 // succeeds but leaves the snapshot to be reclaimed by the TTL reaper.
 func (h *SessionHandler) SetSnapshotStore(s storage.SnapshotStore) {
 	h.snapshotStore = s
+}
+
+// SetPRCredentialStore injects the personal GitHub credential store used to
+// decide whether CreatePR should intercept for authorship authorization.
+func (h *SessionHandler) SetPRCredentialStore(store githubStatusCredentialStore) {
+	h.prCredentials = store
+}
+
+// SetPRAuthCredentialChecker injects the refresh-aware GitHub user-auth checker
+// used to determine whether Create PR should intercept for authorization.
+func (h *SessionHandler) SetPRAuthCredentialChecker(checker interface {
+	HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
+}) {
+	h.prAuthChecker = checker
+}
+
+// SetPRAuthFlow wires the signing key and frontend URL used by the on-demand
+// Create PR GitHub-auth flow.
+func (h *SessionHandler) SetPRAuthFlow(signingKey, frontendURL string) {
+	h.prAuthSigningKey = []byte(signingKey)
+	h.frontendURL = frontendURL
 }
 
 func NewSessionHandler(
@@ -771,9 +798,11 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse optional request body for per-PR overrides (e.g. draft).
+	// Parse optional request body for per-PR overrides and authorship flow.
 	var req struct {
-		Draft *bool `json:"draft,omitempty"`
+		Draft       *bool  `json:"draft,omitempty"`
+		AuthorMode  string `json:"author_mode,omitempty"`
+		ResumeToken string `json:"resume_token,omitempty"`
 	}
 	if r.Body != nil && r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
@@ -781,13 +810,104 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	authorMode, err := parsePRAuthorMode(req.AuthorMode)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body", err)
+		return
+	}
 
+	orgSettings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	if h.orgStore != nil {
+		if org, orgErr := h.orgStore.GetByID(r.Context(), orgID); orgErr == nil {
+			if parsed, parseErr := models.ParseOrgSettings(org.Settings); parseErr == nil {
+				orgSettings = parsed
+			}
+		}
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if shouldPromptForPRAuth(authorMode, orgSettings.PRAuthorship) &&
+		session.TriggeredByUserID != nil &&
+		user != nil &&
+		user.ID == *session.TriggeredByUserID {
+		if req.ResumeToken != "" {
+			if len(h.prAuthSigningKey) == 0 {
+				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
+				return
+			}
+			claims, tokenErr := parsePRAuthResumeToken(h.prAuthSigningKey, req.ResumeToken, time.Now())
+			if tokenErr != nil || claims.SessionID != sessionID || claims.UserID != user.ID || claims.OrgID != orgID {
+				writeJSON(w, http.StatusConflict, models.ErrorResponse{
+					Error: models.ErrorDetail{
+						Code:    "PR_RESUME_EXPIRED",
+						Message: "GitHub authorization completed, but the PR resume request expired. Please click Create PR again.",
+					},
+				})
+				return
+			}
+		}
+
+		hasCredential := false
+		authUnavailable := h.prAuthChecker == nil
+		if h.prAuthChecker != nil {
+			var checkErr error
+			hasCredential, checkErr = h.prAuthChecker.HasValidCredential(r.Context(), orgID, user.ID)
+			if checkErr != nil {
+				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to verify GitHub PR authorization", checkErr)
+				return
+			}
+		}
+		if authUnavailable && !hasCredential {
+			if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == prAuthorModeUser {
+				writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
+				return
+			}
+			goto enqueuePR
+		}
+		if !hasCredential {
+			if len(h.prAuthSigningKey) == 0 {
+				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
+				return
+			}
+			resumeToken, signErr := signPRAuthResumeToken(h.prAuthSigningKey, prAuthResumeClaims{
+				SessionID:  sessionID,
+				UserID:     user.ID,
+				OrgID:      orgID,
+				Draft:      req.Draft,
+				AuthorMode: string(prAuthorModeUser),
+				ExpiresAt:  time.Now().Add(prAuthResumeTokenTTL).Unix(),
+			})
+			if signErr != nil {
+				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to prepare GitHub PR authorization", signErr)
+				return
+			}
+			writeJSON(w, http.StatusConflict, models.ErrorResponse{
+				Error: models.ErrorDetail{
+					Code:    "GITHUB_PR_AUTHORSHIP_REQUIRED",
+					Message: "Authorize GitHub to create this pull request as you.",
+					Details: map[string]any{
+						"session_id":            sessionID.String(),
+						"connect_url":           "/api/v1/users/me/github/connect?flow=pr_authorship",
+						"resume_token":          resumeToken,
+						"can_fallback_to_app":   orgSettings.PRAuthorship != models.PRAuthorshipUserRequired,
+						"suggested_author_mode": string(prAuthorModeUser),
+					},
+				},
+			})
+			return
+		}
+	}
+
+enqueuePR:
 	payload := map[string]any{
 		"session_id": sessionID.String(),
 		"org_id":     orgID.String(),
 	}
 	if req.Draft != nil {
 		payload["draft"] = *req.Draft
+	}
+	if authorMode != prAuthorModeAuto {
+		payload["author_mode"] = string(authorMode)
 	}
 	dedupeKey := fmt.Sprintf("open_pr:%s", sessionID)
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "open_pr", payload, 5, &dedupeKey); err != nil {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -4020,6 +4020,197 @@ func TestSessionHandler_CreatePR_ReturnsAuthInterceptWhenUserCredentialMissing(t
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionHandler_CreatePR_InvalidAuthorMode(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_InvalidAuthorMode"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			)...),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"bogus"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "CreatePR should reject invalid author modes")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_PRAuthCheckerError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_PRAuthCheckerError"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRAuthCredentialChecker(&stubSessionPRAuthCredentialChecker{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, context.DeadlineExceeded
+		},
+	})
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			)...),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_preferred"}`), now, now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "CreatePR should surface PR auth checker failures")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_ResumeTokenRequiresSigningKey(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_ResumeTokenRequiresSigningKey"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			)...),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_preferred"}`), now, now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto","resume_token":"resume"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "CreatePR should reject resume tokens when signing is not configured")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -24,6 +24,34 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type stubSessionPRCredentialStore struct {
+	cred *models.DecryptedUserCredential
+	err  error
+}
+
+func (s *stubSessionPRCredentialStore) GetForUser(_ context.Context, _, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedUserCredential, error) {
+	return s.cred, s.err
+}
+
+type stubSessionPRAuthCredentialChecker struct {
+	hasValidCredentialFunc func(context.Context, uuid.UUID, uuid.UUID) (bool, error)
+}
+
+func (s *stubSessionPRAuthCredentialChecker) HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error) {
+	if s.hasValidCredentialFunc != nil {
+		return s.hasValidCredentialFunc(ctx, orgID, userID)
+	}
+	return false, nil
+}
+
+func (s *stubSessionPRCredentialStore) Upsert(_ context.Context, _, _ uuid.UUID, _ models.ProviderConfig, _ bool) error {
+	return nil
+}
+
+func (s *stubSessionPRCredentialStore) Disable(_ context.Context, _, _ uuid.UUID, _ models.ProviderName) error {
+	return nil
+}
+
 type archiveTestSnapshotStore struct {
 	deleted []string
 	err     error
@@ -3910,6 +3938,452 @@ func TestSessionHandler_CreatePR_DedupeConflict(t *testing.T) {
 
 	require.Equal(t, http.StatusAccepted, w.Code, "dedupe conflict should be a success — the existing job satisfies the request")
 	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should still indicate queued status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_ReturnsAuthInterceptWhenUserCredentialMissing(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_ReturnsAuthInterceptWhenUserCredentialMissing"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRCredentialStore(&stubSessionPRCredentialStore{err: pgx.ErrNoRows})
+	handler.SetPRAuthCredentialChecker(&stubSessionPRAuthCredentialChecker{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, nil
+		},
+	})
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_preferred"}`), now, now))
+
+	body := strings.NewReader(`{"author_mode":"auto"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", body)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "missing user credential should trigger PR authorship auth intercept")
+	var resp models.ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response should decode")
+	require.Equal(t, "GITHUB_PR_AUTHORSHIP_REQUIRED", resp.Error.Code, "response should carry auth-required code")
+	details, ok := resp.Error.Details.(map[string]any)
+	require.True(t, ok, "error details should be present")
+	require.Equal(t, sessionID.String(), details["session_id"], "details should name the session being resumed")
+	require.NotEmpty(t, details["resume_token"], "details should include a resume token")
+	require.Equal(t, true, details["can_fallback_to_app"], "user_preferred should allow app fallback")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	jobID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRCredentialStore(&stubSessionPRCredentialStore{err: pgx.ErrNoRows})
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	body := strings.NewReader(`{"author_mode":"app"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", body)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "explicit app author mode should enqueue PR creation without auth intercept")
+	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should indicate job was queued")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_InvalidStoredCredentialTriggersAuthIntercept(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_InvalidStoredCredentialTriggersAuthIntercept"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRCredentialStore(&stubSessionPRCredentialStore{
+		cred: &models.DecryptedUserCredential{
+			Config: models.GitHubAppUserConfig{
+				AccessToken:           "ghu_stale",
+				TokenType:             "bearer",
+				ExpiresAt:             now.Add(-time.Minute),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: now.Add(30 * 24 * time.Hour),
+			},
+		},
+	})
+	handler.SetPRAuthCredentialChecker(&stubSessionPRAuthCredentialChecker{
+		hasValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (bool, error) {
+			return false, nil
+		},
+	})
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_preferred"}`), now, now))
+
+	body := strings.NewReader(`{"author_mode":"auto"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", body)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "stale user credential should trigger reconnect instead of enqueueing PR creation")
+	var resp models.ErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "response should decode")
+	require.Equal(t, "GITHUB_PR_AUTHORSHIP_REQUIRED", resp.Error.Code, "response should request GitHub reauthorization")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_UserPreferredWithoutGitHubAppUserAuthFallsBackToApp(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_UserPreferredWithoutGitHubAppUserAuthFallsBackToApp"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	jobID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_preferred"}`), now, now))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "user_preferred should fall back to app auth when GitHub App user auth is unavailable")
+	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should enqueue PR creation")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_UserRequiredWithoutGitHubAppUserAuthFailsFast(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_UserRequiredWithoutGitHubAppUserAuthFailsFast"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_required"}`), now, now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "user_required should fail fast when GitHub App user auth is unavailable")
+	require.Contains(t, w.Body.String(), "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "response should explain the missing GitHub App user auth configuration")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_CreatePR_UserRequiredWithoutCheckerIgnoresStoredGitHubAppUserCredential(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	snapshotKey := "snap-TestSessionHandler_CreatePR_UserRequiredWithoutCheckerIgnoresStoredGitHubAppUserCredential"
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetPRCredentialStore(&stubSessionPRCredentialStore{
+		cred: &models.DecryptedUserCredential{
+			Config: models.GitHubAppUserConfig{
+				AccessToken:           "ghu_present_but_unusable",
+				TokenType:             "bearer",
+				ExpiresAt:             now.Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: now.Add(30 * 24 * time.Hour),
+			},
+		},
+	})
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length", "https://app.143.dev")
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).AddRow(
+				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				&userID,
+				nil, 0, now, "none", &snapshotKey,
+				nil, nil, nil, nil, nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle", (*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
+			"title", "body", "status", "review_status", "authored_by", "ci_status", "merged_at", "created_at", "updated_at",
+		}))
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "name", "settings", "created_at", "updated_at"}).
+			AddRow(orgID, "Acme", json.RawMessage(`{"pr_authorship":"user_required"}`), now, now))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto"}`))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.CreatePR(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "user_required should fail fast even if a stored github_app_user row exists when the resolver is unwired")
+	require.Contains(t, w.Body.String(), "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "response should explain the missing GitHub App user auth configuration")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -3966,7 +3966,7 @@ func TestSessionHandler_CreatePR_ReturnsAuthInterceptWhenUserCredentialMissing(t
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -3983,7 +3983,7 @@ func TestSessionHandler_CreatePR_ReturnsAuthInterceptWhenUserCredentialMissing(t
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4041,7 +4041,7 @@ func TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept(t *testing.T
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -4058,7 +4058,7 @@ func TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept(t *testing.T
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4125,7 +4125,7 @@ func TestSessionHandler_CreatePR_InvalidStoredCredentialTriggersAuthIntercept(t 
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -4142,7 +4142,7 @@ func TestSessionHandler_CreatePR_InvalidStoredCredentialTriggersAuthIntercept(t 
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4194,7 +4194,7 @@ func TestSessionHandler_CreatePR_UserPreferredWithoutGitHubAppUserAuthFallsBackT
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -4211,7 +4211,7 @@ func TestSessionHandler_CreatePR_UserPreferredWithoutGitHubAppUserAuthFallsBackT
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4265,7 +4265,7 @@ func TestSessionHandler_CreatePR_UserRequiredWithoutGitHubAppUserAuthFailsFast(t
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -4282,7 +4282,7 @@ func TestSessionHandler_CreatePR_UserRequiredWithoutGitHubAppUserAuthFailsFast(t
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4341,7 +4341,7 @@ func TestSessionHandler_CreatePR_UserRequiredWithoutCheckerIgnoresStoredGitHubAp
 	mock.ExpectQuery("SELECT .+ FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(sessionColumns).AddRow(
+			pgxmock.NewRows(sessionColumns).AddRow(sessionTestRow(
 				sessionID, issueID, orgID, "claude_code", "completed", "semi", "low",
 				nil, nil, nil, nil,
 				nil, false, &now, &now, nil,
@@ -4358,7 +4358,7 @@ func TestSessionHandler_CreatePR_UserRequiredWithoutCheckerIgnoresStoredGitHubAp
 				"idle", (*string)(nil),
 				nil,
 				now,
-			),
+			)...),
 		)
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -94,6 +94,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 
 	// Create PRService if GitHub App credentials are configured.
 	var prService *ghservice.PRService
+	var appUserAuthSvc *ghservice.AppUserAuthService
 	if cfg.GitHubAppID != 0 && cfg.GitHubAppPrivateKey != "" {
 		ghSvc, err := ghservice.NewService(cfg.GitHubAppID, cfg.GitHubAppPrivateKey)
 		if err != nil {
@@ -107,6 +108,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			prService.SetIntegrationStore(integrationStore)
 			prService.SetSandboxPushDeps(sandboxProvider, snapshotStore)
 		}
+	}
+	if cfg.GitHubAppClientID != "" && cfg.GitHubAppClientSecret != "" {
+		appUserAuthSvc = ghservice.NewAppUserAuthService(userCredentialStore, cfg.GitHubAppClientID, cfg.GitHubAppClientSecret, cfg.BaseURL, logger)
 	}
 
 	// Create handlers
@@ -169,6 +173,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionHandler.SetViewStore(sessionViewStore)
 	sessionHandler.SetShutdownSignal(shutdownCh)
 	sessionHandler.SetSnapshotStore(snapshotStore)
+	sessionHandler.SetPRCredentialStore(userCredentialStore)
+	sessionHandler.SetPRAuthCredentialChecker(appUserAuthSvc)
+	sessionHandler.SetPRAuthFlow(cfg.CSRFSigningKey, cfg.FrontendURL)
 	threadSvc := threadservice.NewService(
 		sessionThreadStore,
 		sessionStore,
@@ -219,13 +226,16 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	prTemplateStore := db.NewPRTemplateStore(pool)
 	githubStatusHandler := handlers.NewGitHubStatusHandler(
 		userCredentialStore, orgStore,
-		cfg.GitHubOAuthClientID, cfg.GitHubOAuthClientSecret,
+		cfg.GitHubAppClientID, cfg.GitHubAppClientSecret,
 		cfg.BaseURL, cfg.FrontendURL,
 	)
+	githubStatusHandler.SetPRAuthFlow(cfg.CSRFSigningKey)
+	githubStatusHandler.SetAppUserAuth(appUserAuthSvc)
 
 	// Wire user credential store and LLM client into PR service.
 	if prService != nil {
 		prService.SetUserCredentialStore(userCredentialStore)
+		prService.SetAppUserAuth(appUserAuthSvc)
 		prService.SetUserStore(userStore)
 		prService.SetOrgStore(orgStore)
 		prService.SetLLMClient(llmClient)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,10 +74,12 @@ type Config struct {
 	SlackSummaryModel      string `env:"SLACK_SUMMARY_MODEL" envDefault:"gpt-5.4-nano"`
 
 	// GitHub App
-	GitHubAppID         int64  `env:"GITHUB_APP_ID"`
-	GitHubAppPrivateKey string `env:"GITHUB_APP_PRIVATE_KEY"`
-	GitHubWebhookSecret string `env:"GITHUB_WEBHOOK_SECRET"`
-	GitHubAppSlug       string `env:"GITHUB_APP_SLUG"`
+	GitHubAppID           int64  `env:"GITHUB_APP_ID"`
+	GitHubAppClientID     string `env:"GITHUB_APP_CLIENT_ID"`
+	GitHubAppClientSecret string `env:"GITHUB_APP_CLIENT_SECRET"`
+	GitHubAppPrivateKey   string `env:"GITHUB_APP_PRIVATE_KEY"`
+	GitHubWebhookSecret   string `env:"GITHUB_WEBHOOK_SECRET"`
+	GitHubAppSlug         string `env:"GITHUB_APP_SLUG"`
 
 	// CSRF
 	CSRFSigningKey string `env:"CSRF_SIGNING_KEY"`
@@ -335,6 +337,7 @@ func (c *Config) LogStatus(logger zerolog.Logger) {
 		{"Sentry OAuth", c.SentryOAuthClientID != "" && c.SentryOAuthClientSecret != "", "integration auth"},
 		{"Backend Sentry", c.SentryDSN != "", "automatic API 5xx + panic reporting"},
 		{"GitHub App", c.GitHubAppEnabled(), "webhooks, PRs"},
+		{"GitHub App User Auth", c.GitHubAppClientID != "" && c.GitHubAppClientSecret != "", "user-authored PRs"},
 		{"Credential encryption", c.EncryptionMasterKey != "", "encrypted credential storage"},
 	}
 

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -19,6 +19,7 @@ const (
 	ProviderOpenAIChatGPT ProviderName = "openai_chatgpt"
 	ProviderOpenRouter    ProviderName = "openrouter"
 	ProviderGitHubApp     ProviderName = "github_app"
+	ProviderGitHubAppUser ProviderName = "github_app_user"
 	ProviderGitHubOAuth   ProviderName = "github_oauth"
 	ProviderSentry        ProviderName = "sentry"
 	ProviderLinear        ProviderName = "linear"
@@ -29,7 +30,7 @@ const (
 // AllProviders is the canonical list of credential providers.
 var AllProviders = []ProviderName{
 	ProviderAnthropic, ProviderOpenAI, ProviderGemini, ProviderOpenAIChatGPT, ProviderOpenRouter,
-	ProviderGitHubApp, ProviderGitHubOAuth,
+	ProviderGitHubApp, ProviderGitHubAppUser, ProviderGitHubOAuth,
 	ProviderSentry, ProviderLinear, ProviderSlack, ProviderNotion,
 }
 
@@ -161,6 +162,14 @@ type GitHubOAuthConfig struct {
 	Scope        string `json:"scope,omitempty"`
 }
 
+type GitHubAppUserConfig struct {
+	AccessToken           string    `json:"access_token"`  // #nosec G117 -- JSON config field
+	RefreshToken          string    `json:"refresh_token"` // #nosec G117 -- JSON config field
+	TokenType             string    `json:"token_type,omitempty"`
+	ExpiresAt             time.Time `json:"expires_at"`
+	RefreshTokenExpiresAt time.Time `json:"refresh_token_expires_at"`
+}
+
 type SentryConfig struct {
 	WebhookSecret string `json:"webhook_secret,omitempty"`
 	AccessToken   string `json:"access_token,omitempty"`  // #nosec G117 -- JSON config field
@@ -218,6 +227,27 @@ func (c OpenAIChatGPTConfig) NeedsRefresh(window time.Duration) bool {
 	return time.Now().Add(window).After(c.ExpiresAt)
 }
 
+// IsExpired returns true if the access token has expired.
+func (c GitHubAppUserConfig) IsExpired() bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().After(c.ExpiresAt)
+}
+
+// NeedsRefresh returns true if the access token will expire within the given window.
+func (c GitHubAppUserConfig) NeedsRefresh(window time.Duration) bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(window).After(c.ExpiresAt)
+}
+
+// RefreshTokenExpired returns true if the refresh token is expired.
+func (c GitHubAppUserConfig) RefreshTokenExpired() bool {
+	return !c.RefreshTokenExpiresAt.IsZero() && time.Now().After(c.RefreshTokenExpiresAt)
+}
+
 // --- Provider() implementations ---
 
 func (c AnthropicConfig) Provider() ProviderName     { return ProviderAnthropic }
@@ -225,6 +255,7 @@ func (c OpenAIConfig) Provider() ProviderName        { return ProviderOpenAI }
 func (c GeminiConfig) Provider() ProviderName        { return ProviderGemini }
 func (c OpenRouterConfig) Provider() ProviderName    { return ProviderOpenRouter }
 func (c GitHubAppConfig) Provider() ProviderName     { return ProviderGitHubApp }
+func (c GitHubAppUserConfig) Provider() ProviderName { return ProviderGitHubAppUser }
 func (c GitHubOAuthConfig) Provider() ProviderName   { return ProviderGitHubOAuth }
 func (c SentryConfig) Provider() ProviderName        { return ProviderSentry }
 func (c LinearConfig) Provider() ProviderName        { return ProviderLinear }
@@ -303,6 +334,13 @@ func (c GitHubOAuthConfig) Validate() error {
 	}
 	if c.ClientSecret == "" {
 		return errors.New("client_secret is required")
+	}
+	return nil
+}
+
+func (c GitHubAppUserConfig) Validate() error {
+	if c.AccessToken == "" {
+		return errors.New("access_token is required")
 	}
 	return nil
 }
@@ -399,6 +437,14 @@ func (c GitHubAppConfig) MaskedSummary() CredentialSummary {
 	}
 }
 
+func (c GitHubAppUserConfig) MaskedSummary() CredentialSummary {
+	return CredentialSummary{
+		Provider:   ProviderGitHubAppUser,
+		Configured: true,
+		MaskedKey:  MaskKey(c.AccessToken),
+	}
+}
+
 func (c GitHubOAuthConfig) MaskedSummary() CredentialSummary {
 	return CredentialSummary{
 		Provider:   ProviderGitHubOAuth,
@@ -481,6 +527,12 @@ func ParseProviderConfig(provider ProviderName, data []byte) (ProviderConfig, er
 		var cfg GitHubAppConfig
 		if err := json.Unmarshal(data, &cfg); err != nil {
 			return nil, fmt.Errorf("invalid github_app config: %w", err)
+		}
+		return cfg, nil
+	case ProviderGitHubAppUser:
+		var cfg GitHubAppUserConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("invalid github_app_user config: %w", err)
 		}
 		return cfg, nil
 	case ProviderGitHubOAuth:

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -20,6 +20,7 @@ func TestProviderName_Valid(t *testing.T) {
 		{"gemini is valid", ProviderGemini, true},
 		{"openrouter is valid", ProviderOpenRouter, true},
 		{"github_app is valid", ProviderGitHubApp, true},
+		{"github_app_user is valid", ProviderGitHubAppUser, true},
 		{"github_oauth is valid", ProviderGitHubOAuth, true},
 		{"sentry is valid", ProviderSentry, true},
 		{"linear is valid", ProviderLinear, true},
@@ -185,6 +186,22 @@ func TestParseProviderConfig_GitHubOAuth(t *testing.T) {
 	require.Equal(t, "secret_test", ghoc.ClientSecret, "should parse client_secret")
 }
 
+func TestParseProviderConfig_GitHubAppUser(t *testing.T) {
+	t.Parallel()
+
+	input := `{"access_token":"ghu_test","refresh_token":"ghr_test","token_type":"bearer","expires_at":"2026-04-22T12:00:00Z","refresh_token_expires_at":"2026-05-22T12:00:00Z"}`
+	cfg, err := ParseProviderConfig(ProviderGitHubAppUser, []byte(input))
+	require.NoError(t, err, "ParseProviderConfig should not return an error")
+
+	ghuc, ok := cfg.(GitHubAppUserConfig)
+	require.True(t, ok, "config should be GitHubAppUserConfig")
+	require.Equal(t, "ghu_test", ghuc.AccessToken, "should parse access_token")
+	require.Equal(t, "ghr_test", ghuc.RefreshToken, "should parse refresh_token")
+	require.Equal(t, "bearer", ghuc.TokenType, "should parse token_type")
+	require.Equal(t, time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC), ghuc.ExpiresAt, "should parse expires_at")
+	require.Equal(t, time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC), ghuc.RefreshTokenExpiresAt, "should parse refresh_token_expires_at")
+}
+
 func TestParseProviderConfig_Sentry(t *testing.T) {
 	t.Parallel()
 
@@ -230,6 +247,7 @@ func TestProviderConfig_Provider(t *testing.T) {
 		{"GeminiConfig", GeminiConfig{}, ProviderGemini},
 		{"OpenRouterConfig", OpenRouterConfig{}, ProviderOpenRouter},
 		{"GitHubAppConfig", GitHubAppConfig{}, ProviderGitHubApp},
+		{"GitHubAppUserConfig", GitHubAppUserConfig{}, ProviderGitHubAppUser},
 		{"GitHubOAuthConfig", GitHubOAuthConfig{}, ProviderGitHubOAuth},
 		{"SentryConfig", SentryConfig{}, ProviderSentry},
 		{"LinearConfig", LinearConfig{}, ProviderLinear},
@@ -268,6 +286,11 @@ func TestProviderConfig_Validate(t *testing.T) {
 		{"github_app valid", GitHubAppConfig{AppID: 123, PrivateKey: "key"}, false},
 		{"github_app missing app_id", GitHubAppConfig{AppID: 0, PrivateKey: "key"}, true},
 		{"github_app missing private_key", GitHubAppConfig{AppID: 123, PrivateKey: ""}, true},
+		{"github_app_user valid", GitHubAppUserConfig{AccessToken: "ghu", RefreshToken: "ghr", ExpiresAt: time.Now().Add(time.Hour)}, false},
+		{"github_app_user valid non-expiring", GitHubAppUserConfig{AccessToken: "ghu"}, false},
+		{"github_app_user missing access token", GitHubAppUserConfig{RefreshToken: "ghr", ExpiresAt: time.Now().Add(time.Hour)}, true},
+		{"github_app_user missing refresh token", GitHubAppUserConfig{AccessToken: "ghu", ExpiresAt: time.Now().Add(time.Hour)}, false},
+		{"github_app_user missing expires_at", GitHubAppUserConfig{AccessToken: "ghu", RefreshToken: "ghr"}, false},
 		{"github_oauth valid client creds", GitHubOAuthConfig{ClientID: "id", ClientSecret: "secret"}, false},
 		{"github_oauth valid access token", GitHubOAuthConfig{AccessToken: "gh-token"}, false},
 		{"github_oauth missing client_id", GitHubOAuthConfig{ClientID: "", ClientSecret: "secret"}, true},

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -322,6 +322,37 @@ func TestProviderConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestGitHubAppUserConfig_TimeHelpersAndSummary(t *testing.T) {
+	t.Parallel()
+
+	expired := GitHubAppUserConfig{
+		AccessToken:           "ghu_expired_token",
+		ExpiresAt:             time.Now().Add(-time.Minute),
+		RefreshTokenExpiresAt: time.Now().Add(-time.Minute),
+	}
+	require.True(t, expired.IsExpired(), "IsExpired should report expired access tokens")
+	require.True(t, expired.NeedsRefresh(time.Minute), "NeedsRefresh should report near-expiry access tokens")
+	require.True(t, expired.RefreshTokenExpired(), "RefreshTokenExpired should report expired refresh tokens")
+
+	nonExpiring := GitHubAppUserConfig{AccessToken: "ghu_nonexpiring"}
+	require.False(t, nonExpiring.IsExpired(), "IsExpired should treat zero expiries as non-expiring")
+	require.False(t, nonExpiring.NeedsRefresh(time.Hour), "NeedsRefresh should not refresh zero expiries")
+	require.False(t, nonExpiring.RefreshTokenExpired(), "RefreshTokenExpired should treat zero refresh expiries as active")
+
+	summary := expired.MaskedSummary()
+	require.Equal(t, ProviderGitHubAppUser, summary.Provider, "MaskedSummary should tag GitHub App user credentials correctly")
+	require.True(t, summary.Configured, "MaskedSummary should mark the credential configured")
+	require.NotEmpty(t, summary.MaskedKey, "MaskedSummary should mask the access token")
+}
+
+func TestParseProviderConfig_GitHubAppUser_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseProviderConfig(ProviderGitHubAppUser, []byte(`{`))
+	require.Error(t, err, "ParseProviderConfig should reject malformed GitHub App user config JSON")
+	require.Contains(t, err.Error(), "invalid github_app_user config", "ParseProviderConfig should preserve provider context for malformed GitHub App user config")
+}
+
 func TestMaskKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/app_user_auth.go
+++ b/internal/services/github/app_user_auth.go
@@ -1,0 +1,258 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+const (
+	defaultGitHubOAuthBaseURL  = "https://github.com"
+	githubAppUserRefreshWindow = 5 * time.Minute
+)
+
+var (
+	ErrGitHubAppUserCredentialMissing = errors.New("github app user credential missing")
+	ErrGitHubAppUserAuthorizationLost = errors.New("github app user authorization lost")
+)
+
+type appUserCredentialStore interface {
+	GetForUser(ctx context.Context, orgID, userID uuid.UUID, provider models.ProviderName) (*models.DecryptedUserCredential, error)
+	Upsert(ctx context.Context, userID, orgID uuid.UUID, cfg models.ProviderConfig, isTeamDefault bool) error
+	Disable(ctx context.Context, orgID, userID uuid.UUID, provider models.ProviderName) error
+}
+
+type AppUserAuthService struct {
+	credentials   appUserCredentialStore
+	clientID      string
+	clientSecret  string
+	redirectURI   string
+	oauthBaseURL  string
+	apiBaseURL    string
+	httpClient    *http.Client
+	logger        zerolog.Logger
+	now           func() time.Time
+	refreshWindow time.Duration
+}
+
+func NewAppUserAuthService(credentials *db.UserCredentialStore, clientID, clientSecret, baseURL string, logger zerolog.Logger) *AppUserAuthService {
+	return &AppUserAuthService{
+		credentials:   credentials,
+		clientID:      clientID,
+		clientSecret:  clientSecret,
+		redirectURI:   strings.TrimRight(baseURL, "/") + "/api/v1/users/me/github/callback",
+		oauthBaseURL:  defaultGitHubOAuthBaseURL,
+		apiBaseURL:    defaultGitHubAPI,
+		httpClient:    &http.Client{Timeout: 15 * time.Second},
+		logger:        logger,
+		now:           time.Now,
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+}
+
+func (s *AppUserAuthService) SetOAuthBaseURL(baseURL string) {
+	s.oauthBaseURL = strings.TrimRight(baseURL, "/")
+}
+
+func (s *AppUserAuthService) SetAPIBaseURL(baseURL string) {
+	s.apiBaseURL = strings.TrimRight(baseURL, "/")
+}
+
+func (s *AppUserAuthService) ExchangeCode(ctx context.Context, code string) (*models.GitHubAppUserConfig, error) {
+	values := url.Values{
+		"client_id":     {s.clientID},
+		"client_secret": {s.clientSecret},
+		"code":          {code},
+	}
+	if s.redirectURI != "" {
+		values.Set("redirect_uri", s.redirectURI)
+	}
+	return s.exchangeToken(ctx, values)
+}
+
+func (s *AppUserAuthService) HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error) {
+	_, err := s.GetValidCredential(ctx, orgID, userID)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrGitHubAppUserCredentialMissing) {
+		return false, nil
+	}
+	return false, err
+}
+
+func (s *AppUserAuthService) GetValidCredential(ctx context.Context, orgID, userID uuid.UUID) (*models.GitHubAppUserConfig, error) {
+	if s.credentials == nil {
+		return nil, ErrGitHubAppUserCredentialMissing
+	}
+	cred, err := s.credentials.GetForUser(ctx, orgID, userID, models.ProviderGitHubAppUser)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrGitHubAppUserCredentialMissing
+		}
+		return nil, fmt.Errorf("get github app user credential: %w", err)
+	}
+	cfg, ok := cred.Config.(models.GitHubAppUserConfig)
+	if !ok {
+		return nil, fmt.Errorf("unexpected github app user credential config type %T", cred.Config)
+	}
+
+	refreshed := false
+	if cfg.NeedsRefresh(s.refreshWindow) {
+		var refreshErr error
+		cfg, refreshErr = s.refreshStoredCredential(ctx, orgID, userID, cfg)
+		if refreshErr != nil {
+			return nil, refreshErr
+		}
+		refreshed = true
+	}
+
+	valid, err := s.validateAccessToken(ctx, cfg.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	if valid {
+		return &cfg, nil
+	}
+	if !refreshed {
+		cfg, err = s.refreshStoredCredential(ctx, orgID, userID, cfg)
+		if err != nil {
+			return nil, err
+		}
+		valid, err = s.validateAccessToken(ctx, cfg.AccessToken)
+		if err != nil {
+			return nil, err
+		}
+		if valid {
+			return &cfg, nil
+		}
+	}
+	if disableErr := s.credentials.Disable(ctx, orgID, userID, models.ProviderGitHubAppUser); disableErr != nil {
+		s.logger.Warn().Err(disableErr).Str("org_id", orgID.String()).Str("user_id", userID.String()).Msg("failed to disable invalid github app user credential")
+	}
+	return nil, ErrGitHubAppUserCredentialMissing
+}
+
+func (s *AppUserAuthService) refreshStoredCredential(ctx context.Context, orgID, userID uuid.UUID, cfg models.GitHubAppUserConfig) (models.GitHubAppUserConfig, error) {
+	if cfg.RefreshToken == "" || cfg.RefreshTokenExpired() {
+		if disableErr := s.credentials.Disable(ctx, orgID, userID, models.ProviderGitHubAppUser); disableErr != nil {
+			s.logger.Warn().Err(disableErr).Str("org_id", orgID.String()).Str("user_id", userID.String()).Msg("failed to disable expired github app user credential")
+		}
+		return models.GitHubAppUserConfig{}, ErrGitHubAppUserCredentialMissing
+	}
+	values := url.Values{
+		"client_id":     {s.clientID},
+		"client_secret": {s.clientSecret},
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {cfg.RefreshToken},
+	}
+	refreshed, err := s.exchangeToken(ctx, values)
+	if err != nil {
+		if errors.Is(err, ErrGitHubAppUserAuthorizationLost) {
+			if disableErr := s.credentials.Disable(ctx, orgID, userID, models.ProviderGitHubAppUser); disableErr != nil {
+				s.logger.Warn().Err(disableErr).Str("org_id", orgID.String()).Str("user_id", userID.String()).Msg("failed to disable revoked github app user credential")
+			}
+			return models.GitHubAppUserConfig{}, ErrGitHubAppUserCredentialMissing
+		}
+		return models.GitHubAppUserConfig{}, err
+	}
+	if err := s.credentials.Upsert(ctx, userID, orgID, *refreshed, false); err != nil {
+		return models.GitHubAppUserConfig{}, fmt.Errorf("persist refreshed github app user credential: %w", err)
+	}
+	return *refreshed, nil
+}
+
+func (s *AppUserAuthService) exchangeToken(ctx context.Context, values url.Values) (*models.GitHubAppUserConfig, error) {
+	if s.clientID == "" || s.clientSecret == "" {
+		return nil, errors.New("github app user auth is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.oauthBaseURL+"/login/oauth/access_token", strings.NewReader(values.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("build token exchange request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request github app user token: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read github app user token response: %w", err)
+	}
+
+	var parsed struct {
+		AccessToken           string `json:"access_token"`
+		TokenType             string `json:"token_type"`
+		RefreshToken          string `json:"refresh_token"`
+		ExpiresIn             int64  `json:"expires_in"`
+		RefreshTokenExpiresIn int64  `json:"refresh_token_expires_in"`
+		Error                 string `json:"error"`
+		ErrorDescription      string `json:"error_description"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, fmt.Errorf("decode github app user token response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest || parsed.Error != "" {
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusBadRequest {
+			return nil, ErrGitHubAppUserAuthorizationLost
+		}
+		return nil, fmt.Errorf("github app user token exchange failed: %s", strings.TrimSpace(parsed.ErrorDescription))
+	}
+	if parsed.AccessToken == "" {
+		return nil, fmt.Errorf("github app user token response missing access token")
+	}
+
+	now := s.now()
+	cfg := &models.GitHubAppUserConfig{
+		AccessToken:  parsed.AccessToken,
+		RefreshToken: parsed.RefreshToken,
+		TokenType:    parsed.TokenType,
+	}
+	if parsed.ExpiresIn > 0 {
+		cfg.ExpiresAt = now.Add(time.Duration(parsed.ExpiresIn) * time.Second)
+	}
+	if parsed.RefreshTokenExpiresIn > 0 {
+		cfg.RefreshTokenExpiresAt = now.Add(time.Duration(parsed.RefreshTokenExpiresIn) * time.Second)
+	}
+	return cfg, nil
+}
+
+func (s *AppUserAuthService) validateAccessToken(ctx context.Context, token string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.apiBaseURL+"/user", nil)
+	if err != nil {
+		return false, fmt.Errorf("build github user validation request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("request github user validation: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("github user validation failed: %d %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return true, nil
+}

--- a/internal/services/github/app_user_auth_test.go
+++ b/internal/services/github/app_user_auth_test.go
@@ -240,3 +240,256 @@ func TestAppUserAuthService_GetValidCredential_MissingCredential(t *testing.T) {
 	_, err := svc.GetValidCredential(context.Background(), uuid.New(), uuid.New())
 	require.ErrorIs(t, err, ErrGitHubAppUserCredentialMissing, "missing credential should map to ErrGitHubAppUserCredentialMissing")
 }
+
+func TestNewAppUserAuthService_ConfiguresDefaultEndpoints(t *testing.T) {
+	t.Parallel()
+
+	svc := NewAppUserAuthService(nil, "client-id", "client-secret", "https://app.143.dev/", zerolog.Nop())
+	require.Equal(t, "https://app.143.dev/api/v1/users/me/github/callback", svc.redirectURI, "constructor should derive the callback URL from the base URL")
+	require.Equal(t, defaultGitHubOAuthBaseURL, svc.oauthBaseURL, "constructor should default the OAuth base URL")
+	require.Equal(t, defaultGitHubAPI, svc.apiBaseURL, "constructor should default the API base URL")
+
+	svc.SetOAuthBaseURL("https://github.example.com/")
+	svc.SetAPIBaseURL("https://api.github.example.com/")
+	require.Equal(t, "https://github.example.com", svc.oauthBaseURL, "SetOAuthBaseURL should trim trailing slashes")
+	require.Equal(t, "https://api.github.example.com", svc.apiBaseURL, "SetAPIBaseURL should trim trailing slashes")
+}
+
+func TestAppUserAuthService_HasValidCredential_PropagatesUnexpectedErrors(t *testing.T) {
+	t.Parallel()
+
+	svc := &AppUserAuthService{
+		credentials: &stubAppUserCredentialStore{
+			getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+				return nil, context.DeadlineExceeded
+			},
+		},
+		logger:        zerolog.Nop(),
+		now:           time.Now,
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	ok, err := svc.HasValidCredential(context.Background(), uuid.New(), uuid.New())
+	require.False(t, ok, "HasValidCredential should report false when the lookup fails")
+	require.Error(t, err, "HasValidCredential should propagate unexpected store failures")
+}
+
+func TestAppUserAuthService_GetValidCredential_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	tests := []struct {
+		name      string
+		setup     func() *AppUserAuthService
+		expectErr error
+		errSubstr string
+	}{
+		{
+			name: "missing credential store",
+			setup: func() *AppUserAuthService {
+				return &AppUserAuthService{logger: zerolog.Nop(), now: time.Now, refreshWindow: githubAppUserRefreshWindow}
+			},
+			expectErr: ErrGitHubAppUserCredentialMissing,
+		},
+		{
+			name: "unexpected config type",
+			setup: func() *AppUserAuthService {
+				return &AppUserAuthService{
+					credentials: &stubAppUserCredentialStore{
+						getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+							return &models.DecryptedUserCredential{Config: models.GitHubOAuthConfig{AccessToken: "token"}}, nil
+						},
+					},
+					logger:        zerolog.Nop(),
+					now:           time.Now,
+					refreshWindow: githubAppUserRefreshWindow,
+				}
+			},
+			errSubstr: "unexpected github app user credential config type",
+		},
+		{
+			name: "validation request error",
+			setup: func() *AppUserAuthService {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					_, _ = w.Write([]byte("boom"))
+				}))
+				t.Cleanup(server.Close)
+				return &AppUserAuthService{
+					credentials: &stubAppUserCredentialStore{
+						getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+							return &models.DecryptedUserCredential{Config: models.GitHubAppUserConfig{AccessToken: "ghu", ExpiresAt: time.Now().Add(time.Hour)}}, nil
+						},
+					},
+					apiBaseURL:    server.URL,
+					httpClient:    server.Client(),
+					logger:        zerolog.Nop(),
+					now:           time.Now,
+					refreshWindow: githubAppUserRefreshWindow,
+				}
+			},
+			errSubstr: "github user validation failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := tt.setup().GetValidCredential(context.Background(), orgID, userID)
+			if tt.expectErr != nil {
+				require.ErrorIs(t, err, tt.expectErr, "GetValidCredential should return the expected sentinel error")
+				return
+			}
+			require.Error(t, err, "GetValidCredential should fail for this error path")
+			require.Contains(t, err.Error(), tt.errSubstr, "GetValidCredential should include the expected context")
+		})
+	}
+}
+
+func TestAppUserAuthService_RefreshStoredCredential_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	t.Run("missing refresh token disables credential", func(t *testing.T) {
+		t.Parallel()
+		disabled := false
+		svc := &AppUserAuthService{
+			credentials: &stubAppUserCredentialStore{
+				disableFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) error {
+					disabled = true
+					return nil
+				},
+			},
+			logger: zerolog.Nop(),
+		}
+
+		_, err := svc.refreshStoredCredential(context.Background(), orgID, userID, models.GitHubAppUserConfig{})
+		require.ErrorIs(t, err, ErrGitHubAppUserCredentialMissing, "refreshStoredCredential should reject missing refresh tokens")
+		require.True(t, disabled, "refreshStoredCredential should disable unusable stored credentials")
+	})
+
+	t.Run("authorization lost disables credential", func(t *testing.T) {
+		t.Parallel()
+		disabled := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"revoked"}`))
+		}))
+		defer server.Close()
+
+		svc := &AppUserAuthService{
+			credentials: &stubAppUserCredentialStore{
+				disableFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) error {
+					disabled = true
+					return nil
+				},
+			},
+			clientID:      "client-id",
+			clientSecret:  "client-secret",
+			oauthBaseURL:  server.URL,
+			httpClient:    server.Client(),
+			logger:        zerolog.Nop(),
+			now:           time.Now,
+			refreshWindow: githubAppUserRefreshWindow,
+		}
+
+		_, err := svc.refreshStoredCredential(context.Background(), orgID, userID, models.GitHubAppUserConfig{
+			AccessToken:           "ghu",
+			RefreshToken:          "ghr",
+			RefreshTokenExpiresAt: time.Now().Add(time.Hour),
+		})
+		require.ErrorIs(t, err, ErrGitHubAppUserCredentialMissing, "authorization loss should map to missing credential")
+		require.True(t, disabled, "authorization loss should disable the stored credential")
+	})
+
+	t.Run("upsert failure returns error", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"ghu_new","refresh_token":"ghr_new","token_type":"bearer","expires_in":3600}`))
+		}))
+		defer server.Close()
+
+		svc := &AppUserAuthService{
+			credentials: &stubAppUserCredentialStore{
+				upsertFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderConfig, bool) error {
+					return context.DeadlineExceeded
+				},
+			},
+			clientID:      "client-id",
+			clientSecret:  "client-secret",
+			oauthBaseURL:  server.URL,
+			httpClient:    server.Client(),
+			logger:        zerolog.Nop(),
+			now:           time.Now,
+			refreshWindow: githubAppUserRefreshWindow,
+		}
+
+		_, err := svc.refreshStoredCredential(context.Background(), orgID, userID, models.GitHubAppUserConfig{
+			AccessToken:           "ghu",
+			RefreshToken:          "ghr",
+			RefreshTokenExpiresAt: time.Now().Add(time.Hour),
+		})
+		require.Error(t, err, "refreshStoredCredential should return persistence failures")
+		require.Contains(t, err.Error(), "persist refreshed github app user credential", "refreshStoredCredential should include upsert context")
+	})
+}
+
+func TestAppUserAuthService_ExchangeCode_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not configured", func(t *testing.T) {
+		t.Parallel()
+		svc := &AppUserAuthService{}
+		_, err := svc.ExchangeCode(context.Background(), "auth-code")
+		require.Error(t, err, "ExchangeCode should fail when client credentials are missing")
+	})
+
+	t.Run("authorization lost", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"bad_verification_code","error_description":"expired code"}`))
+		}))
+		defer server.Close()
+
+		svc := &AppUserAuthService{
+			clientID:      "client-id",
+			clientSecret:  "client-secret",
+			oauthBaseURL:  server.URL,
+			httpClient:    server.Client(),
+			logger:        zerolog.Nop(),
+			now:           time.Now,
+			refreshWindow: githubAppUserRefreshWindow,
+		}
+		_, err := svc.ExchangeCode(context.Background(), "auth-code")
+		require.ErrorIs(t, err, ErrGitHubAppUserAuthorizationLost, "ExchangeCode should map revoked auth codes to authorization lost")
+	})
+
+	t.Run("missing access token", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"token_type":"bearer"}`))
+		}))
+		defer server.Close()
+
+		svc := &AppUserAuthService{
+			clientID:      "client-id",
+			clientSecret:  "client-secret",
+			oauthBaseURL:  server.URL,
+			httpClient:    server.Client(),
+			logger:        zerolog.Nop(),
+			now:           time.Now,
+			refreshWindow: githubAppUserRefreshWindow,
+		}
+		_, err := svc.ExchangeCode(context.Background(), "auth-code")
+		require.Error(t, err, "ExchangeCode should require an access token in the response")
+		require.Contains(t, err.Error(), "missing access token", "ExchangeCode should surface the malformed response")
+	})
+}

--- a/internal/services/github/app_user_auth_test.go
+++ b/internal/services/github/app_user_auth_test.go
@@ -1,0 +1,242 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type stubAppUserCredentialStore struct {
+	getFunc     func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error)
+	upsertFunc  func(context.Context, uuid.UUID, uuid.UUID, models.ProviderConfig, bool) error
+	disableFunc func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) error
+}
+
+func (s *stubAppUserCredentialStore) GetForUser(ctx context.Context, orgID, userID uuid.UUID, provider models.ProviderName) (*models.DecryptedUserCredential, error) {
+	return s.getFunc(ctx, orgID, userID, provider)
+}
+
+func (s *stubAppUserCredentialStore) Upsert(ctx context.Context, userID, orgID uuid.UUID, cfg models.ProviderConfig, isTeamDefault bool) error {
+	if s.upsertFunc != nil {
+		return s.upsertFunc(ctx, userID, orgID, cfg, isTeamDefault)
+	}
+	return nil
+}
+
+func (s *stubAppUserCredentialStore) Disable(ctx context.Context, orgID, userID uuid.UUID, provider models.ProviderName) error {
+	if s.disableFunc != nil {
+		return s.disableFunc(ctx, orgID, userID, provider)
+	}
+	return nil
+}
+
+func TestAppUserAuthService_ExchangeCode(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/login/oauth/access_token", r.URL.Path, "token exchange should hit the GitHub OAuth token endpoint")
+		require.NoError(t, r.ParseForm(), "token exchange request should parse as form data")
+		require.Equal(t, "client-id", r.Form.Get("client_id"), "token exchange should include the app client id")
+		require.Equal(t, "client-secret", r.Form.Get("client_secret"), "token exchange should include the app client secret")
+		require.Equal(t, "auth-code", r.Form.Get("code"), "token exchange should include the auth code")
+		require.Equal(t, "https://app.143.dev/api/v1/users/me/github/callback", r.Form.Get("redirect_uri"), "token exchange should echo the configured callback URL")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"ghu_test","token_type":"bearer","refresh_token":"ghr_test","expires_in":3600,"refresh_token_expires_in":7200}`))
+	}))
+	defer server.Close()
+
+	svc := &AppUserAuthService{
+		clientID:      "client-id",
+		clientSecret:  "client-secret",
+		redirectURI:   "https://app.143.dev/api/v1/users/me/github/callback",
+		oauthBaseURL:  server.URL,
+		httpClient:    server.Client(),
+		logger:        zerolog.Nop(),
+		now:           func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	cfg, err := svc.ExchangeCode(context.Background(), "auth-code")
+	require.NoError(t, err, "ExchangeCode should succeed for a valid GitHub response")
+	require.Equal(t, "ghu_test", cfg.AccessToken, "ExchangeCode should return the access token")
+	require.Equal(t, "ghr_test", cfg.RefreshToken, "ExchangeCode should return the refresh token")
+	require.Equal(t, time.Date(2026, 4, 22, 13, 0, 0, 0, time.UTC), cfg.ExpiresAt, "ExchangeCode should convert expires_in to an absolute timestamp")
+	require.Equal(t, time.Date(2026, 4, 22, 14, 0, 0, 0, time.UTC), cfg.RefreshTokenExpiresAt, "ExchangeCode should convert refresh_token_expires_in to an absolute timestamp")
+}
+
+func TestAppUserAuthService_ExchangeCode_AcceptsNonRefreshingToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"ghu_test","token_type":"bearer"}`))
+	}))
+	defer server.Close()
+
+	svc := &AppUserAuthService{
+		clientID:      "client-id",
+		clientSecret:  "client-secret",
+		redirectURI:   "https://app.143.dev/api/v1/users/me/github/callback",
+		oauthBaseURL:  server.URL,
+		httpClient:    server.Client(),
+		logger:        zerolog.Nop(),
+		now:           func() time.Time { return time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC) },
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	cfg, err := svc.ExchangeCode(context.Background(), "auth-code")
+	require.NoError(t, err, "ExchangeCode should accept valid non-refreshing GitHub App user tokens")
+	require.Equal(t, "ghu_test", cfg.AccessToken, "ExchangeCode should return the access token")
+	require.Empty(t, cfg.RefreshToken, "non-refreshing tokens should not require a refresh token")
+}
+
+func TestAppUserAuthService_GetValidCredential_RefreshesExpiredToken(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	upserted := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			require.NoError(t, r.ParseForm(), "refresh request should parse as form data")
+			require.Equal(t, "refresh_token", r.Form.Get("grant_type"), "refresh should use the refresh_token grant")
+			require.Equal(t, "ghr_old", r.Form.Get("refresh_token"), "refresh should use the stored refresh token")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"ghu_new","token_type":"bearer","refresh_token":"ghr_new","expires_in":3600,"refresh_token_expires_in":7200}`))
+		case "/user":
+			require.Equal(t, "Bearer ghu_new", r.Header.Get("Authorization"), "validation should use the refreshed access token")
+			_, _ = w.Write([]byte(`{"login":"alice"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	store := &stubAppUserCredentialStore{
+		getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+			return &models.DecryptedUserCredential{
+				Config: models.GitHubAppUserConfig{
+					AccessToken:           "ghu_old",
+					RefreshToken:          "ghr_old",
+					ExpiresAt:             time.Now().Add(-time.Minute),
+					RefreshTokenExpiresAt: time.Now().Add(time.Hour),
+				},
+			}, nil
+		},
+		upsertFunc: func(_ context.Context, gotUserID, gotOrgID uuid.UUID, cfg models.ProviderConfig, isTeamDefault bool) error {
+			upserted = true
+			require.Equal(t, userID, gotUserID, "refresh should persist the credential for the same user")
+			require.Equal(t, orgID, gotOrgID, "refresh should persist the credential for the same org")
+			require.False(t, isTeamDefault, "refreshed PR auth credentials should not be team defaults")
+			gotCfg, ok := cfg.(models.GitHubAppUserConfig)
+			require.True(t, ok, "refresh should persist a GitHubAppUserConfig")
+			require.Equal(t, "ghu_new", gotCfg.AccessToken, "refresh should persist the refreshed access token")
+			return nil
+		},
+	}
+
+	svc := &AppUserAuthService{
+		credentials:   store,
+		clientID:      "client-id",
+		clientSecret:  "client-secret",
+		oauthBaseURL:  server.URL,
+		apiBaseURL:    server.URL,
+		httpClient:    server.Client(),
+		logger:        zerolog.Nop(),
+		now:           time.Now,
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	cfg, err := svc.GetValidCredential(context.Background(), orgID, userID)
+	require.NoError(t, err, "GetValidCredential should refresh expired tokens")
+	require.Equal(t, "ghu_new", cfg.AccessToken, "GetValidCredential should return the refreshed access token")
+	require.True(t, upserted, "GetValidCredential should persist refreshed credentials")
+}
+
+func TestAppUserAuthService_HasValidCredential_DisablesRevokedCredential(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	disabled := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/user":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+		case "/login/oauth/access_token":
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"expired refresh token"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	store := &stubAppUserCredentialStore{
+		getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+			return &models.DecryptedUserCredential{
+				Config: models.GitHubAppUserConfig{
+					AccessToken:           "ghu_old",
+					RefreshToken:          "ghr_old",
+					ExpiresAt:             time.Now().Add(time.Hour),
+					RefreshTokenExpiresAt: time.Now().Add(2 * time.Hour),
+				},
+			}, nil
+		},
+		disableFunc: func(_ context.Context, gotOrgID, gotUserID uuid.UUID, provider models.ProviderName) error {
+			disabled = true
+			require.Equal(t, orgID, gotOrgID, "disable should target the same org")
+			require.Equal(t, userID, gotUserID, "disable should target the same user")
+			require.Equal(t, models.ProviderGitHubAppUser, provider, "disable should target the github_app_user provider")
+			return nil
+		},
+	}
+
+	svc := &AppUserAuthService{
+		credentials:   store,
+		clientID:      "client-id",
+		clientSecret:  "client-secret",
+		oauthBaseURL:  server.URL,
+		apiBaseURL:    server.URL,
+		httpClient:    server.Client(),
+		logger:        zerolog.Nop(),
+		now:           time.Now,
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	ok, err := svc.HasValidCredential(context.Background(), orgID, userID)
+	require.NoError(t, err, "HasValidCredential should treat revoked credentials as disconnected, not as a hard error")
+	require.False(t, ok, "HasValidCredential should return false for revoked credentials")
+	require.True(t, disabled, "HasValidCredential should disable revoked stored credentials")
+}
+
+func TestAppUserAuthService_GetValidCredential_MissingCredential(t *testing.T) {
+	t.Parallel()
+
+	svc := &AppUserAuthService{
+		credentials: &stubAppUserCredentialStore{
+			getFunc: func(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (*models.DecryptedUserCredential, error) {
+				return nil, pgx.ErrNoRows
+			},
+		},
+		logger:        zerolog.Nop(),
+		now:           time.Now,
+		refreshWindow: githubAppUserRefreshWindow,
+	}
+
+	_, err := svc.GetValidCredential(context.Background(), uuid.New(), uuid.New())
+	require.ErrorIs(t, err, ErrGitHubAppUserCredentialMissing, "missing credential should map to ErrGitHubAppUserCredentialMissing")
+}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -54,6 +54,9 @@ type PRService struct {
 	reviewComments  *db.ReviewCommentStore
 	integrations    *db.IntegrationStore
 	userCredentials *db.UserCredentialStore
+	appUserAuth     interface {
+		GetValidCredential(ctx context.Context, orgID, userID uuid.UUID) (*models.GitHubAppUserConfig, error)
+	}
 	users           *db.UserStore
 	orgs            *db.OrganizationStore
 	prTemplates     *db.PRTemplateStore
@@ -107,6 +110,14 @@ func (s *PRService) SetIntegrationStore(store *db.IntegrationStore) {
 // SetUserCredentialStore sets the user credential store for user-authored PRs.
 func (s *PRService) SetUserCredentialStore(store *db.UserCredentialStore) {
 	s.userCredentials = store
+}
+
+// SetAppUserAuth wires the refresh-aware GitHub App user auth service used to
+// author PRs as the triggering user.
+func (s *PRService) SetAppUserAuth(auth interface {
+	GetValidCredential(ctx context.Context, orgID, userID uuid.UUID) (*models.GitHubAppUserConfig, error)
+}) {
+	s.appUserAuth = auth
 }
 
 // SetLLMClient sets the LLM client for repo PR template filling.
@@ -259,8 +270,15 @@ func (s *PRService) getInstallationTokenForRepo(ctx context.Context, orgID uuid.
 }
 
 // resolveToken determines which GitHub token to use for PR creation.
-// Order: user's personal GitHub token → GitHub App installation token.
-func (s *PRService) resolveToken(ctx context.Context, run *models.Session, repo *models.Repository, orgSettings models.OrgSettings) (*tokenResolution, error) {
+// Order: user's GitHub App user token → GitHub App installation token.
+func (s *PRService) resolveToken(ctx context.Context, run *models.Session, repo *models.Repository, orgSettings models.OrgSettings, authorMode string) (*tokenResolution, error) {
+	if authorMode == "app" {
+		token, err := s.tokenProvider.GetInstallationToken(ctx, repo.InstallationID)
+		if err != nil {
+			return nil, fmt.Errorf("get installation token: %w", err)
+		}
+		return &tokenResolution{Token: token, IsUserToken: false}, nil
+	}
 	// If org is set to app_only, skip user token lookup.
 	if orgSettings.PRAuthorship == models.PRAuthorshipAppOnly {
 		token, err := s.getInstallationTokenForRepo(ctx, run.OrgID, repo)
@@ -270,35 +288,35 @@ func (s *PRService) resolveToken(ctx context.Context, run *models.Session, repo 
 		return &tokenResolution{Token: token, IsUserToken: false}, nil
 	}
 
-	// Try user token if user triggered the session and we have credential stores.
-	if run.TriggeredByUserID != nil && s.userCredentials != nil && s.users != nil {
-		cred, err := s.userCredentials.GetForUser(ctx, run.OrgID, *run.TriggeredByUserID, models.ProviderGitHubOAuth)
-		if err == nil && cred != nil && cred.Config != nil {
-			cfg, ok := cred.Config.(models.GitHubOAuthConfig)
-			// The token must have "repo" scope to push code and create PRs.
-			// Login-only tokens (read:user,user:email) lack this — skip them.
-			if ok && cfg.AccessToken != "" && hasRepoScope(cfg.Scope) {
-				// Validate token is still active before using it.
-				if s.validateUserToken(ctx, cfg.AccessToken) {
-					user, userErr := s.users.GetByID(ctx, run.OrgID, *run.TriggeredByUserID)
-					if userErr == nil {
-						return &tokenResolution{
-							Token:       cfg.AccessToken,
-							IsUserToken: true,
-							User:        &user,
-						}, nil
-					}
-				} else {
-					// Token was revoked — disable the stored credential and fall through.
-					s.logger.Warn().Str("user_id", run.TriggeredByUserID.String()).Msg("user GitHub token revoked, disabling credential and falling back to app token")
-					_ = s.userCredentials.Disable(ctx, run.OrgID, *run.TriggeredByUserID, models.ProviderGitHubOAuth)
+	// Try user token if user triggered the session and we have the auth service.
+	if run.TriggeredByUserID != nil && s.appUserAuth != nil {
+		cfg, err := s.appUserAuth.GetValidCredential(ctx, run.OrgID, *run.TriggeredByUserID)
+		if err == nil && cfg != nil && cfg.AccessToken != "" {
+			canAccessRepo, accessErr := s.userTokenCanAccessRepo(ctx, cfg.AccessToken, repo.FullName)
+			if accessErr != nil {
+				return nil, fmt.Errorf("check user github access: %w", accessErr)
+			}
+			if !canAccessRepo {
+				if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == "user" {
+					return nil, fmt.Errorf("user GitHub auth cannot access repo %s", repo.FullName)
 				}
+			} else {
+				resolution := &tokenResolution{
+					Token:       cfg.AccessToken,
+					IsUserToken: true,
+				}
+				if s.users != nil {
+					if user, userErr := s.users.GetByID(ctx, run.OrgID, *run.TriggeredByUserID); userErr == nil {
+						resolution.User = &user
+					}
+				}
+				return resolution, nil
 			}
 		}
 	}
 
 	// If org requires user auth and we couldn't get a user token, block.
-	if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired {
+	if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == "user" {
 		return nil, fmt.Errorf("org requires user GitHub auth for PR creation, but no valid user token found")
 	}
 
@@ -317,6 +335,22 @@ func (s *PRService) validateUserToken(ctx context.Context, token string) bool {
 	return err == nil
 }
 
+func (s *PRService) userTokenCanAccessRepo(ctx context.Context, token, fullName string) (bool, error) {
+	owner, repo := splitRepo(fullName)
+	if owner == "" || repo == "" {
+		return false, fmt.Errorf("invalid repo full name %q", fullName)
+	}
+	_, err := s.doGitHubRequest(ctx, token, http.MethodGet, fmt.Sprintf("/repos/%s/%s", owner, repo), nil)
+	if err == nil {
+		return true, nil
+	}
+	var apiErr *githubAPIError
+	if errors.As(err, &apiErr) && (apiErr.StatusCode == http.StatusForbidden || apiErr.StatusCode == http.StatusNotFound) {
+		return false, nil
+	}
+	return false, err
+}
+
 // SetBaseURL overrides the GitHub API base URL (for testing).
 func (s *PRService) SetBaseURL(url string) {
 	s.baseURL = url
@@ -326,7 +360,8 @@ func (s *PRService) SetBaseURL(url string) {
 // API request (as opposed to org-level defaults). Fields use pointers to
 // distinguish "caller explicitly set this" from "use org default".
 type CreatePRParams struct {
-	Draft *bool `json:"draft,omitempty"`
+	Draft      *bool  `json:"draft,omitempty"`
+	AuthorMode string `json:"author_mode,omitempty"`
 }
 
 // CreatePR opens a GitHub PR from a completed agent session by restoring the
@@ -399,7 +434,17 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		}
 	}
 
-	resolution, err := s.resolveToken(ctx, run, &repo, orgSettings)
+	var opts CreatePRParams
+	for _, param := range params {
+		if param.Draft != nil {
+			opts.Draft = param.Draft
+		}
+		if param.AuthorMode != "" {
+			opts.AuthorMode = param.AuthorMode
+		}
+	}
+
+	resolution, err := s.resolveToken(ctx, run, &repo, orgSettings, opts.AuthorMode)
 	if err != nil {
 		return nil, fmt.Errorf("resolve token: %w", err)
 	}
@@ -441,8 +486,8 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 	}
 
 	draft := orgSettings.PRDraftDefault
-	if len(params) > 0 && params[0].Draft != nil {
-		draft = *params[0].Draft
+	if opts.Draft != nil {
+		draft = *opts.Draft
 	}
 	var prOpts []prCreateOption
 	if draft {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -1390,6 +1390,34 @@ func TestResolveToken_UserRequired_NoUser(t *testing.T) {
 	require.Contains(t, err.Error(), "org requires user GitHub auth")
 }
 
+func TestPRService_SetAppUserAuth(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{}
+	auth := &stubPRAppUserAuth{}
+	svc.SetAppUserAuth(auth)
+	require.Same(t, auth, svc.appUserAuth, "SetAppUserAuth should store the provided auth service")
+}
+
+func TestResolveToken_AuthorModeAppUsesInstallationToken(t *testing.T) {
+	t.Parallel()
+
+	tokenSvc := &Service{cache: make(map[int64]*cachedToken)}
+	tokenSvc.cache[1] = &cachedToken{
+		Token:     "app-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		logger:        zerolog.Nop(),
+	}
+
+	resolution, err := svc.resolveToken(context.Background(), &models.Session{ID: uuid.New(), OrgID: uuid.New()}, &models.Repository{InstallationID: 1}, models.OrgSettings{}, "app")
+	require.NoError(t, err, "resolveToken should accept explicit app author mode")
+	require.Equal(t, "app-token", resolution.Token, "resolveToken should use the installation token in app mode")
+	require.False(t, resolution.IsUserToken, "app mode should not report a user token")
+}
+
 func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationMissing(t *testing.T) {
 	t.Parallel()
 
@@ -1859,6 +1887,36 @@ func TestResolveToken_UserRequiredErrorsWhenUserTokenCannotAccessRepo(t *testing
 	_, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.Error(t, err, "user_required should fail when the user token cannot access the target repo")
 	require.Contains(t, err.Error(), "cannot access repo", "resolveToken should surface repo access failures for user-required auth")
+}
+
+func TestUserTokenCanAccessRepo_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid repo name", func(t *testing.T) {
+		t.Parallel()
+		svc := &PRService{httpClient: &http.Client{}, logger: zerolog.Nop()}
+		ok, err := svc.userTokenCanAccessRepo(context.Background(), "token", "/repo")
+		require.False(t, ok, "userTokenCanAccessRepo should reject malformed repo names")
+		require.Error(t, err, "userTokenCanAccessRepo should return an error for malformed repo names")
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"boom"}`))
+		}))
+		defer server.Close()
+
+		svc := &PRService{
+			baseURL:    server.URL,
+			httpClient: server.Client(),
+			logger:     zerolog.Nop(),
+		}
+		ok, err := svc.userTokenCanAccessRepo(context.Background(), "token", "owner/repo")
+		require.False(t, ok, "userTokenCanAccessRepo should not grant access on GitHub API failures")
+		require.Error(t, err, "userTokenCanAccessRepo should propagate unexpected API errors")
+	})
 }
 
 func TestValidateUserToken_ValidToken(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -1549,10 +1549,10 @@ func TestIntegrationInstallationID(t *testing.T) {
 		},
 	}
 
-		for _, tt := range tests {
-			tt := tt
-			t.Run(tt.name, func(t *testing.T) {
-				t.Parallel()
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			installationID, err := integrationInstallationID(tt.integration)
 			if tt.expectErr {
@@ -1751,9 +1751,9 @@ func TestGetInstallationTokenForRepo_ErrorPaths(t *testing.T) {
 			svc := tt.setupSvc(t)
 			_, err := svc.getInstallationTokenForRepo(context.Background(), orgID, tt.repo)
 			require.Error(t, err, "getInstallationTokenForRepo should return an error for this path")
-				require.Contains(t, err.Error(), tt.wantError, "getInstallationTokenForRepo should preserve the expected error context")
-			})
-		}
+			require.Contains(t, err.Error(), tt.wantError, "getInstallationTokenForRepo should preserve the expected error context")
+		})
+	}
 
 }
 

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -129,6 +129,14 @@ func (p *prTestSandboxProvider) WriteFile(_ context.Context, _ *agent.Sandbox, p
 	return nil
 }
 
+type stubPRAppUserAuth struct {
+	getValidCredentialFunc func(context.Context, uuid.UUID, uuid.UUID) (*models.GitHubAppUserConfig, error)
+}
+
+func (s *stubPRAppUserAuth) GetValidCredential(ctx context.Context, orgID, userID uuid.UUID) (*models.GitHubAppUserConfig, error) {
+	return s.getValidCredentialFunc(ctx, orgID, userID)
+}
+
 func (p *prTestSandboxProvider) Destroy(context.Context, *agent.Sandbox) error {
 	p.destroyed++
 	return p.destroyErr
@@ -1334,11 +1342,11 @@ func TestResolveToken_AppOnly(t *testing.T) {
 		logger:        zerolog.Nop(),
 	}
 
-	repo := &models.Repository{InstallationID: 1}
+	repo := &models.Repository{InstallationID: 1, FullName: "owner/repo"}
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipAppOnly}
 	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
 
-	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.NoError(t, err)
 	require.Equal(t, "app-token-123", resolution.Token)
 	require.False(t, resolution.IsUserToken)
@@ -1362,7 +1370,7 @@ func TestResolveToken_UserPreferred_NoUser(t *testing.T) {
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
 	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()} // no TriggeredByUserID
 
-	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.NoError(t, err)
 	require.Equal(t, "app-token-fallback", resolution.Token)
 	require.False(t, resolution.IsUserToken, "should fall back to app token when no user")
@@ -1377,7 +1385,7 @@ func TestResolveToken_UserRequired_NoUser(t *testing.T) {
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserRequired}
 	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
 
-	_, err := svc.resolveToken(context.Background(), run, repo, settings)
+	_, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.Error(t, err, "should fail when user_required but no user token")
 	require.Contains(t, err.Error(), "org requires user GitHub auth")
 }
@@ -1411,7 +1419,7 @@ func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationMiss
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
 	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
 
-	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.NoError(t, err, "resolveToken should recover when the repo row is missing installation_id")
 	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should use the repository integration installation token")
 	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
@@ -1465,7 +1473,7 @@ func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationIsSt
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
 	run := &models.Session{ID: uuid.New(), OrgID: orgID}
 
-	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
 	require.NoError(t, err, "resolveToken should recover when the repo installation_id is stale")
 	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should retry with the repository integration installation token")
 	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
@@ -1513,10 +1521,10 @@ func TestIntegrationInstallationID(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
 
 			installationID, err := integrationInstallationID(tt.integration)
 			if tt.expectErr {
@@ -1715,9 +1723,142 @@ func TestGetInstallationTokenForRepo_ErrorPaths(t *testing.T) {
 			svc := tt.setupSvc(t)
 			_, err := svc.getInstallationTokenForRepo(context.Background(), orgID, tt.repo)
 			require.Error(t, err, "getInstallationTokenForRepo should return an error for this path")
-			require.Contains(t, err.Error(), tt.wantError, "getInstallationTokenForRepo should preserve the expected error context")
-		})
+				require.Contains(t, err.Error(), tt.wantError, "getInstallationTokenForRepo should preserve the expected error context")
+			})
+		}
+
+}
+
+func TestResolveToken_UsesGitHubAppUserCredential(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			require.Equal(t, "token ghu_user_token", r.Header.Get("Authorization"), "repo access probe should use the user token")
+			_, _ = w.Write([]byte(`{"full_name":"owner/repo"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	svc := &PRService{
+		appUserAuth: &stubPRAppUserAuth{
+			getValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (*models.GitHubAppUserConfig, error) {
+				return &models.GitHubAppUserConfig{
+					AccessToken:           "ghu_user_token",
+					RefreshToken:          "ghr_refresh",
+					ExpiresAt:             time.Now().Add(time.Hour),
+					RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+				}, nil
+			},
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
 	}
+
+	repo := &models.Repository{InstallationID: 1, FullName: "owner/repo"}
+	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	run := &models.Session{ID: uuid.New(), OrgID: orgID, TriggeredByUserID: &userID}
+
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
+	require.NoError(t, err, "resolveToken should use the GitHub App user credential when available")
+	require.Equal(t, "ghu_user_token", resolution.Token, "resolveToken should return the user access token")
+	require.True(t, resolution.IsUserToken, "resolveToken should mark GitHub App user tokens as user-authored")
+}
+
+func TestResolveToken_UserPreferredFallsBackWhenUserTokenCannotAccessRepo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			require.Equal(t, "token ghu_user_token", r.Header.Get("Authorization"), "repo access probe should use the user token")
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tokenSvc := &Service{cache: make(map[int64]*cachedToken)}
+	tokenSvc.cache[1] = &cachedToken{
+		Token:     "app-token-fallback",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	repo := &models.Repository{InstallationID: 1, FullName: "owner/repo"}
+	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	run := &models.Session{ID: uuid.New(), OrgID: orgID, TriggeredByUserID: &userID}
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		appUserAuth: &stubPRAppUserAuth{
+			getValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (*models.GitHubAppUserConfig, error) {
+				return &models.GitHubAppUserConfig{
+					AccessToken:           "ghu_user_token",
+					RefreshToken:          "ghr_refresh",
+					ExpiresAt:             time.Now().Add(time.Hour),
+					RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+				}, nil
+			},
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings, "")
+	require.NoError(t, err, "user_preferred should fall back to the app token when the user token cannot access the repo")
+	require.Equal(t, "app-token-fallback", resolution.Token, "resolveToken should fall back to the installation token")
+	require.False(t, resolution.IsUserToken, "resolveToken should mark the fallback token as app-authored")
+}
+
+func TestResolveToken_UserRequiredErrorsWhenUserTokenCannotAccessRepo(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/owner/repo":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	repo := &models.Repository{InstallationID: 1, FullName: "owner/repo"}
+	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserRequired}
+	run := &models.Session{ID: uuid.New(), OrgID: orgID, TriggeredByUserID: &userID}
+	svc := &PRService{
+		appUserAuth: &stubPRAppUserAuth{
+			getValidCredentialFunc: func(context.Context, uuid.UUID, uuid.UUID) (*models.GitHubAppUserConfig, error) {
+				return &models.GitHubAppUserConfig{
+					AccessToken:           "ghu_user_token",
+					RefreshToken:          "ghr_refresh",
+					ExpiresAt:             time.Now().Add(time.Hour),
+					RefreshTokenExpiresAt: time.Now().Add(24 * time.Hour),
+				}, nil
+			},
+		},
+		baseURL:    server.URL,
+		httpClient: server.Client(),
+		logger:     zerolog.Nop(),
+	}
+
+	_, err := svc.resolveToken(context.Background(), run, repo, settings, "")
+	require.Error(t, err, "user_required should fail when the user token cannot access the target repo")
+	require.Contains(t, err.Error(), "cannot access repo", "resolveToken should surface repo access failures for user-required auth")
 }
 
 func TestValidateUserToken_ValidToken(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -971,9 +971,10 @@ func newValidateHandler(stores *Stores, services *Services, logger zerolog.Logge
 func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger) JobHandler {
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
 		var input struct {
-			SessionID string `json:"session_id"`
-			OrgID     string `json:"org_id"`
-			Draft     *bool  `json:"draft,omitempty"`
+			SessionID  string `json:"session_id"`
+			OrgID      string `json:"org_id"`
+			Draft      *bool  `json:"draft,omitempty"`
+			AuthorMode string `json:"author_mode,omitempty"`
 		}
 		if err := json.Unmarshal(payload, &input); err != nil {
 			return fmt.Errorf("unmarshal open_pr payload: %w", err)
@@ -1005,6 +1006,9 @@ func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger)
 		var params []ghservice.CreatePRParams
 		if input.Draft != nil {
 			params = append(params, ghservice.CreatePRParams{Draft: input.Draft})
+		}
+		if input.AuthorMode != "" {
+			params = append(params, ghservice.CreatePRParams{AuthorMode: input.AuthorMode})
 		}
 
 		_, createErr := services.PR.CreatePR(ctx, &run, params...)

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -621,6 +621,45 @@ func TestOpenPRHandler_SuccessMarksPushingAndSucceeded(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestOpenPRHandler_ForwardsAuthorModeToPRService(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-open-pr-author-mode"
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	services := &Services{
+		PR: &stubPRService{
+			createPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				require.Len(t, params, 1, "open_pr should forward a single author mode param when only author_mode is set")
+				require.Equal(t, "user", params[0].AuthorMode, "open_pr should forward author_mode to PR creation")
+				return &models.PullRequest{ID: uuid.New(), OrgID: orgID}, nil
+			},
+		},
+	}
+
+	handler := newOpenPRHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","author_mode":"user"}`)
+	err := handler(context.Background(), "open_pr", payload)
+
+	require.NoError(t, err, "open_pr should succeed when author mode is forwarded to PR creation")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestOpenPRHandler_NonTerminalPRErrorsMarkFailedAndRetry(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add on-demand GitHub App user authorization so a session creator can open PRs as themselves
- Store and refresh GitHub App user tokens separately from login OAuth, with fallback to the installation token when allowed
- Wire the new auth flow through the session UI, API handlers, worker, and PR creation path
- Update the design docs to describe the revised PR authorship flow and required GitHub App config

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `frontend/npm run typecheck`
- `frontend/npm run lint`
- `frontend/npm run build`