### PR TITLE
Update PM schedule default to 24 hours

### DIFF
--- a/docs/design/implemented/28-agent-ticket-prioritization.md
+++ b/docs/design/implemented/28-agent-ticket-prioritization.md
@@ -266,7 +266,7 @@ The PM agent runs on a straightforward cron schedule. No complex trigger logic.
 ┌─────────────────────────────────────────────────────┐
 │  Scheduler (existing scheduler_lock.go)             │
 │                                                     │
-│  Every N hours (configurable per org, default: 4h): │
+│  Every N hours (configurable per org, default: 24h): │
 │    For each org with active integrations:            │
 │      Enqueue "pm_analyze" job                       │
 │                                                     │
@@ -282,7 +282,7 @@ The PM agent runs on a straightforward cron schedule. No complex trigger logic.
 - Avoids the complexity of counter-based triggers, race conditions, and "how often is too often" tuning
 - Admins can always trigger manually when something urgent comes in
 
-**Org setting:** `pm_schedule_hours` (default: `4`). The scheduler checks `last_pm_run_at + pm_schedule_hours < now()` for each org.
+**Org setting:** `pm_schedule_hours` (default: `24`). The scheduler checks `last_pm_run_at + pm_schedule_hours < now()` for each org.
 
 ### 2. The PM Agent
 
@@ -971,7 +971,7 @@ Existing endpoints are unchanged. The `GET /api/v1/runs/{id}` response gains the
 
 ```go
 // New fields in OrgSettings:
-PMScheduleHours  int              `json:"pm_schedule_hours"`  // hours between PM runs (default: 4)
+PMScheduleHours  int              `json:"pm_schedule_hours"`  // hours between PM runs (default: 24)
 PMModel          string           `json:"pm_model"`           // LLM model for PM agent (default: "sonnet")
 ProductContext   *ProductContext  `json:"product_context,omitempty"` // replaces product_direction string
 ```
@@ -1145,7 +1145,7 @@ The PM has full repo access and could spend its entire 10-minute timeout reading
 
 ### Risk 2: Stale plans
 
