### PR TITLE
Show ghost skeleton on session chat while loading instead of empty-state copy

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -436,13 +436,14 @@ describe('SessionDetailPage', () => {
     expect(screen.getByText(/2 log entries/)).toBeInTheDocument();
   });
 
-  it('shows empty message state when no messages', async () => {
+  it('shows loading skeleton when no messages and hides files-changed pill', async () => {
     const idleSession: Session = {
       ...mockSessions[0],
       status: 'idle',
       completed_at: undefined,
       current_turn: 1,
       sandbox_state: 'snapshotted',
+      diff_stats: { added: 2, removed: 5, files_changed: 2 },
     };
 
     server.use(
@@ -463,9 +464,79 @@ describe('SessionDetailPage', () => {
     );
 
     renderWithProviders(<SessionDetailContent id={idleSession.id} />);
-    expect(await screen.findByText('No activity yet')).toBeInTheDocument();
-    expect(screen.getByText('The session is processing its initial turn.')).toBeInTheDocument();
+    expect(await screen.findByTestId('session-timeline-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('No activity yet')).not.toBeInTheDocument();
+    expect(screen.queryByText(/files? changed/)).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText('Send a follow-up message...')).toBeInTheDocument();
+  });
+
+  it('shows loading skeleton for a running session before any timeline entries arrive', async () => {
+    const runningSession: Session = {
+      ...mockSessions[0],
+      status: 'running',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: runningSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/timeline', () => {
+        return HttpResponse.json({ data: [] as SessionTimelineEntry[], meta: {} } satisfies ListResponse<SessionTimelineEntry>);
+      }),
+      http.get('/api/v1/issues/:id', ({ params }) => {
+        const issue = mockIssues.find((i) => i.id === params.id);
+        if (!issue) {
+          return HttpResponse.json(
+            { error: { code: 'NOT_FOUND', message: 'Issue not found' } },
+            { status: 404 },
+          );
+        }
+        return HttpResponse.json({ data: { ...issue, description: '' } } satisfies SingleResponse<typeof issue>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={runningSession.id} />);
+    expect(await screen.findByTestId('session-timeline-skeleton')).toBeInTheDocument();
+    expect(screen.queryByText('Agent is working...')).not.toBeInTheDocument();
+    expect(screen.queryByText(/files? changed/)).not.toBeInTheDocument();
+  });
+
+  it('does not shimmer forever for a terminal session with an empty timeline', async () => {
+    const completedSession: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: completedSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/timeline', () => {
+        return HttpResponse.json({ data: [] as SessionTimelineEntry[], meta: {} } satisfies ListResponse<SessionTimelineEntry>);
+      }),
+      http.get('/api/v1/issues/:id', ({ params }) => {
+        const issue = mockIssues.find((i) => i.id === params.id);
+        if (!issue) {
+          return HttpResponse.json(
+            { error: { code: 'NOT_FOUND', message: 'Issue not found' } },
+            { status: 404 },
+          );
+        }
+        return HttpResponse.json({ data: { ...issue, description: '' } } satisfies SingleResponse<typeof issue>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id={completedSession.id} />);
+    // Wait for the timeline query to settle by looking for the diff-summary
+    // pill, which lives inside ChatTimeline (only rendered once we're past
+    // the loading state).
+    expect(await screen.findByText(/files? changed/)).toBeInTheDocument();
+    expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
   });
 
   it('restores the saved scroll position when reopening an existing session', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -81,6 +81,7 @@ import { PendingAttachmentStrip } from "@/components/pending-attachment-strip";
 import { PRHealthBanner } from "@/components/pr-health-banner";
 import { useAuth } from "@/hooks/use-auth";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
+import { activeSet } from "@/lib/session-status-groups";
 
 const PREVIEW_ORIGIN_TEMPLATE =
   process.env.NEXT_PUBLIC_PREVIEW_ORIGIN_TEMPLATE ||
@@ -121,12 +122,6 @@ export function formatDuration(startedAt?: string, completedAt?: string): string
   const days = Math.floor(hours / 24);
   return `${days}d ${hours % 24}h`;
 }
-
-/** Returns true if the session has been pending for more than 2 minutes. */
-function isPendingTooLong(createdAt: string): boolean {
-  return Date.now() - new Date(createdAt).getTime() > 2 * 60 * 1000;
-}
-
 
 const validationChecks: { key: string; label: string }[] = [
   { key: "direction_check", label: "Direction check" },
@@ -844,6 +839,48 @@ function isNearBottom(el: HTMLElement): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_NEAR_BOTTOM_THRESHOLD;
 }
 
+function SessionTimelineSkeleton() {
+  const rows: { align: "left" | "right"; widths: string[] }[] = [
+    { align: "right", widths: ["w-3/5", "w-2/5"] },
+    { align: "left", widths: ["w-4/5", "w-3/4", "w-1/2"] },
+    { align: "left", widths: ["w-2/3", "w-1/3"] },
+    { align: "left", widths: ["w-3/4", "w-3/5"] },
+  ];
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Loading session activity"
+      data-testid="session-timeline-skeleton"
+      className="space-y-3 py-1"
+    >
+      {rows.map((row, i) => (
+        <div
+          key={i}
+          className={`flex ${row.align === "right" ? "justify-end" : "justify-start"}`}
+        >
+          <div
+            className={`max-w-[92%] min-w-[40%] rounded-lg px-3 py-2.5 space-y-2 animate-pulse ${
+              row.align === "right" ? "bg-primary/10" : "bg-muted"
+            }`}
+          >
+            {row.widths.map((w, j) => (
+              <div
+                key={j}
+                className={`h-3 rounded ${w} ${
+                  row.align === "right" ? "bg-primary/20" : "bg-muted-foreground/15"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading session activity…</span>
+    </div>
+  );
+}
+
 function ChatPanel({
   session,
   sessionId,
@@ -966,6 +1003,12 @@ function ChatPanel({
     return [...baseTimelineEntries, ...overlayEntries];
   }, [baseTimelineEntries, streamedLogs]);
   const hasLoadedTimelineInputs = timelineQuery.isFetched && (!hasIssue || issueQuery.isFetched);
+  // Skeleton only while we'd reasonably expect content: timeline still loading,
+  // or session is active. Terminal sessions with empty timelines must not shimmer forever.
+  const showLoadingSkeleton =
+    timelineEntries.length === 0 &&
+    session.status !== "pending" &&
+    (!hasLoadedTimelineInputs || activeSet.has(session.status));
 
   const persistScrollPosition = useCallback((scrollTop: number) => {
     if (typeof window === "undefined" || !viewerScope) return;
@@ -1168,51 +1211,23 @@ function ChatPanel({
       )}
       {/* Unified timeline */}
       <div ref={scrollRef} onScroll={handleScroll} className="flex-1 overflow-y-auto space-y-2 p-4">
-        {timelineEntries.length === 0 && !isRunning && session.status !== "pending" && (
-          <div className="flex items-center justify-center py-12">
-            <div className="text-center space-y-2 max-w-[320px]">
-              {session.status === "pending" ? (
-                <>
-                  <Loader2 className="h-8 w-8 text-muted-foreground/40 mx-auto animate-spin" />
-                  <p className="text-xs font-medium text-muted-foreground">Waiting to start</p>
-                  <p className="text-xs text-muted-foreground/60">
-                    This session is queued and waiting for an available slot. Queued {formatTimeAgo(session.created_at)}.
-                  </p>
-                  {isPendingTooLong(session.created_at) && (
-                    <div className="mt-3 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 px-3 py-2 text-left">
-                      <p className="text-xs font-medium text-amber-700 dark:text-amber-400 flex items-center gap-1.5">
-                        <AlertTriangle className="h-3 w-3 shrink-0" />
-                        Taking longer than expected
-                      </p>
-                      <p className="text-xs text-amber-600 dark:text-amber-500 mt-1">
-                        This session has been waiting for over 2 minutes. It may be blocked by other running sessions or an internal issue. Try cancelling and retrying if it doesn&apos;t start soon.
-                      </p>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <>
-                  <MessageSquare className="h-8 w-8 text-muted-foreground/40 mx-auto" />
-                  <p className="text-xs font-medium text-muted-foreground">No activity yet</p>
-                  <p className="text-xs text-muted-foreground/60">The session is processing its initial turn.</p>
-                </>
-              )}
-            </div>
-          </div>
+        {showLoadingSkeleton ? (
+          <SessionTimelineSkeleton />
+        ) : (
+          <ChatTimeline
+            entries={timelineEntries}
+            isRunning={isRunning}
+            diffStats={session.diff_stats}
+            onDiffClick={onDiffClick}
+            onApprovePlan={canSendMessage ? onApprovePlan : undefined}
+            onAdjustPlan={canSendMessage ? onAdjustPlan : undefined}
+            getEntryContainerProps={(_, index) =>
+              ({
+                "data-session-entry-index": index,
+              }) as React.HTMLAttributes<HTMLDivElement> & Record<`data-${string}`, string | number | undefined>
+            }
+          />
         )}
-        <ChatTimeline
-          entries={timelineEntries}
-          isRunning={isRunning}
-          diffStats={session.diff_stats}
-          onDiffClick={onDiffClick}
-          onApprovePlan={canSendMessage ? onApprovePlan : undefined}
-          onAdjustPlan={canSendMessage ? onAdjustPlan : undefined}
-          getEntryContainerProps={(_, index) =>
-            ({
-              "data-session-entry-index": index,
-            }) as React.HTMLAttributes<HTMLDivElement> & Record<`data-${string}`, string | number | undefined>
-          }
-        />
         {session.status === "pending" && (
           <div className="flex items-center justify-center py-12">
             <div className="text-center space-y-2 max-w-[280px]">


### PR DESCRIPTION
## Summary
- Replaces the misleading "No activity yet — The session is processing its initial turn." empty state on the session detail chat with a pulsing ghost-card skeleton (`SessionTimelineSkeleton`) that matches the loader style used in the sidebar and login fallback.
- Suppresses the "Files changed" diff pill (rendered inside `ChatTimeline`) while the skeleton is showing so a still-loading session does not surface partial state.
- Skeleton only renders for non-pending sessions where new entries are still expected (timeline query in flight, or status in `activeSet`) — terminal sessions with empty timelines fall through to `ChatTimeline` so we do not shimmer forever. Drops the dead `isPendingTooLong` helper while in the area.

## Test plan
- [x] `vitest run page.test.tsx` — 117/117 pass (added two cases: running session with empty entries shows the skeleton; terminal session with empty timeline does NOT shimmer)
- [x] `vitest run chat-timeline.test.tsx` — 19/19 pass
- [x] `tsc --noEmit` clean, `eslint` clean, `next build` clean
- [ ] Visual check in dev server — not yet run; please eyeball the skeleton animation in a fresh session before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)