### PR TITLE
Fix preview error banner and duplicate start button

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -155,9 +155,7 @@ describe("PreviewPanel component", () => {
     await waitFor(() => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
-    // Two "Start Preview" buttons: one in controls bar, one in idle panel
-    const startButtons = screen.getAllByText("Start Preview");
-    expect(startButtons.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("button", { name: "Start Preview" })).toBeInTheDocument();
   });
 
   it('shows idle state when phase is "stopped"', async () => {
@@ -531,8 +529,7 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
 
-    const startButtons = screen.getAllByText("Start Preview");
-    await user.click(startButtons[0]);
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
       expect(mockStart).toHaveBeenCalledWith("sess-1");
@@ -590,10 +587,10 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
 
-    const startButtons = screen.getAllByText("Start Preview");
-    await user.click(startButtons[0]);
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
+      expect(screen.getByText("Preview action failed")).toBeInTheDocument();
       expect(screen.getByText("Failed to start preview: connection refused")).toBeInTheDocument();
     });
   });
@@ -611,10 +608,10 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
 
-    const startButtons = screen.getAllByText("Start Preview");
-    await user.click(startButtons[0]);
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
+      expect(screen.getByText("Preview unavailable")).toBeInTheDocument();
       expect(
         screen.getByText(
           "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again."
@@ -634,18 +631,13 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
 
-    const startButtons = screen.getAllByText("Start Preview");
-    await user.click(startButtons[0]);
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
       expect(screen.getByText("Failed to start preview: connection refused")).toBeInTheDocument();
     });
 
-    // Click the dismiss button (X icon)
-    const dismissBtn = screen.getByText("Failed to start preview: connection refused")
-      .closest("div")!
-      .querySelector("button")!;
-    await user.click(dismissBtn);
+    await user.click(screen.getByRole("button", { name: "Dismiss preview error" }));
 
     await waitFor(() => {
       expect(screen.queryByText("Failed to start preview: connection refused")).not.toBeInTheDocument();

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -590,7 +590,6 @@ describe("PreviewPanel component", () => {
     await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Preview action failed")).toBeInTheDocument();
       expect(screen.getByText("Failed to start preview: connection refused")).toBeInTheDocument();
     });
   });
