### PR TITLE
Prevent no-op autosaves and add settings PATCH logging

### DIFF
--- a/frontend/src/hooks/useAutosave.test.ts
+++ b/frontend/src/hooks/useAutosave.test.ts
@@ -253,6 +253,80 @@ describe("useAutosave", () => {
     expect(queryClient.getQueryData(queryKey)).toEqual({ data: { settings: { existing: "value" } } });
   });
 
+  it("skips dispatch when the optimistic end state is unchanged", async () => {
+    const mutationFn = vi.fn().mockResolvedValue(undefined);
+    const queryKey = ["settings", "test-noop"];
+    queryClient.setQueryData(queryKey, { data: { settings: { foo: "bar" } } });
+
+    const { result } = renderHook(
+      () =>
+        useAutosave<{ settings: { foo: string } }>({
+          queryKey,
+          mutationFn,
+          applyOptimistic,
+          debounceMs: 0,
+        }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    act(() => {
+      result.current.save({ settings: { foo: "bar" } });
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mutationFn).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(queryKey)).toEqual({ data: { settings: { foo: "bar" } } });
+  });
+
+  it("does not queue a follow-up mutation when an in-flight save already matches the requested end state", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const mutationFn = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValue(undefined);
+
+    const queryKey = ["settings", "test-inflight-noop"];
+    queryClient.setQueryData(queryKey, { data: { settings: { default_agent_type: "codex" } } });
+
+    const { result } = renderHook(
+      () =>
+        useAutosave<{ settings: { default_agent_type: string } }>({
+          queryKey,
+          mutationFn,
+          applyOptimistic,
+          debounceMs: 0,
+        }),
+      { wrapper: makeWrapper(queryClient) },
+    );
+
+    act(() => {
+      result.current.save({ settings: { default_agent_type: "claude_code" } });
+    });
+    await waitFor(() => expect(mutationFn).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      result.current.save({ settings: { default_agent_type: "claude_code" } });
+    });
+
+    await act(async () => {
+      resolveFirst?.();
+      await Promise.resolve();
+    });
+
+    expect(mutationFn).toHaveBeenCalledTimes(1);
+    expect(queryClient.getQueryData(queryKey)).toEqual({
+      data: { settings: { default_agent_type: "claude_code" } },
+    });
+  });
+
   it("transitions status idle → saving → saved → idle", async () => {
     // Fake timers let us jump past SAVED_LINGER_MS (1500ms) without burning
     // real wall-clock time. `shouldAdvanceTime` keeps waitFor's polling alive

--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -64,6 +64,42 @@ type QueueStatus = "idle" | "saving" | "saved" | "error";
 
 const queues = new Map<string, QueueEntry>();
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+      return false;
+    }
+    for (let i = 0; i < a.length; i += 1) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+
+  if (isPlainObject(a) || isPlainObject(b)) {
+    if (!isPlainObject(a) || !isPlainObject(b)) return false;
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+      if (!deepEqual(a[key], b[key])) return false;
+    }
+    return true;
+  }
+
+  return false;
+}
+
 function getQueue(key: QueryKey): QueueEntry {
   const id = hashKey(key);
   let entry = queues.get(id);
@@ -270,6 +306,18 @@ export function useAutosave<TVars>({
 
   const dispatch = useCallback(
     (vars: TVars) => {
+      const current = queryClient.getQueryData(queryKey);
+      if (current !== undefined) {
+        const next = applyOptimisticRef.current(current, vars);
+        // Guard against spurious autosaves: if applying `vars` would leave the
+        // cache unchanged, we already reached the requested end state (either
+        // from the server, from our own optimistic write, or from another
+        // component sharing the query scope). Skip the network call entirely.
+        if (deepEqual(current, next)) {
+          return;
+        }
+      }
+
       const entry = getQueue(queryKey);
       // First dispatcher wins on coalesce: if two components share a queryKey
       // with different coalesce fns, the first one registered is used for all

--- a/internal/api/handlers/settings.go
+++ b/internal/api/handlers/settings.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/google/uuid"
@@ -87,6 +88,7 @@ func (h *SettingsHandler) GetLLMModels(w http.ResponseWriter, r *http.Request) {
 
 func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	logger := zerolog.Ctx(r.Context())
 	var req struct {
 		Name     *string          `json:"name"`
 		Settings *json.RawMessage `json:"settings"`
@@ -144,18 +146,6 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 		org.Settings = merged
 	}
 
-	if err := h.orgStore.Update(r.Context(), &org); err != nil {
-		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update organization", err)
-		return
-	}
-
-	// Drop any cached agent_config for this org so the next Amp/Pi session
-	// start observes the write. Skipping invalidation would leave stale env
-	// overrides in place until the cache TTL expires.
-	if h.invalidator != nil {
-		h.invalidator.InvalidateOrg(orgID)
-	}
-
 	// Build the audit diff from what actually changed. Skip the emit entirely
 	// when nothing changed so a no-op PATCH (client re-saving the current
 	// values) doesn't pollute the timeline with empty "updated settings" rows.
@@ -168,11 +158,41 @@ func (h *SettingsHandler) Update(w http.ResponseWriter, r *http.Request) {
 			changes[k] = v
 		}
 	}
+	changedKeys := sortedSettingsChangeKeys(changes)
+	requestSettingsKeys := topLevelSettingsPatchKeys(req.Settings)
+	patchLogger := logger.Info().
+		Str("path", r.URL.Path).
+		Str("origin", r.Header.Get("Origin")).
+		Str("referer", r.Referer()).
+		Str("user_agent", r.UserAgent()).
+		Bool("has_name_patch", req.Name != nil).
+		Strs("request_settings_keys", requestSettingsKeys).
+		Strs("changed_keys", changedKeys)
+
+	if len(changes) == 0 {
+		patchLogger.Bool("noop", true).Msg("settings patch noop")
+		writeJSON(w, http.StatusOK, models.SingleResponse[models.Organization]{Data: org})
+		return
+	}
+
+	if err := h.orgStore.Update(r.Context(), &org); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "UPDATE_FAILED", "failed to update organization", err)
+		return
+	}
+
+	// Drop any cached agent_config for this org so the next Amp/Pi session
+	// start observes the write. Skipping invalidation would leave stale env
+	// overrides in place until the cache TTL expires.
+	if h.invalidator != nil {
+		h.invalidator.InvalidateOrg(orgID)
+	}
+
 	if len(changes) > 0 {
 		orgIDStr := orgID.String()
 		emitUserAudit(h.audit, r, models.AuditActionSettingsUpdated, models.AuditResourceSettings, &orgIDStr,
 			marshalAuditDetails(h.logger, map[string]any{"changes": changes}))
 	}
+	patchLogger.Bool("noop", false).Msg("settings patch applied")
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.Organization]{Data: org})
 }
 
