### PR TITLE
Add native session review support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/logging"
 	"github.com/assembledhq/143/internal/metrics"
-	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/observability"
 	"github.com/assembledhq/143/internal/services"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -241,7 +240,13 @@ func main() {
 	// Closed when the process receives SIGTERM so long-lived handlers (SSE
 	// streams, etc.) can end their loops cleanly during graceful shutdown.
 	shutdownCh := make(chan struct{})
-	router, gwSrv, recycleWorker, inspectorCloser, previewManager, err := api.NewRouter(cfg, pool, logger, sentryReporter, codexAuthSvc, claudeCodeAuthSvc, llmClient, fileReader, cancelRegistry, pvProvider, snapshotExec, apiSandboxProvider, apiSnapshotStore, orgSettingsCache, shutdownCh, redisClient, sessionStreams)
+	// The router's session-review service needs to know which agents support
+	// native review. adapters.DefaultMap is the single source of truth for
+	// shipped agents — the orchestrator wires the same factory in
+	// buildServices below, so capability lookup and execution stay aligned
+	// without manual sync.
+	reviewModesProvider := agent.ReviewModeProvider(adapters.DefaultMap(logger))
+	router, gwSrv, recycleWorker, inspectorCloser, previewManager, err := api.NewRouter(cfg, pool, logger, sentryReporter, codexAuthSvc, claudeCodeAuthSvc, llmClient, fileReader, cancelRegistry, pvProvider, snapshotExec, apiSandboxProvider, apiSnapshotStore, orgSettingsCache, shutdownCh, redisClient, sessionStreams, reviewModesProvider)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize API router")
 	}
@@ -690,14 +695,8 @@ func buildServices(
 		appUserAuthSvc = ghservice.NewAppUserAuthService(userCredentialStore, cfg.GitHubAppClientID, cfg.GitHubAppClientSecret, cfg.BaseURL, logger)
 	}
 
-	// Agent adapters.
-	agentAdapters := map[models.AgentType]agent.AgentAdapter{
-		models.AgentTypeClaudeCode: adapters.NewClaudeCodeAdapter(logger),
-		models.AgentTypeGeminiCLI:  adapters.NewGeminiCLIAdapter(logger),
-		models.AgentTypeCodex:      adapters.NewCodexAdapter(logger),
-		models.AgentTypeAmp:        adapters.NewAmpAdapter(logger),
-		models.AgentTypePi:         adapters.NewPiAdapter(logger),
-	}
+	// Agent adapters. Shared factory with the router; see adapters.DefaultMap.
+	agentAdapters := adapters.DefaultMap(logger)
 
 	// Shared agent env/auth helper — consumed by both the session Orchestrator
 	// and the PM service so both paths resolve provider credentials, Codex

--- a/docs/design/implemented/63-agent-native-review-button.md
+++ b/docs/design/implemented/63-agent-native-review-button.md
@@ -1,8 +1,8 @@
 # Design: Agent-Native Review Button
 
-> **Status:** Not Started | **Last reviewed:** 2026-04-25
+> **Status:** Implemented | **Last reviewed:** 2026-04-25
 >
-> **Related docs:** [../11-review-feedback-loop.md](../11-review-feedback-loop.md), [../36-code-review-display.md](../36-code-review-display.md), [../implemented/61-pr-state-sync-and-repair-actions.md](../implemented/61-pr-state-sync-and-repair-actions.md), [53-session-composer-mentions.md](53-session-composer-mentions.md)
+> **Related docs:** [../11-review-feedback-loop.md](../11-review-feedback-loop.md), [../36-code-review-display.md](../36-code-review-display.md), [61-pr-state-sync-and-repair-actions.md](61-pr-state-sync-and-repair-actions.md), [../future/53-session-composer-mentions.md](../future/53-session-composer-mentions.md)
 
 ## Summary
 
@@ -207,6 +207,16 @@ No frontend changes. No migrations. No new endpoints.
 
 ## Phasing
 
-1. **Phase 1** — Backend: add `SessionReviewMode`, session-scoped endpoint/service, and `RevisionContext.ReviewContext`. Update Claude Code adapter to invoke its native review affordances when review context is present.
-2. **Phase 2** — Frontend: add the button + spinner state in the session detail header, gated on capability check.
-3. **Phase 3** — Per-agent rollout: Codex, Amp, then any future agents. Each is independent and lands in its own PR.
+1. **Phase 1** — Backend: add `SessionReviewMode`, session-scoped endpoint/service, and `RevisionContext.ReviewContext`. Update Claude Code adapter to invoke its native review affordances when review context is present. ✅ shipped
+2. **Phase 2** — Frontend: add the button + spinner state in the session detail header, gated on capability check. ✅ shipped
+3. **Phase 3** — Per-agent rollout: Codex, Amp, then any future agents. Each is independent and lands in its own PR. ⏳ deferred — Codex / Amp do not yet ship a curated CLI review surface; the button correctly hides for those sessions until upstream lands one.
+
+## What shipped
+
+- `models.SessionReviewMode` (`default`, `security`) and `SessionReviewCapabilities` API shape (`internal/models/session_review.go`).
+- `agent.RevisionContext.ReviewContext` + `SessionReviewContext`, plus `agent.ReviewCapableAdapter`, `agent.AdapterReviewModes`, `agent.ReviewModeProvider`, and `AgentPrompt.RevisionContext` so adapters can branch in `Execute` without re-running `PreparePrompt` (`internal/services/agent/adapter.go`).
+- `sessionreview.Service` owning validation + claim/enqueue, decoupled from PR repair (`internal/services/sessionreview/service.go`).
+- `POST /api/v1/sessions/{id}/review` and `GET /api/v1/sessions/{id}/review-capabilities` (`internal/api/handlers/session_review.go`).
+- `ClaudeCodeAdapter.ReviewModes()` + `claudeCodeReviewSlashCommand` so review turns route to `/review` and `/security-review`.
+- `<ReviewButton>` in the session detail header, single-mode button or 2+ mode dropdown, spinner mirroring PR health repair affordances (`frontend/src/components/review-button.tsx`, `session-detail-content.tsx`).
+- Audit action `session.review.requested` recorded on every successful start.

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -103,6 +103,51 @@ describe('SessionDetailPage', () => {
     expect(screen.getAllByText(/Claude Code/).length).toBeGreaterThanOrEqual(1);
   });
 
+  it('shows the native Review button for review-capable sessions', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id/review-capabilities', () => {
+        return HttpResponse.json({
+          data: {
+            can_review: true,
+            modes: ['default', 'security'],
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    expect(await screen.findByRole('button', { name: 'Review' })).toBeInTheDocument();
+  });
+
+  it('hides the native Review button for viewers even when the session is review-capable', async () => {
+    server.use(
+      http.get('/api/v1/auth/me', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockMembers[0],
+            role: 'viewer',
+          },
+        } satisfies SingleResponse<User>);
+      }),
+      http.get('/api/v1/sessions/:id/review-capabilities', () => {
+        return HttpResponse.json({
+          data: {
+            can_review: true,
+            modes: ['default', 'security'],
+          },
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
+    });
+  });
+
   it('renders the session header title at text-sm size', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -79,6 +79,7 @@ import { AgentBadge } from "@/components/agent-badge";
 import { PreviewPanel } from "@/components/preview/preview-panel";
 import { PendingAttachmentStrip } from "@/components/pending-attachment-strip";
 import { PRHealthBanner } from "@/components/pr-health-banner";
+import { ReviewButton } from "@/components/review-button";
 import { useAuth } from "@/hooks/use-auth";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
 
@@ -1282,6 +1283,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [localPRActionError, setLocalPRActionError] = useState<PRActionErrorState | null>(null);
   const [pendingRepairAction, setPendingRepairAction] = useState<"fix_tests" | "resolve_conflicts" | null>(null);
   const [repairActionError, setRepairActionError] = useState<string | null>(null);
+  const [pendingReviewMode, setPendingReviewMode] = useState<import("@/lib/types").SessionReviewMode | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthInterceptDetails | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
@@ -1315,6 +1317,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   const isActive = session ? !terminalStatuses.has(session.status) : false;
   const isRunning = session?.status === "running";
   const currentTitle = session ? sessionTitle(session) : "";
+  const { user } = useAuth();
+  const canRequestReview = user?.role === "admin" || user?.role === "member";
 
   const queryClient = useQueryClient();
 
@@ -1413,6 +1417,38 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRUrlRef.current = prUrl;
   }, [localPRState, prUrl, session?.pr_creation_state]);
