### PR TITLE
Fix PREVIEW_NO_WORKERS by persisting per-host worker identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,10 +299,41 @@ secrets-rotate:
 #   make provision-db     HOST=87.99.157.55
 #   make provision-redis  HOST=10.0.0.50
 #
+# Worker-only env vars (per-host identity, written to /opt/143/.env.local
+# and preserved across deploys):
+#   WORKER_PRIVATE_IP            — auto-detected via SSH if unset
+#   NODE_ID                      — defaults to "worker-<last octet of WORKER_PRIVATE_IP>"
+#   PREVIEW_INTERNAL_BASE_URL    — defaults to "http://${WORKER_PRIVATE_IP}:8080"
+#
+# Example with overrides:
+#   make provision-worker HOST=87.99.158.39 WORKER_PRIVATE_IP=10.0.0.4 NODE_ID=worker-1
+#
 # To tear down and reprovision an existing node:
 #   make provision-app    HOST=87.99.150.138  REPROVISION=true
+#
+# Migration note for fleets provisioned before /opt/143/.env.local existed:
+# `make deploy-worker` against such a host fails loudly at the secrets step
+# with "ERROR: /opt/143/.env.local is missing on this host." To recover,
+# either run `make provision-worker HOST=<host> REPROVISION=true` (tears
+# down the worker container — drains active jobs first) or seed .env.local
+# manually:
+#   ssh deploy@<host> 'cat > /opt/143/.env.local <<EOF
+#   NODE_ID=worker-N
+#   WORKER_PRIVATE_IP=10.0.0.N
+#   PREVIEW_INTERNAL_BASE_URL=http://10.0.0.N:8080
+#   EOF
+#   chmod 600 /opt/143/.env.local'
 
 REPROVISION ?=
+
+# Per-host worker identity (forwarded as env vars to provision.sh / deploy.sh
+# so users can write `make provision-worker HOST=… WORKER_PRIVATE_IP=…` instead
+# of prefixing the env var on the command line). Empty by default; provision.sh
+# auto-detects WORKER_PRIVATE_IP via SSH when unset and derives NODE_ID and
+# PREVIEW_INTERNAL_BASE_URL from it.
+export WORKER_PRIVATE_IP
+export NODE_ID
+export PREVIEW_INTERNAL_BASE_URL
 
 # Auto-detect SSH key: use ~/.ssh/143-deploy if it exists.
 SSH_KEY ?= $(wildcard ~/.ssh/143-deploy)

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -13,10 +13,17 @@
 #   export GITHUB_APP_CLIENT_ID="Iv1.0123456789abcdef"
 #   export GITHUB_APP_CLIENT_SECRET="your_github_app_client_secret"
 #   export NODE_ID="worker-1"
-#   export PREVIEW_INTERNAL_BASE_URL="http://10.0.0.12:8080"
+#   export WORKER_PRIVATE_IP="10.0.0.12"            # this worker's private IPv4
+#   export PREVIEW_INTERNAL_BASE_URL="http://10.0.0.12:8080"  # usually http://${WORKER_PRIVATE_IP}:8080
 #   export CHROME_WS_URL="ws://chrome:9222"
 #   export REPO_URL="https://github.com/assembledhq/143.git"
 #   envsubst < deploy/cloud-init/worker.yml > /tmp/user-data.yml
+#
+# NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL are *per-host*
+# identity. They are written to /opt/143/.env.local once at bootstrap and
+# preserved across deploys (deploy.sh only rewrites /opt/143/.env, then
+# concatenates .env.local back in for docker compose). This split is what
+# lets the same .env.production.enc deploy to every worker in the fleet.
 
 users:
   - name: deploy
@@ -69,6 +76,12 @@ runcmd:
   # Apply kernel tuning
   - sysctl -p /etc/sysctl.d/99-worker.conf
 
+  # Concatenate per-host identity (.env.local) into the shared .env so docker
+  # compose can interpolate ${NODE_ID}, ${WORKER_PRIVATE_IP}, etc. when it
+  # parses docker-compose.worker.yml. Subsequent deploys (deploy.sh) repeat
+  # this step so .env.local stays the source of truth for per-host values.
+  - su - deploy -c 'cat /opt/143/.env.local >> /opt/143/.env'
+
   # Start the worker
   - su - deploy -c 'cd /opt/143 && docker compose -f docker-compose.worker.yml up -d --remove-orphans'
 
