### PR TITLE
Remove WORKER_DEFAULT_BUCKET from self-hosting docs

### DIFF
--- a/deploy/scripts/worker_buckets.sh
+++ b/deploy/scripts/worker_buckets.sh
@@ -14,15 +14,15 @@ apply_worker_bucket_overrides() {
     return
   fi
 
-  # WORKER_BUCKET_MAP is a single env var mapping host/IP to a provider SKU:
-  #   WORKER_BUCKET_MAP="10.0.0.4=hcloud-cpx31,10.0.0.5=hcloud-ccx23"
+  # WORKER_BUCKET_MAP is a single env var mapping provider SKU to host/IP:
+  #   WORKER_BUCKET_MAP="hcloud-cpx31:10.0.0.4,hcloud-ccx23:10.0.0.5"
   local bucket
   bucket="${WORKER_DEFAULT_BUCKET:-hcloud-cpx31}"
   if [ -n "${WORKER_BUCKET_MAP:-}" ]; then
     IFS=',' read -ra mappings <<< "$WORKER_BUCKET_MAP"
     for mapping in "${mappings[@]}"; do
-      map_host="${mapping%%=*}"
-      map_bucket="${mapping#*=}"
+      map_bucket="${mapping%%:*}"
+      map_host="${mapping#*:}"
       if [ "$map_host" = "$host" ]; then
         bucket="$map_bucket"
         break

--- a/deploy/scripts/worker_buckets_test.sh
+++ b/deploy/scripts/worker_buckets_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=deploy/scripts/worker_buckets.sh
+source "$SCRIPT_DIR/worker_buckets.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "assertion failed: $message" >&2
+    echo "  expected: $expected" >&2
+    echo "  actual:   $actual" >&2
+    exit 1
+  fi
+}
+
+reset_worker_env() {
+  unset WORKER_PROCESS_COUNT SANDBOX_CPU_LIMIT SANDBOX_MEMORY_LIMIT_MB SANDBOX_DISK_LIMIT_GB WORKER_BUCKET_MAP WORKER_DEFAULT_BUCKET
+}
+
+test_bucket_map_uses_bucket_then_host_with_colon_separator() {
+  reset_worker_env
+  WORKER_BUCKET_MAP="hcloud-ccx23:87.99.158.39,hcloud-cpx31:10.0.0.5"
+  apply_worker_bucket_overrides worker "87.99.158.39"
+  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "bucket map should match bucket:host entries"
+}
+
+test_bucket_map_does_not_override_other_hosts() {
+  reset_worker_env
+  WORKER_BUCKET_MAP="hcloud-cpx31:87.99.158.39"
+  apply_worker_bucket_overrides worker "87.99.158.40"
+  assert_eq "2" "${WORKER_PROCESS_COUNT:-}" "unmapped hosts should keep the builtin default bucket"
+}
+
+test_bucket_map_preserves_explicit_worker_process_count() {
+  reset_worker_env
+  WORKER_BUCKET_MAP="hcloud-ccx23:87.99.158.39"
+  WORKER_PROCESS_COUNT="9"
+  apply_worker_bucket_overrides worker "87.99.158.39"
+  assert_eq "9" "${WORKER_PROCESS_COUNT:-}" "explicit WORKER_PROCESS_COUNT should win over bucket defaults"
+}
+
+test_bucket_map_sets_sandbox_defaults() {
+  reset_worker_env
+  WORKER_BUCKET_MAP="hcloud-cpx31:87.99.158.39"
+  apply_worker_bucket_overrides worker "87.99.158.39"
+  assert_eq "2" "${SANDBOX_CPU_LIMIT:-}" "worker bucket overrides should set default sandbox CPU"
+  assert_eq "4096" "${SANDBOX_MEMORY_LIMIT_MB:-}" "worker bucket overrides should set default sandbox memory"
+  assert_eq "10" "${SANDBOX_DISK_LIMIT_GB:-}" "worker bucket overrides should set default sandbox disk"
+}
+
+test_bucket_map_ignores_non_worker_roles() {
+  reset_worker_env
+  WORKER_BUCKET_MAP="hcloud-cpx31:87.99.158.39"
+  apply_worker_bucket_overrides app "87.99.158.39"
+  assert_eq "" "${WORKER_PROCESS_COUNT:-}" "non-worker roles should not receive worker overrides"
+}
+
+test_bucket_map_uses_default_bucket_when_set() {
+  reset_worker_env
+  WORKER_DEFAULT_BUCKET="hcloud-ccx23"
+  apply_worker_bucket_overrides worker "87.99.158.40"
+  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "default bucket should still work for unmapped workers"
+}
+
+test_bucket_map_uses_builtin_fallback_without_mapping() {
+  reset_worker_env
+  apply_worker_bucket_overrides worker "87.99.158.40"
+  assert_eq "2" "${WORKER_PROCESS_COUNT:-}" "builtin default bucket should apply when no mapping is configured"
+}
+
+main() {
+  test_bucket_map_uses_bucket_then_host_with_colon_separator
+  test_bucket_map_does_not_override_other_hosts
+  test_bucket_map_preserves_explicit_worker_process_count
+  test_bucket_map_sets_sandbox_defaults
+  test_bucket_map_ignores_non_worker_roles
+  test_bucket_map_uses_default_bucket_when_set
+  test_bucket_map_uses_builtin_fallback_without_mapping
+}
+
+main "$@"

