### PR TITLE
Fix GitHub PR token resolution fallback

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -104,6 +104,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				deployStore, validationStore, repoStore, jobStore, logger,
 			)
 			prService.SetReviewCommentStore(reviewCommentStore)
+			prService.SetIntegrationStore(integrationStore)
 			prService.SetSandboxPushDeps(sandboxProvider, snapshotStore)
 		}
 	}

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -1,6 +1,10 @@
 package api
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"testing"
 
 	"github.com/assembledhq/143/internal/config"
@@ -49,4 +53,32 @@ func TestNewRouter_EncryptionKeyValidation(t *testing.T) {
 			require.NotNil(t, router, "NewRouter should construct a router when encryption key is unset")
 		})
 	}
+}
+
+func testRouterPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err, "rsa key generation should not return an error")
+
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}
+	return string(pem.EncodeToMemory(block))
+}
+
+func TestNewRouter_GitHubAppConfigBuildsRouter(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		GitHubAppID:         143,
+		GitHubAppPrivateKey: testRouterPrivateKeyPEM(t),
+	}
+	codexSvc := codexauth.NewService(nil, zerolog.Nop())
+	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
+
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "NewRouter should build successfully when GitHub App credentials are valid")
+	require.NotNil(t, router, "NewRouter should construct a router when GitHub App credentials are valid")
 }

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -171,12 +171,70 @@ type tokenResolution struct {
 	User        *models.User // set when IsUserToken is true
 }
 
