### PR TITLE
Fix data races in pull request stream subscription and SSE test

### DIFF
--- a/internal/api/handlers/pull_requests_test.go
+++ b/internal/api/handlers/pull_requests_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,27 @@ import (
 	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/models"
 )
+
+type lockedRecorder struct {
+	*httptest.ResponseRecorder
+	mu sync.Mutex
+}
+
+func newLockedRecorder() *lockedRecorder {
+	return &lockedRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (r *lockedRecorder) Write(b []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ResponseRecorder.Write(b)
+}
+
+func (r *lockedRecorder) BodyString() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.ResponseRecorder.Body.String()
+}
 
 type stubPullRequestHealthService struct {
 	getHealthFunc func(context.Context, uuid.UUID, uuid.UUID) (*models.PullRequestHealthResponse, error)
@@ -507,7 +529,7 @@ func TestPullRequestHandler_StreamUpdates(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/pull-requests/stream", nil).WithContext(ctx)
 	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
 	req = req.WithContext(middleware.WithUser(req.Context(), user))
-	rr := httptest.NewRecorder()
+	rr := newLockedRecorder()
 
 	done := make(chan struct{})
 	go func() {
@@ -527,13 +549,13 @@ func TestPullRequestHandler_StreamUpdates(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return strings.Contains(rr.Body.String(), "pull_request.updated")
+		return strings.Contains(rr.BodyString(), "pull_request.updated")
 	}, 2*time.Second, 20*time.Millisecond, "StreamUpdates should write published pull request update events to the SSE response")
 
 	cancel()
 	<-done
 
-	require.Contains(t, rr.Body.String(), event.PullRequestID.String(), "StreamUpdates should serialize the published pull request ID")
+	require.Contains(t, rr.BodyString(), event.PullRequestID.String(), "StreamUpdates should serialize the published pull request ID")
 }
 
 func newTestPullRequestStreams(t *testing.T) *cache.PullRequestStreams {

--- a/internal/cache/pull_request_streams.go
+++ b/internal/cache/pull_request_streams.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
@@ -21,10 +22,18 @@ type PullRequestStreams struct {
 type PullRequestSubscription struct {
 	C <-chan models.PullRequestUpdatedEvent
 
-	ch          chan models.PullRequestUpdatedEvent
-	cancel      context.CancelFunc
-	pubsub      *redis.PubSub
+	ch     chan models.PullRequestUpdatedEvent
+	cancel context.CancelFunc
+	pubsub *redis.PubSub
+
+	mu          sync.Mutex
 	closeReason string
+}
+
+func (s *PullRequestSubscription) setCloseReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeReason = reason
 }
 
 func NewPullRequestStreams(client *Client, logger zerolog.Logger) *PullRequestStreams {
@@ -97,16 +106,16 @@ func (s *PullRequestStreams) Subscribe(orgID uuid.UUID) (*PullRequestSubscriptio
 			select {
 			case sub.ch <- event:
 			case <-ctx.Done():
-				sub.closeReason = ctx.Err().Error()
+				sub.setCloseReason(ctx.Err().Error())
 				return
 			}
 		}
 
 		if err := ctx.Err(); err != nil {
-			sub.closeReason = err.Error()
+			sub.setCloseReason(err.Error())
 			return
 		}
-		sub.closeReason = "subscription closed"
+		sub.setCloseReason("subscription closed")
 	}()
 
 	return sub, nil
@@ -125,7 +134,12 @@ func (s *PullRequestSubscription) Close() {
 }
 
 func (s *PullRequestSubscription) CloseReason() string {
-	if s == nil || s.closeReason == "" {
+	if s == nil {
+		return "subscription closed"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closeReason == "" {
 		return "subscription closed"
 	}
 	return s.closeReason

--- a/internal/cache/pull_request_streams_test.go
+++ b/internal/cache/pull_request_streams_test.go
@@ -27,6 +27,18 @@ func TestPullRequestStreams_AvailabilityAndHelpers(t *testing.T) {
 	sub.Close()
 	require.NotEmpty(t, sub.CloseReason(), "closing a subscription should leave a non-empty close reason")
 
+	require.Equal(t, "subscription closed", (*PullRequestSubscription)(nil).CloseReason(), "nil subscription receivers should report the default close reason")
+
+	naturalSub, err := streams.Subscribe(uuid.New())
+	require.NoError(t, err, "subscribe should succeed for the natural-close case")
+	require.NoError(t, naturalSub.pubsub.Close(), "closing pubsub directly should drive the goroutine to its default close path")
+	select {
+	case <-naturalSub.C:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscription goroutine did not exit after pubsub close")
+	}
+	require.Equal(t, "subscription closed", naturalSub.CloseReason(), "natural pubsub closure should record the default close reason")
+
 	require.Equal(t, "143:stream:{org:00000000-0000-0000-0000-000000000000}:pull_requests", pullRequestStreamChannel(uuid.Nil), "channel helper should scope pull request streams by org")
 }
 


### PR DESCRIPTION
## Summary
- Guard `PullRequestSubscription.closeReason` with a `sync.Mutex` so the Subscribe goroutine's writes don't race with `CloseReason()` readers in the handler.
- Wrap the `StreamUpdates` test's `httptest.ResponseRecorder` in a mutex-protected `lockedRecorder` so the `require.Eventually` loop can read SSE bytes safely while the handler goroutine is still writing.

## Test plan
- [x] `go test -race ./internal/cache/...`
- [x] `go test -race -run 'TestPullRequest' ./internal/api/handlers/...`
- [x] `go test -race ./internal/api/sse/...`
