### PR TITLE
Fix fullscreen image lightbox sizing and move close button to top-right

### DIFF
--- a/frontend/src/components/image-lightbox.test.tsx
+++ b/frontend/src/components/image-lightbox.test.tsx
@@ -20,15 +20,20 @@ describe("ImageLightbox", () => {
     expect(dialog).toHaveClass("flex");
     expect(dialog).toHaveClass("items-center");
     expect(dialog).toHaveClass("justify-center");
+    expect(dialog).toHaveClass("h-screen");
+    expect(dialog).toHaveClass("w-screen");
+    expect(dialog).toHaveClass("border-none");
+    expect(dialog).toHaveClass("bg-transparent");
 
     const image = screen.getByRole("img", { name: "screenshot.png" });
     expect(image).toHaveClass("max-h-[88vh]");
     expect(image).toHaveClass("max-w-[92vw]");
 
     const closeButton = screen.getByRole("button", { name: "Close image preview" });
-    expect(closeButton).toHaveClass("fixed");
+    expect(closeButton).toHaveClass("absolute");
     expect(closeButton).toHaveClass("right-4");
     expect(closeButton).toHaveClass("top-4");
+    expect(dialog).toContainElement(closeButton);
   });
 
   it("closes when the backdrop is clicked", async () => {

--- a/frontend/src/components/image-lightbox.tsx
+++ b/frontend/src/components/image-lightbox.tsx
@@ -3,7 +3,16 @@
 import { X } from "lucide-react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogClose, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogClose,
+  DialogDescription,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { Dialog as DialogPrimitive } from "radix-ui";
 
 type ImageLightboxProps = {
   open: boolean;
@@ -15,37 +24,41 @@ type ImageLightboxProps = {
 export function ImageLightbox({ open, src, alt, onOpenChange }: ImageLightboxProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent
-        aria-label="Image preview"
-        showCloseButton={false}
-        className="pointer-events-none inset-0 flex max-w-none translate-x-0 translate-y-0 items-center justify-center border-none bg-transparent p-4 shadow-none sm:p-6"
-      >
-        <DialogTitle className="sr-only">Image preview</DialogTitle>
-        <DialogDescription className="sr-only">
-          Enlarged preview of {alt}
-        </DialogDescription>
-        <DialogClose asChild>
-          <Button
-            type="button"
-            variant="secondary"
-            size="icon"
-            aria-label="Close image preview"
-            className="pointer-events-auto fixed right-4 top-4 z-10 rounded-full bg-background/90 shadow-lg backdrop-blur-sm hover:bg-background sm:right-6 sm:top-6"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </DialogClose>
-        <div className="pointer-events-auto flex max-h-full max-w-full items-center justify-center">
-          <Image
-            src={src}
-            alt={alt}
-            width={1600}
-            height={1200}
-            unoptimized
-            className="max-h-[88vh] max-w-[92vw] rounded-xl object-contain shadow-2xl"
-          />
-        </div>
-      </DialogContent>
+      <DialogPortal>
+        <DialogOverlay className="bg-black/80 backdrop-blur-sm" />
+        <DialogPrimitive.Content
+          aria-label="Image preview"
+          className={cn(
+            "fixed inset-0 z-50 flex h-screen w-screen items-center justify-center border-none bg-transparent p-4 outline-none sm:p-6",
+          )}
+        >
+          <DialogTitle className="sr-only">Image preview</DialogTitle>
+          <DialogDescription className="sr-only">
+            Enlarged preview of {alt}
+          </DialogDescription>
+          <DialogClose asChild>
+            <Button
+              type="button"
+              variant="secondary"
+              size="icon"
+              aria-label="Close image preview"
+              className="absolute right-4 top-4 z-10 rounded-full bg-background/90 shadow-lg backdrop-blur-sm hover:bg-background sm:right-6 sm:top-6"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </DialogClose>
+          <div className="flex max-h-full max-w-full items-center justify-center">
+            <Image
+              src={src}
+              alt={alt}
+              width={1600}
+              height={1200}
+              unoptimized
+              className="max-h-[88vh] max-w-[92vw] rounded-xl object-contain shadow-2xl"
+            />
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPortal>
     </Dialog>
   );
 }


### PR DESCRIPTION
## Summary
Update the fullscreen image viewer to use a dedicated fullscreen lightbox layer, ensuring the image stage fills the viewport and stays correctly centered. Also reposition the close button so it consistently appears in the top-right corner.

## Changes
- **frontend/src/components/image-lightbox.tsx**
  - Replaced the shared centered `DialogContent` approach with a dedicated fullscreen portal using `DialogPortal`, `DialogOverlay`, and Radix `DialogPrimitive.Content`.
  - Set the lightbox content to `fixed inset-0` with `h-screen w-screen` so the stage covers the full viewport.
  - Moved/updated the close button positioning to `absolute right-4 top-4` within the fullscreen layer to prevent it from visually drifting.
- **frontend/src/components/image-lightbox.test.tsx**
  - Tightened assertions to verify the fullscreen stage uses `h-screen`/`w-screen` and transparent fullscreen styling.
  - Updated close-button assertions to expect `absolute` positioning and confirmed the close control is contained within the fullscreen dialog element.

## Test plan
- `npm run test -- image-lightbox.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (build succeeded; existing Next.js workspace root multiple-lockfiles warning remains)

---
*Generated by [143.dev](https://143.dev) — [session 03e85e76](https://app.143.dev/sessions/03e85e76-f540-4e97-a505-61b2213bb538)*