+func shouldRetryWithOrgInstallation(err error) bool {
+	var apiErr *githubAPIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
+}
+
+func (s *PRService) getInstallationTokenForRepo(ctx context.Context, orgID uuid.UUID, repo *models.Repository) (string, error) {
+	tryInstallation := func(installationID int64) (string, error) {
+		if installationID <= 0 {
+			return "", fmt.Errorf("repository %s has no github installation_id", repo.FullName)
+		}
+		token, err := s.tokenProvider.GetInstallationToken(ctx, installationID)
+		if err != nil {
+			return "", fmt.Errorf("get installation token for installation %d: %w", installationID, err)
+		}
+		return token, nil
+	}
+
+	var primaryErr error
+	if repo.InstallationID > 0 {
+		token, err := tryInstallation(repo.InstallationID)
+		if err == nil {
+			return token, nil
+		}
+		primaryErr = err
+		if !shouldRetryWithOrgInstallation(err) {
+			return "", err
+		}
+	} else {
+		primaryErr = fmt.Errorf("repository %s has no github installation_id", repo.FullName)
+	}
+
+	if s.repos == nil {
+		return "", primaryErr
+	}
+
+	fallbackInstallationID, err := s.repos.GetAnyInstallationIDByOrg(ctx, orgID)
+	if err != nil {
+		return "", primaryErr
+	}
+	if fallbackInstallationID <= 0 || fallbackInstallationID == repo.InstallationID {
+		return "", primaryErr
+	}
+
+	token, err := tryInstallation(fallbackInstallationID)
+	if err != nil {
+		return "", err
+	}
+
+	s.logger.Warn().
+		Str("org_id", orgID.String()).
+		Str("repo", repo.FullName).
+		Int64("repo_installation_id", repo.InstallationID).
+		Int64("fallback_installation_id", fallbackInstallationID).
+		Msg("using fallback GitHub installation for PR creation")
+
+	return token, nil
+}
+
 // resolveToken determines which GitHub token to use for PR creation.
 // Order: user's personal GitHub token → GitHub App installation token.
 func (s *PRService) resolveToken(ctx context.Context, run *models.Session, repo *models.Repository, orgSettings models.OrgSettings) (*tokenResolution, error) {
 	// If org is set to app_only, skip user token lookup.
 	if orgSettings.PRAuthorship == models.PRAuthorshipAppOnly {
-		token, err := s.tokenProvider.GetInstallationToken(ctx, repo.InstallationID)
+		token, err := s.getInstallationTokenForRepo(ctx, run.OrgID, repo)
 		if err != nil {
 			return nil, fmt.Errorf("get installation token: %w", err)
 		}
@@ -216,7 +274,7 @@ func (s *PRService) resolveToken(ctx context.Context, run *models.Session, repo 
 	}
 
 	// Fall back to app installation token.
-	token, err := s.tokenProvider.GetInstallationToken(ctx, repo.InstallationID)
+	token, err := s.getInstallationTokenForRepo(ctx, run.OrgID, repo)
 	if err != nil {
 		return nil, fmt.Errorf("get installation token: %w", err)
 	}

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -52,6 +52,7 @@ type PRService struct {
 	repos           *db.RepositoryStore
 	jobs            *db.JobStore
 	reviewComments  *db.ReviewCommentStore
+	integrations    *db.IntegrationStore
 	userCredentials *db.UserCredentialStore
 	users           *db.UserStore
 	orgs            *db.OrganizationStore
@@ -96,6 +97,11 @@ func NewPRService(
 // SetReviewCommentStore sets the review comment store for the feedback loop.
 func (s *PRService) SetReviewCommentStore(store *db.ReviewCommentStore) {
 	s.reviewComments = store
+}
+
+// SetIntegrationStore sets the integration store for installation fallback lookups.
+func (s *PRService) SetIntegrationStore(store *db.IntegrationStore) {
+	s.integrations = store
 }
 
 // SetUserCredentialStore sets the user credential store for user-authored PRs.
@@ -176,6 +182,23 @@ func shouldRetryWithOrgInstallation(err error) bool {
 	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusNotFound
 }
 
+func integrationInstallationID(integration *models.Integration) (int64, error) {
+	if integration == nil || len(integration.Config) == 0 {
+		return 0, fmt.Errorf("github integration config missing installation_id")
+	}
+
+	var cfg struct {
+		InstallationID int64 `json:"installation_id"`
+	}
+	if err := json.Unmarshal(integration.Config, &cfg); err != nil {
+		return 0, fmt.Errorf("parse github integration config: %w", err)
+	}
+	if cfg.InstallationID <= 0 {
+		return 0, fmt.Errorf("github integration config missing installation_id")
+	}
+	return cfg.InstallationID, nil
+}
+
 func (s *PRService) getInstallationTokenForRepo(ctx context.Context, orgID uuid.UUID, repo *models.Repository) (string, error) {
 	tryInstallation := func(installationID int64) (string, error) {
 		if installationID <= 0 {
@@ -202,15 +225,20 @@ func (s *PRService) getInstallationTokenForRepo(ctx context.Context, orgID uuid.
 		primaryErr = fmt.Errorf("repository %s has no github installation_id", repo.FullName)
 	}
 
-	if s.repos == nil {
+	if s.integrations == nil || repo.IntegrationID == uuid.Nil {
 		return "", primaryErr
 	}
 
-	fallbackInstallationID, err := s.repos.GetAnyInstallationIDByOrg(ctx, orgID)
+	integration, err := s.integrations.GetByID(ctx, repo.IntegrationID)
 	if err != nil {
 		return "", primaryErr
 	}
-	if fallbackInstallationID <= 0 || fallbackInstallationID == repo.InstallationID {
+
+	fallbackInstallationID, err := integrationInstallationID(&integration)
+	if err != nil {
+		return "", primaryErr
+	}
+	if fallbackInstallationID == repo.InstallationID {
 		return "", primaryErr
 	}
 
@@ -222,9 +250,10 @@ func (s *PRService) getInstallationTokenForRepo(ctx context.Context, orgID uuid.
 	s.logger.Warn().
 		Str("org_id", orgID.String()).
 		Str("repo", repo.FullName).
+		Str("integration_id", repo.IntegrationID.String()).
 		Int64("repo_installation_id", repo.InstallationID).
 		Int64("fallback_installation_id", fallbackInstallationID).
-		Msg("using fallback GitHub installation for PR creation")
+		Msg("using GitHub integration installation fallback for PR creation")
 
 	return token, nil
 }

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -83,6 +83,18 @@ func TestSetReviewCommentStore(t *testing.T) {
 	require.NotNil(t, svc.reviewComments, "SetReviewCommentStore should set the review comment store")
 }
 
+func TestSetIntegrationStore(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{}
+	require.Nil(t, svc.integrations, "integrations should be nil initially")
+
+	mockPool := newMockPool(t)
+	store := db.NewIntegrationStore(mockPool)
+	svc.SetIntegrationStore(store)
+	require.NotNil(t, svc.integrations, "SetIntegrationStore should set the integration store")
+}
+
 func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -1381,16 +1381,18 @@ func TestResolveToken_UserRequired_NoUser(t *testing.T) {
 	require.Contains(t, err.Error(), "org requires user GitHub auth")
 }
 
-func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationMissing(t *testing.T) {
+func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationMissing(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "should create mock pool")
 	defer mock.Close()
 
-	mock.ExpectQuery("SELECT installation_id FROM repositories").
+	integrationID := uuid.New()
+	mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
 		WithArgs(pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(2)))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+			AddRow(integrationID, uuid.New(), "github", []byte(`{"installation_id":2}`), "active", nil, time.Now()))
 
 	tokenSvc := &Service{cache: make(map[int64]*cachedToken)}
 	tokenSvc.cache[2] = &cachedToken{
@@ -1400,31 +1402,34 @@ func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationMissing(t *t
 
 	svc := &PRService{
 		tokenProvider: tokenSvc,
-		repos:         db.NewRepositoryStore(mock),
+		integrations:  db.NewIntegrationStore(mock),
 		logger:        zerolog.Nop(),
 	}
 
-	repo := &models.Repository{InstallationID: 0}
+	repo := &models.Repository{InstallationID: 0, IntegrationID: integrationID}
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
 	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
 
 	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
 	require.NoError(t, err, "resolveToken should recover when the repo row is missing installation_id")
-	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should use the org fallback installation token")
+	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should use the repository integration installation token")
 	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
-	require.NoError(t, mock.ExpectationsWereMet(), "all repository fallback expectations should be met")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration fallback expectations should be met")
 }
 
-func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationIsStale(t *testing.T) {
+func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationIsStale(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err, "should create mock pool")
 	defer mock.Close()
 
-	mock.ExpectQuery("SELECT installation_id FROM repositories").
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
 		WithArgs(pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(2)))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+			AddRow(integrationID, orgID, "github", []byte(`{"installation_id":2}`), "active", nil, time.Now()))
 
 	tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
 	require.NoError(t, err, "should create a GitHub service with a test private key")
@@ -1451,19 +1456,19 @@ func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationIsStale(t *t
 
 	svc := &PRService{
 		tokenProvider: tokenSvc,
-		repos:         db.NewRepositoryStore(mock),
+		integrations:  db.NewIntegrationStore(mock),
 		logger:        zerolog.Nop(),
 	}
 
-	repo := &models.Repository{InstallationID: 1}
+	repo := &models.Repository{InstallationID: 1, IntegrationID: integrationID}
 	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
-	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	run := &models.Session{ID: uuid.New(), OrgID: orgID}
 
 	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
 	require.NoError(t, err, "resolveToken should recover when the repo installation_id is stale")
-	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should retry with the org fallback installation token")
+	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should retry with the repository integration installation token")
 	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
-	require.NoError(t, mock.ExpectationsWereMet(), "all repository fallback expectations should be met")
+	require.NoError(t, mock.ExpectationsWereMet(), "all integration fallback expectations should be met")
 }
 
 func TestValidateUserToken_ValidToken(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -1381,6 +1381,91 @@ func TestResolveToken_UserRequired_NoUser(t *testing.T) {
 	require.Contains(t, err.Error(), "org requires user GitHub auth")
 }
 
+func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationMissing(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT installation_id FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(2)))
+
+	tokenSvc := &Service{cache: make(map[int64]*cachedToken)}
+	tokenSvc.cache[2] = &cachedToken{
+		Token:     "fallback-token",
+		ExpiresAt: time.Now().Add(30 * time.Minute),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.Nop(),
+	}
+
+	repo := &models.Repository{InstallationID: 0}
+	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	require.NoError(t, err, "resolveToken should recover when the repo row is missing installation_id")
+	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should use the org fallback installation token")
+	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
+	require.NoError(t, mock.ExpectationsWereMet(), "all repository fallback expectations should be met")
+}
+
+func TestResolveToken_FallsBackToOrgInstallationWhenRepoInstallationIsStale(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT installation_id FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(2)))
+
+	tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+	require.NoError(t, err, "should create a GitHub service with a test private key")
+	tokenSvc.httpClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			switch req.URL.Path {
+			case "/app/installations/1/access_tokens":
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`{"message":"Not Found"}`)),
+					Header:     make(http.Header),
+				}, nil
+			case "/app/installations/2/access_tokens":
+				return &http.Response{
+					StatusCode: http.StatusCreated,
+					Body:       io.NopCloser(strings.NewReader(`{"token":"fallback-token","expires_at":"2030-01-01T00:00:00Z"}`)),
+					Header:     make(http.Header),
+				}, nil
+			default:
+				return nil, errors.New("unexpected installation token request path")
+			}
+		}),
+	}
+
+	svc := &PRService{
+		tokenProvider: tokenSvc,
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.Nop(),
+	}
+
+	repo := &models.Repository{InstallationID: 1}
+	settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+
+	resolution, err := svc.resolveToken(context.Background(), run, repo, settings)
+	require.NoError(t, err, "resolveToken should recover when the repo installation_id is stale")
+	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should retry with the org fallback installation token")
+	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
+	require.NoError(t, mock.ExpectationsWereMet(), "all repository fallback expectations should be met")
+}
+
 func TestValidateUserToken_ValidToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -1469,6 +1470,254 @@ func TestResolveToken_FallsBackToIntegrationInstallationWhenRepoInstallationIsSt
 	require.Equal(t, "fallback-token", resolution.Token, "resolveToken should retry with the repository integration installation token")
 	require.False(t, resolution.IsUserToken, "fallback installation token should still be treated as an app token")
 	require.NoError(t, mock.ExpectationsWereMet(), "all integration fallback expectations should be met")
