### PR TITLE
Harden worker auto-provisioning against /24 collisions and multi-homed hosts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,13 @@ secrets-rotate:
 #
 # Worker-only env vars (per-host identity, written to /opt/143/.env.local
 # and preserved across deploys):
-#   WORKER_PRIVATE_IP            — auto-detected via SSH if unset
-#   NODE_ID                      — defaults to "worker-<last octet of WORKER_PRIVATE_IP>"
+#   WORKER_PRIVATE_IP            — auto-detected via SSH if unset. Multi-homed
+#                                  hosts (cluster NIC + storage VLAN, etc.)
+#                                  abort with the candidate list so you can
+#                                  pick the one app nodes will reach.
+#   NODE_ID                      — defaults to "worker-<WORKER_PRIVATE_IP with
+#                                  dots replaced by dashes>" (e.g. worker-10-0-0-4),
+#                                  unique across the full RFC1918 space.
 #   PREVIEW_INTERNAL_BASE_URL    — defaults to "http://${WORKER_PRIVATE_IP}:8080"
 #
 # Example with overrides:

--- a/Makefile
+++ b/Makefile
@@ -328,6 +328,17 @@ secrets-rotate:
 #   PREVIEW_INTERNAL_BASE_URL=http://10.0.0.N:8080
 #   EOF
 #   chmod 600 /opt/143/.env.local'
+#
+# Reprovisioning leaves the old `nodes` row behind. nodes.id stores NODE_ID,
+# so a host that was provisioned as e.g. "worker-4" and later reprovisioned
+# under the new dotted-to-dash default ("worker-10-0-0-4") registers a fresh
+# row instead of updating the old one. The MarkStaleNodesDead reaper flips
+# the orphan to status='dead' once heartbeats stop, and ListActive filters
+# 'active'/'draining' only — so the orphan does NOT route preview traffic.
+# It just sits in the table until cleaned up. To delete it explicitly:
+#   psql "$DATABASE_URL" -c "DELETE FROM nodes WHERE id = 'worker-4' AND status = 'dead';"
+# Preserve old NODE_IDs across reprovision instead by passing the old value:
+#   make provision-worker HOST=<host> REPROVISION=true NODE_ID=worker-4
 
 REPROVISION ?=
 

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -70,3 +70,22 @@ func TestWorkerPerHostIdentityIsPreservedAcrossDeploys(t *testing.T) {
 	require.Contains(t, string(deployScript), "cat /opt/143/.env.local >> /opt/143/.env", "deploy.sh worker branch should re-append .env.local into .env on every deploy — without this, every secret refresh wipes the per-host identity")
 	require.Contains(t, string(deployScript), "/opt/143/.env.local is missing", "deploy.sh worker branch should abort loudly when .env.local is missing instead of coming up with empty NODE_ID and WORKER_PRIVATE_IP")
 }
+
+// The auto-default for NODE_ID must use the full IP (dotted-to-dash), not
+// just the last octet — otherwise a fleet that spans multiple /24s would
+// silently produce duplicate NODE_IDs (10.0.0.4 and 10.0.1.4 both mapping
+// to "worker-4"), and the worker registry would clobber one node's row
+// with the other's heartbeats.
+//
+// And auto-detection must refuse to guess on multi-homed hosts: picking
+// the wrong NIC's IP would publish a preview_internal_base_url that app
+// nodes can't reach, and start-preview would fail intermittently.
+func TestWorkerProvisioningHandlesAddressingEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	provisionScript, err := os.ReadFile("../deploy/scripts/provision.sh")
+	require.NoError(t, err, "test should read the provisioning script")
+	require.Contains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP//./-}`, "provision.sh's NODE_ID default should use the full dotted-to-dash IP so workers across multiple /24s don't collide on \"worker-<last-octet>\"")
+	require.NotContains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP##*.}`, "provision.sh should not fall back to the last-octet-only default — it collides across /24s")
+	require.Contains(t, string(provisionScript), "private IPv4 addresses on real interfaces", "provision.sh should detect multi-homed hosts and require the operator to set WORKER_PRIVATE_IP explicitly rather than silently picking a NIC")
+}

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -120,23 +120,37 @@ SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 if [ "$ROLE" = "worker" ]; then
   if [ -z "${WORKER_PRIVATE_IP:-}" ]; then
     echo "Auto-detecting WORKER_PRIVATE_IP via SSH..."
-    # Pick the first private IPv4 on a real network interface, deliberately
+    # Enumerate every private IPv4 on a real network interface, deliberately
     # skipping docker/bridge/veth/loopback. A naive "first private IPv4"
     # filter would silently return 172.17.0.1 (docker0) on hosts where the
     # bridge enumerates before the NIC, and `ip route get 1.1.1.1` returns
     # the *public* IP because the default route goes through the public NIC.
