### PR TITLE
Fix missing Create PR button for expired snapshots

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -825,6 +825,35 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByRole('button', { name: /Create PR/ })).not.toBeInTheDocument();
   });
 
+  it('shows disabled Create PR button with snapshot expiry explanation when diff exists but snapshot is missing', async () => {
+    const sessionWithMissingSnapshot: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: undefined,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithMissingSnapshot } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const createPRButton = await screen.findByRole('button', { name: /Create PR/ });
+    expect(createPRButton).toBeDisabled();
+    expect(createPRButton).toHaveAttribute('title', 'Session state expired — re-run to create a PR.');
+  });
+
   it('does not show Create PR button when session is running', async () => {
     const runningSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -851,7 +851,7 @@ describe('SessionDetailPage', () => {
 
     const createPRButton = await screen.findByRole('button', { name: /Create PR/ });
     expect(createPRButton).toBeDisabled();
-    expect(createPRButton).toHaveAttribute('title', 'Session state expired — re-run to create a PR.');
+    expect(screen.getByText('Session state expired — re-run to create a PR.')).toBeInTheDocument();
   });
 
   it('does not show Create PR button when session is running', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1456,7 +1456,9 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const hasPR = !!prData?.data;
   const hasSnapshot = !!session?.snapshot_key;
+  const hasSessionChanges = !!session?.diff || !!session?.diff_stats;
   const canCreatePR = hasSnapshot && !hasPR && !isRunning;
+  const showExpiredPRAction = hasSessionChanges && !hasSnapshot && !hasPR && !isRunning;
 
   const { data: ghStatus } = useQuery({
     queryKey: ["github-status"],
@@ -1708,7 +1710,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                   );
                 }
                 const prState = session.pr_creation_state;
-                const showPRAction = canCreatePR || queueingPR || creatingPR || finalizingPR || prState === "failed";
+                const showPRAction =
+                  canCreatePR || showExpiredPRAction || queueingPR || creatingPR || finalizingPR || prState === "failed";
                 if (!showPRAction) return null;
                 const snapshotExpired = !session.snapshot_key;
                 const ghBlocked = ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected;

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1714,10 +1714,13 @@ export function SessionDetailContent({ id }: { id: string }) {
                   canCreatePR || showExpiredPRAction || queueingPR || creatingPR || finalizingPR || prState === "failed";
                 if (!showPRAction) return null;
                 const snapshotExpired = !session.snapshot_key;
+                const snapshotExpiredMessage =
+                  session.pr_creation_error || "Session state expired — re-run to create a PR.";
                 const ghBlocked = ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected;
                 const succeededButNoPR = prState === "succeeded" && !hasPR;
                 const prActionError =
                   localPRActionError ||
+                  (snapshotExpired ? snapshotExpiredMessage : null) ||
                   (prState === "failed" ? session.pr_creation_error || PR_ERROR_TOAST_MESSAGE : null);
 
                 let label = "Create PR";
@@ -1738,10 +1741,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 } else if (snapshotExpired) {
                   label = "Create PR";
                   disabled = true;
-                  // Prefer the server-produced message (e.g. from the last
-                  // failed attempt) when available so the UI stays aligned
-                  // with server-side wording.
-                  title = session.pr_creation_error || "Session state expired — re-run to create a PR.";
+                  title = snapshotExpiredMessage;
                 } else if (succeededButNoPR) {
                   label = "Finalizing PR\u2026";
                   spinning = true;

--- a/internal/services/storage/s3.go
+++ b/internal/services/storage/s3.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -48,10 +49,32 @@ func (s *S3SnapshotStore) fullKey(key string) string {
 }
 
 func (s *S3SnapshotStore) Save(ctx context.Context, key string, reader io.Reader) error {
-	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+	// Some S3-compatible providers reject chunked uploads without an explicit
+	// Content-Length header. Snapshot streams come from an io.Pipe-backed tar
+	// process, so stage them to a temp file first so we can upload with a known
+	// byte size.
+	tmp, err := os.CreateTemp("", "session-snapshot-*.tar.zst")
+	if err != nil {
+		return fmt.Errorf("create temp snapshot file %s: %w", key, err)
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+
+	size, err := io.Copy(tmp, reader)
+	if err != nil {
+		return fmt.Errorf("buffer snapshot %s: %w", key, err)
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind snapshot %s: %w", key, err)
+	}
+
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:               aws.String(s.bucket),
 		Key:                  aws.String(s.fullKey(key)),
-		Body:                 reader,
+		Body:                 tmp,
+		ContentLength:        aws.Int64(size),
 		ServerSideEncryption: s3types.ServerSideEncryptionAes256,
 	})
 	if err != nil {

--- a/internal/services/storage/s3.go
+++ b/internal/services/storage/s3.go
@@ -32,6 +32,12 @@ type S3SnapshotStore struct {
 	prefix string
 }
 
+var createSnapshotTempFile = os.CreateTemp
+var copySnapshotToTemp = io.Copy
+var rewindSnapshotTempFile = func(f *os.File) (int64, error) {
+	return f.Seek(0, io.SeekStart)
+}
+
 // NewS3SnapshotStore creates an S3SnapshotStore for the given bucket.
 func NewS3SnapshotStore(client S3Client, bucket, prefix string) *S3SnapshotStore {
 	return &S3SnapshotStore{
@@ -53,7 +59,7 @@ func (s *S3SnapshotStore) Save(ctx context.Context, key string, reader io.Reader
 	// Content-Length header. Snapshot streams come from an io.Pipe-backed tar
 	// process, so stage them to a temp file first so we can upload with a known
 	// byte size.
-	tmp, err := os.CreateTemp("", "session-snapshot-*.tar.zst")
+	tmp, err := createSnapshotTempFile("", "session-snapshot-*.tar.zst")
 	if err != nil {
 		return fmt.Errorf("create temp snapshot file %s: %w", key, err)
 	}
@@ -62,11 +68,11 @@ func (s *S3SnapshotStore) Save(ctx context.Context, key string, reader io.Reader
 		_ = os.Remove(tmp.Name())
 	}()
 
-	size, err := io.Copy(tmp, reader)
+	size, err := copySnapshotToTemp(tmp, reader)
 	if err != nil {
 		return fmt.Errorf("buffer snapshot %s: %w", key, err)
 	}
-	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+	if _, err := rewindSnapshotTempFile(tmp); err != nil {
 		return fmt.Errorf("rewind snapshot %s: %w", key, err)
 	}
 

--- a/internal/services/storage/s3_test.go
+++ b/internal/services/storage/s3_test.go
@@ -61,6 +61,8 @@ func TestS3SnapshotStore_UsesConfiguredPrefix(t *testing.T) {
 	require.Equal(t, "snapshot-bucket", aws.ToString(client.putInput.Bucket), "Save should target the configured bucket")
 	require.Equal(t, "sessions/snapshots/org-1/session-1/workspace.tar.zst", aws.ToString(client.putInput.Key), "Save should prepend the configured prefix to snapshot keys")
 	require.Equal(t, s3types.ServerSideEncryptionAes256, client.putInput.ServerSideEncryption, "Save should enable AES256 server-side encryption")
+	require.NotNil(t, client.putInput.ContentLength, "Save should declare the snapshot content length for S3-compatible backends")
+	require.EqualValues(t, len("snapshot-bytes"), aws.ToInt64(client.putInput.ContentLength), "Save should set ContentLength to the uploaded byte size")
 
 	var loaded bytes.Buffer
 	err = store.Load(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", &loaded)
@@ -85,4 +87,18 @@ func TestS3SnapshotStore_LoadNotFoundWrapsSnapshotSentinel(t *testing.T) {
 	err := store.Load(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", &loaded)
 	require.Error(t, err, "Load should return an error when the object does not exist")
 	require.True(t, errors.Is(err, ErrSnapshotNotFound), "Load should wrap ErrSnapshotNotFound for missing snapshot objects")
+}
+
+func TestS3SnapshotStore_SaveSetsContentLengthForStreamingReader(t *testing.T) {
+	t.Parallel()
+
+	client := &snapshotMockS3Client{}
+	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
+
+	reader := io.NopCloser(bytes.NewBufferString("streamed-snapshot"))
+	err := store.Save(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", reader)
+	require.NoError(t, err, "Save should upload snapshots from streaming readers without error")
+	require.NotNil(t, client.putInput, "Save should issue a PutObject request")
+	require.NotNil(t, client.putInput.ContentLength, "Save should compute ContentLength even for streaming readers")
+	require.EqualValues(t, len("streamed-snapshot"), aws.ToInt64(client.putInput.ContentLength), "Save should set ContentLength to the streamed byte size")
 }

--- a/internal/services/storage/s3_test.go
+++ b/internal/services/storage/s3_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -50,8 +51,6 @@ func (m *snapshotMockS3Client) HeadBucket(ctx context.Context, params *s3.HeadBu
 }
 
 func TestS3SnapshotStore_UsesConfiguredPrefix(t *testing.T) {
-	t.Parallel()
-
 	client := &snapshotMockS3Client{getBody: []byte("snapshot-bytes")}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -78,8 +77,6 @@ func TestS3SnapshotStore_UsesConfiguredPrefix(t *testing.T) {
 }
 
 func TestS3SnapshotStore_LoadNotFoundWrapsSnapshotSentinel(t *testing.T) {
-	t.Parallel()
-
 	client := &snapshotMockS3Client{getErr: &s3types.NoSuchKey{}}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -90,8 +87,6 @@ func TestS3SnapshotStore_LoadNotFoundWrapsSnapshotSentinel(t *testing.T) {
 }
 
 func TestS3SnapshotStore_SaveSetsContentLengthForStreamingReader(t *testing.T) {
-	t.Parallel()
-
 	client := &snapshotMockS3Client{}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -101,4 +96,52 @@ func TestS3SnapshotStore_SaveSetsContentLengthForStreamingReader(t *testing.T) {
 	require.NotNil(t, client.putInput, "Save should issue a PutObject request")
 	require.NotNil(t, client.putInput.ContentLength, "Save should compute ContentLength even for streaming readers")
 	require.EqualValues(t, len("streamed-snapshot"), aws.ToInt64(client.putInput.ContentLength), "Save should set ContentLength to the streamed byte size")
+}
+
+func TestS3SnapshotStore_SaveReturnsTempFileCreationError(t *testing.T) {
+	origCreateTemp := createSnapshotTempFile
+	createSnapshotTempFile = func(dir, pattern string) (*os.File, error) {
+		return nil, errors.New("disk full")
+	}
+	t.Cleanup(func() {
+		createSnapshotTempFile = origCreateTemp
+	})
+
+	store := NewS3SnapshotStore(&snapshotMockS3Client{}, "snapshot-bucket", "sessions")
+
+	err := store.Save(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", bytes.NewReader([]byte("snapshot-bytes")))
+	require.Error(t, err, "Save should return an error when temp file creation fails")
+	require.Contains(t, err.Error(), "create temp snapshot file snapshots/org-1/session-1/workspace.tar.zst", "Save should identify temp file creation failures")
+}
+
+func TestS3SnapshotStore_SaveReturnsCopyError(t *testing.T) {
+	origCopy := copySnapshotToTemp
+	copySnapshotToTemp = func(dst io.Writer, src io.Reader) (int64, error) {
+		return 0, errors.New("read failed")
+	}
+	t.Cleanup(func() {
+		copySnapshotToTemp = origCopy
+	})
+
+	store := NewS3SnapshotStore(&snapshotMockS3Client{}, "snapshot-bucket", "sessions")
+
+	err := store.Save(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", bytes.NewReader([]byte("snapshot-bytes")))
+	require.Error(t, err, "Save should return an error when buffering the snapshot fails")
+	require.Contains(t, err.Error(), "buffer snapshot snapshots/org-1/session-1/workspace.tar.zst", "Save should identify snapshot buffering failures")
+}
+
+func TestS3SnapshotStore_SaveReturnsRewindError(t *testing.T) {
+	origRewind := rewindSnapshotTempFile
+	rewindSnapshotTempFile = func(f *os.File) (int64, error) {
+		return 0, errors.New("seek failed")
+	}
+	t.Cleanup(func() {
+		rewindSnapshotTempFile = origRewind
+	})
+
+	store := NewS3SnapshotStore(&snapshotMockS3Client{}, "snapshot-bucket", "sessions")
+
+	err := store.Save(context.Background(), "snapshots/org-1/session-1/workspace.tar.zst", bytes.NewReader([]byte("snapshot-bytes")))
+	require.Error(t, err, "Save should return an error when rewinding the temp file fails")
+	require.Contains(t, err.Error(), "rewind snapshot snapshots/org-1/session-1/workspace.tar.zst", "Save should identify snapshot rewind failures")
 }

--- a/internal/services/storage/s3_test.go
+++ b/internal/services/storage/s3_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -22,6 +23,8 @@ type snapshotMockS3Client struct {
 	getBody        []byte
 	getErr         error
 }
+
+var snapshotStoreTestHooksMu sync.Mutex
 
 func (m *snapshotMockS3Client) PutObject(_ context.Context, params *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	m.putInput = params
@@ -51,6 +54,11 @@ func (m *snapshotMockS3Client) HeadBucket(ctx context.Context, params *s3.HeadBu
 }
 
 func TestS3SnapshotStore_UsesConfiguredPrefix(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	client := &snapshotMockS3Client{getBody: []byte("snapshot-bytes")}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -77,6 +85,11 @@ func TestS3SnapshotStore_UsesConfiguredPrefix(t *testing.T) {
 }
 
 func TestS3SnapshotStore_LoadNotFoundWrapsSnapshotSentinel(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	client := &snapshotMockS3Client{getErr: &s3types.NoSuchKey{}}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -87,6 +100,11 @@ func TestS3SnapshotStore_LoadNotFoundWrapsSnapshotSentinel(t *testing.T) {
 }
 
 func TestS3SnapshotStore_SaveSetsContentLengthForStreamingReader(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	client := &snapshotMockS3Client{}
 	store := NewS3SnapshotStore(client, "snapshot-bucket", "sessions")
 
@@ -99,6 +117,11 @@ func TestS3SnapshotStore_SaveSetsContentLengthForStreamingReader(t *testing.T) {
 }
 
 func TestS3SnapshotStore_SaveReturnsTempFileCreationError(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	origCreateTemp := createSnapshotTempFile
 	createSnapshotTempFile = func(dir, pattern string) (*os.File, error) {
 		return nil, errors.New("disk full")
@@ -115,6 +138,11 @@ func TestS3SnapshotStore_SaveReturnsTempFileCreationError(t *testing.T) {
 }
 
 func TestS3SnapshotStore_SaveReturnsCopyError(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	origCopy := copySnapshotToTemp
 	copySnapshotToTemp = func(dst io.Writer, src io.Reader) (int64, error) {
 		return 0, errors.New("read failed")
@@ -131,6 +159,11 @@ func TestS3SnapshotStore_SaveReturnsCopyError(t *testing.T) {
 }
 
 func TestS3SnapshotStore_SaveReturnsRewindError(t *testing.T) {
+	t.Parallel()
+
+	snapshotStoreTestHooksMu.Lock()
+	t.Cleanup(snapshotStoreTestHooksMu.Unlock)
+
 	origRewind := rewindSnapshotTempFile
 	rewindSnapshotTempFile = func(f *os.File) (int64, error) {
 		return 0, errors.New("seek failed")


### PR DESCRIPTION
## Summary
- Show a disabled Create PR control with an expiry tooltip when a session has changes but its snapshot is gone
- Add a regression test for the missing-snapshot session detail state
- Fix snapshot uploads to S3-compatible storage by buffering to a temp file and sending an explicit content length

## Testing
- `go test ./internal/services/storage`
- `go vet ./...`
- `go build ./...`
- `go test ./...`