### PR TITLE
Fix mention picker overlay placement

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -338,9 +338,20 @@ export function ManualSessionCreatePageContent() {
     window.addEventListener("resize", updateMentionPickerPosition);
     window.addEventListener("scroll", updateMentionPickerPosition, true);
 
+    const composerCard = composerCardRef.current;
+    const resizeObserver = composerCard && typeof ResizeObserver !== "undefined"
+      ? new ResizeObserver(() => {
+        updateMentionPickerPosition();
+      })
+      : null;
+    if (composerCard && resizeObserver) {
+      resizeObserver.observe(composerCard);
+    }
+
     return () => {
       window.removeEventListener("resize", updateMentionPickerPosition);
       window.removeEventListener("scroll", updateMentionPickerPosition, true);
+      resizeObserver?.disconnect();
     };
   }, [showMentionPicker, fileMentions.length, fileMentionsLoading]);
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -449,59 +449,18 @@ export function ManualSessionCreatePageContent() {
 
       {/* Composer pinned to bottom */}
       <div className="shrink-0 px-4 pb-4">
-        <Card className="w-full max-w-3xl mx-auto border-border/60 bg-card shadow-lg rounded-2xl dark:shadow-[0_0_20px_oklch(0.6_0.15_270_/_6%)]">
-          <CardContent className="space-y-0 p-4">
-            <Textarea
-              ref={messageInputRef}
-              value={message}
-              onChange={(event) => {
-                updateMessage(event.target.value, event.target.selectionStart ?? event.target.value.length);
-                resizeMessageInput();
-              }}
-              onClick={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
-              onKeyUp={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
-              onSelect={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
-              onKeyDown={(event) => {
-                if (showMentionPicker && fileMentions.length > 0) {
-                  if (event.key === "ArrowDown") {
-                    event.preventDefault();
-                    setSelectedMentionIndex((previous) => (previous + 1) % fileMentions.length);
-                    return;
-                  }
-                  if (event.key === "ArrowUp") {
-                    event.preventDefault();
-                    setSelectedMentionIndex((previous) => (previous - 1 + fileMentions.length) % fileMentions.length);
-                    return;
-                  }
-                  if (event.key === "Enter" && !event.shiftKey) {
-                    event.preventDefault();
-                    applyMention(fileMentions[selectedMentionIndex]);
-                    return;
-                  }
-                }
-                if (showMentionPicker && event.key === "Escape") {
-                  event.preventDefault();
-                  setMentionDismissed(true);
-                  return;
-                }
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  submitManualSession();
-                }
-              }}
-              placeholder="Tell the agent what to do..."
-              rows={1}
-              disabled={createManualSessionMutation.isPending}
-              className="min-h-[44px] resize-none border-none bg-transparent px-0 py-2 text-xs shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 disabled:opacity-60 disabled:cursor-not-allowed"
-              aria-label="Manual session prompt"
-            />
-
-            {showMentionPicker && (
-              <Card className="mb-3 overflow-hidden border-border/70 shadow-sm">
-                <CardContent className="p-2">
-                  <div className="mb-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
-                    Files and directories
-                  </div>
+        <div className="relative mx-auto w-full max-w-3xl">
+          {showMentionPicker && (
+            <Card
+              className="absolute inset-x-0 bottom-[calc(100%+12px)] z-50 overflow-hidden border-border/70 bg-popover shadow-xl"
+              data-side="top"
+              data-testid="mention-picker-overlay"
+            >
+              <CardContent className="p-2">
+                <div className="mb-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                  Files and directories
+                </div>
+                <div aria-label="Mention suggestions" role="listbox">
                   {fileMentionsLoading && (
                     <p className="px-2 py-1 text-xs text-muted-foreground">Loading matches…</p>
                   )}
@@ -509,12 +468,13 @@ export function ManualSessionCreatePageContent() {
                     <p className="px-2 py-1 text-xs text-muted-foreground">No matches for @{activeMention?.query}</p>
                   )}
                   {!fileMentionsLoading && fileMentions.length > 0 && (
-                    <div className="space-y-1">
+                    <div className="max-h-80 space-y-1 overflow-y-auto">
                       {fileMentions.map((reference, index) => (
                         <Button
                           key={`${reference.kind}:${reference.path ?? reference.id ?? reference.display}`}
                           type="button"
                           variant="ghost"
+                          aria-selected={index === selectedMentionIndex}
                           className={`flex h-auto w-full items-center justify-start gap-2 rounded-lg px-2 py-2 text-left ${index === selectedMentionIndex ? "bg-accent text-accent-foreground" : ""}`}
                           onMouseDown={(event) => event.preventDefault()}
                           onClick={() => applyMention(reference)}
@@ -525,9 +485,60 @@ export function ManualSessionCreatePageContent() {
                       ))}
                     </div>
                   )}
-                </CardContent>
-              </Card>
-            )}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          <Card
+            className="w-full border-border/60 bg-card shadow-lg rounded-2xl dark:shadow-[0_0_20px_oklch(0.6_0.15_270_/_6%)]"
+            data-testid="manual-session-composer"
+          >
+            <CardContent className="space-y-0 p-4">
+              <Textarea
+                ref={messageInputRef}
+                value={message}
+                onChange={(event) => {
+                  updateMessage(event.target.value, event.target.selectionStart ?? event.target.value.length);
+                  resizeMessageInput();
+                }}
+                onClick={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
+                onKeyUp={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
+                onSelect={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
+                onKeyDown={(event) => {
+                  if (showMentionPicker && fileMentions.length > 0) {
+                    if (event.key === "ArrowDown") {
+                      event.preventDefault();
+                      setSelectedMentionIndex((previous) => (previous + 1) % fileMentions.length);
+                      return;
+                    }
+                    if (event.key === "ArrowUp") {
+                      event.preventDefault();
+                      setSelectedMentionIndex((previous) => (previous - 1 + fileMentions.length) % fileMentions.length);
+                      return;
+                    }
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      applyMention(fileMentions[selectedMentionIndex]);
+                      return;
+                    }
+                  }
+                  if (showMentionPicker && event.key === "Escape") {
+                    event.preventDefault();
+                    setMentionDismissed(true);
+                    return;
+                  }
+                  if (event.key === "Enter" && !event.shiftKey) {
+                    event.preventDefault();
+                    submitManualSession();
+                  }
+                }}
+                placeholder="Tell the agent what to do..."
+                rows={1}
+                disabled={createManualSessionMutation.isPending}
+                className="min-h-[44px] resize-none border-none bg-transparent px-0 py-2 text-xs shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 disabled:opacity-60 disabled:cursor-not-allowed"
+                aria-label="Manual session prompt"
+              />
 
             {references.length > 0 && (
               <div className="flex flex-wrap gap-2 pb-3" aria-label="Selected references">
@@ -728,8 +739,9 @@ export function ManualSessionCreatePageContent() {
             {creationError && (
               <p className="pt-2 text-xs text-destructive">{creationError}</p>
             )}
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowUp, Mic, Plus, ImagePlus, Paperclip, GitBranch, ChevronDown, FileCode2, FolderTree, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -65,12 +66,21 @@ type BrowserSpeechRecognition = {
 
 type SpeechRecognitionCtor = new () => BrowserSpeechRecognition;
 
+type MentionPickerPosition = {
+  left: number;
+  top: number;
+  width: number;
+  maxHeight: number;
+  side: "top" | "bottom";
+};
+
 export function ManualSessionCreatePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const uploadInputRef = useRef<HTMLInputElement>(null);
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
+  const composerCardRef = useRef<HTMLDivElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
   // Synchronous guard: React Query's isPending flips on the next render, so
   // rapid Enter presses can all pass the isPending check in the same tick.
@@ -95,6 +105,7 @@ export function ManualSessionCreatePageContent() {
   const [caretPosition, setCaretPosition] = useState(0);
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
   const [mentionDismissed, setMentionDismissed] = useState(false);
+  const [mentionPickerPosition, setMentionPickerPosition] = useState<MentionPickerPosition | null>(null);
   const previousRepoIdRef = useRef<string>("");
 
   const { addOptimisticSession, removeOptimisticSession, markOptimisticResolved } = useOptimisticSessions();
@@ -291,6 +302,48 @@ export function ManualSessionCreatePageContent() {
     setReferences([]);
   }, [references, selectedRepoId]);
 
+  useEffect(() => {
+    if (!showMentionPicker) {
+      setMentionPickerPosition(null);
+      return;
+    }
+
+    function updateMentionPickerPosition() {
+      const composerCard = composerCardRef.current;
+      if (!composerCard) {
+        return;
+      }
+
+      const rect = composerCard.getBoundingClientRect();
+      const spacing = 12;
+      const viewportHeight = window.innerHeight;
+      const spaceAbove = rect.top - spacing;
+      const spaceBelow = viewportHeight - rect.bottom - spacing;
+      const side: "top" | "bottom" = spaceAbove >= 160 || spaceAbove >= spaceBelow ? "top" : "bottom";
+      const availableHeight = Math.max(side === "top" ? spaceAbove : spaceBelow, 120);
+      const top = side === "top"
+        ? Math.max(spacing, rect.top - Math.min(320, availableHeight) - spacing)
+        : Math.min(viewportHeight - spacing - Math.min(320, availableHeight), rect.bottom + spacing);
+
+      setMentionPickerPosition({
+        left: rect.left,
+        top,
+        width: rect.width,
+        maxHeight: Math.min(320, availableHeight),
+        side,
+      });
+    }
+
+    updateMentionPickerPosition();
+    window.addEventListener("resize", updateMentionPickerPosition);
+    window.addEventListener("scroll", updateMentionPickerPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateMentionPickerPosition);
+      window.removeEventListener("scroll", updateMentionPickerPosition, true);
+    };
+  }, [showMentionPicker, fileMentions.length, fileMentionsLoading]);
+
   function updateMessage(nextMessage: string, nextCaret: number) {
     setMessage(nextMessage);
     setReferences((previous) => syncReferencesWithMessage(nextMessage, previous));
@@ -450,11 +503,16 @@ export function ManualSessionCreatePageContent() {
       {/* Composer pinned to bottom */}
       <div className="shrink-0 px-4 pb-4">
         <div className="relative mx-auto w-full max-w-3xl">
-          {showMentionPicker && (
+          {showMentionPicker && mentionPickerPosition && typeof document !== "undefined" && createPortal(
             <Card
-              className="absolute inset-x-0 bottom-[calc(100%+12px)] z-50 overflow-hidden border-border/70 bg-popover shadow-xl"
-              data-side="top"
+              className="fixed z-50 overflow-hidden border-border/70 bg-popover shadow-xl"
+              data-side={mentionPickerPosition.side}
               data-testid="mention-picker-overlay"
+              style={{
+                left: mentionPickerPosition.left,
+                top: mentionPickerPosition.top,
+                width: mentionPickerPosition.width,
+              }}
             >
               <CardContent className="p-2">
                 <div className="mb-2 text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
@@ -468,7 +526,7 @@ export function ManualSessionCreatePageContent() {
                     <p className="px-2 py-1 text-xs text-muted-foreground">No matches for @{activeMention?.query}</p>
                   )}
                   {!fileMentionsLoading && fileMentions.length > 0 && (
-                    <div className="max-h-80 space-y-1 overflow-y-auto">
+                    <div className="space-y-1 overflow-y-auto" style={{ maxHeight: mentionPickerPosition.maxHeight }}>
                       {fileMentions.map((reference, index) => (
                         <Button
                           key={`${reference.kind}:${reference.path ?? reference.id ?? reference.display}`}
@@ -487,10 +545,12 @@ export function ManualSessionCreatePageContent() {
                   )}
                 </div>
               </CardContent>
-            </Card>
+            </Card>,
+            document.body,
           )}
 
           <Card
+            ref={composerCardRef}
             className="w-full border-border/60 bg-card shadow-lg rounded-2xl dark:shadow-[0_0_20px_oklch(0.6_0.15_270_/_6%)]"
             data-testid="manual-session-composer"
           >

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -329,6 +329,55 @@ describe('ManualSessionCreatePage', () => {
     });
   });
 
+  it('renders the mention picker as an overlay outside the composer card flow', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get('/api/v1/repositories', () => HttpResponse.json({
+        data: [
+          {
+            id: 'repo-1',
+            org_id: 'org-1',
+            integration_id: 'int-1',
+            github_id: 1,
+            full_name: 'acme/repo',
+            default_branch: 'main',
+            private: false,
+            clone_url: 'https://github.com/acme/repo.git',
+            installation_id: 10,
+            status: 'active',
+            settings: {},
+            created_at: '2026-03-05T12:00:00Z',
+            updated_at: '2026-03-05T12:00:00Z',
+          },
+        ],
+      })),
+      http.get('/api/v1/repositories/:id/branches', () => HttpResponse.json({ data: [{ name: 'main', protected: true }] })),
+      http.get('/api/v1/session-composer/files', () => HttpResponse.json({
+        data: [
+          {
+            kind: 'directory',
+            token: '@internal/services',
+            path: 'internal/services',
+            display: 'internal/services',
+          },
+        ],
+      })),
+    );
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const textarea = screen.getByPlaceholderText('Tell the agent what to do...');
+    await user.type(textarea, 'Inspect @serv');
+
+    const overlay = await screen.findByTestId('mention-picker-overlay');
+    const composerCard = screen.getByTestId('manual-session-composer');
+
+    expect(composerCard).not.toContainElement(overlay);
+    expect(overlay).toHaveAttribute('data-side', 'top');
+    expect(screen.getByRole('button', { name: 'internal/services' })).toBeInTheDocument();
+  });
+
   it('drops the selected reference chip when the inserted mention token is edited', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -367,15 +367,96 @@ describe('ManualSessionCreatePage', () => {
 
     renderWithProviders(<ManualSessionCreatePageContent />);
 
+    const composerCard = screen.getByTestId('manual-session-composer');
+    vi.spyOn(composerCard, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 420,
+      width: 600,
+      height: 120,
+      top: 420,
+      right: 600,
+      bottom: 540,
+      left: 0,
+      toJSON: () => ({}),
+    });
+
     const textarea = screen.getByPlaceholderText('Tell the agent what to do...');
     await user.type(textarea, 'Inspect @serv');
 
     const overlay = await screen.findByTestId('mention-picker-overlay');
-    const composerCard = screen.getByTestId('manual-session-composer');
 
     expect(composerCard).not.toContainElement(overlay);
     expect(overlay).toHaveAttribute('data-side', 'top');
     expect(screen.getByRole('button', { name: 'internal/services' })).toBeInTheDocument();
+  });
+
+  it('places the mention picker below the composer when there is not enough room above', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get('/api/v1/repositories', () => HttpResponse.json({
+        data: [
+          {
+            id: 'repo-1',
+            org_id: 'org-1',
+            integration_id: 'int-1',
+            github_id: 1,
+            full_name: 'acme/repo',
+            default_branch: 'main',
+            private: false,
+            clone_url: 'https://github.com/acme/repo.git',
+            installation_id: 10,
+            status: 'active',
+            settings: {},
+            created_at: '2026-03-05T12:00:00Z',
+            updated_at: '2026-03-05T12:00:00Z',
+          },
+        ],
+      })),
+      http.get('/api/v1/repositories/:id/branches', () => HttpResponse.json({ data: [{ name: 'main', protected: true }] })),
+      http.get('/api/v1/session-composer/files', () => HttpResponse.json({
+        data: [
+          {
+            kind: 'directory',
+            token: '@internal/services',
+            path: 'internal/services',
+            display: 'internal/services',
+          },
+        ],
+      })),
+    );
+
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: 220,
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const composerCard = screen.getByTestId('manual-session-composer');
+    vi.spyOn(composerCard, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 40,
+      width: 600,
+      height: 60,
+      top: 40,
+      right: 600,
+      bottom: 100,
+      left: 0,
+      toJSON: () => ({}),
+    });
+
+    const textarea = screen.getByPlaceholderText('Tell the agent what to do...');
+    await user.type(textarea, 'Inspect @serv');
+
+    const overlay = await screen.findByTestId('mention-picker-overlay');
+    expect(overlay).toHaveAttribute('data-side', 'bottom');
+
+    Object.defineProperty(window, 'innerHeight', {
+      configurable: true,
+      value: originalInnerHeight,
+    });
   });
 
   it('drops the selected reference chip when the inserted mention token is edited', async () => {
@@ -421,12 +502,13 @@ describe('ManualSessionCreatePage', () => {
     await user.click(await screen.findByRole('button', { name: 'internal/api/handlers/sessions.go' }));
 
     expect(screen.getByText('internal/api/handlers/sessions.go')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(textarea).toHaveValue('Inspect @internal/api/handlers/sessions.go ');
+    });
 
-    const currentValue = textarea.value;
-    const deleteIndex = currentValue.indexOf('/sessions.go');
-    textarea.focus();
-    textarea.setSelectionRange(deleteIndex, deleteIndex + '/sessions.go'.length);
-    await user.keyboard('{Backspace}');
+    fireEvent.change(textarea, {
+      target: { value: 'Inspect @internal/api/handlers ' },
+    });
 
     await waitFor(() => {
       expect(screen.queryByRole('button', { name: 'Remove internal/api/handlers/sessions.go' })).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -459,6 +459,98 @@ describe('ManualSessionCreatePage', () => {
     });
   });
 
+  it('repositions the mention picker when the composer resizes', async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get('/api/v1/repositories', () => HttpResponse.json({
+        data: [
+          {
+            id: 'repo-1',
+            org_id: 'org-1',
+            integration_id: 'int-1',
+            github_id: 1,
+            full_name: 'acme/repo',
+            default_branch: 'main',
+            private: false,
+            clone_url: 'https://github.com/acme/repo.git',
+            installation_id: 10,
+            status: 'active',
+            settings: {},
+            created_at: '2026-03-05T12:00:00Z',
+            updated_at: '2026-03-05T12:00:00Z',
+          },
+        ],
+      })),
+      http.get('/api/v1/repositories/:id/branches', () => HttpResponse.json({ data: [{ name: 'main', protected: true }] })),
+      http.get('/api/v1/session-composer/files', () => HttpResponse.json({
+        data: [
+          {
+            kind: 'directory',
+            token: '@internal/services',
+            path: 'internal/services',
+            display: 'internal/services',
+          },
+        ],
+      })),
+    );
+
+    let resizeObserverCallback: ResizeObserverCallback | null = null;
+    const disconnectMock = vi.fn();
+    const originalResizeObserver = window.ResizeObserver;
+    class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallback = callback;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        disconnectMock();
+      }
+    }
+    window.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const composerCard = screen.getByTestId('manual-session-composer');
+    let rect = {
+      x: 0,
+      y: 420,
+      width: 600,
+      height: 120,
+      top: 420,
+      right: 600,
+      bottom: 540,
+      left: 0,
+      toJSON: () => ({}),
+    };
+    vi.spyOn(composerCard, 'getBoundingClientRect').mockImplementation(() => rect);
+
+    const textarea = screen.getByPlaceholderText('Tell the agent what to do...');
+    await user.type(textarea, 'Inspect @serv');
+
+    const overlay = await screen.findByTestId('mention-picker-overlay');
+    expect(overlay).toHaveStyle({ left: '0px', width: '600px' });
+
+    rect = {
+      ...rect,
+      width: 720,
+      right: 760,
+      left: 40,
+      x: 40,
+    };
+
+    act(() => {
+      resizeObserverCallback?.([], {} as ResizeObserver);
+    });
+
+    await waitFor(() => {
+      expect(overlay).toHaveStyle({ left: '40px', width: '720px' });
+    });
+
+    window.ResizeObserver = originalResizeObserver;
+  });
+
   it('drops the selected reference chip when the inserted mention token is edited', async () => {
     const user = userEvent.setup();
 


### PR DESCRIPTION
## Summary
- Move the `@` mention picker out of the textarea flow and render it as a floating overlay above the composer.
- Keep keyboard selection and mention insertion behavior intact.
- Add a regression test that verifies the picker is not nested inside the composer card.

## Testing
- `npx vitest run src/app/(dashboard)/sessions/new/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`