### PR TITLE
Fix redis deploy role handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,6 +391,10 @@ deploy-logging:
 	$(check-ssh-key)
 	@$(call resolve-host,logging)
 
+deploy-redis:
+	$(check-ssh-key)
+	@$(call resolve-host,redis)
+
 # Deploy all nodes in the fleet.
 # Uses FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.
 deploy-fleet:

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 #   1. FLEET_HOSTS env var             — comma-separated "role:IP" pairs
 #   2. .env.production.enc (FLEET_HOSTS) — encrypted, decrypted via SOPS
 #
-# FLEET_HOSTS format:  app:10.0.0.2,worker:10.0.0.4,worker:10.0.0.5
+# FLEET_HOSTS format:  app:10.0.0.2,worker:10.0.0.4,db:10.0.0.3,logging:10.0.0.6,redis:10.0.0.5
 
 SSH_KEY="$1"
 TAG="${2:-latest}"

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Deploy to a node via SSH.
 # Usage: ./deploy.sh <role> <host> <ssh-key-path> [image-tag]
 #
-# Roles: app, worker, db, logging
+# Roles: app, worker, db, logging, redis
 # Provider-agnostic — just needs SSH access to the target.
 
 ROLE="$1"
@@ -33,7 +33,11 @@ case "$ROLE" in
     COMPOSE_FILE="docker-compose.logging.yml"
     HEALTH_SERVICE="grafana"
     ;;
-  *)      echo "Unknown role: $ROLE (expected: app, worker, db, logging)"; exit 1 ;;
+  redis)
+    COMPOSE_FILE="docker-compose.redis.yml"
+    HEALTH_SERVICE="redis"
+    ;;
+  *)      echo "Unknown role: $ROLE (expected: app, worker, db, logging, redis)"; exit 1 ;;
 esac
 
 echo "Deploying role=$ROLE tag=$TAG to $HOST..."
@@ -78,6 +82,11 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for db role (set it or add to .env.production.enc)}"
     printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+  elif [ "$ROLE" = "redis" ]; then
+    : "${REDIS_PASSWORD:?REDIS_PASSWORD is required for redis role (set it or add to .env.production.enc)}"
+    : "${REDIS_PRIVATE_IP:?REDIS_PRIVATE_IP is required for redis role (set it or add to .env.production.enc)}"
+    printf 'REDIS_PASSWORD=%s\nREDIS_PRIVATE_IP=%s\n' "$REDIS_PASSWORD" "$REDIS_PRIVATE_IP" \
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   elif [ "$ROLE" = "worker" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for worker role (set it or add to .env.production.enc)}"
     : "${DB_HOST:?DB_HOST is required for worker role (set it or add to .env.production.enc)}"
@@ -87,8 +96,8 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
     ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 644 /opt/143/.env.production.enc"
   else
-    # Both app and worker nodes need SOPS_AGE_KEY + the encrypted secrets file
-    # so the entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
+    # App nodes need SOPS_AGE_KEY + the encrypted secrets file so the
+    # entrypoint can decrypt GitHub App creds, API keys, etc. at boot.
     : "${DB_PASSWORD:?DB_PASSWORD is required for app role (set it or add to .env.production.enc)}"
     : "${DB_HOST:?DB_HOST is required for app role (set it or add to .env.production.enc)}"
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for app role (set it or add to .env.production.enc)}"