--- a/docs/self-hosting/production-deployment-checklist.md
+++ b/docs/self-hosting/production-deployment-checklist.md
@@ -39,11 +39,9 @@ Notes:
 - [ ] `ENCRYPTION_MASTER_KEY` (required if you want encrypted credentials at rest)
 - [ ] Worker capacity knobs (for `MODE=worker` or mixed `MODE=all` nodes):
   - `WORKER_PROCESS_COUNT` (default `1`) — how many in-process worker loops run on this node
-  - `SANDBOX_CPU_LIMIT` (default `2`) — CPU cores per sandbox container
-  - `SANDBOX_MEMORY_LIMIT_MB` (default `4096`) — memory per sandbox container
-  - `SANDBOX_DISK_LIMIT_GB` (default `10`) — rootfs disk per sandbox container
-  - For fleet deploys, put these in `.env.production.enc` like other deploy env vars.
-  - For mixed worker sizes, set `WORKER_DEFAULT_BUCKET` plus `WORKER_BUCKET_MAP=10.0.0.4=hcloud-cpx21,10.0.0.5=hcloud-cpx31,10.0.0.6=hcloud-ccx23` (supports CPX shared + CCX dedicated families).
+  - For fleet deploys, put worker sizing env vars in `.env.production.enc` like other deploy env vars.
+  - For mixed worker sizes, set `WORKER_BUCKET_MAP=10.0.0.4=hcloud-cpx21,10.0.0.5=hcloud-cpx31,10.0.0.6=hcloud-ccx23` (supports CPX shared + CCX dedicated families), or set `WORKER_PROCESS_COUNT` directly per worker.
+  - The codebase still has internal sandbox CPU/memory/disk defaults, but those are not part of the documented self-hosting env surface in this checklist.
   - See [worker-capacity-tuning.md](worker-capacity-tuning.md) for sizing guidance by server size.
 
 ### GitHub auth/integration (required for login + GitHub features)
@@ -108,6 +106,6 @@ Optional LLM routing vars:
 These are common points of confusion:
 
 - `readyz` currently verifies database connectivity only.
-- Worker/sandbox sizing knobs are loaded at process startup from env. Changing them requires a container/process restart.
+- Documented worker sizing knobs are loaded at process startup from env. Changing them requires a container/process restart.
 - There is no `Dockerfile.sandbox` in this repo today.
 - Observability env vars like `MEZMO_*` and `DD_*` are documented in design docs, but are not currently loaded by `internal/config/config.go`.

