### PR TITLE
Stop iOS Safari auto-zoom on input focus

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -152,4 +152,14 @@
   h1, h2, h3 {
     @apply tracking-tight;
   }
+  /* Prevent iOS Safari from auto-zooming when focusing form fields. Triggered
+     when computed font-size is <16px. Scoped to mobile widths so desktop
+     typography is unchanged. */
+  @media (max-width: 640px) {
+    input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+    textarea,
+    select {
+      font-size: 16px;
+    }
+  }
 }


### PR DESCRIPTION
iOS Safari zooms the page when focusing a form field whose computed
font-size is below 16px. The session input (and other inputs) inherit
text-xs (12px), which triggered the zoom and pushed the composer out of
view. Force inputs/textareas/selects to 16px under 640px to suppress the
zoom while leaving desktop typography untouched.