@@ -84,9 +97,18 @@ write_files:
       DB_HOST=${DB_HOST}
       GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID}
       GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}
-      NODE_ID=${NODE_ID}
-      PREVIEW_INTERNAL_BASE_URL=${PREVIEW_INTERNAL_BASE_URL}
       CHROME_WS_URL=${CHROME_WS_URL}
+
+  # Per-host identity. Stays put across deploys — deploy.sh only rewrites
+  # /opt/143/.env, then re-appends this file. If you re-IP the host or
+  # rename the node, edit this file directly and `docker compose up -d`.
+  - path: /opt/143/.env.local
+    owner: deploy:deploy
+    permissions: '0600'
+    content: |
+      NODE_ID=${NODE_ID}
+      WORKER_PRIVATE_IP=${WORKER_PRIVATE_IP}
+      PREVIEW_INTERNAL_BASE_URL=${PREVIEW_INTERNAL_BASE_URL}
 
   - path: /opt/143/.ghcr-token
     owner: deploy:deploy

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -32,3 +32,41 @@ func TestWorkerProvisioningIncludesGitHubAppUserAuthSecrets(t *testing.T) {
 	require.Contains(t, string(provisionScript), "GITHUB_APP_CLIENT_ID=%s", "worker reprovision path should write the GitHub App user auth client ID into .env")
 	require.Contains(t, string(provisionScript), "GITHUB_APP_CLIENT_SECRET=%s", "worker reprovision path should write the GitHub App user auth client secret into .env")
 }
