### PR TITLE
Preserve /sessions/new draft across navigation within a tab

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { fireEvent } from "@testing-library/react";
 import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { ManualSessionCreatePageContent } from "./manual-session-create-page-content";
+
+const DRAFT_STORAGE_KEY = "143:new-session-draft";
 
 const mocks = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
@@ -108,6 +111,7 @@ vi.mock("@/contexts/optimistic-sessions", () => ({
 describe("ManualSessionCreatePageContent", () => {
   beforeEach(() => {
     Object.values(mocks).forEach((m) => m.mockClear());
+    window.sessionStorage.clear();
   });
 
   it("renders the session creation form", async () => {
@@ -252,6 +256,83 @@ describe("ManualSessionCreatePageContent", () => {
           reasoning_effort: "max",
         }),
       );
+    });
+  });
+
+  describe("draft persistence", () => {
+    it("restores a stored prompt on mount", async () => {
+      window.sessionStorage.setItem(
+        DRAFT_STORAGE_KEY,
+        JSON.stringify({
+          __v: 1,
+          message: "Previously typed prompt",
+          attachments: [],
+          references: [],
+          selectedModel: "",
+          userSelectedRepoId: null,
+          branchByRepoId: {},
+          showImageInput: false,
+          imageURL: "",
+        }),
+      );
+
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
+        "Tell the agent what to do...",
+      );
+      await waitFor(() => {
+        expect(textarea.value).toBe("Previously typed prompt");
+      });
+    });
+
+    it("writes the prompt to sessionStorage as the user types", async () => {
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
+        "Tell the agent what to do...",
+      );
+      fireEvent.change(textarea, { target: { value: "draft in progress" } });
+
+      await waitFor(() => {
+        const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+        expect(stored).not.toBeNull();
+        expect(JSON.parse(stored!)).toMatchObject({
+          __v: 1,
+          message: "draft in progress",
+        });
+      });
+    });
+
+    it("clears the stored draft on successful submit", async () => {
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
+        "Tell the agent what to do...",
+      );
+      fireEvent.change(textarea, { target: { value: "ship it" } });
+
+      await waitFor(() => {
+        expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).not.toBeNull();
+      });
+
+      fireEvent.keyDown(textarea, { key: "Enter" });
+
+      await waitFor(() => {
+        expect(mocks.createSessionMock).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+      });
+    });
+
+    it("does not persist an empty draft", async () => {
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      await screen.findByPlaceholderText("Tell the agent what to do...");
+      // Give the persist effect a chance to run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -334,5 +334,40 @@ describe("ManualSessionCreatePageContent", () => {
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
     });
+
+    it("clears a hydrated repo id that no longer exists once repos load", async () => {
+      window.sessionStorage.setItem(
+        DRAFT_STORAGE_KEY,
+        JSON.stringify({
+          __v: 1,
+          message: "still typing",
+          attachments: [],
+          references: [],
+          selectedModel: "",
+          // Not present in repositoriesListMock, which only returns repo-1.
+          userSelectedRepoId: "repo-deleted",
+          branchByRepoId: { "repo-deleted": "feature-branch" },
+          showImageInput: false,
+          imageURL: "",
+        }),
+      );
+
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      await screen.findByPlaceholderText("Tell the agent what to do...");
+      await waitFor(() => {
+        expect(mocks.repositoriesListMock).toHaveBeenCalled();
+      });
+
+      // The draft should be re-saved with the stale repo id cleared so it
+      // doesn't haunt future mounts. Message content survives.
+      await waitFor(() => {
+        const raw = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+        expect(raw).not.toBeNull();
+        const stored = JSON.parse(raw!);
+        expect(stored.userSelectedRepoId).toBeNull();
+        expect(stored.message).toBe("still typing");
+      });
+    });
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -335,6 +335,45 @@ describe("ManualSessionCreatePageContent", () => {
       expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
     });
 