-    WORKER_PRIVATE_IP="$(ssh "${SSH_OPTS[@]}" root@"$HOST" \
-      'ip -4 -o addr show | awk "\$2 !~ /^(docker|br-|veth|virbr|lo)/ && /inet (10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)/ { split(\$4, a, \"/\"); print a[1]; exit }"')"
-    if [ -z "$WORKER_PRIVATE_IP" ]; then
+    # We collect candidates (no awk `exit`) so multi-homed hosts surface as
+    # an error rather than silently picking whichever NIC enumerates first.
+    WORKER_PRIVATE_IP_CANDIDATES="$(ssh "${SSH_OPTS[@]}" root@"$HOST" \
+      'ip -4 -o addr show | awk "\$2 !~ /^(docker|br-|veth|virbr|lo)/ && /inet (10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)/ { split(\$4, a, \"/\"); print a[1] }"')"
+    CANDIDATE_COUNT="$(printf '%s\n' "$WORKER_PRIVATE_IP_CANDIDATES" | grep -c . || true)"
+    if [ "$CANDIDATE_COUNT" -eq 0 ]; then
       echo "ERROR: could not auto-detect WORKER_PRIVATE_IP on $HOST."
       echo "       Set WORKER_PRIVATE_IP=<ip> and re-run."
       exit 1
+    elif [ "$CANDIDATE_COUNT" -gt 1 ]; then
+      # Multi-homed hosts (e.g. cluster NIC + storage VLAN) need the operator
+      # to disambiguate — the worker registers exactly one preview URL, and
+      # silently picking the wrong NIC would make app→worker traffic dead.
+      echo "ERROR: $HOST has $CANDIDATE_COUNT private IPv4 addresses on real interfaces:"
+      printf '%s\n' "$WORKER_PRIVATE_IP_CANDIDATES" | sed 's/^/         /'
+      echo "       Pick the one app nodes will reach and re-run with WORKER_PRIVATE_IP=<ip>."
+      exit 1
     fi
+    WORKER_PRIVATE_IP="$WORKER_PRIVATE_IP_CANDIDATES"
   fi
-  # Default NODE_ID to "worker-<last octet of private IP>" — stable because
-  # the private IP is stable across reboots, and unique within a /24 fleet.
+  # Default NODE_ID to "worker-<dotted-to-dash private IP>" — stable because
+  # the private IP is stable across reboots, and unique across the full
+  # RFC1918 space (a last-octet-only default would collide whenever the
+  # fleet spans more than one /24, e.g. 10.0.0.4 and 10.0.1.4).
   if [ -z "${NODE_ID:-}" ]; then
-    NODE_ID="worker-${WORKER_PRIVATE_IP##*.}"
+    NODE_ID="worker-${WORKER_PRIVATE_IP//./-}"
   fi
   if [ -z "${PREVIEW_INTERNAL_BASE_URL:-}" ]; then
     PREVIEW_INTERNAL_BASE_URL="http://${WORKER_PRIVATE_IP}:8080"


### PR DESCRIPTION
## Summary

Follow-ups to #596 from the post-merge review:

- **`NODE_ID` default now uses the full IP** (dotted-to-dash, e.g. `worker-10-0-0-4`) instead of just the last octet. The previous `worker-${WORKER_PRIVATE_IP##*.}` default would silently produce duplicate `NODE_ID`s whenever the fleet spanned more than one /24 (e.g. `10.0.0.4` and `10.0.1.4` both became `worker-4`), causing the worker registry to clobber one node's heartbeat row with the other's.
- **Auto-detection refuses to guess on multi-homed hosts.** If more than one RFC1918 IPv4 is bound to a real interface, the candidate list is printed and the operator is required to set `WORKER_PRIVATE_IP=<ip>` explicitly. Picking the wrong NIC's IP would publish a `preview_internal_base_url` that app nodes can't route to, and `StartPreview` would fail intermittently from each app node depending on which network they share with the worker.
- **Makefile help** documents both behaviors so the operator sees the new defaults and the multi-homed requirement at the top of the worker-provisioning workflow.
- **Contract test** (`TestWorkerProvisioningHandlesAddressingEdgeCases`) guards the dotted-to-dash default and the multi-homed error message so a future refactor that regresses either fails at PR time, not at production startup.

## Test plan

- [ ] `go test ./deploy/...` passes (covers the new contract test)
- [ ] `bash -n deploy/scripts/provision.sh` clean
- [ ] On a single-NIC worker host: `make provision-worker HOST=<host>` resolves `NODE_ID=worker-<dashed-ip>` and proceeds
- [ ] On a multi-homed host (or a host with a manually-added second private IP): `make provision-worker HOST=<host>` exits with the candidate list and the "Pick the one app nodes will reach" hint
- [ ] On a host where the operator sets `WORKER_PRIVATE_IP=<ip>` and `NODE_ID=<custom>`: those overrides bypass detection and the dashed default

🤖 Generated with [Claude Code](https://claude.com/claude-code)