### PR TITLE
Add GitHub setup badge to the empty session sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -137,6 +137,29 @@ describe('SessionSidebar', () => {
     });
   });
 
+  it('shows a GitHub setup notice when no repository integration is connected', async () => {
+    serveSessions([]);
+    server.use(
+      http.get('/api/v1/integrations', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get('/api/v1/repositories', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    renderWithProviders(<SessionSidebar />);
+
+    expect(await screen.findByText('GitHub setup required')).toBeInTheDocument();
+    expect(
+      screen.getByText(/connect github before creating sessions or projects/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open integrations' })).toHaveAttribute(
+      'href',
+      '/settings/integrations',
+    );
+  });
+
   // -----------------------------------------------------------------------
   // Optimistic session rows
   // -----------------------------------------------------------------------

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -17,6 +17,7 @@ import { SessionOwnerToggle } from "./session-owner-toggle";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
+import { NoReposWarning } from "@/components/no-repos-warning";
 import type { SessionListItem } from "@/lib/types";
 import {
   workingSet,
@@ -287,6 +288,8 @@ export function SessionSidebar() {
   const counts = countsData?.data;
 
   const isNewSession = pathname === "/sessions/new";
+  const showDefaultEmptyState =
+    currentFilter === "all" && !trimmedSearch && (!counts || counts.all === 0);
 
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
@@ -386,11 +389,18 @@ export function SessionSidebar() {
           </div>
         )}
 
-        {!isLoading && displayedSessions.length === 0 && (
+        {!isLoading && displayedSessions.length === 0 && showDefaultEmptyState && (
+          <div className="space-y-3 px-2 py-3">
+            <NoReposWarning showDisconnectedState compact />
+            <div className="px-2 py-5 text-center text-xs text-muted-foreground">
+              No sessions yet
+            </div>
+          </div>
+        )}
+
+        {!isLoading && displayedSessions.length === 0 && !showDefaultEmptyState && (
           <div className="px-2 py-8 text-center text-xs text-muted-foreground">
-            {currentFilter === "all" && !trimmedSearch && (!counts || counts.all === 0)
-              ? "No sessions yet"
-              : "No sessions match this filter."}
+            No sessions match this filter.
           </div>
         )}
 

--- a/frontend/src/components/no-repos-warning.tsx
+++ b/frontend/src/components/no-repos-warning.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useEffect } from "react";
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { AlertTriangle, RefreshCw, Check } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { useGitHubRepoSync } from "@/hooks/use-github-repo-sync";
+import { cn } from "@/lib/utils";
 
 /** Error codes that mean the user needs to reinstall the GitHub App. */
 const REINSTALL_ERROR_CODES = new Set([
@@ -25,7 +28,15 @@ function isReinstallError(err: unknown): boolean {
   );
 }
 
-export function NoReposWarning() {
+interface NoReposWarningProps {
+  showDisconnectedState?: boolean;
+  compact?: boolean;
+}
+
+export function NoReposWarning({
+  showDisconnectedState = false,
+  compact = false,
+}: NoReposWarningProps) {
   const { data: integrationsResp } = useQuery({
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
@@ -57,8 +68,36 @@ export function NoReposWarning() {
     autoSyncIfNeeded(githubAppInstalled, hasRepos);
   }, [githubAppInstalled, hasRepos, autoSyncIfNeeded]);
 
-  // Don't render if GitHub isn't connected or repos exist (and no recent sync result to show)
-  if (!hasGitHub || (hasRepos && !syncResult && githubAppInstalled)) return null;
+  if (!hasGitHub) {
+    if (!showDisconnectedState) return null;
+
+    return (
+      <div
+        className={cn(
+          "rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3",
+          compact ? "space-y-3" : "flex items-start gap-3",
+        )}
+      >
+        <div className={cn("flex gap-3", compact && "items-start")}>
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div className="min-w-0 flex-1">
+            <Badge variant="secondary" className="mb-2">
+              GitHub setup required
+            </Badge>
+            <p className="text-xs text-amber-700 dark:text-amber-300">
+              Connect GitHub before creating sessions or projects. Until a repository is linked, the agent won&apos;t have any code to work with.
+            </p>
+          </div>
+        </div>
+        <Button size="sm" variant="outline" asChild className={cn("gap-1.5", compact && "w-full")}>
+          <Link href="/settings/integrations">Open integrations</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  // Don't render if repos exist (and no recent sync result to show)
+  if (hasRepos && !syncResult && githubAppInstalled) return null;
 
   // After a successful sync that found repos, show success briefly then hide
   if (syncResult && syncResult.repos_synced > 0 && hasRepos) {


### PR DESCRIPTION
## Summary
- Add a disconnected GitHub setup state to the shared repo warning with a badge and integrations link
- Show that setup prompt in the default empty session sidebar state when no repos are connected
- Update sidebar tests to cover the new empty-state behavior

## Testing
- `npx vitest run 'src/components/no-repos-warning.test.tsx' 'src/app/(dashboard)/sessions/session-sidebar.test.tsx'`