### PR TITLE
Align PR health banner header and metadata typography to text-sm

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PullRequestHealthResponse } from "@/lib/types";
+import { renderWithProviders, screen } from "@/test/test-utils";
+
+import { PRHealthBanner } from "./pr-health-banner";
+
+const baseHealth: PullRequestHealthResponse = {
+  pull_request_id: "pr-123",
+  pull_request_number: 42,
+  repository: "acme/widgets",
+  url: "https://github.com/acme/widgets/pull/42",
+  status: "open",
+  head_sha: "head-sha",
+  base_sha: "base-sha",
+  health_version: 2,
+  merge_state: "clean",
+  has_conflicts: false,
+  failing_test_count: 0,
+  needs_agent_action: false,
+  github_state_synced_at: "2026-04-24T00:00:00.000Z",
+  summary: "PR #42 is healthy.",
+  checks: [],
+  can_resolve_conflicts: false,
+  can_fix_tests: false,
+  enrichment_status: "ready",
+  enrichment_requested: true,
+  enrichment_ready: true,
+  conflict_detail_available: false,
+  failing_test_detail_available: false,
+  obsolete_active_repair_sessions: false,
+};
+
+describe("PRHealthBanner", () => {
+  it("uses text-sm sizing for the header and metadata copy", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={baseHealth}
+        pendingAction={null}
+        repairError={null}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("PR health")).toHaveClass("text-sm");
+    expect(screen.getByText("PR #42 · acme/widgets")).toHaveClass("text-sm");
+  });
+});

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -41,8 +41,8 @@ export function PRHealthBanner({
                 {isHealthy ? <CheckCircle2 className="h-4 w-4" /> : <GitPullRequest className="h-4 w-4" />}
               </div>
               <div className="min-w-0">
-                <div className="text-xs font-medium text-foreground">PR health</div>
-                <div className="text-xs text-muted-foreground">
+                <div className="text-sm font-medium text-foreground">PR health</div>
+                <div className="text-sm text-muted-foreground">
                   PR #{health.pull_request_number} · {health.repository}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
Updated the PR health banner typography so the “PR health” header and PR metadata use `text-sm` instead of `text-xs`, matching the session details side view for consistent sizing. Added a regression test to ensure this styling doesn’t drift back.

## Changes
- **frontend/src/components/pr-health-banner.tsx**
  - Changed header and metadata classes from `text-xs` to `text-sm` for consistent UI typography.
- **frontend/src/components/pr-health-banner.test.tsx**
  - Added a focused Vitest regression test asserting both “PR health” and the metadata line use `text-sm` (would fail with the previous `text-xs` styles).

## Test plan
- `npx vitest run src/components/pr-health-banner.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
  - Note: ran `npm ci` first because `frontend/node_modules` was missing in this workspace.

---
*Generated by [143.dev](https://143.dev) — [session 6a0a919b](https://app.143.dev/sessions/6a0a919b-5286-41a7-8777-67121dab8a76)*
