### PR TITLE
Add mobile navigation drawer and responsive layout

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -84,7 +84,7 @@ describe("AuthenticatedLayout", () => {
     expect(sidebar).toHaveClass("w-[236px]");
   });
 
-  it("uses a full-width content area with generous padding", () => {
+  it("uses a full-width content area with responsive padding", () => {
     const { container } = renderWithProviders(
       <AuthenticatedLayout>
         <div>content</div>
@@ -93,8 +93,12 @@ describe("AuthenticatedLayout", () => {
 
     const contentWrapper = container.querySelector("main > div:last-child");
     expect(contentWrapper).toHaveClass("max-w-none");
-    expect(contentWrapper).toHaveClass("px-8");
-    expect(contentWrapper).toHaveClass("py-6");
+    // Mobile-first: tight padding by default, wider on larger breakpoints.
+    expect(contentWrapper).toHaveClass("px-4");
+    expect(contentWrapper).toHaveClass("sm:px-6");
+    expect(contentWrapper).toHaveClass("lg:px-10");
+    expect(contentWrapper).toHaveClass("py-5");
+    expect(contentWrapper).toHaveClass("sm:py-6");
   });
 
   it("content wrapper supports full-height children via flex-1 and min-h-0", () => {
@@ -255,7 +259,8 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    expect(screen.getByRole("button", { name: "Search" })).toBeInTheDocument();
+    // Rendered in both the desktop sidebar and the mobile top bar.
+    expect(screen.getAllByRole("button", { name: "Search" }).length).toBeGreaterThan(0);
   });
 
   it("has a new session button", () => {
@@ -265,7 +270,7 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    expect(screen.getByRole("button", { name: "New session" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "New session" }).length).toBeGreaterThan(0);
   });
 
   it("opens create session dialog when new session button is clicked", async () => {
@@ -277,7 +282,9 @@ describe("AuthenticatedLayout", () => {
       </AuthenticatedLayout>
     );
 
-    await user.click(screen.getByRole("button", { name: "New session" }));
+    // Click the first "New session" trigger (desktop sidebar); both triggers
+    // wire up to the same handler.
+    await user.click(screen.getAllByRole("button", { name: "New session" })[0]);
 
     await waitFor(() => {
       expect(screen.getByRole("dialog")).toBeInTheDocument();

--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { AuthenticatedLayout } from "./authenticated-layout";
 import { http, HttpResponse } from "msw";
 import { server } from "@/test/mocks/server";
@@ -303,6 +303,96 @@ describe("AuthenticatedLayout", () => {
       const trigger = screen.getByTestId("org-switcher");
       expect(trigger).toHaveTextContent("Test Org");
       expect(trigger.getAttribute("aria-haspopup")).not.toBeNull();
+    });
+  });
+
+  describe("mobile navigation drawer", () => {
+    it("hamburger opens the drawer and reflects state via aria-expanded", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      const hamburger = screen.getByRole("button", { name: "Open navigation menu" });
+      expect(hamburger).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+      await user.click(hamburger);
+
+      const drawer = await screen.findByRole("dialog");
+      expect(drawer).toBeInTheDocument();
+      expect(hamburger).toHaveAttribute("aria-expanded", "true");
+      // The drawer exposes an accessible name for screen readers.
+      expect(within(drawer).getByText("Navigation")).toBeInTheDocument();
+    });
+
+    it("closes the drawer when a primary nav link is tapped", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+      const drawer = await screen.findByRole("dialog");
+
+      // Click a nav link inside the drawer (scope with `within` to avoid
+      // matching the desktop sidebar's duplicate link).
+      await user.click(within(drawer).getByRole("link", { name: "Sessions" }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+    });
+
+    it("closes the drawer when a Settings sub-link is tapped", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+      const drawer = await screen.findByRole("dialog");
+
+      // Expand the Settings group inside the drawer, then tap a sub-link.
+      // This verifies onNavigate threads through SidebarSettingsSection.
+      await user.click(within(drawer).getByRole("button", { name: /Settings/ }));
+      await user.click(within(drawer).getByRole("link", { name: "Account" }));
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+    });
+
+    it("does not close the drawer on modifier-clicks (cmd/ctrl/middle)", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+      const drawer = await screen.findByRole("dialog");
+
+      // Cmd/Ctrl click opens the link in a new tab — current page is unchanged
+      // for the user, so the drawer should stay put.
+      await user.keyboard("{Meta>}");
+      await user.click(within(drawer).getByRole("link", { name: "Sessions" }));
+      await user.keyboard("{/Meta}");
+
+      // Drawer is still in the DOM after a deliberate wait.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(screen.queryByRole("dialog")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -12,6 +12,9 @@ import {
   Info,
   Copy,
   Check,
+  Menu,
+  X,
+  type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
@@ -25,6 +28,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import {
   Tooltip,
   TooltipContent,
@@ -40,6 +49,13 @@ import { OrgSwitcher } from "@/components/org-switcher";
 import { CommandPalette } from "@/components/command-palette/command-palette";
 import { SidebarSettingsSection } from "@/components/sidebar-settings-section";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
+
+type SidebarUser = {
+  email?: string;
+  name?: string;
+  role?: string;
+  avatar_url?: string;
+};
 
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "dev";
 const shortSha = buildSha === "dev" ? "dev" : buildSha.slice(0, 7);
@@ -79,12 +95,251 @@ function VersionMenuItem() {
   );
 }
 
-const navItems = [
+type NavItem = {
+  label: string;
+  icon: LucideIcon;
+  href: string;
+  showProposalBadge: boolean;
+};
+
+const navItems: NavItem[] = [
   { label: "Sessions", icon: Play, href: "/sessions", showProposalBadge: false },
   { label: "Automations", icon: RefreshCw, href: "/automations", showProposalBadge: false },
   { label: "Projects", icon: FolderKanban, href: "/projects", showProposalBadge: true },
   { label: "Autopilot", icon: Zap, href: "/autopilot", showProposalBadge: false },
 ];
+
+type SidebarBodyProps = {
+  variant: "desktop" | "mobile";
+  user: SidebarUser;
+  pathname: string;
+  proposalCount: number;
+  onPaletteOpen: () => void;
+  onCreateSession: () => void;
+  onNavigate?: () => void;
+  onLogout: () => void;
+};
+
+function SidebarBody({
+  variant,
+  user,
+  pathname,
+  proposalCount,
+  onPaletteOpen,
+  onCreateSession,
+  onNavigate,
+  onLogout,
+}: SidebarBodyProps) {
+  const isMobile = variant === "mobile";
+  // Touch-friendly sizing on mobile: nav items ~44px tall, icon buttons 44×44.
+  const navItemClasses = isMobile
+    ? "py-3 text-sm"
+    : "py-[7px] text-xs";
+  const iconBtnClasses = isMobile ? "h-11 w-11" : "h-7 w-7";
+  const iconSize = isMobile ? "h-5 w-5" : "h-4 w-4";
+
+  return (
+    <>
+      {/* Header: org switcher + actions (+ close on mobile) */}
+      <div
+        className={cn(
+          "relative flex items-center justify-between",
+          isMobile ? "px-3 py-3" : "px-4 py-3.5"
+        )}
+      >
+        <div className="flex items-center min-w-0 flex-1">
+          <OrgSwitcher userEmail={user?.email} />
+        </div>
+        {isMobile ? (
+          <SheetClose asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+              aria-label="Close navigation menu"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+          </SheetClose>
+        ) : (
+          <TooltipProvider>
+            <div className="flex items-center gap-0.5">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onPaletteOpen}
+                    className={cn(
+                      iconBtnClasses,
+                      "rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+                    )}
+                    aria-label="Search"
+                  >
+                    <Search className={iconSize} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>Search</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={onCreateSession}
+                    className={cn(
+                      iconBtnClasses,
+                      "rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+                    )}
+                    aria-label="New session"
+                  >
+                    <PenSquare className={iconSize} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>New session</TooltipContent>
+              </Tooltip>
+            </div>
+          </TooltipProvider>
+        )}
+      </div>
+
+      {/* Navigation */}
+      <nav className="relative flex-1 px-2 space-y-0.5 overflow-y-auto">
+        {navItems.map((item) => {
+          const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              onClick={onNavigate}
+              aria-current={isActive ? "page" : undefined}
+              className={cn(
+                "relative flex items-center gap-2.5 rounded-md px-2.5 font-medium transition-colors duration-150 active:bg-sidebar-accent",
+                navItemClasses,
+                isActive
+                  ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                  : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+              )}
+            >
+              <item.icon className="h-4 w-4 shrink-0" />
+              {item.label}
+              {item.showProposalBadge && proposalCount > 0 && (
+                <Badge variant="secondary" className="ml-auto text-xs px-1.5 py-0 h-5 bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300">
+                  {proposalCount}
+                </Badge>
+              )}
+            </Link>
+          );
+        })}
+        <SidebarSettingsSection
+          pathname={pathname}
+          userRole={user?.role}
+          onNavigate={onNavigate}
+        />
+      </nav>
+
+      {/* Repo context switcher */}
+      <div className="relative px-2 pb-1 border-t border-border/50 pt-2">
+        <RepoContextSwitcher />
+      </div>
+
+      {/* User menu */}
+      <div
+        className={cn(
+          "relative px-2 border-t border-border/50 pt-2",
+          isMobile ? "pb-[max(0.5rem,env(safe-area-inset-bottom))]" : "pb-1"
+        )}
+      >
+        {user && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                className={cn(
+                  "w-full justify-start gap-2 rounded-md px-2.5 font-medium transition-colors duration-150 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                  isMobile ? "h-11 text-sm" : "h-8 text-xs"
+                )}
+              >
+                {user.avatar_url ? (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img
+                    src={user.avatar_url}
+                    alt=""
+                    className="h-5 w-5 rounded-full"
+                  />
+                ) : (
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                    {user.name?.[0]?.toUpperCase() ?? "?"}
+                  </div>
+                )}
+                <span className="truncate flex-1 text-left">{user.name}</span>
+                <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" side="top" className="w-48">
+              <DropdownMenuItem onClick={onLogout}>
+                <LogOut className="h-4 w-4" />
+                Log out
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <VersionMenuItem />
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+    </>
+  );
+}
+
+type MobileTopBarProps = {
+  onOpenMenu: () => void;
+  onPaletteOpen: () => void;
+  onCreateSession: () => void;
+  menuOpen: boolean;
+};
+
+function MobileTopBar({
+  onOpenMenu,
+  onPaletteOpen,
+  onCreateSession,
+  menuOpen,
+}: MobileTopBarProps) {
+  return (
+    <header className="md:hidden sticky top-0 z-30 flex h-14 items-center gap-1 border-b border-border/50 bg-background/95 px-2 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onOpenMenu}
+        aria-label="Open navigation menu"
+        aria-expanded={menuOpen}
+        aria-controls="mobile-nav-drawer"
+        className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+      >
+        <Menu className="h-5 w-5" />
+      </Button>
+      <div className="flex-1" />
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onPaletteOpen}
+        aria-label="Search"
+        className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+      >
+        <Search className="h-5 w-5" />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onCreateSession}
+        aria-label="New session"
+        className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+      >
+        <PenSquare className="h-5 w-5" />
+      </Button>
+    </header>
+  );
+}
 
 export function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -110,6 +365,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   // Global Cmd+K / Ctrl+K shortcut
   useEffect(() => {
@@ -123,7 +379,16 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     return () => document.removeEventListener("keydown", handler);
   }, []);
 
-  const handlePaletteOpen = useCallback(() => setPaletteOpen(true), []);
+  const handlePaletteOpen = useCallback(() => {
+    setPaletteOpen(true);
+    setMobileMenuOpen(false);
+  }, []);
+  const handleCreateSessionOpen = useCallback(() => {
+    setCreateOpen(true);
+    setMobileMenuOpen(false);
+  }, []);
+  const handleOpenMobileMenu = useCallback(() => setMobileMenuOpen(true), []);
+  const handleCloseMobileMenu = useCallback(() => setMobileMenuOpen(false), []);
 
   useEffect(() => {
     // Only redirect on a confirmed 401. Transient network errors (5xx during
@@ -177,7 +442,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
         <aside
           className={cn(
             APP_SIDEBAR_WIDTH_CLASS,
-            "border-r border-border bg-sidebar flex flex-col"
+            "hidden md:flex border-r border-border bg-sidebar flex-col"
           )}
         >
           <div className="px-4 py-4">
@@ -198,20 +463,27 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
             </div>
           </div>
         </aside>
-        <main className="flex-1 overflow-auto bg-background">
-          <div className="max-w-none px-8 py-6 space-y-4">
-            <div className="h-7 w-40 rounded bg-muted animate-pulse" />
-            <div className="space-y-3">
-              <div className="h-4 w-full rounded bg-muted animate-pulse" />
-              <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+        <div className="flex flex-1 min-w-0 flex-col">
+          <header className="md:hidden flex h-14 items-center gap-2 border-b border-border/50 bg-background px-3">
+            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+            <div className="ml-auto h-6 w-6 rounded bg-muted animate-pulse" />
+            <div className="h-6 w-6 rounded bg-muted animate-pulse" />
+          </header>
+          <main className="flex-1 overflow-auto bg-background">
+            <div className="max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 space-y-4">
+              <div className="h-7 w-40 rounded bg-muted animate-pulse" />
+              <div className="space-y-3">
+                <div className="h-4 w-full rounded bg-muted animate-pulse" />
+                <div className="h-4 w-3/4 rounded bg-muted animate-pulse" />
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
+                ))}
+              </div>
             </div>
-            <div className="grid grid-cols-3 gap-4">
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className="h-24 rounded-lg border border-border bg-muted/30 animate-pulse" />
-              ))}
-            </div>
-          </div>
-        </main>
+          </main>
+        </div>
       </div>
     );
   }
@@ -222,127 +494,60 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   return (
     <div className="flex h-screen">
+      {/* Desktop sidebar (md and up) */}
       <aside
         className={cn(
           APP_SIDEBAR_WIDTH_CLASS,
-          "border-r border-border/50 bg-sidebar flex flex-col relative"
+          "hidden md:flex border-r border-border/50 bg-sidebar flex-col relative"
         )}
       >
-        {/* Header: org switcher + actions */}
-        <div className="relative flex items-center justify-between px-4 py-3.5">
-          <div className="flex items-center min-w-0 flex-1">
-            <OrgSwitcher userEmail={user?.email} />
-          </div>
-          <TooltipProvider>
-            <div className="flex items-center gap-0.5">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={handlePaletteOpen}
-                    className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
-                    aria-label="Search"
-                  >
-                    <Search className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={4}>Search</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    onClick={() => setCreateOpen(true)}
-                    className="h-7 w-7 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
-                    aria-label="New session"
-                  >
-                    <PenSquare className="h-4 w-4" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={4}>New session</TooltipContent>
-              </Tooltip>
-            </div>
-          </TooltipProvider>
-        </div>
-
-        {/* Navigation */}
-        <nav className="relative flex-1 px-2 space-y-0.5 overflow-y-auto">
-          {navItems.map((item) => {
-            const isActive = pathname === item.href || pathname.startsWith(item.href + "/");
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={cn(
-                  "relative flex items-center gap-2.5 rounded-md px-2.5 py-[7px] text-xs font-medium transition-colors duration-150",
-                  isActive
-                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
-                )}
-              >
-                <item.icon className="h-4 w-4 shrink-0" />
-                {item.label}
-                {item.showProposalBadge && proposalCount > 0 && (
-                  <Badge variant="secondary" className="ml-auto text-xs px-1.5 py-0 h-5 bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300">
-                    {proposalCount}
-                  </Badge>
-                )}
-              </Link>
-            );
-          })}
-          <SidebarSettingsSection pathname={pathname} userRole={user?.role} />
-        </nav>
-
-        {/* Repo context switcher */}
-        <div className="relative px-2 pb-1 border-t border-border/50 pt-2">
-          <RepoContextSwitcher />
-        </div>
-
-        {/* User menu */}
-        <div className="relative px-2 pb-1 border-t border-border/50 pt-2">
-          {user && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-8 w-full justify-start gap-2 rounded-md px-2.5 text-xs font-medium transition-colors duration-150 text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
-                >
-                  {user.avatar_url ? (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img
-                      src={user.avatar_url}
-                      alt=""
-                      className="h-5 w-5 rounded-full"
-                    />
-                  ) : (
-                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs font-medium">
-                      {user.name?.[0]?.toUpperCase() ?? "?"}
-                    </div>
-                  )}
-                  <span className="truncate flex-1 text-left">{user.name}</span>
-                  <ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-40" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" side="top" className="w-48">
-                <DropdownMenuItem onClick={logout}>
-                  <LogOut className="h-4 w-4" />
-                  Log out
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <VersionMenuItem />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
-        </div>
+        <SidebarBody
+          variant="desktop"
+          user={user}
+          pathname={pathname}
+          proposalCount={proposalCount}
+          onPaletteOpen={handlePaletteOpen}
+          onCreateSession={handleCreateSessionOpen}
+          onLogout={logout}
+        />
       </aside>
-      <main className="flex-1 overflow-auto bg-background relative flex flex-col">
-        <div className="relative max-w-none px-8 py-6 lg:px-10 flex-1 min-h-0">
-          {children}
-        </div>
-      </main>
+
+      {/* Mobile drawer (below md) */}
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent
+          id="mobile-nav-drawer"
+          side="left"
+          hideCloseButton
+          className="w-[280px] p-0 bg-sidebar border-r border-border/50 flex flex-col gap-0 sm:max-w-[320px]"
+        >
+          <SheetTitle className="sr-only">Navigation</SheetTitle>
+          <SidebarBody
+            variant="mobile"
+            user={user}
+            pathname={pathname}
+            proposalCount={proposalCount}
+            onPaletteOpen={handlePaletteOpen}
+            onCreateSession={handleCreateSessionOpen}
+            onNavigate={handleCloseMobileMenu}
+            onLogout={logout}
+          />
+        </SheetContent>
+      </Sheet>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        <MobileTopBar
+          menuOpen={mobileMenuOpen}
+          onOpenMenu={handleOpenMobileMenu}
+          onPaletteOpen={handlePaletteOpen}
+          onCreateSession={handleCreateSessionOpen}
+        />
+        <main className="flex-1 overflow-auto bg-background relative flex flex-col">
+          <div className="relative max-w-none px-4 sm:px-6 lg:px-10 py-5 sm:py-6 flex-1 min-h-0">
+            {children}
+          </div>
+        </main>
+      </div>
+
       {user && (
         <CommandPalette
           open={paletteOpen}

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -50,12 +50,20 @@ import { CommandPalette } from "@/components/command-palette/command-palette";
 import { SidebarSettingsSection } from "@/components/sidebar-settings-section";
 import { CreateSessionDialog } from "@/components/create-session-dialog";
 
-type SidebarUser = {
-  email?: string;
-  name?: string;
-  role?: string;
-  avatar_url?: string;
-};
+type SidebarUser = NonNullable<ReturnType<typeof useAuth>["user"]>;
+
+// Skip drawer-close side effects when the user opens a link in a new tab/window
+// (modifier or middle click). The current page hasn't changed for them, so the
+// drawer should stay where it is.
+function isPlainNavClick(e: React.MouseEvent): boolean {
+  return (
+    e.button === 0 &&
+    !e.metaKey &&
+    !e.ctrlKey &&
+    !e.shiftKey &&
+    !e.altKey
+  );
+}
 
 const buildSha = process.env.NEXT_PUBLIC_BUILD_SHA || "dev";
 const shortSha = buildSha === "dev" ? "dev" : buildSha.slice(0, 7);
@@ -211,7 +219,7 @@ function SidebarBody({
             <Link
               key={item.href}
               href={item.href}
-              onClick={onNavigate}
+              onClick={onNavigate ? (e) => { if (isPlainNavClick(e)) onNavigate(); } : undefined}
               aria-current={isActive ? "page" : undefined}
               className={cn(
                 "relative flex items-center gap-2.5 rounded-md px-2.5 font-medium transition-colors duration-150 active:bg-sidebar-accent",
@@ -306,14 +314,13 @@ function MobileTopBar({
   menuOpen,
 }: MobileTopBarProps) {
   return (
-    <header className="md:hidden sticky top-0 z-30 flex h-14 items-center gap-1 border-b border-border/50 bg-background/95 px-2 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+    <header className="md:hidden flex h-14 shrink-0 items-center gap-1 border-b border-border/50 bg-background px-2">
       <Button
         variant="ghost"
         size="icon"
         onClick={onOpenMenu}
         aria-label="Open navigation menu"
         aria-expanded={menuOpen}
-        aria-controls="mobile-nav-drawer"
         className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
       >
         <Menu className="h-5 w-5" />
@@ -379,6 +386,14 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
     return () => document.removeEventListener("keydown", handler);
   }, []);
 
+  // Sync the drawer to the URL: any pathname change closes it. Direct nav-link
+  // taps already call onNavigate for instant feedback, but indirect navigation
+  // (org switcher, repo switcher, programmatic router.push) wouldn't otherwise
+  // dismiss the drawer. The effect runs after a confirmed external (URL) state
+  // change, which is the canonical use case the lint rule exempts.
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setMobileMenuOpen(false); }, [pathname]);
+
   const handlePaletteOpen = useCallback(() => {
     setPaletteOpen(true);
     setMobileMenuOpen(false);
@@ -411,7 +426,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
       <div
         role="alert"
         aria-live="polite"
-        className="flex h-screen items-center justify-center bg-background px-6"
+        className="flex h-dvh items-center justify-center bg-background px-6"
       >
         <div className="max-w-sm text-center space-y-4">
           <h2 className="text-base font-semibold text-foreground">
@@ -438,7 +453,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
 
   if (showLoadingSkeleton) {
     return (
-      <div className="flex h-screen">
+      <div className="flex h-dvh">
         <aside
           className={cn(
             APP_SIDEBAR_WIDTH_CLASS,
@@ -493,7 +508,7 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
   }
 
   return (
-    <div className="flex h-screen">
+    <div className="flex h-dvh">
       {/* Desktop sidebar (md and up) */}
       <aside
         className={cn(
@@ -515,10 +530,10 @@ export function AuthenticatedLayout({ children }: { children: React.ReactNode })
       {/* Mobile drawer (below md) */}
       <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
         <SheetContent
-          id="mobile-nav-drawer"
           side="left"
           hideCloseButton
-          className="w-[280px] p-0 bg-sidebar border-r border-border/50 flex flex-col gap-0 sm:max-w-[320px]"
+          aria-describedby={undefined}
+          className="w-[min(85vw,320px)] p-0 bg-sidebar border-r border-border/50 flex flex-col gap-0"
         >
           <SheetTitle className="sr-only">Navigation</SheetTitle>
           <SidebarBody

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -165,7 +165,24 @@ export function SidebarSettingsSection({
                       <Link
                         key={item.href}
                         href={item.href}
-                        onClick={onNavigate}
+                        onClick={
+                          onNavigate
+                            ? (e) => {
+                                // Skip on modifier/middle clicks — the user is
+                                // opening in a new tab and the current page
+                                // hasn't changed for them.
+                                if (
+                                  e.button === 0 &&
+                                  !e.metaKey &&
+                                  !e.ctrlKey &&
+                                  !e.shiftKey &&
+                                  !e.altKey
+                                ) {
+                                  onNavigate();
+                                }
+                              }
+                            : undefined
+                        }
                         className={cn(
                           "relative flex items-center gap-2 rounded-lg py-1.5 pl-7 pr-2.5 text-xs font-medium transition-colors duration-150",
                           active

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -79,9 +79,11 @@ function isItemActive(pathname: string, href: string): boolean {
 export function SidebarSettingsSection({
   pathname,
   userRole,
+  onNavigate,
 }: {
   pathname: string;
   userRole: string | undefined;
+  onNavigate?: () => void;
 }) {
   const onSettingsPage = isSettingsPath(pathname);
 
@@ -163,6 +165,7 @@ export function SidebarSettingsSection({
                       <Link
                         key={item.href}
                         href={item.href}
+                        onClick={onNavigate}
                         className={cn(
                           "relative flex items-center gap-2 rounded-lg py-1.5 pl-7 pr-2.5 text-xs font-medium transition-colors duration-150",
                           active

--- a/frontend/src/components/ui/sheet.tsx
+++ b/frontend/src/components/ui/sheet.tsx
@@ -37,26 +37,47 @@ function SheetOverlay({
   )
 }
 
+type SheetSide = "left" | "right" | "top" | "bottom"
+
+const sheetSideClasses: Record<SheetSide, string> = {
+  right:
+    "inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-md data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+  left:
+    "inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+  top:
+    "inset-x-0 top-0 w-full border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+  bottom:
+    "inset-x-0 bottom-0 w-full border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+}
+
 function SheetContent({
   className,
   children,
+  side = "right",
+  hideCloseButton = false,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content>) {
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  side?: SheetSide
+  hideCloseButton?: boolean
+}) {
   return (
     <SheetPortal>
       <SheetOverlay />
       <DialogPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed inset-y-0 right-0 z-50 h-full w-3/4 gap-4 border-l bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-md",
+          "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-300 data-[state=open]:animate-in data-[state=closed]:animate-out",
+          sheetSideClasses[side],
           className
         )}
         {...props}
       >
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </DialogPrimitive.Close>
+        {!hideCloseButton && (
+          <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
         {children}
       </DialogPrimitive.Content>
     </SheetPortal>


### PR DESCRIPTION
## Summary
This PR adds mobile-responsive navigation to the authenticated layout by introducing a navigation drawer for mobile devices and a mobile top bar, while refactoring the sidebar into reusable components that work across desktop and mobile variants.

## Key Changes

- **Mobile Navigation Drawer**: Added a Sheet-based drawer that slides in from the left on mobile devices, containing the full navigation menu, org switcher, and user menu
- **Mobile Top Bar**: Created a new header component for mobile (below `md` breakpoint) with hamburger menu, search, and new session buttons
- **Refactored Sidebar**: Extracted sidebar content into a reusable `SidebarBody` component that supports both "desktop" and "mobile" variants with appropriate sizing and spacing
- **Responsive Layout**: Updated main content area with mobile-first responsive padding (`px-4 sm:px-6 lg:px-10`) and adjusted grid layouts for mobile
- **Smart Drawer Closing**: Implemented logic to close the mobile drawer on navigation, with special handling for modifier clicks (cmd/ctrl/middle-click) that open links in new tabs
- **Enhanced Sheet Component**: Extended the `SheetContent` component to support configurable sides (`left`/`right`/`top`/`bottom`) and optional close button hiding
- **Updated Tests**: Added comprehensive test coverage for mobile drawer interactions including hamburger toggle, nav link taps, settings sub-links, and modifier-click behavior

## Notable Implementation Details

- Used `h-dvh` (dynamic viewport height) instead of `h-screen` for better mobile viewport handling
- Implemented `isPlainNavClick()` utility to distinguish regular clicks from modifier/middle clicks, preventing drawer closure when users intentionally open links in new tabs
- Added `onNavigate` callback threading through `SidebarSettingsSection` to support drawer closure on settings sub-link navigation
- Desktop sidebar hidden on mobile with `hidden md:flex` class
- Mobile drawer respects safe area insets for notched devices
- Touch-friendly sizing on mobile: nav items ~44px tall, icon buttons 44×44
- Synchronized drawer state with URL changes via `useEffect` to handle indirect navigation (org switcher, repo switcher, programmatic navigation)

https://claude.ai/code/session_01JsnvtxKpriPLFDe4RVQgU8