### PR TITLE
Preserve PR Health Snapshot When GitHub Signals Are Indeterminate

### DIFF
--- a/internal/services/github/pr_health.go
+++ b/internal/services/github/pr_health.go
@@ -1,11 +1,78 @@
 package github
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/assembledhq/143/internal/models"
 )
+
+// detectIndeterminateSignals reports whether GitHub's response leaves
+// mergeability or test results still being computed. Mergeability is
+// indeterminate when GitHub returns mergeable=null without an explicit
+// conflict label (it computes the value lazily after pushes and base merges).
+// Tests are indeterminate when any test-category check_run is queued, waiting,
+// or in progress. Callers use these flags to avoid clobbering prior actionable
+// state on the same head SHA with a transient-blank snapshot.
+func detectIndeterminateSignals(mergeable *bool, githubState string, checkRuns []gitHubCheckRun) (mergeStateIndeterminate, testsIndeterminate bool) {
+	state := strings.ToLower(strings.TrimSpace(githubState))
+	mergeStateIndeterminate = mergeable == nil && state != "dirty" && state != "blocked"
+	for _, check := range checkRuns {
+		if classifyCheckRunCategory(check.Name) != models.PullRequestCheckCategoryTest {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(check.Status)) {
+		case "in_progress", "queued", "waiting":
+			testsIndeterminate = true
+			return
+		}
+	}
+	return
+}
+
+// shouldSkipIndeterminateSnapshotWrite returns true when persisting the new
+// summary would regress prior actionable state on the same head SHA. It
+// fires only if (a) GitHub's signals are still being computed, (b) the prior
+// snapshot is for the same head SHA, and (c) the regression would erase a
+// prior conflict signal or drop a prior failing-test count while reruns are
+// still in flight.
+//
+// Callers should treat a true return as "return nil from the sync." That
+// intentionally also skips UpdateCIStatus and publishPullRequestUpdated for
+// this cycle — there is no new information to broadcast, and the next sync
+// will emit those side effects once GitHub finishes computing.
+//
+// One deliberate tradeoff: if a test rerun on the same SHA fixes one of N
+// failing checks while another rerun is still in_progress, the new count
+// (N-1) is technically accurate but we hold onto the prior N until *all*
+// reruns finish. That's preferable to flickering the "Fix tests" button
+// off and back on as reruns complete one by one.
+func shouldSkipIndeterminateSnapshotWrite(
+	mergeStateIndeterminate, testsIndeterminate bool,
+	newHeadSHA string,
+	newFailingTestCount int,
+	prior models.PullRequestHealthCurrent,
+) bool {
+	if !mergeStateIndeterminate && !testsIndeterminate {
+		return false
+	}
+	if prior.HeadSHA != newHeadSHA {
+		return false
+	}
+	var priorSummary models.PullRequestHealthSummary
+	if err := json.Unmarshal(prior.SummaryJSON, &priorSummary); err != nil {
+		return false
+	}
+	priorConflicted := priorSummary.HasConflicts || priorSummary.MergeState == models.PullRequestMergeStateConflicted
+	if mergeStateIndeterminate && priorConflicted {
+		return true
+	}
+	if testsIndeterminate && priorSummary.FailingTestCount > newFailingTestCount {
+		return true
+	}
+	return false
+}
 
 func normalizeMergeState(mergeable *bool, githubState string) (models.PullRequestMergeState, bool) {
 	state := strings.ToLower(strings.TrimSpace(githubState))

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -212,6 +212,20 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 	}
 	summary.NeedsAgentAction = summary.HasConflicts || summary.FailingTestCount > 0
 
