### PR TITLE
Fix snapshot expiry notice margins

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -855,6 +855,33 @@ describe('SessionDetailPage', () => {
     expect(within(alert).queryByRole('button')).not.toBeInTheDocument();
   });
 
+  it('matches the snapshot expiry notice horizontal margins to overview cards', async () => {
+    const sessionWithMissingSnapshot: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: undefined,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithMissingSnapshot } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.className).toContain('mx-2');
+  });
+
   it('does not show Create PR button when session is running', async () => {
     const runningSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1845,7 +1845,7 @@ export function SessionDetailContent({ id }: { id: string }) {
               </div>
               {prErrorNotice && (
                 <ErrorNotice
-                  className="mt-2"
+                  className="mx-2 mt-2"
                   title={prErrorNotice.title}
                   description={prErrorNotice.description}
                   action={prErrorNotice.action}


### PR DESCRIPTION
## Summary
- Add horizontal margin to the PR session expired notice so it aligns with the overview result card.
- Add a UI regression test to lock in the expected notice spacing.

## Testing
- `vitest` UI test for `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`