### PR TITLE
Remove Preview tab icon in session details sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1504,6 +1504,7 @@ describe('SessionDetailPage', () => {
 
     const previewTab = screen.getByRole('tab', { name: /Preview/ });
     expect(previewTab).toBeInTheDocument();
+    expect(previewTab.querySelector('svg')).toBeNull();
 
     const user = userEvent.setup();
     await user.click(previewTab);

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -9,7 +9,6 @@ import {
   ArrowUp,
   ClipboardList,
   ExternalLink,
-  Eye,
   FileCode2,
   GitPullRequest,
   Loader2,
@@ -1731,10 +1730,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                 {showValidationTab && (
                   <TabsTrigger value="validation">Validation</TabsTrigger>
                 )}
-                <TabsTrigger value="preview">
-                  <Eye className="h-3 w-3 mr-1" />
-                  Preview
-                </TabsTrigger>
+                <TabsTrigger value="preview">Preview</TabsTrigger>
               </TabsList>
               {(() => {
                 if (hasPR && prData?.data?.github_pr_url) {


### PR DESCRIPTION
## Summary
Removed the standalone icon from the “Preview” tab in the session details sidebar so it matches the styling of the other tabs (which have no icons). Updated the page test to enforce that the Preview tab renders without an inline SVG.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Removed the `Eye` icon import and deleted the `<Eye ... />` usage from the `TabsTrigger` for the `preview` tab.
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Tightened the SessionDetailPage test to assert the Preview tab contains no `svg` icon.

## Test plan
- Ran targeted Vitest for the session detail page (`frontend/`)
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; only the existing Next.js multiple-lockfiles warning was emitted)

---
*Generated by [143.dev](https://143.dev) — [session b9914e6b](https://app.143.dev/sessions/b9914e6b-bfd7-45ec-9604-6b8c20698a59)*