@@ -260,4 +280,29 @@ func deepMergeMap(base, incoming map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func sortedSettingsChangeKeys(changes map[string]any) []string {
+	keys := make([]string, 0, len(changes))
+	for key := range changes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func topLevelSettingsPatchKeys(raw *json.RawMessage) []string {
+	if raw == nil || len(*raw) == 0 {
+		return nil
+	}
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(*raw, &payload); err != nil {
+		return nil
+	}
+	keys := make([]string, 0, len(payload))
+	for key := range payload {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +13,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -331,6 +333,89 @@ func TestSettingsHandler_Update(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestSettingsHandler_Update_SkipsNoOpPatch(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(orgColumns()).AddRow(
+				orgID,
+				"Test Org",
+				json.RawMessage(`{"default_agent_type":"codex"}`),
+				now,
+				now,
+			),
+		)
+
+	store := db.NewOrganizationStore(mock)
+	handler := NewSettingsHandler(store, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/settings", strings.NewReader(`{"settings":{"default_agent_type":"codex"}}`))
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should return success for a no-op patch")
+	require.Contains(t, w.Body.String(), `"default_agent_type":"codex"`, "response should return the existing settings")
+	require.NoError(t, mock.ExpectationsWereMet(), "no-op patch should not issue an UPDATE")
+}
+
+func TestSettingsHandler_Update_LogsPatchMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(orgColumns()).AddRow(
+				orgID,
+				"Test Org",
+				json.RawMessage(`{"default_agent_type":"codex"}`),
+				now,
+				now,
+			),
+		)
+	mock.ExpectQuery("UPDATE organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"updated_at"}).AddRow(now),
+		)
+
+	store := db.NewOrganizationStore(mock)
+	handler := NewSettingsHandler(store, nil)
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/settings", strings.NewReader(`{"settings":{"default_agent_type":"claude_code"}}`))
+	req.Header.Set("Origin", "https://app.example.com")
+	req.Header.Set("Referer", "https://app.example.com/settings/agent")
+	req.Header.Set("User-Agent", "TestBrowser/1.0")
+	req = req.WithContext(logger.WithContext(middleware.WithOrgID(req.Context(), orgID)))
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should update settings successfully")
+	require.Contains(t, logs.String(), `"message":"settings patch applied"`, "patch updates should be logged")
+	require.Contains(t, logs.String(), `"changed_keys":["default_agent_type"]`, "log should include the changed settings key")
+	require.Contains(t, logs.String(), `"origin":"https://app.example.com"`, "log should include the request origin")
+	require.Contains(t, logs.String(), `"referer":"https://app.example.com/settings/agent"`, "log should include the request referer")
+	require.Contains(t, logs.String(), `"user_agent":"TestBrowser/1.0"`, "log should include the request user agent")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestMergeSettingsJSON_ShallowKey(t *testing.T) {

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -21,6 +21,16 @@ func orgColumns() []string {
 	return []string{"id", "name", "settings", "created_at", "updated_at"}
 }
 
+type testOrgSettingsInvalidator struct {
+	called bool
+	orgID  uuid.UUID
+}
+
+func (i *testOrgSettingsInvalidator) InvalidateOrg(orgID uuid.UUID) {
+	i.called = true
+	i.orgID = orgID
+}
+
 func TestSettingsHandler_Get(t *testing.T) {
 	t.Parallel()
 
@@ -418,6 +428,85 @@ func TestSettingsHandler_Update_LogsPatchMetadata(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSettingsHandler_Update_ReturnsErrorWhenStoreUpdateFails(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(orgColumns()).AddRow(
+				orgID,
+				"Test Org",
+				json.RawMessage(`{"default_agent_type":"codex"}`),
+				now,
+				now,
+			),
+		)
+	mock.ExpectQuery("UPDATE organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(assertAnError("write failed"))
+
+	store := db.NewOrganizationStore(mock)
+	handler := NewSettingsHandler(store, nil)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/settings", strings.NewReader(`{"settings":{"default_agent_type":"claude_code"}}`))
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code, "should return 500 when the organization update fails")
+	require.Contains(t, w.Body.String(), "UPDATE_FAILED", "response should surface the update failure code")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSettingsHandler_Update_InvalidatesOrgSettingsCacheOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool without error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	now := time.Now()
+	mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(orgColumns()).AddRow(
+				orgID,
+				"Test Org",
+				json.RawMessage(`{"default_agent_type":"codex"}`),
+				now,
+				now,
+			),
+		)
+	mock.ExpectQuery("UPDATE organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"updated_at"}).AddRow(now),
+		)
+
+	store := db.NewOrganizationStore(mock)
+	handler := NewSettingsHandler(store, nil)
+	invalidator := &testOrgSettingsInvalidator{}
+	handler.SetOrgSettingsInvalidator(invalidator)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/settings", strings.NewReader(`{"settings":{"default_agent_type":"claude_code"}}`))
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.Update(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "should update settings successfully")
+	require.True(t, invalidator.called, "successful updates should invalidate the cached org settings")
+	require.Equal(t, orgID, invalidator.orgID, "invalidator should receive the updated org id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestMergeSettingsJSON_ShallowKey(t *testing.T) {
 	t.Parallel()
 	existing := json.RawMessage(`{"llm_model":"gpt-5.3","pm_schedule_hours":4}`)
@@ -647,4 +736,55 @@ func TestMergeSettingsJSON_PreservesIntegerEncoding(t *testing.T) {
 	bigGot, err := mergeSettingsJSON(bigExisting, json.RawMessage(`{"other":"x"}`))
 	require.NoError(t, err)
 	require.Contains(t, string(bigGot), `"big":9007199254740993`)
+}
+
+func TestTopLevelSettingsPatchKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		raw      *json.RawMessage
+		expected []string
+	}{
+		{
+			name:     "returns nil for nil input",
+			raw:      nil,
+			expected: nil,
+		},
+		{
+			name: "returns nil for malformed json",
+			raw: func() *json.RawMessage {
+				raw := json.RawMessage(`{"default_agent_type":`)
+				return &raw
+			}(),
+			expected: nil,
+		},
+		{
+			name: "returns sorted top level keys",
+			raw: func() *json.RawMessage {
+				raw := json.RawMessage(`{"z":1,"a":{"nested":true},"m":null}`)
+				return &raw
+			}(),
+			expected: []string{"a", "m", "z"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, topLevelSettingsPatchKeys(tt.raw), "should return the expected top-level patch keys")
+		})
+	}
+}
+
+func assertAnError(msg string) error {
+	return &testError{msg: msg}
+}
+
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
 }


### PR DESCRIPTION
## Summary
- Skip autosave dispatches when applying a payload would not change the cached end state
- Add regression tests for unchanged autosaves and in-flight duplicate end states
- Log safe request metadata for `/api/v1/settings` PATCHes and skip no-op writes server-side
- Add handler tests for no-op suppression and patch logging

## Testing
- `npx vitest run src/hooks/useAutosave.test.ts`
- `go test ./internal/api/handlers -run 'TestSettingsHandler_Update_(SkipsNoOpPatch|LogsPatchMetadata)$'`
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`