### PR TITLE
Fix duplicate assistant transcript detection by normalizing only trailing whitespace

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -956,6 +956,13 @@ function ChatPanel({
     const fetchedLogIds = new Set<number>();
     const assistantTranscriptByTurn = new Map<number, Set<string>>();
     const planModeSeedMessages: SessionMessage[] = [];
+    const normalizeTranscriptContent = (content: string) =>
+      content
+        .replace(/\r\n/g, "\n")
+        .split("\n")
+        .map((line) => line.replace(/[ \t\r]+$/g, ""))
+        .join("\n")
+        .replace(/\n+$/g, "");
 
     for (const entry of baseTimelineEntries) {
       switch (entry.kind) {
@@ -965,13 +972,13 @@ function ChatPanel({
           }
           if (entry.data.role === "assistant") {
             const contents = assistantTranscriptByTurn.get(entry.data.turn_number) ?? new Set<string>();
-            contents.add(entry.data.content);
+            contents.add(normalizeTranscriptContent(entry.data.content));
             assistantTranscriptByTurn.set(entry.data.turn_number, contents);
           }
           break;
         case "plan_message": {
           const contents = assistantTranscriptByTurn.get(entry.data.turn_number) ?? new Set<string>();
-          contents.add(entry.data.content);
+          contents.add(normalizeTranscriptContent(entry.data.content));
           assistantTranscriptByTurn.set(entry.data.turn_number, contents);
           break;
         }
@@ -995,7 +1002,7 @@ function ChatPanel({
       if (log.level !== "output") return true;
       if (log.metadata?.type === "tool_result") return true;
       if (log.metadata?.type === "assistant_final" && log.metadata?.duplicate_of_transcript === true) return false;
-      return !assistantTranscriptByTurn.get(log.turn_number)?.has(log.message);
+      return !assistantTranscriptByTurn.get(log.turn_number)?.has(normalizeTranscriptContent(log.message));
     });
 
     if (overlayLogs.length === 0) return baseTimelineEntries;

--- a/frontend/src/lib/timeline.test.ts
+++ b/frontend/src/lib/timeline.test.ts
@@ -108,6 +108,35 @@ describe("buildTimeline", () => {
     expect(result[1].kind).toBe("message");
   });
 
+  it("suppresses duplicate output log when the only difference is trailing whitespace", () => {
+    const messages = [
+      makeMessage({ id: 1, created_at: "2026-01-01T00:00:03Z", content: "Found the issue.\n" }),
+    ];
+    const logs = [
+      makeLog({ id: 1, created_at: "2026-01-01T00:00:01Z", level: "output", message: "Analyzing..." }),
+      makeLog({ id: 2, created_at: "2026-01-01T00:00:02Z", level: "output", message: "Found the issue." }),
+    ];
+    const result = buildTimeline(messages, logs);
+    expect(result).toHaveLength(2);
+    expect(result[0].kind).toBe("assistant_output");
+    expect(result[1].kind).toBe("message");
+  });
+
+  it("keeps output log when the difference is leading indentation", () => {
+    const messages = [
+      makeMessage({ id: 1, created_at: "2026-01-01T00:00:03Z", content: "  Found the issue." }),
+    ];
+    const logs = [
+      makeLog({ id: 1, created_at: "2026-01-01T00:00:01Z", level: "output", message: "Analyzing..." }),
+      makeLog({ id: 2, created_at: "2026-01-01T00:00:02Z", level: "output", message: "Found the issue." }),
+    ];
+    const result = buildTimeline(messages, logs);
+    expect(result).toHaveLength(3);
+    expect(result[0].kind).toBe("assistant_output");
+    expect(result[1].kind).toBe("assistant_output");
+    expect(result[2].kind).toBe("message");
+  });
+
   it("treats assistant_final output logs as visible output", () => {
     const logs = [
       makeLog({ id: 1, created_at: "2026-01-01T00:00:01Z", level: "output", message: "assistant text", metadata: { type: "assistant_final" } }),

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -20,21 +20,31 @@ function isVisibleAssistantOutput(log: SessionLog): boolean {
   return log.level === "output" && (!log.metadata || !log.metadata.type || isAssistantFinalMetadata(log.metadata));
 }
 
+function normalizeTranscriptContent(content: string): string {
+  return content
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t\r]+$/g, ""))
+    .join("\n")
+    .replace(/\n+$/g, "");
+}
+
 function duplicateOutputLogIds(messages: SessionMessage[], logs: SessionLog[]): Set<number> {
   const visibleByTurnAndContent = new Map<number, Map<string, SessionLog[]>>();
   for (const log of logs) {
     if (!isVisibleAssistantOutput(log)) continue;
     const turnMap = visibleByTurnAndContent.get(log.turn_number) ?? new Map<string, SessionLog[]>();
-    const group = turnMap.get(log.message) ?? [];
+    const normalizedMessage = normalizeTranscriptContent(log.message);
+    const group = turnMap.get(normalizedMessage) ?? [];
     group.push(log);
-    turnMap.set(log.message, group);
+    turnMap.set(normalizedMessage, group);
     visibleByTurnAndContent.set(log.turn_number, turnMap);
   }
 
   const duplicateIDs = new Set<number>();
   for (const msg of messages) {
     if (msg.role !== "assistant") continue;
-    const candidates = visibleByTurnAndContent.get(msg.turn_number)?.get(msg.content) ?? [];
+    const candidates = visibleByTurnAndContent.get(msg.turn_number)?.get(normalizeTranscriptContent(msg.content)) ?? [];
     if (candidates.length === 0) continue;
     const marked = candidates.filter((candidate) => candidate.metadata?.duplicate_of_transcript === true && isAssistantFinalMetadata(candidate.metadata));
     const suppress = marked.length > 0 ? marked : candidates;

--- a/internal/db/session_log_store_test.go
+++ b/internal/db/session_log_store_test.go
@@ -235,22 +235,22 @@ func TestSessionLogStore_MarkAssistantTranscriptDuplicate(t *testing.T) {
 		setupMock func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID)
 		expectErr string
 	}{
-		{
-			name: "success",
-			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
-				mock.ExpectExec("UPDATE session_logs").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), 3, "Final answer").
-					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			{
+				name: "success",
+				setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+					mock.ExpectExec("UPDATE session_logs").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
+						WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				},
 			},
-		},
-		{
-			name: "database error",
-			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
-				mock.ExpectExec("UPDATE session_logs").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), 3, "Final answer").
-					WillReturnError(context.DeadlineExceeded)
-			},
-			expectErr: "mark assistant transcript duplicate",
+			{
+				name: "database error",
+				setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+					mock.ExpectExec("UPDATE session_logs").
+						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
+						WillReturnError(context.DeadlineExceeded)
+				},
+				expectErr: "mark assistant transcript duplicate",
 		},
 	}
 
