### PR TITLE
Fix sessions PR detail layout, remove duplicate merged badge, and unify merged icon color

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -965,6 +965,17 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByText('View PR')).toBeInTheDocument();
   });
 
+  it('keeps the tab rail scrollable while separating top-right actions', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const tabRail = await screen.findByLabelText('Session detail tabs');
+    const actions = screen.getByLabelText('Session detail actions');
+
+    expect(tabRail).toHaveClass('overflow-x-auto');
+    expect(actions).toHaveClass('shrink-0');
+    expect(within(actions).getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+  });
+
   it('renders the PR health banner at the top of Overview when a linked PR is open', async () => {
     server.use(
       http.get('/api/v1/pull-requests/:id/health', () => {
@@ -1091,9 +1102,11 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect((await screen.findAllByText('PR merged')).length).toBeGreaterThanOrEqual(2);
+    expect(await screen.findByText('PR merged')).toBeInTheDocument();
+    expect(screen.queryAllByText('PR merged')).toHaveLength(1);
     expect(screen.getByText('PR #42 was merged successfully.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-violet-700', 'dark:text-violet-400');
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -108,6 +108,7 @@ import { PRHealthBanner } from "@/components/pr-health-banner";
 import { ReviewButton } from "@/components/review-button";
 import { MobileBackButton } from "@/components/mobile-back-button";
 import { useAuth } from "@/hooks/use-auth";
+import { prMergedAccent } from "@/lib/pr-status-styles";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
 import { activeSet } from "@/lib/session-status-groups";
 
@@ -2309,67 +2310,66 @@ export function SessionDetailContent({ id }: { id: string }) {
       className="flex flex-col flex-1 min-h-0 gap-0"
     >
       <div className="border-b border-border px-2 py-2 shrink-0">
-        <div className="flex items-center gap-2">
-          <TabsList variant="line" size="sm" className="border-b-0 flex-1">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="changes">
-              Changes
-              {changesCount != null && changesCount > 0 && (
-                <Badge variant="secondary" className="ml-1 min-w-[18px] h-[18px] rounded-full px-1 text-xs font-semibold leading-none">
-                  {changesCount}
-                </Badge>
+        <div className="flex items-center gap-2 min-w-0">
+          <div aria-label="Session detail tabs" className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
+            <TabsList variant="line" size="sm" className="border-b-0 min-w-max">
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="changes">
+                Changes
+                {changesCount != null && changesCount > 0 && (
+                  <Badge variant="secondary" className="ml-1 min-w-[18px] h-[18px] rounded-full px-1 text-xs font-semibold leading-none">
+                    {changesCount}
+                  </Badge>
+                )}
+              </TabsTrigger>
+              {showValidationTab && (
+                <TabsTrigger value="validation">Validation</TabsTrigger>
               )}
-            </TabsTrigger>
-            {showValidationTab && (
-              <TabsTrigger value="validation">Validation</TabsTrigger>
+              <TabsTrigger value="preview">Preview</TabsTrigger>
+            </TabsList>
+          </div>
+          <div aria-label="Session detail actions" className="flex items-center gap-2 shrink-0 pl-2">
+            {canRequestReview && (
+              <ReviewButton
+                capabilities={reviewCapabilities}
+                pendingMode={pendingReviewMode}
+                onReview={(mode) => startReviewMutation.mutate(mode)}
+              />
             )}
-            <TabsTrigger value="preview">Preview</TabsTrigger>
-          </TabsList>
-          {canRequestReview && (
-            <ReviewButton
-              capabilities={reviewCapabilities}
-              pendingMode={pendingReviewMode}
-              onReview={(mode) => startReviewMutation.mutate(mode)}
-            />
-          )}
-          {hasPR && prData?.data?.github_pr_url ? (
-            <>
-              {prStatus === "closed" && (
-                <Badge variant="secondary" className="h-7 px-2 text-xs">
-                  PR closed
-                </Badge>
-              )}
-              {prStatus === "merged" && (
-                <Badge variant="secondary" className="h-7 px-2 text-xs">
-                  PR merged
-                </Badge>
-              )}
-              <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
-                <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
-                  <ExternalLink className="h-3 w-3" />
-                  View PR
-                </Button>
-              </a>
-            </>
-          ) : showPRAction && !prErrorNotice ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 text-xs gap-1.5"
-              disabled={prActionDisabled}
-              title={prActionTitle}
-              onClick={() => createPRMutation.mutate(undefined)}
-            >
-              {prActionSpinning ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : prState === "failed" || localPRActionError ? (
-                <AlertTriangle className="h-3 w-3" />
-              ) : (
-                <GitPullRequest className="h-3 w-3" />
-              )}
-              {prActionLabel}
-            </Button>
-          ) : null}
+            {hasPR && prData?.data?.github_pr_url ? (
+              <>
+                {prStatus === "closed" && (
+                  <Badge variant="secondary" className="h-7 px-2 text-xs">
+                    PR closed
+                  </Badge>
+                )}
+                <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
+                  <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
+                    <ExternalLink className="h-3 w-3" />
+                    View PR
+                  </Button>
+                </a>
+              </>
+            ) : showPRAction && !prErrorNotice ? (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-xs gap-1.5"
+                disabled={prActionDisabled}
+                title={prActionTitle}
+                onClick={() => createPRMutation.mutate(undefined)}
+              >
+                {prActionSpinning ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : prState === "failed" || localPRActionError ? (
+                  <AlertTriangle className="h-3 w-3" />
+                ) : (
+                  <GitPullRequest className="h-3 w-3" />
+                )}
+                {prActionLabel}
+              </Button>
+            ) : null}
+          </div>
         </div>
         {prErrorNotice && (
           <ErrorNotice
@@ -2443,7 +2443,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             <Card className="border-border/60">
               <CardContent className="p-4">
                 <div className="flex items-start gap-3">
-                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-emerald-100 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+                  <div aria-label="Merged PR status" className={cn("flex h-8 w-8 items-center justify-center rounded-full", prMergedAccent.bg, prMergedAccent.text)}>
                     <CheckCircle2 className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 space-y-1">

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -21,6 +21,7 @@ import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimi
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import { NoReposWarning } from "@/components/no-repos-warning";
 import type { SessionListItem } from "@/lib/types";
+import { prMergedAccent } from "@/lib/pr-status-styles";
 import {
   workingSet,
   filterToStatusParam,
@@ -80,7 +81,7 @@ function PRStatusBadge({ prSummary }: { prSummary?: SessionListItem["pr_summary"
   let label: string;
 
   if (prSummary.status === "merged") {
-    dotColor = "bg-violet-500";
+    dotColor = prMergedAccent.dot;
     label = "Merged";
   } else if (prSummary.status === "closed") {
     dotColor = "bg-muted-foreground";

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -34,6 +34,7 @@ import { StatusDot } from "@/components/status-dot";
 import { AnimatedEllipsis } from "@/components/animated-ellipsis";
 import { AgentBadge } from "@/components/agent-badge";
 import { useSessionUserFilter } from "@/hooks/use-session-user-filter";
+import { prMergedAccent } from "@/lib/pr-status-styles";
 import { SessionOwnerToggle } from "./session-owner-toggle";
 import type { Session, SessionListItem, User } from "@/lib/types";
 import {
@@ -53,7 +54,7 @@ const statusConfig: Record<string, { dot: string; text: string; bg: string; labe
   awaiting_input: { dot: "bg-amber-500", text: "text-amber-700 dark:text-amber-400", bg: "bg-amber-50 dark:bg-amber-950/30", label: "Awaiting input" },
   needs_human_guidance: { dot: "bg-orange-500", text: "text-orange-700 dark:text-orange-400", bg: "bg-orange-50 dark:bg-orange-950/30", label: "Needs guidance" },
   completed: { dot: "bg-emerald-500", text: "text-emerald-700 dark:text-emerald-400", bg: "bg-emerald-50 dark:bg-emerald-950/30", label: "Completed" },
-  pr_created: { dot: "bg-violet-500", text: "text-violet-700 dark:text-violet-400", bg: "bg-violet-50 dark:bg-violet-950/30", label: "PR created" },
+  pr_created: { dot: prMergedAccent.dot, text: prMergedAccent.text, bg: prMergedAccent.bg, label: "PR created" },
   failed: { dot: "bg-destructive", text: "text-destructive", bg: "bg-destructive/10", label: "Failed" },
   cancelled: { dot: "bg-muted-foreground/50", text: "text-muted-foreground", bg: "bg-muted", label: "Cancelled" },
   skipped: { dot: "bg-muted-foreground/30", text: "text-muted-foreground", bg: "bg-muted", label: "Skipped" },

--- a/frontend/src/components/code-review/session-footer.tsx
+++ b/frontend/src/components/code-review/session-footer.tsx
@@ -1,5 +1,6 @@
 import { MessageSquare } from "lucide-react";
 import { StatusDot } from "@/components/status-dot";
+import { prMergedAccent } from "@/lib/pr-status-styles";
 import { DiffStatsBadge } from "./diff-stats-badge";
 import type { DiffStats } from "@/lib/diff-parser";
 
@@ -23,7 +24,7 @@ const statusDotColor: Record<string, string> = {
   awaiting_input: "bg-amber-500",
   needs_human_guidance: "bg-orange-500",
   completed: "bg-emerald-500",
-  pr_created: "bg-violet-500",
+  pr_created: prMergedAccent.dot,
   failed: "bg-destructive",
   cancelled: "bg-muted-foreground/50",
   skipped: "bg-muted-foreground/30",

--- a/frontend/src/lib/pr-status-styles.ts
+++ b/frontend/src/lib/pr-status-styles.ts
@@ -1,0 +1,5 @@
+export const prMergedAccent = {
+  dot: "bg-violet-500",
+  text: "text-violet-700 dark:text-violet-400",
+  bg: "bg-violet-50 dark:bg-violet-950/30",
+} as const;


### PR DESCRIPTION
## Summary
This updates the Sessions PR detail header layout so the tab rail can scroll horizontally without displacing the “View PR” action. It also removes a redundant “PR merged” badge and centralizes the merged accent color token for consistent styling.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Split the top-right actions from the tab rail to keep the actions visible while tabs scroll (`overflow-x-auto` on the tabs container, `shrink-0` on the actions).
  - Removed the duplicated “PR merged” badge in the top row so it only renders once.
  - Reused the centralized merged accent styling via `prMergedAccent`.
- **frontend/src/app/(dashboard)/sessions/session-sidebar.tsx**
  - Updated merged PR styling to use the shared `prMergedAccent` token.
- **frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx**
  - Updated merged PR styling to use the shared `prMergedAccent` token.
- **frontend/src/components/code-review/session-footer.tsx**
  - Updated merged PR styling to use the shared `prMergedAccent` token.
- **frontend/src/lib/pr-status-styles.ts**
  - Centralized the merged PR accent/color as `prMergedAccent` for reuse across the sessions UI.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added a focused test ensuring the tab rail remains scrollable while “View PR” remains present.
  - Strengthened badge assertions to ensure “PR merged” renders exactly once and that the merged status uses the expected merged accent classes.

## Test plan
- `npx vitest run "src/app/(dashboard)/sessions/[id]/page.test.tsx"`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session d92ee92e](https://app.143.dev/sessions/d92ee92e-c03c-4ee9-ae4c-30d4561fa502)*
