### PR TITLE
Fix ordered list numbering in markdown renderer by forwarding ol props

### DIFF
--- a/frontend/src/components/markdown.test.tsx
+++ b/frontend/src/components/markdown.test.tsx
@@ -54,6 +54,13 @@ describe("MarkdownContent", () => {
     expect(list).not.toBeNull();
   });
 
+  it("preserves ordered list start numbers", () => {
+    const md = "2. Second\n3. Third";
+    render(<MarkdownContent content={md} />);
+    const list = screen.getByText("Second").closest("ol");
+    expect(list).toHaveAttribute("start", "2");
+  });
+
   it("renders headings", () => {
     const md = "# Title\n## Subtitle\n### Section";
     render(<MarkdownContent content={md} />);

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -61,8 +61,15 @@ const components: Components = {
   ul({ children }) {
     return <ul className="mb-2 ml-4 list-disc space-y-0.5 last:mb-0">{children}</ul>;
   },
-  ol({ children }) {
-    return <ol className="mb-2 ml-4 list-decimal space-y-0.5 last:mb-0">{children}</ol>;
+  ol({ children, className, ...props }) {
+    return (
+      <ol
+        className={cn("mb-2 ml-4 list-decimal space-y-0.5 last:mb-0", className)}
+        {...props}
+      >
+        {children}
+      </ol>
+    );
   },
   li({ children }) {
     return <li className="leading-relaxed">{children}</li>;


### PR DESCRIPTION
## Summary
Fixed ordered-list numbering in rendered markdown outputs (e.g., “2. …”, “3. …” showing as restarting at 1). The issue was that our custom `ol` renderer dropped props from `react-markdown`, preventing the `start` attribute from being applied.

## Changes
- **frontend/src/components/markdown.tsx**
  - Updated the custom `ol` component to forward `...props` (including `start`) to the rendered `<ol>`.
  - Preserves any ordered-list start index provided by `react-markdown`.
- **frontend/src/components/markdown.test.tsx**
  - Added regression test asserting markdown like `2. Second\n3. Third` renders an `<ol start="2">`.

## Test plan
- `npx vitest run src/components/markdown.test.tsx --reporter=dot`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 8b15e831](https://app.143.dev/sessions/8b15e831-5647-4083-897a-371a8a57a8dc)*
