### PR TITLE
Add browser notifications when sessions finish

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -53,6 +53,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { ChatTimeline } from "@/components/chat-timeline";
 import { api, ApiError } from "@/lib/api";
 import { AGENTS, AGENTS_BY_KEY } from "@/lib/agents";
+import { maybeNotifySessionCompleted } from "@/lib/browser-notifications";
 import { SSE_EVENT, addSSEListener } from "@/lib/sse";
 import { buildTimeline, buildTimelineFromResponse } from "@/lib/timeline";
 import { parseDiffStats, type DiffFile } from "@/lib/diff-parser";
@@ -1460,6 +1461,23 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRUrlRef.current = prUrl;
   }, [localPRState, prUrl, session?.pr_creation_state]);
+  const previousSessionStatusRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const currentStatus = session?.status;
+    if (!session?.id || !currentStatus) {
+      return;
+    }
+
+    void maybeNotifySessionCompleted({
+      previousStatus: previousSessionStatusRef.current,
+      nextStatus: currentStatus,
+      sessionId: session.id,
+      title: session.title,
+      visibilityState: document.visibilityState,
+    });
+
+    previousSessionStatusRef.current = currentStatus;
+  }, [session?.id, session?.status, session?.title]);
   // Record that the user has viewed this session (for unread tracking).
   useEffect(() => {
     if (id) {

--- a/frontend/src/lib/browser-notifications.test.ts
+++ b/frontend/src/lib/browser-notifications.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { maybeNotifySessionCompleted } from './browser-notifications';
+
+describe('maybeNotifySessionCompleted', () => {
+  const openSession = {
+    id: 'session-1',
+    status: 'running',
+    title: 'Fix flaky tests',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends a browser notification when the session transitions to completed and permission is granted', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      previousStatus: openSession.status,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'hidden',
+    });
+
+    expect(notificationSpy).toHaveBeenCalledWith('Session completed', {
+      body: 'Fix flaky tests',
+      tag: 'session-1',
+    });
+  });
+
+  it('does not notify when the tab is visible', async () => {
+    const notificationSpy = vi.fn();
+    vi.stubGlobal('Notification', Object.assign(notificationSpy, {
+      permission: 'granted',
+      requestPermission: vi.fn().mockResolvedValue('granted'),
+    }));
+
+    await maybeNotifySessionCompleted({
+      previousStatus: openSession.status,
+      nextStatus: 'completed',
+      sessionId: openSession.id,
+      title: openSession.title,
+      visibilityState: 'visible',
+    });
+
+    expect(notificationSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/browser-notifications.ts
+++ b/frontend/src/lib/browser-notifications.ts
@@ -1,0 +1,57 @@
+const terminalSessionStatuses = new Set([
+  'completed',
+  'pr_created',
+  'failed',
+  'cancelled',
+  'skipped',
+]);
+
+type VisibilityState = 'visible' | 'hidden' | 'prerender';
+
+interface NotifySessionCompletedOptions {
+  previousStatus?: string;
+  nextStatus?: string;
+  sessionId: string;
+  title?: string;
+  visibilityState: VisibilityState;
+}
+
+export async function maybeNotifySessionCompleted(options: NotifySessionCompletedOptions): Promise<void> {
+  const {
+    previousStatus,
+    nextStatus,
+    sessionId,
+    title,
+    visibilityState,
+  } = options;
+
+  if (!nextStatus || !terminalSessionStatuses.has(nextStatus)) {
+    return;
+  }
+
+  if (previousStatus && terminalSessionStatuses.has(previousStatus)) {
+    return;
+  }
+
+  if (visibilityState === 'visible') {
+    return;
+  }
+
+  if (typeof window === 'undefined' || typeof Notification === 'undefined') {
+    return;
+  }
+
+  let permission = Notification.permission;
+  if (permission === 'default') {
+    permission = await Notification.requestPermission();
+  }
+
+  if (permission !== 'granted') {
+    return;
+  }
+
+  new Notification('Session completed', {
+    body: title || 'Your session has finished running.',
+    tag: sessionId,
+  });
+}


### PR DESCRIPTION
### Motivation
- Let users receive a browser-level alert when a session they started finishes while their tab is in the background.  
- Avoid noisy or duplicate notifications by only notifying on a non-terminal→terminal transition and when the tab is not visible.  
- Integrate with the existing session detail polling so the notification is triggered as soon as the server-side status changes are observed.

### Description
- Add `maybeNotifySessionCompleted` in `frontend/src/lib/browser-notifications.ts`, which requests permission if needed and sends a native `Notification` titled "Session completed" with the session title as the body when appropriate.  
- Wire the helper into the session detail view by calling it from `session-detail-content.tsx` when the session status changes, preserving existing in-app toast behavior.  
- Add unit tests in `frontend/src/lib/browser-notifications.test.ts` covering the notify / no-notify cases (hidden vs visible tab + permission behavior).  
- Implementation details: notifications are tagged by `sessionId`, only fire for terminal statuses (`completed`, `pr_created`, `failed`, `cancelled`, `skipped`), and early-return when running in non-browser environments.

### Testing
- Ran unit tests with `cd frontend && npm run test -- src/lib/browser-notifications.test.ts`, and the test file passed.  
- Ran typecheck with `cd frontend && npm run typecheck`, which succeeded.  
- Ran lint with `cd frontend && npm run lint`, which succeeded.  
- Built the frontend with `cd frontend && npm run build`, which produced a successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea45c469108320b719ac16a1f3c6ac)