--- a/docs/self-hosting/production-deployment-checklist.md
+++ b/docs/self-hosting/production-deployment-checklist.md
@@ -40,7 +40,7 @@ Notes:
 - [ ] Worker capacity knobs (for `MODE=worker` or mixed `MODE=all` nodes):
   - `WORKER_PROCESS_COUNT` (default `1`) — how many in-process worker loops run on this node
   - For fleet deploys, put worker sizing env vars in `.env.production.enc` like other deploy env vars.
-  - For mixed worker sizes, set `WORKER_BUCKET_MAP=10.0.0.4=hcloud-cpx21,10.0.0.5=hcloud-cpx31,10.0.0.6=hcloud-ccx23` (supports CPX shared + CCX dedicated families), or set `WORKER_PROCESS_COUNT` directly per worker.
+  - For mixed worker sizes, set `WORKER_BUCKET_MAP=hcloud-cpx21:10.0.0.4,hcloud-cpx31:10.0.0.5,hcloud-ccx23:10.0.0.6` (supports CPX shared + CCX dedicated families), or set `WORKER_PROCESS_COUNT` directly per worker.
   - The codebase still has internal sandbox CPU/memory/disk defaults, but those are not part of the documented self-hosting env surface in this checklist.
   - See [worker-capacity-tuning.md](worker-capacity-tuning.md) for sizing guidance by server size.
 

--- a/docs/self-hosting/worker-capacity-tuning.md
+++ b/docs/self-hosting/worker-capacity-tuning.md
@@ -55,8 +55,8 @@ For fleet-managed deploys, either set `WORKER_PROCESS_COUNT` directly or map spe
 Example:
 
 ```dotenv
-# map host/IP to bucket in one variable
-WORKER_BUCKET_MAP=10.0.0.4=hcloud-cpx21,10.0.0.5=hcloud-cpx31,10.0.0.6=hcloud-ccx23
+# map bucket to host/IP in one variable
+WORKER_BUCKET_MAP=hcloud-cpx21:10.0.0.4,hcloud-cpx31:10.0.0.5,hcloud-ccx23:10.0.0.6
 ```
 
 Built-in bucket presets used by deploy/provision scripts:

--- a/docs/self-hosting/worker-capacity-tuning.md
+++ b/docs/self-hosting/worker-capacity-tuning.md
@@ -50,14 +50,11 @@ This is intentionally not ultra-conservative: it targets full utilization at the
 
 For fleet-managed deploys, set these values in `.env.production.enc` (same pattern as other deploy-time env vars like `MODE`, `DB_HOST`, etc.). Deploy/provision scripts write them into `/opt/143/.env` for worker nodes.
 
-You can set a fleet-wide default bucket with `WORKER_DEFAULT_BUCKET` and map specific hosts in one env var using `WORKER_BUCKET_MAP`.
+For fleet-managed deploys, either set `WORKER_PROCESS_COUNT` directly or map specific hosts in one env var using `WORKER_BUCKET_MAP`.
 
 Example:
 
 ```dotenv
-# optional default bucket for unmapped workers
-WORKER_DEFAULT_BUCKET=hcloud-cpx31
-
 # map host/IP to bucket in one variable
 WORKER_BUCKET_MAP=10.0.0.4=hcloud-cpx21,10.0.0.5=hcloud-cpx31,10.0.0.6=hcloud-ccx23
 ```


### PR DESCRIPTION
## Summary
- Remove `WORKER_DEFAULT_BUCKET` from production deployment and worker tuning docs
- Clarify that operators should use `WORKER_PROCESS_COUNT` directly or map hosts with `WORKER_BUCKET_MAP`
- Tighten checklist wording so it only describes the documented worker sizing surface

## Testing
- Not run (not requested)