### PR TITLE
Fix leaky searchParams mock in login page tests

### DIFF
--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -68,7 +68,7 @@ describe('LoginPage', () => {
     registerMock.mockReset();
     pushMock.mockReset();
     replaceMock.mockReset();
-    searchParamsMock.forEach((_, key) => {
+    Array.from(searchParamsMock.keys()).forEach((key) => {
       searchParamsMock.delete(key);
     });
 


### PR DESCRIPTION
## Summary
- The `beforeEach` cleanup in `login/page.test.tsx` used `URLSearchParams.forEach` while mutating the same object via `.delete()`, which skips entries and leaked params from one test into the next.
- The signup test then ran with a pre-filled email, causing `user.type` to append rather than replace and `registerMock` to be called with the wrong value.
- Snapshot the keys with `Array.from(...keys())` before deleting so cleanup is reliable.

## Test plan
- [x] `npx vitest run "src/app/(auth)/login/page.test.tsx"` — all 19 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)