### PR TITLE
Fix PR snapshot error handling

### DIFF
--- a/docs/design/40-pr-creation-revamp.md
+++ b/docs/design/40-pr-creation-revamp.md
@@ -2,7 +2,7 @@
 
 > **Status:** Partially Implemented | **Last reviewed:** 2026-04-22
 >
-> **Implementation notes:** PR template detection and caching implemented (`pr_templates` store). The on-demand `Create PR` authorization flow now uses encrypted `github_app_user` credentials with refresh-aware validation, app fallback, and frontend auto-resume after callback. The implementation reuses `/api/v1/users/me/github/*` routes for PR authorship instead of introducing separate `/github-app/*` endpoints. Remaining work: issueless session support and any future reconnect/error-taxonomy tightening.
+> **Implementation notes:** PR template detection and caching implemented (`pr_templates` store). The on-demand `Create PR` authorization flow now uses encrypted `github_app_user` credentials with refresh-aware validation, app fallback, and frontend auto-resume after callback. The implementation reuses `/api/v1/users/me/github/*` routes for PR authorship instead of introducing separate `/github-app/*` endpoints. The session UI now distinguishes stale GitHub PR resume tokens from snapshot-unavailable PR creation states instead of collapsing both into a generic "session expired" banner. Remaining work: issueless session support and any deeper reconnect-policy refinements.
 
 **Depends on**: [08-pr-and-ship.md](implemented/08-pr-and-ship.md), [13-repository-onboarding.md](implemented/13-repository-onboarding.md), [34-personal-team-coding-agents.md](implemented/34-personal-team-coding-agents.md)
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -916,8 +916,8 @@ describe('SessionDetailPage', () => {
     await screen.findAllByText('Fixed TypeError by adding null check');
 
     const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('PR session expired');
-    expect(alert).toHaveTextContent('Session state expired — re-run to create a PR.');
+    expect(alert).toHaveTextContent('PR snapshot unavailable');
+    expect(alert).toHaveTextContent('This session snapshot is unavailable. Send a new message to rebuild the sandbox, then create the PR again.');
     expect(within(alert).queryByRole('button')).not.toBeInTheDocument();
   });
 
