### PR TITLE
Preserve sessions/projects sidebar filters when opening detail pages

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -217,4 +217,40 @@ describe('ProjectSidebar', () => {
     // At least 2: the top "+ New project" link + the ghost entry
     expect(newProjectTexts.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('preserves the user/status/repo filters in project detail links', async () => {
+    renderWithProviders(<ProjectSidebar />, {
+      searchParams: { user: 'all', status: 'active', repo: 'repo-1' },
+    });
+
+    const link = (await screen.findByText('Test Project')).closest('a');
+    expect(link?.getAttribute('href')).toMatch(
+      /^\/projects\/[^?]+\?user=all&status=active&repo=repo-1$/,
+    );
+  });
+
+  it('preserves a member-id user filter (not just "all")', async () => {
+    renderWithProviders(<ProjectSidebar />, {
+      searchParams: { user: 'user-2' },
+    });
+
+    const link = (await screen.findByText('Test Project')).closest('a');
+    expect(link?.getAttribute('href')).toMatch(/^\/projects\/[^?]+\?user=user-2$/);
+  });
+
+  it('only serializes the filters that are actually set', async () => {
+    renderWithProviders(<ProjectSidebar />, {
+      searchParams: { status: 'active' },
+    });
+
+    const link = (await screen.findByText('Test Project')).closest('a');
+    expect(link?.getAttribute('href')).toMatch(/^\/projects\/[^?]+\?status=active$/);
+  });
+
+  it('omits the query suffix on project detail links when no filters are active', async () => {
+    renderWithProviders(<ProjectSidebar />);
+
+    const link = (await screen.findByText('Test Project')).closest('a');
+    expect(link?.getAttribute('href')).toMatch(/^\/projects\/[^?]+$/);
+  });
 });

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -14,6 +14,7 @@ import { StatusDot } from "@/components/status-dot";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { useProjectUserFilter } from "@/hooks/use-project-user-filter";
+import { useFilterSuffix } from "@/hooks/use-owner-scope-filter";
 import { projectStatusConfig, projectStatusDotColor } from "@/lib/types";
 import type { Project } from "@/lib/types";
 const filterTabs = [
@@ -70,6 +71,10 @@ export function ProjectSidebar() {
         p.goal.toLowerCase().includes(q),
     );
   }, [filteredProjects, search]);
+
+  // Carry the sidebar's filters into detail-page links so opening a project
+  // doesn't reset the scope back to "Mine".
+  const filterSuffix = useFilterSuffix(currentUserFilter, activeFilter, repo);
 
   const isNewProject = pathname === "/projects/new";
   const showMineEmptyState =
@@ -185,7 +190,7 @@ export function ProjectSidebar() {
           return (
             <Link
               key={project.id}
-              href={`/projects/${project.id}`}
+              href={`/projects/${project.id}${filterSuffix}`}
               className={cn(
                 "block rounded-lg px-3 py-2.5 mb-0.5 transition-all duration-150",
                 isSelected

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -526,4 +526,65 @@ describe('SessionSidebar', () => {
     expect(selectedLink?.className).toContain('shadow-sm');
   });
 
+  // -----------------------------------------------------------------------
+  // Filter preservation in detail links
+  // -----------------------------------------------------------------------
+
+  it('preserves the user/status/repo filters in session detail links', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Linked session' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />, {
+      searchParams: { user: 'all', status: 'active', repo: 'repo-1' },
+    });
+    await screen.findByText('Linked session');
+
+    const link = screen.getByText('Linked session').closest('a');
+    expect(link).toHaveAttribute(
+      'href',
+      '/sessions/s1?user=all&status=active&repo=repo-1',
+    );
+  });
+
+  it('preserves a member-id user filter (not just "all")', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Member-scoped session' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />, {
+      searchParams: { user: 'user-2' },
+    });
+    await screen.findByText('Member-scoped session');
+
+    const link = screen.getByText('Member-scoped session').closest('a');
+    expect(link).toHaveAttribute('href', '/sessions/s1?user=user-2');
+  });
+
+  it('only serializes the filters that are actually set', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Status-only session' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />, {
+      searchParams: { status: 'archived' },
+    });
+    await screen.findByText('Status-only session');
+
+    const link = screen.getByText('Status-only session').closest('a');
+    expect(link).toHaveAttribute('href', '/sessions/s1?status=archived');
+  });
+
+  it('omits the query suffix when no filters are active', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Plain session' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />);
+    await screen.findByText('Plain session');
+
+    const link = screen.getByText('Plain session').closest('a');
+    expect(link).toHaveAttribute('href', '/sessions/s1');
+  });
+
 });

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
+import { useFilterSuffix } from "@/hooks/use-owner-scope-filter";
 import { SessionOwnerToggle } from "./session-owner-toggle";
 import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
