### PR TITLE
Add session-completion browser notifications with per-user preference

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -53,6 +53,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { ChatTimeline } from "@/components/chat-timeline";
 import { api, ApiError } from "@/lib/api";
 import { AGENTS, AGENTS_BY_KEY } from "@/lib/agents";
+import { maybeNotifySessionCompleted } from "@/lib/browser-notifications";
 import { SSE_EVENT, addSSEListener } from "@/lib/sse";
 import { buildTimeline, buildTimelineFromResponse } from "@/lib/timeline";
 import { parseDiffStats, type DiffFile } from "@/lib/diff-parser";
@@ -1328,6 +1329,14 @@ const MAX_DETAIL = 600;
 const DEFAULT_DETAIL = 384;
 
 export function SessionDetailContent({ id }: { id: string }) {
+  const { user } = useAuth();
+  const { data: notificationPreferenceResp } = useQuery({
+    queryKey: ["account", "notification-preferences"],
+    queryFn: () => api.auth.getNotificationPreferences(),
+    enabled: !!user,
+  });
+  const sessionCompletionNotificationEnabled =
+    notificationPreferenceResp?.data?.session_completion_browser_enabled ?? false;
   const terminalStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
   const [reviewParam, setReviewParam] = useQueryState("review");
   const [previewParam, setPreviewParam] = useQueryState("preview");
@@ -1460,6 +1469,24 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRUrlRef.current = prUrl;
   }, [localPRState, prUrl, session?.pr_creation_state]);
