### PR TITLE
Wire sandbox auth socket dir through bind-mount and pinned UIDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,12 @@ EXPOSE 8080
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:8080/healthz || exit 1
 
-RUN useradd -r -s /usr/sbin/nologin appuser \
+# UID 1000 is pinned so the host-side bind-mount source for the sandbox
+# auth socket directory (/var/run/143/sandbox-auth, owned 1000:1000 by
+# systemd-tmpfiles — see deploy/scripts/provision.sh) is writable by
+# this user, and so the per-session unix socket created here at mode 0600
+# is readable by the sandbox container's `sandbox` user (also UID 1000).
+RUN useradd --uid 1000 --user-group --shell /usr/sbin/nologin appuser \
     && mkdir -p /app/.data \
     && chown -R appuser:appuser /app
 USER appuser

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -301,9 +301,8 @@ RESOLV
       # internal/services/sandboxauth/server.go); owner 1000:1000 matches
       # the worker container's appuser so MkdirAll on per-session subdirs
       # succeeds.
-      install -d -m 0755 /etc/tmpfiles.d
       cat > /etc/tmpfiles.d/143-sandbox-auth.conf <<'TMPFILES'
-d /var/run/143             0755 root root -
+d /var/run/143 0755 root root -
 d /var/run/143/sandbox-auth 0750 1000 1000 -
 TMPFILES
       systemd-tmpfiles --create /etc/tmpfiles.d/143-sandbox-auth.conf

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -286,14 +286,27 @@ options edns0 trust-ad ndots:0
 RESOLV
       chmod 644 /etc/143/sandbox-resolv.conf
       # Provision /var/run/143/sandbox-auth/ for the per-session GitHub
-      # credential sockets. The orchestrator opens one Unix-domain socket
-      # per session here and bind-mounts it into the container; in-sandbox
-      # 143-tools dials the socket whenever git/gh need a fresh token.
-      # Owned by the docker daemon group (or wide-open under tmpfs perms)
-      # so the daemon can read the socket file when wiring up the bind
-      # mount. SANDBOX_AUTH_SOCKET_DIR points the server at this path.
-      mkdir -p /var/run/143/sandbox-auth
-      chmod 0750 /var/run/143/sandbox-auth
+      # credential sockets. The worker container bind-mounts this path
+      # in (see docker-compose.worker.yml); the orchestrator running as
+      # appuser uid 1000 opens one Unix-domain socket per session here,
+      # and the docker daemon bind-mounts the per-session subdir into
+      # the sandbox container at /run/143-auth/. SANDBOX_AUTH_SOCKET_DIR
+      # points the server at this path.
+      #
+      # /run is tmpfs on systemd hosts (and /var/run is a symlink to it),
+      # so the directory disappears on every reboot. We register it with
+      # systemd-tmpfiles so it's recreated at boot — and via --create
+      # below, immediately on first provision. Mode 0750 satisfies the
+      # orchestrator's startup assertion (assertParentDirPerms in
+      # internal/services/sandboxauth/server.go); owner 1000:1000 matches
+      # the worker container's appuser so MkdirAll on per-session subdirs
+      # succeeds.
+      install -d -m 0755 /etc/tmpfiles.d
+      cat > /etc/tmpfiles.d/143-sandbox-auth.conf <<'TMPFILES'
+d /var/run/143             0755 root root -
+d /var/run/143/sandbox-auth 0750 1000 1000 -
+TMPFILES
+      systemd-tmpfiles --create /etc/tmpfiles.d/143-sandbox-auth.conf
 PULL_WORKER
     ;;
   db|logging|redis)

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -65,6 +65,14 @@ services:
       - ${DOCKER_GID:-988}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      # Per-session GitHub credential sockets. Bind-mounted into this
+      # container so the orchestrator (running as appuser uid 1000) can
+      # create per-session unix sockets here, AND so the host docker
+      # daemon — which resolves bind sources against the host filesystem
+      # when wiring those sockets into sandbox containers — sees the same
+      # path. The host directory is provisioned 0750 and owned 1000:1000
+      # via systemd-tmpfiles in deploy/scripts/provision.sh.
+      - /var/run/143/sandbox-auth:/var/run/143/sandbox-auth
       - .env.production.enc:/.env.production.enc:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]