+  // Session-native review affordance. Capabilities are server-driven so the
+  // button only appears when the agent's adapter implements ReviewCapableAdapter
+  // and the session is in a state that can run another turn (idle/paused with
+  // a non-empty diff). Key on status only so the button flips visibility when
+  // the session transitions running → idle, without burning a refetch on every
+  // assistant SSE tick (which advances last_activity_at).
+  const { data: reviewCapabilitiesData } = useQuery({
+    queryKey: ["session", id, "review-capabilities", session?.status],
+    queryFn: () => api.sessions.getReviewCapabilities(id),
+    enabled: !!session && canRequestReview,
+  });
+  const reviewCapabilities = reviewCapabilitiesData?.data;
+  const startReviewMutation = useMutation({
+    mutationFn: (mode: import("@/lib/types").SessionReviewMode) => api.sessions.startReview(id, mode),
+    onMutate: (mode) => {
+      setPendingReviewMode(mode);
+    },
+    onSuccess: () => {
+      // Stay in the current view; the assistant message will stream into the
+      // session timeline via SSE just like any other turn. Bust caches so the
+      // status flips from idle → running immediately.
+      void queryClient.invalidateQueries({ queryKey: ["session", id] });
+      void queryClient.invalidateQueries({ queryKey: ["session", id, "messages"] });
+      void queryClient.invalidateQueries({ queryKey: ["session", id, "timeline"] });
+      setPendingReviewMode(null);
+    },
+    onError: (err) => {
+      setPendingReviewMode(null);
+      const message = err instanceof ApiError ? err.message : "Failed to start review";
+      toast.error(message);
+    },
+  });
   const startRepairMutation = useMutation({
     mutationFn: async (action: "fix_tests" | "resolve_conflicts") => {
       if (!pullRequestId) {
@@ -2065,6 +2101,13 @@ export function SessionDetailContent({ id }: { id: string }) {
                   )}
                   <TabsTrigger value="preview">Preview</TabsTrigger>
                 </TabsList>
+                {canRequestReview && (
+                  <ReviewButton
+                    capabilities={reviewCapabilities}
+                    pendingMode={pendingReviewMode}
+                    onReview={(mode) => startReviewMutation.mutate(mode)}
+                  />
+                )}
                 {hasPR && prData?.data?.github_pr_url ? (
                   <>
                     {prStatus === "closed" && (

--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useEffect } from 'react';
 import { renderWithProviders, screen, waitFor } from '@/test/test-utils';
 import SettingsLayout from './layout';
 
@@ -21,6 +22,14 @@ beforeEach(() => {
 });
 
 describe('SettingsLayout', () => {
+  function EffectChild({ onMount }: { onMount: () => void }) {
+    useEffect(() => {
+      onMount();
+    }, [onMount]);
+
+    return <div>child content</div>;
+  }
+
   it('renders children for admins on any settings page', () => {
     useAuthMock.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
     pathnameMock.value = '/settings/integrations';
@@ -171,9 +180,25 @@ describe('SettingsLayout', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
-  it('does not redirect while auth is still loading', () => {
+  it('does not mount children for access-controlled pages while auth is still loading', () => {
     useAuthMock.mockReturnValue({ user: null, isLoading: true });
-    pathnameMock.value = '/settings/integrations';
+    pathnameMock.value = '/settings/team';
+    const onMount = vi.fn();
+
+    renderWithProviders(
+      <SettingsLayout>
+        <EffectChild onMount={onMount} />
+      </SettingsLayout>
+    );
+
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(onMount).not.toHaveBeenCalled();
+    expect(screen.queryByText('child content')).not.toBeInTheDocument();
+  });
+
+  it('still renders unrestricted pages while auth is still loading', () => {
+    useAuthMock.mockReturnValue({ user: null, isLoading: true });
+    pathnameMock.value = '/settings/account';
 
     renderWithProviders(
       <SettingsLayout>
@@ -181,6 +206,7 @@ describe('SettingsLayout', () => {
       </SettingsLayout>
     );
 
+    expect(screen.getByText('child content')).toBeInTheDocument();
     expect(replaceMock).not.toHaveBeenCalled();
   });
 

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -49,6 +49,7 @@ export default function SettingsLayout({
   const pathname = usePathname();
   const { user, isLoading } = useAuth();
 
+  const roleGuardedPath = isAdminOnlyPath(pathname) || isViewerBlockedPath(pathname);
   const role = user?.role;
   let restricted = false;
   if (!isLoading && role !== undefined) {
@@ -58,6 +59,7 @@ export default function SettingsLayout({
       restricted = true;
     }
   }
+  const waitForRole = isLoading && roleGuardedPath;
 
   useEffect(() => {
     if (restricted) {
@@ -65,7 +67,7 @@ export default function SettingsLayout({
     }
   }, [restricted, router]);
 
-  if (restricted) return null;
+  if (waitForRole || restricted) return null;
 
   return <>{children}</>;
 }

--- a/frontend/src/components/review-button.tsx
+++ b/frontend/src/components/review-button.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { ChevronDown, Loader2, Sparkles } from "lucide-react";
+
+import type { SessionReviewCapabilities, SessionReviewMode } from "@/lib/types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+const MODE_LABELS: Record<SessionReviewMode, string> = {
+  default: "Code review",
+  security: "Security review",
+};
+
+type ReviewButtonProps = {
+  capabilities: SessionReviewCapabilities | undefined;
+  pendingMode: SessionReviewMode | null;
+  onReview: (mode: SessionReviewMode) => void;
+};
+
+// ReviewButton renders the session-native Review action when the agent
+// supports a curated review surface (e.g. Claude Code's /review skill).
+// Hidden entirely for agents without native review support — by design we
+// don't fall back to a hand-rolled prompt.
+export function ReviewButton({ capabilities, pendingMode, onReview }: ReviewButtonProps) {
+  if (!capabilities || capabilities.modes.length === 0) {
+    return null;
+  }
+
+  const disabled = pendingMode !== null || !capabilities.can_review;
+  const isPending = pendingMode !== null;
+
+  if (capabilities.modes.length === 1) {
+    const [only] = capabilities.modes;
+    return (
+      <Button
+        size="sm"
+        variant="outline"
+        disabled={disabled}
+        onClick={() => onReview(only)}
+        title={!capabilities.can_review ? capabilities.reason : undefined}
+      >
+        {isPending ? (
+          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+        )}
+        {isPending ? "Reviewing…" : MODE_LABELS[only] ?? only}
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          title={!capabilities.can_review ? capabilities.reason : undefined}
+        >
+          {isPending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isPending ? "Reviewing…" : "Review"}
+          {!isPending && <ChevronDown className="ml-1 h-3.5 w-3.5" />}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        {capabilities.modes.map((mode) => (
+          <DropdownMenuItem
+            key={mode}
+            onSelect={() => onReview(mode)}
+            disabled={disabled}
+          >
+            {MODE_LABELS[mode] ?? mode}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -361,6 +361,10 @@ export const api = {
       del(`/api/v1/sessions/${sessionId}/review-comments/${commentId}`),
     sendReviewComments: (sessionId: string) =>
       post<import('./types').SingleResponse<{ message: string; sent: boolean }>>(`/api/v1/sessions/${sessionId}/review-comments/send`),
+    getReviewCapabilities: (sessionId: string) =>
+      get<import('./types').SingleResponse<import('./types').SessionReviewCapabilities>>(`/api/v1/sessions/${sessionId}/review-capabilities`),
+    startReview: (sessionId: string, mode?: import('./types').SessionReviewMode) =>
+      post<import('./types').SingleResponse<import('./types').SessionReviewResponse>>(`/api/v1/sessions/${sessionId}/review`, mode ? { mode } : {}),
     listFiles: (sessionId: string, path?: string) => {
       const params = new URLSearchParams();
       if (path) params.set('path', path);

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -369,6 +369,22 @@ export interface PullRequestUpdatedEvent {
   synced_at: string;
 }
 
+export type SessionReviewMode = 'default' | 'security';
+
+// Mirrors models.SessionReviewCapabilities. The Review button uses `modes`
+// to decide whether to render a single button or a dropdown, and `can_review`
+// to gate against in-flight or empty-diff sessions before the user clicks.
+export interface SessionReviewCapabilities {
+  can_review: boolean;
+  reason?: string;
+  modes: SessionReviewMode[];
+}
+
+export interface SessionReviewResponse {
+  session_id: string;
+  mode: SessionReviewMode;
+}
+
 export interface SessionReviewComment {
   id: string;
   session_id: string;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import type { Issue, Session, SessionLog, SessionMessage, SessionReviewComment, SessionTimelineEntry, User, Validation, PullRequest, PullRequestHealthResponse, PullRequestRepairResponse, ListResponse, SingleResponse, PMStatus, PMDecisionsResponse, Project, ProjectDetail } from '@/lib/types';
+import type { Issue, Session, SessionLog, SessionMessage, SessionReviewComment, SessionTimelineEntry, User, Validation, PullRequest, PullRequestHealthResponse, PullRequestRepairResponse, ListResponse, SingleResponse, PMStatus, PMDecisionsResponse, Project, ProjectDetail, SessionReviewCapabilities, SessionReviewResponse } from '@/lib/types';
 
 export const mockIssues: Issue[] = [
   {
@@ -400,6 +400,26 @@ export const handlers = [
       data: [] as SessionReviewComment[],
       meta: {},
     } satisfies ListResponse<SessionReviewComment>);
+  }),
+
+  http.get('/api/v1/sessions/:id/review-capabilities', ({ params }) => {
+    const session = mockSessions.find((candidate) => candidate.id === params.id);
+    const capabilities: SessionReviewCapabilities =
+      session?.agent_type === 'claude_code'
+        ? { can_review: false, reason: 'session is not reviewable in this test fixture', modes: ['default', 'security'] }
+        : { can_review: false, modes: [] };
+
+    return HttpResponse.json({ data: capabilities } satisfies SingleResponse<SessionReviewCapabilities>);
+  }),
+
+  http.post('/api/v1/sessions/:id/review', async ({ request, params }) => {
+    const body = await request.json().catch(() => ({})) as { mode?: 'default' | 'security' };
+    return HttpResponse.json({
+      data: {
+        session_id: params.id as string,
+        mode: body.mode ?? 'default',
+      },
+    } satisfies SingleResponse<SessionReviewResponse>, { status: 202 });
   }),
 
   http.post('/api/v1/sessions/:id/review-comments', async ({ request, params }) => {

--- a/internal/api/handlers/session_review.go
+++ b/internal/api/handlers/session_review.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/sessionreview"
+)
+
+// SessionReviewHandler exposes the session-native review endpoints. Reviews
+// are a single follow-up turn on the existing session; this handler is a
+// thin transport layer around sessionreview.Service.
+type SessionReviewHandler struct {
+	service *sessionreview.Service
+	logger  zerolog.Logger
+	audit   *db.AuditEmitter
+}
+
+func NewSessionReviewHandler(service *sessionreview.Service, logger zerolog.Logger) *SessionReviewHandler {
+	return &SessionReviewHandler{
+		service: service,
+		logger:  logger,
+	}
+}
+
+func (h *SessionReviewHandler) SetAuditEmitter(audit *db.AuditEmitter) {
+	h.audit = audit
+}
+
+// Capabilities handles GET /api/v1/sessions/{id}/review-capabilities.
+// Returns the modes the agent supports natively and whether the session is
+// in a state that can be reviewed right now.
+func (h *SessionReviewHandler) Capabilities(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	caps, err := h.service.Capabilities(r.Context(), orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, sessionreview.ErrSessionNotFound) {
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "REVIEW_CAPABILITIES_FAILED", "failed to load review capabilities", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, models.SingleResponse[models.SessionReviewCapabilities]{Data: *caps})
+}
+
+// Start handles POST /api/v1/sessions/{id}/review with body { "mode": ... }.
+// Enqueues a review continuation turn on the session.
+func (h *SessionReviewHandler) Start(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "user not found in context")
+		return
+	}
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	body := struct {
+		Mode models.SessionReviewMode `json:"mode"`
+	}{}
+	// An empty body is allowed and means "default mode". Decode errors that
+	// aren't EOF are real problems and should be surfaced.
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+			return
+		}
+	}
+
+	resp, err := h.service.StartReview(r.Context(), orgID, sessionID, user.ID, body.Mode)
+	if err != nil {
+		switch {
+		case errors.Is(err, sessionreview.ErrSessionNotFound):
+			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		case errors.Is(err, sessionreview.ErrSnapshotExpired):
+			writeError(w, r, http.StatusGone, "SNAPSHOT_EXPIRED", "session sandbox has expired and can no longer be reviewed")
+		case errors.Is(err, sessionreview.ErrNoChangesToReview):
+			writeError(w, r, http.StatusConflict, "NO_CHANGES", "session has no changes to review yet")
+		case errors.Is(err, sessionreview.ErrSessionNotResumable):
+			writeError(w, r, http.StatusConflict, "NOT_RESUMABLE", "session must be idle or paused to start a review")
+		case errors.Is(err, sessionreview.ErrAgentReviewUnsupported):
+			writeError(w, r, http.StatusNotImplemented, "REVIEW_UNSUPPORTED", "this agent does not support native review")
+		case errors.Is(err, sessionreview.ErrReviewModeUnsupported):
+			writeError(w, r, http.StatusBadRequest, "MODE_UNSUPPORTED", "requested review mode is not supported by this agent")
+		default:
+			writeError(w, r, http.StatusInternalServerError, "REVIEW_START_FAILED", "failed to start review", err)
+		}
+		return
+	}
+
+	if h.audit != nil {
+		sid := resp.SessionID
+		emitUserAuditWithSession(h.audit, r, models.AuditActionSessionReviewRequested, models.AuditResourceSession, nil, &sid, nil,
+			marshalAuditDetails(h.logger, map[string]any{
+				"session_id": resp.SessionID.String(),
+				"mode":       string(resp.Mode),
+			}))
+	}
+
+	writeJSON(w, http.StatusAccepted, models.SingleResponse[models.SessionReviewResponse]{Data: *resp})
+}

--- a/internal/api/handlers/session_review_test.go
+++ b/internal/api/handlers/session_review_test.go
@@ -1,0 +1,448 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/sessionreview"
+)
+
+var sessionReviewHandlerSessionColumns = []string{
+	"id", "issue_id", "org_id", "origin", "interaction_mode", "validation_policy", "agent_type", "status", "autonomy_level", "token_mode",
+	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
+	"container_id", "worker_node_id", "turn_holding_container", "started_at", "completed_at", "token_usage",
+	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
+	"parent_session_id", "revision_context", "error", "result_summary", "diff",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
+	"project_task_id", "model_override", "reasoning_effort", "triggered_by_user_id",
+	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
+	"runtime_soft_deadline_at", "runtime_hard_deadline_at", "runtime_last_progress_at", "runtime_last_progress_type", "runtime_last_progress_strength",
+	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
+	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
+	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id", "deleted_at", "created_at",
+}
+
+func newSessionReviewHandlerSessionRow(sessionID, orgID uuid.UUID, status string, sandboxState string, snapshotKey *string, diff *string, now time.Time) []any {
+	issueID := uuid.New()
+	return []any{
+		sessionID, issueID, orgID, models.SessionOriginManual, models.SessionInteractionModeInteractive, models.SessionValidationPolicyOnTurnComplete, models.AgentTypeClaudeCode, status, "semi", "low",
+		nil, nil, nil, nil,
+		nil, nil, false, &now, nil, nil,
+		nil, nil, nil, false,
+		nil, nil, nil, nil, diff,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil,
+		nil, 0, now, sandboxState, snapshotKey,
+		nil, nil, nil, "", "",
+		0, 0, "", nil,
+		nil, "", "", int64(0), nil,
+		"", nil, nil, 0,
+		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, "idle", (*string)(nil), nil, nil, nil, now,
+	}
+}
+
+func newSessionReviewHandlerForTest(mock pgxmock.PgxPoolIface, reviewModes sessionreview.ReviewModeProvider) *SessionReviewHandler {
+	service := sessionreview.NewService(sessionreview.Deps{
+		Sessions:        db.NewSessionStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+		ReviewModes:     reviewModes,
+		Logger:          zerolog.Nop(),
+	})
+	return NewSessionReviewHandler(service, zerolog.Nop())
+}
+
+func sessionReviewRequest(t *testing.T, method string, body []byte, orgID uuid.UUID, user *models.User, sessionID string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(method, fmt.Sprintf("/api/v1/sessions/%s/review", sessionID), bytes.NewReader(body))
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	ctx := middleware.WithOrgID(req.Context(), orgID)
+	if user != nil {
+		ctx = middleware.WithUser(ctx, user)
+	}
+	routeCtx := chi.NewRouteContext()
+	routeCtx.URLParams.Add("id", sessionID)
+	req = req.WithContext(context.WithValue(ctx, chi.RouteCtxKey, routeCtx))
+	return req
+}
+
+func TestNewSessionReviewHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := NewSessionReviewHandler(nil, zerolog.Nop())
+	require.NotNil(t, handler, "NewSessionReviewHandler should construct a handler even before wiring an audit emitter")
+}
+
+func TestSessionReviewHandler_Capabilities(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns bad request for invalid session id", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock.NewPool should create the handler mock")
+		defer mock.Close()
+
+		handler := newSessionReviewHandlerForTest(mock, nil)
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/not-a-uuid/review-capabilities", nil)
+		req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+		routeCtx := chi.NewRouteContext()
+		routeCtx.URLParams.Add("id", "not-a-uuid")
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+		w := httptest.NewRecorder()
+		handler.Capabilities(w, req)
+
+		require.Equal(t, http.StatusBadRequest, w.Code, "Capabilities should reject malformed session IDs before touching the database")
+	})
+
+	t.Run("maps not found and success responses", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name         string
+			setup        func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, now time.Time)
+			reviewModes  sessionreview.ReviewModeProvider
+			expectedCode int
+			assertBody   func(t *testing.T, body []byte)
+		}{
+			{
+				name: "returns not found",
+				setup: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ time.Time) {
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnError(pgx.ErrNoRows)
+				},
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				expectedCode: http.StatusNotFound,
+			},
+			{
+				name: "returns success payload",
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+				},
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}
+				},
+				expectedCode: http.StatusOK,
+				assertBody: func(t *testing.T, body []byte) {
+					t.Helper()
+					var resp models.SingleResponse[models.SessionReviewCapabilities]
+					require.NoError(t, json.Unmarshal(body, &resp), "Capabilities should return JSON on success")
+					require.True(t, resp.Data.CanReview, "Capabilities should mark resumable Claude sessions as reviewable")
+					require.Equal(t, []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}, resp.Data.Modes, "Capabilities should echo the adapter's supported review modes")
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mock, err := pgxmock.NewPool()
+				require.NoError(t, err, "pgxmock.NewPool should create the handler mock")
+				defer mock.Close()
+
+				now := time.Now().UTC()
+				orgID := uuid.New()
+				sessionID := uuid.New()
+				tt.setup(mock, orgID, sessionID, now)
+				handler := newSessionReviewHandlerForTest(mock, tt.reviewModes)
+
+				req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/api/v1/sessions/%s/review-capabilities", sessionID), nil)
+				req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+				routeCtx := chi.NewRouteContext()
+				routeCtx.URLParams.Add("id", sessionID.String())
+				req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, routeCtx))
+
+				w := httptest.NewRecorder()
+				handler.Capabilities(w, req)
+
+				require.Equal(t, tt.expectedCode, w.Code, "Capabilities should map the service result to the expected HTTP status")
+				if tt.assertBody != nil {
+					tt.assertBody(t, w.Body.Bytes())
+				}
+				require.NoError(t, mock.ExpectationsWereMet(), "Capabilities should consume every expected store call")
+			})
+		}
+	})
+}
+
+func TestSessionReviewHandler_Start(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns unauthorized when user is missing", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock.NewPool should create the handler mock")
+		defer mock.Close()
+
+		handler := newSessionReviewHandlerForTest(mock, nil)
+		req := sessionReviewRequest(t, http.MethodPost, nil, uuid.New(), nil, uuid.New().String())
+		w := httptest.NewRecorder()
+
+		handler.Start(w, req)
+
+		require.Equal(t, http.StatusUnauthorized, w.Code, "Start should require an authenticated user before attempting a review")
+	})
+
+	t.Run("returns bad request for invalid session id and malformed body", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock.NewPool should create the handler mock")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		user := &models.User{ID: uuid.New(), OrgID: orgID}
+		handler := newSessionReviewHandlerForTest(mock, nil)
+
+		invalidIDReq := sessionReviewRequest(t, http.MethodPost, nil, orgID, user, "not-a-uuid")
+		invalidIDW := httptest.NewRecorder()
+		handler.Start(invalidIDW, invalidIDReq)
+		require.Equal(t, http.StatusBadRequest, invalidIDW.Code, "Start should reject malformed session IDs before decoding the request body")
+
+		validID := uuid.New().String()
+		invalidBodyReq := sessionReviewRequest(t, http.MethodPost, []byte("{"), orgID, user, validID)
+		invalidBodyW := httptest.NewRecorder()
+		handler.Start(invalidBodyW, invalidBodyReq)
+		require.Equal(t, http.StatusBadRequest, invalidBodyW.Code, "Start should reject malformed JSON payloads")
+	})
+
+	t.Run("maps service errors and success", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name         string
+			body         []byte
+			reviewModes  sessionreview.ReviewModeProvider
+			setup        func(mock pgxmock.PgxPoolIface, orgID, sessionID, userID uuid.UUID, now time.Time)
+			expectedCode int
+			assertBody   func(t *testing.T, body []byte)
+		}{
+			{
+				name: "maps session not found",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, _, _, _ uuid.UUID, _ time.Time) {
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnError(pgx.ErrNoRows)
+				},
+				expectedCode: http.StatusNotFound,
+			},
+			{
+				name: "maps snapshot expired",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateDestroyed), &snapshot, &diff, now)...,
+						))
+				},
+				expectedCode: http.StatusGone,
+			},
+			{
+				name: "maps no changes",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					emptyDiff := ""
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &emptyDiff, now)...,
+						))
+				},
+				expectedCode: http.StatusConflict,
+			},
+			{
+				name: "maps not resumable",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusSkipped), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+				},
+				expectedCode: http.StatusConflict,
+			},
+			{
+				name: "maps unsupported agent",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return nil
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+				},
+				expectedCode: http.StatusNotImplemented,
+			},
+			{
+				name: "maps unsupported mode",
+				body: []byte(`{"mode":"security"}`),
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+				},
+				expectedCode: http.StatusBadRequest,
+			},
+			{
+				name: "maps internal service error",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+					mock.ExpectBegin().WillReturnError(fmt.Errorf("db unavailable"))
+				},
+				expectedCode: http.StatusInternalServerError,
+			},
+			{
+				name: "returns accepted on success and emits audit log",
+				reviewModes: func(models.AgentType) []models.SessionReviewMode {
+					return []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}
+				},
+				setup: func(mock pgxmock.PgxPoolIface, orgID, sessionID, _ uuid.UUID, now time.Time) {
+					snapshot := "snapshots/session.tar"
+					diff := "diff --git a/foo b/foo\n"
+					mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusIdle), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+					mock.ExpectBegin()
+					mock.ExpectQuery("UPDATE sessions").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnRows(pgxmock.NewRows(sessionReviewHandlerSessionColumns).AddRow(
+							newSessionReviewHandlerSessionRow(sessionID, orgID, string(models.SessionStatusRunning), string(models.SandboxStateSnapshotted), &snapshot, &diff, now)...,
+						))
+					mock.ExpectExec("UPDATE sessions.+SET revision_context").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+					mock.ExpectQuery("INSERT INTO session_messages").
+						WithArgs(
+							pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+							pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						).
+						WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+					mock.ExpectQuery("INSERT INTO jobs").
+						WithArgs(pgx.NamedArgs{
+							"org_id":     orgID,
+							"queue":      "agent",
+							"job_type":   "continue_session",
+							"payload":    pgxmock.AnyArg(),
+							"priority":   5,
+							"dedupe_key": (*string)(nil),
+						}).
+						WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+					mock.ExpectCommit()
+					expectAuditInsert(mock)
+				},
+				expectedCode: http.StatusAccepted,
+				assertBody: func(t *testing.T, body []byte) {
+					t.Helper()
+					var resp models.SingleResponse[models.SessionReviewResponse]
+					require.NoError(t, json.Unmarshal(body, &resp), "Start should return a JSON payload for accepted reviews")
+					require.Equal(t, models.SessionReviewModeDefault, resp.Data.Mode, "Start should default an empty request body to the default review mode")
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				mock, err := pgxmock.NewPool()
+				require.NoError(t, err, "pgxmock.NewPool should create the handler mock")
+				defer mock.Close()
+
+				now := time.Now().UTC()
+				orgID := uuid.New()
+				sessionID := uuid.New()
+				userID := uuid.New()
+				tt.setup(mock, orgID, sessionID, userID, now)
+
+				handler := newSessionReviewHandlerForTest(mock, tt.reviewModes)
+				if tt.name == "returns accepted on success and emits audit log" {
+					handler.SetAuditEmitter(newAuditEmitterForTest(mock))
+				}
+
+				req := sessionReviewRequest(t, http.MethodPost, tt.body, orgID, &models.User{ID: userID, OrgID: orgID}, sessionID.String())
+				w := httptest.NewRecorder()
+
+				handler.Start(w, req)
+
+				require.Equal(t, tt.expectedCode, w.Code, "Start should map the service outcome to the correct HTTP status")
+				if tt.assertBody != nil {
+					tt.assertBody(t, w.Body.Bytes())
+				}
+				require.NoError(t, mock.ExpectationsWereMet(), "Start should satisfy the expected review transaction and audit calls")
+			})
+		}
+	})
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/assembledhq/143/internal/crypto"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/llm"
+	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/observability"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/claudecodeauth"
@@ -34,11 +35,12 @@ import (
 	"github.com/assembledhq/143/internal/services/ingestion"
 	"github.com/assembledhq/143/internal/services/preview"
 	"github.com/assembledhq/143/internal/services/sandbox"
+	"github.com/assembledhq/143/internal/services/sessionreview"
 	"github.com/assembledhq/143/internal/services/storage"
 	threadservice "github.com/assembledhq/143/internal/services/thread"
 )
 
