### PR TITLE
Default session and project filters to Mine

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen } from '@/test/test-utils';
+import userEvent from '@testing-library/user-event';
 import { server } from '@/test/mocks/server';
 import { ProjectSidebar } from './project-sidebar';
 import type { Project, ListResponse } from '@/lib/types';
@@ -20,6 +21,10 @@ vi.mock('next/navigation', () => ({
   useParams: () => ({}),
 }));
 
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({ isAuthenticated: true, user: { id: 'user-1' }, isLoading: false, logout: vi.fn() }),
+}));
+
 describe('ProjectSidebar', () => {
   beforeEach(() => {
     mockPathname = '/projects';
@@ -34,6 +39,48 @@ describe('ProjectSidebar', () => {
     renderWithProviders(<ProjectSidebar />);
     expect(await screen.findByText('Test Project')).toBeInTheDocument();
     expect(screen.getByText('Security Sweep')).toBeInTheDocument();
+  });
+
+  it('defaults the owner scope to Mine', async () => {
+    let capturedCreatedBy: string | null = null;
+    server.use(
+      http.get('*/api/v1/projects', ({ request }) => {
+        capturedCreatedBy = new URL(request.url).searchParams.get('created_by');
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<Project>);
+      }),
+    );
+
+    renderWithProviders(<ProjectSidebar />);
+
+    await screen.findByRole('radio', { name: 'Mine' });
+    expect(capturedCreatedBy).toBe('user-1');
+  });
+
+  it('switches the owner scope to Everyone', async () => {
+    const createdByValues: string[] = [];
+    server.use(
+      http.get('*/api/v1/projects', ({ request }) => {
+        createdByValues.push(new URL(request.url).searchParams.get('created_by') ?? '');
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<Project>);
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<ProjectSidebar />);
+
+    await screen.findByRole('radio', { name: 'Mine' });
+    await user.click(screen.getByRole('radio', { name: 'Everyone' }));
+
+    expect(createdByValues).toContain('user-1');
+    expect(createdByValues).toContain('');
+  });
+
+  it('shows the owner scope toggle', async () => {
+    renderWithProviders(<ProjectSidebar />);
+    await screen.findByText('Test Project');
+
+    expect(screen.getByRole('radio', { name: 'Everyone' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Mine' })).toBeInTheDocument();
   });
 
   it('displays New project link at top', () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -13,6 +13,17 @@ vi.mock('next/link', () => ({
 }));
 
 let mockPathname = '/projects';
+const mockAuthState: {
+  isAuthenticated: boolean;
+  user: { id: string } | null;
+  isLoading: boolean;
+  logout: ReturnType<typeof vi.fn>;
+} = {
+  isAuthenticated: true,
+  user: { id: 'user-1' },
+  isLoading: false,
+  logout: vi.fn(),
+};
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
@@ -22,12 +33,16 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
-  useAuth: () => ({ isAuthenticated: true, user: { id: 'user-1' }, isLoading: false, logout: vi.fn() }),
+  useAuth: () => mockAuthState,
 }));
 
 describe('ProjectSidebar', () => {
   beforeEach(() => {
     mockPathname = '/projects';
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = { id: 'user-1' };
+    mockAuthState.isLoading = false;
+    mockAuthState.logout = vi.fn();
   });
 
   it('shows loading state initially', () => {
@@ -96,8 +111,65 @@ describe('ProjectSidebar', () => {
       }),
     );
 
-    renderWithProviders(<ProjectSidebar />);
+    renderWithProviders(<ProjectSidebar />, { searchParams: { user: 'all' } });
     expect(await screen.findByText('No projects yet')).toBeInTheDocument();
+  });
+
+  it('shows filtered empty state when Mine has no matching projects', async () => {
+    server.use(
+      http.get('*/api/v1/projects', ({ request }) => {
+        const createdBy = new URL(request.url).searchParams.get('created_by');
+        if (createdBy === 'user-1') {
+          return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<Project>);
+        }
+        return HttpResponse.json({
+          data: [{
+            id: 'proj-team',
+            org_id: 'org-1',
+            repository_id: 'repo-1',
+            title: 'Teammate Project',
+            goal: 'Owned by someone else',
+            status: 'active',
+            priority: 50,
+            execution_mode: 'sequential',
+            max_concurrent: 1,
+            auto_merge: false,
+            base_branch: 'main',
+            total_tasks: 0,
+            completed_tasks: 0,
+            failed_tasks: 0,
+            proposed_by_pm: false,
+            created_at: '2026-02-17T07:00:00Z',
+            updated_at: '2026-02-17T07:00:00Z',
+          }],
+          meta: {},
+        } satisfies ListResponse<Project>);
+      }),
+    );
+
+    renderWithProviders(<ProjectSidebar />);
+
+    expect(await screen.findByText('No projects match this filter.')).toBeInTheDocument();
+  });
+
+  it('does not fetch projects until the Mine scope can resolve the current user', async () => {
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    mockAuthState.isLoading = true;
+
+    let requestCount = 0;
+    server.use(
+      http.get('*/api/v1/projects', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<Project>);
+      }),
+    );
+
+    renderWithProviders(<ProjectSidebar />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(requestCount).toBe(0);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('shows status filter tabs', async () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -115,7 +115,7 @@ describe('ProjectSidebar', () => {
     expect(await screen.findByText('No projects yet')).toBeInTheDocument();
   });
 
-  it('shows filtered empty state when Mine has no matching projects', async () => {
+  it('shows a dedicated empty state when the default Mine view is empty', async () => {
     server.use(
       http.get('*/api/v1/projects', ({ request }) => {
         const createdBy = new URL(request.url).searchParams.get('created_by');
@@ -149,7 +149,8 @@ describe('ProjectSidebar', () => {
 
     renderWithProviders(<ProjectSidebar />);
 
-    expect(await screen.findByText('No projects match this filter.')).toBeInTheDocument();
+    expect(await screen.findByText('No projects in Mine yet')).toBeInTheDocument();
+    expect(screen.getByText('Switch to Everyone to browse team projects, or create a new one.')).toBeInTheDocument();
   });
 
   it('does not fetch projects until the Mine scope can resolve the current user', async () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -36,7 +36,7 @@ export function ProjectSidebar() {
   const params = useParams();
   const pathname = usePathname();
   const selectedId = params?.id as string | undefined;
-  const { currentUserFilter, createdByUserId, setUserFilter } = useProjectUserFilter();
+  const { currentUserFilter, createdByUserId, isResolved, setUserFilter } = useProjectUserFilter();
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
@@ -44,6 +44,7 @@ export function ProjectSidebar() {
   const { data, isLoading } = useQuery({
     queryKey: ["projects", activeFilter, repo, currentUserFilter, createdByUserId],
     queryFn: () => api.projects.list({ limit: 50, repository_id: repo ?? undefined, created_by: createdByUserId }),
+    enabled: isResolved,
     refetchInterval: 10000,
   });
 
@@ -142,15 +143,15 @@ export function ProjectSidebar() {
           </Link>
         )}
 
-        {isLoading && (
+        {(!isResolved || isLoading) && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
             Loading...
           </div>
         )}
 
-        {!isLoading && displayedProjects.length === 0 && (
+        {isResolved && !isLoading && displayedProjects.length === 0 && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
-            {allProjects.length === 0 ? (
+            {allProjects.length === 0 && currentUserFilter === "all" ? (
               <div className="space-y-2">
                 <FolderKanban className="h-5 w-5 mx-auto text-muted-foreground/40" />
                 <p>No projects yet</p>

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -72,6 +72,11 @@ export function ProjectSidebar() {
   }, [filteredProjects, search]);
 
   const isNewProject = pathname === "/projects/new";
+  const showMineEmptyState =
+    currentUserFilter === "mine" &&
+    currentFilter === "all" &&
+    !search.trim() &&
+    displayedProjects.length === 0;
 
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
@@ -155,6 +160,12 @@ export function ProjectSidebar() {
               <div className="space-y-2">
                 <FolderKanban className="h-5 w-5 mx-auto text-muted-foreground/40" />
                 <p>No projects yet</p>
+              </div>
+            ) : showMineEmptyState ? (
+              <div className="space-y-2">
+                <FolderKanban className="h-5 w-5 mx-auto text-muted-foreground/40" />
+                <p className="text-foreground">No projects in Mine yet</p>
+                <p>Switch to Everyone to browse team projects, or create a new one.</p>
               </div>
             ) : (
               "No projects match this filter."

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -6,10 +6,14 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
+import { OwnerScopeToggle } from "@/components/owner-scope-toggle";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { cn, formatTimeAgo } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
+import { useProjectUserFilter } from "@/hooks/use-project-user-filter";
 import { projectStatusConfig, projectStatusDotColor } from "@/lib/types";
 import type { Project } from "@/lib/types";
 const filterTabs = [
@@ -32,13 +36,14 @@ export function ProjectSidebar() {
   const params = useParams();
   const pathname = usePathname();
   const selectedId = params?.id as string | undefined;
+  const { currentUserFilter, createdByUserId, setUserFilter } = useProjectUserFilter();
   const [search, setSearch] = useState("");
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
 
   const { data, isLoading } = useQuery({
-    queryKey: ["projects", activeFilter, repo],
-    queryFn: () => api.projects.list({ limit: 50, repository_id: repo ?? undefined }),
+    queryKey: ["projects", activeFilter, repo, currentUserFilter, createdByUserId],
+    queryFn: () => api.projects.list({ limit: 50, repository_id: repo ?? undefined, created_by: createdByUserId }),
     refetchInterval: 10000,
   });
 
@@ -71,27 +76,30 @@ export function ProjectSidebar() {
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
       {/* Header */}
       <div className="px-4 pt-3 pb-3 space-y-3">
-
-        {/* Search */}
-        <div className="relative">
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1 min-w-0">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/50" />
-          <input
-            type="text"
+          <Input
             placeholder="Search projects..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-            className="w-full h-8 pl-8 pr-3 rounded-md border border-border bg-background text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-ring"
+            className="h-8 pl-8 text-xs"
+          />
+        </div>
+          <OwnerScopeToggle
+            currentUserFilter={currentUserFilter}
+            onFilterChange={setUserFilter}
+            className="shrink-0"
           />
         </div>
 
         {/* New project button */}
-        <Link
-          href="/projects/new"
-          className="flex items-center justify-center gap-2 w-full h-9 rounded-md border border-border bg-background text-xs font-medium text-foreground hover:bg-accent transition-colors shadow-sm"
-        >
-          <Plus className="h-4 w-4" />
-          New project
-        </Link>
+        <Button asChild variant="outline" className="w-full gap-2 bg-background text-xs shadow-sm">
+          <Link href="/projects/new">
+            <Plus className="h-4 w-4" />
+            New project
+          </Link>
+        </Button>
 
         {/* Filter tabs */}
         <Tabs

--- a/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-owner-toggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { OwnerScopeToggle } from "@/components/owner-scope-toggle";
 import type { UserFilterParam } from "@/hooks/use-session-user-filter";
 
 interface SessionOwnerToggleProps {
@@ -15,18 +15,10 @@ export function SessionOwnerToggle({
   className,
 }: SessionOwnerToggleProps) {
   return (
-    <ToggleGroup
-      type="single"
-      size="sm"
-      value={currentUserFilter}
-      onValueChange={(value: string) => {
-        if (!value) return; // prevent deselecting
-        onFilterChange(value === "all" ? null : "mine");
-      }}
+    <OwnerScopeToggle
+      currentUserFilter={currentUserFilter}
+      onFilterChange={onFilterChange}
       className={className}
-    >
-      <ToggleGroupItem value="all">Everyone</ToggleGroupItem>
-      <ToggleGroupItem value="mine">Mine</ToggleGroupItem>
-    </ToggleGroup>
+    />
   );
 }

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -15,6 +15,17 @@ vi.mock('next/link', () => ({
 
 let mockPathname = '/sessions';
 let mockParams: Record<string, string> = {};
+const mockAuthState: {
+  isAuthenticated: boolean;
+  user: { id: string } | null;
+  isLoading: boolean;
+  logout: ReturnType<typeof vi.fn>;
+} = {
+  isAuthenticated: true,
+  user: { id: 'user-1' },
+  isLoading: false,
+  logout: vi.fn(),
+};
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
@@ -24,7 +35,7 @@ vi.mock('next/navigation', () => ({
 }));
 
 vi.mock('@/hooks/use-auth', () => ({
-  useAuth: () => ({ isAuthenticated: true, user: { id: 'user-1' }, isLoading: false, logout: vi.fn() }),
+  useAuth: () => mockAuthState,
 }));
 
 const mockOptimisticSessions: { id: string; title: string; status: 'pending'; created_at: string; resolvedId?: string }[] = [];
@@ -74,6 +85,10 @@ describe('SessionSidebar', () => {
     mockPathname = '/sessions';
     mockParams = {};
     mockOptimisticSessions.length = 0;
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = { id: 'user-1' };
+    mockAuthState.isLoading = false;
+    mockAuthState.logout = vi.fn();
   });
 
   it('defaults the owner scope to Mine', async () => {
@@ -89,6 +104,30 @@ describe('SessionSidebar', () => {
 
     await screen.findByRole('radio', { name: 'Mine' });
     expect(capturedUserId).toBe('user-1');
+  });
+
+  it('does not fetch sessions until the Mine scope can resolve the current user', async () => {
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    mockAuthState.isLoading = true;
+
+    let requestCount = 0;
+    server.use(
+      http.get('/api/v1/sessions', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get('/api/v1/sessions/counts', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: { all: 0, active: 0, archived: 0, cap: 0 } });
+      }),
+    );
+
+    renderWithProviders(<SessionSidebar />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(requestCount).toBe(0);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   // -----------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -76,6 +76,21 @@ describe('SessionSidebar', () => {
     mockOptimisticSessions.length = 0;
   });
 
+  it('defaults the owner scope to Mine', async () => {
+    let capturedUserId: string | null = null;
+    server.use(
+      http.get('/api/v1/sessions', ({ request }) => {
+        capturedUserId = new URL(request.url).searchParams.get('triggered_by_user_id');
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    renderWithProviders(<SessionSidebar />);
+
+    await screen.findByRole('radio', { name: 'Mine' });
+    expect(capturedUserId).toBe('user-1');
+  });
+
   // -----------------------------------------------------------------------
   // Search filtering
   // -----------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -151,7 +151,7 @@ export function SessionSidebar() {
   const params = useParams();
   const pathname = usePathname();
   const queryClient = useQueryClient();
-  const { currentUserFilter, triggeredByUserId, setUserFilter } = useSessionUserFilter();
+  const { currentUserFilter, triggeredByUserId, isResolved, setUserFilter } = useSessionUserFilter();
   const selectedId = params?.id as string | undefined;
   const [search, setSearch] = useState("");
   // Debounce the search query so rapid typing doesn't fire a request per
@@ -208,6 +208,7 @@ export function SessionSidebar() {
   const { data: listData, isLoading } = useQuery({
     queryKey: [...queryKeys.sessions.list(repo), "filtered", currentFilter, triggeredByUserId, trimmedSearch],
     queryFn: () => api.sessions.list(listParams),
+    enabled: isResolved,
     refetchInterval: isPaginated ? false : 10000,
   });
 
@@ -220,6 +221,7 @@ export function SessionSidebar() {
         repository_id: repo ?? undefined,
         triggered_by_user_id: triggeredByUserId,
       }),
+    enabled: isResolved,
     refetchInterval: 10000,
   });
 
@@ -383,13 +385,13 @@ export function SessionSidebar() {
             <OptimisticSessionRow key={os.id} session={os} />
           ))}
 
-        {isLoading && (
+        {(!isResolved || isLoading) && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
             Loading...
           </div>
         )}
 
-        {!isLoading && displayedSessions.length === 0 && showDefaultEmptyState && (
+        {isResolved && !isLoading && displayedSessions.length === 0 && showDefaultEmptyState && (
           <div className="space-y-3 px-2 py-3">
             <NoReposWarning showDisconnectedState compact />
             <div className="px-2 py-5 text-center text-xs text-muted-foreground">
@@ -398,7 +400,7 @@ export function SessionSidebar() {
           </div>
         )}
 
-        {!isLoading && displayedSessions.length === 0 && !showDefaultEmptyState && (
+        {isResolved && !isLoading && displayedSessions.length === 0 && !showDefaultEmptyState && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
             No sessions match this filter.
           </div>

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders, screen } from '@/test/test-utils';
+import { server } from '@/test/mocks/server';
+import { SessionsPageContent } from './sessions-page-content';
+
+const mockAuthState: {
+  isAuthenticated: boolean;
+  user: { id: string } | null;
+  isLoading: boolean;
+  logout: ReturnType<typeof vi.fn>;
+} = {
+  isAuthenticated: true,
+  user: { id: 'user-1' },
+  isLoading: false,
+  logout: vi.fn(),
+};
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => '/sessions',
+  useParams: () => ({}),
+}));
+
+vi.mock('@/hooks/use-auth', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+describe('SessionsPageContent', () => {
+  beforeEach(() => {
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = { id: 'user-1' };
+    mockAuthState.isLoading = false;
+    mockAuthState.logout = vi.fn();
+  });
+
+  it('shows loading while Mine is waiting on auth resolution', async () => {
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    mockAuthState.isLoading = true;
+
+    let requestCount = 0;
+    server.use(
+      http.get('/api/v1/sessions', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get('/api/v1/sessions/counts', () => {
+        requestCount += 1;
+        return HttpResponse.json({ data: { all: 0, active: 0, archived: 0, cap: 0 } });
+      }),
+    );
+
+    renderWithProviders(<SessionsPageContent />);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(requestCount).toBe(0);
+    expect(screen.getByText('Loading sessions...')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -270,6 +270,7 @@ export function SessionsPageContent() {
   });
 
   const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);
+  const isPendingScope = !showDecisions && (!isResolved || isLoading);
 
   const firstPage = useMemo(() => listData?.data ?? [], [listData?.data]);
   const firstPageCursor = listData?.meta?.next_cursor || undefined;
@@ -373,19 +374,19 @@ export function SessionsPageContent() {
       {showDecisions && <DecisionsView />}
 
       {/* ── Loading / error / empty states ─────────────────────────── */}
-      {!showDecisions && isLoading && (
+      {isPendingScope && (
         <div className="py-16 text-center text-xs text-muted-foreground">
           Loading sessions...
         </div>
       )}
 
-      {!showDecisions && error && (
+      {!isPendingScope && !showDecisions && error && (
         <div className="py-16 text-center text-xs text-muted-foreground">
           Failed to load sessions. Make sure the backend is running.
         </div>
       )}
 
-      {!showDecisions && !isLoading && !error && counts?.all === 0 && (
+      {!isPendingScope && !showDecisions && !error && counts?.all === 0 && (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
             <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
@@ -408,7 +409,7 @@ export function SessionsPageContent() {
       )}
 
       {/* ── Data table ─────────────────────────────────────────────── */}
-      {!showDecisions && !isLoading && !error && counts?.all !== 0 && (
+      {!isPendingScope && !showDecisions && !error && counts?.all !== 0 && (
         <div className="rounded-lg border border-border bg-card overflow-hidden">
           {filteredSessions.length === 0 ? (
             <div className="py-12 text-center text-xs text-muted-foreground">

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -196,7 +196,7 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
 
 export function SessionsPageContent() {
   const router = useRouter();
-  const { currentUserFilter, triggeredByUserId, setUserFilter } = useSessionUserFilter();
+  const { currentUserFilter, triggeredByUserId, isResolved, setUserFilter } = useSessionUserFilter();
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -249,7 +249,7 @@ export function SessionsPageContent() {
     queryKey: [...queryKeys.sessions.list(repo), "filtered", currentFilter, triggeredByUserId],
     queryFn: () => api.sessions.list(listParams),
     refetchInterval: isPaginated || showDecisions ? false : 10000,
-    enabled: !showDecisions,
+    enabled: !showDecisions && isResolved,
   });
 
   // Tab badge counts.
@@ -261,7 +261,7 @@ export function SessionsPageContent() {
         triggered_by_user_id: triggeredByUserId,
       }),
     refetchInterval: showDecisions ? false : 10000,
-    enabled: !showDecisions,
+    enabled: !showDecisions && isResolved,
   });
 
   const { data: membersData } = useQuery({

--- a/frontend/src/components/owner-scope-toggle.tsx
+++ b/frontend/src/components/owner-scope-toggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import type { OwnerScopeParam } from "@/hooks/use-owner-scope-filter";
+
+interface OwnerScopeToggleProps {
+  currentUserFilter: string;
+  onFilterChange: (value: OwnerScopeParam) => void;
+  className?: string;
+}
+
+export function OwnerScopeToggle({
+  currentUserFilter,
+  onFilterChange,
+  className,
+}: OwnerScopeToggleProps) {
+  return (
+    <ToggleGroup
+      type="single"
+      size="sm"
+      value={currentUserFilter}
+      onValueChange={(value: string) => {
+        if (!value) return;
+        onFilterChange(value === "mine" ? null : "all");
+      }}
+      className={className}
+    >
+      <ToggleGroupItem value="all">Everyone</ToggleGroupItem>
+      <ToggleGroupItem value="mine">Mine</ToggleGroupItem>
+    </ToggleGroup>
+  );
+}

--- a/frontend/src/hooks/use-owner-scope-filter.ts
+++ b/frontend/src/hooks/use-owner-scope-filter.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { parseAsString, useQueryState } from "nuqs";
+import { useAuth } from "@/hooks/use-auth";
+import type { User } from "@/lib/types";
+
+export type OwnerScopePreset = "mine" | "all";
+export type OwnerScopeParam = string | null;
+
+export function resolveOwnerScope(param: string | null): OwnerScopePreset | string {
+  return param ?? "mine";
+}
+
+export function deriveScopedUserId(
+  filter: OwnerScopePreset | string,
+  currentUser: User | null,
+): string | undefined {
+  if (filter === "all") return undefined;
+  if (filter === "mine") return currentUser?.id;
+  return filter;
+}
+
+export function ownerScopeLabel(
+  filter: OwnerScopePreset | string,
+  members: User[],
+): string {
+  if (filter === "mine") return "Mine";
+  if (filter === "all") return "Everyone";
+  const member = members.find((m) => m.id === filter);
+  return member ? member.name.split(" ")[0] : "User";
+}
+
+export function ownerScopeParamForMember(
+  memberId: string,
+  currentUserId: string | undefined,
+): OwnerScopeParam {
+  return memberId === currentUserId ? null : memberId;
+}
+
+export function useOwnerScopeFilter() {
+  const { user } = useAuth();
+  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
+
+  const currentUserFilter = resolveOwnerScope(userFilter);
+  const userId = deriveScopedUserId(currentUserFilter, user);
+
+  return {
+    currentUserFilter,
+    currentUser: user,
+    scopedUserId: userId,
+    setUserFilter,
+  };
+}

--- a/frontend/src/hooks/use-owner-scope-filter.ts
+++ b/frontend/src/hooks/use-owner-scope-filter.ts
@@ -38,16 +38,18 @@ export function ownerScopeParamForMember(
 }
 
 export function useOwnerScopeFilter() {
-  const { user } = useAuth();
+  const { user, isLoading } = useAuth();
   const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
 
   const currentUserFilter = resolveOwnerScope(userFilter);
   const userId = deriveScopedUserId(currentUserFilter, user);
+  const isResolved = currentUserFilter !== "mine" || !!user || !isLoading;
 
   return {
     currentUserFilter,
     currentUser: user,
     scopedUserId: userId,
+    isResolved,
     setUserFilter,
   };
 }

--- a/frontend/src/hooks/use-project-user-filter.ts
+++ b/frontend/src/hooks/use-project-user-filter.ts
@@ -3,11 +3,12 @@
 import { useOwnerScopeFilter } from "@/hooks/use-owner-scope-filter";
 
 export function useProjectUserFilter() {
-  const { currentUserFilter, currentUser, scopedUserId, setUserFilter } = useOwnerScopeFilter();
+  const { currentUserFilter, currentUser, scopedUserId, isResolved, setUserFilter } = useOwnerScopeFilter();
 
   return {
     currentUserFilter,
     createdByUserId: scopedUserId,
+    isResolved,
     user: currentUser,
     setUserFilter,
   };

--- a/frontend/src/hooks/use-project-user-filter.ts
+++ b/frontend/src/hooks/use-project-user-filter.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useOwnerScopeFilter } from "@/hooks/use-owner-scope-filter";
+
+export function useProjectUserFilter() {
+  const { currentUserFilter, currentUser, scopedUserId, setUserFilter } = useOwnerScopeFilter();
+
+  return {
+    currentUserFilter,
+    createdByUserId: scopedUserId,
+    user: currentUser,
+    setUserFilter,
+  };
+}

--- a/frontend/src/hooks/use-session-user-filter.ts
+++ b/frontend/src/hooks/use-session-user-filter.ts
@@ -1,91 +1,29 @@
 "use client";
 
-import { useQueryState, parseAsString } from "nuqs";
-import { useAuth } from "@/hooks/use-auth";
-import type { User } from "@/lib/types";
+import {
+  deriveScopedUserId,
+  ownerScopeLabel,
+  ownerScopeParamForMember,
+  resolveOwnerScope,
+  useOwnerScopeFilter,
+  type OwnerScopeParam,
+  type OwnerScopePreset,
+} from "@/hooks/use-owner-scope-filter";
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-/** Well-known user filter presets. Any other string value is a specific user ID. */
-export type UserFilterPreset = "mine" | "all";
-
-/** The resolved value stored in the URL query param. `null` means "all" (default). */
-export type UserFilterParam = string | null;
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the URL-level filter value to the effective filter key.
- * `null` (no param) → "all".
- */
-export function resolveUserFilter(param: string | null): UserFilterPreset | string {
-  return param ?? "all";
-}
-
-/**
- * Derive the `triggered_by_user_id` API param from the resolved filter and
- * the current user.
- *
- * - `"all"`          → `undefined` (no server filter)
- * - `"mine"`         → current user's ID (or `undefined` if not yet loaded)
- * - specific user ID → that ID
- */
-export function deriveTriggeredByUserId(
-  filter: UserFilterPreset | string,
-  currentUser: User | null,
-): string | undefined {
-  if (filter === "all") return undefined;
-  if (filter === "mine") return currentUser?.id;
-  return filter; // specific user ID
-}
-
-/**
- * Compute the display label for the user filter trigger button.
- */
-export function userFilterLabel(
-  filter: UserFilterPreset | string,
-  members: User[],
-): string {
-  if (filter === "mine") return "Mine";
-  if (filter === "all") return "Everyone";
-  const member = members.find((m) => m.id === filter);
-  return member ? member.name.split(" ")[0] : "User";
-}
-
-/**
- * Determine the URL param value to set for a given member selection.
- * Selecting yourself maps to `null` ("mine") for a clean URL.
- */
-export function userFilterParamForMember(
-  memberId: string,
-  currentUserId: string | undefined,
-): UserFilterParam {
-  return memberId === currentUserId ? null : memberId;
-}
-
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+export type UserFilterPreset = OwnerScopePreset;
+export type UserFilterParam = OwnerScopeParam;
+export const resolveUserFilter = resolveOwnerScope;
+export const deriveTriggeredByUserId = deriveScopedUserId;
+export const userFilterLabel = ownerScopeLabel;
+export const userFilterParamForMember = ownerScopeParamForMember;
 
 export function useSessionUserFilter() {
-  const { user } = useAuth();
-  const [userFilter, setUserFilter] = useQueryState("user", parseAsString);
-
-  const currentUserFilter = resolveUserFilter(userFilter);
-  const triggeredByUserId = deriveTriggeredByUserId(currentUserFilter, user);
+  const { currentUserFilter, currentUser, scopedUserId, setUserFilter } = useOwnerScopeFilter();
 
   return {
-    /** The resolved filter value: "mine", "all", or a user ID. */
     currentUserFilter,
-    /** The user ID to pass to the API, or undefined for no filter. */
-    triggeredByUserId,
-    /** The current authenticated user. */
-    user,
-    /** Set the user filter. Pass `null` for "all" (default), `"mine"` for own sessions, or a user ID. */
+    triggeredByUserId: scopedUserId,
+    user: currentUser,
     setUserFilter,
   };
 }

--- a/frontend/src/hooks/use-session-user-filter.ts
+++ b/frontend/src/hooks/use-session-user-filter.ts
@@ -18,11 +18,12 @@ export const userFilterLabel = ownerScopeLabel;
 export const userFilterParamForMember = ownerScopeParamForMember;
 
 export function useSessionUserFilter() {
-  const { currentUserFilter, currentUser, scopedUserId, setUserFilter } = useOwnerScopeFilter();
+  const { currentUserFilter, currentUser, scopedUserId, isResolved, setUserFilter } = useOwnerScopeFilter();
 
   return {
     currentUserFilter,
     triggeredByUserId: scopedUserId,
+    isResolved,
     user: currentUser,
     setUserFilter,
   };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -518,7 +518,7 @@ export const api = {
       ),
   },
   projects: {
-    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string; proposed_by_pm?: boolean }) => {
+    list: (params?: { status?: string; cursor?: string; limit?: number; repository_id?: string; search?: string; proposed_by_pm?: boolean; created_by?: string }) => {
       const searchParams = new URLSearchParams();
       if (params?.status) searchParams.set('status', params.status);
       if (params?.cursor) searchParams.set('cursor', params.cursor);
@@ -526,6 +526,7 @@ export const api = {
       if (params?.repository_id) searchParams.set('repository_id', params.repository_id);
       if (params?.search) searchParams.set('search', params.search);
       if (params?.proposed_by_pm !== undefined) searchParams.set('proposed_by_pm', String(params.proposed_by_pm));
+      if (params?.created_by) searchParams.set('created_by', params.created_by);
       const qs = searchParams.toString();
       return get<import('./types').ListResponse<import('./types').Project>>(`/api/v1/projects${qs ? `?${qs}` : ''}`);
     },

--- a/internal/api/handlers/projects.go
+++ b/internal/api/handlers/projects.go
@@ -108,6 +108,15 @@ func (h *ProjectHandler) List(w http.ResponseWriter, r *http.Request) {
 		filters.RepositoryID = repoID
 	}
 
+	if createdByStr := r.URL.Query().Get("created_by"); createdByStr != "" {
+		createdBy, err := uuid.Parse(createdByStr)
+		if err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_USER_ID", "invalid created_by")
+			return
+		}
+		filters.CreatedBy = createdBy
+	}
+
 	projects, err := h.projectStore.ListByOrg(r.Context(), orgID, filters)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list projects", err)

--- a/internal/api/handlers/projects_handler_test.go
+++ b/internal/api/handlers/projects_handler_test.go
@@ -149,6 +149,48 @@ func TestProjectHandler_List_InvalidRepositoryID(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "INVALID_REPOSITORY_ID")
 }
 
+func TestProjectHandler_List_WithCreatedBy(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	handler := NewProjectHandler(db.NewProjectStore(mock), nil, nil, nil, nil)
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM projects WHERE org_id .+ AND created_by").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(projectColumns()))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects?created_by="+userID.String(), nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "List should accept created_by filter")
+	require.Contains(t, rr.Body.String(), `"data":[]`, "List should return an empty list response")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestProjectHandler_List_InvalidCreatedBy(t *testing.T) {
+	t.Parallel()
+
+	handler := NewProjectHandler(nil, nil, nil, nil, nil)
+	orgID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/projects?created_by=not-a-uuid", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.List(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "List should reject an invalid created_by filter")
+	require.Contains(t, rr.Body.String(), "INVALID_USER_ID", "List should surface the created_by validation error")
+}
+
 // --- Get handler tests ---
 
 func TestProjectHandler_Get_NotFound(t *testing.T) {

--- a/internal/db/project_store_test.go
+++ b/internal/db/project_store_test.go
@@ -383,6 +383,34 @@ func TestProjectStore_ListByOrg_WithSearch(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestProjectStore_ListByOrg_WithCreatedBy(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	userID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM projects WHERE org_id .+ AND created_by").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(projectTestColumns).
+				AddRow(newProjectRow(uuid.New(), orgID, repoID, now)...),
+		)
+
+	store := NewProjectStore(mock)
+	projects, err := store.ListByOrg(context.Background(), orgID, ProjectFilters{
+		CreatedBy: userID,
+	})
+	require.NoError(t, err, "ListByOrg with CreatedBy should not return an error")
+	require.Len(t, projects, 1, "should return one project")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestProjectStore_SoftDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/projects.go
+++ b/internal/db/projects.go
@@ -25,6 +25,7 @@ type ProjectFilters struct {
 	Limit        int
 	Cursor       string
 	RepositoryID uuid.UUID
+	CreatedBy    uuid.UUID
 	Search       string // When non-empty, filter projects by title or goal (case-insensitive substring match).
 	ProposedByPM *bool  // When non-nil, filter by proposed_by_pm flag.
 }
@@ -208,6 +209,10 @@ func applyProjectFilters(query string, args pgx.NamedArgs, filters ProjectFilter
 	if filters.RepositoryID != uuid.Nil {
 		query += ` AND repository_id = @repository_id`
 		args["repository_id"] = &filters.RepositoryID
+	}
+	if filters.CreatedBy != uuid.Nil {
+		query += ` AND created_by = @created_by`
+		args["created_by"] = filters.CreatedBy
 	}
 	if filters.ProposedByPM != nil {
 		query += ` AND proposed_by_pm = @proposed_by_pm`


### PR DESCRIPTION
## Summary
- Default the sessions view to `Mine` and reuse a shared owner-scope toggle for sessions and projects
- Add project owner filtering via `created_by`, with `Mine | Everyone` toggle support in the sidebar
- Add unit and UI coverage for the new default filter behavior and toggle interactions

## Testing
- `go test ./internal/db ./internal/api/handlers`
- `go vet ./...`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run src/app/'(dashboard)'/sessions/session-sidebar.test.tsx src/app/'(dashboard)'/projects/project-sidebar.test.tsx`
- `npm run build`