### PR TITLE
Persist last selected org across logins

### DIFF
--- a/docs/design/future/50-multi-organization-membership.md
+++ b/docs/design/future/50-multi-organization-membership.md
@@ -97,11 +97,12 @@ Per-request flow in the `Auth` middleware:
 2. Resolve active org:
    - If the request carries `X-Active-Org-ID: <uuid>`, use that.
    - Otherwise, fall back to `AuthSession.last_org_id`.
+   - Otherwise, fall back to the user's persisted last-selected org preference (seeded by explicit switch actions and copied into new sessions at login).
    - Otherwise (no hint), pick the user's oldest membership.
 3. Assert `(user.id, active_org_id)` has a row in `organization_memberships`. If not, fall back to the user's oldest remaining membership; if none, 401. Increment a metric on this fallback path — it should be vanishingly rare in steady state.
 4. Set `user`, `org_id`, and active membership role on the request context. Downstream handlers continue to read `org_id` from context and RBAC reads the active role from context.
 
-The frontend attaches `X-Active-Org-ID` via the API client, reading from an `ActiveOrgProvider`. The provider is seeded in this order: explicit `?org=<uuid>` in the current app URL, `sessionStorage` for the current tab, then the session bootstrap hint returned by `/auth/me`. Switching orgs updates React state and `sessionStorage`, then fires `POST /auth/active-org` so new tabs can open in the last-used org. Data mutation on switch is a hint, not a contract.
+The frontend attaches `X-Active-Org-ID` via the API client, reading from an `ActiveOrgProvider`. The provider is seeded in this order: explicit `?org=<uuid>` in the current app URL, `sessionStorage` for the current tab, then the session bootstrap hint returned by `/auth/me`. Switching orgs updates React state and `sessionStorage`, then fires `POST /auth/active-org` so the current session and future logins open in the last-used org. Data mutation on switch is a hint, not a contract.
 
 Do not use `localStorage` as the source of truth for active org. It is shared across tabs and violates the tab-independence goal. `sessionStorage` plus in-memory React state gives each tab its own active org while still surviving reloads in that tab.
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -13,6 +13,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 - The current product is single-organization per user, but the intended long-term identity model is **one user identity, many organization memberships**. A user represents the human account (email, GitHub ID, Google ID); membership represents access to an organization and carries the user's role for that org.
 - All product data remains scoped to exactly one `org_id`. Multi-organization support should change how the active org is resolved for a request, not introduce cross-org views by default.
 - The detailed future design lives in [future/50-multi-organization-membership.md](future/50-multi-organization-membership.md). The key product guardrail is that single-org users should see no new UI or onboarding complexity.
+- Explicit organization switches should persist across logins. The user-visible selection is still tab-local while browsing, but the system should remember the user's last explicitly selected org as the default seed for the next fresh login so multi-org users land back where they left off.
 - Audit log entries are expected to be self-describing. Every emitted audit event should include structured `details` with operator-useful context such as resource names, source/provenance, runtime choices, job IDs, related IDs, counts, and before/after changes. Audit details must not copy secrets, full document contents, large diffs, or access tokens; use booleans, lengths, hashes, masked summaries, and IDs instead.
 
 ## Autopilot workspace UX

--- a/frontend/src/components/create-org-dialog.test.tsx
+++ b/frontend/src/components/create-org-dialog.test.tsx
@@ -5,10 +5,11 @@ import { server } from "@/test/mocks/server";
 import { CreateOrgDialog } from "./create-org-dialog";
 import { getActiveOrgId } from "@/lib/active-org";
 
