### PR TITLE
Remove Preview tab icon from session details sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1709,6 +1709,7 @@ describe('SessionDetailPage', () => {
 
     const previewTab = screen.getByRole('tab', { name: /Preview/ });
     expect(previewTab).toBeInTheDocument();
+    expect(previewTab.querySelector('svg')).not.toBeInTheDocument();
 
     const user = userEvent.setup();
     await user.click(previewTab);

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -9,7 +9,6 @@ import {
   ArrowUp,
   ClipboardList,
   ExternalLink,
-  Eye,
   FileCode2,
   GitPullRequest,
   Loader2,
@@ -1930,10 +1929,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                   {showValidationTab && (
                     <TabsTrigger value="validation">Validation</TabsTrigger>
                   )}
-                  <TabsTrigger value="preview">
-                    <Eye className="h-3 w-3 mr-1" />
-                    Preview
-                  </TabsTrigger>
+                  <TabsTrigger value="preview">Preview</TabsTrigger>
                 </TabsList>
                 {hasPR && prData?.data?.github_pr_url ? (
                   <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
Removed the `svg` icon from the **Preview** tab in the session details sidebar to match the other tabs’ visual consistency. Updated the session detail page test to ensure the icon is not rendered.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Removed the `Eye` icon import and its usage in the `TabsTrigger` for the `preview` tab.
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Strengthened the assertion for the **Preview** tab to verify it does not contain an `svg` icon.

## Test plan
- `npm run test -- --run src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 3ca3b6ca](https://app.143.dev/sessions/3ca3b6ca-199b-4e11-85cc-99adf2477594)*