-func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, sentryReporter observability.Reporter, codexAuthSvc *codexauth.Service, claudeCodeAuthSvc *claudecodeauth.Service, llmClient llm.Client, fileReader sandbox.FileReader, canceller handlers.SessionCanceller, previewProvider preview.PreviewCapableProvider, snapshotExecutor preview.SnapshotExecutor, sandboxProvider agent.SandboxProvider, snapshotStore storage.SnapshotStore, orgSettingsInvalidator handlers.OrgSettingsInvalidator, shutdownCh <-chan struct{}, redisClient *cache.Client, sessionStreams *cache.SessionStreams) (*chi.Mux, *http.Server, *preview.RecycleWorker, io.Closer, *preview.Manager, error) {
+func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, sentryReporter observability.Reporter, codexAuthSvc *codexauth.Service, claudeCodeAuthSvc *claudecodeauth.Service, llmClient llm.Client, fileReader sandbox.FileReader, canceller handlers.SessionCanceller, previewProvider preview.PreviewCapableProvider, snapshotExecutor preview.SnapshotExecutor, sandboxProvider agent.SandboxProvider, snapshotStore storage.SnapshotStore, orgSettingsInvalidator handlers.OrgSettingsInvalidator, shutdownCh <-chan struct{}, redisClient *cache.Client, sessionStreams *cache.SessionStreams, reviewModes sessionreview.ReviewModeProvider) (*chi.Mux, *http.Server, *preview.RecycleWorker, io.Closer, *preview.Manager, error) {
 	// Create stores
 	orgStore := db.NewOrganizationStore(pool)
 	userStore := db.NewUserStore(pool)
@@ -309,6 +311,21 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionReviewCommentHandler := handlers.NewSessionReviewCommentHandler(sessionReviewCommentStore, sessionStore, logger)
 	sessionReviewCommentHandler.SetAuditEmitter(auditEmitter)
 	sessionReviewCommentHandler.SetMessageAndJobStores(sessionMessageStore, jobStore)
+	// Session-native review service. The reviewModes provider is injected
+	// from main.go so it sees the same adapter map the orchestrator uses;
+	// when nil (tests, etc.), no agents are advertised as review-capable.
+	if reviewModes == nil {
+		reviewModes = func(models.AgentType) []models.SessionReviewMode { return nil }
+	}
+	sessionReviewService := sessionreview.NewService(sessionreview.Deps{
+		Sessions:        sessionStore,
+		SessionMessages: sessionMessageStore,
+		Jobs:            jobStore,
+		ReviewModes:     reviewModes,
+		Logger:          logger,
+	})
+	sessionReviewHandler := handlers.NewSessionReviewHandler(sessionReviewService, logger)
+	sessionReviewHandler.SetAuditEmitter(auditEmitter)
 	sessionFileHandler := handlers.NewSessionFileHandler(sessionStore, fileReader, logger)
 
 	// Preview system: inspector, snapshot cache, HMR watcher, manager, recycler, gateway.
@@ -615,6 +632,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Get("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.GetThreadMessages)
 				r.Get("/api/v1/sessions/{id}/threads/{tid}/logs", sessionThreadHandler.GetThreadLogs)
 				r.Get("/api/v1/sessions/{id}/review-comments", sessionReviewCommentHandler.List)
+				r.Get("/api/v1/sessions/{id}/review-capabilities", sessionReviewHandler.Capabilities)
 				r.Get("/api/v1/sessions/{id}/usage", usageHandler.ListBySession)
 				r.Get("/api/v1/usage", usageHandler.GetSummary)
 				r.Get("/api/v1/sessions/{id}/preview", previewHandler.GetPreview)
@@ -723,6 +741,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/sessions/{id}/threads/{tid}/messages", sessionThreadHandler.SendThreadMessage)
 				r.Post("/api/v1/sessions/{id}/threads/{tid}/end", sessionThreadHandler.EndThread)
 				r.Post("/api/v1/sessions/{id}/review-comments", sessionReviewCommentHandler.Create)
+				r.Post("/api/v1/sessions/{id}/review", sessionReviewHandler.Start)
 				r.Post("/api/v1/sessions/{id}/preview", previewHandler.StartPreview)
 				r.Delete("/api/v1/sessions/{id}/preview", previewHandler.StopPreview)
 				r.Post("/api/v1/sessions/{id}/preview/restart", previewHandler.RestartPreview)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -99,6 +99,18 @@ func TestNewRouter_WithRedisWiringBuildsRouter(t *testing.T) {
 	require.NotNil(t, router, "router should still be constructed with Redis wiring enabled")
 }
 
+func TestNewRouter_NilReviewModesProviderDefaultsToNoCapabilities(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{}
+	codexSvc := codexauth.NewService(nil, zerolog.Nop())
+	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
+
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "NewRouter should install the fallback no-review-capabilities provider when none is supplied")
+	require.NotNil(t, router, "NewRouter should still construct the router when review mode wiring is omitted")
+}
+
 func TestNewRouter_InternalPreviewRoutesSkipGlobalBodyLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -46,7 +46,7 @@ func TestNewRouter_EncryptionKeyValidation(t *testing.T) {
 			cfg := &config.Config{EncryptionMasterKey: tt.masterKey}
 			codexSvc := codexauth.NewService(nil, zerolog.Nop())
 			claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
-			router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+			router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 			if tt.expectErr {
 				require.Error(t, err, "NewRouter should return an error when encryption key is invalid")
 				require.Nil(t, router, "NewRouter should not construct a router with an invalid encryption key")
@@ -82,7 +82,7 @@ func TestNewRouter_GitHubAppConfigBuildsRouter(t *testing.T) {
 	codexSvc := codexauth.NewService(nil, zerolog.Nop())
 	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
 
-	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err, "NewRouter should build successfully when GitHub App credentials are valid")
 	require.NotNil(t, router, "NewRouter should construct a router when GitHub App credentials are valid")
 }
@@ -94,7 +94,7 @@ func TestNewRouter_WithRedisWiringBuildsRouter(t *testing.T) {
 	codexSvc := codexauth.NewService(nil, zerolog.Nop())
 	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
 
-	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, &cache.Client{}, &cache.SessionStreams{})
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, &cache.Client{}, &cache.SessionStreams{}, nil)
 	require.NoError(t, err, "router construction should accept optional Redis dependencies")
 	require.NotNil(t, router, "router should still be constructed with Redis wiring enabled")
 }
@@ -110,7 +110,7 @@ func TestNewRouter_InternalPreviewRoutesSkipGlobalBodyLimit(t *testing.T) {
 	codexSvc := codexauth.NewService(nil, zerolog.Nop())
 	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
 
-	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err, "NewRouter should build successfully for worker preview route tests")
 	require.NotNil(t, router, "NewRouter should construct a router for worker preview route tests")
 
