### PR TITLE
Merge screenshot hint into manual session subtitle and remove extra line

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -127,6 +127,11 @@ describe("ManualSessionCreatePageContent", () => {
     await waitFor(() => {
       expect(mocks.repositoriesListMock).toHaveBeenCalled();
     });
+
+    expect(
+      screen.getByText("Start a manual session with text, files, photos, dictation, or a screenshot anywhere here."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Drop a screenshot anywhere here, or use +")).not.toBeInTheDocument();
   });
 
   it("shows repository selection", async () => {

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -721,14 +721,15 @@ export function ManualSessionCreatePageContent() {
               >
                 Let&apos;s build
               </p>
-              <p className="mt-2 text-xs text-muted-foreground">Start a manual session with text, files, photos, or dictation.</p>
               <p
                 className={cn(
-                  "mt-3 text-xs text-muted-foreground transition-all duration-200",
-                  isDragActive ? "translate-y-0 opacity-100" : "translate-y-1 opacity-70",
+                  "mt-2 text-xs text-muted-foreground transition-all duration-200",
+                  isDragActive ? "translate-y-0 opacity-100" : "translate-y-1 opacity-95",
                 )}
               >
-                {isDragActive ? (dragMessage ?? "Drop images to attach") : "Drop a screenshot anywhere here, or use +"}
+                {isDragActive
+                  ? (dragMessage ?? "Drop images to attach")
+                  : "Start a manual session with text, files, photos, dictation, or a screenshot anywhere here."}
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Updated the manual session hero copy to remove the extra screenshot instruction line and fold the screenshot hint into the existing subtitle text. This keeps the message shorter and more consistent while still covering screenshot attachments.

## Changes
- `frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx`
  - Removed the standalone subtitle paragraph: “Start a manual session with text, files, photos, or dictation.”
  - Updated the hero hint paragraph to show:
    - Drag state: existing “Drop images to attach” behavior (unchanged aside from timing/opacity).
    - Idle state: “Start a manual session with text, files, photos, dictation, or a screenshot anywhere here.”
- `frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx`
  - Added assertions to verify the merged sentence renders.
  - Added assertion that the old “Drop a screenshot anywhere here, or use +” text no longer appears.

## Test plan
- Ran targeted Vitest for the manual session page content component.
- Ran `npm run typecheck`, `npm run lint`, and `npm run build` (build completed successfully; existing Next.js workspace/middleware warnings remained).

---
*Generated by [143.dev](https://143.dev) — [session 3740f10c](https://app.143.dev/sessions/3740f10c-9d41-47c8-985e-443234bc2e2d)*
