### PR TITLE
Switch invitation emails to plain-text and update tests

### DIFF
--- a/internal/services/email/sender.go
+++ b/internal/services/email/sender.go
@@ -3,7 +3,6 @@ package email
 import (
 	"context"
 	"fmt"
-	"html"
 	"net/smtp"
 	"strings"
 
@@ -34,20 +33,20 @@ func NewSMTPSender(cfg SMTPConfig) *SMTPSender {
 	return &SMTPSender{cfg: cfg}
 }
 
-// SendInvitation sends an HTML invitation email.
+// SendInvitation sends a plain-text invitation email.
 func (s *SMTPSender) SendInvitation(ctx context.Context, to, inviterName, orgName, acceptURL string) error {
-	subject := fmt.Sprintf("You've been invited to join %s", orgName)
+	subject := fmt.Sprintf("Invitation: join %s on 143.dev", orgName)
 
-	html := invitationHTML(inviterName, orgName, acceptURL)
+	body := invitationText(inviterName, orgName, acceptURL)
 
 	msg := strings.Join([]string{
 		"From: " + s.cfg.From,
 		"To: " + to,
 		"Subject: " + subject,
 		"MIME-Version: 1.0",
-		"Content-Type: text/html; charset=UTF-8",
+		"Content-Type: text/plain; charset=UTF-8",
 		"",
-		html,
+		body,
 	}, "\r\n")
 
 	addr := s.cfg.Host + ":" + s.cfg.Port
@@ -79,40 +78,25 @@ func (n *NoopSender) SendInvitation(ctx context.Context, to, inviterName, orgNam
 	return nil
 }
 
-// invitationHTML returns the HTML body for an invitation email.
-// All dynamic values are HTML-escaped to prevent injection.
-func invitationHTML(inviterName, orgName, acceptURL string) string {
+// invitationText returns the plain-text body for an invitation email.
+func invitationText(inviterName, orgName, acceptURL string) string {
 	inviterText := "Someone"
 	if inviterName != "" {
-		inviterText = html.EscapeString(inviterName)
+		inviterText = inviterName
 	}
-	safeOrg := html.EscapeString(orgName)
-	safeURL := html.EscapeString(acceptURL)
 
-	return fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head><meta charset="UTF-8"></head>
-<body style="margin:0;padding:0;background-color:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
-  <table width="100%%" cellpadding="0" cellspacing="0" style="padding:40px 20px;">
-    <tr><td align="center">
-      <table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
-        <tr><td style="padding:32px 32px 24px;text-align:center;">
-          <h1 style="margin:0 0 8px;font-size:20px;font-weight:600;color:#18181b;">
-            Join %s
-          </h1>
-          <p style="margin:0 0 24px;font-size:14px;color:#71717a;line-height:1.5;">
-            %s has invited you to join <strong>%s</strong>.
-          </p>
-          <a href="%s" style="display:inline-block;padding:10px 24px;background-color:#18181b;color:#ffffff;text-decoration:none;border-radius:6px;font-size:14px;font-weight:500;">
-            Accept Invitation
-          </a>
-          <p style="margin:24px 0 0;font-size:12px;color:#a1a1aa;line-height:1.5;">
-            This invitation expires in 7 days. If you didn't expect this email, you can safely ignore it.
-          </p>
-        </td></tr>
-      </table>
-    </td></tr>
-  </table>
-</body>
-</html>`, safeOrg, inviterText, safeOrg, safeURL)
+	return fmt.Sprintf(`You’ve been invited to join %s on 143.dev
+
+%s invited you to collaborate with their team.
+
+What to do next:
+1. Open the invite link below
+2. Sign in or create your account
+3. You’ll join %s automatically
+
+Accept invitation:
+%s
+
+This link expires in 7 days.
+If you weren’t expecting this, you can ignore this email.`, orgName, inviterText, orgName, acceptURL)
 }

--- a/internal/services/email/sender_test.go
+++ b/internal/services/email/sender_test.go
@@ -15,7 +15,7 @@ func TestNoopSender_SendInvitation(t *testing.T) {
 	require.NoError(t, err, "NoopSender should never return an error")
 }
 
-func TestInvitationHTML(t *testing.T) {
+func TestInvitationText(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -34,7 +34,7 @@ func TestInvitationHTML(t *testing.T) {
 				"Acme Corp",
 				"Alice",
 				"https://example.com/accept?token=abc",
-				"Accept Invitation",
+				"Accept invitation:",
 			},
 		},
 		{
@@ -48,14 +48,14 @@ func TestInvitationHTML(t *testing.T) {
 			},
 		},
 		{
-			name:    "HTML special characters are escaped",
+			name:    "special characters are preserved in plain text",
 			inviter: "<script>alert('xss')</script>",
 			org:     "Org & Co <Ltd>",
 			url:     "https://example.com/invite?a=1&b=2",
 			mustContain: []string{
-				"&lt;script&gt;",
-				"Org &amp; Co &lt;Ltd&gt;",
-				"a=1&amp;b=2",
+				"<script>alert('xss')</script>",
+				"Org & Co <Ltd>",
+				"a=1&b=2",
 			},
 		},
 	}
@@ -64,9 +64,9 @@ func TestInvitationHTML(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			html := invitationHTML(tt.inviter, tt.org, tt.url)
+			text := invitationText(tt.inviter, tt.org, tt.url)
 			for _, s := range tt.mustContain {
-				require.Contains(t, html, s, "invitation HTML should contain %q", s)
+				require.Contains(t, text, s, "invitation text should contain %q", s)
 			}
 		})
 	}


### PR DESCRIPTION
### Motivation

- Move transactional invitation emails from HTML to plain-text to simplify delivery and avoid HTML rendering issues.
- Use a consistent branded subject (`Invitation: join %s on 143.dev`) for invitation messages.
- Remove HTML escaping and templating since the content is plain text and should preserve original characters.

### Description

- Changed `SMTPSender.SendInvitation` to send `Content-Type: text/plain; charset=UTF-8` and updated the subject to `Invitation: join %s on 143.dev`.
- Replaced the HTML template `invitationHTML` with a plain-text function `invitationText` and removed the `html` import and `EscapeString` calls.
- Updated message construction to include the plain-text body and adjusted `NoopSender` behavior remains unchanged.
- Updated tests: renamed `TestInvitationHTML` to `TestInvitationText`, switched usages from `invitationHTML` to `invitationText`, and adjusted assertions to expect unescaped plain-text content.

### Testing

- Ran `TestNoopSender_SendInvitation` which verifies `NoopSender` returns no error and it passed.
- Ran `TestInvitationText` which verifies plain-text body contents and special characters are preserved and it passed.
- Ran `TestNewSMTPSender` which checks `NewSMTPSender` stores config and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea3fc90bec832093e2d48253ef304e)