--- a/internal/services/sandboxauth/server.go
+++ b/internal/services/sandboxauth/server.go
@@ -137,11 +137,13 @@ func (s *Server) Listen(
 	if err != nil {
 		return "", fmt.Errorf("sandboxauth: listen on %s: %w", sockPath, err)
 	}
-	// Keep the socket owner-only. The orchestrator process creates it as
-	// the same numeric uid the sandbox image runs as (`useradd sandbox`
-	// becomes uid 1000 in the image, matching the deploy user on the host),
-	// so the bind-mounted socket remains reachable inside the container
-	// without granting group/world access.
+	// Keep the socket owner-only. The orchestrator (running as appuser in
+	// the worker server image) and the in-sandbox client (running as the
+	// `sandbox` user in the sandbox image) are both pinned to UID 1000,
+	// so the bind-mounted socket file's preserved owner UID matches at
+	// both ends without granting group/world access. See the Dockerfile
+	// and sandbox/Dockerfile for the pinning, and provision.sh for the
+	// matching ownership on the host bind-mount source.
 	if err := os.Chmod(sockPath, 0o600); err != nil {
 		_ = ln.Close()
 		_ = os.Remove(sockPath)

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -108,6 +108,11 @@ COPY --from=go-builder /bin/143-tools /usr/local/bin/143-tools
 
 # Non-root user for sandbox execution. No sudo is provisioned — see the
 # comment on the apt-get block above.
-RUN useradd -m -s /bin/bash sandbox
+#
+# UID 1000 is pinned to match the worker server image's `appuser` (which
+# creates the per-session credential socket at mode 0600). The bind-mounted
+# socket file's owner UID is preserved across the mount, so both processes
+# must agree on the same numeric UID for the in-sandbox client to open it.
+RUN useradd --uid 1000 --create-home --user-group --shell /bin/bash sandbox
 USER sandbox
 WORKDIR /workspace

--- a/sandbox/Dockerfile
+++ b/sandbox/Dockerfile
@@ -113,6 +113,11 @@ COPY --from=go-builder /bin/143-tools /usr/local/bin/143-tools
 # creates the per-session credential socket at mode 0600). The bind-mounted
 # socket file's owner UID is preserved across the mount, so both processes
 # must agree on the same numeric UID for the in-sandbox client to open it.
-RUN useradd --uid 1000 --create-home --user-group --shell /bin/bash sandbox
+#
+# ubuntu:24.04 ships a default `ubuntu` user pre-claiming UID 1000, which
+# collides with our useradd. Remove it first; `|| true` keeps the build
+# working if a future base image drops the user.
+RUN userdel -r ubuntu 2>/dev/null || true \
+    && useradd --uid 1000 --create-home --user-group --shell /bin/bash sandbox
 USER sandbox
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

Fixes the production failure introduced by #583 where every GitHub-linked session failed at start with `open sandbox auth socket: sandboxauth: ensure socket dir: mkdir /var/run/143: permission denied`.

The auth-socket feature shipped without the host/container plumbing it needs, so the orchestrator's `MkdirAll` ran inside the worker container's own filesystem, against `/var/run` it could not write to, with no path back to the host docker daemon. This PR wires it through end to end:

- `docker-compose.worker.yml`: bind-mount `/var/run/143/sandbox-auth` so the worker container and the host docker daemon resolve the same path.
- `Dockerfile` + `sandbox/Dockerfile`: pin both `appuser` (worker) and `sandbox` (sandbox) to UID 1000 so the `chmod 0600` socket is readable across the bind-mount.
- `deploy/scripts/provision.sh`: replace the one-shot `mkdir`+`chmod` with a `systemd-tmpfiles.d` entry that recreates `/var/run/143/sandbox-auth` at `0750` owned `1000:1000` on every boot (and immediately via `systemd-tmpfiles --create`), since `/run` is tmpfs and was wiping the directory on reboot.
- `internal/services/sandboxauth/server.go`: refresh the stale comment that still claimed `appuser` was already UID 1000.

## Test plan

- [x] `make lint` (0 issues)
- [x] `go build ./...` and `go vet ./...` clean
- [x] `go test ./internal/services/sandboxauth/... ./internal/services/agent/... ./internal/worker/... ./cmd/server/...`
- [x] `docker compose -f docker-compose.worker.yml config` renders the new bind-mount
- [x] `bash -n deploy/scripts/provision.sh` shell syntax check
- [ ] Re-provision each worker with `make provision-worker REPROVISION=true HOST=<ip>` (a plain `make deploy-worker` is not sufficient — provisioning is what installs `/etc/tmpfiles.d/143-sandbox-auth.conf` and the updated compose).
- [ ] After deploy, kick off a session against a GitHub-linked repo and confirm session start succeeds and `git push` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
