### PR TITLE
Tighten my settings text sizes and simplify reasoning default label

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -265,7 +265,7 @@ describe("Account settings page", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("combobox", { name: "Codex default coding-agent reasoning" })).toHaveTextContent("High");
-      expect(screen.getByRole("combobox", { name: "Claude Code default coding-agent reasoning" })).toHaveTextContent("Product default");
+      expect(screen.getByRole("combobox", { name: "Claude Code default coding-agent reasoning" })).toHaveTextContent("Default");
     });
   });
 });

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -234,7 +234,7 @@ export default function AccountPage() {
                         <SelectValue placeholder="Default" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="__default__">Product default</SelectItem>
+                        <SelectItem value="__default__">Default</SelectItem>
                         {config.options.map((option) => (
                           <SelectItem key={option.value} value={option.value}>
                             {option.label}
@@ -245,7 +245,7 @@ export default function AccountPage() {
                   </div>
                 );
               })}
-              <p className="text-sm text-muted-foreground">
+              <p className="text-xs text-muted-foreground">
                 Used as the default for supported coding agents in the session composer. You can still override it per prompt.
               </p>
             </div>


### PR DESCRIPTION
## Summary
- Match the reasoning-default helper text size (text-xs) to the rest of the settings pages.
- Rename the reasoning-default option from "Product default" to "Default".

## Test plan
- [ ] Open My settings and confirm the helper text under Coding agent defaults is the same size as other settings pages.
- [ ] Confirm the Codex and Claude Code reasoning-level selects show "Default" as the first option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)