### PR TITLE
Fix sandbox auth socket dir perms when dir pre-exists with 0755

### DIFF
--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -358,6 +358,15 @@ d /var/run/143 0755 root root -
 d /var/run/143/sandbox-auth 0750 1000 1000 -
 TMPFILES
       systemd-tmpfiles --create /etc/tmpfiles.d/143-sandbox-auth.conf
+      # Belt-and-suspenders: if the directory already existed (e.g. Docker
+      # auto-created the bind-mount source as root:root 0755 before this
+      # provision step ran, or an older provision left it 0755), tmpfiles
+      # --create's adjustment isn't always reliable across systemd
+      # versions. Force the desired ownership and mode explicitly so the
+      # orchestrator's assertParentDirPerms check passes on first boot.
+      mkdir -p /var/run/143/sandbox-auth
+      chown 1000:1000 /var/run/143/sandbox-auth
+      chmod 0750 /var/run/143/sandbox-auth
 PULL_WORKER
     ;;
   db|logging|redis)


### PR DESCRIPTION
The orchestrator's assertParentDirPerms check failed at session start
with "socket dir /var/run/143/sandbox-auth has insecure perms 0755".
The provision step relied on `systemd-tmpfiles --create` to drop the
mode to 0750, but if the directory already existed — either because
Docker auto-created the bind-mount source as root:root 0755 before
provision ran, or because an older provision wrote it that way —
tmpfiles --create did not reliably re-tighten it.

Add an explicit `mkdir -p` + `chown 1000:1000` + `chmod 0750` after
the tmpfiles invocation so re-provisioning fixes any pre-existing
bad state regardless of systemd-tmpfiles version behavior.

https://claude.ai/code/session_01V5GDrd96CamhwGRXscEFd2