### PR TITLE
Hold loading state on new-automation submit through redirect

### DIFF
--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -63,6 +63,7 @@ export default function NewAutomationPage() {
   const [advancedOpen, setAdvancedOpen] = useState(false);
   const [baseBranchByRepoId, setBaseBranchByRepoId] = useState<Record<string, string>>({});
   const [priority, setPriority] = useState(50);
+  const [redirecting, setRedirecting] = useState(false);
 
   // Load repos
   const { data: reposData } = useQuery({
@@ -103,6 +104,7 @@ export default function NewAutomationPage() {
         priority,
       }),
     onSuccess: (res) => {
+      setRedirecting(true);
       router.push(`/automations/${res.data.id}`);
     },
   });
@@ -383,9 +385,9 @@ export default function NewAutomationPage() {
           <div className="flex items-center gap-3 pt-2">
             <Button
               onClick={() => createMutation.mutate()}
-              disabled={!canSubmit || createMutation.isPending}
+              disabled={!canSubmit || createMutation.isPending || redirecting}
             >
-              {createMutation.isPending ? (
+              {createMutation.isPending || redirecting ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   Creating...


### PR DESCRIPTION
## Summary
- The Create automation button briefly flashed back to its idle label between API success and the router.push to the detail page.
- Added an explicit redirecting flag set inside onSuccess (right next to router.push, so future maintainers see them as a pair) and ORed it into the button disabled and spinner conditions, so the Creating... state holds continuously until the component unmounts during navigation.

## Test plan
- [ ] On /automations/new, fill in the form and click Create automation; confirm the button stays in the Creating... state with no flash before the detail page loads.
- [ ] Submit a form that fails (e.g. with an invalid payload) and confirm the button returns to its idle state and the inline error appears, so retry still works.

Generated with [Claude Code](https://claude.com/claude-code)