@@ -268,7 +268,7 @@ func TestSessionLogStore_MarkAssistantTranscriptDuplicate(t *testing.T) {
 			sessionID := uuid.New()
 			tt.setupMock(mock, orgID, sessionID)
 
-			err = store.MarkAssistantTranscriptDuplicate(context.Background(), orgID, sessionID, 3, "Final answer")
+			err = store.MarkAssistantTranscriptDuplicate(context.Background(), orgID, sessionID, nil, 3, "Final answer")
 			if tt.expectErr != "" {
 				require.Error(t, err, "MarkAssistantTranscriptDuplicate should return an error")
 				require.Contains(t, err.Error(), tt.expectErr, "MarkAssistantTranscriptDuplicate should wrap the store error")

--- a/internal/db/session_logs.go
+++ b/internal/db/session_logs.go
@@ -61,7 +61,7 @@ func (s *SessionLogStore) Create(ctx context.Context, log *models.SessionLog) er
 	return nil
 }
 
-func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, turnNumber int, message string) error {
+func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error {
 	query := `
 		UPDATE session_logs
 		SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"type":"assistant_final","duplicate_of_transcript":true}'::jsonb
@@ -70,6 +70,7 @@ func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, 
 			FROM session_logs
 			WHERE org_id = @org_id
 			  AND session_id = @session_id
+			  AND thread_id IS NOT DISTINCT FROM @thread_id
 			  AND turn_number = @turn_number
 			  AND level = 'output'
 			  AND message = @message
@@ -80,6 +81,7 @@ func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, 
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"org_id":      orgID,
 		"session_id":  sessionID,
+		"thread_id":   threadID,
 		"turn_number": turnNumber,
 		"message":     message,
 	})

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -215,6 +217,7 @@ type LogEntry struct {
 	Timestamp time.Time              `json:"timestamp"`
 	Level     string                 `json:"level"` // info, debug, error, tool_use, output, question
 	Message   string                 `json:"message"`
+	ThreadID  *uuid.UUID             `json:"thread_id,omitempty"`
 	Metadata  map[string]interface{} `json:"metadata,omitempty"`
 }
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1051,7 +1051,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, run.ID, run.OrgID, run.CurrentTurn, logCh, runtimeTracker)
+		o.streamLogs(ctx, run.ID, run.OrgID, nil, run.CurrentTurn, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -1060,7 +1060,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Wait()
 
 	// 10b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, run.CurrentTurn, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, nil, run.CurrentTurn, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 11. Handle result.
 	stopReason := StopReasonNone
@@ -1153,7 +1153,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 
 	if isInteractive {
 		turnNumber := run.CurrentTurn + 1
-		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, turnNumber, result); err != nil {
+		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, nil, turnNumber, result); err != nil {
 			log.Warn().Err(err).Msg("failed to persist assistant message for interactive turn")
 		}
 
@@ -1308,6 +1308,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		o.failRun(ctx, session, "no user message found for continue_session")
 		return fmt.Errorf("no user message found")
 	}
+	threadID := latestMsg.ThreadID
 	userMessage := latestMsg.Content
 	var planMode bool
 
@@ -1370,6 +1371,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			errMsg := &models.SessionMessage{
 				SessionID:  session.ID,
 				OrgID:      session.OrgID,
+				ThreadID:   threadID,
 				TurnNumber: session.CurrentTurn + 1,
 				Role:       models.MessageRoleAssistant,
 				Content:    authErr.Error(),
@@ -1699,7 +1701,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, session.ID, session.OrgID, turnNumber, logCh, runtimeTracker)
+		o.streamLogs(ctx, session.ID, session.OrgID, threadID, turnNumber, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -1708,7 +1710,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	logWg.Wait()
 
 	// 6b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.ID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.ID, threadID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	stopReason := StopReasonNone
 	if o.cancels != nil {
@@ -1751,7 +1753,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 
 	// 7. Create assistant message with result summary.
-	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, turnNumber, result); err != nil {
+	if err := o.createAssistantMessage(ctx, session.ID, session.OrgID, threadID, turnNumber, result); err != nil {
 		log.Warn().Err(err).Msg("failed to create assistant message")
 	}
 
@@ -2034,7 +2036,7 @@ func (o *Orchestrator) checkConcurrency(ctx context.Context, orgID uuid.UUID, ex
 
 // streamLogs reads LogEntry values from the channel and persists them to the DB.
 // It also detects question-level log entries and creates SessionQuestion records.
-func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, turnNumber int, logCh <-chan LogEntry, tracker *runtimeProgressTracker) {
+func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, threadID *uuid.UUID, turnNumber int, logCh <-chan LogEntry, tracker *runtimeProgressTracker) {
 	for entry := range logCh {
 		if tracker != nil {
 			if progressType, strength, ok := runtimeProgressFromLog(entry); ok {
@@ -2047,9 +2049,15 @@ func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, t
 			metadata = nil
 		}
 
+		effectiveThreadID := threadID
+		if effectiveThreadID == nil {
+			effectiveThreadID = entry.ThreadID
+		}
+
 		log := &models.SessionLog{
 			SessionID:  runID,
 			OrgID:      orgID,
+			ThreadID:   effectiveThreadID,
 			Level:      entry.Level,
 			Message:    entry.Message,
 			Metadata:   metadata,
@@ -2637,7 +2645,7 @@ func gracefulStopFailure(reason StopReason, checkpointedThisTurn, hadPriorCheckp
 	}
 }
 
-func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, orgID uuid.UUID, turnNumber int, result *AgentResult) error {
+func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, orgID uuid.UUID, threadID *uuid.UUID, turnNumber int, result *AgentResult) error {
 	if o.sessionMessages == nil {
 		return nil
 	}
@@ -2645,6 +2653,7 @@ func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, or
 	assistantMsg := &models.SessionMessage{
 		SessionID:  sessionID,
 		OrgID:      orgID,
+		ThreadID:   threadID,
 		TurnNumber: turnNumber,
 		Role:       models.MessageRoleAssistant,
 		Content:    result.Summary,
@@ -2660,9 +2669,9 @@ func (o *Orchestrator) createAssistantMessage(ctx context.Context, sessionID, or
 		return err
 	}
 	if marker, ok := o.agentRunLogs.(interface {
-		MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, turnNumber int, message string) error
+		MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error
 	}); ok && result.Summary != "" {
-		if err := marker.MarkAssistantTranscriptDuplicate(ctx, orgID, sessionID, turnNumber, result.Summary); err != nil {
+		if err := marker.MarkAssistantTranscriptDuplicate(ctx, orgID, sessionID, threadID, turnNumber, result.Summary); err != nil {
 			o.logger.Warn().
 				Err(err).
 				Str("session_id", sessionID.String()).
@@ -2797,6 +2806,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 	agentType models.AgentType,
 	orgID uuid.UUID,
 	sessionID uuid.UUID,
+	threadID *uuid.UUID,
 	turnNumber int,
 	sandbox *Sandbox,
 	adapter AgentAdapter,
@@ -2826,7 +2836,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 	retryLogWg.Add(1)
 	go func() {
 		defer retryLogWg.Done()
-		o.streamLogs(ctx, sessionID, orgID, turnNumber, retryLogCh, nil)
+		o.streamLogs(ctx, sessionID, orgID, threadID, turnNumber, retryLogCh, nil)
 	}()
 
 	result, err = adapter.Execute(execCtx, sandbox, prompt, retryLogCh)

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+type testInternalSessionLogStore struct {
+	logs             []models.SessionLog
+	markedThreadID   *uuid.UUID
+	markedOrgID      uuid.UUID
+	markedSessionID  uuid.UUID
+	markedTurnNumber int
+	markedMessage    string
+}
+
+func (s *testInternalSessionLogStore) Create(ctx context.Context, log *models.SessionLog) error {
+	s.logs = append(s.logs, *log)
+	return nil
+}
+
+func (s *testInternalSessionLogStore) MarkAssistantTranscriptDuplicate(
+	ctx context.Context,
+	orgID, sessionID uuid.UUID,
+	threadID *uuid.UUID,
+	turnNumber int,
+	message string,
+) error {
+	s.markedOrgID = orgID
+	s.markedSessionID = sessionID
+	if threadID != nil {
+		copied := *threadID
+		s.markedThreadID = &copied
+	}
+	s.markedTurnNumber = turnNumber
+	s.markedMessage = message
+	return nil
+}
+
+type testInternalSessionMessageStore struct {
+	messages []models.SessionMessage
+}
+
+func (s *testInternalSessionMessageStore) Create(ctx context.Context, msg *models.SessionMessage) error {
+	s.messages = append(s.messages, *msg)
+	return nil
+}
+
+func (s *testInternalSessionMessageStore) ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error) {
+	return nil, nil
+}
+
+func TestCreateAssistantMessage_CarriesThreadID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
+	logs := &testInternalSessionLogStore{}
+	messages := &testInternalSessionMessageStore{}
+	orch := &Orchestrator{
+		agentRunLogs:    logs,
+		sessionMessages: messages,
+		logger:          zerolog.Nop(),
+	}
+
+	err := orch.createAssistantMessage(context.Background(), sessionID, orgID, &threadID, 4, &AgentResult{
+		Summary: "Final answer",
+	})
+	require.NoError(t, err, "createAssistantMessage should persist the assistant transcript")
+	require.Len(t, messages.messages, 1, "assistant message should be created")
+	require.NotNil(t, messages.messages[0].ThreadID, "assistant message should preserve the thread id")
+	require.Equal(t, threadID, *messages.messages[0].ThreadID, "assistant message should use the provided thread id")
+	require.NotNil(t, logs.markedThreadID, "duplicate marker should preserve the thread id")
+	require.Equal(t, threadID, *logs.markedThreadID, "duplicate marker should use the provided thread id")
+	require.Equal(t, 4, logs.markedTurnNumber, "duplicate marker should use the provided turn number")
+	require.Equal(t, "Final answer", logs.markedMessage, "duplicate marker should target the assistant summary")
+}
+
+func TestStreamLogs_CarriesThreadID(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	threadID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+
+	logs := &testInternalSessionLogStore{}
+	orch := &Orchestrator{
+		agentRunLogs: logs,
+		logger:       zerolog.Nop(),
+	}
+
+	logCh := make(chan LogEntry, 1)
+	logCh <- LogEntry{
+		Timestamp: time.Now(),
+		Level:     "output",
+		Message:   "streamed message",
+	}
+	close(logCh)
+
+	orch.streamLogs(context.Background(), sessionID, orgID, &threadID, 2, logCh, nil)
+
+	require.Len(t, logs.logs, 1, "streamLogs should persist the log entry")
+	require.NotNil(t, logs.logs[0].ThreadID, "persisted log should preserve the thread id")
+	require.Equal(t, threadID, *logs.logs[0].ThreadID, "persisted log should use the provided thread id")
+	require.Equal(t, 2, logs.logs[0].TurnNumber, "persisted log should keep the turn number")
+	require.Equal(t, "streamed message", logs.logs[0].Message, "persisted log should keep the message content")
+}

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -463,6 +463,7 @@ type mockSessionLogStore struct {
 	mu                   sync.Mutex
 	logs                 []models.SessionLog
 	count                int
+	markedThreadID       *uuid.UUID
 	markedTurnNumber     int
 	markedMessage        string
 	markedOrgID          uuid.UUID
@@ -485,12 +486,16 @@ func (m *mockSessionLogStore) getCount() int {
 	return m.count
 }
 
-func (m *mockSessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, turnNumber int, message string) error {
+func (m *mockSessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.markDuplicateInvoked = true
 	m.markedOrgID = orgID
 	m.markedSessionID = sessionID
+	if threadID != nil {
+		copied := *threadID
+		m.markedThreadID = &copied
+	}
 	m.markedTurnNumber = turnNumber
 	m.markedMessage = message
 	return m.markDuplicateErr
@@ -2358,6 +2363,7 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	t.Parallel()
 
 	orgID := testOrg()
+	threadID := uuid.New()
 	issue := testIssue(orgID)
 	issue.Source = models.IssueSourceManual
 	session := testRun(orgID, issue.ID)
@@ -2376,6 +2382,7 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 			ID:         1,
 			SessionID:  session.ID,
 			OrgID:      orgID,
+			ThreadID:   &threadID,
 			TurnNumber: 2,
 			Role:       models.MessageRoleUser,
 			Content:    "Please add regression coverage too.",
@@ -2392,6 +2399,7 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 		require.True(t, prompt.Continuation, "continue_session should execute the adapter in continuation mode")
 		require.Equal(t, "Please add regression coverage too.", prompt.UserMessage, "continue_session should pass the latest user message")
 		require.Equal(t, models.ReasoningEffortHigh, prompt.ReasoningEffort, "continue_session should preserve the stored reasoning effort on snapshot-backed turns")
+		logCh <- agent.LogEntry{Timestamp: time.Now(), Level: "output", Message: "Added the regression test"}
 		return &agent.AgentResult{
 			Diff:                "--- a/main_test.go\n+++ b/main_test.go",
 			Summary:             "Added the regression test",
@@ -2422,6 +2430,13 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Len(t, messages, 2, "continue_session should append an assistant reply")
 	require.Equal(t, models.MessageRoleAssistant, messages[1].Role, "assistant reply should be stored for the continued turn")
 	require.Equal(t, 2, messages[1].TurnNumber, "assistant reply should use the new turn number")
+	require.NotNil(t, messages[1].ThreadID, "assistant reply should preserve the thread id of the triggering message")
+	require.Equal(t, threadID, *messages[1].ThreadID, "assistant reply should keep the triggering thread id")
+	require.NotEmpty(t, d.logs.logs, "continue_session should persist streamed output logs")
+	require.NotNil(t, d.logs.logs[0].ThreadID, "persisted output logs should preserve the thread id")
+	require.Equal(t, threadID, *d.logs.logs[0].ThreadID, "persisted output logs should keep the triggering thread id")
+	require.NotNil(t, d.logs.markedThreadID, "duplicate marker should preserve the thread id")
+	require.Equal(t, threadID, *d.logs.markedThreadID, "duplicate marker should use the triggering thread id")
 }
 
 func TestContinueSession_FreshResumeClaudeTokenFailureFallsBackToAPIKey(t *testing.T) {

--- a/internal/services/sessiontimeline/timeline.go
+++ b/internal/services/sessiontimeline/timeline.go
@@ -25,6 +25,15 @@ type transcriptIdentity struct {
 	content    string
 }
 
+func normalizeTranscriptContent(content string) string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimRight(line, " \t\r")
+	}
+	return strings.TrimRight(strings.Join(lines, "\n"), "\n")
+}
+
 // Compose merges session messages and logs into a server-owned timeline.
 func Compose(messages []models.SessionMessage, logs []models.SessionLog) []models.SessionTimelineEntry {
 	messages = dedupeAssistantTranscriptMessages(messages)
@@ -228,7 +237,7 @@ func assistantTranscriptIdentity(msg models.SessionMessage) (transcriptIdentity,
 	return transcriptIdentity{
 		threadID:   optionalThreadID(msg.ThreadID),
 		turnNumber: msg.TurnNumber,
-		content:    msg.Content,
+		content:    normalizeTranscriptContent(msg.Content),
 	}, true
 }
 
@@ -239,7 +248,7 @@ func visibleAssistantTranscriptIdentity(log models.SessionLog) (transcriptIdenti
 	return transcriptIdentity{
 		threadID:   optionalThreadID(log.ThreadID),
 		turnNumber: log.TurnNumber,
-		content:    log.Message,
+		content:    normalizeTranscriptContent(log.Message),
 	}, true
 }
 

--- a/internal/services/sessiontimeline/timeline_test.go
+++ b/internal/services/sessiontimeline/timeline_test.go
@@ -102,6 +102,41 @@ func TestComposeTimeline_DedupesLegacyRowsWithoutMetadata(t *testing.T) {
 	require.Equal(t, models.SessionTimelineKindMessage, result[0].Kind, "assistant message should win for transcript rendering")
 }
 
+func TestComposeTimeline_SuppressesDuplicateAssistantOutputWithWhitespaceDifferences(t *testing.T) {
+	t.Parallel()
+
+	messages := []models.SessionMessage{
+		makeMessage(t, func(msg *models.SessionMessage) {
+			msg.Content = "assistant reply\n"
+		}, "2026-01-01T00:00:03Z"),
+	}
+	logs := []models.SessionLog{
+		makeLog(t, nil, "2026-01-01T00:00:02Z", "output", "assistant reply"),
+	}
+
+	result := Compose(messages, logs)
+	require.Len(t, result, 1, "trivial trailing whitespace differences should not duplicate the final assistant output")
+	require.Equal(t, models.SessionTimelineKindMessage, result[0].Kind, "assistant transcript should remain visible after whitespace-normalized dedupe")
+}
+
+func TestComposeTimeline_KeepsAssistantOutputWhenDifferenceIsLeadingIndentation(t *testing.T) {
+	t.Parallel()
+
+	messages := []models.SessionMessage{
+		makeMessage(t, func(msg *models.SessionMessage) {
+			msg.Content = "  assistant reply"
+		}, "2026-01-01T00:00:03Z"),
+	}
+	logs := []models.SessionLog{
+		makeLog(t, nil, "2026-01-01T00:00:02Z", "output", "assistant reply"),
+	}
+
+	result := Compose(messages, logs)
+	require.Len(t, result, 2, "leading indentation should remain part of transcript identity")
+	require.Equal(t, models.SessionTimelineKindAssistantOutput, result[0].Kind, "output log should remain visible when indentation differs")
+	require.Equal(t, models.SessionTimelineKindMessage, result[1].Kind, "assistant transcript should remain visible when indentation differs")
+}
+
 func TestComposeTimeline_PrefersMarkedDuplicateEvenWithMultipleOutputs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
This change fixes end-of-session duplicate assistant outputs (and related transcript dedupe) by normalizing transcript content consistently before comparing against persisted/streamed log messages. It also corrects transcript thread-awareness so the thread ID is carried through continuation/streaming and used for log streaming fallback.

## Changes
- **Frontend**
  - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
    - Added `normalizeTranscriptContent()` to normalize only:
      - CRLF → LF
      - trailing spaces/tabs per line
      - trailing newlines at the end
    - Updated duplicate suppression logic to compare normalized transcript content.
  - `frontend/src/lib/timeline.test.ts`
    - Added regression tests for:
      - suppressing duplicates when differences are only **trailing whitespace**
      - keeping output logs when differences are **leading indentation**
- **Backend (thread-aware continuation + streaming)**
  - `internal/services/agent/orchestrator.go` / `internal/services/agent/adapter.go`
    - Wired thread-aware continuation so `ContinueSession` carries `latestMsg.ThreadID` through:
      - streamed logs
      - persisted assistant reply
      - duplicate marking
      - retry path
  - `internal/services/agent/orchestrator_test.go` and `internal/services/agent/orchestrator_internal_test.go`
    - Added/kept test coverage validating the thread-aware continuation behavior.
  - `internal/services/sessiontimeline/timeline.go` / `internal/services/sessiontimeline/timeline_test.go`
    - Narrowed transcript normalization to match the intended behavior (CRLF + trailing whitespace/newlines only) and added regression tests.
- **Logging/persistence**
  - Updated/covered session log handling to ensure thread IDs are respected during streaming/persistence:
    - `internal/db/session_logs.go`
    - `internal/db/session_log_store_test.go`

## Test plan
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Frontend:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
  - `npx vitest --run src/lib/timeline.test.ts`

---
*Generated by [143.dev](https://143.dev) — [session c379c66f](https://app.143.dev/sessions/c379c66f-cbae-4207-bd35-ab6806439d34)*
