### PR TITLE
Add autofocus to new session textarea

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -113,4 +113,13 @@ describe("ManualSessionCreatePageContent", () => {
       expect(textareas.length).toBeGreaterThanOrEqual(1);
     });
   });
+
+  it("autofocuses the main message textarea", async () => {
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const textarea = await screen.findByPlaceholderText("Tell the agent what to do...");
+    await waitFor(() => {
+      expect(textarea).toHaveFocus();
+    });
+  });
 });

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -569,6 +569,7 @@ export function ManualSessionCreatePageContent() {
               <Textarea
                 ref={messageInputRef}
                 value={message}
+                autoFocus
                 onChange={(event) => {
                   updateMessage(event.target.value, event.target.selectionStart ?? event.target.value.length);
                   resizeMessageInput();


### PR DESCRIPTION
## Summary
- Autofocus the main prompt textarea on `/sessions/new` using the native `autoFocus` attribute
- Add a UI test that verifies the textarea receives focus on render

## Testing
- UI test: `manual-session-create-page-content.test.tsx`