+	mergeStateIndeterminate, testsIndeterminate := detectIndeterminateSignals(details.Mergeable, details.MergeableState, checkRuns)
+	if mergeStateIndeterminate || testsIndeterminate {
+		prior, priorErr := s.pullRequests.GetHealthCurrent(ctx, orgID, pullRequestID)
+		if priorErr == nil && shouldSkipIndeterminateSnapshotWrite(mergeStateIndeterminate, testsIndeterminate, details.Head.SHA, summary.FailingTestCount, prior) {
+			s.logger.Debug().
+				Str("pull_request_id", pullRequestID.String()).
+				Str("head_sha", details.Head.SHA).
+				Bool("merge_state_indeterminate", mergeStateIndeterminate).
+				Bool("tests_indeterminate", testsIndeterminate).
+				Msg("skipping pull request health snapshot write; GitHub data still indeterminate on same head SHA")
+			return nil
+		}
+	}
+
 	current, err := s.pullRequests.UpsertHealthSummary(ctx, orgID, pullRequestID, details.Head.SHA, details.Base.SHA, summary, nil)
 	if err != nil {
 		return err

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -369,6 +369,151 @@ func TestPRServiceSyncPullRequestState(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all sync expectations should be met")
 }
 
+// When GitHub returns mergeable=null while it recomputes (without an explicit
+// dirty/blocked label) on the same head SHA where we already know the PR is
+// conflicted, persisting the new snapshot would clobber has_conflicts=true
+// with false and break the "Resolve conflicts" repair button. The sync should
+// skip the write and let the next sync pick up GitHub's resolved value.
+func TestPRServiceSyncPullRequestStateSkipsIndeterminateMergeRegression(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"open","mergeable":null,"mergeable_state":"unknown","head":{"ref":"feature","sha":"head-flap"},"base":{"ref":"main","sha":"base-flap"}}`))
+		case "/repos/assembledhq/143/commits/head-flap/check-runs":
+			_, _ = w.Write([]byte(`{"check_runs":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	priorSummary := models.PullRequestHealthSummary{
+		MergeState:       models.PullRequestMergeStateConflicted,
+		HasConflicts:     true,
+		FailingTestCount: 0,
+		NeedsAgentAction: true,
+	}
+	priorJSON, err := json.Marshal(priorSummary)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Flaky PR", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			models.PullRequestMergeStateConflicted, true, 0, true, (*time.Time)(nil), int64(3), &now, now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			pullRequestID, orgID, int64(3), "head-flap", "base-flap", priorJSON, priorJSON, models.PullRequestHealthEnrichmentStatusReady, &now, now, now,
+		))
+
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+
+	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
+	require.NoError(t, err, "SyncPullRequestState should not error when skipping an indeterminate snapshot")
+	require.NoError(t, mock.ExpectationsWereMet(), "no snapshot upsert should have been issued")
+}
+
+// Same fix shape for the fix-tests path: when test-category checks are still
+// in_progress on the same head SHA and the apparent failing-test count would
+// regress below the prior snapshot's count, skip the write so the
+// "Fix tests" button keeps working until checks finish.
+func TestPRServiceSyncPullRequestStateSkipsIndeterminateTestRegression(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"open","mergeable":true,"mergeable_state":"clean","head":{"ref":"feature","sha":"head-rerun"},"base":{"ref":"main","sha":"base-rerun"}}`))
+		case "/repos/assembledhq/143/commits/head-rerun/check-runs":
+			// Rerun in progress: no conclusion yet, so it would not be counted as failing,
+			// dropping FailingTestCount from the prior snapshot's value of 2 down to 0.
+			_, _ = w.Write([]byte(`{"check_runs":[{"id":11,"name":"unit tests","status":"in_progress","conclusion":"","app":{"slug":"github-actions"},"output":{}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	priorSummary := models.PullRequestHealthSummary{
+		MergeState:       models.PullRequestMergeStateClean,
+		HasConflicts:     false,
+		FailingTestCount: 2,
+		NeedsAgentAction: true,
+	}
+	priorJSON, err := json.Marshal(priorSummary)
+	require.NoError(t, err)
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Tests rerun", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			models.PullRequestMergeStateClean, false, 2, true, (*time.Time)(nil), int64(4), &now, now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": pullRequestID}).
+		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
+			pullRequestID, orgID, int64(4), "head-rerun", "base-rerun", priorJSON, priorJSON, models.PullRequestHealthEnrichmentStatusReady, &now, now, now,
+		))
+
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+
+	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
+	require.NoError(t, err, "SyncPullRequestState should not error when skipping an indeterminate test snapshot")
+	require.NoError(t, mock.ExpectationsWereMet(), "no snapshot upsert should have been issued")
+}
+
 func TestPRServiceEnrichPullRequestHealth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_health_test.go