-const { pushMock, toastSuccess, toastInfo } = vi.hoisted(() => ({
+const { pushMock, toastSuccess, toastInfo, toastError } = vi.hoisted(() => ({
   pushMock: vi.fn(),
   toastSuccess: vi.fn(),
   toastInfo: vi.fn(),
+  toastError: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -16,18 +17,20 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("sonner", () => ({
-  toast: { success: toastSuccess, info: toastInfo, error: vi.fn() },
+  toast: { success: toastSuccess, info: toastInfo, error: toastError },
 }));
 
 beforeEach(() => {
   pushMock.mockReset();
   toastSuccess.mockReset();
   toastInfo.mockReset();
+  toastError.mockReset();
   window.sessionStorage.clear();
 });
 
 describe("CreateOrgDialog", () => {
   it("on success: sets active org, pushes /sessions, closes, toasts", async () => {
+    let persistedOrgId: string | null = null;
     server.use(
       http.post("/api/v1/organizations", async () => {
         return HttpResponse.json(
@@ -42,6 +45,11 @@ describe("CreateOrgDialog", () => {
           { status: 201 },
         );
       }),
+      http.post("/api/v1/auth/active-org", async ({ request }) => {
+        const body = (await request.json()) as { org_id: string };
+        persistedOrgId = body.org_id;
+        return new HttpResponse(null, { status: 204 });
+      }),
     );
 
     const onOpenChange = vi.fn();
@@ -55,7 +63,52 @@ describe("CreateOrgDialog", () => {
       expect(pushMock).toHaveBeenCalledWith("/sessions");
     });
     expect(getActiveOrgId()).toBe("org-new");
+    expect(persistedOrgId).toBe("org-new");
     expect(toastSuccess).toHaveBeenCalledWith("Created Acme");
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("warns when the org is created but the default workspace could not be saved", async () => {
+    server.use(
+      http.post("/api/v1/organizations", async () => {
+        return HttpResponse.json(
+          {
+            data: {
+              id: "org-new",
+              name: "Acme",
+              role: "admin",
+              created_at: "2026-04-21T00:00:00Z",
+            },
+          },
+          { status: 201 },
+        );
+      }),
+      http.post("/api/v1/auth/active-org", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "ACTIVE_ORG_UPDATE_FAILED",
+              message: "failed to persist active organization",
+            },
+          },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(<CreateOrgDialog open={true} onOpenChange={onOpenChange} />);
+
+    await user.type(screen.getByLabelText("Name"), "Acme");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/sessions");
+      expect(toastError).toHaveBeenCalled();
+    });
+    expect(getActiveOrgId()).toBe("org-new");
+    expect(toastSuccess).not.toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 

--- a/frontend/src/components/create-org-dialog.tsx
+++ b/frontend/src/components/create-org-dialog.tsx
@@ -46,6 +46,16 @@ export interface CreateOrgDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+function messageForActiveOrgPersistenceWarning(err: unknown, orgName: string): string {
+  const code = typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
+  switch (code) {
+    case "UNAUTHORIZED":
+      return `Created ${orgName}, but your session expired before we could save it as the default workspace. Future logins may open your previous workspace until you sign in again.`;
+    default:
+      return `Created ${orgName}, but couldn't save it as your default workspace. Future logins may open your previous workspace.`;
+  }
+}
+
 export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -65,15 +75,24 @@ export function CreateOrgDialog({ open, onOpenChange }: CreateOrgDialogProps) {
 
   const mutation = useMutation({
     mutationFn: (trimmed: string) => api.organizations.create(trimmed),
-    onSuccess: (response) => {
+    onSuccess: async (response) => {
       const created = response.data;
       setActiveOrgId(created.id);
+      let persistedActiveOrg = true;
+      try {
+        await api.auth.setActiveOrg(created.id);
+      } catch (err: unknown) {
+        persistedActiveOrg = false;
+        toast.error(messageForActiveOrgPersistenceWarning(err, created.name));
+      }
       // clear() over invalidateQueries(): invalidating would fire refetches
       // against the current page right before navigation unmounts it.
       // Clearing drops cached data so the next page's queries fetch fresh
       // under the new active-org header.
       queryClient.clear();
-      toast.success(`Created ${created.name}`);
+      if (persistedActiveOrg) {
+        toast.success(`Created ${created.name}`);
+      }
       handleOpenChange(false);
       router.push("/sessions");
     },

--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -10,14 +10,27 @@ import {
   setActiveOrgId,
 } from "@/lib/active-org";
 
-const { pushMock } = vi.hoisted(() => ({ pushMock: vi.fn() }));
+const { pushMock, toastInfo, toastError } = vi.hoisted(() => ({
+  pushMock: vi.fn(),
+  toastInfo: vi.fn(),
+  toastError: vi.fn(),
+}));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: pushMock, replace: vi.fn() }),
 }));
 
+vi.mock("sonner", () => ({
+  toast: {
+    info: toastInfo,
+    error: toastError,
+  },
+}));
+
 beforeEach(() => {
   pushMock.mockReset();
+  toastInfo.mockReset();
+  toastError.mockReset();
   window.sessionStorage.clear();
 });
 
@@ -71,12 +84,20 @@ describe("OrgSwitcher", () => {
   });
 
   it("switching orgs writes sessionStorage and pushes /sessions", async () => {
+    let persistedOrgId: string | null = null;
     mockMemberships(
       [
         { org_id: "org-1", org_name: "Acme", role: "admin" },
         { org_id: "org-2", org_name: "Globex", role: "member" },
       ],
       "org-1",
+    );
+    server.use(
+      http.post("/api/v1/auth/active-org", async ({ request }) => {
+        const body = (await request.json()) as { org_id: string };
+        persistedOrgId = body.org_id;
+        return new HttpResponse(null, { status: 204 });
+      }),
     );
 
     const user = userEvent.setup();
@@ -85,8 +106,47 @@ describe("OrgSwitcher", () => {
     await user.click(await screen.findByTestId("org-switcher"));
     await user.click(await screen.findByTestId("org-switcher-item-org-2"));
 
-    expect(getActiveOrgId()).toBe("org-2");
-    expect(pushMock).toHaveBeenCalledWith("/sessions");
+    await waitFor(() => {
+      expect(getActiveOrgId()).toBe("org-2");
+      expect(persistedOrgId).toBe("org-2");
+      expect(pushMock).toHaveBeenCalledWith("/sessions");
+    });
+  });
+
+  it("switch failure leaves the previous org selected and shows an error", async () => {
+    setActiveOrgId("org-1");
+    mockMemberships(
+      [
+        { org_id: "org-1", org_name: "Acme", role: "admin" },
+        { org_id: "org-2", org_name: "Globex", role: "member" },
+      ],
+      "org-1",
+    );
+    server.use(
+      http.post("/api/v1/auth/active-org", () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "ACTIVE_ORG_UPDATE_FAILED",
+              message: "failed to persist active organization",
+            },
+          },
+          { status: 500 },
+        ),
+      ),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("org-switcher-item-org-2"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled();
+    });
+    expect(getActiveOrgId()).toBe("org-1");
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it("clicking the already-active org is a no-op", async () => {

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -33,6 +33,16 @@ export interface OrgSwitcherProps {
   userEmail?: string;
 }
 
+function messageForActiveOrgSwitchError(err: unknown, orgName: string): string {
+  const code = typeof err === "object" && err !== null ? (err as { code?: unknown }).code : undefined;
+  switch (code) {
+    case "UNAUTHORIZED":
+      return "Your session expired. Please sign in again before switching workspaces.";
+    default:
+      return `Couldn't switch to ${orgName}. Please try again.`;
+  }
+}
+
 export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -110,8 +120,14 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     return memberships.filter((m) => m.org_name.toLowerCase().includes(q));
   }, [memberships, search]);
 
-  const handleSwitch = (membership: MembershipSummary) => {
+  const handleSwitch = async (membership: MembershipSummary) => {
     if (membership.org_id === effectiveActiveOrgId) return;
+    try {
+      await api.auth.setActiveOrg(membership.org_id);
+    } catch (err: unknown) {
+      toast.error(messageForActiveOrgSwitchError(err, membership.org_name));
+      return;
+    }
     setActiveOrgId(membership.org_id);
     // clear() over invalidateQueries(): invalidating here would refetch every
     // cached query against the *current* page right before it unmounts on

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -186,6 +186,8 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/login', { email, password }),
     register: (email: string, password: string, name: string, invitation?: string) =>
       post<import('./types').SingleResponse<import('./types').User>>('/api/v1/auth/register', { email, password, name, ...(invitation && { invitation }) }),
+    setActiveOrg: (orgId: string) =>
+      post('/api/v1/auth/active-org', { org_id: orgId }),
     logout: () => post('/api/v1/auth/logout'),
     memberships: () =>
       get<import('./types').SingleResponse<import('./types').MembershipsResponse>>('/api/v1/auth/memberships'),

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -216,6 +216,10 @@ export const handlers = [
     } satisfies SingleResponse<User>);
   }),
 
+  http.post('/api/v1/auth/active-org', () => {
+    return new HttpResponse(null, { status: 204 });
+  }),
+
   http.post('/api/v1/sessions/:id/view', () => {
     return new HttpResponse(null, { status: 204 });
   }),

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -137,6 +137,58 @@ func (h *AuthHandler) Memberships(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// SetActiveOrg persists the user's explicitly selected org so future sessions
+// can default to it across logins. The target org must be one the user
+// currently belongs to.
+//
+// lint:allow-no-orgid reason="user-scoped preference write validated against memberships"
+func (h *AuthHandler) SetActiveOrg(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	var body struct {
+		OrgID string `json:"org_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+		return
+	}
+
+	orgID, err := uuid.Parse(strings.TrimSpace(body.OrgID))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ORG_ID", "invalid organization id")
+		return
+	}
+
+	if _, err := h.memberships.Get(r.Context(), user.ID, orgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusForbidden, "FORBIDDEN", "organization not available to user")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "ACTIVE_ORG_LOOKUP_FAILED", "failed to validate organization membership", err)
+		return
+	}
+
+	if err := h.userStore.UpdateLastOrgID(r.Context(), user.ID, &orgID); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "ACTIVE_ORG_UPDATE_FAILED", "failed to persist active organization", err)
+		return
+	}
+
+	if h.sessionStore != nil {
+		if cookie, err := r.Cookie(middleware.SessionCookieName); err == nil && cookie.Value != "" {
+			if updateErr := h.sessionStore.UpdateLastOrgID(r.Context(), cookie.Value, &orgID); updateErr != nil {
+				writeError(w, r, http.StatusInternalServerError, "ACTIVE_ORG_UPDATE_FAILED", "failed to persist active organization", updateErr)
+				return
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // Register handles email/password sign-up.
 // If an invitation token is provided, the user joins the inviting org instead of creating a new one.
 func (h *AuthHandler) Register(w http.ResponseWriter, r *http.Request) {
@@ -693,6 +745,11 @@ func (h *AuthHandler) persistSessionTx(ctx context.Context, dbtx db.DBTX, user *
 	if err != nil {
 		return "", fmt.Errorf("generate session token: %w", err)
 	}
+	userStore := db.NewUserStore(dbtx)
+	lastOrgID, err := userStore.GetLastOrgID(ctx, user.ID)
+	if err != nil {
+		return "", fmt.Errorf("get user last_org_id: %w", err)
+	}
 	// TODO(2026-04-25): drop OrgID from AuthSession once the legacy column
 	// is removed. Session->org resolution now flows through the middleware
 	// (X-Active-Org-ID header → session.last_org_id → oldest membership);
@@ -712,6 +769,7 @@ func (h *AuthHandler) persistSessionTx(ctx context.Context, dbtx db.DBTX, user *
 	session := &models.AuthSession{
 		UserID:    user.ID,
 		OrgID:     user.OrgID,
+		LastOrgID: lastOrgID,
 		Token:     sessionToken,
 		ExpiresAt: time.Now().Add(middleware.SessionTTL),
 	}

--- a/internal/api/handlers/auth_claim.go
+++ b/internal/api/handlers/auth_claim.go
@@ -18,7 +18,8 @@ import (
 // claimInvitationForExistingUser validates a pending invitation and grants the
 // user a membership in the inviting org. Unlike the signup claim helpers,
 // there is no user creation: the caller is already authenticated and this
-// transaction only accepts the invitation and inserts/updates the membership.
+// transaction accepts the invitation, inserts/updates the membership, and
+// updates the user's persisted active-org preference to the claimed org.
 //
 // The (email, githubLogin) pair must match the invitation per the same rules
 // as the signup flow; a mismatch returns an invitationError so handlers can
@@ -70,6 +71,9 @@ func (h *AuthHandler) claimInvitationForExistingUser(
 	effectiveRole, err := txMemberships.GrantAtLeast(ctx, userID, inv.OrgID, role)
 	if err != nil {
 		return &inv, "", nil, fmt.Errorf("grant membership: %w", err)
+	}
+	if err := db.NewUserStore(tx).UpdateLastOrgID(ctx, userID, &inv.OrgID); err != nil {
+		return &inv, "", nil, fmt.Errorf("update user last org: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -259,8 +259,81 @@ func TestAuthHandler_PersistSessionTx_UsesDBTXForLastOrgLookup(t *testing.T) {
 	require.NoError(t, handlerStoreDB.ExpectationsWereMet(), "handler-scoped user store should be unused")
 }
 
+func TestAuthHandler_PersistSessionTx_ReturnsLookupErrors(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	user := &models.User{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+	}
+
+	mock.ExpectQuery(`SELECT last_org_id FROM users WHERE id = @id`).
+		WithArgs(user.ID).
+		WillReturnError(errors.New("lookup failed"))
+
+	handler := NewAuthHandler(&config.Config{}, nil, nil, db.NewAuthSessionStore(mock), nil, nil)
+	token, err := handler.persistSessionTx(context.Background(), mock, user)
+	require.Error(t, err, "persistSessionTx should return last-org lookup failures")
+	require.Empty(t, token, "persistSessionTx should not return a session token on lookup failure")
+	require.Contains(t, err.Error(), "get user last_org_id", "persistSessionTx should wrap the lookup failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestAuthHandler_SetActiveOrg(t *testing.T) {
 	t.Parallel()
+
+	t.Run("requires an authenticated user", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewAuthHandler(&config.Config{}, nil, nil, nil, nil, nil)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", bytes.NewBufferString(`{"org_id":"`+uuid.New().String()+`"}`))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusUnauthorized, w.Code, "SetActiveOrg should reject unauthenticated requests")
+	})
+
+	t.Run("rejects invalid request bodies", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(nil),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(nil),
+		)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", bytes.NewBufferString(`{"org_id":`))
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: uuid.New()}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "SetActiveOrg should reject malformed JSON")
+	})
+
+	t.Run("rejects invalid org ids", func(t *testing.T) {
+		t.Parallel()
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(nil),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(nil),
+		)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", bytes.NewBufferString(`{"org_id":"not-a-uuid"}`))
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: uuid.New()}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "SetActiveOrg should reject invalid organization ids")
+	})
 
 	t.Run("persists a membership the user holds", func(t *testing.T) {
 		t.Parallel()
@@ -332,6 +405,123 @@ func TestAuthHandler_SetActiveOrg(t *testing.T) {
 
 		handler.SetActiveOrg(w, req)
 		require.Equal(t, http.StatusForbidden, w.Code, "SetActiveOrg should reject unrelated org ids")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("returns 500 when membership lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		userID := uuid.New()
+		targetOrgID := uuid.New()
+
+		mock.ExpectQuery("SELECT .+ FROM organization_memberships").
+			WithArgs(userID, targetOrgID).
+			WillReturnError(errors.New("db down"))
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(mock),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(mock),
+		)
+
+		body := bytes.NewBufferString(fmt.Sprintf(`{"org_id":"%s"}`, targetOrgID))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", body)
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusInternalServerError, w.Code, "SetActiveOrg should surface membership lookup failures as 500s")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("returns 500 when user preference persistence fails", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		userID := uuid.New()
+		targetOrgID := uuid.New()
+		now := time.Now()
+
+		mock.ExpectQuery("SELECT .+ FROM organization_memberships").
+			WithArgs(userID, targetOrgID).
+			WillReturnRows(
+				pgxmock.NewRows([]string{"user_id", "org_id", "role", "created_at"}).
+					AddRow(userID, targetOrgID, "member", now),
+			)
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&targetOrgID, userID).
+			WillReturnError(errors.New("write failed"))
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(mock),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(mock),
+		)
+
+		body := bytes.NewBufferString(fmt.Sprintf(`{"org_id":"%s"}`, targetOrgID))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", body)
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusInternalServerError, w.Code, "SetActiveOrg should surface user preference persistence failures as 500s")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("returns 500 when session hint persistence fails", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		userID := uuid.New()
+		targetOrgID := uuid.New()
+		now := time.Now()
+
+		mock.ExpectQuery("SELECT .+ FROM organization_memberships").
+			WithArgs(userID, targetOrgID).
+			WillReturnRows(
+				pgxmock.NewRows([]string{"user_id", "org_id", "role", "created_at"}).
+					AddRow(userID, targetOrgID, "member", now),
+			)
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&targetOrgID, userID).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		mock.ExpectExec(`UPDATE auth_sessions SET last_org_id = @last_org_id WHERE token = @token`).
+			WithArgs(&targetOrgID, "session-token").
+			WillReturnError(errors.New("session write failed"))
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(mock),
+			db.NewAuthSessionStore(mock),
+			nil,
+			db.NewOrganizationMembershipStore(mock),
+		)
+
+		body := bytes.NewBufferString(fmt.Sprintf(`{"org_id":"%s"}`, targetOrgID))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", body)
+		req.AddCookie(&http.Cookie{Name: middleware.SessionCookieName, Value: "session-token"})
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusInternalServerError, w.Code, "SetActiveOrg should fail when it cannot update the current session hint")
 		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	})
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,6 +22,18 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+func expectUserLastOrgLookup(mock pgxmock.PgxPoolIface, userID uuid.UUID, lastOrgID *uuid.UUID) {
+	rows := pgxmock.NewRows([]string{"last_org_id"})
+	if lastOrgID == nil {
+		rows.AddRow(nil)
+	} else {
+		rows.AddRow(lastOrgID.String())
+	}
+	mock.ExpectQuery(`SELECT last_org_id FROM users WHERE id = @id`).
+		WithArgs(userID).
+		WillReturnRows(rows)
+}
 
 func TestAuthHandler_Login_Redirects(t *testing.T) {
 	t.Parallel()
@@ -172,6 +185,155 @@ func TestAuthHandler_Logout(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAuthHandler_PersistSessionTx_SeedsLastOrgIDFromUserPreference(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	cfg := &config.Config{}
+	userStore := db.NewUserStore(mock)
+	handler := NewAuthHandler(cfg, mock, userStore, db.NewAuthSessionStore(mock), nil, nil)
+
+	user := &models.User{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+	}
+	lastOrgID := uuid.New()
+
+	expectUserLastOrgLookup(mock, user.ID, &lastOrgID)
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), &lastOrgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(uuid.New(), time.Now()),
+		)
+
+	token, err := handler.persistSessionTx(context.Background(), mock, user)
+	require.NoError(t, err, "persistSessionTx should create a session successfully")
+	require.NotEmpty(t, token, "persistSessionTx should return the minted session token")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestAuthHandler_PersistSessionTx_UsesDBTXForLastOrgLookup(t *testing.T) {
+	t.Parallel()
+
+	sessionDB, err := pgxmock.NewPool()
+	require.NoError(t, err, "session database mock should initialize")
+	defer sessionDB.Close()
+
+	handlerStoreDB, err := pgxmock.NewPool()
+	require.NoError(t, err, "handler user store mock should initialize")
+	defer handlerStoreDB.Close()
+
+	lastOrgID := uuid.New()
+	user := &models.User{
+		ID:    uuid.New(),
+		OrgID: uuid.New(),
+	}
+
+	expectUserLastOrgLookup(sessionDB, user.ID, &lastOrgID)
+	sessionDB.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), &lastOrgID, pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at"}).
+				AddRow(uuid.New(), time.Now()),
+		)
+
+	handler := NewAuthHandler(
+		&config.Config{},
+		nil,
+		db.NewUserStore(handlerStoreDB),
+		db.NewAuthSessionStore(sessionDB),
+		nil,
+		nil,
+	)
+
+	token, err := handler.persistSessionTx(context.Background(), sessionDB, user)
+	require.NoError(t, err, "persistSessionTx should read and write through the provided dbtx")
+	require.NotEmpty(t, token, "persistSessionTx should return the minted session token")
+	require.NoError(t, sessionDB.ExpectationsWereMet(), "all dbtx expectations should be met")
+	require.NoError(t, handlerStoreDB.ExpectationsWereMet(), "handler-scoped user store should be unused")
+}
+
+func TestAuthHandler_SetActiveOrg(t *testing.T) {
+	t.Parallel()
+
+	t.Run("persists a membership the user holds", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		userID := uuid.New()
+		targetOrgID := uuid.New()
+		now := time.Now()
+
+		mock.ExpectQuery("SELECT .+ FROM organization_memberships").
+			WithArgs(userID, targetOrgID).
+			WillReturnRows(
+				pgxmock.NewRows([]string{"user_id", "org_id", "role", "created_at"}).
+					AddRow(userID, targetOrgID, "member", now),
+			)
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&targetOrgID, userID).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(mock),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(mock),
+		)
+
+		body := bytes.NewBufferString(fmt.Sprintf(`{"org_id":"%s"}`, targetOrgID))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", body)
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusNoContent, w.Code, "SetActiveOrg should persist the preference and return 204")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("rejects orgs the user is not a member of", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		userID := uuid.New()
+		targetOrgID := uuid.New()
+
+		mock.ExpectQuery("SELECT .+ FROM organization_memberships").
+			WithArgs(userID, targetOrgID).
+			WillReturnRows(pgxmock.NewRows([]string{"user_id", "org_id", "role", "created_at"}))
+
+		handler := NewAuthHandler(
+			&config.Config{},
+			nil,
+			db.NewUserStore(mock),
+			nil,
+			nil,
+			db.NewOrganizationMembershipStore(mock),
+		)
+
+		body := bytes.NewBufferString(fmt.Sprintf(`{"org_id":"%s"}`, targetOrgID))
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/active-org", body)
+		req = req.WithContext(middleware.WithUser(req.Context(), &models.User{ID: userID}))
+		w := httptest.NewRecorder()
+
+		handler.SetActiveOrg(w, req)
+		require.Equal(t, http.StatusForbidden, w.Code, "SetActiveOrg should reject unrelated org ids")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
 }
 
 func TestAuthHandler_Callback(t *testing.T) {
@@ -830,6 +992,7 @@ func TestAuthHandler_AcceptInvitationAndUpsertUser_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO organization_memberships").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	expectUserLastOrgLookup(mock, expectedUserID, nil)
 	mock.ExpectQuery("INSERT INTO auth_sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), time.Now()))
@@ -1075,6 +1238,7 @@ func TestAuthHandler_Register_WithInvitation_Success(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
 	// Create session inside the signup tx (5 named args: user_id, org_id, last_org_id, token, expires_at).
 	sessionID := uuid.New()
+	expectUserLastOrgLookup(mock, newUserID, nil)
 	mock.ExpectQuery("INSERT INTO auth_sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(sessionID, time.Now()))
@@ -1377,6 +1541,7 @@ func TestAuthHandler_Register_NoInvitation_Success(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	// Session insert happens inside the signup tx before commit.
+	expectUserLastOrgLookup(mock, newUserID, nil)
 	mock.ExpectQuery("INSERT INTO auth_sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), now))
@@ -1461,6 +1626,9 @@ func TestAuthHandler_ClaimInvitationForExistingUser_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO organization_memberships").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+		WithArgs(&orgID, userID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectCommit()
 
 	cfg := &config.Config{}
@@ -1600,6 +1768,9 @@ func TestAuthHandler_ClaimInvitation_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO organization_memberships").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+		WithArgs(&invOrgID, userID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectCommit()
 
 	cfg := &config.Config{}
@@ -1708,6 +1879,9 @@ func TestAuthHandler_ClaimInvitation_EmitsAcceptedAudit(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO organization_memberships").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+		WithArgs(&invOrgID, userID).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectCommit()
 	// Audit emitter runs post-commit; this is the row `emitInvitationAccepted`
 	// writes into audit_logs. AuditLogStore.Create binds 13 named args, which
@@ -1912,6 +2086,7 @@ func TestAuthHandler_CreateSignupOrg_DBErrors(t *testing.T) {
 		mock.ExpectExec("INSERT INTO organization_memberships").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		expectUserLastOrgLookup(mock, userID, nil)
 		mock.ExpectQuery("INSERT INTO auth_sessions").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnError(errors.New("session"))
@@ -1939,6 +2114,7 @@ func TestAuthHandler_CreateSignupOrg_DBErrors(t *testing.T) {
 		mock.ExpectExec("INSERT INTO organization_memberships").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		expectUserLastOrgLookup(mock, userID, nil)
 		mock.ExpectQuery("INSERT INTO auth_sessions").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), time.Now()))
@@ -2024,7 +2200,32 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 		mock.ExpectQuery("INSERT INTO organization_memberships").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&orgID, pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 		mock.ExpectCommit().WillReturnError(errors.New("commit"))
+
+		_, _, _, err = newHandler(mock).claimInvitationForExistingUser(context.Background(), "valid", "u@example.com", "", uuid.New())
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("last org update fails", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+		setupBeginSelect(mock)
+		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		mock.ExpectQuery("INSERT INTO organization_memberships").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&orgID, pgxmock.AnyArg()).
+			WillReturnError(errors.New("update last org"))
+		mock.ExpectRollback()
 
 		_, _, _, err = newHandler(mock).claimInvitationForExistingUser(context.Background(), "valid", "u@example.com", "", uuid.New())
 		require.Error(t, err)
@@ -2133,12 +2334,14 @@ func TestAuthHandler_AcceptInvitationAndUpsertUser_DBErrors(t *testing.T) {
 		mock.ExpectQuery("INSERT INTO organization_memberships").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+		userID := uuid.New()
+		expectUserLastOrgLookup(mock, userID, nil)
 		mock.ExpectQuery("INSERT INTO auth_sessions").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), time.Now()))
 		mock.ExpectCommit().WillReturnError(errors.New("commit"))
 
-		_, _, _, err = newHandler(mock).acceptInvitationAndUpsertUser(context.Background(), uuid.New(), &models.User{ID: uuid.New(), OrgID: uuid.New(), Role: "member"}, func(context.Context, *db.UserStore, *models.User) error { return nil })
+		_, _, _, err = newHandler(mock).acceptInvitationAndUpsertUser(context.Background(), uuid.New(), &models.User{ID: userID, OrgID: uuid.New(), Role: "member"}, func(context.Context, *db.UserStore, *models.User) error { return nil })
 		require.Error(t, err)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -2183,6 +2386,8 @@ func TestAuthHandler_createSessionAndRespond_SetsCookiesWithMiddlewareConstants(
 	require.NoError(t, err)
 	defer mock.Close()
 
+	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
+	expectUserLastOrgLookup(mock, user.ID, nil)
 	mock.ExpectQuery("INSERT INTO auth_sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
@@ -2203,7 +2408,6 @@ func TestAuthHandler_createSessionAndRespond_SetsCookiesWithMiddlewareConstants(
 	req.TLS = nil
 	w := httptest.NewRecorder()
 
-	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
 	handler.createSessionAndRespond(w, req, user)
 
 	require.Equal(t, http.StatusOK, w.Code)
@@ -2230,6 +2434,8 @@ func TestAuthHandler_createSessionAndRedirect_SetsCookiesAndRedirects(t *testing
 	require.NoError(t, err)
 	defer mock.Close()
 
+	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
+	expectUserLastOrgLookup(mock, user.ID, nil)
 	mock.ExpectQuery("INSERT INTO auth_sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
@@ -2253,7 +2459,6 @@ func TestAuthHandler_createSessionAndRedirect_SetsCookiesAndRedirects(t *testing
 	req.Header.Set("X-Forwarded-Proto", "https")
 	w := httptest.NewRecorder()
 
-	user := &models.User{ID: uuid.New(), OrgID: uuid.New(), Email: "u@example.com"}
 	handler.createSessionAndRedirect(w, req, user)
 
 	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
@@ -2310,6 +2515,9 @@ func TestAuthHandler_ClaimPendingInvitationForExistingUser(t *testing.T) {
 		mock.ExpectQuery("INSERT INTO organization_memberships").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+		mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+			WithArgs(&orgID, userID).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 		mock.ExpectCommit()
 
 		cfg := &config.Config{}

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -50,6 +50,7 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		// Authenticated but legitimately no org-scoped data access.
 		"AuthHandler.Me":                   "returns user from context only",
 		"AuthHandler.Logout":               "deletes session by cookie token only",
+		"AuthHandler.SetActiveOrg":         "user-scoped preference write; validates membership directly instead of using request org context",
 		"AuthHandler.ClaimInvitation":      "grants membership in a different org than the active one; target org comes from the invitation token, not the request context",
 		"OrganizationsHandler.Create":      "creates a new org; runs outside OrgContext, no pre-existing org to scope against",
 		"SettingsHandler.GetLLMDefaults":   "returns static server config",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -527,6 +527,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			// empty list so the switcher can render an invite-me state rather
 			// than a 403 spinner.
 			r.Get("/api/v1/auth/memberships", authHandler.Memberships)
+			r.Post("/api/v1/auth/active-org", authHandler.SetActiveOrg)
 			r.Post("/api/v1/auth/logout", authHandler.Logout)
 			// Available to any authenticated user (no RequireRole) — an invited
 			// user may not yet have a role in the target org when they claim.

--- a/internal/db/organization_memberships.go
+++ b/internal/db/organization_memberships.go
@@ -252,6 +252,13 @@ func (s *OrganizationMembershipStore) Remove(ctx context.Context, userID, orgID 
 			WHERE user_id = @user_id
 			  AND last_org_id = @org_id
 			  AND EXISTS (SELECT 1 FROM deleted_membership)
+		),
+		cleared_user_hint AS (
+			UPDATE users
+			SET last_org_id = NULL
+			WHERE id = @user_id
+			  AND last_org_id = @org_id
+			  AND EXISTS (SELECT 1 FROM deleted_membership)
 		)
 		SELECT EXISTS (SELECT 1 FROM deleted_membership)`
 

--- a/internal/db/organization_memberships_test.go
+++ b/internal/db/organization_memberships_test.go
@@ -348,10 +348,10 @@ func TestOrganizationMembershipStore_Remove_AllSideEffectsInOneStatement(t *test
 
 	store := NewOrganizationMembershipStore(mock)
 
-	// Require all four CTEs (deleted_membership + three side-effects) to appear
+	// Require all five CTEs (deleted_membership + four side-effects) to appear
 	// in order in a single WITH statement. Any future refactor that splits one
 	// out into a separate Exec call trips this regex.
-	mock.ExpectQuery(`(?s)WITH deleted_membership AS \(.+cleared_answers AS \(.+revoked_invitations AS \(.+cleared_session_hints AS \(`).
+	mock.ExpectQuery(`(?s)WITH deleted_membership AS \(.+cleared_answers AS \(.+revoked_invitations AS \(.+cleared_session_hints AS \(.+cleared_user_hint AS \(`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
 
@@ -378,6 +378,24 @@ func TestOrganizationMembershipStore_Remove_ClearsSessionHint(t *testing.T) {
 	store := NewOrganizationMembershipStore(mock)
 
 	mock.ExpectQuery(`(?s)UPDATE auth_sessions\s+SET last_org_id = NULL.+user_id = @user_id\s+AND last_org_id = @org_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
+
+	err = store.Remove(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestOrganizationMembershipStore_Remove_ClearsUserHint(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewOrganizationMembershipStore(mock)
+
+	mock.ExpectQuery(`(?s)UPDATE users\s+SET last_org_id = NULL.+id = @user_id\s+AND last_org_id = @org_id`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"exists"}).AddRow(true))
 

--- a/internal/db/user_store_test.go
+++ b/internal/db/user_store_test.go
@@ -17,6 +17,10 @@ var userColumns = []string{
 	"id", "org_id", "email", "name", "role", "github_id", "github_login", "avatar_url", "password_hash", "google_id", "created_at",
 }
 
+func ptrUUID(id uuid.UUID) *uuid.UUID {
+	return &id
+}
+
 func TestUserStore_UpsertFromGitHub(t *testing.T) {
 	t.Parallel()
 
@@ -258,6 +262,115 @@ func TestUserStore_GetByIDGlobal(t *testing.T) {
 	require.Equal(t, userID, u.ID)
 	require.Equal(t, orgID, u.OrgID)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUserStore_GetLastOrgID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lastOrgID *uuid.UUID
+		expectNil bool
+		expectErr bool
+	}{
+		{
+			name:      "returns stored last org id",
+			lastOrgID: ptrUUID(uuid.New()),
+		},
+		{
+			name:      "returns nil when preference is unset",
+			expectNil: true,
+		},
+		{
+			name:      "returns error when user is missing",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewUserStore(mock)
+			userID := uuid.New()
+
+			query := mock.ExpectQuery(`SELECT last_org_id FROM users WHERE id = @id`).
+				WithArgs(userID)
+			switch {
+			case tt.expectErr:
+				query.WillReturnRows(pgxmock.NewRows([]string{"last_org_id"}))
+			case tt.expectNil:
+				query.WillReturnRows(
+					pgxmock.NewRows([]string{"last_org_id"}).
+						AddRow(nil),
+				)
+			default:
+				query.WillReturnRows(
+					pgxmock.NewRows([]string{"last_org_id"}).
+						AddRow(tt.lastOrgID.String()),
+				)
+			}
+
+			lastOrgID, err := store.GetLastOrgID(context.Background(), userID)
+			if tt.expectErr {
+				require.Error(t, err, "GetLastOrgID should return an error when the user row is missing")
+				require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+				return
+			}
+
+			require.NoError(t, err, "GetLastOrgID should not return an error")
+			if tt.expectNil {
+				require.Nil(t, lastOrgID, "GetLastOrgID should return nil when the preference is unset")
+			} else {
+				require.NotNil(t, lastOrgID, "GetLastOrgID should return the stored org id")
+				require.Equal(t, *tt.lastOrgID, *lastOrgID, "GetLastOrgID should return the stored org id")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestUserStore_UpdateLastOrgID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lastOrgID *uuid.UUID
+	}{
+		{
+			name:      "stores a concrete org id",
+			lastOrgID: ptrUUID(uuid.New()),
+		},
+		{
+			name:      "clears the stored preference",
+			lastOrgID: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewUserStore(mock)
+			userID := uuid.New()
+
+			mock.ExpectExec(`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`).
+				WithArgs(tt.lastOrgID, userID).
+				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+			err = store.UpdateLastOrgID(context.Background(), userID, tt.lastOrgID)
+			require.NoError(t, err, "UpdateLastOrgID should not return an error")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
 }
 
 // GetByIDGlobal wraps Query errors with a "query user" prefix so callers

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -114,10 +114,7 @@ func (s *UserStore) GetLastOrgID(ctx context.Context, userID uuid.UUID) (*uuid.U
 		return nil, nil
 	}
 	id, err := uuid.FromBytes(lastOrgID.Bytes[:])
-	if err != nil {
-		return nil, err
-	}
-	return &id, nil
+	return &id, err
 }
 
 // UpdateLastOrgID stores the user's cross-login active-org preference. Passing

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/assembledhq/143/internal/models"
 )
@@ -92,6 +93,46 @@ func (s *UserStore) GetByIDGlobal(ctx context.Context, userID uuid.UUID) (models
 		return models.User{}, fmt.Errorf("query user: %w", err)
 	}
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.User])
+}
+
+// GetLastOrgID returns the user's persisted cross-login active-org preference.
+// Nullable: nil means the user has never explicitly selected an org (or the
+// preference was cleared after losing that membership), so callers should fall
+// back to request-time resolution.
+//
+// lint:allow-no-orgid reason="user-scoped preference lookup by globally unique user id"
+func (s *UserStore) GetLastOrgID(ctx context.Context, userID uuid.UUID) (*uuid.UUID, error) {
+	var lastOrgID pgtype.UUID
+	err := s.db.QueryRow(ctx,
+		`SELECT last_org_id FROM users WHERE id = @id`,
+		pgx.NamedArgs{"id": userID},
+	).Scan(&lastOrgID)
+	if err != nil {
+		return nil, err
+	}
+	if !lastOrgID.Valid {
+		return nil, nil
+	}
+	id, err := uuid.FromBytes(lastOrgID.Bytes[:])
+	if err != nil {
+		return nil, err
+	}
+	return &id, nil
+}
+
+// UpdateLastOrgID stores the user's cross-login active-org preference. Passing
+// nil clears the preference (e.g. when the user loses that membership).
+//
+// lint:allow-no-orgid reason="user-scoped preference update by globally unique user id"
+func (s *UserStore) UpdateLastOrgID(ctx context.Context, userID uuid.UUID, lastOrgID *uuid.UUID) error {
+	_, err := s.db.Exec(ctx,
+		`UPDATE users SET last_org_id = @last_org_id WHERE id = @id`,
+		pgx.NamedArgs{
+			"id":          userID,
+			"last_org_id": lastOrgID,
+		},
+	)
+	return err
 }
 
 // GetByGitHubID looks up a user by their GitHub user id (cross-org).

--- a/migrations/000090_users_last_org_id.down.sql
+++ b/migrations/000090_users_last_org_id.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    DROP COLUMN IF EXISTS last_org_id;

--- a/migrations/000090_users_last_org_id.up.sql
+++ b/migrations/000090_users_last_org_id.up.sql
@@ -1,0 +1,16 @@
+ALTER TABLE users
+    ADD COLUMN last_org_id uuid REFERENCES organizations(id) ON DELETE SET NULL;
+
+WITH ranked AS (
+    SELECT
+        user_id,
+        last_org_id,
+        ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY created_at DESC, id DESC) AS rn
+    FROM auth_sessions
+    WHERE last_org_id IS NOT NULL
+)
+UPDATE users u
+SET last_org_id = ranked.last_org_id
+FROM ranked
+WHERE ranked.user_id = u.id
+  AND ranked.rn = 1;


### PR DESCRIPTION
## Summary
- add persisted last-selected org handling for login/session seeding
- save explicit org switches and new-org creation as the default workspace
- clear stale org hints when memberships are removed and update docs/tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `cd frontend && npx vitest --run src/components/org-switcher.test.tsx src/components/create-org-dialog.test.tsx`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`