### PR TITLE
Preserve preview-routing metadata across worker startup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -247,17 +247,9 @@ func main() {
 	}
 
 	nodeManager := cluster.NewNodeManager(pool, logger, cfg.NodeID, cfg.Mode)
+	previewCapable := (cfg.Mode == "worker" || cfg.Mode == "all") && pvProvider != nil
 	nodeManager.SetMetadataProvider(func() map[string]any {
-		metadata := map[string]any{
-			"build_sha": version.BuildSHA,
-		}
-		if cfg.PreviewInternalBaseURL != "" {
-			metadata["preview_internal_base_url"] = cfg.PreviewInternalBaseURL
-		}
-		if (cfg.Mode == "worker" || cfg.Mode == "all") && pvProvider != nil {
-			metadata["preview_capable"] = true
-		}
-		return metadata
+		return buildBaseMetadata(previewCapable, cfg.PreviewInternalBaseURL)
 	})
 	if err := nodeManager.Register(ctx, hostname); err != nil {
 		logger.Fatal().Err(err).Msg("failed to register cluster node")
@@ -359,7 +351,6 @@ func main() {
 			LogsDays:    cfg.DataRetentionLogsDays,
 			JobsDays:    cfg.DataRetentionJobsDays,
 		}
-		previewCapable := pvProvider != nil
 		processWorkers = startProcessWorkers(
 			ctx,
 			pool,
@@ -548,29 +539,40 @@ func startProcessWorkers(
 		})
 	}
 
-	// Preserve preview-routing fields here. SetMetadataProvider replaces
-	// the previous provider, so omitting these would let the next heartbeat
-	// wipe preview_capable from the node row and route requests to nothing.
-	nodeManager.SetMetadataProvider(func() map[string]any {
-		metadata := map[string]any{
-			"build_sha":              version.BuildSHA,
-			"active_job_count":       totalActiveJobs(workers),
-			"active_run_agent_count": totalActiveRunAgentJobs(workers),
-		}
-		if previewCapable {
-			metadata["preview_capable"] = true
-		}
-		if previewInternalBaseURL != "" {
-			metadata["preview_internal_base_url"] = previewInternalBaseURL
-		}
-		return metadata
-	})
+	nodeManager.SetMetadataProvider(buildWorkerMetadataProvider(workers, previewCapable, previewInternalBaseURL))
 
 	for i, w := range workers {
 		go w.Start(ctx)
 		logger.Info().Int("worker_index", i).Msg("worker started with registered handlers")
 	}
 	return workers
