### PR TITLE
Match “Send invite” button height with shared modal action sizing

### DIFF
--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -167,6 +167,19 @@ describe('TeamSettingsPage', () => {
     expect(emailInput).toHaveClass('h-9');
   });
 
+  it('uses the shared modal action sizing for the invite footer buttons', async () => {
+    renderWithProviders(<TeamSettingsPage />);
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Invite' }));
+
+    const cancelButton = await screen.findByRole('button', { name: 'Cancel' });
+    const sendInviteButton = screen.getByRole('button', { name: 'Send invite' });
+
+    expect(cancelButton).toHaveClass('h-8');
+    expect(sendInviteButton).toHaveClass('h-8');
+    expect(sendInviteButton).not.toHaveClass('h-9');
+  });
+
   it('renders pending invitations', async () => {
     renderWithProviders(<TeamSettingsPage />);
 

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -730,7 +730,6 @@ export default function TeamSettingsPage() {
                 <AlertDialogCancel type="button">Cancel</AlertDialogCancel>
                 <Button
                   type="submit"
-                  className="h-9"
                   disabled={
                     inviteMutation.isPending ||
                     !inviteDraft ||


### PR DESCRIPTION
## Summary
Updated the Invite modal footer so the “Send invite” button uses the same shared modal action sizing as “Cancel” and other modal actions. This removes the custom `h-9` height override and adds a regression test to prevent style drift.

## Changes
- `frontend/src/app/(dashboard)/settings/team/page.tsx`
  - Removed the custom `className="h-9"` from the “Send invite” button so it matches the shared modal action height.
- `frontend/src/app/(dashboard)/settings/team/page.test.tsx`
  - Added a test asserting both “Cancel” and “Send invite” footer buttons use `h-8` and that “Send invite” does not use `h-9`.

## Test plan
- `npx vitest run src/app/\(dashboard\)/settings/team/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 1d9475ec](https://app.143.dev/sessions/1d9475ec-ecd2-4f1c-8ebb-b5e755952d14)*