@@ -292,6 +293,10 @@ export function SessionSidebar() {
 
   const counts = countsData?.data;
 
+  // Carry the sidebar's filters into detail-page links so opening a session
+  // doesn't reset the scope back to "Mine".
+  const filterSuffix = useFilterSuffix(currentUserFilter, activeFilter, repo);
+
   const isNewSession = pathname === "/sessions/new";
   const showDefaultEmptyState =
     currentFilter === "all" && !trimmedSearch && (!counts || counts.all === 0);
@@ -420,7 +425,7 @@ export function SessionSidebar() {
           return (
             <div key={session.id} className="group relative">
               <Link
-                href={`/sessions/${session.id}`}
+                href={`/sessions/${session.id}${filterSuffix}`}
                 className={cn(
                   "block rounded-lg px-3 py-2.5 mb-0.5 transition-all duration-150",
                   isSelected

--- a/frontend/src/hooks/use-owner-scope-filter.ts
+++ b/frontend/src/hooks/use-owner-scope-filter.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { parseAsString, useQueryState } from "nuqs";
 import { useAuth } from "@/hooks/use-auth";
 import type { User } from "@/lib/types";
@@ -35,6 +36,24 @@ export function ownerScopeParamForMember(
   currentUserId: string | undefined,
 ): OwnerScopeParam {
   return memberId === currentUserId ? null : memberId;
+}
+
+// Builds the `?user=…&status=…&repo=…` suffix to append to detail-page links
+// so the sidebar's filters survive navigation. "mine" is the implicit default
+// and is never serialized.
+export function useFilterSuffix(
+  currentUserFilter: string,
+  status: string | null,
+  repo: string | null,
+): string {
+  return useMemo(() => {
+    const params = new URLSearchParams();
+    if (currentUserFilter !== "mine") params.set("user", currentUserFilter);
+    if (status) params.set("status", status);
+    if (repo) params.set("repo", repo);
+    const qs = params.toString();
+    return qs ? `?${qs}` : "";
+  }, [currentUserFilter, status, repo]);
 }
 
 export function useOwnerScopeFilter() {


### PR DESCRIPTION
## Summary
- Fixes a UX bug where clicking a row in the sessions or projects sidebar dropped the URL's `user`, `status`, and `repo` query params, causing the sidebar to revert to the default "Mine" scope on the detail page — hiding the very item the user just opened.
- Adds a shared `useFilterSuffix` hook in `use-owner-scope-filter.ts` that serializes the active filters; both `SessionSidebar` and `ProjectSidebar` now append it to their detail-page Link hrefs.
- Adds 6 unit tests across the two sidebars covering the full-filter, member-id, partial-filter, and no-filter cases.

## Test plan
- [x] `npx vitest run` on both sidebar test files (46 tests pass)
- [x] `npm run typecheck` clean
- [x] `npx eslint` on touched files clean
- [ ] Manually: set "Everyone" on `/sessions`, click into a session, confirm sidebar still shows "Everyone" and the opened session is visible
- [ ] Repeat for `/projects`