--- a/deploy/scripts/deploy_redis_test.sh
+++ b/deploy/scripts/deploy_redis_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+STUB_DIR="$TMP_DIR/stubs"
+mkdir -p "$STUB_DIR"
+
+cat >"$STUB_DIR/sops" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "${SOPS_STUB_OUTPUT:-}"
+EOF
+chmod +x "$STUB_DIR/sops"
+
+cat >"$STUB_DIR/scp" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+capture_file="${SCP_CAPTURE_FILE:?}"
+{
+  printf 'ARGS:'
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$capture_file"
+exit 0
+EOF
+chmod +x "$STUB_DIR/scp"
+
+cat >"$STUB_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+capture_file="${SSH_CAPTURE_FILE:?}"
+counter_file="${SSH_COUNTER_FILE:?}"
+call_number="$(cat "$counter_file")"
+next_call_number=$((call_number + 1))
+printf '%s\n' "$next_call_number" >"$counter_file"
+
+{
+  printf 'ARGS:'
+  printf ' %q' "$@"
+  printf '\n'
+} >>"$capture_file"
+
+stdin_file="${SSH_STDIN_DIR:?}/call-${call_number}.stdin"
+cat >"$stdin_file"
+printf 'STDIN:%s\n' "$stdin_file" >>"$capture_file"
+
+exit 0
+EOF
+chmod +x "$STUB_DIR/ssh"
+
+HOME_DIR="$TMP_DIR/home"
+mkdir -p "$HOME_DIR/.config/sops/age"
+printf 'AGE-SECRET-KEY-test\n' >"$HOME_DIR/.config/sops/age/keys.txt"
+
+CAPTURE_FILE="$TMP_DIR/deploy.capture"
+: >"$CAPTURE_FILE"
+STDIN_DIR="$TMP_DIR/stdin"
+mkdir -p "$STDIN_DIR"
+COUNTER_FILE="$TMP_DIR/deploy.counter"
+printf '1\n' >"$COUNTER_FILE"
+OUTPUT_FILE="$TMP_DIR/deploy.out"
+
+(
+  export HOME="$HOME_DIR"
+  export PATH="$STUB_DIR:$PATH"
+  export SOPS_STUB_OUTPUT=$'REDIS_PASSWORD=redis-secret\nREDIS_PRIVATE_IP=10.0.0.50'
+  export SSH_CAPTURE_FILE="$CAPTURE_FILE"
+  export SSH_STDIN_DIR="$STDIN_DIR"
+  export SSH_COUNTER_FILE="$COUNTER_FILE"
+  export SCP_CAPTURE_FILE="$CAPTURE_FILE"
+  export REDIS_PASSWORD="redis-secret"
+  export REDIS_PRIVATE_IP="10.0.0.50"
+
+  bash "$ROOT_DIR/deploy/scripts/deploy.sh" redis 127.0.0.1 "$TMP_DIR/fake-key" >"$OUTPUT_FILE" 2>&1
+)
+
+grep -R -q "REDIS_PASSWORD=redis-secret" "$STDIN_DIR"
+grep -R -q "REDIS_PRIVATE_IP=10.0.0.50" "$STDIN_DIR"
+grep -q "docker-compose.redis.yml" "$CAPTURE_FILE"
+
+printf 'redis deploy test passed\n'

--- a/docs/design/47-logging-victorialogs.md
+++ b/docs/design/47-logging-victorialogs.md
@@ -277,7 +277,7 @@ VictoriaLogs must not be exposed to the public internet. All inter-server commun
 ### Hetzner Private Network
 
 1. Create a Hetzner Cloud Network (e.g., `10.0.0.0/24`)
-2. Attach all four servers (app, worker, db, logging)
+2. Attach the shared infrastructure servers (app, worker, db, logging, plus redis if enabled)
 3. Bind VictoriaLogs to the private IP only (shown in compose above)
 4. Vector on app/worker connects via private IP
 5. No firewall rules needed — traffic stays on the private network
@@ -470,7 +470,7 @@ case "$ROLE" in
   worker)  COMPOSE_FILE="docker-compose.worker.yml" ;;
   db)      COMPOSE_FILE="docker-compose.db.yml" ;;
   logging) COMPOSE_FILE="docker-compose.logging.yml" ;;
-  *)       echo "Unknown role: $ROLE (expected: app, worker, db, logging)"; exit 1 ;;
+  *)       echo "Unknown role: $ROLE (expected: app, worker, db, logging, redis)"; exit 1 ;;
 esac
 ```
 


### PR DESCRIPTION
## Summary
- Add `redis` as a valid deploy role in `deploy.sh` and stage the Redis-specific env file
- Add `make deploy-redis` and update fleet role documentation/examples
- Add a regression test covering the Redis deploy path

## Testing
- `bash deploy/scripts/deploy_redis_test.sh`
- `bash deploy/scripts/logging_webhook_optional_test.sh`
- `go test ./deploy/...`