@@ -134,7 +134,7 @@ func TestNewRouter_InternalPreviewRoutesSkipGlobalRateLimit(t *testing.T) {
 	codexSvc := codexauth.NewService(nil, zerolog.Nop())
 	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
 
-	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err, "NewRouter should build successfully for worker preview route tests")
 	require.NotNil(t, router, "NewRouter should construct a router for worker preview route tests")
 

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -39,6 +39,7 @@ const (
 	AuditActionSessionReviewCommentCreated AuditAction = "session.review_comment.created"
 	AuditActionSessionReviewCommentUpdated AuditAction = "session.review_comment.updated"
 	AuditActionSessionReviewCommentDeleted AuditAction = "session.review_comment.deleted"
+	AuditActionSessionReviewRequested      AuditAction = "session.review.requested"
 	AuditActionSessionPRRequested          AuditAction = "session.pr_requested"
 	AuditActionSessionRetried              AuditAction = "session.retried"
 	AuditActionSessionArchived             AuditAction = "session.archived"
@@ -120,6 +121,7 @@ func (a AuditAction) Validate() error {
 		AuditActionSessionFailed, AuditActionSessionCancelled, AuditActionSessionStatusChanged,
 		AuditActionSessionQuestionCreated, AuditActionSessionQuestionAnswered, AuditActionSessionResumedLocally,
 		AuditActionSessionReviewCommentCreated, AuditActionSessionReviewCommentUpdated, AuditActionSessionReviewCommentDeleted,
+		AuditActionSessionReviewRequested,
 		AuditActionSessionPRRequested, AuditActionSessionRetried,
 		AuditActionSessionArchived, AuditActionSessionUnarchived,
 		AuditActionProjectCreated, AuditActionProjectUpdated, AuditActionProjectDeleted,

--- a/internal/models/session_review.go
+++ b/internal/models/session_review.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// SessionReviewMode selects which native review surface the agent should run.
+// "default" is the agent's standard review; "security" targets vulnerabilities.
+// Adapters declare which modes they support via ReviewCapableAdapter.
+type SessionReviewMode string
+
+const (
+	SessionReviewModeDefault  SessionReviewMode = "default"
+	SessionReviewModeSecurity SessionReviewMode = "security"
+)
+
+func (m SessionReviewMode) Validate() error {
+	switch m {
+	case SessionReviewModeDefault, SessionReviewModeSecurity:
+		return nil
+	default:
+		return fmt.Errorf("invalid SessionReviewMode: %q", m)
+	}
+}
+
+// SessionReviewResponse is returned when a review turn is enqueued.
+type SessionReviewResponse struct {
+	SessionID uuid.UUID         `json:"session_id"`
+	Mode      SessionReviewMode `json:"mode"`
+}
+
+// SessionReviewCapabilities describes whether the session can run a review
+// turn right now and which modes the agent's adapter supports.
+type SessionReviewCapabilities struct {
+	CanReview bool                `json:"can_review"`
+	Reason    string              `json:"reason,omitempty"`
+	Modes     []SessionReviewMode `json:"modes"`
+}

--- a/internal/models/session_review_test.go
+++ b/internal/models/session_review_test.go
@@ -1,0 +1,35 @@
+package models
+
+import "testing"
+
+func TestSessionReviewModeValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mode    SessionReviewMode
+		wantErr bool
+	}{
+		{name: "default is valid", mode: SessionReviewModeDefault},
+		{name: "security is valid", mode: SessionReviewModeSecurity},
+		{name: "unknown is invalid", mode: SessionReviewMode("unknown"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.mode.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("Validate(%q) should return an error for unsupported modes", tt.mode)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Validate(%q) should accept supported review modes: %v", tt.mode, err)
+			}
+		})
+	}
+}

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -68,6 +68,79 @@ type RevisionContext struct {
 	CommentSummary    string                             `json:"comment_summary"`
 	RepairAction      models.PullRequestRepairActionType `json:"repair_action,omitempty"`
 	RepairContext     *PullRequestRepairContext          `json:"repair_context,omitempty"`
+	// ReviewContext is set when the user triggered a session-native review
+	// turn (e.g. via the Review button). Adapters that implement
+	// ReviewCapableAdapter branch on this to invoke the agent's native
+	// review surface (Claude Code's /review skill, etc.) instead of
+	// running the next conversational turn.
+	ReviewContext *SessionReviewContext `json:"review_context,omitempty"`
+}
+
+// SessionReviewContext describes a single user-initiated review turn. It is
+// session-scoped — reviews can run before a PR exists — and intentionally
+// distinct from PullRequestRepairContext so the two flows don't drift.
+type SessionReviewContext struct {
+	Mode           models.SessionReviewMode `json:"mode"`
+	PreviousDiff   string                   `json:"previous_diff,omitempty"`
+	RequestSummary string                   `json:"request_summary,omitempty"`
+}
+
+// ReviewCapableAdapter is implemented by adapters whose underlying agent has
+// a curated, native review surface (e.g. Claude Code's /review and
+// /security-review skills). Adapters without a native review surface MUST
+// NOT implement this interface — the Review button will hide for sessions
+// using those agents, by design (see doc 63: "no fallback prompt-based
+// review for agents without native support").
+type ReviewCapableAdapter interface {
+	// ReviewModes returns the review modes this adapter supports natively,
+	// in display order. Returning nil or an empty slice has the same effect
+	// as not implementing the interface.
+	ReviewModes() []models.SessionReviewMode
+}
+
+// AdapterReviewModes returns the review modes a given adapter supports, or
+// nil if the adapter does not implement ReviewCapableAdapter. Centralized so
+// callers (HTTP handlers, the session review service) don't have to repeat
+// the type assertion and nil-check pattern.
+func AdapterReviewModes(adapter AgentAdapter) []models.SessionReviewMode {
+	if adapter == nil {
+		return nil
+	}
+	capable, ok := adapter.(ReviewCapableAdapter)
+	if !ok {
+		return nil
+	}
+	modes := capable.ReviewModes()
+	if len(modes) == 0 {
+		return nil
+	}
+	return modes
+}
+
+// AdapterSupportsReviewMode reports whether the adapter natively supports
+// the given review mode.
+func AdapterSupportsReviewMode(adapter AgentAdapter, mode models.SessionReviewMode) bool {
+	for _, m := range AdapterReviewModes(adapter) {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}
+
+// ReviewModeProvider returns a function that maps an agent type to the
+// review modes its adapter supports natively. Empty/nil result means the
+// agent has no native review surface. Used to wire the session review
+// service to the orchestrator's adapter map without coupling the
+// sessionreview package to the full agent package.
+func ReviewModeProvider(adapters map[models.AgentType]AgentAdapter) func(models.AgentType) []models.SessionReviewMode {
+	return func(agentType models.AgentType) []models.SessionReviewMode {
+		adapter, ok := adapters[agentType]
+		if !ok {
+			return nil
+		}
+		return AdapterReviewModes(adapter)
+	}
 }
 
 type PullRequestRepairContext struct {
@@ -100,10 +173,51 @@ func ParseRevisionContext(raw json.RawMessage) (*RevisionContext, error) {
 	return &parsed, nil
 }
 
+// MarshalRevisionContextWithoutReview returns the JSON encoding of ctx with
+// ReviewContext stripped out. Returns (nil, nil) when ctx is nil or only
+// carried review context — a nil byte slice cleanly clears the persisted
+// row. Returns the re-encoded payload otherwise so other fields
+// (RepairAction, RepairContext, FormattedFeedback, ...) are preserved.
+//
+// Used by the orchestrator to consume a one-shot review directive without
+// disturbing PR-repair revision state that may be set on the same row.
+func MarshalRevisionContextWithoutReview(ctx *RevisionContext) ([]byte, error) {
+	if ctx == nil {
+		return nil, nil
+	}
+	stripped := *ctx
+	stripped.ReviewContext = nil
+	if isRevisionContextEmpty(&stripped) {
+		return nil, nil
+	}
+	return json.Marshal(stripped)
+}
+
+func isRevisionContextEmpty(ctx *RevisionContext) bool {
+	if ctx == nil {
+		return true
+	}
+	return ctx.FormattedFeedback == "" &&
+		ctx.PreviousDiff == "" &&
+		ctx.CommentSummary == "" &&
+		ctx.RepairAction == "" &&
+		ctx.RepairContext == nil &&
+		ctx.ReviewContext == nil
+}
+
 func FormatRevisionContextForContinuation(ctx *RevisionContext) string {
 	if ctx == nil {
 		return ""
 	}
+
+	// Reviews are routed through adapter-native review surfaces by Execute
+	// when ReviewCapableAdapter is implemented. The orchestrator only reaches
+	// FormatRevisionContextForContinuation here for the prompt-text fallback,
+	// so emitting any review framing here would double-prompt or — worse —
+	// silently produce a hand-rolled review on agents the design explicitly
+	// chose not to fake (see doc 63 § "What we are explicitly *not* building").
+	// Adapters that handle reviews natively read ReviewContext directly off
+	// AgentPrompt.RevisionContext.
 
 	var b strings.Builder
 	if ctx.FormattedFeedback != "" || ctx.CommentSummary != "" || ctx.PreviousDiff != "" {
@@ -188,6 +302,17 @@ type AgentPrompt struct {
 	Continuation    bool     // true when resuming an existing interactive session
 	ResumeSessionID string   // agent's session ID for --resume/--continue (set on subsequent turns)
 	UserMessage     string   // follow-up message from the user (set on subsequent turns)
+	// RevisionContext carries revision/repair/review metadata into Execute.
+	// PreparePrompt is bypassed on continuation turns, so adapters that need
+	// to branch on review or repair context (e.g. to invoke Claude Code's
+	// /review skill) read it from here. Nil for ordinary turns.
+	RevisionContext *RevisionContext
+}
+
+// IsReview reports whether this prompt represents a session-native review
+// turn that adapters should route to the agent's curated review surface.
+func (p *AgentPrompt) IsReview() bool {
+	return p != nil && p.RevisionContext != nil && p.RevisionContext.ReviewContext != nil
 }
 
 // AgentResult is the outcome of an agent execution.

--- a/internal/services/agent/adapter_test.go
+++ b/internal/services/agent/adapter_test.go
@@ -210,3 +210,54 @@ func TestAgentPrompt_IsReview(t *testing.T) {
 		},
 	}).IsReview(), "prompt with review context is a review")
 }
+
+func TestMarshalRevisionContextWithoutReview(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ctx      *RevisionContext
+		wantNil  bool
+		wantJSON string
+	}{
+		{
+			name:    "nil context clears row",
+			ctx:     nil,
+			wantNil: true,
+		},
+		{
+			name: "review-only context clears row",
+			ctx: &RevisionContext{
+				ReviewContext: &SessionReviewContext{Mode: models.SessionReviewModeDefault},
+			},
+			wantNil: true,
+		},
+		{
+			name: "non-review fields are preserved",
+			ctx: &RevisionContext{
+				FormattedFeedback: "fix the bug",
+				CommentSummary:    "one comment left",
+				RepairAction:      models.PullRequestRepairActionTypeFixTests,
+				ReviewContext:     &SessionReviewContext{Mode: models.SessionReviewModeSecurity},
+			},
+			wantJSON: `"repair_action":"fix_tests"`,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw, err := MarshalRevisionContextWithoutReview(tt.ctx)
+			require.NoError(t, err, "MarshalRevisionContextWithoutReview should not fail for supported revision payloads")
+			if tt.wantNil {
+				require.Nil(t, raw, "MarshalRevisionContextWithoutReview should clear review-only payloads")
+				return
+			}
+			require.NotNil(t, raw, "MarshalRevisionContextWithoutReview should preserve non-review revision fields")
+			require.Contains(t, string(raw), tt.wantJSON, "MarshalRevisionContextWithoutReview should keep the non-review state intact")
+			require.NotContains(t, string(raw), "review_context", "MarshalRevisionContextWithoutReview should strip the review directive before persistence")
+		})
+	}
+}

--- a/internal/services/agent/adapter_test.go
+++ b/internal/services/agent/adapter_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
@@ -123,4 +124,89 @@ func TestParseAndFormatRevisionContext(t *testing.T) {
 	require.Equal(t, "", FormatRevisionContextForContinuation(nil), "FormatRevisionContextForContinuation should return an empty string for nil input")
 	require.Equal(t, "", FormatRevisionContextForContinuation(&RevisionContext{}), "FormatRevisionContextForContinuation should return an empty string for empty revision context")
 	require.Equal(t, models.PullRequestRepairActionTypeFixTests, parsed.RepairAction, "ParseRevisionContext should decode the repair action type")
+}
+
+// stubReviewAdapter implements both AgentAdapter and ReviewCapableAdapter so
+// the helpers can be exercised against a known-good fake without depending
+// on the concrete adapter packages.
+type stubReviewAdapter struct {
+	name  models.AgentType
+	modes []models.SessionReviewMode
+}
+
+func (s *stubReviewAdapter) Name() models.AgentType { return s.name }
+func (s *stubReviewAdapter) PreparePrompt(_ context.Context, _ *AgentInput) (*AgentPrompt, error) {
+	return nil, nil
+}
+func (s *stubReviewAdapter) Execute(_ context.Context, _ *Sandbox, _ *AgentPrompt, _ chan<- LogEntry) (*AgentResult, error) {
+	return nil, nil
+}
+func (s *stubReviewAdapter) ReviewModes() []models.SessionReviewMode { return s.modes }
+
+type stubBareAdapter struct{ name models.AgentType }
+
+func (s *stubBareAdapter) Name() models.AgentType { return s.name }
+func (s *stubBareAdapter) PreparePrompt(_ context.Context, _ *AgentInput) (*AgentPrompt, error) {
+	return nil, nil
+}
+func (s *stubBareAdapter) Execute(_ context.Context, _ *Sandbox, _ *AgentPrompt, _ chan<- LogEntry) (*AgentResult, error) {
+	return nil, nil
+}
+
+func TestAdapterReviewModes(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, AdapterReviewModes(nil), "nil adapter has no review modes")
+
+	bare := &stubBareAdapter{name: models.AgentTypeGeminiCLI}
+	require.Nil(t, AdapterReviewModes(bare), "adapters that don't implement ReviewCapableAdapter should report no modes")
+
+	emptyCapable := &stubReviewAdapter{name: models.AgentTypePi}
+	require.Nil(t, AdapterReviewModes(emptyCapable), "adapters returning an empty slice are treated as not review-capable")
+
+	full := &stubReviewAdapter{
+		name:  models.AgentTypeClaudeCode,
+		modes: []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity},
+	}
+	require.Equal(
+		t,
+		[]models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity},
+		AdapterReviewModes(full),
+	)
+
+	require.True(t, AdapterSupportsReviewMode(full, models.SessionReviewModeSecurity))
+	require.False(t, AdapterSupportsReviewMode(full, models.SessionReviewMode("unknown")))
+	require.False(t, AdapterSupportsReviewMode(bare, models.SessionReviewModeDefault))
+}
+
+func TestReviewModeProvider(t *testing.T) {
+	t.Parallel()
+
+	full := &stubReviewAdapter{
+		name:  models.AgentTypeClaudeCode,
+		modes: []models.SessionReviewMode{models.SessionReviewModeDefault},
+	}
+	bare := &stubBareAdapter{name: models.AgentTypeCodex}
+
+	provider := ReviewModeProvider(map[models.AgentType]AgentAdapter{
+		models.AgentTypeClaudeCode: full,
+		models.AgentTypeCodex:      bare,
+	})
+
+	require.Equal(t, []models.SessionReviewMode{models.SessionReviewModeDefault}, provider(models.AgentTypeClaudeCode))
+	require.Nil(t, provider(models.AgentTypeCodex), "agents whose adapter lacks ReviewCapableAdapter must report no modes")
+	require.Nil(t, provider(models.AgentTypeAmp), "unknown agent types should report no modes")
+}
+
+func TestAgentPrompt_IsReview(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, (*AgentPrompt)(nil).IsReview(), "nil prompt is not a review")
+	require.False(t, (&AgentPrompt{}).IsReview(), "prompt with no revision context is not a review")
+	require.False(t, (&AgentPrompt{RevisionContext: &RevisionContext{}}).IsReview(), "prompt with revision context but no review context is not a review")
+	require.True(t, (&AgentPrompt{
+		RevisionContext: &RevisionContext{
+			ReviewContext: &SessionReviewContext{Mode: models.SessionReviewModeDefault},
+		},
+	}).IsReview(), "prompt with review context is a review")
 }

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -60,6 +60,32 @@ func (a *ClaudeCodeAdapter) Name() models.AgentType {
 	return models.AgentTypeClaudeCode
 }
 