@@ -611,7 +610,6 @@ describe("PreviewPanel component", () => {
     await user.click(screen.getByRole("button", { name: "Start Preview" }));
 
     await waitFor(() => {
-      expect(screen.getByText("Preview unavailable")).toBeInTheDocument();
       expect(
         screen.getByText(
           "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again."
@@ -637,7 +635,11 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("Failed to start preview: connection refused")).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: "Dismiss preview error" }));
+    // Click the dismiss button (X icon)
+    const dismissBtn = screen.getByText("Failed to start preview: connection refused")
+      .closest("div")!
+      .querySelector("button")!;
+    await user.click(dismissBtn);
 
     await waitFor(() => {
       expect(screen.queryByText("Failed to start preview: connection refused")).not.toBeInTheDocument();

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -50,11 +50,6 @@ export interface PreviewPanelProps {
   previewOriginTemplate: string; // e.g. "http://{id}.preview.localhost:9090"
 }
 
-type PreviewMutationError = {
-  title: string;
-  message: string;
-};
-
 const WIDTH_PRESETS = [
   { name: "Mobile", width: 375, icon: Smartphone },
   { name: "Tablet", width: 768, icon: Tablet },
@@ -125,7 +120,7 @@ export function PreviewPanel({
   const [selectedWidth, setSelectedWidth] = useState<number>(0); // 0 = full
   const [designMode, setDesignMode] = useState(false);
   const [bootstrapComplete, setBootstrapComplete] = useState(false);
-  const [mutationError, setMutationError] = useState<PreviewMutationError | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
 
   // Poll preview status every 3s when active
   const {
@@ -178,40 +173,28 @@ export function PreviewPanel({
       // buries the real issue (capacity, expired snapshot, etc.).
       const code = (err as { code?: string })?.code;
       if (code === PREVIEW_ERROR_CODES.CAPACITY_REACHED) {
-        setMutationError({
-          title: "Preview unavailable",
-          message: err.message,
-        });
+        setMutationError(err.message);
         return;
       }
       if (code === PREVIEW_ERROR_CODES.SNAPSHOT_EXPIRED) {
-        setMutationError({
-          title: "Preview unavailable",
-          message:
-            "This session's sandbox snapshot has expired. Send a new message to the agent to rebuild it, then try Start Preview again.",
-        });
+        setMutationError(
+          "This session's sandbox snapshot has expired. Send a new message to the agent to rebuild it, then try Start Preview again."
+        );
         return;
       }
       if (code === PREVIEW_ERROR_CODES.SNAPSHOT_UNAVAILABLE) {
-        setMutationError({
-          title: "Preview unavailable",
-          message:
-            "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again.",
-        });
+        setMutationError(
+          "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again."
+        );
         return;
       }
       if (code === PREVIEW_ERROR_CODES.NO_SANDBOX) {
-        setMutationError({
-          title: "Preview unavailable",
-          message:
-            "Preview is unavailable on this server (Docker not configured). Contact an admin.",
-        });
+        setMutationError(
+          "Preview is unavailable on this server (Docker not configured). Contact an admin."
+        );
         return;
       }
-      setMutationError({
-        title: "Preview action failed",
-        message: `Failed to start preview: ${err.message}`,
-      });
+      setMutationError(`Failed to start preview: ${err.message}`);
     },
   });
 
@@ -228,10 +211,7 @@ export function PreviewPanel({
     mutationFn: () => api.sessions.preview.stop(sessionId),
     onSuccess: resetPreviewState,
     onError: (err) => {
-      setMutationError({
-        title: "Preview action failed",
-        message: `Failed to stop preview: ${err.message}`,
-      });
+      setMutationError(`Failed to stop preview: ${err.message}`);
     },
   });
 
@@ -240,10 +220,7 @@ export function PreviewPanel({
     mutationFn: () => api.sessions.preview.restart(sessionId),
     onSuccess: resetPreviewState,
     onError: (err) => {
-      setMutationError({
-        title: "Preview action failed",
-        message: `Failed to restart preview: ${err.message}`,
-      });
+      setMutationError(`Failed to restart preview: ${err.message}`);
     },
   });
 
@@ -251,10 +228,7 @@ export function PreviewPanel({
   const bootstrapMutation = useMutation({
     mutationFn: () => api.sessions.preview.bootstrap(sessionId),
     onError: (err) => {
-      setMutationError({
-        title: "Preview action failed",
-        message: `Failed to bootstrap preview: ${err.message}`,
-      });
+      setMutationError(`Failed to bootstrap preview: ${err.message}`);
     },
   });
 
@@ -527,19 +501,13 @@ export function PreviewPanel({
 
       {/* Mutation error banner */}
       {mutationError && (
-        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-destructive">
-          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-          <div className="min-w-0">
-            <p className="text-sm font-medium">{mutationError.title}</p>
-            <p className="mt-1 text-sm leading-6 break-words text-destructive/90">
-              {mutationError.message}
-            </p>
-          </div>
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-2 text-sm text-destructive">
+          <AlertTriangle className="size-4 shrink-0" />
+          <span className="flex-1">{mutationError}</span>
           <Button
             variant="ghost"
             size="icon-xs"
             onClick={() => setMutationError(null)}
-            aria-label="Dismiss preview error"
             className="rounded p-0.5 hover:bg-destructive/10"
           >
             <X className="size-3.5" />

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -50,6 +50,11 @@ export interface PreviewPanelProps {
   previewOriginTemplate: string; // e.g. "http://{id}.preview.localhost:9090"
 }
 
+type PreviewMutationError = {
+  title: string;
+  message: string;
+};
+
 const WIDTH_PRESETS = [
   { name: "Mobile", width: 375, icon: Smartphone },
   { name: "Tablet", width: 768, icon: Tablet },
@@ -120,7 +125,7 @@ export function PreviewPanel({
   const [selectedWidth, setSelectedWidth] = useState<number>(0); // 0 = full
   const [designMode, setDesignMode] = useState(false);
   const [bootstrapComplete, setBootstrapComplete] = useState(false);
-  const [mutationError, setMutationError] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<PreviewMutationError | null>(null);
 
   // Poll preview status every 3s when active
   const {
@@ -173,28 +178,40 @@ export function PreviewPanel({
       // buries the real issue (capacity, expired snapshot, etc.).
       const code = (err as { code?: string })?.code;
       if (code === PREVIEW_ERROR_CODES.CAPACITY_REACHED) {
-        setMutationError(err.message);
+        setMutationError({
+          title: "Preview unavailable",
+          message: err.message,
+        });
         return;
       }
       if (code === PREVIEW_ERROR_CODES.SNAPSHOT_EXPIRED) {
-        setMutationError(
-          "This session's sandbox snapshot has expired. Send a new message to the agent to rebuild it, then try Start Preview again."
-        );
+        setMutationError({
+          title: "Preview unavailable",
+          message:
+            "This session's sandbox snapshot has expired. Send a new message to the agent to rebuild it, then try Start Preview again.",
+        });
         return;
       }
       if (code === PREVIEW_ERROR_CODES.SNAPSHOT_UNAVAILABLE) {
-        setMutationError(
-          "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again."
-        );
+        setMutationError({
+          title: "Preview unavailable",
+          message:
+            "This session's last sandbox snapshot is unavailable. Send a new message to rebuild the sandbox, then try Start Preview again.",
+        });
         return;
       }
       if (code === PREVIEW_ERROR_CODES.NO_SANDBOX) {
-        setMutationError(
-          "Preview is unavailable on this server (Docker not configured). Contact an admin."
-        );
+        setMutationError({
+          title: "Preview unavailable",
+          message:
+            "Preview is unavailable on this server (Docker not configured). Contact an admin.",
+        });
         return;
       }
-      setMutationError(`Failed to start preview: ${err.message}`);
+      setMutationError({
+        title: "Preview action failed",
+        message: `Failed to start preview: ${err.message}`,
+      });
     },
   });
 
@@ -211,7 +228,10 @@ export function PreviewPanel({
     mutationFn: () => api.sessions.preview.stop(sessionId),
     onSuccess: resetPreviewState,
     onError: (err) => {
-      setMutationError(`Failed to stop preview: ${err.message}`);
+      setMutationError({
+        title: "Preview action failed",
+        message: `Failed to stop preview: ${err.message}`,
+      });
     },
   });
 
@@ -220,7 +240,10 @@ export function PreviewPanel({
     mutationFn: () => api.sessions.preview.restart(sessionId),
     onSuccess: resetPreviewState,
     onError: (err) => {
-      setMutationError(`Failed to restart preview: ${err.message}`);
+      setMutationError({
+        title: "Preview action failed",
+        message: `Failed to restart preview: ${err.message}`,
+      });
     },
   });
 
@@ -228,7 +251,10 @@ export function PreviewPanel({
   const bootstrapMutation = useMutation({
     mutationFn: () => api.sessions.preview.bootstrap(sessionId),
     onError: (err) => {
-      setMutationError(`Failed to bootstrap preview: ${err.message}`);
+      setMutationError({
+        title: "Preview action failed",
+        message: `Failed to bootstrap preview: ${err.message}`,
+      });
     },
   });
 
@@ -371,17 +397,7 @@ export function PreviewPanel({
       <div className="flex items-center gap-2 flex-wrap">
         {/* Start / Stop / Restart */}
         <div className="flex items-center gap-1">
-          {!isActive ? (
-            <Button
-              size="sm"
-              onClick={() => startMutation.mutate()}
-              disabled={isMutating}
-              loading={startMutation.isPending}
-            >
-              <Play className="size-3.5" />
-              Start Preview
-            </Button>
-          ) : (
+          {isActive ? (
             <>
               <Button
                 size="sm"
@@ -404,7 +420,7 @@ export function PreviewPanel({
                 Restart
               </Button>
             </>
-          )}
+          ) : null}
         </div>
 
         {/* Status badge */}
@@ -511,13 +527,19 @@ export function PreviewPanel({
 
       {/* Mutation error banner */}
       {mutationError && (
-        <div className="flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-2 text-sm text-destructive">
-          <AlertTriangle className="size-4 shrink-0" />
-          <span className="flex-1">{mutationError}</span>
+        <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-3 rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-destructive">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium">{mutationError.title}</p>
+            <p className="mt-1 text-sm leading-6 break-words text-destructive/90">
+              {mutationError.message}
+            </p>
+          </div>
           <Button
             variant="ghost"
             size="icon-xs"
             onClick={() => setMutationError(null)}
+            aria-label="Dismiss preview error"
             className="rounded p-0.5 hover:bg-destructive/10"
           >
             <X className="size-3.5" />


### PR DESCRIPTION
## Summary
- Remove the duplicate idle-state `Start Preview` action so the preview tab shows one clear launch path.
- Rework preview mutation errors into a structured banner with a title, wrapped body text, and an accessible dismiss button.
- Update preview panel tests to match the single CTA and the improved error presentation.

## Testing
- `npx vitest run src/components/preview/preview-panel.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`