### PR TITLE
Fix coding-agent auth settings page UX (modal, reorder, priority)

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen, userEvent, waitFor, within } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
-import AgentPage from "./page";
+import type { CodingAuth } from "@/lib/types";
+import AgentPage, { reorderRows } from "./page";
 
 vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({
@@ -329,5 +330,67 @@ describe("Agent settings page", () => {
     renderWithProviders(<AgentPage />);
 
     expect(screen.queryByText("Agent-specific access")).not.toBeInTheDocument();
+  });
+});
+
+describe("reorderRows", () => {
+  function makeRows(ids: string[]): CodingAuth[] {
+    return ids.map((id, index) => ({
+      id,
+      org_id: "org-1",
+      priority: index + 1,
+      agent: "codex",
+      auth_type: "subscription",
+      label: id,
+      scope: "organization",
+      provider: "openai_chatgpt",
+      status: "healthy",
+      is_default: index === 0,
+      created_at: "2026-04-22T10:00:00Z",
+      updated_at: "2026-04-22T10:00:00Z",
+    }));
+  }
+
+  function ids(rows: CodingAuth[]) {
+    return rows.map((row) => row.id);
+  }
+
+  it("returns the same array when source and target match", () => {
+    const rows = makeRows(["a", "b", "c"]);
+    expect(reorderRows(rows, "b", "b", "before")).toBe(rows);
+  });
+
+  it("drops 'before' an earlier target by inserting source above it", () => {
+    const rows = makeRows(["a", "b", "c", "d"]);
+    expect(ids(reorderRows(rows, "d", "b", "before"))).toEqual(["a", "d", "b", "c"]);
+  });
+
+  it("drops 'after' an earlier target by inserting source below it", () => {
+    const rows = makeRows(["a", "b", "c", "d"]);
+    expect(ids(reorderRows(rows, "d", "b", "after"))).toEqual(["a", "b", "d", "c"]);
+  });
+
+  it("drops 'before' a later target by inserting source above it", () => {
+    const rows = makeRows(["a", "b", "c", "d"]);
+    expect(ids(reorderRows(rows, "a", "c", "before"))).toEqual(["b", "a", "c", "d"]);
+  });
+
+  it("drops 'after' a later target by inserting source below it", () => {
+    const rows = makeRows(["a", "b", "c", "d"]);
+    expect(ids(reorderRows(rows, "a", "c", "after"))).toEqual(["b", "c", "a", "d"]);
+  });
+
+  it("returns the same array when the move would not change positions", () => {
+    const rows = makeRows(["a", "b", "c"]);
+    // Dropping 'b' "after" 'a' leaves the array in the same order.
+    expect(reorderRows(rows, "b", "a", "after")).toBe(rows);
+    // Dropping 'b' "before" 'c' likewise.
+    expect(reorderRows(rows, "b", "c", "before")).toBe(rows);
+  });
+
+  it("returns the same array when source or target is missing", () => {
+    const rows = makeRows(["a", "b"]);
+    expect(reorderRows(rows, "missing", "a", "before")).toBe(rows);
+    expect(reorderRows(rows, "a", "missing", "before")).toBe(rows);
   });
 });

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -84,6 +84,26 @@ function moveRowToTop(rows: CodingAuth[], id: string) {
   return next;
 }
 
+export function reorderRows(
+  rows: CodingAuth[],
+  sourceId: string,
+  targetId: string,
+  position: "before" | "after",
+) {
+  if (sourceId === targetId) return rows;
+  const sourceIdx = rows.findIndex((row) => row.id === sourceId);
+  const targetIdx = rows.findIndex((row) => row.id === targetId);
+  if (sourceIdx === -1 || targetIdx === -1) return rows;
+  const next = [...rows];
+  const [row] = next.splice(sourceIdx, 1);
+  // After removing the source, indices past it shift down by one.
+  const targetIdxAfterRemove = sourceIdx < targetIdx ? targetIdx - 1 : targetIdx;
+  const insertAt = position === "before" ? targetIdxAfterRemove : targetIdxAfterRemove + 1;
+  if (insertAt === sourceIdx) return rows;
+  next.splice(insertAt, 0, row);
+  return next;
+}
+
 function defaultLabel(provider: ModalProvider, authType: AddFlowAuthType) {
   switch (provider) {
     case "codex":
@@ -238,11 +258,11 @@ export default function AgentPage() {
       void queryClient.invalidateQueries({ queryKey: queryKeys.credentials.resolved });
       setSelectedId(null);
       setRenameValue("");
-      toast.success("Auth disabled");
+      toast.success("Auth removed");
     },
     onError: (error) => {
       captureError(error, { feature: "coding-auth-delete" });
-      toast.error("Could not disable auth");
+      toast.error("Could not remove auth");
     },
   });
 