@@ -946,6 +946,59 @@ describe('SessionDetailPage', () => {
 
     const alert = await screen.findByRole('alert');
     expect(alert.className).toContain('mx-2');
+  });
+
+  it('shows a resume-specific PR error instead of session expiry when the GitHub resume token is stale', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.get('/api/v1/users/me/github-status', () => {
+        return HttpResponse.json({
+          connected: true,
+          has_repo_scope: true,
+          github_login: 'alice',
+          pr_authorship_mode: 'user_preferred',
+          pr_draft_default: false,
+        });
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: 'PR_RESUME_EXPIRED',
+              message: 'GitHub authorization completed, but the PR resume request expired. Please click Create PR again.',
+            },
+          },
+          { status: 409 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />, {
+      searchParams: { github_pr: 'connected', resume_pr: 'resume-123' },
+    });
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent("Couldn't resume PR creation");
+    expect(alert).toHaveTextContent('GitHub authorization completed, but the PR resume request expired. Please click Create PR again.');
+    expect(alert).not.toHaveTextContent('PR session expired');
   });
 
   it('does not show Create PR button when session is running', async () => {
@@ -1387,6 +1440,58 @@ describe('SessionDetailPage', () => {
     expect(alert).toHaveTextContent('GitHub rejected the branch push.');
     expect(within(alert).getByRole('button', { name: 'Retry' })).toBeInTheDocument();
   }, 8000);
+
+  it('shows snapshot-unavailable guidance without a retry action when direct PR creation loses the snapshot', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          {
+            error: {
+              code: 'SNAPSHOT_EXPIRED',
+              message: 'session state expired — re-run to create a PR',
+            },
+          },
+          { status: 400 },
+        );
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole('button', { name: /Create PR/ }));
+
+    await waitFor(
+      () => {
+        expect(toast.error).toHaveBeenCalledWith('PR creation failed', { duration: 10000 });
+      },
+      { timeout: 5000 },
+    );
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('PR snapshot unavailable');
+    expect(alert).toHaveTextContent('This session snapshot is unavailable. Send a new message to rebuild the sandbox, then create the PR again.');
+    expect(within(alert).queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
 
   it('shows file count badge on Changes tab when session has diff', async () => {
     const sessionWithDiff: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -155,7 +155,14 @@ type PRAuthInterceptDetails = {
   can_fallback_to_app: boolean;
 };
 
+type PRActionErrorState = {
+  code?: string;
+  message: string;
+};
+
 const terminalSessionStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
+const SNAPSHOT_UNAVAILABLE_PR_MESSAGE =
+  "This session snapshot is unavailable. Send a new message to rebuild the sandbox, then create the PR again.";
 
 function isPRAuthInterceptDetails(value: unknown): value is PRAuthInterceptDetails {
   if (!value || typeof value !== "object") return false;
@@ -163,6 +170,23 @@ function isPRAuthInterceptDetails(value: unknown): value is PRAuthInterceptDetai
   return typeof details.connect_url === "string" &&
     typeof details.resume_token === "string" &&
     typeof details.can_fallback_to_app === "boolean";
+}
+
+function normalizeSnapshotPRMessage(message?: string | null): string {
+  if (!message || /^session state expired\b/i.test(message)) {
+    return SNAPSHOT_UNAVAILABLE_PR_MESSAGE;
+  }
+  return message;
+}
+
+function prErrorTitle(snapshotUnavailable: boolean, errorCode?: string): string {
+  if (snapshotUnavailable || errorCode === "SNAPSHOT_EXPIRED") {
+    return "PR snapshot unavailable";
+  }
+  if (errorCode === "PR_RESUME_EXPIRED") {
+    return "Couldn't resume PR creation";
+  }
+  return "Couldn't create the PR";
 }
 
 function OverviewTab({ session, members }: { session: Session; members: User[] }) {
@@ -1375,7 +1399,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
   }, [centerMode, exitReview, setPreviewParam]);
   const [localPRState, setLocalPRState] = useState<"idle" | "submitting" | "queued">("idle");
-  const [localPRActionError, setLocalPRActionError] = useState<string | null>(null);
+  const [localPRActionError, setLocalPRActionError] = useState<PRActionErrorState | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthInterceptDetails | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
 
@@ -1547,13 +1571,16 @@ export function SessionDetailContent({ id }: { id: string }) {
       setLocalPRActionError(null);
       setLocalPRState("submitting");
     },
-    onSuccess: () => {
+    onSuccess: (_data, options) => {
       setLocalPRActionError(null);
       setLocalPRState("queued");
+      if (options?.resumeToken) {
+        clearPRResumeParams();
+      }
       queryClient.invalidateQueries({ queryKey: ["session", id] });
       queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
     },
-    onError: (err) => {
+    onError: (err, options) => {
       if (err instanceof ApiError &&
         (err.code === "GITHUB_PR_AUTHORSHIP_REQUIRED" || err.code === "GITHUB_PR_AUTHORSHIP_REAUTH_REQUIRED") &&
         isPRAuthInterceptDetails(err.details)) {
@@ -1565,7 +1592,13 @@ export function SessionDetailContent({ id }: { id: string }) {
       }
       setLocalPRState("idle");
       const msg = err instanceof Error ? err.message : PR_ERROR_TOAST_MESSAGE;
-      setLocalPRActionError(msg);
+      setLocalPRActionError({
+        code: err instanceof ApiError ? err.code : undefined,
+        message: msg,
+      });
+      if (options?.resumeToken) {
+        clearPRResumeParams();
+      }
       toast.error(PR_ERROR_TOAST_MESSAGE, { duration: PR_ERROR_TOAST_DURATION_MS });
     },
   });
@@ -1669,13 +1702,17 @@ export function SessionDetailContent({ id }: { id: string }) {
   const showValidationTab = !session.triggered_by_user_id;
   const prState = session.pr_creation_state;
   const snapshotExpired = !session.snapshot_key;
-  const snapshotExpiredMessage =
-    session.pr_creation_error || "Session state expired — re-run to create a PR.";
+  const serverSnapshotUnavailable = /^session state expired\b/i.test(session.pr_creation_error || "");
+  const localSnapshotUnavailable = localPRActionError?.code === "SNAPSHOT_EXPIRED";
+  const snapshotUnavailable = snapshotExpired || localSnapshotUnavailable || serverSnapshotUnavailable;
+  const snapshotExpiredMessage = normalizeSnapshotPRMessage(
+    localSnapshotUnavailable ? localPRActionError.message : session.pr_creation_error
+  );
   const ghBlocked = ghStatus?.pr_authorship_mode === "user_required" && !ghStatus?.connected;
   const succeededButNoPR = prState === "succeeded" && !hasPR;
   const prActionError =
-    localPRActionError ||
-    (snapshotExpired ? snapshotExpiredMessage : null) ||
+    (localSnapshotUnavailable ? snapshotExpiredMessage : localPRActionError?.message) ||
+    (snapshotUnavailable ? snapshotExpiredMessage : null) ||
     (prState === "failed" ? session.pr_creation_error || PR_ERROR_TOAST_MESSAGE : null);
   const showPRAction =
     canCreatePR ||
@@ -1701,12 +1738,12 @@ export function SessionDetailContent({ id }: { id: string }) {
     prActionSpinning = true;
     prActionDisabled = true;
     prActionTitle = "Pushing changes and opening the pull request";
-  } else if (localPRActionError) {
-    prActionLabel = "Retry";
-    prActionTitle = localPRActionError;
-  } else if (snapshotExpired) {
+  } else if (snapshotUnavailable) {
     prActionDisabled = true;
     prActionTitle = snapshotExpiredMessage;
+  } else if (localPRActionError) {
+    prActionLabel = "Retry";
+    prActionTitle = localPRActionError.message;
   } else if (succeededButNoPR) {
     prActionLabel = "Finalizing PR…";
     prActionSpinning = true;
@@ -1720,7 +1757,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   }
 
   const prErrorNotice = prActionError ? {
-    title: snapshotExpired || /expired/i.test(prActionError) ? "PR session expired" : "Couldn't create the PR",
+    title: prErrorTitle(snapshotUnavailable, localPRActionError?.code),
     description: prActionError,
     action: prActionDisabled ? undefined : {
       label: prActionLabel,


### PR DESCRIPTION
## Summary
- Distinguish PR resume-token expiry from snapshot-unavailable PR creation states in the session UI
- Normalize direct `SNAPSHOT_EXPIRED` responses to the snapshot-unavailable copy and disable the misleading retry action
- Update session detail tests and design notes to cover the revised PR error behavior

## Testing
- `npx vitest run 'src/app/(dashboard)/sessions/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`