+}
+
+// buildBaseMetadata returns the node metadata fields that must appear on every
+// heartbeat. SetMetadataProvider replaces the previous provider entirely, so
+// any provider installed later (e.g. by startProcessWorkers) must continue to
+// emit these fields or the next heartbeat will wipe preview_capable from the
+// node row and break preview routing.
+func buildBaseMetadata(previewCapable bool, previewInternalBaseURL string) map[string]any {
+	metadata := map[string]any{
+		"build_sha": version.BuildSHA,
+	}
+	if previewCapable {
+		metadata["preview_capable"] = true
+	}
+	if previewInternalBaseURL != "" {
+		metadata["preview_internal_base_url"] = previewInternalBaseURL
+	}
+	return metadata
+}
+
+func buildWorkerMetadataProvider(workers []*worker.Worker, previewCapable bool, previewInternalBaseURL string) func() map[string]any {
+	return func() map[string]any {
+		metadata := buildBaseMetadata(previewCapable, previewInternalBaseURL)
+		metadata["active_job_count"] = totalActiveJobs(workers)
+		metadata["active_run_agent_count"] = totalActiveRunAgentJobs(workers)
+		return metadata
+	}
 }
 
 func totalActiveJobs(workers []*worker.Worker) int {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -359,6 +359,7 @@ func main() {
 			LogsDays:    cfg.DataRetentionLogsDays,
 			JobsDays:    cfg.DataRetentionJobsDays,
 		}
+		previewCapable := pvProvider != nil
 		processWorkers = startProcessWorkers(
 			ctx,
 			pool,
@@ -370,6 +371,8 @@ func main() {
 			retentionCfg,
 			jobNotifier,
 			nodeManager,
+			previewCapable,
+			cfg.PreviewInternalBaseURL,
 		)
 
 		recoveryLoop := cluster.NewRecoveryLoop(nodeManager, jobStore, logger, 90*time.Second, 100)
@@ -527,6 +530,8 @@ func startProcessWorkers(
 	retentionCfg worker.DataRetentionConfig,
 	jobNotifier *cache.JobNotifier,
 	nodeManager *cluster.NodeManager,
+	previewCapable bool,
+	previewInternalBaseURL string,
 ) []*worker.Worker {
 	workers := make([]*worker.Worker, 0, workerCount)
 	for i := 0; i < workerCount; i++ {
@@ -543,12 +548,22 @@ func startProcessWorkers(
 		})
 	}
 
+	// Preserve preview-routing fields here. SetMetadataProvider replaces
+	// the previous provider, so omitting these would let the next heartbeat
+	// wipe preview_capable from the node row and route requests to nothing.
 	nodeManager.SetMetadataProvider(func() map[string]any {
-		return map[string]any{
+		metadata := map[string]any{
 			"build_sha":              version.BuildSHA,
 			"active_job_count":       totalActiveJobs(workers),
 			"active_run_agent_count": totalActiveRunAgentJobs(workers),
 		}
+		if previewCapable {
+			metadata["preview_capable"] = true
+		}
+		if previewInternalBaseURL != "" {
+			metadata["preview_internal_base_url"] = previewInternalBaseURL
+		}
+		return metadata
 	})
 
 	for i, w := range workers {

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -5,6 +5,8 @@ import (
 )
 
 func TestBuildBaseMetadata(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name                   string
 		previewCapable         bool
@@ -37,6 +39,8 @@ func TestBuildBaseMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			metadata := buildBaseMetadata(tt.previewCapable, tt.previewInternalBaseURL)
 
 			if _, ok := metadata["build_sha"]; !ok {
@@ -69,6 +73,8 @@ func TestBuildBaseMetadata(t *testing.T) {
 // initial provider without re-emitting preview-routing fields, causing the
 // next heartbeat to wipe preview_capable and break Start Preview routing.
 func TestBuildWorkerMetadataProvider_PreservesPreviewFields(t *testing.T) {
+	t.Parallel()
+
 	provider := buildWorkerMetadataProvider(nil, true, "http://worker-1:8080")
 
 	metadata := provider()
@@ -88,6 +94,8 @@ func TestBuildWorkerMetadataProvider_PreservesPreviewFields(t *testing.T) {
 }
 
 func TestBuildWorkerMetadataProvider_NonPreviewCapable(t *testing.T) {
+	t.Parallel()
+
 	provider := buildWorkerMetadataProvider(nil, false, "")
 
 	metadata := provider()

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestBuildBaseMetadata(t *testing.T) {
+	tests := []struct {
+		name                   string
+		previewCapable         bool
+		previewInternalBaseURL string
+		wantPreviewCapable     bool
+		wantInternalBaseURL    string
+	}{
+		{
+			name:                   "preview-capable worker advertises both fields",
+			previewCapable:         true,
+			previewInternalBaseURL: "http://worker-1:8080",
+			wantPreviewCapable:     true,
+			wantInternalBaseURL:    "http://worker-1:8080",
+		},
+		{
+			name:                   "non-preview-capable node omits preview_capable",
+			previewCapable:         false,
+			previewInternalBaseURL: "",
+			wantPreviewCapable:     false,
+			wantInternalBaseURL:    "",
+		},
+		{
+			name:                   "internal base URL without capability still emits URL",
+			previewCapable:         false,
+			previewInternalBaseURL: "http://worker-1:8080",
+			wantPreviewCapable:     false,
+			wantInternalBaseURL:    "http://worker-1:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := buildBaseMetadata(tt.previewCapable, tt.previewInternalBaseURL)
+
+			if _, ok := metadata["build_sha"]; !ok {
+				t.Errorf("expected build_sha to always be present")
+			}
+
+			gotCapable, hasCapable := metadata["preview_capable"]
+			if tt.wantPreviewCapable {
+				if !hasCapable || gotCapable != true {
+					t.Errorf("expected preview_capable=true, got %v (present=%v)", gotCapable, hasCapable)
+				}
+			} else if hasCapable {
+				t.Errorf("expected preview_capable to be omitted, got %v", gotCapable)
+			}
+
+			gotURL, hasURL := metadata["preview_internal_base_url"]
+			if tt.wantInternalBaseURL != "" {
+				if !hasURL || gotURL != tt.wantInternalBaseURL {
+					t.Errorf("expected preview_internal_base_url=%q, got %v (present=%v)", tt.wantInternalBaseURL, gotURL, hasURL)
+				}
+			} else if hasURL {
+				t.Errorf("expected preview_internal_base_url to be omitted, got %v", gotURL)
+			}
+		})
+	}
+}
+
+// TestBuildWorkerMetadataProvider_PreservesPreviewFields guards against the
+// regression where SetMetadataProvider in startProcessWorkers replaced the
+// initial provider without re-emitting preview-routing fields, causing the
+// next heartbeat to wipe preview_capable and break Start Preview routing.
+func TestBuildWorkerMetadataProvider_PreservesPreviewFields(t *testing.T) {
+	provider := buildWorkerMetadataProvider(nil, true, "http://worker-1:8080")
+
+	metadata := provider()
+
+	if got, ok := metadata["preview_capable"]; !ok || got != true {
+		t.Errorf("preview_capable must persist across worker startup, got %v (present=%v)", got, ok)
+	}
+	if got, ok := metadata["preview_internal_base_url"]; !ok || got != "http://worker-1:8080" {
+		t.Errorf("preview_internal_base_url must persist across worker startup, got %v (present=%v)", got, ok)
+	}
+	if _, ok := metadata["active_job_count"]; !ok {
+		t.Errorf("expected active_job_count to be present in worker metadata")
+	}
+	if _, ok := metadata["active_run_agent_count"]; !ok {
+		t.Errorf("expected active_run_agent_count to be present in worker metadata")
+	}
+}
+
+func TestBuildWorkerMetadataProvider_NonPreviewCapable(t *testing.T) {
+	provider := buildWorkerMetadataProvider(nil, false, "")
+
+	metadata := provider()
+
+	if _, ok := metadata["preview_capable"]; ok {
+		t.Errorf("preview_capable should be omitted when worker is not preview-capable")
+	}
+	if _, ok := metadata["preview_internal_base_url"]; ok {
+		t.Errorf("preview_internal_base_url should be omitted when not configured")
+	}
+}


### PR DESCRIPTION
## Summary
- The worker boot path called `nodeManager.SetMetadataProvider` twice. The second provider (in `startProcessWorkers`) omitted `preview_capable` and `preview_internal_base_url`, so the next heartbeat (~30s after start) wiped those fields from `nodes.metadata` and `WorkerSelector` started returning `ErrNoPreviewWorkers` — surfacing as "no preview-capable workers are available" on Start Preview.
- Fix threads `previewCapable` and `previewInternalBaseURL` into `startProcessWorkers` and re-includes them in the worker-side metadata provider so heartbeats no longer drop the routing fields.

## Test plan
- [x] `go build ./cmd/server/`
- [x] `go test ./internal/cluster/ ./internal/services/preview/`
- [ ] After deploy, confirm `SELECT metadata FROM nodes WHERE mode IN ('worker','all') AND status='active'` shows `preview_capable: true` post-heartbeat
- [ ] Start Preview succeeds for an existing session

🤖 Generated with [Claude Code](https://claude.com/claude-code)