+}
+
+func TestIntegrationInstallationID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		integration *models.Integration
+		expected    int64
+		expectErr   bool
+	}{
+		{
+			name:      "nil integration",
+			expectErr: true,
+		},
+		{
+			name:        "empty config",
+			integration: &models.Integration{},
+			expectErr:   true,
+		},
+		{
+			name: "invalid config",
+			integration: &models.Integration{
+				Config: []byte(`{`),
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing installation id",
+			integration: &models.Integration{
+				Config: []byte(`{"installation_id":0}`),
+			},
+			expectErr: true,
+		},
+		{
+			name: "valid installation id",
+			integration: &models.Integration{
+				Config: []byte(`{"installation_id":42}`),
+			},
+			expected: 42,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			installationID, err := integrationInstallationID(tt.integration)
+			if tt.expectErr {
+				require.Error(t, err, "integrationInstallationID should return an error for invalid integration config")
+				return
+			}
+
+			require.NoError(t, err, "integrationInstallationID should parse a valid installation id")
+			require.Equal(t, tt.expected, installationID, "integrationInstallationID should return the parsed installation id")
+		})
+	}
+}
+
+func TestGetInstallationTokenForRepo_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoName := "acme/repo"
+
+	tests := []struct {
+		name      string
+		repo      *models.Repository
+		setupSvc  func(t *testing.T) *PRService
+		wantError string
+	}{
+		{
+			name: "missing repo installation without integration store",
+			repo: &models.Repository{FullName: repoName},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				return &PRService{logger: zerolog.Nop()}
+			},
+			wantError: "has no github installation_id",
+		},
+		{
+			name: "primary non 404 error returns immediately",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusUnauthorized,
+							Body:       io.NopCloser(strings.NewReader(`{"message":"bad credentials"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, logger: zerolog.Nop()}
+			},
+			wantError: "returned 401",
+		},
+		{
+			name: "missing integration id after stale 404",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(strings.NewReader(`{"message":"not found"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, integrations: db.NewIntegrationStore(newMockPool(t)), logger: zerolog.Nop()}
+			},
+			wantError: "returned 404",
+		},
+		{
+			name: "integration lookup failure returns primary error",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1, IntegrationID: uuid.New()},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				mock := newMockPool(t)
+				mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(strings.NewReader(`{"message":"not found"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, integrations: db.NewIntegrationStore(mock), logger: zerolog.Nop()}
+			},
+			wantError: "returned 404",
+		},
+		{
+			name: "integration config parse failure returns primary error",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1, IntegrationID: uuid.New()},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				mock := newMockPool(t)
+				mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+						AddRow(uuid.New(), orgID, "github", []byte(`{`), "active", nil, time.Now()))
+
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(strings.NewReader(`{"message":"not found"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, integrations: db.NewIntegrationStore(mock), logger: zerolog.Nop()}
+			},
+			wantError: "returned 404",
+		},
+		{
+			name: "same installation id returns primary error",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1, IntegrationID: uuid.New()},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				mock := newMockPool(t)
+				mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+						AddRow(uuid.New(), orgID, "github", []byte(`{"installation_id":1}`), "active", nil, time.Now()))
+
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusNotFound,
+							Body:       io.NopCloser(strings.NewReader(`{"message":"not found"}`)),
+							Header:     make(http.Header),
+						}, nil
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, integrations: db.NewIntegrationStore(mock), logger: zerolog.Nop()}
+			},
+			wantError: "returned 404",
+		},
+		{
+			name: "fallback installation token failure is returned",
+			repo: &models.Repository{FullName: repoName, InstallationID: 1, IntegrationID: uuid.New()},
+			setupSvc: func(t *testing.T) *PRService {
+				t.Helper()
+				mock := newMockPool(t)
+				mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE id").
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+						AddRow(uuid.New(), orgID, "github", []byte(`{"installation_id":2}`), "active", nil, time.Now()))
+
+				tokenSvc, err := NewService(143, testPrivateKeyPEM(t))
+				require.NoError(t, err, "should create a GitHub service with a test private key")
+				tokenSvc.httpClient = &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						switch req.URL.Path {
+						case "/app/installations/1/access_tokens":
+							return &http.Response{
+								StatusCode: http.StatusNotFound,
+								Body:       io.NopCloser(strings.NewReader(`{"message":"not found"}`)),
+								Header:     make(http.Header),
+							}, nil
+						case "/app/installations/2/access_tokens":
+							return &http.Response{
+								StatusCode: http.StatusUnauthorized,
+								Body:       io.NopCloser(strings.NewReader(`{"message":"bad credentials"}`)),
+								Header:     make(http.Header),
+							}, nil
+						default:
+							return nil, errors.New("unexpected installation token request path")
+						}
+					}),
+				}
+				return &PRService{tokenProvider: tokenSvc, integrations: db.NewIntegrationStore(mock), logger: zerolog.Nop()}
+			},
+			wantError: "installation 2",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			svc := tt.setupSvc(t)
+			_, err := svc.getInstallationTokenForRepo(context.Background(), orgID, tt.repo)
+			require.Error(t, err, "getInstallationTokenForRepo should return an error for this path")
+			require.Contains(t, err.Error(), tt.wantError, "getInstallationTokenForRepo should preserve the expected error context")
+		})
+	}
 }
 
 func TestValidateUserToken_ValidToken(t *testing.T) {

--- a/internal/services/github/service.go
+++ b/internal/services/github/service.go
@@ -80,7 +80,8 @@ func (s *Service) generateJWT() (string, error) {
 }
 
 func (s *Service) exchangeForInstallationToken(ctx context.Context, jwtToken string, installationID int64) (string, time.Time, error) {
-	url := fmt.Sprintf("https://api.github.com/app/installations/%d/access_tokens", installationID)
+	path := fmt.Sprintf("/app/installations/%d/access_tokens", installationID)
+	url := "https://api.github.com" + path
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
 	if err != nil {
 		return "", time.Time{}, err
@@ -96,7 +97,12 @@ func (s *Service) exchangeForInstallationToken(ctx context.Context, jwtToken str
 
 	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		return "", time.Time{}, fmt.Errorf("GitHub API error %d: %s", resp.StatusCode, body)
+		return "", time.Time{}, &githubAPIError{
+			Method:     http.MethodPost,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Body:       body,
+		}
 	}
 
 	var result struct {

--- a/internal/services/github/service_test.go
+++ b/internal/services/github/service_test.go
@@ -151,7 +151,7 @@ func TestService_ExchangeForInstallationToken(t *testing.T) {
 			status:      http.StatusUnauthorized,
 			body:        `{"message":"bad credentials"}`,
 			expectErr:   true,
-			errContains: "GitHub API error 401",
+			errContains: "returned 401",
 		},
 		{
 			name:        "returns error for invalid JSON body",


### PR DESCRIPTION
## Summary
- Add a fallback path when PR creation cannot use the repo’s stored GitHub App installation ID
- Retry against an org-level installation ID when the repo installation is missing or stale
- Return structured GitHub API errors from installation-token exchange for better retry handling
- Add regression tests for missing and stale installation metadata

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`