### PR TITLE
Refactor session timeline transcript dedupe into shared helper

### DIFF
--- a/internal/services/sessiontimeline/timeline.go
+++ b/internal/services/sessiontimeline/timeline.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
 )
 
 const (
@@ -18,8 +19,15 @@ type logMetadata struct {
 	DuplicateOfTranscript bool   `json:"duplicate_of_transcript"`
 }
 
+type transcriptIdentity struct {
+	threadID   string
+	turnNumber int
+	content    string
+}
+
 // Compose merges session messages and logs into a server-owned timeline.
 func Compose(messages []models.SessionMessage, logs []models.SessionLog) []models.SessionTimelineEntry {
+	messages = dedupeAssistantTranscriptMessages(messages)
 	duplicateLogIDs := duplicateTranscriptLogIDs(messages, logs)
 
 	planModeTurns := make(map[int]struct{})
@@ -127,28 +135,47 @@ func Compose(messages []models.SessionMessage, logs []models.SessionLog) []model
 	return entries
 }
 
-func duplicateTranscriptLogIDs(messages []models.SessionMessage, logs []models.SessionLog) map[int64]struct{} {
-	visibleByTurnAndContent := make(map[int]map[string][]models.SessionLog)
-	for _, log := range logs {
-		if !isVisibleAssistantOutput(log) {
+func dedupeAssistantTranscriptMessages(messages []models.SessionMessage) []models.SessionMessage {
+	if len(messages) == 0 {
+		return messages
+	}
+
+	deduped := make([]models.SessionMessage, 0, len(messages))
+	seen := make(map[transcriptIdentity]struct{}, len(messages))
+
+	for _, msg := range messages {
+		key, ok := assistantTranscriptIdentity(msg)
+		if !ok {
+			deduped = append(deduped, msg)
 			continue
 		}
-		if _, ok := visibleByTurnAndContent[log.TurnNumber]; !ok {
-			visibleByTurnAndContent[log.TurnNumber] = make(map[string][]models.SessionLog)
+		if _, ok := seen[key]; ok {
+			continue
 		}
-		visibleByTurnAndContent[log.TurnNumber][log.Message] = append(visibleByTurnAndContent[log.TurnNumber][log.Message], log)
+		seen[key] = struct{}{}
+		deduped = append(deduped, msg)
+	}
+
+	return deduped
+}
+
+func duplicateTranscriptLogIDs(messages []models.SessionMessage, logs []models.SessionLog) map[int64]struct{} {
+	visibleByTranscript := make(map[transcriptIdentity][]models.SessionLog)
+	for _, log := range logs {
+		key, ok := visibleAssistantTranscriptIdentity(log)
+		if !ok {
+			continue
+		}
+		visibleByTranscript[key] = append(visibleByTranscript[key], log)
 	}
 
 	duplicateLogIDs := make(map[int64]struct{})
 	for _, msg := range messages {
-		if msg.Role != models.MessageRoleAssistant {
+		key, ok := assistantTranscriptIdentity(msg)
+		if !ok {
 			continue
 		}
-		turnGroups := visibleByTurnAndContent[msg.TurnNumber]
-		if len(turnGroups) == 0 {
-			continue
-		}
-		candidates := turnGroups[msg.Content]
+		candidates := visibleByTranscript[key]
 		if len(candidates) == 0 {
 			continue
 		}
@@ -192,4 +219,33 @@ func parseMetadata(raw json.RawMessage) logMetadata {
 		return logMetadata{}
 	}
 	return meta
+}
+
+func assistantTranscriptIdentity(msg models.SessionMessage) (transcriptIdentity, bool) {
+	if msg.Role != models.MessageRoleAssistant {
+		return transcriptIdentity{}, false
+	}
+	return transcriptIdentity{
+		threadID:   optionalThreadID(msg.ThreadID),
+		turnNumber: msg.TurnNumber,
+		content:    msg.Content,
+	}, true
+}
+
+func visibleAssistantTranscriptIdentity(log models.SessionLog) (transcriptIdentity, bool) {
+	if !isVisibleAssistantOutput(log) {
+		return transcriptIdentity{}, false
+	}
+	return transcriptIdentity{
+		threadID:   optionalThreadID(log.ThreadID),
+		turnNumber: log.TurnNumber,
+		content:    log.Message,
+	}, true
+}
+
+func optionalThreadID(threadID *uuid.UUID) string {
+	if threadID == nil {
+		return ""
+	}
+	return threadID.String()
 }

--- a/internal/services/sessiontimeline/timeline_test.go
+++ b/internal/services/sessiontimeline/timeline_test.go
@@ -234,6 +234,26 @@ func TestComposeTimeline_IgnoresAssistantMessagesWithoutMatchingTurnLogs(t *test
 	require.Equal(t, models.SessionTimelineKindMessage, result[1].Kind, "assistant message should remain visible")
 }
 
+func TestComposeTimeline_SuppressesDuplicateAssistantMessagesForSameTurn(t *testing.T) {
+	t.Parallel()
+
+	messages := []models.SessionMessage{
+		makeMessage(t, func(msg *models.SessionMessage) {
+			msg.ID = 1
+		}, "2026-01-01T00:00:02Z"),
+		makeMessage(t, func(msg *models.SessionMessage) {
+			msg.ID = 2
+			msg.CreatedAt = mustTime(t, "2026-01-01T00:00:03Z")
+		}, "2026-01-01T00:00:03Z"),
+	}
+
+	result := Compose(messages, nil)
+	require.Len(t, result, 1, "duplicate assistant transcript rows for the same turn should collapse to a single message")
+	require.Equal(t, models.SessionTimelineKindMessage, result[0].Kind, "deduped assistant transcript should still render as a message")
+	require.NotNil(t, result[0].Message, "message entry should include the assistant transcript payload")
+	require.Equal(t, int64(1), result[0].Message.ID, "the earliest duplicate assistant transcript should be preserved")
+}
+
 func TestComposeTimeline_TreatsInvalidMetadataAsVisibleOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
Refactored `sessiontimeline` to centralize “transcript identity” matching used for deduping end-of-session result messages. This removes duplicated matching semantics between assistant message dedupe and assistant-visible output dedupe while preserving the narrow matching behavior.

## Changes
- `internal/services/sessiontimeline/timeline.go`
  - Added `transcriptIdentity` and helper functions:
    - `assistantTranscriptIdentity`
    - `visibleAssistantTranscriptIdentity`
    - `optionalThreadID`
  - Introduced `dedupeAssistantTranscriptMessages(messages)` and applied it at the start of `Compose`.
  - Updated `duplicateTranscriptLogIDs` to key visible assistant output logs by the shared `transcriptIdentity` instead of separate turn/content maps.
- `internal/services/sessiontimeline/timeline_test.go`
  - Kept/updated the regression coverage to ensure matching behavior and dedupe results remain correct.

## Test plan
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Note: repo-wide checks were run sequentially (not concurrently) due to environment `/var/tmp` size limits; final sequential runs completed cleanly.

---
*Generated by [143.dev](https://143.dev) — [session 8b82681b](https://app.143.dev/sessions/8b82681b-7716-435d-a967-673f2974679b)*