+
+// Worker preview routing requires three per-host values: NODE_ID,
+// WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL. They live in
+// /opt/143/.env.local (not the shared .env that gets rewritten on every
+// deploy). If we ever stop writing or appending that file, every preview
+// start will fail with PREVIEW_NO_WORKERS — guard the wiring here so that
+// regression is loud at PR time, not at production start-preview time.
+func TestWorkerPerHostIdentityIsPreservedAcrossDeploys(t *testing.T) {
+	t.Parallel()
+
+	compose, err := os.ReadFile("../docker-compose.worker.yml")
+	require.NoError(t, err, "test should read the worker compose file")
+	require.Contains(t, string(compose), "${WORKER_PRIVATE_IP:?", "worker compose should bind port 8080 to the worker's private IP and fail loudly if WORKER_PRIVATE_IP is unset (binding to 0.0.0.0 would expose the internal preview API)")
+	require.Contains(t, string(compose), "${NODE_ID:?", "worker compose should require NODE_ID rather than silently falling back to a random container hostname")
+	require.Contains(t, string(compose), "${PREVIEW_INTERNAL_BASE_URL:?", "worker compose should require PREVIEW_INTERNAL_BASE_URL — without it, parseWorkerNode rejects the node and StartPreview returns PREVIEW_NO_WORKERS")
+	require.Contains(t, string(compose), ":8080:8080", "worker compose should publish port 8080 so the app node can reach the worker's internal preview API")
+
+	cloudInit, err := os.ReadFile("../deploy/cloud-init/worker.yml")
+	require.NoError(t, err, "test should read the worker cloud-init template")
+	require.Contains(t, string(cloudInit), "/opt/143/.env.local", "worker cloud-init should write per-host identity to .env.local so deploy.sh can preserve it across deploys")
+	require.Contains(t, string(cloudInit), "NODE_ID=${NODE_ID}", "worker cloud-init should populate NODE_ID in .env.local")
+	require.Contains(t, string(cloudInit), "WORKER_PRIVATE_IP=${WORKER_PRIVATE_IP}", "worker cloud-init should populate WORKER_PRIVATE_IP in .env.local")
+	require.Contains(t, string(cloudInit), "PREVIEW_INTERNAL_BASE_URL=${PREVIEW_INTERNAL_BASE_URL}", "worker cloud-init should populate PREVIEW_INTERNAL_BASE_URL in .env.local")
+	require.Contains(t, string(cloudInit), "cat /opt/143/.env.local >> /opt/143/.env", "worker cloud-init should concatenate .env.local into .env so docker compose can interpolate ${WORKER_PRIVATE_IP} etc.")
+
+	provisionScript, err := os.ReadFile("../deploy/scripts/provision.sh")
+	require.NoError(t, err, "test should read the provisioning script")
+	require.Contains(t, string(provisionScript), "NODE_ID=%s", "provision.sh should write NODE_ID into .env.local")
+	require.Contains(t, string(provisionScript), "WORKER_PRIVATE_IP=%s", "provision.sh should write WORKER_PRIVATE_IP into .env.local")
+	require.Contains(t, string(provisionScript), "PREVIEW_INTERNAL_BASE_URL=%s", "provision.sh should write PREVIEW_INTERNAL_BASE_URL into .env.local")
+	require.Contains(t, string(provisionScript), "/opt/143/.env.local", "provision.sh should target /opt/143/.env.local")
+	require.Contains(t, string(provisionScript), "cat /opt/143/.env.local >> /opt/143/.env", "provision.sh should concatenate .env.local into .env after writing both")
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read the deploy script")
+	require.Contains(t, string(deployScript), "cat /opt/143/.env.local >> /opt/143/.env", "deploy.sh worker branch should re-append .env.local into .env on every deploy — without this, every secret refresh wipes the per-host identity")
+	require.Contains(t, string(deployScript), "/opt/143/.env.local is missing", "deploy.sh worker branch should abort loudly when .env.local is missing instead of coming up with empty NODE_ID and WORKER_PRIVATE_IP")
+}

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -97,10 +97,28 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for worker role (set it or add to .env.production.enc)}"
     : "${DB_HOST:?DB_HOST is required for worker role (set it or add to .env.production.enc)}"
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for worker role (set it or add to .env.production.enc)}"
+    # Refresh the shared secrets in /opt/143/.env, then re-append the per-host
+    # identity from /opt/143/.env.local (NODE_ID, WORKER_PRIVATE_IP,
+    # PREVIEW_INTERNAL_BASE_URL) so docker compose can still interpolate them
+    # when it parses the compose file. .env.local is owned by provisioning
+    # and we abort if it's missing instead of silently coming up with an
+    # empty NODE_ID and WORKER_PRIVATE_IP=0.0.0.0 (would expose worker to
+    # the public internet).
     printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nWORKER_PROCESS_COUNT=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\n' \
       "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       "${WORKER_PROCESS_COUNT:-}" "${SANDBOX_CPU_LIMIT:-}" "${SANDBOX_MEMORY_LIMIT_MB:-}" "${SANDBOX_DISK_LIMIT_GB:-}" \
-      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
+      | ssh "${SSH_OPTS[@]}" deploy@"$HOST" '
+          set -euo pipefail
+          cat > /opt/143/.env
+          chmod 600 /opt/143/.env
+          if [ ! -f /opt/143/.env.local ]; then
+            echo "ERROR: /opt/143/.env.local is missing on this host." >&2
+            echo "       It holds NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL." >&2
+            echo "       Re-run: make provision-worker HOST=<this-host>" >&2
+            exit 1
+          fi
+          cat /opt/143/.env.local >> /opt/143/.env
+        '
     scp "${SCP_OPTS[@]}" "$ENC_FILE" deploy@"$HOST":/opt/143/
     ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod 644 /opt/143/.env.production.enc"
   else

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -110,6 +110,46 @@ fi
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 
+# Per-host identity for workers. These are written to /opt/143/.env.local and
+# preserved across deploys (deploy.sh never overwrites .env.local). Auto-detect
+# WORKER_PRIVATE_IP from the host's outbound source address if the caller
+# didn't supply one. NODE_ID and PREVIEW_INTERNAL_BASE_URL get sensible
+# defaults derived from WORKER_PRIVATE_IP — override either via env var if
+# needed. Resolved values are echoed before writing so the operator can
+# eyeball them and Ctrl-C if something looks wrong.
+if [ "$ROLE" = "worker" ]; then
+  if [ -z "${WORKER_PRIVATE_IP:-}" ]; then
+    echo "Auto-detecting WORKER_PRIVATE_IP via SSH..."
+    # Pick the first private IPv4 on a real network interface, deliberately
+    # skipping docker/bridge/veth/loopback. A naive "first private IPv4"
+    # filter would silently return 172.17.0.1 (docker0) on hosts where the
+    # bridge enumerates before the NIC, and `ip route get 1.1.1.1` returns
+    # the *public* IP because the default route goes through the public NIC.
+    WORKER_PRIVATE_IP="$(ssh "${SSH_OPTS[@]}" root@"$HOST" \
+      'ip -4 -o addr show | awk "\$2 !~ /^(docker|br-|veth|virbr|lo)/ && /inet (10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)/ { split(\$4, a, \"/\"); print a[1]; exit }"')"
+    if [ -z "$WORKER_PRIVATE_IP" ]; then
+      echo "ERROR: could not auto-detect WORKER_PRIVATE_IP on $HOST."
+      echo "       Set WORKER_PRIVATE_IP=<ip> and re-run."
+      exit 1
+    fi
+  fi
+  # Default NODE_ID to "worker-<last octet of private IP>" — stable because
+  # the private IP is stable across reboots, and unique within a /24 fleet.
+  if [ -z "${NODE_ID:-}" ]; then
+    NODE_ID="worker-${WORKER_PRIVATE_IP##*.}"
+  fi
+  if [ -z "${PREVIEW_INTERNAL_BASE_URL:-}" ]; then
+    PREVIEW_INTERNAL_BASE_URL="http://${WORKER_PRIVATE_IP}:8080"
+  fi
+  # Echo resolved values before writing so the operator can eyeball them
+  # and Ctrl-C if a stray env var (e.g. NODE_ID leaked from a dev shell)
+  # is about to land on a production worker.
+  echo "Worker per-host identity for $HOST:"
+  echo "  WORKER_PRIVATE_IP         = $WORKER_PRIVATE_IP"
+  echo "  NODE_ID                   = $NODE_ID"
+  echo "  PREVIEW_INTERNAL_BASE_URL = $PREVIEW_INTERNAL_BASE_URL"
+fi
+
 # Check if already provisioned
 RUNNING=$(ssh "${SSH_OPTS[@]}" root@"$HOST" "su - deploy -c 'cd /opt/143 && docker compose -f $COMPOSE_FILE ps -q 2>/dev/null'" 2>/dev/null || true)
 if [ -n "$RUNNING" ]; then
@@ -222,6 +262,18 @@ elif [ "$ROLE" = "worker" ]; then
     "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" "${REDIS_TOPOLOGY:-standalone}" "${REDIS_PRIVATE_IP:-}" "${REDIS_PASSWORD:-}" "${GITHUB_APP_CLIENT_ID:-}" "${GITHUB_APP_CLIENT_SECRET:-}" \
     "${WORKER_PROCESS_COUNT:-}" "${SANDBOX_CPU_LIMIT:-}" "${SANDBOX_MEMORY_LIMIT_MB:-}" "${SANDBOX_DISK_LIMIT_GB:-}" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
+
+  # Per-host identity (NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL)
+  # lives in .env.local and survives every deploy — the secret refresh in
+  # deploy.sh only rewrites /opt/143/.env, then re-appends .env.local.
+  printf 'NODE_ID=%s\nWORKER_PRIVATE_IP=%s\nPREVIEW_INTERNAL_BASE_URL=%s\n' \
+    "$NODE_ID" "$WORKER_PRIVATE_IP" "$PREVIEW_INTERNAL_BASE_URL" \
+    | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env.local && chown deploy:deploy /opt/143/.env.local && chmod 600 /opt/143/.env.local'
+
+  # Concatenate so docker compose can interpolate ${WORKER_PRIVATE_IP} etc.
+  # when parsing docker-compose.worker.yml. deploy.sh repeats this on every
+  # deploy.
+  ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat /opt/143/.env.local >> /opt/143/.env'
 else
   # App nodes get the full secret set for SOPS decryption
   printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nREDIS_TOPOLOGY=%s\nREDIS_PRIVATE_IP=%s\nREDIS_PASSWORD=%s\n' "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" "${REDIS_TOPOLOGY:-standalone}" "${REDIS_PRIVATE_IP:-}" "${REDIS_PASSWORD:-}" \

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -44,14 +44,22 @@ services:
         condition: service_started
       gvisor-check:
         condition: service_completed_successfully
+    # NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL are per-host
+    # identity. They live in /opt/143/.env.local and are concatenated into
+    # /opt/143/.env by provision.sh / deploy.sh so docker compose can
+    # interpolate them below. The :? syntax fails the deploy loudly if any
+    # value is missing — without it, port 8080 would bind to 0.0.0.0 (exposes
+    # the internal preview API publicly) and the node would heartbeat without
+    # a preview_internal_base_url (StartPreview returns PREVIEW_NO_WORKERS).
+    # If any error below fires, run: make provision-worker HOST=<this-host>
     environment:
       DATABASE_URL: postgres://onefortythree:${DB_PASSWORD}@${DB_HOST}:5432/onefortythree?sslmode=disable
       ENV: production
       MODE: worker
       CHROME_WS_URL: ${CHROME_WS_URL:-ws://chrome:9222}
       MAX_CONCURRENT_RUNS: ${MAX_CONCURRENT_RUNS:-5}
-      NODE_ID: ${NODE_ID:-}
-      PREVIEW_INTERNAL_BASE_URL: ${PREVIEW_INTERNAL_BASE_URL:-}
+      NODE_ID: ${NODE_ID:?missing in /opt/143/.env.local}
+      PREVIEW_INTERNAL_BASE_URL: ${PREVIEW_INTERNAL_BASE_URL:?missing in /opt/143/.env.local}
       SANDBOX_IMAGE: ghcr.io/assembledhq/143-sandbox:${IMAGE_TAG:-latest}
       SANDBOX_RUNTIME: runsc
       SANDBOX_REQUIRE_GVISOR: "true"
@@ -61,6 +69,13 @@ services:
       SANDBOX_RESOLV_CONF: /etc/143/sandbox-resolv.conf
     env_file:
       - .env
+    # App nodes reach this worker at http://${WORKER_PRIVATE_IP}:8080 over the
+    # private fleet network to drive preview start/stop and proxy browser
+    # HTTP/WebSocket traffic. Binding to the private IP (not 0.0.0.0) keeps
+    # the internal API off the public interface — many providers already
+    # expose 8080 on the public IP for monitoring.
+    ports:
+      - "${WORKER_PRIVATE_IP:?missing in /opt/143/.env.local}:8080:8080"
     group_add:
       - ${DOCKER_GID:-988}
     volumes:


### PR DESCRIPTION
## Summary

Production was returning `PREVIEW_NO_WORKERS` on every Start Preview because `deploy.sh` rewrote `/opt/143/.env` on each deploy without `NODE_ID`, `WORKER_PRIVATE_IP`, or `PREVIEW_INTERNAL_BASE_URL`, leaving the worker's `nodes.metadata` row missing `preview_internal_base_url` so `parseWorkerNode` skipped it — and the worker container never published port 8080, so even with valid metadata the app node couldn't reach it. This change splits shared deploy secrets (`/opt/143/.env`) from per-host identity (`/opt/143/.env.local`, written once at provision time and re-appended on every deploy), binds port 8080 explicitly to the worker's private IP via `${WORKER_PRIVATE_IP:?...}` (fail-loud rather than the previous silent fallback to `0.0.0.0`), and auto-detects `WORKER_PRIVATE_IP` plus sensible defaults for `NODE_ID` and `PREVIEW_INTERNAL_BASE_URL` so `make provision-worker HOST=…` is usually enough.

## Test plan

- [ ] `go test ./deploy/...` passes (covers the new `TestWorkerPerHostIdentityIsPreservedAcrossDeploys` contract)
- [ ] `bash -n deploy/scripts/{provision,deploy}.sh` clean
- [ ] After merge, run `make provision-worker HOST=87.99.158.39 REPROVISION=true` (or the manual `.env.local` heredoc documented in the Makefile) and confirm `nodes.metadata` for the active worker now contains `preview_internal_base_url`
- [ ] From an app host, `curl -m 5 http://10.0.0.4:8080/healthz` returns OK
- [ ] Start a preview from the UI on the original failing session — no longer returns `PREVIEW_NO_WORKERS`