+// ReviewModes declares the curated review surfaces Claude Code ships with.
+// "default" maps to the /review skill, "security" to /security-review. These
+// are vendor-tuned prompts that improve as Anthropic updates the CLI without
+// 143 shipping anything.
+func (a *ClaudeCodeAdapter) ReviewModes() []models.SessionReviewMode {
+	return []models.SessionReviewMode{
+		models.SessionReviewModeDefault,
+		models.SessionReviewModeSecurity,
+	}
+}
+
+// claudeCodeReviewSlashCommand returns the slash command that triggers the
+// requested native review surface inside Claude Code. Returns the empty
+// string for unsupported modes; callers should treat that as "fall through
+// to the regular continuation path."
+func claudeCodeReviewSlashCommand(mode models.SessionReviewMode) string {
+	switch mode {
+	case models.SessionReviewModeDefault:
+		return "/review"
+	case models.SessionReviewModeSecurity:
+		return "/security-review"
+	default:
+		return ""
+	}
+}
+
 // PreparePrompt constructs the system and user prompts for Claude Code
 // based on the issue context.
 func (a *ClaudeCodeAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
@@ -97,7 +123,18 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	if prompt.Continuation {
 		// Subsequent turn: resume the latest session with --continue.
 		// The prompt is a positional argument to --print.
-		msg := shellEscapeDouble(prompt.UserMessage)
+		// For session-native review turns, swap in Claude Code's curated
+		// review skill (`/review` or `/security-review`) instead of the
+		// user message. The skill ships with vendor-tuned prompting and
+		// improves as Anthropic updates the CLI; we never want to wrap or
+		// re-prompt around it.
+		userMessage := prompt.UserMessage
+		if prompt.IsReview() {
+			if slash := claudeCodeReviewSlashCommand(prompt.RevisionContext.ReviewContext.Mode); slash != "" {
+				userMessage = slash
+			}
+		}
+		msg := shellEscapeDouble(userMessage)
 		cmd = fmt.Sprintf(
 			"claude --print --output-format stream-json --verbose%s --continue \"%s\"",
 			effortArg,

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -345,6 +345,78 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	require.False(t, exists, "continuation should not write a fresh prompt file")
 }
 
+func TestClaudeCodeAdapter_ReviewModes(t *testing.T) {
+	t.Parallel()
+	a := NewClaudeCodeAdapter(zerolog.Nop())
+	require.Equal(
+		t,
+		[]models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity},
+		a.ReviewModes(),
+		"Claude Code ships native /review and /security-review skills",
+	)
+	// Confirm the helper resolves the published modes to non-empty commands
+	// so a future rename of either skill is surfaced by a focused test.
+	require.Equal(t, "/review", claudeCodeReviewSlashCommand(models.SessionReviewModeDefault))
+	require.Equal(t, "/security-review", claudeCodeReviewSlashCommand(models.SessionReviewModeSecurity))
+	require.Equal(t, "", claudeCodeReviewSlashCommand(models.SessionReviewMode("nonsense")))
+}
+
+func TestClaudeCodeAdapter_Execute_ReviewTurnInvokesNativeSkill(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		mode        models.SessionReviewMode
+		wantCommand string
+	}{
+		{name: "default review uses /review", mode: models.SessionReviewModeDefault, wantCommand: "/review"},
+		{name: "security review uses /security-review", mode: models.SessionReviewModeSecurity, wantCommand: "/security-review"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider := testutil.NewMockSandboxProvider()
+			provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				if strings.HasPrefix(cmd, "claude") {
+					_, _ = stdout.Write([]byte(`{"type":"assistant","content":"reviewing"}`))
+					return 0, nil
+				}
+				if strings.HasPrefix(cmd, "git rev-parse") {
+					_, _ = stdout.Write([]byte("true\n"))
+					return 0, nil
+				}
+				return 0, nil
+			}
+
+			adapter := NewClaudeCodeAdapter(zerolog.Nop())
+			sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+			prompt := &agent.AgentPrompt{
+				// The user-facing message is what the API persists for the
+				// transcript; Execute should ignore it and substitute the
+				// vendor slash-command for review turns.
+				UserMessage:  "Please review your changes.",
+				MaxTokens:    50_000,
+				Continuation: true,
+				RevisionContext: &agent.RevisionContext{
+					ReviewContext: &agent.SessionReviewContext{Mode: tc.mode},
+				},
+			}
+			logCh := make(chan agent.LogEntry, 10)
+			ctx := WithSandboxProvider(context.Background(), provider)
+
+			_, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+			require.NoError(t, err)
+			require.NotEmpty(t, provider.ExecCalls)
+			require.Contains(t, provider.ExecCalls[0], "--continue", "review turn must reuse Claude's continue mode")
+			require.Contains(t, provider.ExecCalls[0], tc.wantCommand, "review turn must invoke the native review slash command")
+			require.NotContains(t, provider.ExecCalls[0], "Please review your changes.", "review turn must not echo the persisted prompt body alongside the slash command")
+		})
+	}
+}
+
 func TestClaudeCodeAdapter_Execute_IncludesReasoningEffortOverride(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/adapters/registry.go
+++ b/internal/services/agent/adapters/registry.go
@@ -1,0 +1,27 @@
+// Package adapters contains implementations of the agent.AgentAdapter interface
+// for specific coding agent CLIs.
+package adapters
+
+import (
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+// DefaultMap returns the canonical agent adapter map: every shipped adapter
+// keyed by its AgentType. It is the single source of truth for "what agents
+// does this build support" and is consumed both by the orchestrator (for
+// agent execution) and by the API router's session-review service (for
+// capability lookup). Adapter constructors take only a logger, so calling
+// this twice during boot is safe and cheap — but having one factory means
+// adding a new agent only requires editing one place.
+func DefaultMap(logger zerolog.Logger) map[models.AgentType]agent.AgentAdapter {
+	return map[models.AgentType]agent.AgentAdapter{
+		models.AgentTypeClaudeCode: NewClaudeCodeAdapter(logger),
+		models.AgentTypeGeminiCLI:  NewGeminiCLIAdapter(logger),
+		models.AgentTypeCodex:      NewCodexAdapter(logger),
+		models.AgentTypeAmp:        NewAmpAdapter(logger),
+		models.AgentTypePi:         NewPiAdapter(logger),
+	}
+}

--- a/internal/services/agent/adapters/registry_test.go
+++ b/internal/services/agent/adapters/registry_test.go
@@ -1,0 +1,26 @@
+package adapters
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+func TestDefaultMap(t *testing.T) {
+	t.Parallel()
+
+	adapters := DefaultMap(zerolog.Nop())
+
+	require.Len(t, adapters, 5, "DefaultMap should expose every shipped adapter")
+	require.NotNil(t, adapters[models.AgentTypeClaudeCode], "DefaultMap should include Claude Code")
+	require.NotNil(t, adapters[models.AgentTypeGeminiCLI], "DefaultMap should include Gemini CLI")
+	require.NotNil(t, adapters[models.AgentTypeCodex], "DefaultMap should include Codex")
+	require.NotNil(t, adapters[models.AgentTypeAmp], "DefaultMap should include Amp")
+	require.NotNil(t, adapters[models.AgentTypePi], "DefaultMap should include Pi")
+	require.Equal(t, []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}, agent.AdapterReviewModes(adapters[models.AgentTypeClaudeCode]), "Claude Code should advertise the native review modes through the shared registry")
+	require.Nil(t, agent.AdapterReviewModes(adapters[models.AgentTypeCodex]), "non-review-capable adapters should continue to report no review modes")
+}

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -91,6 +91,10 @@ type SessionStore interface {
 	UpdateBaseCommitSHA(ctx context.Context, orgID, sessionID uuid.UUID, baseCommitSHA string) error
 	UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
 	UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error
+	// UpdateRevisionContext rewrites sessions.revision_context. The orchestrator
+	// uses it to clear ReviewContext after consumption so a subsequent user
+	// message isn't silently swapped for /review again.
+	UpdateRevisionContext(ctx context.Context, orgID, sessionID uuid.UUID, revisionContext []byte) error
 	GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error)
 	// AcquireTurnHold flips turn_holding_container=TRUE and publishes the
 	// turn's proposed container_id via COALESCE. The returned
@@ -1326,10 +1330,37 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			"User's request:\n" + originalMessage
 	}
 	_ = planMode // used by adapters that support explicit plan mode
-	if revisionContext, revErr := ParseRevisionContext(session.RevisionContext); revErr != nil {
+	revisionContext, revErr := ParseRevisionContext(session.RevisionContext)
+	if revErr != nil {
 		log.Warn().Err(revErr).Msg("failed to parse session revision context during continue_session")
-	} else if formatted := FormatRevisionContextForContinuation(revisionContext); formatted != "" {
-		userMessage = strings.TrimSpace(userMessage + "\n\n" + formatted)
+		revisionContext = nil
+	}
+	// Review turns route through the adapter's native review surface (e.g.
+	// Claude Code's /review skill). Appending the formatted revision context
+	// here would either pollute the slash-command line or hand-roll a fake
+	// review prompt — both are explicitly out of scope per doc 63. Skip the
+	// formatter for review turns; the adapter reads ReviewContext directly
+	// off AgentPrompt.RevisionContext.
+	if revisionContext != nil && revisionContext.ReviewContext == nil {
+		if formatted := FormatRevisionContextForContinuation(revisionContext); formatted != "" {
+			userMessage = strings.TrimSpace(userMessage + "\n\n" + formatted)
+		}
+	}
+	// ReviewContext is one-shot: clear it from the persisted row before the
+	// agent runs so the next user message ("now actually fix the issue you
+	// found") doesn't get silently swapped for /review again. Done before
+	// Execute on purpose — even if the turn fails or is retried, the user
+	// will retry by clicking the button again, not by re-firing the same
+	// stale directive against an unrelated message. Other RevisionContext
+	// fields (RepairAction, RepairContext, ...) are preserved so PR-repair
+	// behavior is unchanged.
+	if revisionContext != nil && revisionContext.ReviewContext != nil {
+		cleared, marshalErr := MarshalRevisionContextWithoutReview(revisionContext)
+		if marshalErr != nil {
+			log.Warn().Err(marshalErr).Msg("failed to re-encode revision context after review consumption")
+		} else if updateErr := o.sessions.UpdateRevisionContext(ctx, session.OrgID, session.ID, cleared); updateErr != nil {
+			log.Warn().Err(updateErr).Msg("failed to clear consumed review context; subsequent turns may double-fire /review")
+		}
 	}
 
 	turnNumber := session.CurrentTurn + 1
@@ -1627,6 +1658,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 				}
 				return *session.ReasoningEffort
 			}(),
+			RevisionContext: revisionContext,
 		}
 
 		if reusedExisting {
@@ -1666,7 +1698,8 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 				}
 				return *session.ReasoningEffort
 			}(),
