### PR TITLE
Match slash/at trigger picker overlay width to continue-session input width

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3336,6 +3336,102 @@ describe('SessionDetailPage', () => {
     expect(screen.getByLabelText('Model override')).toBeInTheDocument();
   });
 
+  it('matches both trigger menus to the continue-session input width', async () => {
+    const resumableSession: Session = {
+      ...mockSessions[0],
+      agent_type: 'codex',
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      repository_id: 'repo-1',
+      target_branch: 'main',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: resumableSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/session-composer/files', () => {
+        return HttpResponse.json({
+          data: [
+            {
+              kind: 'directory',
+              token: '@internal/services',
+              path: 'internal/services',
+              display: 'internal/services',
+            },
+          ],
+          meta: {},
+        } satisfies ListResponse<{ kind: 'file' | 'directory'; token?: string; path?: string; id?: string; display: string }>);
+      }),
+      http.get('/api/v1/session-composer/slash-commands', () => {
+        return HttpResponse.json({
+          groups: [
+            {
+              source: 'builtin',
+              label: 'Codex commands',
+              items: [
+                {
+                  kind: 'command',
+                  agent_type: 'codex',
+                  name: 'review',
+                  token: '/review',
+                  display: '/review',
+                  description: 'Review pending changes',
+                  source: 'builtin',
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const composer = await screen.findByPlaceholderText('Send a follow-up message...') as HTMLTextAreaElement;
+    const composerShell = screen.getByTestId('session-composer-shell');
+    const inputSurface = screen.getByTestId('session-composer-input-surface');
+
+    vi.spyOn(composerShell, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 680,
+      width: 760,
+      height: 132,
+      top: 680,
+      right: 760,
+      bottom: 812,
+      left: 0,
+      toJSON: () => ({}),
+    });
+    vi.spyOn(inputSurface, 'getBoundingClientRect').mockReturnValue({
+      x: 48,
+      y: 692,
+      width: 640,
+      height: 108,
+      top: 692,
+      right: 688,
+      bottom: 800,
+      left: 48,
+      toJSON: () => ({}),
+    });
+
+    await user.type(composer, 'Inspect @serv');
+
+    const mentionOverlay = await screen.findByTestId('trigger-picker-overlay');
+    expect(mentionOverlay).toHaveStyle({ left: '48px', width: '640px' });
+
+    await user.clear(composer);
+    await user.type(composer, '/rev');
+
+    expect(await screen.findByText('/review')).toBeInTheDocument();
+
+    const commandOverlay = screen.getByTestId('trigger-picker-overlay');
+    expect(commandOverlay).toHaveStyle({ left: '48px', width: '640px' });
+  });
+
   it('shows Gemini CLI agent type label', async () => {
     const geminiSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -679,6 +679,7 @@ function SessionComposer({
   }, [message, textareaRef]);
 
   const composerCardRef = useRef<HTMLDivElement>(null);
+  const composerInputSurfaceRef = useRef<HTMLDivElement>(null);
   const [caretPosition, setCaretPosition] = useState(message.length);
   const [selectedTriggerIndex, setSelectedTriggerIndex] = useState(0);
   const [triggerDismissed, setTriggerDismissed] = useState(false);
@@ -762,9 +763,9 @@ function SessionComposer({
       return;
     }
     function update() {
-      const card = composerCardRef.current;
-      if (!card) return;
-      const rect = card.getBoundingClientRect();
+      const anchor = composerInputSurfaceRef.current ?? composerCardRef.current;
+      if (!anchor) return;
+      const rect = anchor.getBoundingClientRect();
       const spacing = 8;
       const viewportHeight = window.innerHeight;
       const availableHeight = Math.max(rect.top - spacing, 120);
@@ -927,7 +928,11 @@ function SessionComposer({
         }}
       />
 
-      <div className="border-t border-border p-3 bg-background shrink-0" ref={composerCardRef}>
+      <div
+        className="border-t border-border p-3 bg-background shrink-0"
+        ref={composerCardRef}
+        data-testid="session-composer-shell"
+      >
         {planMode && (
           <div className="flex items-center gap-2 mb-2 px-1">
             <div className="flex items-center gap-1.5 rounded-full bg-amber-500/10 border border-amber-200 dark:border-amber-800/50 px-2.5 py-1">
@@ -945,7 +950,11 @@ function SessionComposer({
           </div>
         )}
 
-        <div className={cn("rounded-xl border bg-muted/30 focus-within:border-ring focus-within:ring-1 focus-within:ring-ring", planMode ? "border-amber-200 dark:border-amber-800/50" : "border-border")}>
+        <div
+          ref={composerInputSurfaceRef}
+          data-testid="session-composer-input-surface"
+          className={cn("rounded-xl border bg-muted/30 focus-within:border-ring focus-within:ring-1 focus-within:ring-ring", planMode ? "border-amber-200 dark:border-amber-800/50" : "border-border")}
+        >
           {openComments.length > 0 && (
             <div className="flex flex-wrap gap-1.5 px-3 pt-2.5 pb-1">
               {openComments.map((c) => {


### PR DESCRIPTION
## Summary
The session detail composer’s trigger picker overlay is now sized to match the continue-session input surface for both “/” and “@” menus. This prevents the overlay from appearing misaligned with the input when opening different command/mention pickers.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`**
  - Updated the session composer trigger-picker geometry logic so the overlay’s `left`/`width` align with the continue-session input surface when rendering both slash and at trigger menus.
- **`frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`**
  - Added a regression test **`matches both trigger menus to the continue-session input width`** to verify the overlay `left` and `width` match the input surface for:
    - “@” mention picker (e.g., `@serv`)
    - “/” command picker (e.g., `/rev`)

## Test plan
- Ran the updated unit tests in `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`, including the new overlay geometry regression test that asserts the picker overlay styling after typing trigger characters.

---
*Generated by [143.dev](https://143.dev) — [session b57580ea](https://app.143.dev/sessions/b57580ea-dedd-4b09-9eac-9f94691c54ea)*