@@ -299,10 +319,12 @@ export default function AgentPage() {
     if (effectiveAuthType === "subscription") {
       if (provider === "codex") {
         setShowCodexModal(true);
+        setAddOpen(false);
         return;
       }
       if (provider === "claude_code") {
         setShowClaudeModal(true);
+        setAddOpen(false);
         return;
       }
     }
@@ -467,14 +489,15 @@ export default function AgentPage() {
             selectedId={selectedId}
             onSelect={(id) => {
               setSelectedId(id);
-              setRenameValue("");
+              setRenameValue(rows.find((row) => row.id === id)?.label ?? "");
             }}
             onMove={(id, direction) => {
               const nextRows = moveRows(rows, id, direction);
               void reorderMutation.mutateAsync(nextRows);
             }}
-            onMoveToTop={(id) => {
-              const nextRows = moveRowToTop(rows, id);
+            onReorder={(sourceId, targetId, position) => {
+              const nextRows = reorderRows(rows, sourceId, targetId, position);
+              if (nextRows === rows) return;
               void reorderMutation.mutateAsync(nextRows);
             }}
           />
@@ -587,7 +610,7 @@ export default function AgentPage() {
                     </Button>
                     <Button variant="destructive" onClick={() => deleteMutation.mutate(selected.id)}>
                       <Trash2 className="mr-2 h-4 w-4" />
-                      Disable
+                      Remove
                     </Button>
                   </div>
                 </div>
@@ -732,7 +755,10 @@ export default function AgentPage() {
         {showCodexModal ? (
           <CodexDeviceCodeModal
             label={generatedLabel}
-            onClose={() => setShowCodexModal(false)}
+            onClose={() => {
+              setShowCodexModal(false);
+              closeAddModal();
+            }}
             onConnected={() => {
               setShowCodexModal(false);
               closeAddModal();
@@ -744,7 +770,10 @@ export default function AgentPage() {
         {showClaudeModal ? (
           <ClaudeCodeAuthModal
             label={generatedLabel}
-            onClose={() => setShowClaudeModal(false)}
+            onClose={() => {
+              setShowClaudeModal(false);
+              closeAddModal();
+            }}
             onConnected={() => {
               setShowClaudeModal(false);
               closeAddModal();

--- a/frontend/src/components/coding-auth-stack.test.tsx
+++ b/frontend/src/components/coding-auth-stack.test.tsx
@@ -44,7 +44,7 @@ describe("CodingAuthStack", () => {
         selectedId={null}
         onSelect={vi.fn()}
         onMove={vi.fn()}
-        onMoveToTop={vi.fn()}
+        onReorder={vi.fn()}
       />,
     );
 
@@ -57,22 +57,22 @@ describe("CodingAuthStack", () => {
   it("supports keyboard-accessible move controls", async () => {
     const user = userEvent.setup();
     const onMove = vi.fn();
-    const onMoveToTop = vi.fn();
+    const onSelect = vi.fn();
 
     renderWithProviders(
       <CodingAuthStack
         rows={rows}
         selectedId={null}
-        onSelect={vi.fn()}
+        onSelect={onSelect}
         onMove={onMove}
-        onMoveToTop={onMoveToTop}
+        onReorder={vi.fn()}
       />,
     );
 
     await user.click(screen.getByRole("button", { name: "Move Pi backup up" }));
     expect(onMove).toHaveBeenCalledWith("auth-2", "up");
 
-    await user.click(screen.getByRole("button", { name: "Move Pi backup to top" }));
-    expect(onMoveToTop).toHaveBeenCalledWith("auth-2");
+    await user.click(screen.getByRole("button", { name: "Edit Pi backup" }));
+    expect(onSelect).toHaveBeenCalledWith("auth-2");
   });
 });

--- a/frontend/src/components/coding-auth-stack.tsx
+++ b/frontend/src/components/coding-auth-stack.tsx
@@ -128,13 +128,12 @@ export function CodingAuthStack({
                 className={cn(
                   selectedId === row.id ? "bg-muted/40" : "",
                   draggingId === row.id ? "opacity-40" : "",
-                  showDropAbove ? "shadow-[inset_0_2px_0_0_var(--color-primary)]" : "",
-                  showDropBelow ? "shadow-[inset_0_-2px_0_0_var(--color-primary)]" : "",
-                  "cursor-grab active:cursor-grabbing",
+                  showDropAbove ? "border-t-2 border-t-primary" : "",
+                  showDropBelow ? "border-b-2 border-b-primary" : "",
                 )}
               >
                 <TableCell>
-                  <div className="flex h-9 items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 text-sm font-medium text-foreground">
+                  <div className="flex h-9 items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 text-sm font-medium text-foreground cursor-grab active:cursor-grabbing">
                     <span>{row.priority}</span>
                     <GripVertical className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
                   </div>

--- a/frontend/src/components/coding-auth-stack.tsx
+++ b/frontend/src/components/coding-auth-stack.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { GripVertical, MoveUp, MoveDown, ChevronsUp } from "lucide-react";
+import { useState } from "react";
+import { GripVertical, MoveUp, MoveDown, Pencil } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { AGENTS_BY_KEY } from "@/lib/agents";
+import { cn } from "@/lib/utils";
 import type { CodingAuth } from "@/lib/types";
 
 type MoveDirection = "up" | "down";
+export type DropPosition = "before" | "after";
 
 function agentLabel(agent: CodingAuth["agent"]) {
   return AGENTS_BY_KEY[agent]?.label ?? agent;
@@ -55,14 +58,17 @@ export function CodingAuthStack({
   selectedId,
   onSelect,
   onMove,
-  onMoveToTop,
+  onReorder,
 }: {
   rows: CodingAuth[];
   selectedId: string | null;
   onSelect: (id: string) => void;
   onMove: (id: string, direction: MoveDirection) => void;
-  onMoveToTop: (id: string) => void;
+  onReorder: (sourceId: string, targetId: string, position: DropPosition) => void;
 }) {
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOver, setDragOver] = useState<{ id: string; position: DropPosition } | null>(null);
+
   return (
     <div className="overflow-hidden rounded-2xl border border-border bg-card">
       <Table className="table-fixed">
@@ -77,81 +83,121 @@ export function CodingAuthStack({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {rows.map((row, index) => (
-            <TableRow
-              key={row.id}
-              className={selectedId === row.id ? "bg-muted/40" : ""}
-            >
-              <TableCell>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="h-9 rounded-lg border border-border bg-muted/30 px-3 py-0 text-sm font-medium text-foreground hover:bg-muted/60"
-                  onClick={() => onSelect(row.id)}
-                >
-                  <span>{row.priority}</span>
-                  <GripVertical className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                </Button>
-              </TableCell>
-              <TableCell className="font-medium whitespace-normal">{agentLabel(row.agent)}</TableCell>
-              <TableCell>{authTypeLabel(row.auth_type)}</TableCell>
-              <TableCell className="whitespace-normal">
-                <div className="space-y-1">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    className="h-auto justify-start px-0 py-0 font-medium text-foreground hover:bg-transparent"
-                    onClick={() => onSelect(row.id)}
-                  >
-                    {row.label}
-                  </Button>
-                  {row.usage_note ? <div className="text-xs text-muted-foreground">{row.usage_note}</div> : null}
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <Badge variant="outline" className={statusBadgeClass(row.status)}>
-                    {statusLabel(row.status)}
-                  </Badge>
-                  {row.is_default ? <Badge>Default</Badge> : null}
-                </div>
-              </TableCell>
-              <TableCell>
-                <div className="flex items-center justify-end gap-1">
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Move ${row.label} to top`}
-                    onClick={() => onMoveToTop(row.id)}
-                    disabled={index === 0}
-                  >
-                    <ChevronsUp className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Move ${row.label} up`}
-                    onClick={() => onMove(row.id, "up")}
-                    disabled={index === 0}
-                  >
-                    <MoveUp className="h-4 w-4" />
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label={`Move ${row.label} down`}
-                    onClick={() => onMove(row.id, "down")}
-                    disabled={index === rows.length - 1}
-                  >
-                    <MoveDown className="h-4 w-4" />
-                  </Button>
-                </div>
-              </TableCell>
-            </TableRow>
-          ))}
+          {rows.map((row, index) => {
+            const showDropAbove = dragOver?.id === row.id && dragOver.position === "before";
+            const showDropBelow = dragOver?.id === row.id && dragOver.position === "after";
+            return (
+              <TableRow
+                key={row.id}
+                draggable
+                onDragStart={(event) => {
+                  setDraggingId(row.id);
+                  event.dataTransfer.effectAllowed = "move";
+                  event.dataTransfer.setData("text/plain", row.id);
+                }}
+                onDragOver={(event) => {
+                  if (!draggingId || draggingId === row.id) return;
+                  event.preventDefault();
+                  event.dataTransfer.dropEffect = "move";
+                  const rect = event.currentTarget.getBoundingClientRect();
+                  const position: DropPosition =
+                    event.clientY < rect.top + rect.height / 2 ? "before" : "after";
+                  setDragOver((prev) =>
+                    prev?.id === row.id && prev.position === position
+                      ? prev
+                      : { id: row.id, position },
+                  );
+                }}
+                onDragLeave={(event) => {
+                  // Only clear if leaving the row itself, not entering a child element.
+                  if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+                  if (dragOver?.id === row.id) setDragOver(null);
+                }}
+                onDrop={(event) => {
+                  event.preventDefault();
+                  if (draggingId && draggingId !== row.id && dragOver?.id === row.id) {
+                    onReorder(draggingId, row.id, dragOver.position);
+                  }
+                  setDraggingId(null);
+                  setDragOver(null);
+                }}
+                onDragEnd={() => {
+                  setDraggingId(null);
+                  setDragOver(null);
+                }}
+                className={cn(
+                  selectedId === row.id ? "bg-muted/40" : "",
+                  draggingId === row.id ? "opacity-40" : "",
+                  showDropAbove ? "shadow-[inset_0_2px_0_0_var(--color-primary)]" : "",
+                  showDropBelow ? "shadow-[inset_0_-2px_0_0_var(--color-primary)]" : "",
+                  "cursor-grab active:cursor-grabbing",
+                )}
+              >
+                <TableCell>
+                  <div className="flex h-9 items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 text-sm font-medium text-foreground">
+                    <span>{row.priority}</span>
+                    <GripVertical className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  </div>
+                </TableCell>
+                <TableCell className="font-medium whitespace-normal">{agentLabel(row.agent)}</TableCell>
+                <TableCell>{authTypeLabel(row.auth_type)}</TableCell>
+                <TableCell className="whitespace-normal">
+                  <div className="space-y-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      className="h-auto justify-start px-0 py-0 font-medium text-foreground hover:bg-transparent"
+                      onClick={() => onSelect(row.id)}
+                    >
+                      {row.label}
+                    </Button>
+                    {row.usage_note ? <div className="text-xs text-muted-foreground">{row.usage_note}</div> : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className={statusBadgeClass(row.status)}>
+                      {statusLabel(row.status)}
+                    </Badge>
+                    {row.is_default ? <Badge>Default</Badge> : null}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Move ${row.label} up`}
+                      onClick={() => onMove(row.id, "up")}
+                      disabled={index === 0}
+                    >
+                      <MoveUp className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Move ${row.label} down`}
+                      onClick={() => onMove(row.id, "down")}
+                      disabled={index === rows.length - 1}
+                    >
+                      <MoveDown className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      aria-label={`Edit ${row.label}`}
+                      onClick={() => onSelect(row.id)}
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </div>

--- a/internal/db/org_credentials.go
+++ b/internal/db/org_credentials.go
@@ -72,35 +72,35 @@ func (s *OrgCredentialStore) UpsertWithLabel(ctx context.Context, orgID uuid.UUI
 	}
 
 	if isCodingAuthProvider(provider) {
-		nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
+		var id uuid.UUID
+		err := s.withCodingAuthPriority(ctx, orgID, func(tx pgx.Tx, nextPriority int) error {
+			query := `
+				INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
+				VALUES (@org_id, @provider, @label, @config, 'active', @created_by, @priority)
+				ON CONFLICT (org_id, provider, label)
+				DO UPDATE SET config = EXCLUDED.config, status = 'active', updated_at = now(),
+					priority = CASE
+						WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
+						ELSE org_credentials.priority
+					END
+				RETURNING id`
+
+			args := pgx.NamedArgs{
+				"org_id":     orgID,
+				"provider":   string(provider),
+				"label":      label,
+				"config":     encrypted,
+				"created_by": createdBy,
+				"priority":   nextPriority,
+			}
+
+			if err := tx.QueryRow(ctx, query, args).Scan(&id); err != nil {
+				return fmt.Errorf("upsert %s credential: %w", provider, err)
+			}
+			return nil
+		})
 		if err != nil {
 			return nil, err
-		}
-
-		query := `
-			INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
-			VALUES (@org_id, @provider, @label, @config, 'active', @created_by, @priority)
-			ON CONFLICT (org_id, provider, label)
-			DO UPDATE SET config = EXCLUDED.config, status = 'active', updated_at = now(),
-				priority = CASE
-					WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
-					ELSE org_credentials.priority
-				END
-			RETURNING id`
-
-		args := pgx.NamedArgs{
-			"org_id":     orgID,
-			"provider":   string(provider),
-			"label":      label,
-			"config":     encrypted,
-			"created_by": createdBy,
-			"priority":   nextPriority,
-		}
-
-		var id uuid.UUID
-		err = s.db.QueryRow(ctx, query, args).Scan(&id)
-		if err != nil {
-			return nil, fmt.Errorf("upsert %s credential: %w", provider, err)
 		}
 		return &id, nil
 	}
@@ -147,64 +147,66 @@ func (s *OrgCredentialStore) InsertPendingAuth(ctx context.Context, orgID uuid.U
 		return nil, fmt.Errorf("%s: %w", provider, err)
 	}
 
-	nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
-	if err != nil {
-		return nil, err
-	}
-
 	// ON CONFLICT only updates if the existing row is pending_auth or disabled —
 	// never stomps on a credential that holds a real access token (active) or one
 	// that's still mid-rotation in the user's mental model (invalid). When
 	// resurrecting a disabled row we bump its priority to the next slot so it
 	// appears at the bottom of the fallback stack rather than carrying over an
 	// old position the user may not remember.
-	query := `
-		INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
-		VALUES (@org_id, @provider, @label, @config, 'pending_auth', @created_by, @priority)
-		ON CONFLICT (org_id, provider, label)
-		DO UPDATE SET config = EXCLUDED.config, status = 'pending_auth', updated_at = now(),
-			priority = CASE
-				WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
-				ELSE org_credentials.priority
-			END
-		WHERE org_credentials.status IN ('pending_auth', 'disabled')
-		RETURNING id`
-
-	args := pgx.NamedArgs{
-		"org_id":     orgID,
-		"provider":   string(provider),
-		"label":      label,
-		"config":     encrypted,
-		"created_by": createdBy,
-		"priority":   nextPriority,
-	}
-
 	var id uuid.UUID
-	err = s.db.QueryRow(ctx, query, args).Scan(&id)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			// Conflict on (org, provider, label) but the existing row is
-			// active/invalid. Look up the actual status to surface a useful error.
-			existingStatus, lookupErr := s.lookupCredentialStatus(ctx, orgID, provider, label)
-			if lookupErr != nil {
-				return nil, &ErrCredentialLabelTaken{Label: label, ExistingStatus: "unknown"}
-			}
-			return nil, &ErrCredentialLabelTaken{Label: label, ExistingStatus: existingStatus}
+	var labelTakenErr *ErrCredentialLabelTaken
+	err = s.withCodingAuthPriority(ctx, orgID, func(tx pgx.Tx, nextPriority int) error {
+		query := `
+			INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
+			VALUES (@org_id, @provider, @label, @config, 'pending_auth', @created_by, @priority)
+			ON CONFLICT (org_id, provider, label)
+			DO UPDATE SET config = EXCLUDED.config, status = 'pending_auth', updated_at = now(),
+				priority = CASE
+					WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
+					ELSE org_credentials.priority
+				END
+			WHERE org_credentials.status IN ('pending_auth', 'disabled')
+			RETURNING id`
+
+		args := pgx.NamedArgs{
+			"org_id":     orgID,
+			"provider":   string(provider),
+			"label":      label,
+			"config":     encrypted,
+			"created_by": createdBy,
+			"priority":   nextPriority,
 		}
-		return nil, fmt.Errorf("insert pending %s credential: %w", provider, err)
+
+		scanErr := tx.QueryRow(ctx, query, args).Scan(&id)
+		if scanErr == nil {
+			return nil
+		}
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			// Conflict on (org, provider, label) but the existing row is
+			// active/invalid. Look up the actual status (still inside the
+			// transaction so the read is consistent with the failed insert)
+			// to surface a useful error to the caller.
+			var existingStatus string
+			lookupErr := tx.QueryRow(ctx,
+				`SELECT status FROM org_credentials WHERE org_id = @org_id AND provider = @provider AND label = @label`,
+				pgx.NamedArgs{"org_id": orgID, "provider": string(provider), "label": label},
+			).Scan(&existingStatus)
+			if lookupErr != nil {
+				labelTakenErr = &ErrCredentialLabelTaken{Label: label, ExistingStatus: "unknown"}
+			} else {
+				labelTakenErr = &ErrCredentialLabelTaken{Label: label, ExistingStatus: existingStatus}
+			}
+			return labelTakenErr
+		}
+		return fmt.Errorf("insert pending %s credential: %w", provider, scanErr)
+	})
+	if labelTakenErr != nil {
+		return nil, labelTakenErr
+	}
+	if err != nil {
+		return nil, err
 	}
 	return &id, nil
-}
-
-// lookupCredentialStatus returns the raw status string for a (org, provider, label)
-// row. Used by InsertPendingAuth to disambiguate conflict cases.
-func (s *OrgCredentialStore) lookupCredentialStatus(ctx context.Context, orgID uuid.UUID, provider models.ProviderName, label string) (string, error) {
-	var status string
-	err := s.db.QueryRow(ctx,
-		`SELECT status FROM org_credentials WHERE org_id = @org_id AND provider = @provider AND label = @label`,
-		pgx.NamedArgs{"org_id": orgID, "provider": string(provider), "label": label},
-	).Scan(&status)
-	return status, err
 }
 
 // UpsertByID updates an existing credential's config by ID, scoped to org.
@@ -738,32 +740,60 @@ func isCodingAuthProvider(provider models.ProviderName) bool {
 	return false
 }
 
-// nextCodingAuthPriority returns the next priority slot for a new coding-auth row
-// in the org's fallback stack. Disabled rows are excluded so a user who removed
-// an entry can re-add at the bottom without leaving gaps from old positions.
-func (s *OrgCredentialStore) nextCodingAuthPriority(ctx context.Context, orgID uuid.UUID) (int, error) {
+// withCodingAuthPriority runs fn inside a transaction guarded by a per-org
+// advisory lock so that the priority lookup + INSERT pair is serialized
+// across concurrent callers in the same org. Without this, two simultaneous
+// "Add auth" calls could read the same MAX(priority) and end up with
+// duplicate priority numbers — harmless for sorting (created_at breaks ties)
+// but confusing in the UI.
+//
+// fn receives the next priority slot and the active transaction; it must
+// perform its INSERT/UPDATE on tx so the work happens under the same lock.
+// The lock is held until tx commits or rolls back.
+func (s *OrgCredentialStore) withCodingAuthPriority(
+	ctx context.Context,
+	orgID uuid.UUID,
+	fn func(tx pgx.Tx, nextPriority int) error,
+) error {
+	txStarter, ok := s.db.(TxStarter)
+	if !ok {
+		return fmt.Errorf("org credential store db does not support transactions")
+	}
+	tx, err := txStarter.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin priority transaction: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// Per-org advisory lock keyed on a stable namespaced string. Hashed to
+	// the bigint argument pg_advisory_xact_lock expects.
+	if _, err := tx.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"coding_auth_priority:"+orgID.String(),
+	); err != nil {
+		return fmt.Errorf("acquire priority lock: %w", err)
+	}
+
 	var nextPriority int
-	err := s.db.QueryRow(ctx, `
+	if err := tx.QueryRow(ctx, `
 		SELECT COALESCE(MAX(priority), 0) + 1
 		FROM org_credentials
 		WHERE org_id = @org_id
 		  AND provider IN ('anthropic', 'openai', 'openai_chatgpt', 'gemini', 'amp', 'pi')
 		  AND status != 'disabled'`,
 		pgx.NamedArgs{"org_id": orgID},
-	).Scan(&nextPriority)
-	if err != nil {
-		return 0, fmt.Errorf("get next coding auth priority: %w", err)
+	).Scan(&nextPriority); err != nil {
+		return fmt.Errorf("get next coding auth priority: %w", err)
 	}
-	return nextPriority, nil
+
+	if err := fn(tx, nextPriority); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *OrgCredentialStore) CreateCodingAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, input models.CreateCodingAuthInput) (*models.CodingAuth, error) {
 	cfg, provider, err := providerConfigForCodingAuthInput(input)
-	if err != nil {
-		return nil, err
-	}
-
-	nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
@@ -773,26 +803,35 @@ func (s *OrgCredentialStore) CreateCodingAuth(ctx context.Context, orgID uuid.UU
 		return nil, err
 	}
 
-	query := `
-		INSERT INTO org_credentials (org_id, provider, label, config, status, priority, created_by)
-		VALUES (@org_id, @provider, @label, @config, 'active', @priority, @created_by)
-		RETURNING id, org_id, provider, label, config, status, priority, last_verified_at, last_used_at, created_by, created_at, updated_at`
+	var row models.OrgCredential
+	err = s.withCodingAuthPriority(ctx, orgID, func(tx pgx.Tx, nextPriority int) error {
+		query := `
+			INSERT INTO org_credentials (org_id, provider, label, config, status, priority, created_by)
+			VALUES (@org_id, @provider, @label, @config, 'active', @priority, @created_by)
+			RETURNING id, org_id, provider, label, config, status, priority, last_verified_at, last_used_at, created_by, created_at, updated_at`
 
-	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
-		"org_id":     orgID,
-		"provider":   string(provider),
-		"label":      input.Label,
-		"config":     encrypted,
-		"priority":   nextPriority,
-		"created_by": createdBy,
+		rows, qerr := tx.Query(ctx, query, pgx.NamedArgs{
+			"org_id":     orgID,
+			"provider":   string(provider),
+			"label":      input.Label,
+			"config":     encrypted,
+			"priority":   nextPriority,
+			"created_by": createdBy,
+		})
+		if qerr != nil {
+			return fmt.Errorf("create coding auth: %w", qerr)
+		}
+		collected, cerr := pgx.CollectOneRow(rows, pgx.RowToStructByNameLax[models.OrgCredential])
+		if cerr != nil {
+			return fmt.Errorf("create coding auth: %w", cerr)
+		}
+		row = collected
+		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create coding auth: %w", err)
+		return nil, err
 	}
-	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByNameLax[models.OrgCredential])
-	if err != nil {
-		return nil, fmt.Errorf("create coding auth: %w", err)
-	}
+
 	cred, err := s.decryptRow(row)
 	if err != nil {
 		return nil, err

--- a/internal/db/org_credentials.go
+++ b/internal/db/org_credentials.go
@@ -71,11 +71,47 @@ func (s *OrgCredentialStore) UpsertWithLabel(ctx context.Context, orgID uuid.UUI
 		return nil, fmt.Errorf("%s: %w", provider, err)
 	}
 
+	if isCodingAuthProvider(provider) {
+		nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
+		if err != nil {
+			return nil, err
+		}
+
+		query := `
+			INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
+			VALUES (@org_id, @provider, @label, @config, 'active', @created_by, @priority)
+			ON CONFLICT (org_id, provider, label)
+			DO UPDATE SET config = EXCLUDED.config, status = 'active', updated_at = now(),
+				priority = CASE
+					WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
+					ELSE org_credentials.priority
+				END
+			RETURNING id`
+
+		args := pgx.NamedArgs{
+			"org_id":     orgID,
+			"provider":   string(provider),
+			"label":      label,
+			"config":     encrypted,
+			"created_by": createdBy,
+			"priority":   nextPriority,
+		}
+
+		var id uuid.UUID
+		err = s.db.QueryRow(ctx, query, args).Scan(&id)
+		if err != nil {
+			return nil, fmt.Errorf("upsert %s credential: %w", provider, err)
+		}
+		return &id, nil
+	}
+
+	// Non-coding providers (GitHub, Sentry, Linear, Notion, …) ignore priority
+	// — it's only meaningful for the coding-agent fallback stack.
 	query := `
 		INSERT INTO org_credentials (org_id, provider, label, config, status, created_by)
 		VALUES (@org_id, @provider, @label, @config, 'active', @created_by)
 		ON CONFLICT (org_id, provider, label)
-		DO UPDATE SET config = @config, status = 'active', updated_at = now()
+		DO UPDATE SET config = EXCLUDED.config, status = 'active', updated_at = now()
 		RETURNING id`
 
 	args := pgx.NamedArgs{
@@ -111,14 +147,26 @@ func (s *OrgCredentialStore) InsertPendingAuth(ctx context.Context, orgID uuid.U
 		return nil, fmt.Errorf("%s: %w", provider, err)
 	}
 
+	nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
 	// ON CONFLICT only updates if the existing row is pending_auth or disabled —
 	// never stomps on a credential that holds a real access token (active) or one
-	// that's still mid-rotation in the user's mental model (invalid).
+	// that's still mid-rotation in the user's mental model (invalid). When
+	// resurrecting a disabled row we bump its priority to the next slot so it
+	// appears at the bottom of the fallback stack rather than carrying over an
+	// old position the user may not remember.
 	query := `
-		INSERT INTO org_credentials (org_id, provider, label, config, status, created_by)
-		VALUES (@org_id, @provider, @label, @config, 'pending_auth', @created_by)
+		INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
+		VALUES (@org_id, @provider, @label, @config, 'pending_auth', @created_by, @priority)
 		ON CONFLICT (org_id, provider, label)
-		DO UPDATE SET config = @config, status = 'pending_auth', updated_at = now()
+		DO UPDATE SET config = EXCLUDED.config, status = 'pending_auth', updated_at = now(),
+			priority = CASE
+				WHEN org_credentials.status = 'disabled' THEN EXCLUDED.priority
+				ELSE org_credentials.priority
+			END
 		WHERE org_credentials.status IN ('pending_auth', 'disabled')
 		RETURNING id`
 
@@ -128,6 +176,7 @@ func (s *OrgCredentialStore) InsertPendingAuth(ctx context.Context, orgID uuid.U
 		"label":      label,
 		"config":     encrypted,
 		"created_by": createdBy,
+		"priority":   nextPriority,
 	}
 
 	var id uuid.UUID
@@ -673,22 +722,50 @@ func (s *OrgCredentialStore) ReorderCodingAuths(ctx context.Context, orgID uuid.
 	return tx.Commit(ctx)
 }
 
-func (s *OrgCredentialStore) CreateCodingAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, input models.CreateCodingAuthInput) (*models.CodingAuth, error) {
-	cfg, provider, err := providerConfigForCodingAuthInput(input)
-	if err != nil {
-		return nil, err
+// isCodingAuthProvider reports whether a provider participates in the
+// coding-agent fallback stack. Priority is only meaningful for these
+// providers; other credentials (GitHub, Sentry, …) keep the default.
+func isCodingAuthProvider(provider models.ProviderName) bool {
+	switch provider {
+	case models.ProviderAnthropic,
+		models.ProviderOpenAI,
+		models.ProviderOpenAIChatGPT,
+		models.ProviderGemini,
+		models.ProviderAmp,
+		models.ProviderPi:
+		return true
 	}
+	return false
+}
 
+// nextCodingAuthPriority returns the next priority slot for a new coding-auth row
+// in the org's fallback stack. Disabled rows are excluded so a user who removed
+// an entry can re-add at the bottom without leaving gaps from old positions.
+func (s *OrgCredentialStore) nextCodingAuthPriority(ctx context.Context, orgID uuid.UUID) (int, error) {
 	var nextPriority int
-	if scanErr := s.db.QueryRow(ctx, `
+	err := s.db.QueryRow(ctx, `
 		SELECT COALESCE(MAX(priority), 0) + 1
 		FROM org_credentials
 		WHERE org_id = @org_id
 		  AND provider IN ('anthropic', 'openai', 'openai_chatgpt', 'gemini', 'amp', 'pi')
 		  AND status != 'disabled'`,
 		pgx.NamedArgs{"org_id": orgID},
-	).Scan(&nextPriority); scanErr != nil {
-		return nil, fmt.Errorf("get next coding auth priority: %w", scanErr)
+	).Scan(&nextPriority)
+	if err != nil {
+		return 0, fmt.Errorf("get next coding auth priority: %w", err)
+	}
+	return nextPriority, nil
+}
+
+func (s *OrgCredentialStore) CreateCodingAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, input models.CreateCodingAuthInput) (*models.CodingAuth, error) {
+	cfg, provider, err := providerConfigForCodingAuthInput(input)
+	if err != nil {
+		return nil, err
+	}
+
+	nextPriority, err := s.nextCodingAuthPriority(ctx, orgID)
+	if err != nil {
+		return nil, err
 	}
 
 	encrypted, err := s.marshalAndEncrypt(cfg)

--- a/internal/db/org_credentials.go
+++ b/internal/db/org_credentials.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -12,6 +13,44 @@ import (
 	"github.com/assembledhq/143/internal/crypto"
 	"github.com/assembledhq/143/internal/models"
 )
+
+// codingAuthProviders is the canonical list of providers that participate in
+// the org-level coding-auth fallback stack. Priority is meaningful only for
+// these — other credentials (GitHub, Sentry, …) keep the column default.
+//
+// This is intentionally distinct from models.CodingAgentProviders, which
+// enumerates personal-credential coding providers: openai_chatgpt is the
+// Codex subscription/OAuth flavor (org-only), and openrouter is currently
+// only wired into personal LLM credentials, not the org fallback stack.
+var codingAuthProviders = []models.ProviderName{
+	models.ProviderAnthropic,
+	models.ProviderOpenAI,
+	models.ProviderOpenAIChatGPT,
+	models.ProviderGemini,
+	models.ProviderAmp,
+	models.ProviderPi,
+}
+
+// codingAuthProviderSQLList renders codingAuthProviders as a parenthesized
+// SQL value list (e.g. "('anthropic', 'openai', …)") for embedding directly
+// into `provider IN ...` clauses. Provider values are typed constants known
+// at compile time, so there is no SQL injection surface.
+var codingAuthProviderSQLList = func() string {
+	parts := make([]string, len(codingAuthProviders))
+	for i, p := range codingAuthProviders {
+		parts[i] = "'" + string(p) + "'"
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}()
+
+func isCodingAuthProvider(provider models.ProviderName) bool {
+	for _, p := range codingAuthProviders {
+		if p == provider {
+			return true
+		}
+	}
+	return false
+}
 
 // ErrCredentialLabelTaken is returned by InsertPendingAuth when the
 // (org, provider, label) tuple already references a credential that cannot
@@ -154,7 +193,6 @@ func (s *OrgCredentialStore) InsertPendingAuth(ctx context.Context, orgID uuid.U
 	// appears at the bottom of the fallback stack rather than carrying over an
 	// old position the user may not remember.
 	var id uuid.UUID
-	var labelTakenErr *ErrCredentialLabelTaken
 	err = s.withCodingAuthPriority(ctx, orgID, func(tx pgx.Tx, nextPriority int) error {
 		query := `
 			INSERT INTO org_credentials (org_id, provider, label, config, status, created_by, priority)
@@ -181,28 +219,23 @@ func (s *OrgCredentialStore) InsertPendingAuth(ctx context.Context, orgID uuid.U
 		if scanErr == nil {
 			return nil
 		}
-		if errors.Is(scanErr, pgx.ErrNoRows) {
-			// Conflict on (org, provider, label) but the existing row is
-			// active/invalid. Look up the actual status (still inside the
-			// transaction so the read is consistent with the failed insert)
-			// to surface a useful error to the caller.
-			var existingStatus string
-			lookupErr := tx.QueryRow(ctx,
-				`SELECT status FROM org_credentials WHERE org_id = @org_id AND provider = @provider AND label = @label`,
-				pgx.NamedArgs{"org_id": orgID, "provider": string(provider), "label": label},
-			).Scan(&existingStatus)
-			if lookupErr != nil {
-				labelTakenErr = &ErrCredentialLabelTaken{Label: label, ExistingStatus: "unknown"}
-			} else {
-				labelTakenErr = &ErrCredentialLabelTaken{Label: label, ExistingStatus: existingStatus}
-			}
-			return labelTakenErr
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("insert pending %s credential: %w", provider, scanErr)
 		}
-		return fmt.Errorf("insert pending %s credential: %w", provider, scanErr)
+		// Conflict on (org, provider, label) but the existing row is
+		// active/invalid. Look up the actual status (still inside the
+		// transaction so the read is consistent with the failed insert)
+		// to surface a useful error to the caller.
+		existingStatus := "unknown"
+		var status string
+		if lookupErr := tx.QueryRow(ctx,
+			`SELECT status FROM org_credentials WHERE org_id = @org_id AND provider = @provider AND label = @label`,
+			pgx.NamedArgs{"org_id": orgID, "provider": string(provider), "label": label},
+		).Scan(&status); lookupErr == nil {
+			existingStatus = status
+		}
+		return &ErrCredentialLabelTaken{Label: label, ExistingStatus: existingStatus}
 	})
-	if labelTakenErr != nil {
-		return nil, labelTakenErr
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +688,7 @@ func (s *OrgCredentialStore) ListCodingAuths(ctx context.Context, orgID uuid.UUI
 		FROM org_credentials
 		WHERE org_id = @org_id
 		  AND status != 'disabled'
-		  AND provider IN ('anthropic', 'openai', 'openai_chatgpt', 'gemini', 'amp', 'pi')
+		  AND provider IN ` + codingAuthProviderSQLList + `
 		ORDER BY priority, created_at`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"org_id": orgID})
@@ -724,22 +757,6 @@ func (s *OrgCredentialStore) ReorderCodingAuths(ctx context.Context, orgID uuid.
 	return tx.Commit(ctx)
 }
 
-// isCodingAuthProvider reports whether a provider participates in the
-// coding-agent fallback stack. Priority is only meaningful for these
-// providers; other credentials (GitHub, Sentry, …) keep the default.
-func isCodingAuthProvider(provider models.ProviderName) bool {
-	switch provider {
-	case models.ProviderAnthropic,
-		models.ProviderOpenAI,
-		models.ProviderOpenAIChatGPT,
-		models.ProviderGemini,
-		models.ProviderAmp,
-		models.ProviderPi:
-		return true
-	}
-	return false
-}
-
 // withCodingAuthPriority runs fn inside a transaction guarded by a per-org
 // advisory lock so that the priority lookup + INSERT pair is serialized
 // across concurrent callers in the same org. Without this, two simultaneous
@@ -779,7 +796,7 @@ func (s *OrgCredentialStore) withCodingAuthPriority(
 		SELECT COALESCE(MAX(priority), 0) + 1
 		FROM org_credentials
 		WHERE org_id = @org_id
-		  AND provider IN ('anthropic', 'openai', 'openai_chatgpt', 'gemini', 'amp', 'pi')
+		  AND provider IN `+codingAuthProviderSQLList+`
 		  AND status != 'disabled'`,
 		pgx.NamedArgs{"org_id": orgID},
 	).Scan(&nextPriority); err != nil {

--- a/internal/db/org_credentials_test.go
+++ b/internal/db/org_credentials_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 
@@ -167,6 +168,256 @@ func TestOrgCredentialStore_InsertPendingAuth(t *testing.T) {
 		require.NotNil(t, id, "InsertPendingAuth should return the resurrected row id")
 		require.Equal(t, existingID, *id, "InsertPendingAuth should return the existing id on resurrection")
 		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("returns ErrCredentialLabelTaken when label conflicts with active row", func(t *testing.T) {
+		t.Parallel()
+
+		// When the existing row is 'active' or 'invalid', the ON CONFLICT
+		// WHERE clause filters it out, so RETURNING produces zero rows
+		// (pgx.ErrNoRows). The handler then looks up the existing status to
+		// surface a typed *ErrCredentialLabelTaken so the API can render a
+		// status-aware message.
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(2))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 2).
+			WillReturnError(pgx.ErrNoRows)
+		mock.ExpectQuery(`SELECT status FROM org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a").
+			WillReturnRows(pgxmock.NewRows([]string{"status"}).AddRow("active"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		id, err := store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-3"})
+		require.Nil(t, id, "InsertPendingAuth should not return an id when the label is taken")
+		require.Error(t, err, "InsertPendingAuth should return an error when the label is taken")
+		var taken *ErrCredentialLabelTaken
+		require.ErrorAs(t, err, &taken, "InsertPendingAuth should return ErrCredentialLabelTaken")
+		require.Equal(t, "team-a", taken.Label, "ErrCredentialLabelTaken should carry the label")
+		require.Equal(t, "active", taken.ExistingStatus, "ErrCredentialLabelTaken should carry the actual existing status")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("returns ErrCredentialLabelTaken with unknown status when the lookup fails", func(t *testing.T) {
+		t.Parallel()
+
+		// If the status lookup itself fails (e.g. the row vanished between
+		// the failed insert and the SELECT), surface a generic
+		// ExistingStatus="unknown" rather than swallow the conflict.
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(2))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 2).
+			WillReturnError(pgx.ErrNoRows)
+		mock.ExpectQuery(`SELECT status FROM org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a").
+			WillReturnError(errors.New("connection lost"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-4"})
+		require.Error(t, err, "InsertPendingAuth should return an error when status lookup fails")
+		var taken *ErrCredentialLabelTaken
+		require.ErrorAs(t, err, &taken, "InsertPendingAuth should still return ErrCredentialLabelTaken")
+		require.Equal(t, "unknown", taken.ExistingStatus, "ErrCredentialLabelTaken should fall back to 'unknown' status")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("wraps non-conflict insert errors", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(2))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 2).
+			WillReturnError(errors.New("disk full"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-5"})
+		require.Error(t, err, "InsertPendingAuth should surface non-conflict insert errors")
+		require.NotErrorIs(t, err, &ErrCredentialLabelTaken{}, "non-conflict errors should not be reported as label-taken")
+		require.Contains(t, err.Error(), "insert pending", "InsertPendingAuth should wrap the insert failure")
+	})
+}
+
+// TestOrgCredentialStore_WithCodingAuthPriorityErrors covers the error paths
+// in the priority-locking helper: missing transaction support, advisory lock
+// failure, and priority-query failure all bubble up so the caller can
+// distinguish them from the surrounding work.
+func TestOrgCredentialStore_WithCodingAuthPriorityErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects non-transactional stores", func(t *testing.T) {
+		t.Parallel()
+
+		// Plain DBTX without Begin satisfies the store but not TxStarter.
+		// Use a direct UpsertWithLabel call for a coding provider so the
+		// helper is exercised. noTxDB is defined in session_store_test.go.
+		store := NewOrgCredentialStore(noTxDB{}, nil)
+		_, err := store.UpsertWithLabel(context.Background(), uuid.New(), nil, "team-a", models.AnthropicConfig{APIKey: "sk-ant"})
+		require.Error(t, err, "UpsertWithLabel should reject non-transactional stores for coding providers")
+		require.Contains(t, err.Error(), "does not support transactions")
+	})
+
+	t.Run("surfaces Begin failures", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		mock.ExpectBegin().WillReturnError(errors.New("connection reset"))
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.UpsertWithLabel(context.Background(), uuid.New(), nil, "team-a", models.AnthropicConfig{APIKey: "sk-ant"})
+		require.Error(t, err, "UpsertWithLabel should surface Begin failures")
+		require.Contains(t, err.Error(), "begin priority transaction")
+	})
+}
+
+// TestOrgCredentialStore_CreateCodingAuthErrors covers the failure branches
+// inside the CreateCodingAuth INSERT closure so the diff-coverage gate sees
+// these lines exercised.
+func TestOrgCredentialStore_CreateCodingAuthErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wraps insert query failures", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"next_priority"}).AddRow(1))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai", "Codex backup", pgxmock.AnyArg(), 1, &userID).
+			WillReturnError(errors.New("constraint violation"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.CreateCodingAuth(context.Background(), orgID, &userID, models.CreateCodingAuthInput{
+			Agent:    models.AgentTypeCodex,
+			AuthType: models.CodingAuthTypeAPIKey,
+			Label:    "Codex backup",
+			APIKey:   "sk-test",
+		})
+		require.Error(t, err, "CreateCodingAuth should surface query failures")
+		require.Contains(t, err.Error(), "create coding auth")
+	})
+
+	t.Run("wraps row collection failures", func(t *testing.T) {
+		t.Parallel()
+
+		// Returning zero rows from RETURNING tricks pgx.CollectOneRow into
+		// returning ErrNoRows, exercising the cerr branch.
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"next_priority"}).AddRow(1))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai", "Codex backup", pgxmock.AnyArg(), 1, &userID).
+			WillReturnRows(pgxmock.NewRows(codingAuthColumns))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.CreateCodingAuth(context.Background(), orgID, &userID, models.CreateCodingAuthInput{
+			Agent:    models.AgentTypeCodex,
+			AuthType: models.CodingAuthTypeAPIKey,
+			Label:    "Codex backup",
+			APIKey:   "sk-test",
+		})
+		require.Error(t, err, "CreateCodingAuth should surface CollectOneRow failures")
+		require.Contains(t, err.Error(), "create coding auth")
+	})
+
+	t.Run("surfaces advisory lock failures", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnError(errors.New("lock timeout"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.UpsertWithLabel(context.Background(), uuid.New(), nil, "team-a", models.AnthropicConfig{APIKey: "sk-ant"})
+		require.Error(t, err, "UpsertWithLabel should surface advisory lock failures")
+		require.Contains(t, err.Error(), "acquire priority lock")
+	})
+
+	t.Run("surfaces priority query failures", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnError(errors.New("planner exploded"))
+		mock.ExpectRollback()
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.UpsertWithLabel(context.Background(), uuid.New(), nil, "team-a", models.AnthropicConfig{APIKey: "sk-ant"})
+		require.Error(t, err, "UpsertWithLabel should surface priority query failures")
+		require.Contains(t, err.Error(), "get next coding auth priority")
 	})
 }
 

--- a/internal/db/org_credentials_test.go
+++ b/internal/db/org_credentials_test.go
@@ -31,36 +31,51 @@ func TestOrgCredentialStore_Upsert(t *testing.T) {
 			name: "upserts anthropic config",
 			cfg:  models.AnthropicConfig{APIKey: "sk-ant-test", BaseURL: ""},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectBegin()
+				mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("SELECT", 1))
 				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
 					WithArgs(pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+				mock.ExpectCommit()
 			},
 		},
 		{
 			name: "upserts openai config",
 			cfg:  models.OpenAIConfig{APIKey: "sk-test", APIType: "chat"},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectBegin()
+				mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("SELECT", 1))
 				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
 					WithArgs(pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+				mock.ExpectCommit()
 			},
 		},
 		{
 			name: "db error",
 			cfg:  models.AnthropicConfig{APIKey: "sk-ant-test"},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectBegin()
+				mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnResult(pgxmock.NewResult("SELECT", 1))
 				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
 					WithArgs(pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(fmt.Errorf("connection refused"))
+				mock.ExpectRollback()
 			},
 			expectErr: true,
 		},
@@ -101,12 +116,17 @@ func TestOrgCredentialStore_InsertPendingAuth(t *testing.T) {
 
 		orgID := uuid.New()
 		newID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
 		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
 			WithArgs(orgID).
 			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(3))
 		mock.ExpectQuery(`INSERT INTO org_credentials`).
 			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 3).
 			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(newID))
+		mock.ExpectCommit()
 
 		store := NewOrgCredentialStore(mock, nil)
 		id, err := store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-1"})
@@ -116,30 +136,64 @@ func TestOrgCredentialStore_InsertPendingAuth(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	})
 
-	t.Run("does not assign priority for non-coding providers", func(t *testing.T) {
+	t.Run("bumps priority when resurrecting a disabled row", func(t *testing.T) {
 		t.Parallel()
 
-		// UpsertWithLabel must skip the MAX(priority) lookup for non-coding
-		// providers — priority is meaningful only for the coding-agent
-		// fallback stack. The mock is configured to fail loudly if an
-		// unexpected query arrives (no MAX(priority) expectation set).
+		// The ON CONFLICT clause includes a CASE that uses EXCLUDED.priority
+		// when the existing row's status is 'disabled'. This test verifies the
+		// SQL still passes the new priority through so the row appears at the
+		// bottom of the stack on resurrection rather than reusing a stale slot.
 		mock, err := pgxmock.NewPool()
 		require.NoError(t, err, "creating mock pool should not error")
 		defer mock.Close()
 
 		orgID := uuid.New()
-		mock.ExpectQuery(`INSERT INTO org_credentials`).
-			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+		existingID := uuid.New()
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(5))
+		mock.ExpectQuery(`(?s)INSERT INTO org_credentials.*EXCLUDED\.priority`).
+			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 5).
+			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(existingID))
+		mock.ExpectCommit()
 
 		store := NewOrgCredentialStore(mock, nil)
-		_, err = store.UpsertWithLabel(context.Background(), orgID, nil, "github-oauth", models.GitHubOAuthConfig{
-			ClientID:    "client",
-			AccessToken: "gho_test",
-		})
-		require.NoError(t, err, "UpsertWithLabel should not return an error for non-coding providers")
-		require.NoError(t, mock.ExpectationsWereMet(), "no MAX(priority) query should be issued for non-coding providers")
+		id, err := store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-2"})
+		require.NoError(t, err, "InsertPendingAuth should not return an error on resurrection")
+		require.NotNil(t, id, "InsertPendingAuth should return the resurrected row id")
+		require.Equal(t, existingID, *id, "InsertPendingAuth should return the existing id on resurrection")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	})
+}
+
+// TestOrgCredentialStore_UpsertWithLabel_NonCodingProvider verifies the
+// priority gating: priority is meaningful only for the coding-agent fallback
+// stack, so non-coding providers (GitHub/Sentry/Linear/Notion) must skip the
+// MAX(priority) lookup entirely. The mock fails loudly if an unexpected
+// SELECT fires.
+func TestOrgCredentialStore_UpsertWithLabel_NonCodingProvider(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "creating mock pool should not error")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	mock.ExpectQuery(`INSERT INTO org_credentials`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	store := NewOrgCredentialStore(mock, nil)
+	_, err = store.UpsertWithLabel(context.Background(), orgID, nil, "github-oauth", models.GitHubOAuthConfig{
+		ClientID:    "client",
+		AccessToken: "gho_test",
+	})
+	require.NoError(t, err, "UpsertWithLabel should not return an error for non-coding providers")
+	require.NoError(t, mock.ExpectationsWereMet(), "no MAX(priority) query should be issued for non-coding providers")
 }
 
 func TestOrgCredentialStore_Get(t *testing.T) {
@@ -907,6 +961,10 @@ func TestOrgCredentialStore_CodingAuthCRUDAndHelpers(t *testing.T) {
 		defer mock.Close()
 
 		configData := crypto.DevEncrypt([]byte(`{"api_key":"sk-test-123","api_type":"responses"}`))
+		mock.ExpectBegin()
+		mock.ExpectExec(`SELECT pg_advisory_xact_lock`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("SELECT", 1))
 		mock.ExpectQuery(`(?s)SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
 			WithArgs(orgID).
 			WillReturnRows(pgxmock.NewRows([]string{"next_priority"}).AddRow(4))
@@ -914,6 +972,7 @@ func TestOrgCredentialStore_CodingAuthCRUDAndHelpers(t *testing.T) {
 			WithArgs(orgID, "openai", "Codex backup", pgxmock.AnyArg(), 4, &userID).
 			WillReturnRows(pgxmock.NewRows(codingAuthColumns).
 				AddRow(rowID, orgID, "openai", "Codex backup", configData, "active", 4, nil, nil, &userID, now, now))
+		mock.ExpectCommit()
 
 		store := NewOrgCredentialStore(mock, nil)
 		row, err := store.CreateCodingAuth(context.Background(), orgID, &userID, models.CreateCodingAuthInput{

--- a/internal/db/org_credentials_test.go
+++ b/internal/db/org_credentials_test.go
@@ -31,8 +31,11 @@ func TestOrgCredentialStore_Upsert(t *testing.T) {
 			name: "upserts anthropic config",
 			cfg:  models.AnthropicConfig{APIKey: "sk-ant-test", BaseURL: ""},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 			},
 		},
@@ -40,8 +43,11 @@ func TestOrgCredentialStore_Upsert(t *testing.T) {
 			name: "upserts openai config",
 			cfg:  models.OpenAIConfig{APIKey: "sk-test", APIType: "chat"},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 			},
 		},
@@ -49,8 +55,11 @@ func TestOrgCredentialStore_Upsert(t *testing.T) {
 			name: "db error",
 			cfg:  models.AnthropicConfig{APIKey: "sk-ant-test"},
 			setupMock: func(mock pgxmock.PgxPoolIface) {
+				mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+					WithArgs(pgxmock.AnyArg()).
+					WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(1))
 				mock.ExpectQuery("INSERT INTO org_credentials").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(fmt.Errorf("connection refused"))
 			},
 			expectErr: true,
@@ -78,6 +87,59 @@ func TestOrgCredentialStore_Upsert(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestOrgCredentialStore_InsertPendingAuth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("assigns next priority when inserting a fresh pending auth", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		newID := uuid.New()
+		mock.ExpectQuery(`SELECT COALESCE\(MAX\(priority\), 0\) \+ 1`).
+			WithArgs(orgID).
+			WillReturnRows(pgxmock.NewRows([]string{"priority"}).AddRow(3))
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(orgID, "openai_chatgpt", "team-a", pgxmock.AnyArg(), pgxmock.AnyArg(), 3).
+			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(newID))
+
+		store := NewOrgCredentialStore(mock, nil)
+		id, err := store.InsertPendingAuth(context.Background(), orgID, nil, "team-a", models.OpenAIChatGPTConfig{DeviceAuthID: "dev-1"})
+		require.NoError(t, err, "InsertPendingAuth should not return an error")
+		require.NotNil(t, id, "InsertPendingAuth should return the new row id")
+		require.Equal(t, newID, *id, "InsertPendingAuth should return the inserted id")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("does not assign priority for non-coding providers", func(t *testing.T) {
+		t.Parallel()
+
+		// UpsertWithLabel must skip the MAX(priority) lookup for non-coding
+		// providers — priority is meaningful only for the coding-agent
+		// fallback stack. The mock is configured to fail loudly if an
+		// unexpected query arrives (no MAX(priority) expectation set).
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		mock.ExpectQuery(`INSERT INTO org_credentials`).
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+		store := NewOrgCredentialStore(mock, nil)
+		_, err = store.UpsertWithLabel(context.Background(), orgID, nil, "github-oauth", models.GitHubOAuthConfig{
+			ClientID:    "client",
+			AccessToken: "gho_test",
+		})
+		require.NoError(t, err, "UpsertWithLabel should not return an error for non-coding providers")
+		require.NoError(t, mock.ExpectationsWereMet(), "no MAX(priority) query should be issued for non-coding providers")
+	})
 }
 
 func TestOrgCredentialStore_Get(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes five UX/correctness bugs on the Coding Agents settings page reported from the screenshot:

- The Codex/Claude OAuth modal was rendered behind the Add-auth dialog. The Add-auth dialog now closes when the secondary modal opens, and cancelling the secondary modal resets state.
- Removed the redundant double-up-arrow (move-to-top) action button per row; kept single up/down arrows. Added a Pencil edit button that opens the detail Sheet, pre-fills the rename input with the current label, and renames the destructive button "Disable" → "Remove".
- Implemented working drag-and-drop reorder with HTML5 DnD: the drop zone splits into top/bottom halves with a primary-colored before/after indicator on the hovered row.
- New auths were getting `priority = 1000` (the column default) because `InsertPendingAuth` and `UpsertWithLabel` skipped the priority calculation. Both now compute `MAX(priority) + 1` for coding-agent providers (Anthropic/OpenAI/Gemini/Amp/Pi/ChatGPT) while leaving non-coding providers (GitHub/Sentry/Linear/Notion) untouched. Disabled-row resurrection bumps priority to the bottom of the stack.

## Test plan
- [x] `make lint` (backend)
- [x] `go test -short ./internal/db/... ./internal/services/codexauth/... ./internal/services/claudecodeauth/... ./internal/api/handlers/...`
- [x] `npm run typecheck && npm run lint && npx vitest run` (1471 tests pass; +7 new `reorderRows` cases, +2 new `InsertPendingAuth` cases)
- [ ] Manual: add Codex subscription and verify the OAuth modal is foreground and the new row gets priority N+1
- [ ] Manual: drag rows up and down; confirm the before/after indicator and drop position
- [ ] Manual: open the edit Sheet via the Pencil icon; rename and remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)