-			TokenMode: session.TokenMode,
+			TokenMode:       session.TokenMode,
+			RevisionContext: revisionContext,
 		}
 		input.IntegrationSkills = o.BuildIntegrationSkills(ctx, session.OrgID)
 		if o.memory != nil && repoFullName != "" {
@@ -1690,6 +1723,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		// Override UserPrompt with resume context (conversation history + diff).
 		basePrompt.UserPrompt = o.buildResumeContext(session, &issue, messages, userMessage)
 		basePrompt.Continuation = false
+		basePrompt.RevisionContext = revisionContext
 		prompt = basePrompt
 	}
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -163,6 +163,7 @@ type mockSessionStore struct {
 	revisionContextUpdates [][]byte
 	countRunningErr        error
 	beginRuntimeErr        error
+	updateRevisionErr      error
 	acquireHoldFn          func(proposedContainerID string) (string, error)
 	acquireHoldErr         error
 	setWorkerNodeErr       error
@@ -349,7 +350,7 @@ func (m *mockSessionStore) UpdateRevisionContext(ctx context.Context, orgID, ses
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.revisionContextUpdates = append(m.revisionContextUpdates, revisionContext)
-	return nil
+	return m.updateRevisionErr
 }
 
 func (m *mockSessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error {
@@ -2681,6 +2682,144 @@ func TestContinueSession_ClearsReviewContextAfterConsumption(t *testing.T) {
 	// Review-only context: the cleared write should be a nil/empty payload.
 	last := d.sessions.revisionContextUpdates[len(d.sessions.revisionContextUpdates)-1]
 	require.True(t, len(last) == 0, "review-only context should clear the row entirely (got %q)", string(last))
+}
+
+func TestContinueSession_AppendsNonReviewRevisionContextToUserMessage(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-append"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	revisionContextJSON, err := json.Marshal(agent.RevisionContext{
+		FormattedFeedback: "Please address the code review notes.",
+		CommentSummary:    "One unresolved comment remains.",
+		PreviousDiff:      "--- a/foo\n+++ b/foo\n",
+	})
+	require.NoError(t, err, "json.Marshal should encode the non-review revision context")
+	session.RevisionContext = revisionContextJSON
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Please continue.",
+		},
+	}
+
+	var promptSeen *agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		promptSeen = prompt
+		return &agent.AgentResult{Summary: "done", ExitCode: 0}, nil
+	}
+	d.sessions.releaseHoldFn = func() (bool, string, error) { return false, existing, nil }
+
+	err = buildOrchestrator(d).ContinueSession(context.Background(), session)
+	require.NoError(t, err, "ContinueSession should preserve the normal continuation path for non-review revision metadata")
+	require.NotNil(t, promptSeen, "ContinueSession should execute the adapter for resumable sessions")
+	require.Contains(t, promptSeen.UserMessage, "## Revision context", "ContinueSession should append formatted revision context to the user's continuation message")
+	require.Contains(t, promptSeen.UserMessage, "One unresolved comment remains.", "ContinueSession should carry the revision summary into the adapter prompt")
+}
+
+func TestContinueSession_IgnoresMalformedRevisionContext(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-invalid-revision"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+	session.RevisionContext = json.RawMessage(`{"review_context":`)
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Please continue.",
+		},
+	}
+
+	var promptSeen *agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		promptSeen = prompt
+		return &agent.AgentResult{Summary: "done", ExitCode: 0}, nil
+	}
+	d.sessions.releaseHoldFn = func() (bool, string, error) { return false, existing, nil }
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session)
+	require.NoError(t, err, "ContinueSession should keep running even when the persisted revision context is malformed")
+	require.NotNil(t, promptSeen, "ContinueSession should still invoke the adapter after discarding malformed revision context")
+	require.Nil(t, promptSeen.RevisionContext, "ContinueSession should drop malformed revision context instead of propagating corrupt JSON into the adapter")
+	require.NotContains(t, promptSeen.UserMessage, "## Revision context", "ContinueSession should not append revision framing when the revision context could not be parsed")
+}
+
+func TestContinueSession_UpdateRevisionContextErrorDoesNotBlockReviewTurn(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-update-failure"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	reviewCtxJSON, err := json.Marshal(agent.RevisionContext{
+		ReviewContext: &agent.SessionReviewContext{
+			Mode:           models.SessionReviewModeSecurity,
+			RequestSummary: "user clicked Security review",
+		},
+	})
+	require.NoError(t, err, "json.Marshal should encode the review revision context")
+	session.RevisionContext = reviewCtxJSON
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Please review your changes.",
+		},
+	}
+	d.sessions.updateRevisionErr = errors.New("write failed")
+
+	var promptSeen *agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		promptSeen = prompt
+		return &agent.AgentResult{Summary: "done", ExitCode: 0}, nil
+	}
+	d.sessions.releaseHoldFn = func() (bool, string, error) { return false, existing, nil }
+
+	err = buildOrchestrator(d).ContinueSession(context.Background(), session)
+	require.NoError(t, err, "ContinueSession should not fail the review turn when clearing the consumed review context is best-effort")
+	require.NotNil(t, promptSeen, "ContinueSession should still invoke the adapter when UpdateRevisionContext fails")
+	require.True(t, promptSeen.IsReview(), "ContinueSession should preserve the in-memory review directive even if the persisted clear fails")
 }
 
 // TestContinueSession_ReusesExistingContainer covers the branch where

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -147,29 +147,30 @@ func (m *mockCredentialProvider) ListByProvider(ctx context.Context, orgID uuid.
 
 // mockSessionStore implements agent.SessionStore.
 type mockSessionStore struct {
-	mu               sync.Mutex
-	countRunning     int
-	statusUpdates    []string
-	resultUpdates    []resultUpdate
-	turnUpdates      []turnUpdate
-	runtimeBegins    []runtimeBegin
-	progressUpdates  []runtimeProgressUpdate
-	extensionGrants  []runtimeExtensionGrant
-	checkpoints      []checkpointUpdate
-	recoveryStates   []recoveryStateUpdate
-	baseCommitSHAs   []string
-	failureUpdates   []failureUpdate
-	workerOwnerships []workerOwnershipUpdate
-	countRunningErr  error
-	beginRuntimeErr  error
-	acquireHoldFn    func(proposedContainerID string) (string, error)
-	acquireHoldErr   error
-	setWorkerNodeErr error
-	releaseHoldFn    func() (bool, string, error)
-	finalizeFn       func(expectedContainerID string) (bool, error)
-	acquireHoldCalls int
-	releaseHoldCalls int
-	finalizeCalls    int
+	mu                     sync.Mutex
+	countRunning           int
+	statusUpdates          []string
+	resultUpdates          []resultUpdate
+	turnUpdates            []turnUpdate
+	runtimeBegins          []runtimeBegin
+	progressUpdates        []runtimeProgressUpdate
+	extensionGrants        []runtimeExtensionGrant
+	checkpoints            []checkpointUpdate
+	recoveryStates         []recoveryStateUpdate
+	baseCommitSHAs         []string
+	failureUpdates         []failureUpdate
+	workerOwnerships       []workerOwnershipUpdate
+	revisionContextUpdates [][]byte
+	countRunningErr        error
+	beginRuntimeErr        error
+	acquireHoldFn          func(proposedContainerID string) (string, error)
+	acquireHoldErr         error
+	setWorkerNodeErr       error
+	releaseHoldFn          func() (bool, string, error)
+	finalizeFn             func(expectedContainerID string) (bool, error)
+	acquireHoldCalls       int
+	releaseHoldCalls       int
+	finalizeCalls          int
 }
 
 type failureUpdate struct {
@@ -341,6 +342,13 @@ func (m *mockSessionStore) UpdateBaseCommitSHA(ctx context.Context, orgID, sessi
 }
 
 func (m *mockSessionStore) UpdateTitle(ctx context.Context, orgID, sessionID uuid.UUID, title string) error {
+	return nil
+}
+
+func (m *mockSessionStore) UpdateRevisionContext(ctx context.Context, orgID, sessionID uuid.UUID, revisionContext []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revisionContextUpdates = append(m.revisionContextUpdates, revisionContext)
 	return nil
 }
 
@@ -2610,6 +2618,70 @@ func TestContinueSession_ClaudeTokenFailureRemovesStaleCredentialsBeforeAPIKeyFa
 // lifecycle. Named so grep picks it up and future refactors don't silently
 // change behavior if Create's call site moves.
 var errForcedCreateFailure = errors.New("forced create failure to short-circuit test")
+
+// TestContinueSession_ClearsReviewContextAfterConsumption guarantees the
+// one-shot review directive is wiped from sessions.revision_context before
+// (or during) the turn so the next user message can't be silently swapped
+// for /review again. Persists immediately on read; even if the agent run
+// fails or is retried, the user retries by clicking the button — never by
+// re-firing the same stale directive against an unrelated message.
+func TestContinueSession_ClearsReviewContextAfterConsumption(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-abc"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+	// Persist a review-only RevisionContext.
+	reviewCtxJSON, err := json.Marshal(agent.RevisionContext{
+		ReviewContext: &agent.SessionReviewContext{
+			Mode:           models.SessionReviewModeDefault,
+			RequestSummary: "user clicked Review",
+		},
+	})
+	require.NoError(t, err)
+	session.RevisionContext = reviewCtxJSON
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Please review your changes.",
+		},
+	}
+	// Capture the prompt the adapter sees so we can assert the review
+	// context survived the threading even though it was cleared from the
+	// persisted row.
+	var promptSeen *agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		promptSeen = prompt
+		return &agent.AgentResult{Summary: "done", ExitCode: 0}, nil
+	}
+	d.sessions.releaseHoldFn = func() (bool, string, error) { return false, existing, nil }
+
+	orch := buildOrchestrator(d)
+	require.NoError(t, orch.ContinueSession(context.Background(), session))
+
+	require.NotNil(t, promptSeen, "adapter should have run")
+	require.True(t, promptSeen.IsReview(), "the in-memory prompt must still see the review directive even after the row is cleared")
+
+	d.sessions.mu.Lock()
+	defer d.sessions.mu.Unlock()
+	require.NotEmpty(t, d.sessions.revisionContextUpdates, "orchestrator must call UpdateRevisionContext to clear the consumed review directive")
+	// Review-only context: the cleared write should be a nil/empty payload.
+	last := d.sessions.revisionContextUpdates[len(d.sessions.revisionContextUpdates)-1]
+	require.True(t, len(last) == 0, "review-only context should clear the row entirely (got %q)", string(last))
+}
 
 // TestContinueSession_ReusesExistingContainer covers the branch where
 // session.ContainerID is populated (a preview hydrated the sandbox) so

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -113,6 +113,10 @@ func (s *runtimeTestSessionStore) UpdateTitle(context.Context, uuid.UUID, uuid.U
 	return nil
 }
 
+func (s *runtimeTestSessionStore) UpdateRevisionContext(context.Context, uuid.UUID, uuid.UUID, []byte) error {
+	return nil
+}
+
 func (s *runtimeTestSessionStore) GetByID(context.Context, uuid.UUID, uuid.UUID) (models.Session, error) {
 	return models.Session{}, nil
 }

