### PR TITLE
Preserve incoming file order in code review sidebar to match diff detail view

### DIFF
--- a/frontend/src/components/code-review/file-tree.test.tsx
+++ b/frontend/src/components/code-review/file-tree.test.tsx
@@ -21,6 +21,29 @@ const files: DiffFile[] = [
 ];
 
 describe("FileTree", () => {
+  it("preserves incoming file order so the sidebar matches the diff detail view", () => {
+    const orderedFiles: DiffFile[] = [
+      makeDiffFile("src/first.ts", 1, 0),
+      makeDiffFile("src/second.ts", 10, 0),
+      makeDiffFile("src/third.ts", 5, 0),
+    ];
+
+    render(
+      <FileTree files={orderedFiles} activeFileIndex={0} onFileSelect={vi.fn()} />
+    );
+
+    const firstFile = screen.getByText("first.ts");
+    const secondFile = screen.getByText("second.ts");
+    const thirdFile = screen.getByText("third.ts");
+
+    expect(
+      firstFile.compareDocumentPosition(secondFile) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      secondFile.compareDocumentPosition(thirdFile) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
   it("renders file names", () => {
     render(
       <FileTree files={files} activeFileIndex={0} onFileSelect={vi.fn()} />

--- a/frontend/src/components/code-review/file-tree.tsx
+++ b/frontend/src/components/code-review/file-tree.tsx
@@ -67,18 +67,6 @@ function flattenSingleChildDirs(node: TreeNode): TreeNode {
   return { ...node, children: newChildren };
 }
 
-/**
- * Sort files by impact: largest changes first, then alphabetical.
- */
-function sortFilesByImpact(files: DiffFile[]): DiffFile[] {
-  return [...files].sort((a, b) => {
-    const aImpact = a.stats.added + a.stats.removed;
-    const bImpact = b.stats.added + b.stats.removed;
-    if (bImpact !== aImpact) return bImpact - aImpact;
-    return a.newPath.localeCompare(b.newPath);
-  });
-}
-
 const TreeDirectory = memo(function TreeDirectory({
   node,
   activeFileIndex,
@@ -159,14 +147,11 @@ export function FileTree({
 }: FileTreeProps) {
   const [filter, setFilter] = useState("");
 
-  // Sort files by impact (largest changes first) then filter
-  const sortedFiles = useMemo(() => sortFilesByImpact(files), [files]);
-
   const filteredFiles = useMemo(() => {
-    if (!filter.trim()) return sortedFiles;
+    if (!filter.trim()) return files;
     const q = filter.toLowerCase();
-    return sortedFiles.filter((f) => f.newPath.toLowerCase().includes(q));
-  }, [sortedFiles, filter]);
+    return files.filter((f) => f.newPath.toLowerCase().includes(q));
+  }, [files, filter]);
 
   // Build a reference-identity map from DiffFile -> original index for O(1) lookups
   const fileToOrigIndex = useMemo(() => {
@@ -175,27 +160,27 @@ export function FileTree({
     return map;
   }, [files]);
 
-  // Map original indices to sorted indices for active file tracking
-  const sortedIndexMap = useMemo(() => {
+  // Map original indices to filtered indices for active file tracking.
+  const filteredIndexMap = useMemo(() => {
     const map = new Map<number, number>();
-    sortedFiles.forEach((file, sortedIdx) => {
+    filteredFiles.forEach((file, filteredIdx) => {
       const origIdx = fileToOrigIndex.get(file) ?? -1;
-      if (origIdx >= 0) map.set(origIdx, sortedIdx);
+      if (origIdx >= 0) map.set(origIdx, filteredIdx);
     });
     return map;
-  }, [fileToOrigIndex, sortedFiles]);
+  }, [fileToOrigIndex, filteredFiles]);
 
   const tree = useMemo(
     () => flattenSingleChildDirs(buildTree(filteredFiles)),
     [filteredFiles]
   );
 
-  // Convert activeFileIndex from original files array to the sorted position
-  const sortedActiveIndex = sortedIndexMap.get(activeFileIndex) ?? activeFileIndex;
+  // Convert activeFileIndex from original files array to the filtered position.
+  const filteredActiveIndex = filteredIndexMap.get(activeFileIndex) ?? activeFileIndex;
 
-  // When a file is selected in the sorted tree, convert back to original index
-  const handleFileSelect = (sortedIdx: number) => {
-    const file = filteredFiles[sortedIdx];
+  // When a file is selected in the filtered tree, convert back to original index.
+  const handleFileSelect = (filteredIdx: number) => {
+    const file = filteredFiles[filteredIdx];
     if (!file) return;
     const origIdx = fileToOrigIndex.get(file) ?? -1;
     if (origIdx >= 0) onFileSelect(origIdx);
@@ -221,7 +206,7 @@ export function FileTree({
       <div className="flex-1 overflow-y-auto scrollbar-hide px-3 pb-2">
         <TreeDirectory
           node={tree}
-          activeFileIndex={sortedActiveIndex}
+          activeFileIndex={filteredActiveIndex}
           onFileSelect={handleFileSelect}
         />
       </div>


### PR DESCRIPTION
## Summary

The Changes sidebar now preserves the same incoming diff order as the file detail/review view, so both surfaces stay aligned and easier to scan. The fix is in [frontend/src/components/code-review/file-tree.tsx](/home/sandbox/143/frontend/src/components/code-review/file-tree.tsx:147): I removed the sidebar-only impact sort and kept the existing filtered-to-original index mapping so selection/highlighting still works correctly.

I also added a regression test in [frontend/src/components/code-review/file-tree.test.tsx](/home/sandbox/143/frontend/src/components/code-review/file-tree.test.tsx:24) that asserts the sidebar keeps the same file order it receives.

Verification passed:
- `npx vitest run src/components/code-review/file-tree.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

`next build` still emits the existing non-blocking workspace-root warning about multiple lockfiles, but the build succeeds.

## Test plan

Validated by automated agent run.

---
*Generated by [143.dev](https://143.dev) — [session d5ff4343](https://app.143.dev/sessions/d5ff4343-314b-4801-8f26-213fa9513a49)*