+    it("restores a hydrated reasoning override and uses it at submit time", async () => {
+      window.sessionStorage.setItem(
+        DRAFT_STORAGE_KEY,
+        JSON.stringify({
+          __v: 1,
+          message: "tune this",
+          attachments: [],
+          references: [],
+          selectedModel: "",
+          reasoningOverride: "high",
+          userSelectedRepoId: null,
+          branchByRepoId: {},
+          showImageInput: false,
+          imageURL: "",
+        }),
+      );
+
+      const user = userEvent.setup();
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
+        "Tell the agent what to do...",
+      );
+      await waitFor(() => {
+        expect(textarea.value).toBe("tune this");
+      });
+
+      await user.click((await screen.findAllByRole("button", { name: "Start session" }))[0]);
+
+      await waitFor(() => {
+        expect(mocks.createSessionMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            message: "tune this",
+            reasoning_effort: "high",
+          }),
+        );
+      });
+    });
+
     it("clears a hydrated repo id that no longer exists once repos load", async () => {
       window.sessionStorage.setItem(
         DRAFT_STORAGE_KEY,

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -214,6 +214,21 @@ export function ManualSessionCreatePageContent() {
   });
   const repositories = useMemo(() => reposResponse?.data ?? [], [reposResponse]);
 
+  // Drop a hydrated repo id (from the draft or the `?repo=` URL param) if the
+  // repos query has resolved and the id isn't in the list — repo was deleted,
+  // access was revoked, or the URL was bogus. Without this, the picker would
+  // silently show "Select repo" while state still held the dead id, and the
+  // dead id would keep getting re-persisted into the draft. We only act once
+  // the query actually resolves (reposResponse truthy) so that transient
+  // loading/error states don't nuke a valid selection.
+  useEffect(() => {
+    if (userSelectedRepoId === null) return;
+    if (!reposResponse) return;
+    if (!repositories.some((r) => r.id === userSelectedRepoId)) {
+      setUserSelectedRepoId(null);
+    }
+  }, [userSelectedRepoId, reposResponse, repositories]);
+
   const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -30,6 +30,7 @@ import { PendingAttachmentStrip } from "@/components/pending-attachment-strip";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
 import { findActiveMention, insertMentionAtCaret, removeMentionReference, syncReferencesWithMessage } from "@/lib/session-composer-mentions";
+import { clearDraft, loadDraft, saveDraft } from "@/lib/session-draft";
 import { queryKeys } from "@/lib/query-keys";
 import {
   AGENTS,
@@ -115,9 +116,89 @@ export function ManualSessionCreatePageContent() {
   const [selectedMentionIndex, setSelectedMentionIndex] = useState(0);
   const [mentionDismissed, setMentionDismissed] = useState(false);
   const [mentionPickerPosition, setMentionPickerPosition] = useState<MentionPickerPosition | null>(null);
+  // Gates the persist effect until after hydration so we never overwrite a
+  // stored draft with the component's initial (empty) state on first mount.
+  const [draftHydrated, setDraftHydrated] = useState(false);
   const previousRepoIdRef = useRef<string>("");
 
   const { addOptimisticSession, removeOptimisticSession, markOptimisticResolved } = useOptimisticSessions();
+
+  // Hydrate once on mount. A `?repo=` URL param represents fresh explicit
+  // intent (e.g. the user just clicked a repo in the switcher), so it wins
+  // over the repo stored in the draft. When the URL's repo conflicts with
+  // the draft's, we keep repo-agnostic fields (prompt, attachments, model)
+  // but drop references/mentions — they were resolved against a different
+  // repo tree and wouldn't match the new one.
+  useEffect(() => {
+    const draft = loadDraft();
+    if (draft) {
+      const repoConflict =
+        !!repoId && !!draft.userSelectedRepoId && repoId !== draft.userSelectedRepoId;
+
+      setAttachments(draft.attachments);
+      setSelectedModel(draft.selectedModel);
+      setShowImageInput(draft.showImageInput);
+      setImageURL(draft.imageURL);
+      setBranchByRepoId(draft.branchByRepoId);
+      if (!repoId) {
+        setUserSelectedRepoId(draft.userSelectedRepoId);
+      }
+
+      if (repoConflict) {
+        const stripped = draft.references.reduce(
+          (text, reference) => removeMentionReference(text, reference),
+          draft.message,
+        );
+        setMessage(stripped);
+        setReferences([]);
+      } else {
+        setMessage(draft.message);
+        setReferences(draft.references);
+      }
+
+      // Put the caret at the end so the user can keep typing where they left
+      // off rather than having to click into the field.
+      requestAnimationFrame(() => {
+        const el = messageInputRef.current;
+        if (!el) return;
+        const end = el.value.length;
+        el.setSelectionRange(end, end);
+        setCaretPosition(end);
+      });
+    }
+    setDraftHydrated(true);
+    // Intentionally one-shot: we only restore at the moment the composer
+    // mounts. Subsequent URL or state changes should not re-hydrate.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Persist the serializable slice of form state on every change. Pure UI
+  // state (caret, dictation, mention picker, errors, upload-in-flight flag)
+  // is deliberately excluded — restoring it on reload would be meaningless or
+  // confusing.
+  useEffect(() => {
+    if (!draftHydrated) return;
+    saveDraft({
+      message,
+      attachments,
+      references,
+      selectedModel,
+      userSelectedRepoId,
+      branchByRepoId,
+      showImageInput,
+      imageURL,
+    });
+  }, [
+    draftHydrated,
+    message,
+    attachments,
+    references,
+    selectedModel,
+    userSelectedRepoId,
+    branchByRepoId,
+    showImageInput,
+    imageURL,
+  ]);
 
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
@@ -234,6 +315,7 @@ export function ManualSessionCreatePageContent() {
       if (selectedRepoId) {
         try { localStorage.setItem("143:lastUsedRepoId", selectedRepoId); } catch {}
       }
+      clearDraft();
       // Keep the optimistic row visible — the sidebar swaps it for the real
       // session once the refetch lands. See OptimisticSession.resolvedId.
       markOptimisticResolved(context.optimisticId, response.data.id);

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -137,6 +137,7 @@ export function ManualSessionCreatePageContent() {
 
       setAttachments(draft.attachments);
       setSelectedModel(draft.selectedModel);
+      setReasoningOverride(draft.reasoningOverride);
       setShowImageInput(draft.showImageInput);
       setImageURL(draft.imageURL);
       setBranchByRepoId(draft.branchByRepoId);
@@ -183,6 +184,7 @@ export function ManualSessionCreatePageContent() {
       attachments,
       references,
       selectedModel,
+      reasoningOverride,
       userSelectedRepoId,
       branchByRepoId,
       showImageInput,
@@ -194,6 +196,7 @@ export function ManualSessionCreatePageContent() {
     attachments,
     references,
     selectedModel,
+    reasoningOverride,
     userSelectedRepoId,
     branchByRepoId,
     showImageInput,

--- a/frontend/src/lib/session-draft.test.ts
+++ b/frontend/src/lib/session-draft.test.ts
@@ -8,6 +8,7 @@ const emptyDraft: SessionDraft = {
   attachments: [],
   references: [],
   selectedModel: "",
+  reasoningOverride: "",
   userSelectedRepoId: null,
   branchByRepoId: {},
   showImageInput: false,
@@ -31,6 +32,7 @@ describe("session-draft storage", () => {
         { kind: "file", display: "auth.go", path: "internal/auth/auth.go", token: "@auth.go" },
       ],
       selectedModel: "claude-sonnet-4-6",
+      reasoningOverride: "xhigh",
       userSelectedRepoId: "repo-abc",
       branchByRepoId: { "repo-abc": "feature/auth" },
       showImageInput: true,
@@ -38,6 +40,20 @@ describe("session-draft storage", () => {
     };
     saveDraft(draft);
     expect(loadDraft()).toEqual(draft);
+  });
+
+  it("drops a reasoning override that isn't a known value", () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ __v: 1, reasoningOverride: "bogus" }),
+    );
+    expect(loadDraft()?.reasoningOverride).toBe("");
+  });
+
+  it("preserves a populated reasoningOverride as non-empty", () => {
+    saveDraft({ ...emptyDraft, reasoningOverride: "max" });
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+    expect(loadDraft()?.reasoningOverride).toBe("max");
   });
 
   it("does not persist an empty draft and clears existing storage", () => {
@@ -91,6 +107,7 @@ describe("session-draft storage", () => {
       attachments: ["ok"],
       references: [{ kind: "file", display: "ok.go" }],
       selectedModel: "",
+      reasoningOverride: "",
       userSelectedRepoId: null,
       branchByRepoId: {},
       showImageInput: false,

--- a/frontend/src/lib/session-draft.test.ts
+++ b/frontend/src/lib/session-draft.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { clearDraft, loadDraft, saveDraft, type SessionDraft } from "./session-draft";
+
+const STORAGE_KEY = "143:new-session-draft";
+
+const emptyDraft: SessionDraft = {
+  message: "",
+  attachments: [],
+  references: [],
+  selectedModel: "",
+  userSelectedRepoId: null,
+  branchByRepoId: {},
+  showImageInput: false,
+  imageURL: "",
+};
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe("session-draft storage", () => {
+  it("returns null when no draft is stored", () => {
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("round-trips a populated draft", () => {
+    const draft: SessionDraft = {
+      message: "Refactor the auth middleware",
+      attachments: ["https://example.com/a.png", "https://example.com/b.png"],
+      references: [
+        { kind: "file", display: "auth.go", path: "internal/auth/auth.go", token: "@auth.go" },
+      ],
+      selectedModel: "claude-sonnet-4-6",
+      userSelectedRepoId: "repo-abc",
+      branchByRepoId: { "repo-abc": "feature/auth" },
+      showImageInput: true,
+      imageURL: "https://example.com/c.png",
+    };
+    saveDraft(draft);
+    expect(loadDraft()).toEqual(draft);
+  });
+
+  it("does not persist an empty draft and clears existing storage", () => {
+    saveDraft({ ...emptyDraft, message: "seed" });
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).not.toBeNull();
+
+    saveDraft(emptyDraft);
+    expect(window.sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("clearDraft removes the stored value", () => {
+    saveDraft({ ...emptyDraft, message: "hi" });
+    clearDraft();
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("discards drafts with a mismatched schema version", () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ __v: 999, message: "legacy", attachments: [] }),
+    );
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("discards drafts whose JSON is malformed", () => {
+    window.sessionStorage.setItem(STORAGE_KEY, "{not valid json");
+    expect(loadDraft()).toBeNull();
+  });
+
+  it("sanitizes structurally broken fields rather than throwing", () => {
+    window.sessionStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        __v: 1,
+        message: 42,
+        attachments: ["ok", 7, null],
+        references: [
+          { kind: "file", display: "ok.go" },
+          { nope: true },
+        ],
+        selectedModel: null,
+        userSelectedRepoId: 0,
+        branchByRepoId: ["not", "a", "map"],
+        showImageInput: "yes",
+        imageURL: undefined,
+      }),
+    );
+    const draft = loadDraft();
+    expect(draft).toEqual({
+      message: "",
+      attachments: ["ok"],
+      references: [{ kind: "file", display: "ok.go" }],
+      selectedModel: "",
+      userSelectedRepoId: null,
+      branchByRepoId: {},
+      showImageInput: false,
+      imageURL: "",
+    });
+  });
+});

--- a/frontend/src/lib/session-draft.ts
+++ b/frontend/src/lib/session-draft.ts
@@ -8,6 +8,7 @@
 // site. The serialization format here is forward-compatible: a schema-version
 // mismatch silently discards the old draft rather than hydrating junk.
 
+import { toCodingAgentReasoningEffort, type CodingAgentReasoningEffort } from "@/lib/coding-agent-reasoning";
 import type { SessionInputReference } from "@/lib/types";
 
 const STORAGE_KEY = "143:new-session-draft";
@@ -18,6 +19,7 @@ export type SessionDraft = {
   attachments: string[];
   references: SessionInputReference[];
   selectedModel: string;
+  reasoningOverride: CodingAgentReasoningEffort;
   userSelectedRepoId: string | null;
   branchByRepoId: Record<string, string>;
   showImageInput: boolean;
@@ -63,6 +65,10 @@ export function loadDraft(): SessionDraft | null {
       ? parsed.references.filter(isValidReference)
       : [],
     selectedModel: typeof parsed.selectedModel === "string" ? parsed.selectedModel : "",
+    // Sanitize via the canonical coercer: unknown/invalid values collapse to "".
+    reasoningOverride: toCodingAgentReasoningEffort(
+      typeof parsed.reasoningOverride === "string" ? parsed.reasoningOverride : "",
+    ),
     userSelectedRepoId: typeof parsed.userSelectedRepoId === "string" ? parsed.userSelectedRepoId : null,
     branchByRepoId: isStringRecord(parsed.branchByRepoId) ? parsed.branchByRepoId : {},
     showImageInput: parsed.showImageInput === true,
@@ -101,6 +107,7 @@ function isEmptyDraft(draft: SessionDraft): boolean {
     && draft.attachments.length === 0
     && draft.references.length === 0
     && draft.selectedModel === ""
+    && draft.reasoningOverride === ""
     && draft.userSelectedRepoId === null
     && Object.keys(draft.branchByRepoId).length === 0
     && !draft.showImageInput

--- a/frontend/src/lib/session-draft.ts
+++ b/frontend/src/lib/session-draft.ts
@@ -1,0 +1,126 @@
+// Persists in-progress /sessions/new form state across navigation within a
+// tab. Uses sessionStorage so drafts are scoped to the tab and auto-expire on
+// close — matches the "I stepped away mid-compose" use case without leaving
+// stale prompts haunting the user next week.
+//
+// To upgrade to cross-tab-close persistence (localStorage), swap `getStorage()`
+// to return `window.localStorage` and add a TTL/discard affordance at the call
+// site. The serialization format here is forward-compatible: a schema-version
+// mismatch silently discards the old draft rather than hydrating junk.
+
+import type { SessionInputReference } from "@/lib/types";
+
+const STORAGE_KEY = "143:new-session-draft";
+const SCHEMA_VERSION = 1;
+
+export type SessionDraft = {
+  message: string;
+  attachments: string[];
+  references: SessionInputReference[];
+  selectedModel: string;
+  userSelectedRepoId: string | null;
+  branchByRepoId: Record<string, string>;
+  showImageInput: boolean;
+  imageURL: string;
+};
+
+type StoredDraft = SessionDraft & { __v: number };
+
+function getStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function loadDraft(): SessionDraft | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+
+  let parsed: Partial<StoredDraft>;
+  try {
+    parsed = JSON.parse(raw) as Partial<StoredDraft>;
+  } catch {
+    return null;
+  }
+  if (parsed.__v !== SCHEMA_VERSION) return null;
+
+  return {
+    message: typeof parsed.message === "string" ? parsed.message : "",
+    attachments: Array.isArray(parsed.attachments)
+      ? parsed.attachments.filter((a): a is string => typeof a === "string")
+      : [],
+    references: Array.isArray(parsed.references)
+      ? parsed.references.filter(isValidReference)
+      : [],
+    selectedModel: typeof parsed.selectedModel === "string" ? parsed.selectedModel : "",
+    userSelectedRepoId: typeof parsed.userSelectedRepoId === "string" ? parsed.userSelectedRepoId : null,
+    branchByRepoId: isStringRecord(parsed.branchByRepoId) ? parsed.branchByRepoId : {},
+    showImageInput: parsed.showImageInput === true,
+    imageURL: typeof parsed.imageURL === "string" ? parsed.imageURL : "",
+  };
+}
+
+export function saveDraft(draft: SessionDraft): void {
+  const storage = getStorage();
+  if (!storage) return;
+
+  if (isEmptyDraft(draft)) {
+    try { storage.removeItem(STORAGE_KEY); } catch {}
+    return;
+  }
+
+  const stored: StoredDraft = { __v: SCHEMA_VERSION, ...draft };
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(stored));
+  } catch {
+    // Quota exceeded, storage access denied, or serialization failure — a
+    // best-effort save is acceptable here; losing a draft is strictly better
+    // than blowing up the composer.
+  }
+}
+
+export function clearDraft(): void {
+  const storage = getStorage();
+  if (!storage) return;
+  try { storage.removeItem(STORAGE_KEY); } catch {}
+}
+
+function isEmptyDraft(draft: SessionDraft): boolean {
+  return (
+    draft.message.length === 0
+    && draft.attachments.length === 0
+    && draft.references.length === 0
+    && draft.selectedModel === ""
+    && draft.userSelectedRepoId === null
+    && Object.keys(draft.branchByRepoId).length === 0
+    && !draft.showImageInput
+    && draft.imageURL === ""
+  );
+}
+
+function isValidReference(value: unknown): value is SessionInputReference {
+  if (!value || typeof value !== "object") return false;
+  const ref = value as Record<string, unknown>;
+  return (
+    typeof ref.kind === "string"
+    && typeof ref.display === "string"
+    && (ref.token === undefined || typeof ref.token === "string")
+    && (ref.path === undefined || typeof ref.path === "string")
+    && (ref.id === undefined || typeof ref.id === "string")
+  );
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.values(value as Record<string, unknown>).every((v) => typeof v === "string");
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -30,5 +30,9 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   cleanup();
   server.resetHandlers();
+  // Reset browser storage so persisted state (e.g. /sessions/new draft) does
+  // not leak between tests.
+  window.sessionStorage.clear();
+  window.localStorage.clear();
 });
 afterAll(() => server.close());


### PR DESCRIPTION
## Summary
- Adds a `session-draft` module that persists the /sessions/new composer state (prompt, attachments, references, model, repo/branch, image input) to `sessionStorage` with schema-versioned serialization.
- Wires `ManualSessionCreatePageContent` to hydrate once on mount and persist on every change; a `?repo=` URL param overrides the stored repo and drops repo-scoped references to avoid cross-repo mismatches.
- Clears the draft on successful submit, and resets browser storage between tests so persisted state doesn't leak.

## Test plan
- [ ] Run frontend vitest for `session-draft` and `manual-session-create-page-content`.
- [ ] Manual: type a prompt at /sessions/new, navigate away and back, confirm it restores; submit and confirm the draft clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
