### PR TITLE
Authorize org-scoped routes off path/query for header-less clients

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -80,7 +80,12 @@ import { api, ApiError } from "@/lib/api";
 import { AGENTS, AGENTS_BY_KEY } from "@/lib/agents";
 import { getActiveOrgId } from "@/lib/active-org";
 import { maybeNotifySessionCompleted } from "@/lib/browser-notifications";
-import { SSE_EVENT, addSSEListener } from "@/lib/sse";
+import {
+  SSE_EVENT,
+  addSSEListener,
+  buildPullRequestStreamURL,
+  buildSessionLogsStreamURL,
+} from "@/lib/sse";
 import { buildTimeline, buildTimelineFromResponse } from "@/lib/timeline";
 import { parseDiffStats, type DiffFile } from "@/lib/diff-parser";
 import { formatReviewMessage } from "@/lib/format-review-message";
@@ -1152,15 +1157,6 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const SCROLL_NEAR_BOTTOM_THRESHOLD = 100;
 const SCROLL_POSITION_SAVE_DEBOUNCE_MS = 150;
 
-function buildPullRequestStreamURL(apiBase: string, activeOrgId: string | null): string {
-  const searchParams = new URLSearchParams();
-  if (activeOrgId) {
-    searchParams.set("org_id", activeOrgId);
-  }
-  const qs = searchParams.toString();
-  return `${apiBase}/api/v1/pull-requests/stream${qs ? `?${qs}` : ""}`;
-}
-
 function isNearBottom(el: HTMLElement): boolean {
   return el.scrollHeight - el.scrollTop - el.clientHeight < SCROLL_NEAR_BOTTOM_THRESHOLD;
 }