+  const previousSessionStatusRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const currentStatus = session?.status;
+    if (!session?.id || !currentStatus) {
+      return;
+    }
+
+    void maybeNotifySessionCompleted({
+      enabled: sessionCompletionNotificationEnabled,
+      previousStatus: previousSessionStatusRef.current,
+      nextStatus: currentStatus,
+      sessionId: session.id,
+      title: session.title,
+      visibilityState: document.visibilityState,
+    });
+
+    previousSessionStatusRef.current = currentStatus;
+  }, [session?.id, session?.status, session?.title, sessionCompletionNotificationEnabled]);
   // Record that the user has viewed this session (for unread tracking).
   useEffect(() => {
     if (id) {

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import { api } from "@/lib/api";
 import { apiKeyHelp, PERSONAL_PROVIDER_OPTIONS, type PersonalProvider } from "@/lib/coding-auth-metadata";
 import { captureError } from "@/lib/errors";
+import { useAuth } from "@/hooks/use-auth";
 import { APIKeyHelpTooltip } from "@/components/api-key-help-tooltip";
 import { CodingAuthDialog } from "@/components/coding-auth-dialog";
 import { PageContainer } from "@/components/page-container";
@@ -16,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ThemeSelect } from "@/components/theme-select";
 import type { ListResponse, UserCredentialSummary } from "@/lib/types";
@@ -53,10 +55,30 @@ function statusLabel(status?: string) {
 }
 
 export default function AccountPage() {
+  const { user } = useAuth();
   const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
   const [provider, setProvider] = useState<PersonalProvider>("openai");
   const [apiKey, setApiKey] = useState("");
+  const { data: notificationPreferenceResp } = useQuery({
+    queryKey: ["account", "notification-preferences"],
+    queryFn: () => api.auth.getNotificationPreferences(),
+    enabled: !!user,
+  });
+  const sessionCompletionNotificationsEnabled =
+    notificationPreferenceResp?.data?.session_completion_browser_enabled ?? false;
+
+  const notificationPreferenceMutation = useMutation({
+    mutationFn: (enabled: boolean) =>
+      api.auth.updateNotificationPreferences({ session_completion_browser_enabled: enabled }),
+    onSuccess: (response) => {
+      queryClient.setQueryData(["account", "notification-preferences"], response);
+    },
+    onError: (error) => {
+      captureError(error, { feature: "account-notification-preferences-update" });
+      toast.error("Could not update notification settings");
+    },
+  });
 
   const { data: personalResp } = useQuery<ListResponse<UserCredentialSummary>>({
     queryKey: ["user-credentials", "personal"],
@@ -156,6 +178,33 @@ export default function AccountPage() {
           </CardHeader>
           <CardContent className="pb-6">
             <ThemeSelect />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Notifications</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 pb-6">
+            <div className="flex items-center justify-between gap-4">
+              <div className="space-y-1">
+                <Label htmlFor="session-complete-browser-notifications">Session completion browser notifications</Label>
+                <p className="text-xs text-muted-foreground">
+                  Notify me when a session finishes while this tab is in the background.
+                </p>
+              </div>
+              <Switch
+                id="session-complete-browser-notifications"
+                checked={sessionCompletionNotificationsEnabled}
+                onCheckedChange={(checked) => {
+                  notificationPreferenceMutation.mutate(checked);
+                }}
+                disabled={!user || notificationPreferenceMutation.isPending}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Off by default. You can turn this on when you want completion alerts.
+            </p>
           </CardContent>
         </Card>
       </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -189,6 +189,10 @@ export const api = {
     logout: () => post('/api/v1/auth/logout'),
     memberships: () =>
       get<import('./types').SingleResponse<import('./types').MembershipsResponse>>('/api/v1/auth/memberships'),
+    getNotificationPreferences: () =>
+      get<import('./types').SingleResponse<import('./types').UserNotificationPreference>>('/api/v1/account/notification-preferences'),
+    updateNotificationPreferences: (data: { session_completion_browser_enabled: boolean }) =>
+      patch<import('./types').SingleResponse<import('./types').UserNotificationPreference>>('/api/v1/account/notification-preferences', data),
   },
   organizations: {
     create: (name: string) =>

--- a/frontend/src/lib/browser-notifications.test.ts
+++ b/frontend/src/lib/browser-notifications.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { maybeNotifySessionCompleted } from './browser-notifications';
+
+describe('maybeNotifySessionCompleted', () => {
+  const openSession = {
+    id: 'session-1',
+    status: 'running',
+    title: 'Fix flaky tests',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a browser notification when the session transitions to completed and permission is granted', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      enabled: true,
+      previousStatus: openSession.status,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'hidden',
+    });
+
+    expect(notificationSpy).toHaveBeenCalledWith('Session completed', {
+      body: 'Fix flaky tests',
+      tag: 'session-1',
+    });
+  });
+
+  it('does not notify when the tab is visible', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      enabled: true,
+      previousStatus: openSession.status,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'visible',
+    });
+
+    expect(notificationSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not notify on initial load when no previous status was observed', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      enabled: true,
+      previousStatus: undefined,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'hidden',
+    });
+
+    expect(notificationSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not notify when the feature is disabled in settings', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      enabled: false,
+      previousStatus: openSession.status,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'hidden',
+    });
+
+    expect(notificationSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/browser-notifications.ts
+++ b/frontend/src/lib/browser-notifications.ts
@@ -1,0 +1,67 @@
+const terminalSessionStatuses = new Set([
+  'completed',
+  'pr_created',
+  'failed',
+  'cancelled',
+  'skipped',
+]);
+
+type VisibilityState = 'visible' | 'hidden' | 'prerender';
+
+interface NotifySessionCompletedOptions {
+  enabled: boolean;
+  previousStatus?: string;
+  nextStatus?: string;
+  sessionId: string;
+  title?: string;
+  visibilityState: VisibilityState;
+}
+
+export async function maybeNotifySessionCompleted(options: NotifySessionCompletedOptions): Promise<void> {
+  const {
+    enabled,
+    previousStatus,
+    nextStatus,
+    sessionId,
+    title,
+    visibilityState,
+  } = options;
+
+  if (!enabled) {
+    return;
+  }
+
+  if (!nextStatus || !terminalSessionStatuses.has(nextStatus)) {
+    return;
+  }
+
+  if (!previousStatus) {
+    return;
+  }
+
+  if (terminalSessionStatuses.has(previousStatus)) {
+    return;
+  }
+
+  if (visibilityState === 'visible') {
+    return;
+  }
+
+  if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+    return;
+  }
+
+  let permission = Notification.permission;
+  if (permission === 'default') {
+    permission = await Notification.requestPermission();
+  }
+
+  if (permission !== 'granted') {
+    return;
+  }
+
+  new Notification('Session completed', {
+    body: title || 'Your session has finished running.',
+    tag: sessionId,
+  });
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -38,6 +38,14 @@ export interface User {
   created_at: string;
 }
 
+export interface UserNotificationPreference {
+  org_id: string;
+  user_id: string;
+  session_completion_browser_enabled: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
 export interface AuthProviders {
   github: boolean;
   google: boolean;

--- a/internal/api/handlers/user_notification_preferences.go
+++ b/internal/api/handlers/user_notification_preferences.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+)
+
+type UserNotificationPreferenceHandler struct {
+	store *db.UserNotificationPreferenceStore
+}
+
+func NewUserNotificationPreferenceHandler(store *db.UserNotificationPreferenceStore) *UserNotificationPreferenceHandler {
+	return &UserNotificationPreferenceHandler{store: store}
+}
+
+func (h *UserNotificationPreferenceHandler) Get(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	orgID := middleware.OrgIDFromContext(r.Context())
+	pref, err := h.store.GetByUser(r.Context(), orgID, user.ID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "PREFERENCE_LOOKUP_FAILED", "failed to load user notification preferences", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": pref})
+}
+
+func (h *UserNotificationPreferenceHandler) Update(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var body struct {
+		SessionCompletionBrowserEnabled bool `json:"session_completion_browser_enabled"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_JSON", "invalid request body")
+		return
+	}
+
+	orgID := middleware.OrgIDFromContext(r.Context())
+	if err := h.store.Upsert(r.Context(), orgID, user.ID, body.SessionCompletionBrowserEnabled); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "PREFERENCE_UPDATE_FAILED", "failed to update user notification preferences", err)
+		return
+	}
+
+	pref, err := h.store.GetByUser(r.Context(), orgID, user.ID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "PREFERENCE_LOOKUP_FAILED", "failed to load user notification preferences", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": pref})
+}

--- a/internal/api/handlers/user_notification_preferences_test.go
+++ b/internal/api/handlers/user_notification_preferences_test.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestUserNotificationPreferenceHandler_Get(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	store := db.NewUserNotificationPreferenceStore(mock)
+	handler := NewUserNotificationPreferenceHandler(store)
+
+	rows := pgxmock.NewRows([]string{"org_id", "user_id", "session_completion_browser_enabled", "created_at", "updated_at"}).
+		AddRow(orgID, userID, true, now, now)
+	mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnRows(rows)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/account/notification-preferences", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Get(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Get should return 200")
+	var resp struct {
+		Data models.UserNotificationPreference `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
+	require.True(t, resp.Data.SessionCompletionBrowserEnabled, "Get should return stored preference")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestUserNotificationPreferenceHandler_Update(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	store := db.NewUserNotificationPreferenceStore(mock)
+	handler := NewUserNotificationPreferenceHandler(store)
+
+	mock.ExpectExec("INSERT INTO user_notification_preferences").WithArgs(orgID, userID, true).WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	rows := pgxmock.NewRows([]string{"org_id", "user_id", "session_completion_browser_enabled", "created_at", "updated_at"}).
+		AddRow(orgID, userID, true, now, now)
+	mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnRows(rows)
+
+	body := bytes.NewBufferString(`{"session_completion_browser_enabled":true}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/account/notification-preferences", body)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Update(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, "Update should return 200")
+	var resp struct {
+		Data models.UserNotificationPreference `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp), "response should be valid JSON")
+	require.True(t, resp.Data.SessionCompletionBrowserEnabled, "Update should persist enabled preference")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestUserNotificationPreferenceHandler_Get_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	handler := NewUserNotificationPreferenceHandler(db.NewUserNotificationPreferenceStore(mock))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/account/notification-preferences", nil)
+	req = req.WithContext(context.Background())
+	rr := httptest.NewRecorder()
+
+	handler.Get(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "Get should return 401 without authenticated user")
+}

--- a/internal/api/handlers/user_notification_preferences_test.go
+++ b/internal/api/handlers/user_notification_preferences_test.go
@@ -107,3 +107,126 @@ func TestUserNotificationPreferenceHandler_Get_Unauthorized(t *testing.T) {
 
 	require.Equal(t, http.StatusUnauthorized, rr.Code, "Get should return 401 without authenticated user")
 }
+
+func TestUserNotificationPreferenceHandler_Get_StoreError(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	handler := NewUserNotificationPreferenceHandler(db.NewUserNotificationPreferenceStore(mock))
+	mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnError(context.Canceled)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/account/notification-preferences", nil)
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Get(rr, req)
+
+	require.Equal(t, http.StatusInternalServerError, rr.Code, "Get should return 500 when the store read fails")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestUserNotificationPreferenceHandler_Update_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	handler := NewUserNotificationPreferenceHandler(db.NewUserNotificationPreferenceStore(mock))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/account/notification-preferences", bytes.NewBufferString(`{"session_completion_browser_enabled":true}`))
+	req = req.WithContext(context.Background())
+	rr := httptest.NewRecorder()
+
+	handler.Update(rr, req)
+
+	require.Equal(t, http.StatusUnauthorized, rr.Code, "Update should return 401 without authenticated user")
+}
+
+func TestUserNotificationPreferenceHandler_Update_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	handler := NewUserNotificationPreferenceHandler(db.NewUserNotificationPreferenceStore(mock))
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/account/notification-preferences", bytes.NewBufferString("{"))
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.Update(rr, req)
+
+	require.Equal(t, http.StatusBadRequest, rr.Code, "Update should return 400 for invalid JSON")
+}
+
+func TestUserNotificationPreferenceHandler_Update_StoreErrors(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	tests := []struct {
+		name            string
+		setupMock       func(mock pgxmock.PgxPoolIface)
+		expectedStatus  int
+		expectedMessage string
+	}{
+		{
+			name: "returns 500 when upsert fails",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectExec("INSERT INTO user_notification_preferences").WithArgs(orgID, userID, true).WillReturnError(context.DeadlineExceeded)
+			},
+			expectedStatus:  http.StatusInternalServerError,
+			expectedMessage: "Update should return 500 when the store upsert fails",
+		},
+		{
+			name: "returns 500 when follow-up read fails",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectExec("INSERT INTO user_notification_preferences").WithArgs(orgID, userID, true).WillReturnResult(pgxmock.NewResult("INSERT", 1))
+				mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnError(context.DeadlineExceeded)
+			},
+			expectedStatus:  http.StatusInternalServerError,
+			expectedMessage: "Update should return 500 when follow-up preference lookup fails",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgx mock pool")
+			defer mock.Close()
+
+			handler := NewUserNotificationPreferenceHandler(db.NewUserNotificationPreferenceStore(mock))
+			tt.setupMock(mock)
+
+			req := httptest.NewRequest(http.MethodPatch, "/api/v1/account/notification-preferences", bytes.NewBufferString(`{"session_completion_browser_enabled":true}`))
+			ctx := middleware.WithOrgID(req.Context(), orgID)
+			ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID})
+			req = req.WithContext(ctx)
+			rr := httptest.NewRecorder()
+
+			handler.Update(rr, req)
+
+			require.Equal(t, tt.expectedStatus, rr.Code, tt.expectedMessage)
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -99,6 +99,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	}
 	credentialStore := db.NewOrgCredentialStore(pool, cryptoSvc)
 	userCredentialStore := db.NewUserCredentialStore(pool, cryptoSvc)
+	userNotificationPreferenceStore := db.NewUserNotificationPreferenceStore(pool)
 
 	// Create services
 	ingestionSvc := ingestion.NewService(issueStore, webhookDeliveryStore, jobStore, logger)
@@ -206,6 +207,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	credentialHandler := handlers.NewCredentialHandler(credentialStore)
 	memoryHandler := handlers.NewMemoryHandler(memoryStore, reviewCommentStore)
 	userCredentialHandler := handlers.NewUserCredentialHandler(userCredentialStore, credentialStore, userStore)
+	userNotificationPreferenceHandler := handlers.NewUserNotificationPreferenceHandler(userNotificationPreferenceStore)
 	codingAuthHandler := handlers.NewCodingAuthHandler(credentialStore, orgStore)
 	var emailSender email.Sender
 	if cfg.SMTPHost != "" && cfg.SMTPFrom != "" {
@@ -518,6 +520,8 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			r.Get("/api/v1/settings/credentials/personal", userCredentialHandler.ListPersonal)
 			r.Get("/api/v1/settings/credentials/resolved", userCredentialHandler.ListResolved)
 			r.Get("/api/v1/settings/credentials/team", userCredentialHandler.ListTeamDefaults)
+			r.Get("/api/v1/account/notification-preferences", userNotificationPreferenceHandler.Get)
+			r.Patch("/api/v1/account/notification-preferences", userNotificationPreferenceHandler.Update)
 
 			r.Get("/api/v1/repositories", repoHandler.List)
 			r.Get("/api/v1/repositories/summary", repoHandler.Summary)

--- a/internal/db/user_notification_preference_store_test.go
+++ b/internal/db/user_notification_preference_store_test.go
@@ -1,0 +1,86 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserNotificationPreferenceStore_GetByUser(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		setupMock func(mock pgxmock.PgxPoolIface)
+		expected  bool
+		expectErr bool
+	}{
+		{
+			name: "returns stored preference",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				rows := pgxmock.NewRows([]string{"org_id", "user_id", "session_completion_browser_enabled", "created_at", "updated_at"}).
+					AddRow(orgID, userID, true, now, now)
+				mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnRows(rows)
+			},
+			expected: true,
+		},
+		{
+			name: "defaults to disabled when no row exists",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnRows(
+					pgxmock.NewRows([]string{"org_id", "user_id", "session_completion_browser_enabled", "created_at", "updated_at"}),
+				)
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgx mock pool")
+			defer mock.Close()
+
+			store := NewUserNotificationPreferenceStore(mock)
+			tt.setupMock(mock)
+
+			pref, getErr := store.GetByUser(context.Background(), orgID, userID)
+			if tt.expectErr {
+				require.Error(t, getErr, "GetByUser should return an error")
+				return
+			}
+
+			require.NoError(t, getErr, "GetByUser should not return an error")
+			require.Equal(t, tt.expected, pref.SessionCompletionBrowserEnabled, "GetByUser should return expected enabled state")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestUserNotificationPreferenceStore_Upsert(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	store := NewUserNotificationPreferenceStore(mock)
+	mock.ExpectExec("INSERT INTO user_notification_preferences").WithArgs(orgID, userID, true).WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+	upsertErr := store.Upsert(context.Background(), orgID, userID, true)
+	require.NoError(t, upsertErr, "Upsert should not return an error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}

--- a/internal/db/user_notification_preference_store_test.go
+++ b/internal/db/user_notification_preference_store_test.go
@@ -41,6 +41,22 @@ func TestUserNotificationPreferenceStore_GetByUser(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "returns error when query fails",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnError(context.DeadlineExceeded)
+			},
+			expectErr: true,
+		},
+		{
+			name: "returns error when row scan fails",
+			setupMock: func(mock pgxmock.PgxPoolIface) {
+				rows := pgxmock.NewRows([]string{"org_id", "user_id", "session_completion_browser_enabled", "created_at", "updated_at"}).
+					AddRow("not-a-uuid", userID, true, now, now)
+				mock.ExpectQuery("SELECT").WithArgs(orgID, userID).WillReturnRows(rows)
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -82,5 +98,23 @@ func TestUserNotificationPreferenceStore_Upsert(t *testing.T) {
 
 	upsertErr := store.Upsert(context.Background(), orgID, userID, true)
 	require.NoError(t, upsertErr, "Upsert should not return an error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestUserNotificationPreferenceStore_Upsert_Error(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	store := NewUserNotificationPreferenceStore(mock)
+	mock.ExpectExec("INSERT INTO user_notification_preferences").WithArgs(orgID, userID, false).WillReturnError(context.Canceled)
+
+	upsertErr := store.Upsert(context.Background(), orgID, userID, false)
+	require.Error(t, upsertErr, "Upsert should return an error when exec fails")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/db/user_notification_preferences.go
+++ b/internal/db/user_notification_preferences.go
@@ -1,0 +1,70 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type UserNotificationPreferenceStore struct {
+	db DBTX
+}
+
+func NewUserNotificationPreferenceStore(db DBTX) *UserNotificationPreferenceStore {
+	return &UserNotificationPreferenceStore{db: db}
+}
+
+func (s *UserNotificationPreferenceStore) GetByUser(ctx context.Context, orgID, userID uuid.UUID) (models.UserNotificationPreference, error) {
+	query := `
+		SELECT org_id, user_id, session_completion_browser_enabled, created_at, updated_at
+		FROM user_notification_preferences
+		WHERE org_id = @org_id AND user_id = @user_id`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID, "user_id": userID})
+	if err != nil {
+		return models.UserNotificationPreference{}, fmt.Errorf("query user notification preference: %w", err)
+	}
+
+	pref, collectErr := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.UserNotificationPreference])
+	if collectErr != nil {
+		if collectErr == pgx.ErrNoRows {
+			now := time.Now().UTC()
+			return models.UserNotificationPreference{
+				OrgID:                           orgID,
+				UserID:                          userID,
+				SessionCompletionBrowserEnabled: false,
+				CreatedAt:                       now,
+				UpdatedAt:                       now,
+			}, nil
+		}
+		return models.UserNotificationPreference{}, fmt.Errorf("collect user notification preference: %w", collectErr)
+	}
+
+	return pref, nil
+}
+
+func (s *UserNotificationPreferenceStore) Upsert(ctx context.Context, orgID, userID uuid.UUID, sessionCompletionBrowserEnabled bool) error {
+	query := `
+		INSERT INTO user_notification_preferences (org_id, user_id, session_completion_browser_enabled)
+		VALUES (@org_id, @user_id, @session_completion_browser_enabled)
+		ON CONFLICT (org_id, user_id)
+		DO UPDATE
+		SET session_completion_browser_enabled = EXCLUDED.session_completion_browser_enabled,
+		    updated_at = now()`
+
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"org_id":                             orgID,
+		"user_id":                            userID,
+		"session_completion_browser_enabled": sessionCompletionBrowserEnabled,
+	})
+	if err != nil {
+		return fmt.Errorf("upsert user notification preference: %w", err)
+	}
+
+	return nil
+}

--- a/internal/models/user_notification_preference.go
+++ b/internal/models/user_notification_preference.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserNotificationPreference stores per-user notification toggles scoped to an org.
+type UserNotificationPreference struct {
+	OrgID                           uuid.UUID `db:"org_id" json:"org_id"`
+	UserID                          uuid.UUID `db:"user_id" json:"user_id"`
+	SessionCompletionBrowserEnabled bool      `db:"session_completion_browser_enabled" json:"session_completion_browser_enabled"`
+	CreatedAt                       time.Time `db:"created_at" json:"created_at"`
+	UpdatedAt                       time.Time `db:"updated_at" json:"updated_at"`
+}

--- a/migrations/000088_user_notification_preferences.down.sql
+++ b/migrations/000088_user_notification_preferences.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS user_notification_preferences;

--- a/migrations/000088_user_notification_preferences.up.sql
+++ b/migrations/000088_user_notification_preferences.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_notification_preferences (
+    org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_completion_browser_enabled boolean NOT NULL DEFAULT false,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (org_id, user_id)
+);
+
+CREATE INDEX idx_user_notification_preferences_user
+    ON user_notification_preferences (org_id, user_id);


### PR DESCRIPTION
### Motivation

- Provide an opt-in browser notification when a session transitions to a terminal state while the user’s tab is in the background and persist the preference per-user.

### Description

- Backend: introduce `UserNotificationPreference` model, DB store `UserNotificationPreferenceStore`, SQL migrations, and an API handler exposing `GET` and `PATCH /api/v1/account/notification-preferences`.
- Router: wire the new handler into the API router and create store instances in `NewRouter`.
- Frontend: add `api.auth.getNotificationPreferences` and `updateNotificationPreferences`, expose a `Notifications` card on the account settings page with a `Switch` that updates the preference, and call `maybeNotifySessionCompleted` from `SessionDetailContent` to trigger notifications when appropriate.
- Notifications logic: implement `maybeNotifySessionCompleted` which checks feature toggle, status transitions, document visibility, and `Notification` permission before showing a `Notification`.
- Types and tests: add `UserNotificationPreference` TypeScript type and unit tests for the browser notification helper plus Go unit tests for the handler and DB store.

### Testing

- Added frontend unit tests `frontend/src/lib/browser-notifications.test.ts` (Vitest) which exercise permission handling and visibility checks and passed.
- Added Go unit tests for the API handler `internal/api/handlers/user_notification_preferences_test.go` and DB store `internal/db/user_notification_preference_store_test.go` which were run and passed.
- Verified the new API client calls and settings UI update the preference via the `updateNotificationPreferences` mutation during local testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea45c469108320b719ac16a1f3c6ac)