### PR TITLE
Clarify API key empty-state copy with org fallback messaging

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -196,7 +196,7 @@ export default function AccountPage() {
                 )) : (
                   <TableRow>
                     <TableCell colSpan={5} className="text-muted-foreground">
-                      No personal auth configured yet. Add one to take precedence over the organization stack.
+                      No personal auth configured. Click &ldquo;Add auth&rdquo; above to enable sessions to use your own subscription. Org-wide credentials are used as a fallback.
                     </TableCell>
                   </TableRow>
                 )}

--- a/frontend/src/components/agent-key-required-banner.tsx
+++ b/frontend/src/components/agent-key-required-banner.tsx
@@ -9,13 +9,16 @@ export function AgentKeyRequiredBanner({ agentType }: { agentType: string }) {
   const agent = AGENTS_BY_KEY[agentType];
   const label = agent?.label ?? agentType;
   const href = !agent ? "/settings/agent" : agentType === "codex" ? "/settings/agent" : "/settings/account";
-  const message = `No API key configured for ${label}. Add your key in Settings to start sessions.`;
 
   return (
     <div className="flex items-center gap-3 rounded-lg border border-amber-500/20 bg-amber-500/5 px-4 py-3">
       <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
       <div className="flex-1 min-w-0">
-        <p className="text-xs text-amber-700 dark:text-amber-300">{message}</p>
+        <p className="text-xs text-amber-700 dark:text-amber-300">
+          No API key configured for {label}.{" "}
+          <Link href={href} className="underline font-medium">Add one in Settings</Link>
+          {" "}to use your own subscription. Org-wide credentials are used as a fallback.
+        </p>
       </div>
       <Button size="sm" variant="outline" asChild className="shrink-0">
         <Link href={href}>Configure keys</Link>


### PR DESCRIPTION
## Summary
- Reword the "My settings" personal-auth empty state to recommend adding a personal key (so sessions use your own subscription) and clarify org-wide credentials act as a fallback.
- Update the no-key session banner with parallel wording and add an inline link to the settings page alongside the existing "Configure keys" button.

## Test plan
- [ ] Visit `/settings/account` with no personal auths configured; confirm new copy renders.
- [ ] Visit `/sessions/new` for an agent with no resolved credentials; confirm banner copy renders and the inline "Add one in Settings" link navigates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)