+++ b/internal/services/github/pr_health_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
@@ -68,6 +69,212 @@ func TestNormalizeMergeState(t *testing.T) {
 			state, hasConflicts := normalizeMergeState(tt.mergeable, tt.githubState)
 			require.Equal(t, tt.expected, state, "normalizeMergeState should map GitHub merge states to product states")
 			require.Equal(t, tt.hasConflicts, hasConflicts, "normalizeMergeState should mark conflicts only for conflicting states")
+		})
+	}
+}
+
+func TestDetectIndeterminateSignals(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		mergeable        *bool
+		githubState      string
+		checkRuns        []gitHubCheckRun
+		expectMergeIndet bool
+		expectTestsIndet bool
+	}{
+		{
+			name:             "definitive merge state and completed tests",
+			mergeable:        boolPtr(false),
+			githubState:      "dirty",
+			checkRuns:        []gitHubCheckRun{{Name: "unit tests", Status: "completed", Conclusion: "failure"}},
+			expectMergeIndet: false,
+			expectTestsIndet: false,
+		},
+		{
+			name:             "mergeable null without explicit conflict label",
+			mergeable:        nil,
+			githubState:      "unknown",
+			checkRuns:        []gitHubCheckRun{{Name: "unit tests", Status: "completed", Conclusion: "failure"}},
+			expectMergeIndet: true,
+			expectTestsIndet: false,
+		},
+		{
+			name:             "mergeable null but state dirty is still definitive",
+			mergeable:        nil,
+			githubState:      "dirty",
+			expectMergeIndet: false,
+			expectTestsIndet: false,
+		},
+		{
+			name:             "mergeable null but state blocked is still definitive",
+			mergeable:        nil,
+			githubState:      "blocked",
+			expectMergeIndet: false,
+			expectTestsIndet: false,
+		},
+		{
+			name:        "in-progress test check is indeterminate",
+			mergeable:   boolPtr(true),
+			githubState: "clean",
+			checkRuns: []gitHubCheckRun{
+				{Name: "unit tests", Status: "in_progress"},
+			},
+			expectMergeIndet: false,
+			expectTestsIndet: true,
+		},
+		{
+			name:        "queued test check is indeterminate",
+			mergeable:   boolPtr(true),
+			githubState: "clean",
+			checkRuns: []gitHubCheckRun{
+				{Name: "playwright e2e", Status: "queued"},
+			},
+			expectMergeIndet: false,
+			expectTestsIndet: true,
+		},
+		{
+			name:        "waiting test check is indeterminate",
+			mergeable:   boolPtr(true),
+			githubState: "clean",
+			checkRuns: []gitHubCheckRun{
+				{Name: "vitest", Status: "waiting"},
+			},
+			expectMergeIndet: false,
+			expectTestsIndet: true,
+		},
+		{
+			name:        "in-progress lint check is not test indeterminate",
+			mergeable:   boolPtr(true),
+			githubState: "clean",
+			checkRuns: []gitHubCheckRun{
+				{Name: "eslint", Status: "in_progress"},
+			},
+			expectMergeIndet: false,
+			expectTestsIndet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mergeIndet, testsIndet := detectIndeterminateSignals(tt.mergeable, tt.githubState, tt.checkRuns)
+			require.Equal(t, tt.expectMergeIndet, mergeIndet, "merge state indeterminate flag should match")
+			require.Equal(t, tt.expectTestsIndet, testsIndet, "tests indeterminate flag should match")
+		})
+	}
+}
+
+func TestShouldSkipIndeterminateSnapshotWrite(t *testing.T) {
+	t.Parallel()
+
+	makePrior := func(t *testing.T, headSHA string, summary models.PullRequestHealthSummary) models.PullRequestHealthCurrent {
+		t.Helper()
+		raw, err := json.Marshal(summary)
+		require.NoError(t, err)
+		return models.PullRequestHealthCurrent{HeadSHA: headSHA, SummaryJSON: raw}
+	}
+
+	conflictedPrior := models.PullRequestHealthSummary{
+		MergeState:   models.PullRequestMergeStateConflicted,
+		HasConflicts: true,
+	}
+	cleanPrior := models.PullRequestHealthSummary{
+		MergeState:   models.PullRequestMergeStateClean,
+		HasConflicts: false,
+	}
+	twoFailingPrior := models.PullRequestHealthSummary{
+		MergeState:       models.PullRequestMergeStateClean,
+		FailingTestCount: 2,
+	}
+
+	tests := []struct {
+		name            string
+		mergeIndet      bool
+		testsIndet      bool
+		newHeadSHA      string
+		newFailingCount int
+		prior           models.PullRequestHealthCurrent
+		expectSkip      bool
+	}{
+		{
+			name:       "no indeterminate signals never skips",
+			mergeIndet: false,
+			testsIndet: false,
+			newHeadSHA: "sha-1",
+			prior:      makePrior(t, "sha-1", conflictedPrior),
+			expectSkip: false,
+		},
+		{
+			name:       "merge indeterminate on same SHA with conflicted prior skips",
+			mergeIndet: true,
+			newHeadSHA: "sha-1",
+			prior:      makePrior(t, "sha-1", conflictedPrior),
+			expectSkip: true,
+		},
+		{
+			name:       "merge indeterminate on same SHA with non-conflicted prior writes",
+			mergeIndet: true,
+			newHeadSHA: "sha-1",
+			prior:      makePrior(t, "sha-1", cleanPrior),
+			expectSkip: false,
+		},
+		{
+			name:       "merge indeterminate on different SHA writes",
+			mergeIndet: true,
+			newHeadSHA: "sha-new",
+			prior:      makePrior(t, "sha-old", conflictedPrior),
+			expectSkip: false,
+		},
+		{
+			name:            "tests indeterminate on same SHA with regression skips",
+			testsIndet:      true,
+			newHeadSHA:      "sha-1",
+			newFailingCount: 1,
+			prior:           makePrior(t, "sha-1", twoFailingPrior),
+			expectSkip:      true,
+		},
+		{
+			name:            "tests indeterminate on same SHA with equal count writes",
+			testsIndet:      true,
+			newHeadSHA:      "sha-1",
+			newFailingCount: 2,
+			prior:           makePrior(t, "sha-1", twoFailingPrior),
+			expectSkip:      false,
+		},
+		{
+			name:            "tests indeterminate on same SHA with higher count writes",
+			testsIndet:      true,
+			newHeadSHA:      "sha-1",
+			newFailingCount: 3,
+			prior:           makePrior(t, "sha-1", twoFailingPrior),
+			expectSkip:      false,
+		},
+		{
+			name:            "tests indeterminate on different SHA writes",
+			testsIndet:      true,
+			newHeadSHA:      "sha-new",
+			newFailingCount: 0,
+			prior:           makePrior(t, "sha-old", twoFailingPrior),
+			expectSkip:      false,
+		},
+		{
+			name:       "corrupt prior summary JSON falls through to write",
+			mergeIndet: true,
+			newHeadSHA: "sha-1",
+			prior:      models.PullRequestHealthCurrent{HeadSHA: "sha-1", SummaryJSON: []byte(`{not json`)},
+			expectSkip: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			skip := shouldSkipIndeterminateSnapshotWrite(tt.mergeIndet, tt.testsIndet, tt.newHeadSHA, tt.newFailingCount, tt.prior)
+			require.Equal(t, tt.expectSkip, skip, "skip decision should match the expected outcome")
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The PR health sync was overwriting `has_conflicts=true` with `false` whenever GitHub returned `mergeable=null` while it recomputed mergeability — observed flapping every few minutes on the same head SHA, which broke the "Resolve conflicts" repair button mid-click with a generic 500. The same race could affect "Fix tests" while check reruns were in progress. `SyncPullRequestState` now skips the snapshot upsert when GitHub signals are still indeterminate AND the new data would erase prior actionable state on the same head SHA — the next sync cycle picks up GitHub's resolved values. Includes a `detectIndeterminateSignals` helper, a pure `shouldSkipIndeterminateSnapshotWrite` decision function, and unit + integration test coverage for both the conflicts and failing-tests paths.

## Test plan

- [x] `go test ./internal/...` passes
- [x] `make lint` clean
- [ ] Manually verify on PR #562 (the original repro) that the conflicted ↔ unknown flap stops once deployed
