### PR TITLE
Surface pending invitations inside the org switcher

### DIFF
--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -341,6 +341,69 @@ describe("OrgSwitcher", () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
+  it("the pending-invite dot and section disappear after the last invite is accepted and the dropdown reopens", async () => {
+    // Transition coverage for the pending → joined → closed-and-reopened = gone
+    // state machine. The dot is driven by visiblePendingCount (refetched list
+    // minus still-in-justJoined rows), and the section's existence is driven
+    // by hasPendingInvites = count > 0 || joinedEntries.length > 0 — so only a
+    // close+reopen cycle *plus* the server dropping the row (server filters
+    // accepted rows via NOT EXISTS membership) gets us back to neither.
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
+    setActiveOrgId("org-1");
+    mockPendingInvites([
+      {
+        id: "inv-last",
+        org_id: "org-9",
+        org_name: "Soylent",
+        role: "member",
+        invited_by: { id: "u-9", name: "Zed" },
+      },
+    ]);
+    server.use(
+      http.post("/api/v1/invitations/inv-last/accept", () => {
+        // Simulate the server's real behavior: once the membership exists,
+        // ListPendingForUser's NOT EXISTS filter drops the row from /pending.
+        server.use(
+          http.get("/api/v1/invitations/pending", () =>
+            HttpResponse.json({ data: [], meta: {} }),
+          ),
+        );
+        return HttpResponse.json({ data: { org_id: "org-9", role: "member" } });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    // Dot visible before acceptance.
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher-pending-invite-dot")).toBeInTheDocument();
+    });
+
+    // Open, accept, see the inline joined confirmation.
+    await user.click(screen.getByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("pending-invitation-accept-inv-last"));
+    await screen.findByTestId("pending-invitation-joined-inv-last");
+
+    // Close the dropdown — Escape rather than clicking the trigger because
+    // Radix locks pointer-events on the rest of the document while the menu
+    // is open, which makes a second trigger click unreachable in jsdom.
+    // Closing clears justJoined so the section can hide on the next open.
+    await user.keyboard("{Escape}");
+
+    // Dot is already gone (visiblePendingCount derives from the refetched
+    // list, which the server now returns empty). Wait for the refetch to
+    // settle before asserting absence so we don't race the invalidation.
+    await waitFor(() => {
+      expect(screen.queryByTestId("org-switcher-pending-invite-dot")).not.toBeInTheDocument();
+    });
+
+    // Reopen — section must not render.
+    await user.click(screen.getByTestId("org-switcher"));
+    await screen.findByTestId("org-switcher-item-org-1");
+    expect(screen.queryByTestId("pending-invitations-section")).not.toBeInTheDocument();
+  });
+
   it("the post-accept Switch to it link sets the active org and navigates", async () => {
     mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
     setActiveOrgId("org-1");

--- a/frontend/src/components/org-switcher.test.tsx
+++ b/frontend/src/components/org-switcher.test.tsx
@@ -48,6 +48,29 @@ function mockMemberships(memberships: Array<{ org_id: string; org_name: string; 
   );
 }
 
+interface PendingInviteFixture {
+  id: string;
+  org_id: string;
+  org_name: string;
+  role: string;
+  invited_by: { id: string; name: string };
+  expires_at?: string;
+  created_at?: string;
+}
+
+function mockPendingInvites(invites: PendingInviteFixture[]) {
+  const enriched = invites.map((inv) => ({
+    expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    created_at: new Date().toISOString(),
+    ...inv,
+  }));
+  server.use(
+    http.get("/api/v1/invitations/pending", () =>
+      HttpResponse.json({ data: enriched, meta: {} }),
+    ),
+  );
+}
+
 describe("OrgSwitcher", () => {
   it("renders the active org label from the server response", async () => {
     mockMemberships([
@@ -225,6 +248,223 @@ describe("OrgSwitcher", () => {
 
     await waitFor(() => {
       expect(getActiveOrgId()).toBeNull();
+    });
+  });
+
+  it("hides the pending-invite dot and section when there are no invitations", async () => {
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }]);
+    // Default handler in handlers.ts already returns []; explicit override
+    // here makes the intent obvious in the test body.
+    server.use(
+      http.get("/api/v1/invitations/pending", () =>
+        HttpResponse.json({ data: [], meta: {} }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    // userEmail is required because OrgSwitcher gates the pending-invites
+    // query on it (production never mounts the switcher pre-auth).
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    // Wait for the dropdown to open before asserting absence — querying
+    // immediately after click would race the popover mount.
+    await screen.findByTestId("org-switcher-item-org-1");
+    expect(screen.queryByTestId("org-switcher-pending-invite-dot")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("pending-invitations-section")).not.toBeInTheDocument();
+  });
+
+  it("renders the pending-invite dot and section when there is at least one invitation", async () => {
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }]);
+    mockPendingInvites([
+      {
+        id: "inv-1",
+        org_id: "org-2",
+        org_name: "Globex",
+        role: "member",
+        invited_by: { id: "u-2", name: "Bob" },
+      },
+    ]);
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("org-switcher-pending-invite-dot")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("org-switcher"));
+    await screen.findByTestId("pending-invitations-section");
+    expect(screen.getByTestId("pending-invitation-inv-1")).toHaveTextContent("Globex");
+    expect(screen.getByTestId("pending-invitation-inv-1")).toHaveTextContent("Invited by Bob");
+  });
+
+  it("accepting an invitation shows the inline confirmation without auto-switching the active org", async () => {
+    let acceptCalls = 0;
+    let setActiveOrgCalls = 0;
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
+    setActiveOrgId("org-1");
+    mockPendingInvites([
+      {
+        id: "inv-2",
+        org_id: "org-3",
+        org_name: "Initech",
+        role: "member",
+        invited_by: { id: "u-3", name: "Bill" },
+      },
+    ]);
+    server.use(
+      http.post("/api/v1/invitations/inv-2/accept", () => {
+        acceptCalls += 1;
+        return HttpResponse.json({ data: { org_id: "org-3", role: "member" } });
+      }),
+      http.post("/api/v1/auth/active-org", () => {
+        setActiveOrgCalls += 1;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("pending-invitation-accept-inv-2"));
+
+    await waitFor(() => {
+      expect(acceptCalls).toBe(1);
+      expect(screen.getByTestId("pending-invitation-joined-inv-2")).toHaveTextContent("Joined Initech");
+    });
+    // Critical invariant: in-app accept does NOT teleport the user out of
+    // their current workspace. The "Switch to it" link is the explicit opt-in.
+    expect(setActiveOrgCalls).toBe(0);
+    expect(getActiveOrgId()).toBe("org-1");
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("the post-accept Switch to it link sets the active org and navigates", async () => {
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
+    setActiveOrgId("org-1");
+    mockPendingInvites([
+      {
+        id: "inv-3",
+        org_id: "org-4",
+        org_name: "Pied Piper",
+        role: "admin",
+        invited_by: { id: "u-4", name: "Erlich" },
+      },
+    ]);
+    let switchedTo: string | null = null;
+    server.use(
+      http.post("/api/v1/invitations/inv-3/accept", () =>
+        HttpResponse.json({ data: { org_id: "org-4", role: "admin" } }),
+      ),
+      http.post("/api/v1/auth/active-org", async ({ request }) => {
+        const body = (await request.json()) as { org_id: string };
+        switchedTo = body.org_id;
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("pending-invitation-accept-inv-3"));
+    await screen.findByTestId("pending-invitation-joined-inv-3");
+    await user.click(screen.getByTestId("pending-invitation-switch-inv-3"));
+
+    await waitFor(() => {
+      expect(switchedTo).toBe("org-4");
+      expect(getActiveOrgId()).toBe("org-4");
+      expect(pushMock).toHaveBeenCalledWith("/sessions");
+    });
+  });
+
+  it("an accept that returns 410 surfaces an error toast and refetches the list", async () => {
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }], "org-1");
+    setActiveOrgId("org-1");
+    mockPendingInvites([
+      {
+        id: "inv-stale",
+        org_id: "org-9",
+        org_name: "Vandelay",
+        role: "member",
+        invited_by: { id: "u-9", name: "Art" },
+      },
+    ]);
+    let listCallsAfterAccept = 0;
+    server.use(
+      http.post("/api/v1/invitations/inv-stale/accept", () => {
+        // Simulate the row being revoked or accepted by another flow between
+        // the dropdown's last poll and the user's click.
+        server.use(
+          http.get("/api/v1/invitations/pending", () => {
+            listCallsAfterAccept += 1;
+            return HttpResponse.json({ data: [], meta: {} });
+          }),
+        );
+        return HttpResponse.json(
+          {
+            error: { code: "INVITE_INVALID", message: "this invitation is no longer valid" },
+          },
+          { status: 410 },
+        );
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("pending-invitation-accept-inv-stale"));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalled();
+      expect(listCallsAfterAccept).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByTestId("pending-invitation-joined-inv-stale")).not.toBeInTheDocument();
+    });
+    // Active org is unchanged — the failed accept must not move the user.
+    expect(getActiveOrgId()).toBe("org-1");
+  });
+
+  it("declining an invitation calls the API and refetches the list", async () => {
+    mockMemberships([{ org_id: "org-1", org_name: "Acme", role: "admin" }]);
+    mockPendingInvites([
+      {
+        id: "inv-4",
+        org_id: "org-5",
+        org_name: "Hooli",
+        role: "viewer",
+        invited_by: { id: "u-5", name: "Gavin" },
+      },
+    ]);
+    let declineCalls = 0;
+    let listCallsAfterDecline = 0;
+    server.use(
+      http.post("/api/v1/invitations/inv-4/decline", () => {
+        declineCalls += 1;
+        // Subsequent /pending GETs return an empty list — the row should
+        // disappear from the dropdown and the dot should hide.
+        server.use(
+          http.get("/api/v1/invitations/pending", () => {
+            listCallsAfterDecline += 1;
+            return HttpResponse.json({ data: [], meta: {} });
+          }),
+        );
+        return new HttpResponse(null, { status: 204 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OrgSwitcher userEmail="u@example.com" />);
+
+    await user.click(await screen.findByTestId("org-switcher"));
+    await user.click(await screen.findByTestId("pending-invitation-decline-inv-4"));
+
+    await waitFor(() => {
+      expect(declineCalls).toBe(1);
+      expect(listCallsAfterDecline).toBeGreaterThanOrEqual(1);
+      expect(screen.queryByTestId("pending-invitation-inv-4")).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { Check, ChevronsUpDown, Plus, Settings } from "lucide-react";
+import { Check, ChevronsUpDown, Mail, Plus, Settings } from "lucide-react";
 import { toast } from "sonner";
 
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,10 +25,21 @@ import {
 } from "@/lib/active-org";
 import { cn } from "@/lib/utils";
 import { queryKeys } from "@/lib/query-keys";
+import { ApiError } from "@/lib/api";
 import { CreateOrgDialog } from "@/components/create-org-dialog";
-import type { MembershipSummary, SingleResponse, MembershipsResponse } from "@/lib/types";
+import { usePendingInvites } from "@/hooks/use-pending-invites";
+import type {
+  MembershipSummary,
+  PendingInvitationForUser,
+  SingleResponse,
+  MembershipsResponse,
+} from "@/lib/types";
 
 const SEARCH_THRESHOLD = 5;
+// Threshold for the "expires soon" hint on a pending-invite row. Below 24h
+// the user sees an inline warning; above it the expiration is left implicit
+// so the section doesn't shout at them about invites that are days away.
+const EXPIRES_SOON_MS = 24 * 60 * 60 * 1000;
 
 export interface OrgSwitcherProps {
   userEmail?: string;
@@ -43,6 +55,16 @@ function messageForActiveOrgSwitchError(err: unknown, orgName: string): string {
   }
 }
 
+// JoinedOrg is the inline confirmation row that replaces an accepted-invite
+// row inside the dropdown until the dropdown closes. Holding a snapshot of
+// the org name + id (rather than re-deriving from memberships on the next
+// poll) lets the "Joined Acme. [Switch to it]" affordance render instantly
+// without flickering through a "loading…" state while memberships refetch.
+interface JoinedOrg {
+  org_id: string;
+  org_name: string;
+}
+
 export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -52,9 +74,27 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     queryFn: () => api.auth.memberships(),
   });
 
+  // Gate the pending-invites query on having a confirmed user identity. The
+  // switcher mounts inside AuthenticatedLayout so userEmail is set in
+  // practice; the explicit gate keeps a future pre-auth render from polling
+  // /api/v1/invitations/pending and producing 401 noise in the console.
+  const pendingInvites = usePendingInvites({ enabled: !!userEmail });
+
   const [tabOrgId, setTabOrgId] = useState<string | null>(() => getActiveOrgId());
   const [search, setSearch] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  // Tracks invitations the user just accepted in this session so the row
+  // collapses into a confirmation. Cleared when the dropdown closes; the
+  // next open shows the fresh state from the refetched pending list.
+  const [justJoined, setJustJoined] = useState<Record<string, JoinedOrg>>({});
+  // Snapshot of Date.now() at dropdown open, used by the "expires soon"
+  // annotation. Read-during-render of Date.now() is an impure-function rule
+  // violation; capturing the wall clock once per open is plenty of precision
+  // for an hours-grained warning, and reading from state keeps the render pure.
+  // The snapshot intentionally does not tick while the dropdown is open —
+  // a user leaving the menu open across the 24h threshold is pathological
+  // enough that a stale "expires soon" badge is fine.
+  const [openNowMs, setOpenNowMs] = useState<number>(0);
 
   const memberships = useMemo(
     () => membershipsResponse?.data?.memberships ?? [],
@@ -137,21 +177,120 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     router.push("/sessions");
   };
 
+  // Switch to the org the user just joined via an in-app invite accept.
+  // Same path as handleSwitch but synthesizes a MembershipSummary from the
+  // freshly-claimed invite (the memberships query may not have refetched
+  // yet, so we can't go through the regular membership lookup).
+  const handleSwitchToJoined = useCallback(
+    async (joined: JoinedOrg) => {
+      try {
+        await api.auth.setActiveOrg(joined.org_id);
+      } catch (err: unknown) {
+        toast.error(messageForActiveOrgSwitchError(err, joined.org_name));
+        return;
+      }
+      setActiveOrgId(joined.org_id);
+      queryClient.clear();
+      router.push("/sessions");
+    },
+    [queryClient, router],
+  );
+
+  const handleAcceptInvite = useCallback(
+    async (invite: PendingInvitationForUser) => {
+      try {
+        const result = await pendingInvites.accept(invite.id);
+        setJustJoined((prev) => ({
+          ...prev,
+          [invite.id]: { org_id: result.org_id, org_name: invite.org_name },
+        }));
+      } catch (err: unknown) {
+        // 410 (INVITE_INVALID / INVITE_EXPIRED) means the row got out from
+        // under us — refetch silently so the dropdown matches reality on the
+        // next open, but tell the user what happened.
+        if (
+          err instanceof ApiError &&
+          (err.code === "INVITE_INVALID" || err.code === "INVITE_EXPIRED")
+        ) {
+          pendingInvites.refetch();
+          toast.error(`This invitation to ${invite.org_name} is no longer valid.`);
+          return;
+        }
+        toast.error(`Couldn't accept the invitation to ${invite.org_name}. Please try again.`);
+      }
+    },
+    [pendingInvites],
+  );
+
+  const handleDeclineInvite = useCallback(
+    async (invite: PendingInvitationForUser) => {
+      try {
+        await pendingInvites.decline(invite.id);
+      } catch {
+        toast.error(`Couldn't decline the invitation to ${invite.org_name}. Please try again.`);
+      }
+    },
+    [pendingInvites],
+  );
+
   const orgLabel = activeMembership?.org_name ?? "Workspace";
   // Index by code points, not UTF-16 code units: "🏢 Acme"[0] is a lone high
   // surrogate that renders as a replacement char. Array.from splits correctly.
   const initial = Array.from(orgLabel)[0]?.toUpperCase() ?? "?";
 
+  // The pending-invites count drives both the trigger dot and the in-dropdown
+  // section. Treating the *visible* count (pending minus already-joined-in-
+  // this-session) as the indicator stops the dot from lingering after the
+  // user has acted on every invitation but the cache hasn't refetched yet.
+  const visiblePendingInvites = useMemo(
+    () => pendingInvites.invites.filter((inv) => !justJoined[inv.id]),
+    [pendingInvites.invites, justJoined],
+  );
+  const joinedEntries = useMemo(() => Object.entries(justJoined), [justJoined]);
+  const visiblePendingCount = visiblePendingInvites.length;
+  const hasPendingInvites = visiblePendingCount > 0 || joinedEntries.length > 0;
+  const ariaPendingSuffix =
+    visiblePendingCount > 0
+      ? `, ${visiblePendingCount} pending invitation${visiblePendingCount === 1 ? "" : "s"}`
+      : "";
+
   return (
     <>
-      <DropdownMenu onOpenChange={(open) => { if (!open) setSearch(""); }}>
+      <DropdownMenu
+        onOpenChange={(open) => {
+          if (open) {
+            // Refetch on open so the "you have a pending invite" surface is
+            // never staler than the moment the user looked at it. Snapshot
+            // the wall clock so the per-row "expires soon" check stays a
+            // pure read-from-state during the render of the open dropdown.
+            pendingInvites.refetch();
+            setOpenNowMs(Date.now());
+          } else {
+            setSearch("");
+            // Drop the just-joined confirmation rows once the dropdown
+            // closes; the next open shows the freshly-refetched real state.
+            setJustJoined({});
+          }
+        }}
+      >
         <DropdownMenuTrigger
           className="flex w-full min-w-0 items-center gap-1.5 rounded-md px-1.5 py-1 -ml-1.5 hover:bg-sidebar-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           data-testid="org-switcher"
-          aria-label="Switch organization"
+          aria-label={`Switch organization${ariaPendingSuffix}`}
         >
-          <div className="flex h-5 w-5 items-center justify-center rounded bg-foreground text-background text-xs font-semibold shrink-0">
+          <div className="relative flex h-5 w-5 items-center justify-center rounded bg-foreground text-background text-xs font-semibold shrink-0">
             {initial}
+            {visiblePendingCount > 0 && (
+              <span
+                // bg-primary rather than bg-foreground: the avatar is already
+                // bg-foreground, so reusing it would camouflage the dot. The
+                // ring-sidebar halo punches the dot out of the avatar visually,
+                // matching the standard notification-dot affordance.
+                className="absolute -top-0.5 -right-0.5 block h-1.5 w-1.5 rounded-full bg-primary ring-2 ring-sidebar"
+                data-testid="org-switcher-pending-invite-dot"
+                aria-hidden="true"
+              />
+            )}
           </div>
           <span className="text-sm font-semibold text-sidebar-foreground truncate flex-1 text-left">
             {orgLabel}
@@ -164,6 +303,106 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
               <DropdownMenuLabel className="text-xs font-normal text-muted-foreground truncate">
                 {userEmail}
               </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+            </>
+          )}
+          {hasPendingInvites && (
+            <>
+              <DropdownMenuLabel className="text-xs font-normal text-muted-foreground">
+                Pending invitations
+              </DropdownMenuLabel>
+              <div className="px-1 pb-1" data-testid="pending-invitations-section">
+                {/*
+                  Render joined confirmations from justJoined state directly,
+                  not by walking invites[]. The accept mutation invalidates
+                  the pending list, and the server's ListPendingForUser
+                  (status='pending' + NOT EXISTS membership) drops the just-
+                  accepted row within a single refetch — so rendering the
+                  "Joined X — Switch to it" affordance inside invites.map
+                  would flash it for a few hundred ms and then lose the row
+                  before the user could click "Switch to it".
+                */}
+                {joinedEntries.map(([inviteID, joined]) => (
+                  <div
+                    key={`joined-${inviteID}`}
+                    className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm"
+                    data-testid={`pending-invitation-joined-${inviteID}`}
+                  >
+                    <Check className="h-3.5 w-3.5 text-foreground shrink-0" />
+                    <span className="truncate flex-1">Joined {joined.org_name}</span>
+                    <button
+                      type="button"
+                      className="text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:underline"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        void handleSwitchToJoined(joined);
+                      }}
+                      data-testid={`pending-invitation-switch-${inviteID}`}
+                    >
+                      Switch to it
+                    </button>
+                  </div>
+                ))}
+                {visiblePendingInvites.map((invite) => {
+                  const expiresAtMs = new Date(invite.expires_at).getTime();
+                  const expiresSoon =
+                    openNowMs > 0 &&
+                    Number.isFinite(expiresAtMs) &&
+                    expiresAtMs - openNowMs < EXPIRES_SOON_MS;
+                  return (
+                    <div
+                      key={invite.id}
+                      className="flex flex-col gap-1.5 rounded-sm px-2 py-1.5 text-sm"
+                      data-testid={`pending-invitation-${invite.id}`}
+                    >
+                      <div className="flex items-center gap-2 min-w-0">
+                        <Mail className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
+                        <span className="truncate flex-1 font-medium" title={invite.org_name}>
+                          {invite.org_name}
+                        </span>
+                        <span className="text-xs uppercase tracking-wide text-muted-foreground shrink-0">
+                          {invite.role}
+                        </span>
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        Invited by {invite.invited_by.name}
+                        {expiresSoon && (
+                          <span className="ml-1 text-destructive">· expires soon</span>
+                        )}
+                      </div>
+                      <div className="flex items-center justify-end gap-1.5 pt-0.5">
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="ghost"
+                          className="h-6 px-2 text-xs"
+                          disabled={pendingInvites.acceptingId === invite.id || pendingInvites.decliningId === invite.id}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            void handleDeclineInvite(invite);
+                          }}
+                          data-testid={`pending-invitation-decline-${invite.id}`}
+                        >
+                          Decline
+                        </Button>
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="h-6 px-2 text-xs"
+                          disabled={pendingInvites.acceptingId === invite.id || pendingInvites.decliningId === invite.id}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            void handleAcceptInvite(invite);
+                          }}
+                          data-testid={`pending-invitation-accept-${invite.id}`}
+                        >
+                          Accept
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
               <DropdownMenuSeparator />
             </>
           )}

--- a/frontend/src/components/org-switcher.tsx
+++ b/frontend/src/components/org-switcher.tsx
@@ -87,14 +87,12 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   // collapses into a confirmation. Cleared when the dropdown closes; the
   // next open shows the fresh state from the refetched pending list.
   const [justJoined, setJustJoined] = useState<Record<string, JoinedOrg>>({});
-  // Snapshot of Date.now() at dropdown open, used by the "expires soon"
-  // annotation. Read-during-render of Date.now() is an impure-function rule
-  // violation; capturing the wall clock once per open is plenty of precision
-  // for an hours-grained warning, and reading from state keeps the render pure.
-  // The snapshot intentionally does not tick while the dropdown is open —
-  // a user leaving the menu open across the 24h threshold is pathological
-  // enough that a stale "expires soon" badge is fine.
-  const [openNowMs, setOpenNowMs] = useState<number>(0);
+  // Wall-clock snapshot for the per-row "expires soon" annotation. Captured
+  // once on mount and re-captured whenever a fresh pending-invites result
+  // arrives (see the effect below) so a dropdown left open across the
+  // 5-minute poll still sees an accurate badge. Reading from state rather
+  // than calling Date.now() mid-render keeps the render pure.
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
   const memberships = useMemo(
     () => membershipsResponse?.data?.memberships ?? [],
@@ -160,40 +158,39 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     return memberships.filter((m) => m.org_name.toLowerCase().includes(q));
   }, [memberships, search]);
 
-  const handleSwitch = async (membership: MembershipSummary) => {
-    if (membership.org_id === effectiveActiveOrgId) return;
-    try {
-      await api.auth.setActiveOrg(membership.org_id);
-    } catch (err: unknown) {
-      toast.error(messageForActiveOrgSwitchError(err, membership.org_name));
-      return;
-    }
-    setActiveOrgId(membership.org_id);
-    // clear() over invalidateQueries(): invalidating here would refetch every
-    // cached query against the *current* page right before it unmounts on
-    // navigation — doubling request volume. Clearing drops the cache so the
-    // destination page fetches fresh under the new active-org header.
-    queryClient.clear();
-    router.push("/sessions");
-  };
-
-  // Switch to the org the user just joined via an in-app invite accept.
-  // Same path as handleSwitch but synthesizes a MembershipSummary from the
-  // freshly-claimed invite (the memberships query may not have refetched
-  // yet, so we can't go through the regular membership lookup).
-  const handleSwitchToJoined = useCallback(
-    async (joined: JoinedOrg) => {
+  // Shared between the regular membership switch and the post-accept
+  // "Switch to it" affordance. Takes the minimal {org_id, org_name} shape
+  // so the caller can pass either a MembershipSummary or a freshly-claimed
+  // JoinedOrg without going through the memberships cache (which may not
+  // have refetched yet in the just-accepted case).
+  //
+  // clear() over invalidateQueries(): invalidating here would refetch every
+  // cached query against the *current* page right before it unmounts on
+  // navigation — doubling request volume. Clearing drops the cache so the
+  // destination page fetches fresh under the new active-org header.
+  const activateOrgAndNavigate = useCallback(
+    async (org: { org_id: string; org_name: string }) => {
       try {
-        await api.auth.setActiveOrg(joined.org_id);
+        await api.auth.setActiveOrg(org.org_id);
       } catch (err: unknown) {
-        toast.error(messageForActiveOrgSwitchError(err, joined.org_name));
+        toast.error(messageForActiveOrgSwitchError(err, org.org_name));
         return;
       }
-      setActiveOrgId(joined.org_id);
+      setActiveOrgId(org.org_id);
       queryClient.clear();
       router.push("/sessions");
     },
     [queryClient, router],
+  );
+
+  const handleSwitch = async (membership: MembershipSummary) => {
+    if (membership.org_id === effectiveActiveOrgId) return;
+    await activateOrgAndNavigate(membership);
+  };
+
+  const handleSwitchToJoined = useCallback(
+    (joined: JoinedOrg) => activateOrgAndNavigate(joined),
+    [activateOrgAndNavigate],
   );
 
   const handleAcceptInvite = useCallback(
@@ -226,7 +223,21 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
     async (invite: PendingInvitationForUser) => {
       try {
         await pendingInvites.decline(invite.id);
-      } catch {
+      } catch (err: unknown) {
+        // 410 (INVITE_INVALID / INVITE_EXPIRED) means an admin revoked or a
+        // concurrent decline landed first. From the user's perspective the
+        // row they wanted gone *is* gone, so refetch quietly and let them
+        // know the list was already out of sync — same pattern as accept,
+        // but with toast.info instead of .error since the end state matches
+        // what they asked for.
+        if (
+          err instanceof ApiError &&
+          (err.code === "INVITE_INVALID" || err.code === "INVITE_EXPIRED")
+        ) {
+          pendingInvites.refetch();
+          toast.info(`The invitation to ${invite.org_name} was already resolved.`);
+          return;
+        }
         toast.error(`Couldn't decline the invitation to ${invite.org_name}. Please try again.`);
       }
     },
@@ -237,6 +248,18 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
   // Index by code points, not UTF-16 code units: "🏢 Acme"[0] is a lone high
   // surrogate that renders as a replacement char. Array.from splits correctly.
   const initial = Array.from(orgLabel)[0]?.toUpperCase() ?? "?";
+
+  // Sync nowMs with real time whenever new pending-invites data arrives.
+  // This is the "update React state from an external source" shape the
+  // set-state-in-effect rule has a narrow carve-out for — Date.now() is
+  // the external source, pendingInvites.invites identity is the signal
+  // that the data we're rendering against just changed. Stable dep:
+  // pendingInvites.invites is memoized in the hook, so this fires only
+  // on fresh query results, not on every render.
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setNowMs(Date.now());
+  }, [pendingInvites.invites]);
 
   // The pending-invites count drives both the trigger dot and the in-dropdown
   // section. Treating the *visible* count (pending minus already-joined-in-
@@ -260,11 +283,10 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
         onOpenChange={(open) => {
           if (open) {
             // Refetch on open so the "you have a pending invite" surface is
-            // never staler than the moment the user looked at it. Snapshot
-            // the wall clock so the per-row "expires soon" check stays a
-            // pure read-from-state during the render of the open dropdown.
+            // never staler than the moment the user looked at it. The wall-
+            // clock snapshot used by the per-row "expires soon" check rides
+            // on top of the refetched invites identity via nowMs's useMemo.
             pendingInvites.refetch();
-            setOpenNowMs(Date.now());
           } else {
             setSearch("");
             // Drop the just-joined confirmation rows once the dropdown
@@ -346,9 +368,8 @@ export function OrgSwitcher({ userEmail }: OrgSwitcherProps) {
                 {visiblePendingInvites.map((invite) => {
                   const expiresAtMs = new Date(invite.expires_at).getTime();
                   const expiresSoon =
-                    openNowMs > 0 &&
                     Number.isFinite(expiresAtMs) &&
-                    expiresAtMs - openNowMs < EXPIRES_SOON_MS;
+                    expiresAtMs - nowMs < EXPIRES_SOON_MS;
                   return (
                     <div
                       key={invite.id}

--- a/frontend/src/hooks/use-pending-invites.ts
+++ b/frontend/src/hooks/use-pending-invites.ts
@@ -1,9 +1,9 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import type { PendingInvitationForUser } from "@/lib/types";
 
@@ -57,11 +57,7 @@ export function usePendingInvites(opts: { enabled?: boolean } = {}): UsePendingI
     refetchOnWindowFocus: true,
     // Don't retry on 401 — an unauthenticated user has nothing to recover.
     retry: (failureCount, err) => {
-      if (
-        typeof err === "object" &&
-        err !== null &&
-        (err as { code?: unknown }).code === "UNAUTHORIZED"
-      ) {
+      if (err instanceof ApiError && err.code === "UNAUTHORIZED") {
         return false;
       }
       return failureCount < 2;
@@ -104,7 +100,10 @@ export function usePendingInvites(opts: { enabled?: boolean } = {}): UsePendingI
     void refetch();
   }, [refetch]);
 
-  const invites = data?.data ?? [];
+  // Memoize so the array identity is stable between renders until React
+  // Query hands us a new result. Consumers can depend on `invites` in an
+  // effect dep array without the effect firing on every render.
+  const invites = useMemo(() => data?.data ?? [], [data]);
   return {
     invites,
     count: invites.length,

--- a/frontend/src/hooks/use-pending-invites.ts
+++ b/frontend/src/hooks/use-pending-invites.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import type { PendingInvitationForUser } from "@/lib/types";
+
+// Polling cadence for the pending-invites surface. Five minutes is the
+// sweet spot for a list that's empty for ~all users ~all the time:
+// sub-minute polling burns cache + network for nothing, while waiting
+// longer lets a user complete entire sessions before noticing they had
+// access waiting. The dropdown also refetches on open and on window
+// focus, so the worst-case discovery latency in practice is "next time
+// the user clicks the org switcher" rather than the full poll interval.
+const PENDING_INVITES_POLL_MS = 5 * 60 * 1000;
+
+interface UsePendingInvitesResult {
+  invites: PendingInvitationForUser[];
+  count: number;
+  isLoading: boolean;
+  refetch: () => void;
+  accept: (id: string) => Promise<{ org_id: string; role: string }>;
+  decline: (id: string) => Promise<void>;
+  // The id currently being accepted/declined (or null). Exposed so the UI can
+  // disable the row whose mutation is in flight without freezing buttons on
+  // every other row — several invites arriving together should still be
+  // independently actionable.
+  acceptingId: string | null;
+  decliningId: string | null;
+}
+
+// usePendingInvites surfaces the invitations addressed to the authenticated
+// user — the data behind the org-switcher dot and the "Pending invitations"
+// section inside its dropdown.
+//
+// Pass `enabled: false` when the caller can render before the user is
+// authenticated, to avoid generating 401s. The org-switcher does this by
+// gating on whether userEmail has been resolved.
+//
+// Mutations invalidate both the pending-invites list (so the row disappears
+// from the dropdown) and the auth.memberships query (so the new org appears
+// in the switcher's main list). The hook deliberately does NOT switch the
+// active org on accept — that decision belongs to the UI layer, where the
+// user can be offered an explicit "Switch to it" affordance instead of being
+// teleported out of whatever org they were working in.
+export function usePendingInvites(opts: { enabled?: boolean } = {}): UsePendingInvitesResult {
+  const enabled = opts.enabled ?? true;
+  const queryClient = useQueryClient();
+
+  const { data, isLoading, refetch } = useQuery({
+    queryKey: queryKeys.invitations.pending,
+    queryFn: () => api.invitations.listPending(),
+    enabled,
+    refetchInterval: enabled ? PENDING_INVITES_POLL_MS : false,
+    refetchOnWindowFocus: true,
+    // Don't retry on 401 — an unauthenticated user has nothing to recover.
+    retry: (failureCount, err) => {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        (err as { code?: unknown }).code === "UNAUTHORIZED"
+      ) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+
+  const acceptMutation = useMutation({
+    mutationFn: (id: string) => api.invitations.accept(id),
+    onSuccess: () => {
+      // Refresh both: the pending list (so the row disappears) and the
+      // user's memberships (so the new org appears in the switcher).
+      void queryClient.invalidateQueries({ queryKey: queryKeys.invitations.pending });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.auth.memberships });
+    },
+  });
+
+  const declineMutation = useMutation({
+    mutationFn: (id: string) => api.invitations.decline(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.invitations.pending });
+    },
+  });
+
+  const accept = useCallback(
+    async (id: string): Promise<{ org_id: string; role: string }> => {
+      const result = await acceptMutation.mutateAsync(id);
+      return result.data;
+    },
+    [acceptMutation],
+  );
+
+  const decline = useCallback(
+    async (id: string): Promise<void> => {
+      await declineMutation.mutateAsync(id);
+    },
+    [declineMutation],
+  );
+
+  const refetchCallback = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  const invites = data?.data ?? [];
+  return {
+    invites,
+    count: invites.length,
+    isLoading,
+    refetch: refetchCallback,
+    accept,
+    decline,
+    // React Query exposes the in-flight argument via mutation.variables while
+    // isPending is true, which gives us a free per-row pending indicator
+    // without maintaining parallel state.
+    acceptingId: acceptMutation.isPending ? acceptMutation.variables ?? null : null,
+    decliningId: declineMutation.isPending ? declineMutation.variables ?? null : null,
+  };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -544,6 +544,21 @@ export const api = {
     create: (memory: { repo: string; rule: string; category?: string; scope?: string; file_patterns?: string[] }) =>
       post<import('./types').SingleResponse<import('./types').Memory>>('/api/v1/memories', memory),
   },
+  // Invitations addressed to the current user, across orgs. Distinct from
+  // `team.listInvitations` (which lists invitations the *current org's admins*
+  // have sent out): these are the invites *I* can claim, surfaced in the org
+  // switcher's "Pending invitations" section.
+  invitations: {
+    listPending: () =>
+      get<import('./types').ListResponse<import('./types').PendingInvitationForUser>>(
+        '/api/v1/invitations/pending',
+      ),
+    accept: (id: string) =>
+      post<import('./types').SingleResponse<{ org_id: string; role: string }>>(
+        `/api/v1/invitations/${id}/accept`,
+      ),
+    decline: (id: string) => post<void>(`/api/v1/invitations/${id}/decline`),
+  },
   team: {
     listMembers: () => get<import('./types').ListResponse<import('./types').User>>('/api/v1/team/members'),
     changeRole: (id: string, role: string) =>

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -60,6 +60,9 @@ export const queryKeys = {
   auth: {
     memberships: ["auth", "memberships"] as const,
   },
+  invitations: {
+    pending: ["invitations", "pending"] as const,
+  },
   usage: {
     summary: (params: { start: string; end: string }) =>
       ["usage", "summary", params] as const,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -588,6 +588,23 @@ export interface InvitationResponse {
   created_at: string;
 }
 
+// PendingInvitationForUser is the invitee-facing shape: the recipient of an
+// invitation only needs to know which org they're being invited into, by whom,
+// at what role, and when it expires. The token is intentionally omitted —
+// accept/decline are id-routed and re-validated server-side.
+export interface PendingInvitationForUser {
+  id: string;
+  org_id: string;
+  org_name: string;
+  role: string;
+  invited_by: {
+    id: string;
+    name: string;
+  };
+  expires_at: string;
+  created_at: string;
+}
+
 export interface GitHubInviteStatus {
   connected: boolean;
 }

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -472,6 +472,14 @@ export const handlers = [
     });
   }),
 
+  // Default to no pending invites — the org-switcher polls this on mount, so
+  // every test rendering the switcher would otherwise hit an unhandled-request
+  // warning. Tests that want to exercise the pending-invites surface override
+  // this with server.use(...).
+  http.get('/api/v1/invitations/pending', () => {
+    return HttpResponse.json({ data: [], meta: {} });
+  }),
+
   http.patch('/api/v1/settings', () => {
     return HttpResponse.json({
       data: {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -1183,21 +1183,43 @@ func (h *AuthHandler) validateInvitationWithStore(ctx context.Context, invitatio
 		return inv, uuid.Nil, "", &invitationError{http.StatusInternalServerError, "INVITE_LOOKUP_FAILED", "failed to look up invitation"}
 	}
 
+	if invErr := validateInvitationForRecipient(inv, email, githubLogin); invErr != nil {
+		return inv, uuid.Nil, "", invErr
+	}
+	return inv, inv.OrgID, inv.Role, nil
+}
+
+// validateInvitationForRecipient checks the three invariants that gate every
+// invitation claim regardless of how the row was looked up: the invitation
+// is still pending, has not expired, and its recipient identifier matches
+// the authenticated user. Shared by the token-based claim path and the
+// id-based in-app accept/decline paths so the matching rules can never
+// drift between the dropdown's "is this invite mine?" filter and the
+// server's "is this user allowed to accept?" check.
+//
+// Match rules (mirror the ListPendingForUser store query):
+//   - email-only invite: the user's email (case-insensitive) must equal it
+//   - github-only invite: the user's github_login (case-insensitive) must equal it
+//   - both set: either match suffices
+//   - empty user-side identifiers can never satisfy either branch
+//
+// All three failures return invitationError values with status codes that
+// suit the token-claim path. Id-based callers may remap the mismatch code
+// to 403 since the id is part of the URL (the request is naming a specific
+// invitation the user has no claim to, not submitting bad input).
+func validateInvitationForRecipient(inv models.Invitation, email, githubLogin string) *invitationError {
 	if inv.Status != "pending" {
-		return inv, uuid.Nil, "", &invitationError{http.StatusGone, "INVITE_INVALID", "this invitation is no longer valid"}
+		return &invitationError{http.StatusGone, "INVITE_INVALID", "this invitation is no longer valid"}
 	}
-
 	if time.Now().After(inv.ExpiresAt) {
-		return inv, uuid.Nil, "", &invitationError{http.StatusGone, "INVITE_EXPIRED", "this invitation has expired"}
+		return &invitationError{http.StatusGone, "INVITE_EXPIRED", "this invitation has expired"}
 	}
-
 	emailMatches := inv.Email != nil && email != "" && strings.EqualFold(*inv.Email, email)
 	githubMatches := inv.GitHubUsername != nil && githubLogin != "" && strings.EqualFold(*inv.GitHubUsername, githubLogin)
 	if !emailMatches && !githubMatches {
-		return inv, uuid.Nil, "", &invitationError{http.StatusBadRequest, "INVITE_MISMATCH", "this account does not match the invitation"}
+		return &invitationError{http.StatusBadRequest, "INVITE_MISMATCH", "this account does not match the invitation"}
 	}
-
-	return inv, inv.OrgID, inv.Role, nil
+	return nil
 }
 
 // emitAuthEvent emits an audit log entry for an authentication event. It

--- a/internal/api/handlers/auth_claim.go
+++ b/internal/api/handlers/auth_claim.go
@@ -15,69 +15,115 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
-// claimInvitationForExistingUser validates a pending invitation and grants the
-// user a membership in the inviting org. Unlike the signup claim helpers,
-// there is no user creation: the caller is already authenticated and this
-// transaction accepts the invitation, inserts/updates the membership, and
-// updates the user's persisted active-org preference to the claimed org.
+// acceptOptions controls the side-effects of acceptValidatedInvitation that
+// are required by some entry points but harmful at others.
+type acceptOptions struct {
+	// updateLastOrgID, when true, persists the claimed org as the user's
+	// default for future logins. Set on the token-based claim path (user is
+	// acting on the email link / OAuth invite cookie, so landing in the new
+	// org next session is expected). Not set on the in-app id-based accept
+	// path: the user is mid-flow inside their current org and the frontend
+	// offers an explicit "Switch to it" affordance after acceptance.
+	updateLastOrgID bool
+}
+
+// acceptValidatedInvitation runs the write-side of an invitation claim:
+// mark the row accepted, grant a membership at GrantAtLeast semantics, and
+// optionally persist the claimed org as the user's default. Caller must
+// have already validated the invitation (status == "pending", not expired,
+// recipient identifier matches the user) — this helper trusts the row
+// passed in and only re-checks the status race via Accept's WHERE clause.
 //
-// The (email, githubLogin) pair must match the invitation per the same rules
-// as the signup flow; a mismatch returns an invitationError so handlers can
-// map to an HTTP status. The invitation is accepted inside the same tx as the
-// membership upsert, so a race on status will roll the membership back.
+// The accept and grant always commit together; the last_org_id update
+// joins them when opts.updateLastOrgID is set. The Accept WHERE
+// status='pending' guard converts a concurrent Revoke into a clean
+// INVITE_INVALID error, rolling the would-be membership grant back with
+// the rest of the tx.
 //
-// Returns the effective membership role after the grant so the handler can
-// echo it to the client rather than parroting the invite's role — the two
-// differ whenever the claimer already held a higher role in the org (admin
-// re-invited as viewer stays admin; GrantAtLeast never downgrades).
-//
-// The returned *models.Invitation is non-nil whenever the invitation row was
-// loaded — including failure cases past the initial GetByToken lookup. This
-// lets the caller emit org-scoped audit events for failed claims.
-func (h *AuthHandler) claimInvitationForExistingUser(
+// Returns the effective role after the grant — different from inv.Role
+// whenever the user already held a higher role (GrantAtLeast never
+// downgrades; admin re-invited as viewer stays admin).
+func (h *AuthHandler) acceptValidatedInvitation(
 	ctx context.Context,
-	token, userEmail, githubLogin string,
+	inv *models.Invitation,
 	userID uuid.UUID,
-) (*models.Invitation, string, *invitationError, error) {
+	role string,
+	opts acceptOptions,
+) (string, *invitationError, error) {
 	if h.pool == nil {
-		return nil, "", nil, fmt.Errorf("auth handler pool is not configured")
+		return "", nil, fmt.Errorf("auth handler pool is not configured")
+	}
+	if inv == nil {
+		return "", nil, fmt.Errorf("invitation is required")
 	}
 
 	tx, err := h.pool.Begin(ctx)
 	if err != nil {
-		return nil, "", nil, fmt.Errorf("begin claim transaction: %w", err)
+		return "", nil, fmt.Errorf("begin accept transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	txInvitations := db.NewInvitationStore(tx)
-	inv, _, role, invErr := h.validateInvitationWithStore(ctx, txInvitations, token, userEmail, githubLogin)
-	if invErr != nil {
-		return invitationOrNil(inv), "", invErr, nil
-	}
-
-	txMemberships := db.NewOrganizationMembershipStore(tx)
-
-	if err := txInvitations.Accept(ctx, inv.ID); err != nil {
+	if err := db.NewInvitationStore(tx).Accept(ctx, inv.ID); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return &inv, "", &invitationError{
+			return "", &invitationError{
 				status:  http.StatusGone,
 				code:    "INVITE_INVALID",
 				message: "this invitation is no longer valid",
 			}, nil
 		}
-		return &inv, "", nil, fmt.Errorf("accept invitation: %w", err)
+		return "", nil, fmt.Errorf("accept invitation: %w", err)
 	}
 
-	effectiveRole, err := txMemberships.GrantAtLeast(ctx, userID, inv.OrgID, role)
+	effectiveRole, err := db.NewOrganizationMembershipStore(tx).GrantAtLeast(ctx, userID, inv.OrgID, role)
 	if err != nil {
-		return &inv, "", nil, fmt.Errorf("grant membership: %w", err)
+		return "", nil, fmt.Errorf("grant membership: %w", err)
 	}
-	if err := db.NewUserStore(tx).UpdateLastOrgID(ctx, userID, &inv.OrgID); err != nil {
-		return &inv, "", nil, fmt.Errorf("update user last org: %w", err)
+	if opts.updateLastOrgID {
+		if err := db.NewUserStore(tx).UpdateLastOrgID(ctx, userID, &inv.OrgID); err != nil {
+			return "", nil, fmt.Errorf("update user last org: %w", err)
+		}
 	}
-
 	if err := tx.Commit(ctx); err != nil {
-		return &inv, "", nil, fmt.Errorf("commit claim transaction: %w", err)
+		return "", nil, fmt.Errorf("commit accept transaction: %w", err)
+	}
+	return effectiveRole, nil, nil
+}
+
+// claimInvitationForExistingUser validates a pending invitation by token
+// and grants the authenticated user a membership in the inviting org. The
+// caller's email (and GitHub login when present) must match the invitation
+// per the same rules as the signup flow.
+//
+// The user's persisted last_org_id is updated to the claimed org: the only
+// callers are the email-link claim endpoint and the OAuth-callback pending-
+// invite path, both of which represent the user expressing "I want to land
+// in this org next time."
+//
+// The returned *models.Invitation is non-nil whenever the invitation row
+// was loaded — including failure cases past the initial GetByToken lookup —
+// so the caller can emit org-scoped audit events for failed claims.
+func (h *AuthHandler) claimInvitationForExistingUser(
+	ctx context.Context,
+	token, userEmail, githubLogin string,
+	userID uuid.UUID,
+) (*models.Invitation, string, *invitationError, error) {
+	// Fail fast on a misconfigured handler. validateInvitation would otherwise
+	// nil-deref on the invitation store before reaching acceptValidatedInvitation's
+	// own pool check — this preserves the top-level contract that a nil pool
+	// returns an error rather than panicking.
+	if h.pool == nil {
+		return nil, "", nil, fmt.Errorf("auth handler pool is not configured")
+	}
+	inv, _, role, invErr := h.validateInvitation(ctx, token, userEmail, githubLogin)
+	if invErr != nil {
+		return invitationOrNil(inv), "", invErr, nil
+	}
+	effectiveRole, acceptErr, err := h.acceptValidatedInvitation(ctx, &inv, userID, role, acceptOptions{updateLastOrgID: true})
+	if err != nil {
+		return &inv, "", nil, err
+	}
+	if acceptErr != nil {
+		return &inv, "", acceptErr, nil
 	}
 	return &inv, effectiveRole, nil, nil
 }

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -1803,13 +1803,15 @@ func TestAuthHandler_ClaimInvitationForExistingUser_Success(t *testing.T) {
 	orgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
+	// Validation read happens on the pool before any tx is opened.
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, orgID, strPtr("existing@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
+	// acceptValidatedInvitation opens its own tx for the writes.
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -1845,14 +1847,14 @@ func TestAuthHandler_ClaimInvitationForExistingUser_WrongEmail(t *testing.T) {
 	orgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
+	// Validation runs on the pool; on mismatch the helper returns before
+	// opening any tx, so no Begin/Rollback is expected.
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, orgID, strPtr("invitee@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
-	mock.ExpectRollback()
 
 	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
 	inv, _, invErr, err := handler.claimInvitationForExistingUser(context.Background(), "valid", "other@example.com", "", uuid.New())
@@ -1945,13 +1947,13 @@ func TestAuthHandler_ClaimInvitation_Success(t *testing.T) {
 	invID := uuid.New()
 	ghLogin := "octocat"
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -1989,14 +1991,12 @@ func TestAuthHandler_ClaimInvitation_EmailMismatch(t *testing.T) {
 	invOrgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, invOrgID, strPtr("someone-else@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
-	mock.ExpectRollback()
 
 	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
 	user := &models.User{ID: uuid.New(), Email: "mismatch@example.com"}
@@ -2023,11 +2023,9 @@ func TestAuthHandler_ClaimInvitation_UnknownTokenSkipsAudit(t *testing.T) {
 	require.NoError(t, err)
 	defer mock.Close()
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}))
-	mock.ExpectRollback()
 
 	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
 	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
@@ -2056,13 +2054,13 @@ func TestAuthHandler_ClaimInvitation_EmitsAcceptedAudit(t *testing.T) {
 	invOrgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2114,13 +2112,13 @@ func TestAuthHandler_ClaimInvitation_EmitsFailedAudit(t *testing.T) {
 	invOrgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
+	mock.ExpectBegin()
 	// Accept returns ErrNoRows → invitationError{INVITE_INVALID, 410}.
 	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 		WithArgs(pgxmock.AnyArg()).
@@ -2328,14 +2326,16 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 	orgID := uuid.New()
 	invID := uuid.New()
 
-	setupBeginSelect := func(mock pgxmock.PgxPoolIface) {
-		mock.ExpectBegin()
+	// Validation read happens on the pool before any tx is opened; the tx
+	// only fires after validateInvitation returns success.
+	setupSelectThenBegin := func(mock pgxmock.PgxPoolIface) {
 		mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnRows(
 				pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 					AddRow(invID, orgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 			)
+		mock.ExpectBegin()
 	}
 
 	newHandler := func(mock pgxmock.PgxPoolIface) *AuthHandler {
@@ -2348,7 +2348,7 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		defer mock.Close()
-		setupBeginSelect(mock)
+		setupSelectThenBegin(mock)
 		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnError(errors.New("accept"))
@@ -2364,7 +2364,7 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		defer mock.Close()
-		setupBeginSelect(mock)
+		setupSelectThenBegin(mock)
 		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2383,7 +2383,7 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		defer mock.Close()
-		setupBeginSelect(mock)
+		setupSelectThenBegin(mock)
 		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2405,7 +2405,7 @@ func TestAuthHandler_ClaimInvitationForExistingUser_DBErrors(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err)
 		defer mock.Close()
-		setupBeginSelect(mock)
+		setupSelectThenBegin(mock)
 		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2692,13 +2692,13 @@ func TestAuthHandler_ClaimPendingInvitationForExistingUser(t *testing.T) {
 		orgID := uuid.New()
 		invID := uuid.New()
 
-		mock.ExpectBegin()
 		mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnRows(
 				pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 					AddRow(invID, orgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 			)
+		mock.ExpectBegin()
 		mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -2724,14 +2724,13 @@ func TestAuthHandler_ClaimPendingInvitationForExistingUser(t *testing.T) {
 		defer mock.Close()
 
 		invID := uuid.New()
-		mock.ExpectBegin()
+		// Mismatch is detected before any tx is opened — no Begin/Rollback.
 		mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 			WithArgs(pgxmock.AnyArg()).
 			WillReturnRows(
 				pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 					AddRow(invID, uuid.New(), strPtr("invitee@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 			)
-		mock.ExpectRollback()
 
 		handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -2745,6 +2744,16 @@ func TestAuthHandler_ClaimPendingInvitationForExistingUser(t *testing.T) {
 		require.NoError(t, err)
 		defer mock.Close()
 
+		// Validation succeeds (SELECT returns a valid pending invite for the
+		// caller's email), then the accept tx fails to begin — that hard
+		// error must not propagate out of the OAuth-driven best-effort path.
+		invID := uuid.New()
+		mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
+					AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
+			)
 		mock.ExpectBegin().WillReturnError(errors.New("db gone"))
 
 		handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
@@ -2766,13 +2775,13 @@ func TestAuthHandler_ClaimInvitationForExistingUser_AcceptRace(t *testing.T) {
 	orgID := uuid.New()
 	invID := uuid.New()
 
-	mock.ExpectBegin()
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
 				AddRow(invID, orgID, strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
 		)
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnError(pgx.ErrNoRows)
@@ -2790,7 +2799,10 @@ func TestAuthHandler_ClaimInvitationForExistingUser_AcceptRace(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-// claimInvitationForExistingUser bubbles begin-transaction failures.
+// claimInvitationForExistingUser bubbles begin-transaction failures from
+// the accept path. Validation runs on the pool first; the tx only opens
+// after a successful validation, so this test seeds a valid invitation
+// row before failing the Begin.
 func TestAuthHandler_ClaimInvitationForExistingUser_BeginFails(t *testing.T) {
 	t.Parallel()
 
@@ -2798,6 +2810,13 @@ func TestAuthHandler_ClaimInvitationForExistingUser_BeginFails(t *testing.T) {
 	require.NoError(t, err)
 	defer mock.Close()
 
+	invID := uuid.New()
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "valid", "pending", time.Now().Add(time.Hour), time.Now(), nil),
+		)
 	mock.ExpectBegin().WillReturnError(errors.New("db down"))
 
 	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
@@ -2826,11 +2845,11 @@ func TestAuthHandler_ClaimInvitationForExistingUser_TokenNotFound(t *testing.T) 
 	require.NoError(t, err)
 	defer mock.Close()
 
-	mock.ExpectBegin()
+	// Token lookup misses entirely — validation returns INVITE_NOT_FOUND
+	// without ever opening the accept tx, so no Begin/Rollback is expected.
 	mock.ExpectQuery("SELECT .+ FROM invitations WHERE token").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "email", "github_username", "role", "invited_by", "token", "status", "expires_at", "created_at", "accepted_at"}))
-	mock.ExpectRollback()
 
 	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
 	inv, _, invErr, err := handler.claimInvitationForExistingUser(context.Background(), "missing", "u@example.com", "", uuid.New())

--- a/internal/api/handlers/invitations.go
+++ b/internal/api/handlers/invitations.go
@@ -137,12 +137,19 @@ func (h *AuthHandler) AcceptInvitationByID(w http.ResponseWriter, r *http.Reques
 // distinguished in the audit stream (AuditActionTeamInvitationDeclined),
 // which is where downstream analytics belong anyway.
 //
-// Audit is emitted only on successful decline. A non-recipient probe or a
-// malformed id returns early without writing an audit row — these are
-// authorization failures whose breadcrumbs live in the zerolog warn
-// emitted from loadInvitationForRecipient plus the ClaimRateLimit's
-// per-IP ceiling, which is the same pattern the token-based claim path
-// uses for its lookup/mismatch cases.
+// Audit policy — deliberately asymmetric from the token-claim path:
+//
+//   - Success → AuditActionTeamInvitationDeclined row against inv.OrgID.
+//   - Malformed id / 404 / 403 non-recipient probe → no audit row.
+//     Unlike the token-claim path, which emits AuditActionTeamInvitationClaimFailed
+//     for wrong-account attempts, we do NOT persist a claim-failed row for
+//     decline probes: the user is trying to make an invitation go away, not
+//     acquire membership, so there is no privilege-escalation signal in the
+//     attempt that admins of the target org need to see. The zerolog warn
+//     emitted from loadInvitationForRecipient and the ClaimRateLimit's
+//     per-IP ceiling still cover the ops/security-monitoring angle.
+//   - Concurrent revoke race (410) → no audit row: the real action was
+//     whichever write landed first, and it already logged its own row.
 //
 // lint:allow-no-orgid reason="invitee-scoped decline; org context is the invitation's own org_id"
 func (h *AuthHandler) DeclineInvitationByID(w http.ResponseWriter, r *http.Request) {

--- a/internal/api/handlers/invitations.go
+++ b/internal/api/handlers/invitations.go
@@ -1,0 +1,287 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// ListPendingInvitations returns the pending invitations addressed to the
+// authenticated user — surfaces the in-app "you have invitations" affordance
+// in the org switcher without forcing the user to open the email link.
+//
+// Endpoint is intentionally not org-scoped: invitations span organizations,
+// and a user with zero memberships still needs to see the invites that would
+// give them access. Filtering and dedupe happen in the store query (see
+// InvitationStore.ListPendingForUser); this handler only shapes the response.
+//
+// lint:allow-no-orgid reason="user-scoped query spanning all orgs the user is invited to"
+func (h *AuthHandler) ListPendingInvitations(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	githubLogin := ""
+	if user.GitHubLogin != nil {
+		githubLogin = *user.GitHubLogin
+	}
+
+	rows, err := h.invitationStore.ListPendingForUser(r.Context(), user.ID, user.Email, githubLogin)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "LIST_FAILED", "failed to list pending invitations", err)
+		return
+	}
+
+	responses := make([]models.PendingInvitationForUser, 0, len(rows))
+	for _, row := range rows {
+		responses = append(responses, models.PendingInvitationForUser{
+			ID:      row.ID,
+			OrgID:   row.OrgID,
+			OrgName: row.OrgName,
+			Role:    row.Role,
+			InvitedBy: models.UserBrief{
+				ID:   row.InvitedBy,
+				Name: row.InviterName,
+			},
+			ExpiresAt: row.ExpiresAt,
+			CreatedAt: row.CreatedAt,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, models.ListResponse[models.PendingInvitationForUser]{Data: responses})
+}
+
+// AcceptInvitationByID is the in-app counterpart to ClaimInvitation: the user
+// is already authenticated, sees the invitation in their org switcher, and
+// accepts it inline. Distinct from the token route because (a) the token is
+// never returned by the API once the user is in-app, and (b) this path does
+// not move the user's persisted active-org preference — the frontend offers
+// an explicit "Switch to it" affordance after acceptance so the user is not
+// teleported out of whatever org they were working in.
+//
+// Recipient match is re-checked server-side against the session even though
+// the listing already filtered to claimable invites: the URL-named id could
+// otherwise be probed by an authenticated user against any invitation row.
+//
+// lint:allow-no-orgid reason="invitee-scoped accept; org context is the invitation's own org_id"
+func (h *AuthHandler) AcceptInvitationByID(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	invID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid invitation id")
+		return
+	}
+
+	githubLogin := ""
+	if user.GitHubLogin != nil {
+		githubLogin = *user.GitHubLogin
+	}
+
+	inv, invErr, err := h.loadInvitationForRecipient(r, user, invID, githubLogin, false)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "INVITE_LOOKUP_FAILED", "failed to look up invitation", err)
+		return
+	}
+	if invErr != nil {
+		writeError(w, r, invErr.status, invErr.code, invErr.message)
+		return
+	}
+
+	effectiveRole, acceptErr, err := h.acceptValidatedInvitation(r.Context(), &inv, user.ID, inv.Role, acceptOptions{updateLastOrgID: false})
+	if err != nil {
+		zerolog.Ctx(r.Context()).Warn().Err(err).Str("user_id", user.ID.String()).Msg("failed to accept invitation by id")
+		h.emitInvitationClaimFailed(r, user.ID, &inv, "INTERNAL_ERROR", "internal error during invitation accept")
+		writeError(w, r, http.StatusInternalServerError, "ACCEPT_FAILED", "failed to accept invitation", err)
+		return
+	}
+	if acceptErr != nil {
+		h.emitInvitationClaimFailed(r, user.ID, &inv, acceptErr.code, acceptErr.message)
+		writeError(w, r, acceptErr.status, acceptErr.code, acceptErr.message)
+		return
+	}
+
+	h.emitInvitationAccepted(r, user.ID, &inv)
+
+	// Echo the *effective* role rather than inv.Role: GrantAtLeast never
+	// downgrades, so a user who already held a higher membership in this org
+	// keeps it. Returning inv.Role here would mislead the org switcher into
+	// rendering a role the user does not actually hold.
+	writeJSON(w, http.StatusOK, map[string]any{
+		"data": map[string]any{
+			"org_id": inv.OrgID,
+			"role":   effectiveRole,
+		},
+	})
+}
+
+// DeclineInvitationByID lets the invitee dismiss an invitation from the
+// in-app surface. The row is marked 'revoked' (rather than a separate
+// 'declined' status) so the partial unique indexes free up immediately and
+// an admin can re-invite without schema-aware logic. Decline-vs-revoke is
+// distinguished in the audit stream (AuditActionTeamInvitationDeclined),
+// which is where downstream analytics belong anyway.
+//
+// Audit is emitted only on successful decline. A non-recipient probe or a
+// malformed id returns early without writing an audit row — these are
+// authorization failures whose breadcrumbs live in the zerolog warn
+// emitted from loadInvitationForRecipient plus the ClaimRateLimit's
+// per-IP ceiling, which is the same pattern the token-based claim path
+// uses for its lookup/mismatch cases.
+//
+// lint:allow-no-orgid reason="invitee-scoped decline; org context is the invitation's own org_id"
+func (h *AuthHandler) DeclineInvitationByID(w http.ResponseWriter, r *http.Request) {
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "not authenticated")
+		return
+	}
+
+	invID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid invitation id")
+		return
+	}
+
+	githubLogin := ""
+	if user.GitHubLogin != nil {
+		githubLogin = *user.GitHubLogin
+	}
+
+	// allowExpired=true on decline: if the dropdown was stale and the invite
+	// expired while the user stared at it, surfacing INVITE_EXPIRED (410) here
+	// would trap them with a row they can't dismiss. The Revoke WHERE
+	// status='pending' still guards the real concurrency races.
+	inv, invErr, err := h.loadInvitationForRecipient(r, user, invID, githubLogin, true)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "INVITE_LOOKUP_FAILED", "failed to look up invitation", err)
+		return
+	}
+	if invErr != nil {
+		writeError(w, r, invErr.status, invErr.code, invErr.message)
+		return
+	}
+
+	if err := h.invitationStore.Revoke(r.Context(), inv.OrgID, inv.ID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Concurrent revoke / accept landed first. Idempotent from the
+			// invitee's perspective: the invitation is gone, which is what
+			// they asked for. Surface a 410 so the frontend can refresh.
+			writeError(w, r, http.StatusGone, "INVITE_INVALID", "this invitation is no longer valid")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "DECLINE_FAILED", "failed to decline invitation", err)
+		return
+	}
+
+	h.emitInvitationDeclined(r, user.ID, &inv)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// loadInvitationForRecipient is the lookup-and-validate prelude shared by
+// the id-based accept and decline handlers. It returns:
+//   - (inv, nil, nil) on success
+//   - (zero, *invitationError, nil) for client-visible failures (404, 410, 403)
+//   - (zero, nil, error) for unexpected DB failures the caller should log+500
+//
+// INVITE_MISMATCH is remapped to 403 here (vs the token route's 400): the
+// id is part of the URL, so the request *names* a specific invitation the
+// user has no claim to — that's an authorization failure, not malformed
+// input. The mismatch is also logged so security monitoring can spot
+// probing patterns the same way it does for the token-claim path. A
+// lookup miss (ErrNoRows) is logged for the same reason: authenticated
+// users walking random UUIDs is worth a breadcrumb even though the
+// ClaimRateLimit caps the blast radius.
+//
+// allowExpired=true lets callers (the decline path) treat an expired
+// invitation as a valid target — the recipient should still be able to
+// dismiss it from their UI. Status and recipient-match checks are
+// unconditional; the Revoke / Accept WHERE clauses remain the authoritative
+// concurrency guard.
+func (h *AuthHandler) loadInvitationForRecipient(r *http.Request, user *models.User, invID uuid.UUID, githubLogin string, allowExpired bool) (models.Invitation, *invitationError, error) {
+	inv, err := h.invitationStore.GetByID(r.Context(), invID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			zerolog.Ctx(r.Context()).Warn().
+				Str("user_id", user.ID.String()).
+				Str("invitation_id", invID.String()).
+				Msg("invitation accept/decline attempted against unknown id")
+			return models.Invitation{}, &invitationError{http.StatusNotFound, "INVITE_NOT_FOUND", "invitation not found"}, nil
+		}
+		return models.Invitation{}, nil, err
+	}
+
+	invErr := validateInvitationForRecipient(inv, user.Email, githubLogin)
+	if invErr != nil {
+		if allowExpired && invErr.code == "INVITE_EXPIRED" {
+			return inv, nil, nil
+		}
+		if invErr.code == "INVITE_MISMATCH" {
+			// Defensive copy rather than mutating in place: a future refactor
+			// of validateInvitationForRecipient that returns a package-level
+			// sentinel (a common cleanup) would otherwise leak this 403
+			// status into the token-claim path that wants the original 400.
+			invErr = &invitationError{
+				status:  http.StatusForbidden,
+				code:    invErr.code,
+				message: invErr.message,
+			}
+			zerolog.Ctx(r.Context()).Warn().
+				Str("user_id", user.ID.String()).
+				Str("invitation_id", inv.ID.String()).
+				Msg("invitation accept/decline attempted by non-recipient")
+		}
+		return inv, invErr, nil
+	}
+
+	return inv, nil, nil
+}
+
+// emitInvitationDeclined records a decline action against the invitation's
+// org. Mirrors emitInvitationAccepted so the audit stream carries a clean
+// declined-vs-revoked distinction (the row's status column collapses both
+// to 'revoked' to keep the partial unique indexes simple, but downstream
+// analytics that care about the difference can read it from this action).
+func (h *AuthHandler) emitInvitationDeclined(
+	r *http.Request,
+	userID uuid.UUID,
+	inv *models.Invitation,
+) {
+	if h.audit == nil || inv == nil {
+		return
+	}
+	invIDStr := inv.ID.String()
+	details, _ := json.Marshal(map[string]any{
+		"invitation_id":   inv.ID.String(),
+		"email":           optString(inv.Email),
+		"github_username": optString(inv.GitHubUsername),
+		"role":            inv.Role,
+		"invited_by":      inv.InvitedBy.String(),
+		"changes": map[string]any{
+			"status": auditChange("pending", "revoked"),
+		},
+	})
+	h.audit.EmitUserAction(r.Context(), db.UserActionParams{
+		OrgID:        inv.OrgID,
+		UserID:       userID,
+		Action:       models.AuditActionTeamInvitationDeclined,
+		ResourceType: models.AuditResourceInvitation,
+		ResourceID:   &invIDStr,
+		Details:      details,
+	})
+}

--- a/internal/api/handlers/invitations_test.go
+++ b/internal/api/handlers/invitations_test.go
@@ -1,0 +1,580 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/config"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// invitationRowColumns matches the InvitationStore column projection used by
+// GetByToken / GetByID — duplicated here rather than imported because the
+// test file lives in the handlers package, not internal/db.
+var invitationRowColumns = []string{
+	"id", "org_id", "email", "github_username", "role",
+	"invited_by", "token", "status", "expires_at", "created_at", "accepted_at",
+}
+
+// pendingForUserRowColumns matches the wrapper-projection of ListPendingForUser
+// (org_name + inviter_name come from the JOIN, token/email/etc. are dropped).
+var pendingForUserRowColumns = []string{
+	"id", "org_id", "org_name", "role", "invited_by", "inviter_name", "expires_at", "created_at",
+}
+
+// requestWithChiURLParam wraps the request context so chi.URLParam("id")
+// resolves to the supplied value. Required because the handlers read the
+// URL-named id without going through the chi router (httptest skips routing).
+func requestWithChiURLParam(req *http.Request, key, value string) *http.Request {
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add(key, value)
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+// ListPendingInvitations rejects unauthenticated requests with 401 — anyone
+// reading this endpoint must have a session, since the response is filtered
+// to the caller's email/github_login.
+func TestAuthHandler_ListPendingInvitations_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAuthHandler(&config.Config{}, nil, nil, nil, nil, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/invitations/pending", nil)
+	w := httptest.NewRecorder()
+
+	handler.ListPendingInvitations(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// Empty result is a 200 with `data: []`, not a 404 — the org-switcher poll
+// distinguishes "no invites" from "list lookup failed" by status code.
+func TestAuthHandler_ListPendingInvitations_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery("FROM invitations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pendingForUserRowColumns))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/invitations/pending", nil)
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.ListPendingInvitations(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), `"data":[]`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Happy path: the wrapper row projection decodes into the JSON response shape
+// the frontend consumes, with org_name and inviter UserBrief populated.
+func TestAuthHandler_ListPendingInvitations_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	inviterID := uuid.New()
+	invID := uuid.New()
+
+	mock.ExpectQuery("FROM invitations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(pendingForUserRowColumns).
+				AddRow(invID, orgID, "Acme", "member", inviterID, "Alice", now.Add(72*time.Hour), now),
+		)
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "invitee@example.com"}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/invitations/pending", nil)
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.ListPendingInvitations(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	body := w.Body.String()
+	require.Contains(t, body, `"org_name":"Acme"`)
+	require.Contains(t, body, `"role":"member"`)
+	require.Contains(t, body, `"name":"Alice"`)
+	require.Contains(t, body, orgID.String())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// AcceptInvitationByID rejects requests without an authenticated user.
+func TestAuthHandler_AcceptInvitationByID_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAuthHandler(&config.Config{}, nil, nil, nil, nil, nil)
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", uuid.New().String())
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// Malformed id in the URL surfaces as 400 — the handler shouldn't call into
+// the store with a zero-value uuid.
+func TestAuthHandler_AcceptInvitationByID_InvalidID(t *testing.T) {
+	t.Parallel()
+
+	handler := NewAuthHandler(&config.Config{}, nil, nil, nil, nil, nil)
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", "not-a-uuid")
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_ID")
+}
+
+// Happy path. Validation runs on the pool, then the accept tx fires Begin →
+// UPDATE invitations → INSERT memberships → Commit. last_org_id is NOT
+// updated (acceptOptions{updateLastOrgID:false}) so the user stays in their
+// current org.
+func TestAuthHandler_AcceptInvitationByID_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	userID := uuid.New()
+	invOrgID := uuid.New()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	mock.ExpectCommit()
+	// audit_logs INSERT for the accepted action.
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+	user := &models.User{ID: userID, Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Body.String(), invOrgID.String())
+	require.Contains(t, w.Body.String(), `"role":"member"`)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// A user trying to accept an invitation addressed to someone else gets 403,
+// not 400 — the id in the URL names a specific row, so the failure is an
+// authorization problem, not bad input.
+func TestAuthHandler_AcceptInvitationByID_Mismatch_Returns403(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("someone-else@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "wrong@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_MISMATCH")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Expired invitations return 410 GONE so the frontend knows to drop them
+// from the dropdown rather than retry.
+func TestAuthHandler_AcceptInvitationByID_Expired_Returns410(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(-time.Hour), now.Add(-2*time.Hour), nil),
+		)
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusGone, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_EXPIRED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Race: invitation is pending at SELECT time but a concurrent revoke / accept
+// landed before our UPDATE. The Accept WHERE status='pending' clause returns
+// ErrNoRows, which acceptValidatedInvitation maps to INVITE_INVALID 410.
+func TestAuthHandler_AcceptInvitationByID_AcceptRace_Returns410(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+	mock.ExpectRollback()
+	// Failed-claim audit fires after the rollback — invitation row is loaded,
+	// so the audit emitter writes against the inviting org.
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusGone, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_INVALID")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// AcceptInvitationByID does NOT update the user's last_org_id — that's
+// reserved for the email-link claim path. Verified here by the absence of a
+// UPDATE users ... last_org_id expectation; if the handler regressed to
+// updating it, pgxmock would fail the test on an unexpected exec.
+func TestAuthHandler_AcceptInvitationByID_DoesNotUpdateLastOrgID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE invitations SET status = 'accepted'").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("member"))
+	mock.ExpectCommit()
+	// Audit emitter is left nil so no audit_logs INSERT is expected; pgxmock
+	// flags any unexpected statement as a failure, which is the test guard.
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// DeclineInvitationByID happy path: load → match-check → revoke → audit emit.
+func TestAuthHandler_DeclineInvitationByID_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+	invOrgID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+	mock.ExpectExec("UPDATE invitations SET status = 'revoked'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// Decline audit row fires post-revoke.
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/decline", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.DeclineInvitationByID(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Decline by a non-recipient is also 403 — same authorization model as accept.
+// No audit row is written for the failed attempt (we don't have org context
+// for an attempted decline by a non-recipient that's worth persisting).
+func TestAuthHandler_DeclineInvitationByID_Mismatch_Returns403(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("someone-else@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "wrong@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/decline", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.DeclineInvitationByID(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_MISMATCH")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Concurrent revoke or accept landed first → revoke returns ErrNoRows → 410.
+func TestAuthHandler_DeclineInvitationByID_AlreadyResolved_Returns410(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(time.Hour), now, nil),
+		)
+	mock.ExpectExec("UPDATE invitations SET status = 'revoked'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/decline", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.DeclineInvitationByID(w, req)
+	require.Equal(t, http.StatusGone, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_INVALID")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Decline allows expired invitations: the row is still the recipient's to
+// dismiss even if the dropdown staled across expiry. Revoke's status='pending'
+// WHERE clause remains the real concurrency guard — here it succeeds because
+// we model the expired row as still pending (nothing sweeps them today).
+func TestAuthHandler_DeclineInvitationByID_Expired_AllowsDismissal(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+	invOrgID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, invOrgID, strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(-time.Hour), now.Add(-2*time.Hour), nil),
+		)
+	mock.ExpectExec("UPDATE invitations SET status = 'revoked'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// Audit still emits — the user took an action, and downstream analytics
+	// should see the decline regardless of expiry state.
+	mock.ExpectQuery("INSERT INTO audit_logs").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	handler.SetAuditEmitter(db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop()))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/decline", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.DeclineInvitationByID(w, req)
+	require.Equal(t, http.StatusNoContent, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Accept does NOT allow expired invitations — the user is trying to claim a
+// grant that has timed out, which is substantively different from declining
+// one. 410 GONE is the honest status so the dropdown drops the row.
+func TestAuthHandler_AcceptInvitationByID_Expired_Still410(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	invID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationRowColumns).
+				AddRow(invID, uuid.New(), strPtr("u@example.com"), nil, "member", uuid.New(), "tok", "pending", now.Add(-time.Hour), now.Add(-2*time.Hour), nil),
+		)
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", invID.String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusGone, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_EXPIRED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// 404 path: the URL names an id that doesn't exist.
+func TestAuthHandler_AcceptInvitationByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(invitationRowColumns))
+
+	handler := NewAuthHandler(&config.Config{}, mock, db.NewUserStore(mock), nil, db.NewInvitationStore(mock), db.NewOrganizationMembershipStore(mock))
+	user := &models.User{ID: uuid.New(), Email: "u@example.com"}
+
+	req := requestWithChiURLParam(httptest.NewRequest(http.MethodPost, "/api/v1/invitations/x/accept", nil), "id", uuid.New().String())
+	req = req.WithContext(middleware.WithUser(req.Context(), user))
+	w := httptest.NewRecorder()
+
+	handler.AcceptInvitationByID(w, req)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Contains(t, w.Body.String(), "INVITE_NOT_FOUND")
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -48,15 +48,18 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"InternalProjectHandler.Propose": "internal API, uses claims.OrgID",
 
 		// Authenticated but legitimately no org-scoped data access.
-		"AuthHandler.Me":                   "returns user from context only",
-		"AuthHandler.Logout":               "deletes session by cookie token only",
-		"AuthHandler.SetActiveOrg":         "user-scoped preference write; validates membership directly instead of using request org context",
-		"AuthHandler.ClaimInvitation":      "grants membership in a different org than the active one; target org comes from the invitation token, not the request context",
-		"OrganizationsHandler.Create":      "creates a new org; runs outside OrgContext, no pre-existing org to scope against",
-		"SettingsHandler.GetLLMDefaults":   "returns static server config",
-		"SettingsHandler.GetLLMModels":     "returns static server config",
-		"ProjectGenerateHandler.Generate":  "calls LLM only, no org-scoped data",
-		"GitHubStatusHandler.StartConnect": "OAuth redirect only, no store calls",
+		"AuthHandler.Me":                     "returns user from context only",
+		"AuthHandler.Logout":                 "deletes session by cookie token only",
+		"AuthHandler.SetActiveOrg":           "user-scoped preference write; validates membership directly instead of using request org context",
+		"AuthHandler.ClaimInvitation":        "grants membership in a different org than the active one; target org comes from the invitation token, not the request context",
+		"AuthHandler.ListPendingInvitations": "user-scoped query spanning all orgs the user is invited to",
+		"AuthHandler.AcceptInvitationByID":   "invitee-scoped accept; org context comes from the invitation row itself, not the request",
+		"AuthHandler.DeclineInvitationByID":  "invitee-scoped decline; org context comes from the invitation row itself, not the request",
+		"OrganizationsHandler.Create":        "creates a new org; runs outside OrgContext, no pre-existing org to scope against",
+		"SettingsHandler.GetLLMDefaults":     "returns static server config",
+		"SettingsHandler.GetLLMModels":       "returns static server config",
+		"ProjectGenerateHandler.Generate":    "calls LLM only, no org-scoped data",
+		"GitHubStatusHandler.StartConnect":   "OAuth redirect only, no store calls",
 
 		// OAuth start handlers — just redirect to external provider, no org data access.
 		"IntegrationHandler.StartLinearOAuth": "OAuth redirect only",

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -537,6 +537,19 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			// IP limit forces any enumeration attempt into detectable territory.
 			r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/invitations/claim", authHandler.ClaimInvitation)
 
+			// In-app pending-invitation surface (org switcher dot + dropdown
+			// section). Sits alongside /invitations/claim outside the
+			// OrgContext block because invitations span organizations and
+			// matter most to users with no usable active org (e.g. a fresh
+			// signup or someone removed from their last org). The mutation
+			// routes share the claim endpoint's 10/min ClaimRateLimit since
+			// they are equivalent brute-force surfaces — the URL names a
+			// specific invitation row that the server validates against the
+			// session's email/github_login.
+			r.Get("/api/v1/invitations/pending", authHandler.ListPendingInvitations)
+			r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/invitations/{id}/accept", authHandler.AcceptInvitationByID)
+			r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/invitations/{id}/decline", authHandler.DeclineInvitationByID)
+
 			// Creating a new org is zero-membership-safe for the same reason the
 			// other routes in this block are: a user whose only membership was
 			// just revoked must be able to create a fresh org to recover, and

--- a/internal/db/invitation_store_test.go
+++ b/internal/db/invitation_store_test.go
@@ -253,3 +253,199 @@ func TestInvitationStore_Revoke_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
+
+func TestInvitationStore_GetByID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+	now := time.Now()
+	id := uuid.New()
+	orgID := uuid.New()
+	invitedBy := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(invitationColumns).
+				AddRow(id, orgID, strPtr("invitee@example.com"), nil, "member", invitedBy, "tok_abc", "pending", now.Add(72*time.Hour), now, nil),
+		)
+
+	inv, err := store.GetByID(context.Background(), id)
+	require.NoError(t, err)
+	require.Equal(t, id, inv.ID)
+	require.NotNil(t, inv.Email)
+	require.Equal(t, "invitee@example.com", *inv.Email)
+	require.Equal(t, "pending", inv.Status)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInvitationStore_GetByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	mock.ExpectQuery("SELECT .+ FROM invitations WHERE id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(invitationColumns))
+
+	_, err = store.GetByID(context.Background(), uuid.New())
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// pendingForUserColumns mirrors the column projection of ListPendingForUser.
+// The query joins invitations with organizations and users and projects a
+// flatter row than the bare invitation columns above; tests need a matching
+// shape so pgxmock can drive RowToStructByName decoding.
+var pendingForUserColumns = []string{
+	"id", "org_id", "org_name", "role", "invited_by", "inviter_name", "expires_at", "created_at",
+}
+
+func TestInvitationStore_ListPendingForUser(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+	now := time.Now()
+	userID := uuid.New()
+	orgA := uuid.New()
+	orgB := uuid.New()
+	inviterA := uuid.New()
+	inviterB := uuid.New()
+
+	// Two distinct orgs come back from the dedupe layer; the row order is
+	// the wrapper SELECT's ORDER BY created_at DESC, so the most-recent
+	// invite is first.
+	mock.ExpectQuery("FROM invitations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(pendingForUserColumns).
+				AddRow(uuid.New(), orgA, "Acme", "member", inviterA, "Alice", now.Add(72*time.Hour), now).
+				AddRow(uuid.New(), orgB, "Globex", "admin", inviterB, "Bob", now.Add(72*time.Hour), now.Add(-time.Hour)),
+		)
+
+	rows, err := store.ListPendingForUser(context.Background(), userID, "invitee@example.com", "invitee-gh")
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	require.Equal(t, "Acme", rows[0].OrgName)
+	require.Equal(t, "Alice", rows[0].InviterName)
+	require.Equal(t, "member", rows[0].Role)
+	require.Equal(t, "Globex", rows[1].OrgName)
+	require.Equal(t, "Bob", rows[1].InviterName)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInvitationStore_ListPendingForUser_Empty(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	mock.ExpectQuery("FROM invitations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pendingForUserColumns))
+
+	rows, err := store.ListPendingForUser(context.Background(), uuid.New(), "nobody@example.com", "")
+	require.NoError(t, err)
+	require.Empty(t, rows)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInvitationStore_ListPendingForUser_QueryError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	mock.ExpectQuery("FROM invitations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("connection lost"))
+
+	_, err = store.ListPendingForUser(context.Background(), uuid.New(), "x@example.com", "")
+	require.Error(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// The query must use DISTINCT ON (i.org_id) so a user with both an email-
+// invite and a github-invite for the same org sees a single dropdown row,
+// and must filter out invites for orgs the user is already a member of so
+// the dropdown can't surface an invite that would 409 on accept. pgxmock
+// can't evaluate the SQL semantically; this test pins the query *shape*
+// so a refactor that drops either guard breaks loudly instead of silently
+// regressing the user-facing dedupe and already-member behaviors.
+func TestInvitationStore_ListPendingForUser_QueryShape(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	// Both regex anchors must match the SAME query string. ExpectQuery's
+	// argument is a regex, so escape the parens for the DISTINCT ON clause.
+	mock.ExpectQuery(`DISTINCT ON \(i\.org_id\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pendingForUserColumns))
+
+	_, err = store.ListPendingForUser(context.Background(), uuid.New(), "u@example.com", "")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestInvitationStore_ListPendingForUser_FiltersExistingMemberships(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	mock.ExpectQuery(`NOT EXISTS.*organization_memberships`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pendingForUserColumns))
+
+	_, err = store.ListPendingForUser(context.Background(), uuid.New(), "u@example.com", "")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// Expired invites are pending in the DB until they're swept (and there is no
+// sweeper today), so the query must filter them with expires_at > now() to
+// avoid surfacing rows that would 410 on accept. Same anti-drift rationale as
+// the DISTINCT ON / NOT EXISTS pin above.
+func TestInvitationStore_ListPendingForUser_FiltersExpired(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewInvitationStore(mock)
+
+	mock.ExpectQuery(`expires_at > now\(\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(pendingForUserColumns))
+
+	_, err = store.ListPendingForUser(context.Background(), uuid.New(), "u@example.com", "")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/db/invitations.go
+++ b/internal/db/invitations.go
@@ -60,6 +60,78 @@ func (s *InvitationStore) GetByToken(ctx context.Context, token string) (models.
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Invitation])
 }
 
+// GetByID looks up an invitation by id regardless of status. The caller is
+// responsible for any status / expiry / recipient-match checks; this is the
+// primary entry point for the invitee-side accept and decline routes, which
+// authenticate the *user* via the session and then re-validate the invite
+// against that user's email and github_login.
+//
+// lint:allow-no-orgid reason="invitation id is globally unique; org context comes from the row itself"
+func (s *InvitationStore) GetByID(ctx context.Context, id uuid.UUID) (models.Invitation, error) {
+	query := fmt.Sprintf(`SELECT %s FROM invitations WHERE id = @id`, invitationSelectColumns)
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"id": id})
+	if err != nil {
+		return models.Invitation{}, fmt.Errorf("query invitation by id: %w", err)
+	}
+	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Invitation])
+}
+
+// ListPendingForUser returns the active invitations addressed to the given
+// user — those where the invitation's email or github_username matches and
+// the user is not already a member of the target org. Used by the in-app
+// pending-invitations surface (org switcher dot + dropdown section).
+//
+// Match semantics intentionally mirror validateInvitationWithStore in the
+// auth handler: case-insensitive equality on either identifier, with empty
+// inputs treated as no-match (an unauthenticated identifier cannot satisfy
+// either branch). Drift between this query and the claim-time check would
+// produce the worst-possible UX: an invitation visible in the dropdown that
+// rejects on accept with INVITE_MISMATCH. Any change here needs a matching
+// edit there.
+//
+// Dedupe by org: an admin can technically issue both an email-invite and a
+// github-invite that resolve to the same person (the partial unique indexes
+// only constrain duplicates of the *same* identifier, not cross-identifier
+// duplicates for the same target). DISTINCT ON folds those down to one row
+// per org so the UI doesn't show two "Acme [Accept]" rows for one human; the
+// outer ORDER BY restores the most-recent-first display order.
+//
+// lint:allow-no-orgid reason="user-scoped query spanning all orgs the user is invited to"
+func (s *InvitationStore) ListPendingForUser(ctx context.Context, userID uuid.UUID, email, githubLogin string) ([]models.PendingInvitationForUserRow, error) {
+	query := `
+		SELECT id, org_id, org_name, role, invited_by, inviter_name, expires_at, created_at
+		FROM (
+			SELECT DISTINCT ON (i.org_id)
+				i.id, i.org_id, o.name AS org_name, i.role,
+				i.invited_by, COALESCE(u.name, '') AS inviter_name,
+				i.expires_at, i.created_at
+			FROM invitations i
+			JOIN organizations o ON o.id = i.org_id
+			LEFT JOIN users u ON u.id = i.invited_by
+			WHERE i.status = 'pending'
+			  AND i.expires_at > now()
+			  AND (
+			      (i.email IS NOT NULL          AND @email        <> '' AND lower(i.email)          = lower(@email))
+			   OR (i.github_username IS NOT NULL AND @github_login <> '' AND lower(i.github_username) = lower(@github_login))
+			  )
+			  AND NOT EXISTS (
+			      SELECT 1 FROM organization_memberships m
+			      WHERE m.user_id = @user_id AND m.org_id = i.org_id
+			  )
+			ORDER BY i.org_id, i.created_at DESC
+		) deduped
+		ORDER BY created_at DESC`
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"user_id":      userID,
+		"email":        email,
+		"github_login": githubLogin,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query pending invitations for user: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.PendingInvitationForUserRow])
+}
+
 // ListPendingByOrg returns all pending invitations for the org.
 func (s *InvitationStore) ListPendingByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Invitation, error) {
 	query := fmt.Sprintf(`SELECT %s FROM invitations WHERE org_id = @org_id AND status = 'pending' ORDER BY created_at DESC`, invitationSelectColumns)

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -88,6 +88,7 @@ const (
 	AuditActionTeamMemberRemoved         AuditAction = "team.member_removed"
 	AuditActionTeamInvitationRevoked     AuditAction = "team.invitation_revoked"
 	AuditActionTeamInvitationAccepted    AuditAction = "team.invitation_accepted"
+	AuditActionTeamInvitationDeclined    AuditAction = "team.invitation_declined"
 	AuditActionTeamInvitationClaimFailed AuditAction = "team.invitation_claim_failed"
 
 	// Organization actions
@@ -134,7 +135,7 @@ func (a AuditAction) Validate() error {
 		AuditActionPMDocumentUpdated, AuditActionPMDocumentRestored, AuditActionPMDocumentSetPinned,
 		AuditActionSettingsUpdated, AuditActionTeamMemberInvited, AuditActionTeamMemberRoleChanged,
 		AuditActionTeamMemberRemoved, AuditActionTeamInvitationRevoked, AuditActionTeamInvitationAccepted,
-		AuditActionTeamInvitationClaimFailed,
+		AuditActionTeamInvitationDeclined, AuditActionTeamInvitationClaimFailed,
 		AuditActionOrganizationCreated,
 		AuditActionIntegrationConnected, AuditActionCredentialUpdated, AuditActionCredentialDeleted,
 		AuditActionAuthLogin, AuditActionAuthLogout, AuditActionAuthRegister,

--- a/internal/models/invitation.go
+++ b/internal/models/invitation.go
@@ -41,6 +41,41 @@ type InvitationWithInviter struct {
 	InviterName string `db:"inviter_name" json:"-"`
 }
 
+// PendingInvitationForUserRow is the DB row shape for ListPendingForUser:
+// invitations joined with the target organization (for org_name) and the
+// inviting user (for inviter name). Kept separate from the response type
+// because the JSON shape and DB shape differ: the response embeds the
+// inviter as a UserBrief, the row carries the two scalar columns.
+type PendingInvitationForUserRow struct {
+	ID          uuid.UUID `db:"id"`
+	OrgID       uuid.UUID `db:"org_id"`
+	OrgName     string    `db:"org_name"`
+	Role        string    `db:"role"`
+	InvitedBy   uuid.UUID `db:"invited_by"`
+	InviterName string    `db:"inviter_name"`
+	ExpiresAt   time.Time `db:"expires_at"`
+	CreatedAt   time.Time `db:"created_at"`
+}
+
+// PendingInvitationForUser is the API response shape for an invitation
+// surfaced to its potential claimer (the user the invitation matches by
+// email or github_username). Unlike InvitationResponse, this is rendered
+// for the *invitee* — so it carries the target org's name (the invitee
+// has no other way to know which org they're being invited into) and
+// deliberately omits the recipient identifier fields (the user is the
+// recipient; we don't echo their own email back at them) and the token
+// (accept/decline are id-routed and re-validate against the session, so
+// the token never needs to leave server-side state).
+type PendingInvitationForUser struct {
+	ID        uuid.UUID `json:"id"`
+	OrgID     uuid.UUID `json:"org_id"`
+	OrgName   string    `json:"org_name"`
+	Role      string    `json:"role"`
+	InvitedBy UserBrief `json:"invited_by"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // UserBrief is a minimal user representation for embedding in responses.
 type UserBrief struct {
 	ID   uuid.UUID `json:"id"`


### PR DESCRIPTION
## Summary
- Adds an in-app pending-invite surface (dot + "Pending invitations" section in the org switcher) backed by three new routes: `GET /api/v1/invitations/pending`, `POST /api/v1/invitations/{id}/accept`, `POST /api/v1/invitations/{id}/decline`.
- Accept grants membership without teleporting the user out of their current org; a "Switch to it" affordance renders from local state so it survives the list refetch. Decline marks the row revoked and emits a new `team.invitation_declined` audit action distinct from admin revokes.
- Refactors the token-claim path so validation runs on the pool and the accept transaction is shared with the id-based handlers, keeping the dropdown's "is this invite mine?" query in lockstep with the server-side recipient-match check.

## Test plan
- [ ] Unit tests: `go test ./internal/api/handlers/...` (invitation handler + org-id lint) and `go test ./internal/db/...` (store + query-shape pins for `DISTINCT ON`, `NOT EXISTS`, `expires_at > now()`)
- [ ] Frontend tests: `npx vitest run src/components/org-switcher.test.tsx`
- [ ] Manual: invite a user via email, log in as them, confirm the org-switcher dot appears and the dropdown section surfaces the invite; Accept keeps you in your current org; "Switch to it" moves you; Decline dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)