--- a/internal/services/sessionreview/service.go
+++ b/internal/services/sessionreview/service.go
@@ -1,0 +1,326 @@
+// Package sessionreview owns the session-native "Review" turn flow: a single
+// follow-up turn that asks the configured coding agent to review its own
+// changes via the agent's curated review surface (Claude Code's /review
+// skill, etc.).
+//
+// This is intentionally scoped narrowly. It does NOT model reviews as PR
+// repair actions — reviews can run before a PR exists, eligibility is a
+// function of session state (not PR health), and the design explicitly
+// separates review semantics from PullRequestRepairAction* to keep the two
+// flows from drifting into each other. See doc 63 for the rationale.
+package sessionreview
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+// ReviewModeProvider returns the review modes the configured adapter for the
+// given agent type supports natively. An empty/nil result means the agent
+// has no native review surface — the Review button should hide for sessions
+// running that agent (no fallback prompt-based review by design).
+type ReviewModeProvider func(models.AgentType) []models.SessionReviewMode
+
+// Service owns the lifecycle of a session-native review turn.
+type Service struct {
+	sessions        *db.SessionStore
+	sessionMessages *db.SessionMessageStore
+	jobs            *db.JobStore
+	reviewModes     ReviewModeProvider
+	logger          zerolog.Logger
+}
+
+// Deps bundles the dependencies for constructing a Service. All fields are
+// required; nil dependencies will surface as nil-pointer errors at the first
+// API call rather than at construction so wiring problems don't crash boot.
+type Deps struct {
+	Sessions        *db.SessionStore
+	SessionMessages *db.SessionMessageStore
+	Jobs            *db.JobStore
+	ReviewModes     ReviewModeProvider
+	Logger          zerolog.Logger
+}
+
+// NewService wires a session review service. The ReviewModes provider is
+// expected to be sourced from the agent package's AdapterReviewModes helper
+// composed with the orchestrator's adapter map.
+func NewService(deps Deps) *Service {
+	return &Service{
+		sessions:        deps.Sessions,
+		sessionMessages: deps.SessionMessages,
+		jobs:            deps.Jobs,
+		reviewModes:     deps.ReviewModes,
+		logger:          deps.Logger,
+	}
+}
+
+// Errors callers can match on. Distinct values let HTTP handlers map them
+// to specific status codes (404 vs 409 vs 400) without string comparison.
+var (
+	ErrSessionNotFound        = errors.New("session not found")
+	ErrSessionNotResumable    = errors.New("session is not in a resumable state")
+	ErrSnapshotExpired        = errors.New("session sandbox snapshot has expired")
+	ErrNoChangesToReview      = errors.New("session has no changes to review")
+	ErrAgentReviewUnsupported = errors.New("agent does not support native review")
+	ErrReviewModeUnsupported  = errors.New("requested review mode is not supported by this agent")
+)
+
+// Capabilities reports whether the session can run a review turn now and
+// which modes the agent's adapter supports natively. The Review button uses
+// this to decide whether to render and what its dropdown should contain.
+func (s *Service) Capabilities(ctx context.Context, orgID, sessionID uuid.UUID) (*models.SessionReviewCapabilities, error) {
+	session, err := s.sessions.GetByID(ctx, orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("load session: %w", err)
+	}
+
+	// Always return a non-nil slice. A nil slice marshals to JSON `null`,
+	// and the React component reads `.length` on it directly — a `null`
+	// would crash every non-review-capable session detail page.
+	modes := s.reviewModes(session.AgentType)
+	if modes == nil {
+		modes = []models.SessionReviewMode{}
+	}
+	caps := &models.SessionReviewCapabilities{Modes: modes}
+
+	if len(modes) == 0 {
+		caps.Reason = "this agent does not have a native review surface"
+		return caps, nil
+	}
+	if reason, ok := sessionReviewReadiness(session); !ok {
+		caps.Reason = reason
+		return caps, nil
+	}
+
+	caps.CanReview = true
+	return caps, nil
+}
+
+// StartReview validates the session, builds a session-scoped review revision
+// context, claims the session, persists a short prompt, and enqueues a
+// continue_session job. The orchestrator picks up the job and the configured
+// adapter routes the turn to its native review surface.
+//
+// This deliberately does NOT touch PR repair tables, PR repair enums, or
+// pull-request health snapshots. Reviews are session-native; if a PR exists,
+// it's irrelevant to whether and how a review runs.
+func (s *Service) StartReview(ctx context.Context, orgID, sessionID, userID uuid.UUID, mode models.SessionReviewMode) (*models.SessionReviewResponse, error) {
+	if mode == "" {
+		mode = models.SessionReviewModeDefault
+	}
+	// An unknown mode from the client is the same user-visible failure as
+	// "this agent doesn't support this mode" — normalize so the handler
+	// returns 400 instead of leaking a raw error as 500.
+	if err := mode.Validate(); err != nil {
+		return nil, ErrReviewModeUnsupported
+	}
+
+	session, err := s.sessions.GetByID(ctx, orgID, sessionID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("load session: %w", err)
+	}
+
+	supportedModes := s.reviewModes(session.AgentType)
+	if len(supportedModes) == 0 {
+		return nil, ErrAgentReviewUnsupported
+	}
+	if !containsMode(supportedModes, mode) {
+		return nil, ErrReviewModeUnsupported
+	}
+	if reason, ok := sessionReviewReadiness(session); !ok {
+		// Snapshot expiry is a permanent state; surface it distinctly so
+		// the API can return 410 Gone instead of a generic 409.
+		if session.SandboxState == string(models.SandboxStateDestroyed) {
+			return nil, ErrSnapshotExpired
+		}
+		if reason == reasonNoDiff {
+			return nil, ErrNoChangesToReview
+		}
+		return nil, ErrSessionNotResumable
+	}
+
+	revisionContextJSON, err := buildReviewRevisionContext(session, mode)
+	if err != nil {
+		return nil, fmt.Errorf("encode review revision context: %w", err)
+	}
+
+	tx, err := s.sessions.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin session review tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if rbErr := tx.Rollback(ctx); rbErr != nil {
+			s.logger.Error().Err(rbErr).Str("session_id", sessionID.String()).Msg("failed to rollback session review tx")
+		}
+	}()
+
+	txSessions := db.NewSessionStore(tx)
+	txMessages := db.NewSessionMessageStore(tx)
+
+	// Try claiming an idle session first, falling back to a paused/terminal
+	// resume. Mirrors SendMessage semantics so the review affordance matches
+	// what users already expect from "send a follow-up message".
+	claimed, claimErr := txSessions.ClaimIdle(ctx, orgID, sessionID)
+	if claimErr != nil {
+		var resumeErr error
+		claimed, resumeErr = txSessions.ClaimForResume(ctx, orgID, sessionID)
+		if resumeErr != nil {
+			// Both attempts failed. pgx.ErrNoRows means the session was in
+			// a non-claimable state (the expected case — return 409). Any
+			// other error is a real DB problem worth surfacing in logs so
+			// on-call doesn't see a 409 with no signal.
+			if !errors.Is(claimErr, pgx.ErrNoRows) || !errors.Is(resumeErr, pgx.ErrNoRows) {
+				s.logger.Warn().
+					Err(resumeErr).
+					AnErr("claim_idle_err", claimErr).
+					Str("session_id", sessionID.String()).
+					Msg("session review claim failed")
+			}
+			return nil, ErrSessionNotResumable
+		}
+	}
+
+	if err := txSessions.UpdateRevisionContext(ctx, orgID, claimed.ID, revisionContextJSON); err != nil {
+		return nil, fmt.Errorf("persist review revision context: %w", err)
+	}
+
+	msg := &models.SessionMessage{
+		SessionID:  claimed.ID,
+		OrgID:      orgID,
+		UserID:     &userID,
+		TurnNumber: claimed.CurrentTurn + 1,
+		Role:       models.MessageRoleUser,
+		Content:    reviewPromptForMode(mode),
+	}
+	if err := txMessages.Create(ctx, msg); err != nil {
+		return nil, fmt.Errorf("create review message: %w", err)
+	}
+
+	payload := map[string]string{
+		"session_id": claimed.ID.String(),
+		"org_id":     orgID.String(),
+	}
+	if _, err := s.jobs.EnqueueInTx(ctx, tx, orgID, "agent", "continue_session", payload, 5, nil); err != nil {
+		return nil, fmt.Errorf("enqueue continue_session: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit session review: %w", err)
+	}
+	committed = true
+
+	return &models.SessionReviewResponse{
+		SessionID: claimed.ID,
+		Mode:      mode,
+	}, nil
+}
+
+const reasonNoDiff = "session has no changes yet"
+
+// sessionReviewReadiness centralizes the "can we kick off a review turn?"
+// decision so Capabilities and StartReview agree to the byte. Returns a
+// human-readable reason when not ready.
+//
+// The snapshot-key check is load-bearing: without a snapshot, the
+// orchestrator's continue_session takes the fresh-clone path which forces
+// `Continuation = false`, and the Claude Code adapter's `/review` branch
+// only fires when `Continuation == true`. Letting a no-snapshot session
+// reach the adapter would silently degrade the review into a regular
+// resumed turn against an empty workspace. Mirrors PR repair's
+// canResumeRepairSession check (pr_health_service.go).
+func sessionReviewReadiness(session models.Session) (string, bool) {
+	if session.SandboxState == string(models.SandboxStateDestroyed) {
+		return "session sandbox has expired and can no longer be resumed", false
+	}
+	if session.SnapshotKey == nil || *session.SnapshotKey == "" {
+		return "session has no snapshot to review against yet", false
+	}
+	switch session.Status {
+	case string(models.SessionStatusRunning), string(models.SessionStatusPending):
+		return "session is currently running", false
+	case string(models.SessionStatusIdle),
+		string(models.SessionStatusCompleted),
+		string(models.SessionStatusPRCreated),
+		string(models.SessionStatusFailed),
+		string(models.SessionStatusCancelled),
+		string(models.SessionStatusAwaitingInput),
+		string(models.SessionStatusNeedsHumanGuidance):
+		// resumable
+	default:
+		return fmt.Sprintf("session status %q is not resumable", session.Status), false
+	}
+	if session.Diff == nil || *session.Diff == "" {
+		return reasonNoDiff, false
+	}
+	return "", true
+}
+
+// buildReviewRevisionContext assembles the JSON payload persisted on
+// sessions.revision_context. The orchestrator parses this on the next turn
+// and threads it into AgentPrompt.RevisionContext for the adapter.
+func buildReviewRevisionContext(session models.Session, mode models.SessionReviewMode) ([]byte, error) {
+	previousDiff := ""
+	if session.Diff != nil {
+		previousDiff = *session.Diff
+	}
+	payload := agent.RevisionContext{
+		ReviewContext: &agent.SessionReviewContext{
+			Mode:           mode,
+			PreviousDiff:   previousDiff,
+			RequestSummary: requestSummaryForMode(mode),
+		},
+	}
+	return json.Marshal(payload)
+}
+
+// reviewPromptForMode is the short prompt persisted as a user message for
+// the review turn. Adapters with native review surfaces swap this for the
+// vendor slash-command at Execute time; this text is what gets stored in
+// the conversation log and is also what non-review-capable adapters (which
+// shouldn't be reachable here) would receive verbatim.
+func reviewPromptForMode(mode models.SessionReviewMode) string {
+	switch mode {
+	case models.SessionReviewModeSecurity:
+		return "Please run a security review on your changes."
+	default:
+		return "Please review your changes."
+	}
+}
+
+func requestSummaryForMode(mode models.SessionReviewMode) string {
+	switch mode {
+	case models.SessionReviewModeSecurity:
+		return "User requested an agent security review."
+	default:
+		return "User requested an agent review."
+	}
+}
+
+func containsMode(modes []models.SessionReviewMode, mode models.SessionReviewMode) bool {
+	for _, m := range modes {
+		if m == mode {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/services/sessionreview/service_test.go
+++ b/internal/services/sessionreview/service_test.go
@@ -1,0 +1,497 @@
+package sessionreview
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+func TestSessionReviewReadiness(t *testing.T) {
+	t.Parallel()
+
+	diff := "diff --git a/a b/a\n"
+	emptyDiff := ""
+	snapshot := "snapshots/foo.tar"
+
+	cases := []struct {
+		name      string
+		session   models.Session
+		wantReady bool
+		wantHint  string
+	}{
+		{
+			name: "idle session with diff and snapshot is ready",
+			session: models.Session{
+				Status:       string(models.SessionStatusIdle),
+				SandboxState: string(models.SandboxStateSnapshotted),
+				SnapshotKey:  &snapshot,
+				Diff:         &diff,
+			},
+			wantReady: true,
+		},
+		{
+			name: "completed session is resumable",
+			session: models.Session{
+				Status:       string(models.SessionStatusCompleted),
+				SandboxState: string(models.SandboxStateSnapshotted),
+				SnapshotKey:  &snapshot,
+				Diff:         &diff,
+			},
+			wantReady: true,
+		},
+		{
+			name: "running session is rejected",
+			session: models.Session{
+				Status:       string(models.SessionStatusRunning),
+				SandboxState: string(models.SandboxStateRunning),
+				SnapshotKey:  &snapshot,
+				Diff:         &diff,
+			},
+			wantReady: false,
+			wantHint:  "currently running",
+		},
+		{
+			name: "destroyed sandbox is rejected even if status looks resumable",
+			session: models.Session{
+				Status:       string(models.SessionStatusIdle),
+				SandboxState: string(models.SandboxStateDestroyed),
+				SnapshotKey:  &snapshot,
+				Diff:         &diff,
+			},
+			wantReady: false,
+			wantHint:  "expired",
+		},
+		{
+			name: "session with no snapshot is rejected so /review never falls into the fresh-clone path",
+			session: models.Session{
+				Status:       string(models.SessionStatusIdle),
+				SandboxState: string(models.SandboxStateSnapshotted),
+				Diff:         &diff,
+			},
+			wantReady: false,
+			wantHint:  "no snapshot",
+		},
+		{
+			name: "session with no diff is rejected so reviews always have something to look at",
+			session: models.Session{
+				Status:       string(models.SessionStatusIdle),
+				SandboxState: string(models.SandboxStateSnapshotted),
+				SnapshotKey:  &snapshot,
+				Diff:         &emptyDiff,
+			},
+			wantReady: false,
+			wantHint:  "no changes",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			reason, ok := sessionReviewReadiness(tc.session)
+			require.Equal(t, tc.wantReady, ok)
+			if !tc.wantReady {
+				require.Contains(t, reason, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestBuildReviewRevisionContextRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	diff := "--- a/foo\n+++ b/foo\n"
+	session := models.Session{Diff: &diff}
+
+	for _, mode := range []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity} {
+		raw, err := buildReviewRevisionContext(session, mode)
+		require.NoError(t, err, "buildReviewRevisionContext should succeed for %s", mode)
+
+		// Round-trip through agent.ParseRevisionContext to confirm the
+		// orchestrator will see exactly what we wrote — this catches drift
+		// between the JSON tags on RevisionContext / SessionReviewContext.
+		ctx, err := agent.ParseRevisionContext(raw)
+		require.NoError(t, err)
+		require.NotNil(t, ctx.ReviewContext)
+		require.Equal(t, mode, ctx.ReviewContext.Mode)
+		require.Equal(t, diff, ctx.ReviewContext.PreviousDiff)
+		require.NotEmpty(t, ctx.ReviewContext.RequestSummary)
+
+		// Repair fields must stay clear; reviews are session-native and
+		// must not leak into the PR repair plumbing.
+		require.Empty(t, ctx.RepairAction)
+		require.Nil(t, ctx.RepairContext)
+
+		// Sanity: format-for-continuation does not double-emit a review
+		// directive when only the review context is set.
+		require.Equal(t, "", agent.FormatRevisionContextForContinuation(ctx))
+
+		// And the encoded payload uses the documented field name so the
+		// frontend / other readers can rely on the JSON shape.
+		var decoded map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(raw, &decoded))
+		_, hasReview := decoded["review_context"]
+		require.True(t, hasReview, "encoded payload must use the review_context key")
+	}
+}
+
+func TestReviewPromptForMode(t *testing.T) {
+	t.Parallel()
+	require.Contains(t, reviewPromptForMode(models.SessionReviewModeDefault), "review")
+	require.Contains(t, reviewPromptForMode(models.SessionReviewModeSecurity), "security")
+}
+
+// sessionReviewSessionColumns mirrors the column ordering of session-store
+// SELECTs/UPDATEs used by ClaimIdle / ClaimForResume. Kept in this test file
+// because the production code reaches into pgx via the SessionStore directly
+// and we need to feed the exact row shape it expects to scan.
+var sessionReviewSessionColumns = []string{
+	"id", "issue_id", "org_id", "origin", "interaction_mode", "validation_policy", "agent_type", "status", "autonomy_level", "token_mode",
+	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
+	"container_id", "worker_node_id", "turn_holding_container", "started_at", "completed_at", "token_usage",
+	"failure_explanation", "failure_category", "failure_next_steps", "failure_retry_advised",
+	"parent_session_id", "revision_context", "error", "result_summary", "diff",
+	"pm_plan_id", "title", "pm_approach", "pm_reasoning",
+	"project_task_id", "model_override", "reasoning_effort", "triggered_by_user_id",
+	"agent_session_id", "current_turn", "last_activity_at", "sandbox_state", "snapshot_key",
+	"runtime_soft_deadline_at", "runtime_hard_deadline_at", "runtime_last_progress_at", "runtime_last_progress_type", "runtime_last_progress_strength",
+	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
+	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
+	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id", "deleted_at", "created_at",
+}
+
+func newSessionReviewSessionRow(sessionID, orgID uuid.UUID, status string, snapshotKey *string, diff *string, now time.Time) []any {
+	issueID := uuid.New()
+	return []any{
+		sessionID, issueID, orgID, models.SessionOriginManual, models.SessionInteractionModeInteractive, models.SessionValidationPolicyOnTurnComplete, models.AgentTypeClaudeCode, status, "semi", "low",
+		nil, nil, nil, nil,
+		nil, nil, false, &now, nil, nil,
+		nil, nil, nil, false,
+		nil, nil, nil, nil, diff,
+		nil, nil, nil, nil,
+		nil, nil, nil, nil,
+		nil, 0, now, "snapshotted", snapshotKey,
+		nil, nil, nil, "", "",
+		0, 0, "", nil,
+		nil, "", "", int64(0), nil,
+		"", nil, nil, 0,
+		nil, nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, "idle", (*string)(nil), nil, nil, nil, now,
+	}
+}
+
+// reviewModesAlwaysClaude returns Claude-Code-style modes for any agent
+// type. Lets the test focus on the transactional path without dragging in
+// the real adapter map.
+func reviewModesAlwaysClaude(models.AgentType) []models.SessionReviewMode {
+	return []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}
+}
+
+func TestStartReview_HappyPath_ClaimsIdleAndPersistsInOrder(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	snapshot := "snapshots/foo.tar"
+	diff := "diff --git a/a b/a\n"
+
+	// 1. Capabilities pre-flight: GetByID against the session.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+			newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+		))
+
+	// 2. Transaction begins.
+	mock.ExpectBegin()
+
+	// 3. ClaimIdle wins on the first try (UPDATE ... WHERE status='idle' RETURNING ...).
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+			newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+		))
+
+	// 4. UpdateRevisionContext fires BEFORE message create — this ordering is
+	// load-bearing because the orchestrator reads session.revision_context on
+	// the next turn. Asserting the SQL pattern + the call ordering catches
+	// regressions that would let the message + job land before the
+	// directive.
+	mock.ExpectExec("UPDATE sessions.+SET revision_context").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// 5. Message INSERT.
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+	// 6. Job enqueue inside the same tx — must use continue_session, not run_agent.
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      "agent",
+			"job_type":   "continue_session",
+			"payload":    pgxmock.AnyArg(),
+			"priority":   5,
+			"dedupe_key": (*string)(nil),
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	// 7. Commit.
+	mock.ExpectCommit()
+
+	svc := NewService(Deps{
+		Sessions:        db.NewSessionStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+		ReviewModes:     reviewModesAlwaysClaude,
+		Logger:          zerolog.New(io.Discard),
+	})
+
+	resp, err := svc.StartReview(context.Background(), orgID, sessionID, userID, models.SessionReviewModeDefault)
+	require.NoError(t, err, "StartReview should succeed when ClaimIdle wins")
+	require.Equal(t, sessionID, resp.SessionID)
+	require.Equal(t, models.SessionReviewModeDefault, resp.Mode)
+	require.NoError(t, mock.ExpectationsWereMet(), "all StartReview expectations should fire in order")
+}
+
+func TestStartReview_FallsBackToClaimForResumeWhenIdleClaimMissesNoRows(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	snapshot := "snapshots/foo.tar"
+	diff := "diff --git a/a b/a\n"
+
+	// Pre-flight: session is "completed" (not idle). Capabilities.GetByID.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+			newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusCompleted), &snapshot, &diff, now)...,
+		))
+
+	mock.ExpectBegin()
+
+	// ClaimIdle returns ErrNoRows (the session is completed, not idle).
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	// ClaimForResume succeeds against the completed session.
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+			newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+		))
+
+	mock.ExpectExec("UPDATE sessions.+SET revision_context").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      "agent",
+			"job_type":   "continue_session",
+			"payload":    pgxmock.AnyArg(),
+			"priority":   5,
+			"dedupe_key": (*string)(nil),
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	mock.ExpectCommit()
+
+	svc := NewService(Deps{
+		Sessions:        db.NewSessionStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+		ReviewModes:     reviewModesAlwaysClaude,
+		Logger:          zerolog.New(io.Discard),
+	})
+
+	resp, err := svc.StartReview(context.Background(), orgID, sessionID, userID, models.SessionReviewModeSecurity)
+	require.NoError(t, err, "StartReview should fall back to ClaimForResume on a terminal-but-resumable session")
+	require.Equal(t, models.SessionReviewModeSecurity, resp.Mode)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestStartReview_RejectsAtCapabilityCheck(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		modes       []models.SessionReviewMode
+		modeArg     models.SessionReviewMode
+		row         func(orgID, sessionID uuid.UUID, now time.Time) []any
+		wantErrSent bool // true if we expect StartReview to return an error before the tx
+	}{
+		{
+			name:    "agent without native review modes",
+			modes:   nil,
+			modeArg: models.SessionReviewModeDefault,
+			row: func(orgID, sessionID uuid.UUID, now time.Time) []any {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				return newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)
+			},
+			wantErrSent: true,
+		},
+		{
+			name:    "destroyed sandbox",
+			modes:   []models.SessionReviewMode{models.SessionReviewModeDefault},
+			modeArg: models.SessionReviewModeDefault,
+			row: func(orgID, sessionID uuid.UUID, now time.Time) []any {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				row := newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)
+				// sandbox_state is at index 41 in the column list.
+				row[41] = string(models.SandboxStateDestroyed)
+				return row
+			},
+			wantErrSent: true,
+		},
+		{
+			name:    "no snapshot key",
+			modes:   []models.SessionReviewMode{models.SessionReviewModeDefault},
+			modeArg: models.SessionReviewModeDefault,
+			row: func(orgID, sessionID uuid.UUID, now time.Time) []any {
+				diff := "diff --git a/a b/a\n"
+				return newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), nil, &diff, now)
+			},
+			wantErrSent: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			now := time.Now().UTC()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+
+			mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(tc.row(orgID, sessionID, now)...))
+
+			svc := NewService(Deps{
+				Sessions:        db.NewSessionStore(mock),
+				SessionMessages: db.NewSessionMessageStore(mock),
+				Jobs:            db.NewJobStore(mock),
+				ReviewModes:     func(models.AgentType) []models.SessionReviewMode { return tc.modes },
+				Logger:          zerolog.New(io.Discard),
+			})
+
+			_, err = svc.StartReview(context.Background(), orgID, sessionID, uuid.New(), tc.modeArg)
+			if tc.wantErrSent {
+				require.Error(t, err, "StartReview should reject before opening a transaction")
+			} else {
+				require.NoError(t, err)
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "no extra DB calls beyond the initial GetByID should have fired")
+		})
+	}
+}
+
+func TestStartReview_InvalidModeReturnsErrReviewModeUnsupported(t *testing.T) {
+	t.Parallel()
+
+	// No DB calls expected — validation rejects before GetByID.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	svc := NewService(Deps{
+		Sessions:        db.NewSessionStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+		ReviewModes:     reviewModesAlwaysClaude,
+		Logger:          zerolog.New(io.Discard),
+	})
+
+	_, err = svc.StartReview(context.Background(), uuid.New(), uuid.New(), uuid.New(), models.SessionReviewMode("nope"))
+	require.ErrorIs(t, err, ErrReviewModeUnsupported, "invalid mode strings must surface as the typed unsupported error so the handler returns 400")
+	require.NoError(t, mock.ExpectationsWereMet(), "validation must reject before any DB call")
+}
+
+func TestCapabilities_ModesIsNeverNil(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now().UTC()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	snapshot := "snapshots/foo.tar"
+	diff := "diff --git a/a b/a\n"
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+			newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+		))
+
+	svc := NewService(Deps{
+		Sessions:        db.NewSessionStore(mock),
+		SessionMessages: db.NewSessionMessageStore(mock),
+		Jobs:            db.NewJobStore(mock),
+		// Provider returns nil — exactly the case where the encoded JSON
+		// must still be `"modes": []` so the React component doesn't crash
+		// reading .length on a null.
+		ReviewModes: func(models.AgentType) []models.SessionReviewMode { return nil },
+		Logger:      zerolog.New(io.Discard),
+	})
+
+	caps, err := svc.Capabilities(context.Background(), orgID, sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, caps.Modes, "Modes must be a non-nil slice so JSON encodes [] not null")
+	require.Equal(t, 0, len(caps.Modes))
+	require.False(t, caps.CanReview)
+
+	encoded, err := json.Marshal(caps)
+	require.NoError(t, err)
+	require.Contains(t, string(encoded), `"modes":[]`, "encoded payload must use [] for empty modes")
+}

