### PR TITLE
Move agent controls into Autopilot settings

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -120,8 +120,7 @@ describe('AgentPage', () => {
   it('shows Execution section for admins', async () => {
     renderWithProviders(<AgentPage />);
 
-    expect(await screen.findByText('Autonomy level')).toBeInTheDocument();
-    expect(screen.getByText('Execution aggressiveness')).toBeInTheDocument();
+    expect(await screen.findByText('Execution')).toBeInTheDocument();
     expect(screen.getByText('Max concurrent runs')).toBeInTheDocument();
   });
 
@@ -141,6 +140,7 @@ describe('AgentPage', () => {
     expect(screen.queryByText('Organization coding agents')).not.toBeInTheDocument();
     expect(screen.queryByText('Autonomy level')).not.toBeInTheDocument();
     expect(screen.queryByText('Execution aggressiveness')).not.toBeInTheDocument();
+    expect(screen.queryByText('Max concurrent runs')).not.toBeInTheDocument();
   });
 
   it('renders without a save button (autosaves)', async () => {

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -68,8 +68,6 @@ import type {
 // `internal/models/org_settings.go`. The server clamps on save, so UI drift
 // is visible (values snap) rather than corrupting state.
 const DEFAULT_EXECUTION_SETTINGS = {
-  autonomy_level: "auto_simple" as const,
-  execution_aggressiveness: 2,
   max_concurrent_runs: 5,
   max_session_duration_seconds: 25 * 60,
 };
@@ -140,10 +138,6 @@ export default function AgentPage() {
 
   const defaultAgentType = orgSettings.default_agent_type ?? "codex";
   const agentConfig = orgSettings.agent_config ?? {};
-  const autonomyLevel = orgSettings.autonomy_level ?? DEFAULT_EXECUTION_SETTINGS.autonomy_level;
-  const aggressiveness = String(
-    orgSettings.execution_aggressiveness ?? DEFAULT_EXECUTION_SETTINGS.execution_aggressiveness,
-  );
   const maxConcurrentServer = orgSettings.max_concurrent_runs ?? DEFAULT_EXECUTION_SETTINGS.max_concurrent_runs;
   const serverSessionSeconds = orgSettings.max_session_duration_seconds ?? DEFAULT_EXECUTION_SETTINGS.max_session_duration_seconds;
   const serverSessionMinutes = Math.round(serverSessionSeconds / 60);
@@ -680,68 +674,13 @@ export default function AgentPage() {
                 Execution
               </h2>
               <p className="text-xs text-muted-foreground mt-1">
-                Control how the coding agent runs across your organization.
+                Control run limits for coding agents across your organization.
               </p>
             </div>
 
             <Card>
               <CardContent>
                 <div className="space-y-6">
-                  <div className="space-y-3">
-                    <Label>Autonomy level</Label>
-                    <RadioGroup
-                      value={autonomyLevel}
-                      onValueChange={(v) =>
-                        autosave.save({
-                          settings: {
-                            autonomy_level: v as "manual" | "auto_simple" | "auto_all",
-                          },
-                        })
-                      }
-                      className="grid grid-cols-3 gap-3"
-                    >
-                      {[
-                        { value: "manual", label: "Manual", description: "Admin triggers all runs" },
-                        { value: "auto_simple", label: "Auto (simple)", description: "Auto-run simple issues" },
-                        { value: "auto_all", label: "Auto (all)", description: "Auto-run all eligible" },
-                      ].map((option) => (
-                        <RadioCard
-                          key={option.value}
-                          value={option.value}
-                          label={option.label}
-                          description={option.description}
-                          selected={autonomyLevel === option.value}
-                        />
-                      ))}
-                    </RadioGroup>
-                  </div>
-
-                  <div className="space-y-3">
-                    <Label>Execution aggressiveness</Label>
-                    <RadioGroup
-                      value={aggressiveness}
-                      onValueChange={(v) =>
-                        autosave.save({ settings: { execution_aggressiveness: parseInt(v, 10) } })
-                      }
-                      className="grid grid-cols-4 gap-3"
-                    >
-                      {[
-                        { value: "1", label: "Conservative", description: "Minimal changes" },
-                        { value: "2", label: "Moderate", description: "Balanced approach" },
-                        { value: "3", label: "Aggressive", description: "More changes" },
-                        { value: "4", label: "Maximum", description: "Full autonomy" },
-                      ].map((option) => (
-                        <RadioCard
-                          key={option.value}
-                          value={option.value}
-                          label={option.label}
-                          description={option.description}
-                          selected={aggressiveness === option.value}
-                        />
-                      ))}
-                    </RadioGroup>
-                  </div>
-
                   <div className="space-y-2">
                     <Label htmlFor="max-concurrent">Max concurrent runs</Label>
                     <Input

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -5,7 +5,7 @@ import { server } from "@/test/mocks/server";
 import AutopilotSettingsPage from "./page";
 
 describe("AutopilotSettingsPage", () => {
-  it("renders PM model and cadence controls without workspace steering fields", async () => {
+  it("renders Autopilot settings without workspace steering fields", async () => {
     server.use(
       http.get("/api/v1/settings", () => HttpResponse.json({
         data: {
@@ -26,6 +26,7 @@ describe("AutopilotSettingsPage", () => {
 
     renderWithProviders(<AutopilotSettingsPage />);
 
+    expect(await screen.findByText("Autopilot")).toBeInTheDocument();
     expect(await screen.findByLabelText("Schedule (hours)")).toBeInTheDocument();
     expect(screen.getByLabelText("PM model")).toBeInTheDocument();
     expect(screen.queryByText("Reference documents")).not.toBeInTheDocument();
@@ -71,7 +72,7 @@ describe("AutopilotSettingsPage", () => {
     });
   });
 
-  it("renders execution settings with autonomy level and max concurrent runs", async () => {
+  it("renders execution settings with autonomy, aggressiveness, and concurrency controls", async () => {
     server.use(
       http.get("/api/v1/settings", () => HttpResponse.json({
         data: {
@@ -81,6 +82,7 @@ describe("AutopilotSettingsPage", () => {
             pm_schedule_hours: 4,
             pm_model: "claude-sonnet-4-5",
             autonomy_level: "auto_simple",
+            execution_aggressiveness: 3,
             max_concurrent_runs: 5,
             default_agent_type: "codex",
             agent_config: {},
@@ -96,6 +98,9 @@ describe("AutopilotSettingsPage", () => {
 
     expect(await screen.findByText("Execution")).toBeInTheDocument();
     expect(screen.getByLabelText("Act on low-risk")).toBeChecked();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Aggressive")).toBeChecked();
+    });
     await waitFor(() => {
       expect(screen.getByLabelText("Max concurrent runs")).toHaveValue(5);
     });
@@ -136,6 +141,46 @@ describe("AutopilotSettingsPage", () => {
     await waitFor(() => {
       expect(capturedBody).toEqual({
         settings: { autonomy_level: "auto_all" },
+      });
+    });
+  });
+
+  it("autosaves execution aggressiveness immediately", async () => {
+    let capturedBody: unknown;
+    server.use(
+      http.get("/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Org",
+          settings: {
+            pm_schedule_hours: 4,
+            pm_model: "claude-sonnet-4-5",
+            autonomy_level: "auto_simple",
+            execution_aggressiveness: 2,
+            max_concurrent_runs: 3,
+            default_agent_type: "codex",
+            agent_config: {},
+          },
+          created_at: "2026-03-20T00:00:00Z",
+          updated_at: "2026-03-20T00:00:00Z",
+        },
+      })),
+      http.get("/api/v1/repositories", () => HttpResponse.json({ data: [], meta: {} })),
+      http.patch("/api/v1/settings", async ({ request }) => {
+        capturedBody = await request.json();
+        return HttpResponse.json({ data: { id: "org-1", name: "Org", settings: {} } });
+      })
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AutopilotSettingsPage />);
+
+    await screen.findByText("Execution");
+    await user.click(screen.getByLabelText("Maximum"));
+
+    await waitFor(() => {
+      expect(capturedBody).toEqual({
+        settings: { execution_aggressiveness: 4 },
       });
     });
   });

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -1,10 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import AutopilotSettingsPage from "./page";
 
+const { useAuthMock } = vi.hoisted(() => ({
+  useAuthMock: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: useAuthMock,
+}));
+
 describe("AutopilotSettingsPage", () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({
+      user: { id: "user-1", name: "Admin User", email: "admin@example.com", role: "admin" },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+  });
+
   it("renders Autopilot settings without workspace steering fields", async () => {
     server.use(
       http.get("/api/v1/settings", () => HttpResponse.json({
@@ -183,5 +199,20 @@ describe("AutopilotSettingsPage", () => {
         settings: { execution_aggressiveness: 4 },
       });
     });
+  });
+
+  it("shows an admin-only message for non-admin users", async () => {
+    useAuthMock.mockReturnValue({
+      user: { id: "user-2", name: "Member User", email: "member@example.com", role: "member" },
+      isLoading: false,
+      isAuthenticated: true,
+    });
+
+    renderWithProviders(<AutopilotSettingsPage />);
+
+    expect(await screen.findByText("Autopilot")).toBeInTheDocument();
+    expect(screen.getByText("Only admins can manage Autopilot settings.")).toBeInTheDocument();
+    expect(screen.queryByText("PM configuration")).not.toBeInTheDocument();
+    expect(screen.queryByText("Execution aggressiveness")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -70,6 +70,7 @@ export default function AutopilotSettingsPage() {
   const scheduleHoursServer = settings.pm_schedule_hours ?? 4;
   const pmModel = settings.pm_model ?? DEFAULT_PM_MODEL;
   const autonomyLevel = settings.autonomy_level ?? "auto_simple";
+  const executionAggressiveness = String(settings.execution_aggressiveness ?? 2);
   const maxConcurrentRunsServer = settings.max_concurrent_runs ?? 3;
 
   const autosave = useAutosave<SettingsPatch>({
@@ -96,7 +97,7 @@ export default function AutopilotSettingsPage() {
     <PageContainer size="default">
       <div className="space-y-6">
         <PageHeader
-          title="Autopilot settings"
+          title="Autopilot"
           description="Configure PM model, cadence, and organization-wide automation defaults."
           action={<AutosaveIndicator status={autosave.status} />}
         />
@@ -190,6 +191,49 @@ export default function AutopilotSettingsPage() {
                     <div>
                       <span className="text-xs font-medium">Operate broadly</span>
                       <p className="text-xs text-muted-foreground">Autopilot runs automatically on eligible work.</p>
+                    </div>
+                  </label>
+                </RadioGroup>
+              </div>
+              <div className="space-y-2">
+                <Label>Execution aggressiveness</Label>
+                <p className="text-xs text-muted-foreground">
+                  Controls how broadly Autopilot edits once it decides to act.
+                </p>
+                <RadioGroup
+                  value={executionAggressiveness}
+                  onValueChange={(value) =>
+                    autosave.save({
+                      settings: { execution_aggressiveness: parseInt(value, 10) },
+                    })
+                  }
+                >
+                  <label className="flex items-center gap-3 rounded-lg border p-3">
+                    <RadioGroupItem value="1" aria-label="Conservative" />
+                    <div>
+                      <span className="text-xs font-medium">Conservative</span>
+                      <p className="text-xs text-muted-foreground">Prefer smaller, lower-risk edits.</p>
+                    </div>
+                  </label>
+                  <label className="flex items-center gap-3 rounded-lg border p-3">
+                    <RadioGroupItem value="2" aria-label="Moderate" />
+                    <div>
+                      <span className="text-xs font-medium">Moderate</span>
+                      <p className="text-xs text-muted-foreground">Balance scope and caution.</p>
+                    </div>
+                  </label>
+                  <label className="flex items-center gap-3 rounded-lg border p-3">
+                    <RadioGroupItem value="3" aria-label="Aggressive" />
+                    <div>
+                      <span className="text-xs font-medium">Aggressive</span>
+                      <p className="text-xs text-muted-foreground">Allow broader changes when they stay coherent.</p>
+                    </div>
+                  </label>
+                  <label className="flex items-center gap-3 rounded-lg border p-3">
+                    <RadioGroupItem value="4" aria-label="Maximum" />
+                    <div>
+                      <span className="text-xs font-medium">Maximum</span>
+                      <p className="text-xs text-muted-foreground">Optimize for throughput over caution.</p>
                     </div>
                   </label>
                 </RadioGroup>

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useAuth } from "@/hooks/use-auth";
 import { Badge } from "@/components/ui/badge";
 import { AutosaveIndicator } from "@/components/AutosaveIndicator";
 import { Card, CardContent } from "@/components/ui/card";
@@ -39,13 +40,18 @@ import {
 import type { ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
+  const { user } = useAuth();
+  const isAdmin = user?.role === "admin";
+
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
+    enabled: isAdmin,
   });
   const { data: repositoriesResponse } = useQuery<ListResponse<Repository>>({
     queryKey: queryKeys.repositories.all,
     queryFn: () => api.repositories.list(),
+    enabled: isAdmin,
   });
 
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
@@ -92,6 +98,22 @@ export default function AutopilotSettingsPage() {
     toPatch: (v) => ({ settings: { max_concurrent_runs: v } }),
     clamp: (v) => clampNumber(v, MIN_CONCURRENT_RUNS, MAX_CONCURRENT_RUNS),
   });
+
+  if (!isAdmin) {
+    return (
+      <PageContainer size="default">
+        <div className="space-y-6">
+          <PageHeader
+            title="Autopilot"
+            description="Configure PM model, cadence, and organization-wide automation defaults."
+          />
+          <div className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+            Only admins can manage Autopilot settings.
+          </div>
+        </div>
+      </PageContainer>
+    );
+  }
 
   return (
     <PageContainer size="default">

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -170,6 +170,27 @@ describe("AuthenticatedLayout", () => {
     expect(screen.queryByRole("link", { name: "Audit log" })).not.toBeInTheDocument();
   });
 
+  it("hides Autopilot settings from non-admin users", async () => {
+    useAuthMock.mockReturnValue({
+      user: memberUser,
+      isLoading: false,
+      isAuthenticated: true,
+      logout: logoutMock,
+    });
+
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <AuthenticatedLayout>
+        <div>content</div>
+      </AuthenticatedLayout>
+    );
+
+    await user.click(screen.getByRole("button", { name: /Settings/ }));
+
+    expect(screen.queryAllByRole("link", { name: "Autopilot" }).filter((link) => link.getAttribute("href") === "/settings/autopilot")).toHaveLength(0);
+  });
+
   it("does not show repo context switcher when org has only 1 repo", async () => {
     server.use(
       http.get("/api/v1/repositories/summary", () => {

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -70,7 +70,7 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    expect(screen.getByRole("link", { name: "Autopilot" })).toHaveAttribute("href", "/autopilot");
+    expect(screen.getAllByRole("link", { name: "Autopilot" }).find((link) => link.getAttribute("href") === "/autopilot")).toBeDefined();
   });
 
   it("uses a slightly narrower default sidebar width", () => {
@@ -126,7 +126,7 @@ describe("AuthenticatedLayout", () => {
     expect(screen.getByRole("link", { name: "Integrations" })).toHaveAttribute("href", "/settings/integrations");
     expect(screen.getByRole("link", { name: "Coding agents" })).toHaveAttribute("href", "/settings/agent");
     expect(screen.getByRole("link", { name: "LLM" })).toHaveAttribute("href", "/settings/llm");
-    expect(screen.getByRole("link", { name: "Autopilot settings" })).toHaveAttribute("href", "/settings/autopilot");
+    expect(screen.getAllByRole("link", { name: "Autopilot" }).find((link) => link.getAttribute("href") === "/settings/autopilot")).toBeDefined();
     expect(screen.getByRole("link", { name: "Evals" })).toHaveAttribute("href", "/settings/evals");
     expect(screen.getByRole("link", { name: "Team" })).toHaveAttribute("href", "/settings/team");
     expect(screen.getByRole("link", { name: "Audit log" })).toHaveAttribute("href", "/settings/audit-log");

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -44,7 +44,7 @@ export const staticActions: PaletteAction[] = [
   { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/settings/integrations", group: "settings" },
   { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", requiredRole: "admin", group: "settings" },
   { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/settings/llm", group: "settings" },
-  { id: "settings-autopilot", label: "Autopilot settings", icon: Target, href: "/settings/autopilot", group: "settings" },
+  { id: "settings-autopilot", label: "Autopilot", icon: Target, href: "/settings/autopilot", group: "settings" },
   { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", group: "settings" },
   { id: "settings-team", label: "Team", icon: Users, href: "/settings/team", group: "settings" },
   { id: "settings-audit-log", label: "Audit log", icon: ScrollText, href: "/settings/audit-log", requiredRole: "admin", group: "settings" },

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -44,7 +44,7 @@ export const staticActions: PaletteAction[] = [
   { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/settings/integrations", group: "settings" },
   { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", requiredRole: "admin", group: "settings" },
   { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/settings/llm", group: "settings" },
-  { id: "settings-autopilot", label: "Autopilot", icon: Target, href: "/settings/autopilot", group: "settings" },
+  { id: "settings-autopilot", label: "Autopilot", icon: Target, href: "/settings/autopilot", requiredRole: "admin", group: "settings" },
   { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", group: "settings" },
   { id: "settings-team", label: "Team", icon: Users, href: "/settings/team", group: "settings" },
   { id: "settings-audit-log", label: "Audit log", icon: ScrollText, href: "/settings/audit-log", requiredRole: "admin", group: "settings" },

--- a/frontend/src/components/command-palette/command-palette.test.tsx
+++ b/frontend/src/components/command-palette/command-palette.test.tsx
@@ -44,7 +44,7 @@ describe("CommandPalette", () => {
     renderPalette();
     expect(await screen.findByText("Sessions")).toBeInTheDocument();
     expect(screen.getByText("Projects")).toBeInTheDocument();
-    expect(screen.getByText("Autopilot")).toBeInTheDocument();
+    expect(screen.getAllByText("Autopilot")).toHaveLength(2);
   });
 
   it("renders settings items", async () => {
@@ -65,6 +65,7 @@ describe("CommandPalette", () => {
     renderPalette({ userRole: "member" });
     await screen.findByText("General");
     expect(screen.queryByText("Audit log")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Autopilot")).toHaveLength(1);
   });
 
   it("includes admin-only items for admin users", async () => {
@@ -76,7 +77,7 @@ describe("CommandPalette", () => {
     const user = userEvent.setup();
     renderPalette();
 
-    const autopilotItem = await screen.findByText("Autopilot");
+    const [autopilotItem] = await screen.findAllByText("Autopilot");
     await user.click(autopilotItem);
 
     expect(pushMock).toHaveBeenCalledWith("/autopilot");

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -48,7 +48,7 @@ const settingsGroups: SettingsGroup[] = [
       { label: "Integrations", icon: Plug, href: "/settings/integrations" },
       { label: "Coding agents", icon: Bot, href: "/settings/agent", adminOnly: true },
       { label: "LLM", icon: Sparkles, href: "/settings/llm" },
-      { label: "Autopilot settings", icon: Target, href: "/settings/autopilot" },
+      { label: "Autopilot", icon: Target, href: "/settings/autopilot" },
       { label: "Evals", icon: FlaskConical, href: "/settings/evals" },
     ],
   },

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -48,7 +48,7 @@ const settingsGroups: SettingsGroup[] = [
       { label: "Integrations", icon: Plug, href: "/settings/integrations" },
       { label: "Coding agents", icon: Bot, href: "/settings/agent", adminOnly: true },
       { label: "LLM", icon: Sparkles, href: "/settings/llm" },
-      { label: "Autopilot", icon: Target, href: "/settings/autopilot" },
+      { label: "Autopilot", icon: Target, href: "/settings/autopilot", adminOnly: true },
       { label: "Evals", icon: FlaskConical, href: "/settings/evals" },
     ],
   },


### PR DESCRIPTION
## Summary
- Rename the Autopilot settings entry to `Autopilot` in navigation and the command palette
- Move `Autonomy level` and `Execution aggressiveness` from Coding agents into the Autopilot settings page
- Keep Coding agents focused on agent defaults and run limits

## Testing
- `npx vitest run src/app/(dashboard)/settings/autopilot/page.test.tsx src/app/(dashboard)/settings/agent/page.test.tsx src/components/authenticated-layout.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`