@@ -1398,7 +1394,7 @@ function ChatPanel({
       if (cancelled) return;
 
       eventSource = new EventSource(
-        `${apiBase}/api/v1/sessions/${sessionId}/logs/stream`,
+        buildSessionLogsStreamURL(apiBase, sessionId, getActiveOrgId()),
         { withCredentials: true }
       );
 

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -38,7 +38,8 @@ import {
 import { FlaskConical, Plus, Loader2, GitPullRequest, AlertTriangle, Layers, CheckCircle2, XCircle, Eye, RotateCw } from "lucide-react";
 import type { EvalTask, EvalBatch, EvalTaskSource, EvalBootstrapRun, EvalBootstrapStatus, ListResponse, Repository, SessionLog } from "@/lib/types";
 import { evalComplexityConfig, evalSourceConfig } from "@/lib/types";
-import { addSSEListener, SSE_EVENT } from "@/lib/sse";
+import { addSSEListener, SSE_EVENT, buildSessionLogsStreamURL } from "@/lib/sse";
+import { getActiveOrgId } from "@/lib/active-org";
 
 type SourceFilter = "all" | EvalTaskSource | "archived";
 
@@ -460,11 +461,11 @@ function BootstrapDetailSheet({
     let reconnectAttempts = 0;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    function connect() {
+    const connect = () => {
       if (cancelled) return;
 
       eventSource = new EventSource(
-        `${apiBase}/api/v1/sessions/${sessionId}/logs/stream`,
+        buildSessionLogsStreamURL(apiBase, sessionId, getActiveOrgId()),
         { withCredentials: true }
       );
 
@@ -489,7 +490,7 @@ function BootstrapDetailSheet({
           reconnectTimer = setTimeout(connect, delay);
         }
       };
-    }
+    };
 
     connect();
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -846,6 +846,11 @@ export const api = {
       if (params.granularity) searchParams.set('granularity', params.granularity);
       if (params.dimension) searchParams.set('dimension', params.dimension);
       if (params.tz) searchParams.set('tz', params.tz);
+      // window.open() can't send X-Active-Org-ID, so for multi-org users the
+      // backend's session-hint org may not match the actively-viewed org.
+      // Pass org_id explicitly; backend membership-checks it.
+      const activeOrgId = getActiveOrgId();
+      if (activeOrgId) searchParams.set('org_id', activeOrgId);
       return `${API_BASE}/api/v1/usage/export?${searchParams.toString()}`;
     },
   },

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,6 +1,40 @@
 import type { PullRequestUpdatedEvent, Session, SessionLog } from "./types";
 import { captureError } from "./errors";
 
+// EventSource cannot send custom headers like X-Active-Org-ID. The backend
+// auth middleware then resolves the active org from the session's
+// last_org_id hint, which deliberately is NOT updated when the client uses
+// X-Active-Org-ID (so two tabs on different orgs don't trample each other).
+// For multi-org users that hint commonly differs from the org they're
+// actively viewing, so we have to pass the active org via query string and
+// let the backend membership-check it. Used by all SSE endpoints.
+export function buildSessionLogsStreamURL(
+  apiBase: string,
+  sessionId: string,
+  activeOrgId: string | null,
+): string {
+  const searchParams = new URLSearchParams();
+  if (activeOrgId) {
+    searchParams.set("org_id", activeOrgId);
+  }
+  const qs = searchParams.toString();
+  return `${apiBase}/api/v1/sessions/${sessionId}/logs/stream${qs ? `?${qs}` : ""}`;
+}
+
+// Same X-Active-Org-ID workaround as buildSessionLogsStreamURL — see comment
+// above for the underlying reason.
+export function buildPullRequestStreamURL(
+  apiBase: string,
+  activeOrgId: string | null,
+): string {
+  const searchParams = new URLSearchParams();
+  if (activeOrgId) {
+    searchParams.set("org_id", activeOrgId);
+  }
+  const qs = searchParams.toString();
+  return `${apiBase}/api/v1/pull-requests/stream${qs ? `?${qs}` : ""}`;
+}
+
 /**
  * SSE event types emitted by the session log stream.
  * Must stay in sync with the backend sse.EventType constants.

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -77,6 +77,9 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"SessionFileHandler.GetFileContent":        "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionFileHandler.GetFileContext":        "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionComposerHandler.ListSlashCommands": "built-in catalog is not org-scoped; project discovery branch delegates to buildProjectSlashCommandGroup which uses OrgIDFromContext",
+		"SessionHandler.StreamLogs":                "EventSource cannot send X-Active-Org-ID; delegates to streamOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
+		"UploadHandler.ServeUpload":                "<img>/<a> tag fetches cannot send X-Active-Org-ID; authorizes off the path-encoded org-id + UserFromContext membership check rather than active-org context",
+		"UsageHandler.ExportCSV":                   "window.open downloads cannot send X-Active-Org-ID; delegates to exportOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
 
 		// Preview inspector handlers — delegate to requireInspector + getActivePreview
 		// which use OrgIDFromContext.

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -36,6 +36,14 @@ type sessionPRTitleSyncer interface {
 	SyncSessionTitle(ctx context.Context, session *models.Session) error
 }
 
+// sessionMembershipStore is the subset of OrganizationMembershipStore that
+// StreamLogs needs to authorize cross-org SSE subscriptions when the client
+// can't send X-Active-Org-ID (EventSource has no header API). See StreamLogs
+// for context.
+type sessionMembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
+}
+
 type SessionHandler struct {
 	runStore         *db.SessionStore
 	logStore         *db.SessionLogStore
@@ -51,6 +59,7 @@ type SessionHandler struct {
 	issueSnapshots   *db.SessionTurnIssueSnapshotStore
 	threadStore      *db.SessionThreadStore
 	viewStore        *db.SessionViewStore
+	memberships      sessionMembershipStore
 	prCredentials    githubStatusCredentialStore
 	prAuthChecker    interface {
 		HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
@@ -124,6 +133,13 @@ func (h *SessionHandler) SetShutdownSignal(ch <-chan struct{}) {
 // succeeds but leaves the snapshot to be reclaimed by the TTL reaper.
 func (h *SessionHandler) SetSnapshotStore(s storage.SnapshotStore) {
 	h.snapshotStore = s
+}
+
+// SetMembershipStore wires the membership store used by StreamLogs to
+// authorize an explicit ?org_id= query param. Required for the SSE log stream
+// to work for multi-org users (EventSource cannot send X-Active-Org-ID).
+func (h *SessionHandler) SetMembershipStore(store sessionMembershipStore) {
+	h.memberships = store
 }
 
 // SetPRCredentialStore injects the personal GitHub credential store used to
@@ -661,6 +677,58 @@ func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 // and also serves as the initial log fetch for active runs.
 func (h *SessionHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	h.writeLogsForOrg(w, r, orgID)
+}
+
+var (
+	errSessionStreamOrgInvalid   = errors.New("invalid session stream org")
+	errSessionStreamOrgForbidden = errors.New("forbidden session stream org")
+	errSessionStreamUnauthorized = errors.New("unauthorized session stream request")
+)
+
+// streamOrgID resolves the org for a SSE log stream request, honouring an
+// optional ?org_id= query param when the X-Active-Org-ID header is absent
+// (EventSource has no header API). The query value is accepted only when the
+// requesting user holds a membership in that org. Falls back to the auth
+// middleware's resolved active org when no query param is supplied — that
+// preserves the existing fetch-based behaviour for callers that *can* set the
+// header. See pull_requests.go's streamOrgIDFromRequest for the prior art.
+func (h *SessionHandler) streamOrgID(r *http.Request) (uuid.UUID, error) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	requestedRaw := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	if requestedRaw == "" {
+		return orgID, nil
+	}
+
+	requestedOrgID, err := uuid.Parse(requestedRaw)
+	if err != nil {
+		return uuid.Nil, errSessionStreamOrgInvalid
+	}
+	if requestedOrgID == orgID {
+		return requestedOrgID, nil
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		return uuid.Nil, errSessionStreamUnauthorized
+	}
+	if h.memberships == nil {
+		return uuid.Nil, errors.New("membership store not configured")
+	}
+	if _, err := h.memberships.Get(r.Context(), user.ID, requestedOrgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, errSessionStreamOrgForbidden
+		}
+		return uuid.Nil, err
+	}
+	return requestedOrgID, nil
+}
+
+// writeLogsForOrg writes the JSON log list for the given org. Split out so
+// StreamLogs can delegate to it with the org resolved by streamOrgID (which
+// honours the ?org_id= query fallback when the X-Active-Org-ID header is
+// missing).
+func (h *SessionHandler) writeLogsForOrg(w http.ResponseWriter, r *http.Request, orgID uuid.UUID) {
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
@@ -690,7 +758,24 @@ func (h *SessionHandler) GetLogs(w http.ResponseWriter, r *http.Request) {
 
 // StreamLogs streams agent run logs as Server-Sent Events.
 func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
-	orgID := middleware.OrgIDFromContext(r.Context())
+	// EventSource cannot send X-Active-Org-ID, so accept ?org_id= as a
+	// fallback. Validates the requesting user has membership in the org —
+	// see streamOrgID for details. Without this, multi-org users whose
+	// session-hint last_org_id != their actively-viewed org would 404.
+	orgID, err := h.streamOrgID(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errSessionStreamOrgInvalid):
+			writeError(w, r, http.StatusBadRequest, "INVALID_ORG", "invalid org_id")
+		case errors.Is(err, errSessionStreamOrgForbidden):
+			writeError(w, r, http.StatusForbidden, "FORBIDDEN", "access denied")
+		case errors.Is(err, errSessionStreamUnauthorized):
+			writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing user")
+		default:
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL", "failed to authorize log stream", err)
+		}
+		return
+	}
 	runID, err := uuid.Parse(chi.URLParam(r, "id"))
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid run ID")
@@ -705,9 +790,11 @@ func (h *SessionHandler) StreamLogs(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// For terminal runs, return existing logs as JSON instead of SSE
-	// since there will be no new logs to stream.
+	// since there will be no new logs to stream. Pass orgID explicitly so
+	// the resolved org from streamOrgID flows through (GetLogs reads it
+	// from context, which may not match for header-less SSE callers).
 	if isTerminalStatus(run.Status) {
-		h.GetLogs(w, r)
+		h.writeLogsForOrg(w, r, orgID)
 		return
 	}
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2250,12 +2250,17 @@ func TestSessionHandler_StreamLogs_InvalidID(t *testing.T) {
 
 // stubSessionMembershipStore implements sessionMembershipStore for unit tests
 // without spinning up Postgres. allowed lists (userID, orgID) pairs that
-// resolve to a membership; everything else returns pgx.ErrNoRows.
+// resolve to a membership; everything else returns pgx.ErrNoRows. errOverride
+// short-circuits Get to a non-ErrNoRows failure for the generic-error branch.
 type stubSessionMembershipStore struct {
-	allowed map[[2]uuid.UUID]bool
+	allowed     map[[2]uuid.UUID]bool
+	errOverride error
 }
 
 func (s *stubSessionMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.errOverride != nil {
+		return models.OrganizationMembership{}, s.errOverride
+	}
 	if s.allowed[[2]uuid.UUID{userID, orgID}] {
 		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
 	}
@@ -2392,6 +2397,194 @@ func TestSessionHandler_StreamLogs_OrgIDQueryNonMember(t *testing.T) {
 	handler.StreamLogs(w, req)
 	require.Equal(t, http.StatusForbidden, w.Code)
 	require.Contains(t, w.Body.String(), "FORBIDDEN")
+}
+
+// When the client passes ?org_id= matching the context-resolved org, the
+// helper short-circuits without touching the membership store. Covers the
+// equality branch in streamOrgID.
+func TestSessionHandler_StreamLogs_OrgIDQueryMatchesContext(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	now := time.Now()
+	issueID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+	// Intentionally no SetMembershipStore: the equality short-circuit must
+	// return before the membership lookup, so this would 500 if we fell through.
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				runID, issueID, orgID, "claude-code", "completed", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", nil,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				runID, issueID, orgID, "claude-code", "completed", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", nil,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM session_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number"}).
+				AddRow(int64(1), runID, orgID, nil, now, "info", "Done", nil, nil),
+		)
+
+	url := "/api/v1/sessions/" + runID.String() + "/logs/stream?org_id=" + orgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", runID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSessionHandler_StreamLogs_OrgIDQueryMalformed(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := newSessionHandler(t, mock)
+
+	url := "/api/v1/sessions/" + uuid.New().String() + "/logs/stream?org_id=not-a-uuid"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", uuid.New().String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_ORG")
+}
+
+func TestSessionHandler_StreamLogs_OrgIDQueryMissingUser(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetMembershipStore(&stubSessionMembershipStore{allowed: map[[2]uuid.UUID]bool{}})
+
+	url := "/api/v1/sessions/" + uuid.New().String() + "/logs/stream?org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", uuid.New().String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	// No user injected — exercises the errSessionStreamUnauthorized path.
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "UNAUTHORIZED")
+}
+
+func TestSessionHandler_StreamLogs_OrgIDQueryMembershipNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock) // no SetMembershipStore — programmer error.
+
+	url := "/api/v1/sessions/" + uuid.New().String() + "/logs/stream?org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", uuid.New().String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "INTERNAL")
+}
+
+func TestSessionHandler_StreamLogs_OrgIDQueryMembershipStoreError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+	handler := newSessionHandler(t, mock)
+	handler.SetMembershipStore(&stubSessionMembershipStore{
+		allowed:     map[[2]uuid.UUID]bool{},
+		errOverride: errors.New("db unreachable"),
+	})
+
+	url := "/api/v1/sessions/" + uuid.New().String() + "/logs/stream?org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", uuid.New().String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "INTERNAL")
 }
 
 // TestSessionHandler_StreamLogs_ShutdownSignal verifies that the SSE loop

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -2248,6 +2248,152 @@ func TestSessionHandler_StreamLogs_InvalidID(t *testing.T) {
 	require.Contains(t, w.Body.String(), "INVALID_ID")
 }
 
+// stubSessionMembershipStore implements sessionMembershipStore for unit tests
+// without spinning up Postgres. allowed lists (userID, orgID) pairs that
+// resolve to a membership; everything else returns pgx.ErrNoRows.
+type stubSessionMembershipStore struct {
+	allowed map[[2]uuid.UUID]bool
+}
+
+func (s *stubSessionMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.allowed[[2]uuid.UUID{userID, orgID}] {
+		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
+	}
+	return models.OrganizationMembership{}, pgx.ErrNoRows
+}
+
+// Regression: EventSource cannot send X-Active-Org-ID, so multi-org users
+// whose context org (resolved from session last_org_id) differs from the org
+// they're actively viewing previously got a silent 404. The handler must
+// honour the ?org_id= query fallback when the user has membership in that
+// org. Mirrors pull_requests.go's prior art.
+func TestSessionHandler_StreamLogs_OrgIDQueryFallback(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	contextOrgID := uuid.New()   // resolved from session hint — wrong org
+	requestedOrgID := uuid.New() // active org per X-Active-Org-ID, passed via query
+	userID := uuid.New()
+	runID := uuid.New()
+	now := time.Now()
+	issueID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+	handler.SetMembershipStore(&stubSessionMembershipStore{
+		allowed: map[[2]uuid.UUID]bool{{userID, requestedOrgID}: true},
+	})
+
+	// Run lookup uses the *requested* org, not the context org.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				runID, issueID, requestedOrgID, "claude-code", "completed", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+	// Terminal status triggers writeLogsForOrg path: second session lookup + log listing.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				runID, issueID, requestedOrgID, "claude-code", "completed", "supervised", "standard",
+				nil, nil, nil, nil,
+				nil, false, &now, &now, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 0, now, "none", nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM session_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "session_id", "org_id", "thread_id", "timestamp", "level", "message", "metadata", "turn_number"}).
+				AddRow(int64(1), runID, requestedOrgID, nil, now, "info", "Done", nil, nil),
+		)
+
+	url := "/api/v1/sessions/" + runID.String() + "/logs/stream?org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", runID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, contextOrgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionHandler_StreamLogs_OrgIDQueryNonMember(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+
+	handler := newSessionHandler(t, mock)
+	handler.SetMembershipStore(&stubSessionMembershipStore{
+		allowed: map[[2]uuid.UUID]bool{}, // user is not in requestedOrgID
+	})
+
+	url := "/api/v1/sessions/" + uuid.New().String() + "/logs/stream?org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", uuid.New().String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.StreamLogs(w, req)
+	require.Equal(t, http.StatusForbidden, w.Code)
+	require.Contains(t, w.Body.String(), "FORBIDDEN")
+}
+
 // TestSessionHandler_StreamLogs_ShutdownSignal verifies that the SSE loop
 // returns promptly when shutdownCh is closed, instead of blocking
 // Server.Shutdown until its deadline expires.

--- a/internal/api/handlers/uploads.go
+++ b/internal/api/handlers/uploads.go
@@ -1,15 +1,20 @@
 package handlers
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path"
 	"strings"
 	"time"
 
-	"github.com/assembledhq/143/internal/api/middleware"
-	"github.com/assembledhq/143/internal/services/storage"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/storage"
 )
 
 // maxUploadSize is the maximum allowed file size (10 MB).
@@ -17,26 +22,41 @@ const maxUploadSize = 10 << 20
 
 // allowedImageTypes are the MIME types accepted for upload.
 var allowedUploadTypes = map[string]bool{
-	"image/png":      true,
-	"image/jpeg":     true,
-	"image/gif":      true,
-	"image/webp":     true,
-	"image/svg+xml":  true,
-	"application/pdf": true,
-	"text/plain":      true,
-	"text/markdown":   true,
-	"text/csv":        true,
+	"image/png":        true,
+	"image/jpeg":       true,
+	"image/gif":        true,
+	"image/webp":       true,
+	"image/svg+xml":    true,
+	"application/pdf":  true,
+	"text/plain":       true,
+	"text/markdown":    true,
+	"text/csv":         true,
 	"application/json": true,
+}
+
+// uploadMembershipStore is the subset of OrganizationMembershipStore that
+// ServeUpload needs to authorize file reads. Defined as an interface so tests
+// can stub it without spinning up a real Postgres connection.
+type uploadMembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
 }
 
 // UploadHandler handles file uploads to object storage.
 type UploadHandler struct {
-	store storage.UploadStore
+	store       storage.UploadStore
+	memberships uploadMembershipStore
 }
 
 // NewUploadHandler creates an UploadHandler backed by the given store.
 func NewUploadHandler(store storage.UploadStore) *UploadHandler {
 	return &UploadHandler{store: store}
+}
+
+// SetMembershipStore wires the membership store used by ServeUpload to
+// authorize cross-org reads. Required for ServeUpload to authorize requests
+// that arrive without an X-Active-Org-ID header (e.g. <img> tag fetches).
+func (h *UploadHandler) SetMembershipStore(store uploadMembershipStore) {
+	h.memberships = store
 }
 
 // Upload handles POST /api/v1/uploads — accepts a multipart file upload,
@@ -109,6 +129,12 @@ func (h *UploadHandler) Upload(w http.ResponseWriter, r *http.Request) {
 
 // ServeUpload handles GET /api/v1/uploads/files/* — serves uploaded files.
 // Works with both local filesystem and S3 storage backends.
+//
+// Authorization: file URLs are loaded by browser mechanisms (<img>, <a>) that
+// cannot send the X-Active-Org-ID header, so the auth middleware's resolved
+// active-org context may not match the file's owning org for multi-org users.
+// Instead, we parse the org-id from the path itself and verify the requesting
+// user holds a membership in that org. Cross-org access still 403s.
 func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
 	// Extract the file key from the URL path after /api/v1/uploads/files/
 	key := strings.TrimPrefix(r.URL.Path, "/api/v1/uploads/files/")
@@ -117,10 +143,34 @@ func (h *UploadHandler) ServeUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate that the file belongs to the requesting user's org.
-	orgID := middleware.OrgIDFromContext(r.Context())
-	if !strings.HasPrefix(key, orgID.String()+"/") {
-		writeError(w, r, http.StatusForbidden, "FORBIDDEN", "access denied")
+	// File keys are formatted as `<orgID>/<YYYY-MM>/<uuid>.<ext>` (see Upload).
+	// The first path segment is the owning org's UUID; reject anything else.
+	prefix, _, hasSlash := strings.Cut(key, "/")
+	if !hasSlash {
+		writeError(w, r, http.StatusBadRequest, "INVALID_KEY", "invalid file key")
+		return
+	}
+	pathOrgID, err := uuid.Parse(prefix)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_KEY", "invalid file key")
+		return
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing user")
+		return
+	}
+	if h.memberships == nil {
+		writeError(w, r, http.StatusInternalServerError, "NOT_CONFIGURED", "membership store not configured")
+		return
+	}
+	if _, err := h.memberships.Get(r.Context(), user.ID, pathOrgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusForbidden, "FORBIDDEN", "access denied")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL", "failed to authorize upload", err)
 		return
 	}
 

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime/multipart"
 	"net/http"
@@ -22,12 +23,17 @@ import (
 
 // stubUploadMembershipStore implements uploadMembershipStore for tests.
 // allowed lists (userID, orgID) pairs that resolve to a membership; everything
-// else returns pgx.ErrNoRows so the handler 403s.
+// else returns pgx.ErrNoRows so the handler 403s. errOverride lets a test
+// short-circuit Get to a non-ErrNoRows failure (e.g. a synthetic DB error).
 type stubUploadMembershipStore struct {
-	allowed map[[2]uuid.UUID]bool
+	allowed     map[[2]uuid.UUID]bool
+	errOverride error
 }
 
 func (s *stubUploadMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.errOverride != nil {
+		return models.OrganizationMembership{}, s.errOverride
+	}
 	if s.allowed[[2]uuid.UUID{userID, orgID}] {
 		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
 	}
@@ -253,6 +259,82 @@ func TestUploadHandler_ServeUpload_S3Mode(t *testing.T) {
 
 	// S3 client is nil, so GetObject will fail — handler returns 404.
 	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUploadHandler_ServeUpload_KeyWithoutSlash(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+	h.SetMembershipStore(newStubMembershipStore(t))
+
+	// Single-segment key (no "/") — must be rejected before parsing it as a UUID.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/no-slash-here", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_KEY")
+}
+
+func TestUploadHandler_ServeUpload_MissingUser(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+	h.SetMembershipStore(newStubMembershipStore(t))
+
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	// No user injected into the request context.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+orgID.String()+"/file.png", nil)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	require.Contains(t, w.Body.String(), "UNAUTHORIZED")
+}
+
+func TestUploadHandler_ServeUpload_MembershipNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store) // no SetMembershipStore — programmer error.
+
+	userID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+orgID.String()+"/file.png", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "NOT_CONFIGURED")
+}
+
+func TestUploadHandler_ServeUpload_MembershipStoreError(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+	stub := newStubMembershipStore(t)
+	stub.errOverride = errors.New("boom")
+	h.SetMembershipStore(stub)
+
+	userID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+orgID.String()+"/file.png", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	require.Contains(t, w.Body.String(), "INTERNAL")
 }
 
 func TestExtensionFromMIME(t *testing.T) {

--- a/internal/api/handlers/uploads_test.go
+++ b/internal/api/handlers/uploads_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"mime/multipart"
@@ -11,11 +12,36 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/storage"
 )
+
+// stubUploadMembershipStore implements uploadMembershipStore for tests.
+// allowed lists (userID, orgID) pairs that resolve to a membership; everything
+// else returns pgx.ErrNoRows so the handler 403s.
+type stubUploadMembershipStore struct {
+	allowed map[[2]uuid.UUID]bool
+}
+
+func (s *stubUploadMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.allowed[[2]uuid.UUID{userID, orgID}] {
+		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
+	}
+	return models.OrganizationMembership{}, pgx.ErrNoRows
+}
+
+func newStubMembershipStore(t *testing.T, pairs ...[2]uuid.UUID) *stubUploadMembershipStore {
+	t.Helper()
+	allowed := make(map[[2]uuid.UUID]bool, len(pairs))
+	for _, p := range pairs {
+		allowed[p] = true
+	}
+	return &stubUploadMembershipStore{allowed: allowed}
+}
 
 func newUploadRequest(t *testing.T, fieldName, fileName, contentType string, body []byte) *http.Request {
 	t.Helper()
@@ -109,11 +135,9 @@ func TestUploadHandler_ServeUpload_PathTraversal(t *testing.T) {
 
 	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
 	h := NewUploadHandler(store)
+	h.SetMembershipStore(newStubMembershipStore(t))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/../../etc/passwd", nil)
-	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	ctx := middleware.WithOrgID(req.Context(), orgID)
-	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
 	h.ServeUpload(w, req)
@@ -127,11 +151,26 @@ func TestUploadHandler_ServeUpload_EmptyKey(t *testing.T) {
 
 	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
 	h := NewUploadHandler(store)
+	h.SetMembershipStore(newStubMembershipStore(t))
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/", nil)
-	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
-	ctx := middleware.WithOrgID(req.Context(), orgID)
-	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Contains(t, w.Body.String(), "INVALID_KEY")
+}
+
+func TestUploadHandler_ServeUpload_MalformedOrgID(t *testing.T) {
+	t.Parallel()
+
+	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
+	h := NewUploadHandler(store)
+	h.SetMembershipStore(newStubMembershipStore(t))
+
+	// First path segment is not a UUID — must reject before touching the store.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/not-a-uuid/file.png", nil)
 	w := httptest.NewRecorder()
 
 	h.ServeUpload(w, req)
@@ -146,10 +185,14 @@ func TestUploadHandler_ServeUpload_CrossOrgDenied(t *testing.T) {
 	store := storage.NewFileUploadStore(t.TempDir(), "/api/v1/uploads/files")
 	h := NewUploadHandler(store)
 
+	userID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	memberOrgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	otherOrgID := uuid.MustParse("00000000-0000-0000-0000-000000000099")
-	// Request a file keyed under a different org.
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/00000000-0000-0000-0000-000000000001/2025-01/file.png", nil)
-	ctx := middleware.WithOrgID(req.Context(), otherOrgID)
+	// User is a member of memberOrg but the file is keyed under otherOrg.
+	h.SetMembershipStore(newStubMembershipStore(t, [2]uuid.UUID{userID, memberOrgID}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+otherOrgID.String()+"/2025-01/file.png", nil)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID})
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 
@@ -159,16 +202,50 @@ func TestUploadHandler_ServeUpload_CrossOrgDenied(t *testing.T) {
 	require.Contains(t, w.Body.String(), "FORBIDDEN")
 }
 
+// Regression: a multi-org user fetching a file via <img> sends no
+// X-Active-Org-ID header, so the auth middleware's resolved active org may
+// differ from the file's owning org. ServeUpload must authorize off the
+// path-encoded org plus user membership, not the active-org context.
+func TestUploadHandler_ServeUpload_NoActiveOrgHeader_AllowsMember(t *testing.T) {
+	t.Parallel()
+
+	s3Store := storage.NewS3UploadStore(nil, "bucket", "prefix")
+	h := NewUploadHandler(s3Store)
+
+	userID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
+	fileOrgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	resolvedActiveOrgID := uuid.MustParse("00000000-0000-0000-0000-000000000099")
+	h.SetMembershipStore(newStubMembershipStore(t, [2]uuid.UUID{userID, fileOrgID}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+fileOrgID.String()+"/2026-04/file.png", nil)
+	// Active-org context points at a *different* org (the user's other
+	// membership) — this mirrors the production case where the session's
+	// last_org_id hint races against the client's X-Active-Org-ID header.
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID})
+	ctx = middleware.WithOrgID(ctx, resolvedActiveOrgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	h.ServeUpload(w, req)
+
+	// S3 client is nil, so GetObject will fail — handler returns 404. The
+	// important assertion is that we made it past the membership check (i.e.
+	// did not 403 like before the fix).
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestUploadHandler_ServeUpload_S3Mode(t *testing.T) {
 	t.Parallel()
 
 	s3Store := storage.NewS3UploadStore(nil, "bucket", "prefix")
 	h := NewUploadHandler(s3Store)
 
-	// The key must be prefixed by the requesting org's ID.
+	userID := uuid.MustParse("00000000-0000-0000-0000-0000000000aa")
 	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	h.SetMembershipStore(newStubMembershipStore(t, [2]uuid.UUID{userID, orgID}))
+
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/uploads/files/"+orgID.String()+"/file.png", nil)
-	ctx := middleware.WithOrgID(req.Context(), orgID)
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID})
 	req = req.WithContext(ctx)
 	w := httptest.NewRecorder()
 

--- a/internal/api/handlers/usage.go
+++ b/internal/api/handlers/usage.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"context"
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -18,10 +20,18 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
+// usageMembershipStore is the subset of OrganizationMembershipStore that
+// ExportCSV needs to authorize an explicit ?org_id= query param when the
+// X-Active-Org-ID header is absent (window.open download has no header API).
+type usageMembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
+}
+
 // UsageHandler exposes container usage data for billing dashboards.
 type UsageHandler struct {
 	usageStore  *db.ContainerUsageStore
 	rollupStore usageRollupReader
+	memberships usageMembershipStore
 }
 
 type usageRollupReader interface {
@@ -48,6 +58,56 @@ type UsageHandlerOption func(*UsageHandler)
 // WithRollupStore sets the rollup store for timeseries/breakdown/export endpoints.
 func WithRollupStore(rs usageRollupReader) UsageHandlerOption {
 	return func(h *UsageHandler) { h.rollupStore = rs }
+}
+
+// WithMembershipStore wires the membership store used by ExportCSV to
+// authorize an explicit ?org_id= query param. Required for the CSV download
+// to pick the right org for multi-org users (window.open cannot send
+// X-Active-Org-ID).
+func WithMembershipStore(ms usageMembershipStore) UsageHandlerOption {
+	return func(h *UsageHandler) { h.memberships = ms }
+}
+
+var (
+	errUsageExportOrgInvalid   = errors.New("invalid usage export org")
+	errUsageExportOrgForbidden = errors.New("forbidden usage export org")
+	errUsageExportUnauthorized = errors.New("unauthorized usage export request")
+)
+
+// exportOrgID resolves the org for a CSV export, honouring an optional
+// ?org_id= query param when the X-Active-Org-ID header is absent
+// (window.open downloads have no header API). Membership-validated, falls
+// back to the auth middleware's resolved active org. Same shape as
+// pull_requests.streamOrgIDFromRequest and sessions.streamOrgID.
+func (h *UsageHandler) exportOrgID(r *http.Request) (uuid.UUID, error) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	requestedRaw := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	if requestedRaw == "" {
+		return orgID, nil
+	}
+
+	requestedOrgID, err := uuid.Parse(requestedRaw)
+	if err != nil {
+		return uuid.Nil, errUsageExportOrgInvalid
+	}
+	if requestedOrgID == orgID {
+		return requestedOrgID, nil
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		return uuid.Nil, errUsageExportUnauthorized
+	}
+	if h.memberships == nil {
+		return uuid.Nil, errors.New("membership store not configured")
+	}
+	if _, err := h.memberships.Get(r.Context(), user.ID, requestedOrgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, errUsageExportOrgForbidden
+		}
+		return uuid.Nil, err
+	}
+	return requestedOrgID, nil
 }
 
 // maxTimeRange is the maximum allowed duration for usage queries.
@@ -298,7 +358,20 @@ func (h *UsageHandler) ExportCSV(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	orgID := middleware.OrgIDFromContext(r.Context())
+	orgID, err := h.exportOrgID(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errUsageExportOrgInvalid):
+			writeError(w, r, http.StatusBadRequest, "INVALID_ORG", "invalid org_id")
+		case errors.Is(err, errUsageExportOrgForbidden):
+			writeError(w, r, http.StatusForbidden, "FORBIDDEN", "access denied")
+		case errors.Is(err, errUsageExportUnauthorized):
+			writeError(w, r, http.StatusUnauthorized, "UNAUTHORIZED", "missing user")
+		default:
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL", "failed to authorize export", err)
+		}
+		return
+	}
 	start, end, ok := parseTimeRange(w, r)
 	if !ok {
 		return

--- a/internal/api/handlers/usage_test.go
+++ b/internal/api/handlers/usage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -327,11 +328,16 @@ func TestUsageHandler_ExportCSV_NoRollupStore(t *testing.T) {
 }
 
 // stubUsageMembershipStore implements usageMembershipStore for tests.
+// errOverride lets a test exercise the non-ErrNoRows membership-error branch.
 type stubUsageMembershipStore struct {
-	allowed map[[2]uuid.UUID]bool
+	allowed     map[[2]uuid.UUID]bool
+	errOverride error
 }
 
 func (s *stubUsageMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.errOverride != nil {
+		return models.OrganizationMembership{}, s.errOverride
+	}
 	if s.allowed[[2]uuid.UUID{userID, orgID}] {
 		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
 	}
@@ -402,6 +408,138 @@ func TestUsageHandler_ExportCSV_OrgIDQueryNonMember(t *testing.T) {
 	handler.ExportCSV(rr, req)
 	require.Equal(t, http.StatusForbidden, rr.Code)
 	require.Contains(t, rr.Body.String(), "FORBIDDEN")
+}
+
+// When ?org_id= matches the context-resolved org, the helper short-circuits
+// without touching the membership store. Covers the equality branch in
+// exportOrgID.
+func TestUsageHandler_ExportCSV_OrgIDQueryMatchesContext(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	// Intentionally no WithMembershipStore: the equality short-circuit must
+	// return before the membership lookup.
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{
+			exportRows: &stubRows{
+				rows: [][]any{
+					{time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "", "", 30.0, 1, 1, 1, int64(100), int64(50), 0.25},
+				},
+			},
+		}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + orgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestUsageHandler_ExportCSV_OrgIDQueryMalformed(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=not-a-uuid"
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+	require.Contains(t, rr.Body.String(), "INVALID_ORG")
+}
+
+func TestUsageHandler_ExportCSV_OrgIDQueryMissingUser(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{}),
+		WithMembershipStore(&stubUsageMembershipStore{allowed: map[[2]uuid.UUID]bool{}}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	// No user in context — exercises the errUsageExportUnauthorized path.
+	req = req.WithContext(middleware.WithOrgID(req.Context(), uuid.New()))
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusUnauthorized, rr.Code)
+	require.Contains(t, rr.Body.String(), "UNAUTHORIZED")
+}
+
+func TestUsageHandler_ExportCSV_OrgIDQueryMembershipNotConfigured(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+	// No WithMembershipStore — programmer error.
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	ctx := middleware.WithOrgID(req.Context(), uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.Contains(t, rr.Body.String(), "INTERNAL")
+}
+
+func TestUsageHandler_ExportCSV_OrgIDQueryMembershipStoreError(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{}),
+		WithMembershipStore(&stubUsageMembershipStore{
+			allowed:     map[[2]uuid.UUID]bool{},
+			errOverride: errors.New("db unreachable"),
+		}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	ctx := middleware.WithOrgID(req.Context(), uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusInternalServerError, rr.Code)
+	require.Contains(t, rr.Body.String(), "INTERNAL")
 }
 
 func TestUsageHandler_ExportCSV_HourlyGranularity(t *testing.T) {

--- a/internal/api/handlers/usage_test.go
+++ b/internal/api/handlers/usage_test.go
@@ -326,6 +326,84 @@ func TestUsageHandler_ExportCSV_NoRollupStore(t *testing.T) {
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 }
 
+// stubUsageMembershipStore implements usageMembershipStore for tests.
+type stubUsageMembershipStore struct {
+	allowed map[[2]uuid.UUID]bool
+}
+
+func (s *stubUsageMembershipStore) Get(_ context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	if s.allowed[[2]uuid.UUID{userID, orgID}] {
+		return models.OrganizationMembership{UserID: userID, OrgID: orgID, Role: "member"}, nil
+	}
+	return models.OrganizationMembership{}, pgx.ErrNoRows
+}
+
+// Regression: window.open downloads can't send X-Active-Org-ID. Multi-org
+// users whose context org (resolved from session last_org_id) differs from
+// their actively-viewed org would otherwise silently get the wrong org's CSV.
+// The handler must honour ?org_id= when the user has membership in that org.
+func TestUsageHandler_ExportCSV_OrgIDQueryFallback(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	contextOrgID := uuid.New()   // wrong: session last_org_id
+	requestedOrgID := uuid.New() // right: actively-viewed org
+	userID := uuid.New()
+
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{
+			exportRows: &stubRows{
+				rows: [][]any{
+					{time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "", "", 30.0, 1, 1, 1, int64(100), int64(50), 0.25},
+				},
+			},
+		}),
+		WithMembershipStore(&stubUsageMembershipStore{
+			allowed: map[[2]uuid.UUID]bool{{userID, requestedOrgID}: true},
+		}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	ctx := middleware.WithOrgID(req.Context(), contextOrgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestUsageHandler_ExportCSV_OrgIDQueryNonMember(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	requestedOrgID := uuid.New()
+	userID := uuid.New()
+
+	handler := NewUsageHandler(
+		db.NewContainerUsageStore(mock),
+		WithRollupStore(&stubUsageRollupStore{}),
+		WithMembershipStore(&stubUsageMembershipStore{allowed: map[[2]uuid.UUID]bool{}}),
+	)
+
+	url := "/api/v1/usage/export?start=2026-04-01T00:00:00Z&end=2026-04-02T00:00:00Z&org_id=" + requestedOrgID.String()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	ctx := middleware.WithOrgID(req.Context(), uuid.New())
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID})
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.ExportCSV(rr, req)
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	require.Contains(t, rr.Body.String(), "FORBIDDEN")
+}
+
 func TestUsageHandler_ExportCSV_HourlyGranularity(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -167,7 +167,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	webhookHandler := handlers.NewWebhookHandler(cfg, orgStore, userStore, repoStore, integrationStore, prService)
 	containerUsageStore := db.NewContainerUsageStore(pool)
 	usageRollupStore := db.NewUsageRollupStore(pool)
-	usageHandler := handlers.NewUsageHandler(containerUsageStore, handlers.WithRollupStore(usageRollupStore))
+	usageHandler := handlers.NewUsageHandler(
+		containerUsageStore,
+		handlers.WithRollupStore(usageRollupStore),
+		handlers.WithMembershipStore(membershipStore),
+	)
 	settingsHandler := handlers.NewSettingsHandler(orgStore, cfg.SafeLLMEnv())
 	issueHandler := handlers.NewIssueHandler(issueStore)
 	sessionMessageStore := db.NewSessionMessageStore(pool)
@@ -200,6 +204,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionHandler.SetPRAuthCredentialChecker(appUserAuthSvc)
 	sessionHandler.SetPRAuthFlow(cfg.CSRFSigningKey, cfg.FrontendURL)
 	sessionHandler.SetStreams(sessionStreams)
+	sessionHandler.SetMembershipStore(membershipStore)
 	pullRequestHandler.SetStreams(prHealthStreams)
 	pullRequestHandler.SetMembershipStore(membershipStore)
 	if prService != nil {
@@ -465,6 +470,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		uploadStore = storage.NewFileUploadStore(cfg.UploadStorageDir, "/api/v1/uploads/files")
 	}
 	uploadHandler := handlers.NewUploadHandler(uploadStore)
+	uploadHandler.SetMembershipStore(membershipStore)
 
 	r := chi.NewRouter()
 


### PR DESCRIPTION
## Summary

`<img>`, `EventSource`, and `window.open` cannot send the `X-Active-Org-ID` header, and the auth middleware deliberately does not refresh the session's `last_org_id` hint when that header is in use — so for multi-org users the resolved active-org commonly diverges from the actively-viewed org. This broke uploaded image previews (403 on `/api/v1/uploads/files/...`, confirmed in prod logs), silently 404'd session log SSE, and silently exported the wrong org's CSV from `/api/v1/usage/export`.

`ServeUpload` now authorizes off the org-id encoded in the URL path plus a membership check on the requesting user. `StreamLogs` and `ExportCSV` accept a membership-validated `?org_id=` query fallback (mirrors `pull_requests.go`'s existing `streamOrgIDFromRequest` prior art); the frontend passes the active org via that query param. The org-id-lint allowlist is extended with explanations for the three handlers that now reach `OrgIDFromContext` indirectly.

## Test plan

- [x] `make lint` clean (0 issues, multi-tenancy lints pass)
- [x] Go handler suite passes; new regression tests cover the no-header / cross-org cases
- [x] Frontend: `npm run typecheck` + `npm run lint` clean, all 1451 tests pass
- [ ] Verify in prod: drop a screenshot into `/sessions/new`, confirm preview renders for multi-org user
