### PR TITLE
Animate ellipsis on Running/Pending session list rows

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useQueryState, parseAsString } from "nuqs";
 import { cn, formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { api } from "@/lib/api";
@@ -138,7 +139,10 @@ function OptimisticSessionRow({ session }: { session: OptimisticSession }) {
             {session.title}
           </p>
           <div className="flex items-center gap-3 mt-0.5">
-            <span className="text-xs text-muted-foreground shrink-0">{cfg.label}</span>
+            <span className="text-xs text-muted-foreground shrink-0">
+              <span>{cfg.label}</span>
+              <AnimatedEllipsis />
+            </span>
             <span className="text-xs text-muted-foreground/50">just now</span>
           </div>
         </div>
@@ -473,7 +477,8 @@ export function SessionSidebar() {
                   <div className="flex items-center justify-between mt-0.5">
                     <div className="flex items-center gap-3 min-w-0">
                       <span className="text-xs text-muted-foreground shrink-0">
-                        {cfg.label}
+                        <span>{cfg.label}</span>
+                        {isWorkingSession && <AnimatedEllipsis />}
                       </span>
                       {session.pm_plan_id && !session.triggered_by_user_id && (
                         <span className="inline-flex items-center rounded-full bg-primary/10 px-1.5 py-0.5 text-xs font-medium text-primary shrink-0">

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -31,6 +31,7 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { formatTimeAgo, sessionTitle } from "@/lib/utils";
 import { StatusDot } from "@/components/status-dot";
+import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
 import { SessionOwnerToggle } from "./session-owner-toggle";
@@ -108,10 +109,14 @@ function buildColumns(members: User[]): ColumnDef<Session>[] {
       cell: ({ row }) => {
         const status = row.original.status;
         const cfg = statusConfig[status] || statusConfig.pending;
+        const working = workingSet.has(status);
         return (
           <div className="flex items-center gap-2">
             <SessionStatusDot status={status} />
-            <span className={`text-xs font-medium ${cfg.text}`}>{cfg.label}</span>
+            <span className={`text-xs font-medium ${cfg.text}`}>
+              <span>{cfg.label}</span>
+              {working && <AnimatedEllipsis />}
+            </span>
           </div>
         );
       },

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -136,6 +136,39 @@
   -webkit-mask-image: linear-gradient(to right, black calc(100% - 24px), transparent 100%);
 }
 
+/* Animated ellipsis used by <AnimatedEllipsis /> for "Running" / "Pending"
+   states. 1.6s full cycle: each dot fades in 400ms apart, all three fade out
+   together, then the cycle restarts. Calm-but-alive pacing — slower than a
+   loading spinner, faster than a pulse. */
+@keyframes ellipsis-dot-fade-1 {
+  0%, 80%, 100% { opacity: 0; }
+  5%, 75% { opacity: 1; }
+}
+@keyframes ellipsis-dot-fade-2 {
+  0%, 25%, 80%, 100% { opacity: 0; }
+  30%, 75% { opacity: 1; }
+}
+@keyframes ellipsis-dot-fade-3 {
+  0%, 50%, 80%, 100% { opacity: 0; }
+  55%, 75% { opacity: 1; }
+}
+
+.ellipsis-dot {
+  animation-duration: 1.6s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+}
+.ellipsis-dot-1 { animation-name: ellipsis-dot-fade-1; }
+.ellipsis-dot-2 { animation-name: ellipsis-dot-fade-2; }
+.ellipsis-dot-3 { animation-name: ellipsis-dot-fade-3; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ellipsis-dot {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;

--- a/frontend/src/components/animated-ellipsis.tsx
+++ b/frontend/src/components/animated-ellipsis.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+
+/**
+ * Three dots that fade in one at a time, then fade out together.
+ * Inherits its color from the surrounding text via `currentColor`.
+ * Honors `prefers-reduced-motion` (renders a static "...").
+ */
+export function AnimatedEllipsis({ className }: { className?: string }) {
+  return (
+    <span aria-hidden="true" className={cn("inline-flex", className)}>
+      <span className="ellipsis-dot ellipsis-dot-1">.</span>
+      <span className="ellipsis-dot ellipsis-dot-2">.</span>
+      <span className="ellipsis-dot ellipsis-dot-3">.</span>
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds an `AnimatedEllipsis` component (three opacity-animated dots) and uses it after the `Running` / `Pending` labels in the sessions list and sidebar, so active rows read as alive without relying on the easy-to-miss ping dot.
- Animation runs a calm 1.6s cycle (≈Apple iMessage typing-indicator pace), inherits `currentColor` so it picks up the existing label color, animates opacity only to avoid layout twitch, and falls back to a static `...` under `prefers-reduced-motion`.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/app/(dashboard)/sessions` — 211/211 pass
- [x] `npx eslint --max-warnings=0` on changed files
- [ ] Manual: load the sessions list and confirm Running/Pending rows pulse `Running` → `Running.` → `Running..` → `Running...` and that other statuses are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)