--- a/internal/services/sessionreview/service_test.go
+++ b/internal/services/sessionreview/service_test.go
@@ -3,6 +3,7 @@ package sessionreview
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -93,6 +94,17 @@ func TestSessionReviewReadiness(t *testing.T) {
 			},
 			wantReady: false,
 			wantHint:  "no changes",
+		},
+		{
+			name: "session with unsupported status is rejected",
+			session: models.Session{
+				Status:       string(models.SessionStatusSkipped),
+				SandboxState: string(models.SandboxStateSnapshotted),
+				SnapshotKey:  &snapshot,
+				Diff:         &diff,
+			},
+			wantReady: false,
+			wantHint:  "not resumable",
 		},
 	}
 
@@ -494,4 +506,394 @@ func TestCapabilities_ModesIsNeverNil(t *testing.T) {
 	encoded, err := json.Marshal(caps)
 	require.NoError(t, err)
 	require.Contains(t, string(encoded), `"modes":[]`, "encoded payload must use [] for empty modes")
+}
+
+func TestCapabilities_ErrorAndReadinessPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setupMock    func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, now time.Time)
+		reviewModes  ReviewModeProvider
+		expectedErr  error
+		expectReady  bool
+		expectedHint string
+	}{
+		{
+			name: "returns session not found",
+			setupMock: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+			},
+			reviewModes: func(models.AgentType) []models.SessionReviewMode {
+				return []models.SessionReviewMode{models.SessionReviewModeDefault}
+			},
+			expectedErr: ErrSessionNotFound,
+		},
+		{
+			name: "wraps load errors",
+			setupMock: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(errors.New("database offline"))
+			},
+			reviewModes: func(models.AgentType) []models.SessionReviewMode {
+				return []models.SessionReviewMode{models.SessionReviewModeDefault}
+			},
+			expectedHint: "load session",
+		},
+		{
+			name: "returns readiness reason for running session",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+					))
+			},
+			reviewModes: func(models.AgentType) []models.SessionReviewMode {
+				return []models.SessionReviewMode{models.SessionReviewModeDefault}
+			},
+			expectedHint: "currently running",
+		},
+		{
+			name: "returns ready capabilities",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusCompleted), &snapshot, &diff, now)...,
+					))
+			},
+			reviewModes: func(models.AgentType) []models.SessionReviewMode {
+				return []models.SessionReviewMode{models.SessionReviewModeDefault, models.SessionReviewModeSecurity}
+			},
+			expectReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock.NewPool should create the capability test store")
+			defer mock.Close()
+
+			now := time.Now().UTC()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			tt.setupMock(mock, orgID, sessionID, now)
+
+			svc := NewService(Deps{
+				Sessions:        db.NewSessionStore(mock),
+				SessionMessages: db.NewSessionMessageStore(mock),
+				Jobs:            db.NewJobStore(mock),
+				ReviewModes:     tt.reviewModes,
+				Logger:          zerolog.New(io.Discard),
+			})
+
+			caps, err := svc.Capabilities(context.Background(), orgID, sessionID)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr, "Capabilities should surface typed service errors for caller-specific HTTP mapping")
+				require.Nil(t, caps, "Capabilities should not return payload data when the session lookup fails")
+			} else if tt.expectedHint == "load session" {
+				require.Error(t, err, "Capabilities should wrap unexpected store errors")
+				require.Contains(t, err.Error(), tt.expectedHint, "Capabilities should annotate unexpected store failures with context")
+			} else {
+				require.NoError(t, err, "Capabilities should succeed for readiness-only scenarios")
+				require.NotNil(t, caps, "Capabilities should return a payload when the session lookup succeeds")
+				require.Equal(t, tt.expectReady, caps.CanReview, "Capabilities should reflect the session's review readiness")
+				if tt.expectedHint != "" {
+					require.Contains(t, caps.Reason, tt.expectedHint, "Capabilities should surface the session readiness reason for blocked reviews")
+				}
+			}
+
+			require.NoError(t, mock.ExpectationsWereMet(), "Capabilities should satisfy the expected query plan")
+		})
+	}
+}
+
+func TestStartReview_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mode        models.SessionReviewMode
+		setupMock   func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, userID uuid.UUID, now time.Time)
+		reviewModes ReviewModeProvider
+		expectedErr error
+		contains    string
+	}{
+		{
+			name: "wraps session load errors",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, _, _ uuid.UUID, _ uuid.UUID, _ time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(errors.New("database offline"))
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "load session",
+		},
+		{
+			name: "rejects supported-but-unconfigured review mode",
+			mode: models.SessionReviewModeSecurity,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+			},
+			reviewModes: func(models.AgentType) []models.SessionReviewMode {
+				return []models.SessionReviewMode{models.SessionReviewModeDefault}
+			},
+			expectedErr: ErrReviewModeUnsupported,
+		},
+		{
+			name: "returns begin transaction error",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin().WillReturnError(errors.New("tx unavailable"))
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "begin session review tx",
+		},
+		{
+			name: "returns not resumable when both claim paths miss",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusCompleted), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(pgx.ErrNoRows)
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			expectedErr: ErrSessionNotResumable,
+		},
+		{
+			name: "returns not resumable when claim queries fail unexpectedly",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusCompleted), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(errors.New("claim idle failed"))
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(errors.New("claim resume failed"))
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			expectedErr: ErrSessionNotResumable,
+		},
+		{
+			name: "returns update revision context error",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+					))
+				mock.ExpectExec("UPDATE sessions.+SET revision_context").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnError(errors.New("update failed"))
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "persist review revision context",
+		},
+		{
+			name: "returns create message error",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+					))
+				mock.ExpectExec("UPDATE sessions.+SET revision_context").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectQuery("INSERT INTO session_messages").
+					WithArgs(
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+					).
+					WillReturnError(errors.New("insert message failed"))
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "create review message",
+		},
+		{
+			name: "returns enqueue error",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+					))
+				mock.ExpectExec("UPDATE sessions.+SET revision_context").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectQuery("INSERT INTO session_messages").
+					WithArgs(
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+					).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgx.NamedArgs{
+						"org_id":     orgID,
+						"queue":      "agent",
+						"job_type":   "continue_session",
+						"payload":    pgxmock.AnyArg(),
+						"priority":   5,
+						"dedupe_key": (*string)(nil),
+					}).
+					WillReturnError(errors.New("enqueue failed"))
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "enqueue continue_session",
+		},
+		{
+			name: "returns commit error",
+			mode: models.SessionReviewModeDefault,
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, _ uuid.UUID, now time.Time) {
+				snapshot := "snapshots/foo.tar"
+				diff := "diff --git a/a b/a\n"
+				mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusIdle), &snapshot, &diff, now)...,
+					))
+				mock.ExpectBegin()
+				mock.ExpectQuery("UPDATE sessions").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows(sessionReviewSessionColumns).AddRow(
+						newSessionReviewSessionRow(sessionID, orgID, string(models.SessionStatusRunning), &snapshot, &diff, now)...,
+					))
+				mock.ExpectExec("UPDATE sessions.+SET revision_context").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectQuery("INSERT INTO session_messages").
+					WithArgs(
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+					).
+					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+				mock.ExpectQuery("INSERT INTO jobs").
+					WithArgs(pgx.NamedArgs{
+						"org_id":     orgID,
+						"queue":      "agent",
+						"job_type":   "continue_session",
+						"payload":    pgxmock.AnyArg(),
+						"priority":   5,
+						"dedupe_key": (*string)(nil),
+					}).
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+				mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+				mock.ExpectRollback()
+			},
+			reviewModes: reviewModesAlwaysClaude,
+			contains:    "commit session review",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock.NewPool should create the review service mock")
+			defer mock.Close()
+
+			now := time.Now().UTC()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			userID := uuid.New()
+			tt.setupMock(mock, orgID, sessionID, userID, now)
+
+			svc := NewService(Deps{
+				Sessions:        db.NewSessionStore(mock),
+				SessionMessages: db.NewSessionMessageStore(mock),
+				Jobs:            db.NewJobStore(mock),
+				ReviewModes:     tt.reviewModes,
+				Logger:          zerolog.New(io.Discard),
+			})
+
+			resp, err := svc.StartReview(context.Background(), orgID, sessionID, userID, tt.mode)
+			require.Nil(t, resp, "StartReview should not return a response payload on failure")
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr, "StartReview should surface typed errors for expected review failure modes")
+			} else {
+				require.Error(t, err, "StartReview should return an annotated error for infrastructure failures")
+				require.Contains(t, err.Error(), tt.contains, "StartReview should explain which step in the review transaction failed")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "StartReview should satisfy the expected store interactions")
+		})
+	}
 }


### PR DESCRIPTION
This adds agent-native session review support, including session review models, service/handler wiring, audit logging, and router integration for the new review endpoints. It teaches the shared agent adapter layer and Claude Code adapter to advertise native review modes and route review turns through Claude's built-in /review and /security-review flows. On the frontend, it adds the session Review button, API/types support, and role gating so only member/admin users can request reviews while restricted settings pages stay unmounted during auth resolution. It also updates the design doc and expands the frontend/backend tests and MSW mocks covering review capabilities, orchestration, and the settings access guard.