-If the PM runs every 4 hours and a P0 Sentry error arrives at hour 0:05, it waits ~4 hours. Meanwhile, the admin sees it in the dashboard but there's no automated response.
+If the PM runs every 24 hours and a P0 Sentry error arrives at hour 0:05, it waits ~24 hours. Meanwhile, the admin sees it in the dashboard but there's no automated response.
 
 **Mitigation:**
 - The existing "Fix This" button on individual issues still works — it bypasses the PM and creates a direct agent run via `CheckAutoTrigger()`.

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -28,7 +28,6 @@ describe("AutopilotSettingsPage", () => {
           id: "org-1",
           name: "Org",
           settings: {
-            pm_schedule_hours: 4,
             pm_model: "claude-sonnet-4-5",
             default_agent_type: "codex",
             agent_config: {},
@@ -43,7 +42,7 @@ describe("AutopilotSettingsPage", () => {
     renderWithProviders(<AutopilotSettingsPage />);
 
     expect(await screen.findByText("Autopilot")).toBeInTheDocument();
-    expect(await screen.findByLabelText("Schedule (hours)")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Schedule (hours)")).toHaveValue(24);
     expect(screen.getByLabelText("PM model")).toBeInTheDocument();
     expect(screen.queryByText("Reference documents")).not.toBeInTheDocument();
     expect(screen.queryByText("Priority weights")).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -73,7 +73,7 @@ export default function AutopilotSettingsPage() {
       .map(([, { label, models }]) => ({ label, models }));
   }, [settings.agent_config, settings.default_agent_type]);
 
-  const scheduleHoursServer = settings.pm_schedule_hours ?? 4;
+  const scheduleHoursServer = settings.pm_schedule_hours ?? 24;
   const pmModel = settings.pm_model ?? DEFAULT_PM_MODEL;
   const autonomyLevel = settings.autonomy_level ?? "auto_simple";
   const executionAggressiveness = String(settings.execution_aggressiveness ?? 2);

--- a/frontend/src/components/repo-pm-settings.tsx
+++ b/frontend/src/components/repo-pm-settings.tsx
@@ -55,7 +55,7 @@ function seedPMFromOrg(
   override: Partial<RepoPMSettings> = {},
 ): RepoPMSettings {
   return {
-    pm_schedule_hours: orgSettings.pm_schedule_hours ?? 4,
+    pm_schedule_hours: orgSettings.pm_schedule_hours ?? 24,
     pm_model: orgSettings.pm_model ?? DEFAULT_PM_MODEL,
     product_context: {
       philosophy: orgSettings.product_context?.philosophy ?? "",
@@ -88,7 +88,7 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
   // Effective values — what the form renders. When not customized, fall back
   // to org defaults so the "Customize" stamp captures what the user sees.
   const effectiveScheduleHours =
-    repoSettings.pm?.pm_schedule_hours ?? orgSettings.pm_schedule_hours ?? 4;
+    repoSettings.pm?.pm_schedule_hours ?? orgSettings.pm_schedule_hours ?? 24;
   const effectiveModel =
     repoSettings.pm?.pm_model ?? orgSettings.pm_model ?? DEFAULT_PM_MODEL;
   const effectivePhilosophy =
@@ -293,10 +293,10 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
                     value={scheduleField.value}
                     onChange={scheduleField.onChange}
                     onBlur={scheduleField.onBlur}
-                    placeholder="4"
+                    placeholder="24"
                   />
                   <p className="text-xs text-muted-foreground">
-                    Org default: every {orgSettings.pm_schedule_hours ?? 4} hours
+                    Org default: every {orgSettings.pm_schedule_hours ?? 24} hours
                   </p>
                 </div>
                 <div className="space-y-2">

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -432,7 +432,7 @@ export const handlers = [
           default_agent_type: 'claude_code',
           agent_config: {},
           autonomy_level: 'auto_simple',
-          pm_schedule_hours: 4,
+          pm_schedule_hours: 24,
           pm_model: 'claude-sonnet-4-5-20250929',
         },
       },

--- a/internal/api/handlers/pm_test.go
+++ b/internal/api/handlers/pm_test.go
@@ -400,8 +400,8 @@ func TestPMHandler_StatusNextRunAtAccountsForFailure(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
 	require.NotNil(t, resp.Data.NextRunAt, "should compute next run time")
 
-	// With default 4h schedule: plan-based next run = planCreatedAt + 4h = now - 1h (in the past).
-	// Failure-based next run = failedAt + 4h = now + 3h30m (in the future).
+	// With the default schedule: plan-based next run = planCreatedAt + interval = now - 1h (in the past).
+	// Failure-based next run = failedAt + interval = now + 3h30m (in the future).
 	// NextRunAt should use the failure-based time since it's later.
 	defaultInterval := time.Duration(models.DefaultPMScheduleHours) * time.Hour
 	expectedNextRun := failedAt.Add(defaultInterval)

--- a/internal/cluster/runtime_test.go
+++ b/internal/cluster/runtime_test.go
@@ -176,7 +176,7 @@ func TestSchedulerRunOnce(t *testing.T) {
 			},
 			repos:           &schedulerRuntimeRepoStoreMock{},
 			jobs:            &schedulerRuntimeJobsMock{},
-			expectedEnqueue: 8, // 2 orgs × (sync_slack + pm_analyze + audit_retention_cleanup + data_retention_cleanup)
+			expectedEnqueue: 6, // 2 orgs get recurring maintenance jobs; only the org with no prior PM plan is due for pm_analyze under the 24h default
 			expectedRelease: 1,
 		},
 	}

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -254,7 +254,7 @@ const (
 	DefaultAgentAutonomy                            = AgentAutonomyAggressive
 	DefaultMinPriorityThreshold                     = 30.0
 	DefaultDefaultAgentType           AgentType     = AgentTypeCodex
-	DefaultPMScheduleHours                          = 4
+	DefaultPMScheduleHours                          = 24
 	DefaultPMModel                                  = PMModelSonnet
 	DefaultAuditRetentionDays                       = 90
 	DefaultContextRefreshIntervalDays               = 14
@@ -365,7 +365,7 @@ func (s OrgSize) PMScheduleHours() int {
 	case OrgSizeEnterprise:
 		return 1
 	default: // medium
-		return 4
+		return 24
 	}
 }
 

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -274,7 +274,7 @@ func TestOrgSize_PMScheduleHours(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t, 6, OrgSizeSmall.PMScheduleHours(), "small orgs run PM less often")
-	require.Equal(t, 4, OrgSizeMedium.PMScheduleHours(), "medium matches previous default")
+	require.Equal(t, 24, OrgSizeMedium.PMScheduleHours(), "medium orgs should default to daily PM runs")
 	require.Equal(t, 2, OrgSizeLarge.PMScheduleHours(), "large orgs need more frequent PM")
 	require.Equal(t, 1, OrgSizeEnterprise.PMScheduleHours(), "enterprise orgs need hourly PM")
 }
@@ -368,7 +368,7 @@ func TestParseOrgSettings_DefaultOrgSizeIsMedium(t *testing.T) {
 
 	// With no org_size set, defaults should match medium profile (backward compatible)
 	require.Equal(t, 10, s.MaxConcurrentRuns, "default should match medium concurrent runs")
-	require.Equal(t, 4, s.PMScheduleHours, "default should match medium PM schedule")
+	require.Equal(t, 24, s.PMScheduleHours, "default should match medium PM schedule")
 	require.Equal(t, 100, s.ContextLimits.MaxOpenIssues, "default should match medium open issues")
 	require.Equal(t, 50_000, s.ContextLimits.PMMaxTokens, "default should match medium PM tokens")
 	require.Equal(t, 50_000, s.ContextLimits.AgentLowTokenMax, "default should match medium low tokens")


### PR DESCRIPTION
## Summary
- Change the default PM schedule interval from 4 hours to 24 hours.
- Update frontend fallbacks, repo PM defaults, tests, and fixture data to match the new daily cadence.
- Refresh the implemented design doc to describe the new default.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npx vitest --run 'src/app/(dashboard)/settings/autopilot/page.test.tsx'`