### PR TITLE
Resolve 143-tools GitHub creds via the host auth socket

### DIFF
--- a/internal/services/integration/github_reviews.go
+++ b/internal/services/integration/github_reviews.go
@@ -3,11 +3,13 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -25,21 +27,38 @@ var linkNextRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
 // It uses the GitHub REST API to list recent PRs and their review comments.
 //
 // The token is a GitHub installation token (short-lived, generated from the
-// GitHub App credentials). It's injected as GITHUB_TOKEN in the sandbox env.
+// GitHub App credentials). It can be supplied two ways:
+//
+//   - Token (static) — used when a long-lived PAT or pre-resolved installation
+//     token is available in the env (legacy GITHUB_TOKEN sandbox path).
+//   - TokenFunc (deferred) — used when the sandbox reaches its token through
+//     the per-session host auth socket. The func is invoked lazily on first
+//     API call and the resolved value is cached for the lifetime of the
+//     source. Each `143-tools` invocation builds a fresh source, so the cache
+//     never outlives a single CLI process.
 type GitHubCodeReviewSource struct {
 	httpClient *http.Client
 	baseURL    string
-	token      string
 	owner      string
 	repo       string
+
+	staticToken string
+	tokenFunc   func(context.Context) (string, error)
+
+	tokenMu     sync.Mutex
+	cachedToken string
 }
 
 // GitHubCodeReviewConfig holds the connection details for a GitHub CodeReviewSource.
 type GitHubCodeReviewConfig struct {
 	BaseURL string // defaults to "https://api.github.com"
-	Token   string // installation token or PAT
-	Owner   string // repository owner
-	Repo    string // repository name
+	Token   string // installation token or PAT (mutually exclusive with TokenFunc)
+	// TokenFunc resolves a token on first use. Used when the token comes from
+	// a per-session source (e.g. host auth socket) rather than a static env
+	// var. If both Token and TokenFunc are set, Token wins.
+	TokenFunc func(context.Context) (string, error)
+	Owner     string // repository owner
+	Repo      string // repository name
 }
 
 // NewGitHubCodeReviewSource creates a GitHub CodeReviewSource from the given config.
@@ -50,12 +69,40 @@ func NewGitHubCodeReviewSource(cfg GitHubCodeReviewConfig) *GitHubCodeReviewSour
 	}
 
 	return &GitHubCodeReviewSource{
-		httpClient: &http.Client{Timeout: 30 * time.Second},
-		baseURL:    baseURL,
-		token:      cfg.Token,
-		owner:      cfg.Owner,
-		repo:       cfg.Repo,
+		httpClient:  &http.Client{Timeout: 30 * time.Second},
+		baseURL:     baseURL,
+		owner:       cfg.Owner,
+		repo:        cfg.Repo,
+		staticToken: cfg.Token,
+		tokenFunc:   cfg.TokenFunc,
 	}
+}
+
+// resolveToken returns the GitHub token to use for an API call. A static token
+// is returned directly; otherwise TokenFunc is invoked once and the result is
+// cached for the lifetime of the source so all HTTP calls in a single
+// `143-tools` invocation share one resolution.
+func (g *GitHubCodeReviewSource) resolveToken(ctx context.Context) (string, error) {
+	if g.staticToken != "" {
+		return g.staticToken, nil
+	}
+	g.tokenMu.Lock()
+	defer g.tokenMu.Unlock()
+	if g.cachedToken != "" {
+		return g.cachedToken, nil
+	}
+	if g.tokenFunc == nil {
+		return "", errors.New("github: no token configured")
+	}
+	tok, err := g.tokenFunc(ctx)
+	if err != nil {
+		return "", err
+	}
+	if tok == "" {
+		return "", errors.New("github: token func returned empty token")
+	}
+	g.cachedToken = tok
+	return tok, nil
 }
 
 func (g *GitHubCodeReviewSource) Name() string { return "github" }
@@ -170,11 +217,15 @@ func (g *GitHubCodeReviewSource) GetPRReviews(ctx context.Context, prNumber int)
 
 // doGet performs an authenticated GET request and decodes the JSON response.
 func (g *GitHubCodeReviewSource) doGet(ctx context.Context, url string, target any) error {
+	token, err := g.resolveToken(ctx)
+	if err != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", "Bearer "+g.token)
+	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
@@ -196,6 +247,10 @@ func (g *GitHubCodeReviewSource) doGet(ctx context.Context, url string, target a
 // runaway pagination. On mid-pagination errors it returns whatever was
 // collected so far along with a nil error (logging a warning instead).
 func doGetPaginated[T any](ctx context.Context, g *GitHubCodeReviewSource, initialURL string) ([]T, error) {
+	token, err := g.resolveToken(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var all []T
 	nextURL := initialURL
 
@@ -208,7 +263,7 @@ func doGetPaginated[T any](ctx context.Context, g *GitHubCodeReviewSource, initi
 			}
 			return nil, err
 		}
-		req.Header.Set("Authorization", "Bearer "+g.token)
+		req.Header.Set("Authorization", "Bearer "+token)
 		req.Header.Set("Accept", "application/vnd.github+json")
 		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 
@@ -280,17 +335,17 @@ func reviewDecision(reviewComments int) string {
 // GitHub API response types — minimal structs for the fields we need.
 
 type ghPullRequest struct {
-	Number         int       `json:"number"`
-	Title          string    `json:"title"`
-	State          string    `json:"state"`
-	HTMLURL        string    `json:"html_url"`
-	User           ghUser    `json:"user"`
-	CreatedAt      time.Time `json:"created_at"`
+	Number         int        `json:"number"`
+	Title          string     `json:"title"`
+	State          string     `json:"state"`
+	HTMLURL        string     `json:"html_url"`
+	User           ghUser     `json:"user"`
+	CreatedAt      time.Time  `json:"created_at"`
 	MergedAt       *time.Time `json:"merged_at"`
-	Additions      int       `json:"additions"`
-	Deletions      int       `json:"deletions"`
-	ChangedFiles   int       `json:"changed_files"`
-	ReviewComments int       `json:"review_comments"`
+	Additions      int        `json:"additions"`
+	Deletions      int        `json:"deletions"`
+	ChangedFiles   int        `json:"changed_files"`
+	ReviewComments int        `json:"review_comments"`
 }
 
 type ghReview struct {
@@ -302,13 +357,13 @@ type ghReview struct {
 }
 
 type ghReviewComment struct {
-	ID                    int64  `json:"id"`
-	PullRequestReviewID   int64  `json:"pull_request_review_id"`
-	Path                  string `json:"path"`
-	Line                  int    `json:"line"`
-	Body                  string `json:"body"`
-	DiffHunk              string `json:"diff_hunk"`
-	User                  ghUser `json:"user"`
+	ID                  int64  `json:"id"`
+	PullRequestReviewID int64  `json:"pull_request_review_id"`
+	Path                string `json:"path"`
+	Line                int    `json:"line"`
+	Body                string `json:"body"`
+	DiffHunk            string `json:"diff_hunk"`
+	User                ghUser `json:"user"`
 }
 
 type ghUser struct {

--- a/internal/services/integration/github_reviews_test.go
+++ b/internal/services/integration/github_reviews_test.go
@@ -3,9 +3,11 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -185,13 +187,13 @@ func TestGitHubCodeReviewSource_GetPRReviews(t *testing.T) {
 	mux.HandleFunc("/repos/octocat/hello-world/pulls/42/comments", func(w http.ResponseWriter, r *http.Request) {
 		resp := []map[string]any{
 			{
-				"id":                      int64(200),
-				"pull_request_review_id":  int64(101),
-				"path":                    "main.go",
-				"line":                    42,
-				"body":                    "This needs error handling",
+				"id":                     int64(200),
+				"pull_request_review_id": int64(101),
+				"path":                   "main.go",
+				"line":                   42,
+				"body":                   "This needs error handling",
 				"diff_hunk":              "@@ -40,3 +40,5 @@",
-				"user":                    map[string]any{"login": "reviewer2"},
+				"user":                   map[string]any{"login": "reviewer2"},
 			},
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -477,4 +479,111 @@ func TestReviewDecision(t *testing.T) {
 	require.Equal(t, "has_reviews", reviewDecision(5))
 	require.Equal(t, "has_reviews", reviewDecision(1))
 	require.Equal(t, "pending", reviewDecision(0))
+}
+
+func TestGitHubCodeReviewSource_TokenFunc_CachedAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	var authHeaders []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/o/r/pulls", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	mux.HandleFunc("/repos/o/r/pulls/1/reviews", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	mux.HandleFunc("/repos/o/r/pulls/1/comments", func(w http.ResponseWriter, r *http.Request) {
+		authHeaders = append(authHeaders, r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	var resolveCount atomic.Int32
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		BaseURL: server.URL,
+		Owner:   "o",
+		Repo:    "r",
+		TokenFunc: func(ctx context.Context) (string, error) {
+			resolveCount.Add(1)
+			return "dynamic-token", nil
+		},
+	})
+
+	_, err := src.ListRecentPRs(context.Background(), PRFilter{State: "open"})
+	require.NoError(t, err)
+
+	_, err = src.GetPRReviews(context.Background(), 1)
+	require.NoError(t, err, "second call (with paginated GET) should reuse cached token")
+
+	require.Equal(t, int32(1), resolveCount.Load(),
+		"TokenFunc should be invoked once and cached for the lifetime of the source")
+	require.NotEmpty(t, authHeaders, "expected the test server to have received requests")
+	for _, h := range authHeaders {
+		require.Equal(t, "Bearer dynamic-token", h, "all requests should carry the resolved token")
+	}
+}
+
+func TestGitHubCodeReviewSource_TokenFunc_ErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		Owner: "o",
+		Repo:  "r",
+		TokenFunc: func(ctx context.Context) (string, error) {
+			return "", errors.New("socket unavailable")
+		},
+	})
+
+	_, err := src.ListRecentPRs(context.Background(), PRFilter{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "socket unavailable")
+}
+
+func TestGitHubCodeReviewSource_TokenFunc_EmptyTokenIsError(t *testing.T) {
+	t.Parallel()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		Owner: "o",
+		Repo:  "r",
+		TokenFunc: func(ctx context.Context) (string, error) {
+			return "", nil
+		},
+	})
+
+	_, err := src.ListRecentPRs(context.Background(), PRFilter{})
+	require.Error(t, err, "an empty token from TokenFunc must surface as an error, not be cached as a hit")
+	require.Contains(t, err.Error(), "empty token")
+}
+
+func TestGitHubCodeReviewSource_StaticTokenWinsOverFunc(t *testing.T) {
+	t.Parallel()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer static-token", r.Header.Get("Authorization"),
+			"static Token should be used when both Token and TokenFunc are set")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{
+		BaseURL: server.URL,
+		Token:   "static-token",
+		Owner:   "o",
+		Repo:    "r",
+		TokenFunc: func(ctx context.Context) (string, error) {
+			t.Fatal("TokenFunc should not be called when static Token is set")
+			return "", nil
+		},
+	})
+
+	_, err := src.ListRecentPRs(context.Background(), PRFilter{})
+	require.NoError(t, err)
 }

--- a/internal/services/integration/github_reviews_test.go
+++ b/internal/services/integration/github_reviews_test.go
@@ -545,6 +545,26 @@ func TestGitHubCodeReviewSource_TokenFunc_ErrorPropagates(t *testing.T) {
 	require.Contains(t, err.Error(), "socket unavailable")
 }
 
+func TestGitHubCodeReviewSource_NoTokenConfigured(t *testing.T) {
+	t.Parallel()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{Owner: "o", Repo: "r"})
+
+	_, err := src.ListRecentPRs(context.Background(), PRFilter{})
+	require.Error(t, err, "a source with neither Token nor TokenFunc must error rather than send an unauthenticated request")
+	require.Contains(t, err.Error(), "no token configured")
+}
+
+func TestGitHubCodeReviewSource_DoGetPaginated_ResolveTokenError(t *testing.T) {
+	t.Parallel()
+
+	src := NewGitHubCodeReviewSource(GitHubCodeReviewConfig{Owner: "o", Repo: "r"})
+
+	_, err := doGetPaginated[ghReviewComment](context.Background(), src, "http://unused")
+	require.Error(t, err, "doGetPaginated must short-circuit when no token can be resolved")
+	require.Contains(t, err.Error(), "no token configured")
+}
+
 func TestGitHubCodeReviewSource_TokenFunc_EmptyTokenIsError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/mcp/registry_builder.go
+++ b/internal/services/mcp/registry_builder.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -81,19 +80,8 @@ func BuildRegistryFromEnv(logger io.Writer) *integration.Registry {
 			reg.RegisterCodeReviewSource(source)
 			fmt.Fprintf(logger, "143-tools: registered github (%s/%s)\n", owner, repo)
 		} else if sockPath := os.Getenv(sandboxauth.SocketEnvVar); sockPath != "" {
-			client := sandboxauth.NewClient(sockPath)
-			tokenFunc := func(ctx context.Context) (string, error) {
-				resp, err := client.Get(ctx, sandboxauth.ActionAPI)
-				if err != nil {
-					return "", err
-				}
-				if resp.Error != "" {
-					return "", fmt.Errorf("auth socket: %s", resp.Error)
-				}
-				return resp.Token, nil
-			}
 			source := integration.NewGitHubCodeReviewSource(integration.GitHubCodeReviewConfig{
-				TokenFunc: tokenFunc,
+				TokenFunc: sandboxauth.NewClient(sockPath).GetAPIToken,
 				Owner:     owner,
 				Repo:      repo,
 			})

--- a/internal/services/mcp/registry_builder.go
+++ b/internal/services/mcp/registry_builder.go
@@ -1,11 +1,13 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/assembledhq/143/internal/services/integration"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
 )
 
 // BuildRegistryFromEnv creates an integration registry from environment variables.
@@ -59,10 +61,18 @@ func BuildRegistryFromEnv(logger io.Writer) *integration.Registry {
 		}
 	}
 
-	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
-		owner := os.Getenv("GITHUB_REPO_OWNER")
-		repo := os.Getenv("GITHUB_REPO_NAME")
-		if owner != "" && repo != "" {
+	owner := os.Getenv("GITHUB_REPO_OWNER")
+	repo := os.Getenv("GITHUB_REPO_NAME")
+	if owner != "" && repo != "" {
+		// Two credential paths, mutually exclusive in practice (the orchestrator
+		// only injects one — see prepareSandboxGitHubAuth):
+		//   1. GITHUB_TOKEN env var: legacy fallback or PAT-based setups. Token
+		//      sits in the env for the container's lifetime.
+		//   2. _143_AUTH_SOCK: GitHub App identity flow. The socket vends fresh,
+		//      short-lived tokens per request. We resolve once per `143-tools`
+		//      invocation and cache inside the source for the life of that
+		//      single CLI process.
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 			source := integration.NewGitHubCodeReviewSource(integration.GitHubCodeReviewConfig{
 				Token: token,
 				Owner: owner,
@@ -70,6 +80,25 @@ func BuildRegistryFromEnv(logger io.Writer) *integration.Registry {
 			})
 			reg.RegisterCodeReviewSource(source)
 			fmt.Fprintf(logger, "143-tools: registered github (%s/%s)\n", owner, repo)
+		} else if sockPath := os.Getenv(sandboxauth.SocketEnvVar); sockPath != "" {
+			client := sandboxauth.NewClient(sockPath)
+			tokenFunc := func(ctx context.Context) (string, error) {
+				resp, err := client.Get(ctx, sandboxauth.ActionAPI)
+				if err != nil {
+					return "", err
+				}
+				if resp.Error != "" {
+					return "", fmt.Errorf("auth socket: %s", resp.Error)
+				}
+				return resp.Token, nil
+			}
+			source := integration.NewGitHubCodeReviewSource(integration.GitHubCodeReviewConfig{
+				TokenFunc: tokenFunc,
+				Owner:     owner,
+				Repo:      repo,
+			})
+			reg.RegisterCodeReviewSource(source)
+			fmt.Fprintf(logger, "143-tools: registered github (%s/%s) via host auth socket\n", owner, repo)
 		}
 	}
 

--- a/internal/services/mcp/registry_builder_test.go
+++ b/internal/services/mcp/registry_builder_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/services/sandboxauth"
+)
+
+// shortSocketDir mirrors the helper in sandboxauth tests: AF_UNIX paths max
+// out around 104 bytes on macOS, so we sit directly under /tmp to keep the
+// path budget for UUID-style filenames.
+func shortSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "143reg-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+func clearGitHubEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GITHUB_REPO_OWNER", "")
+	t.Setenv("GITHUB_REPO_NAME", "")
+	t.Setenv(sandboxauth.SocketEnvVar, "")
+}
+
+func TestBuildRegistryFromEnv_GitHub_LegacyToken(t *testing.T) {
+	clearGitHubEnv(t)
+	t.Setenv("GITHUB_TOKEN", "tok-123")
+	t.Setenv("GITHUB_REPO_OWNER", "octocat")
+	t.Setenv("GITHUB_REPO_NAME", "hello-world")
+
+	reg := BuildRegistryFromEnv(io.Discard)
+
+	src, err := reg.CodeReviewSource("github")
+	require.NoError(t, err, "GITHUB_TOKEN + owner/repo should register the github source")
+	require.Equal(t, "github", src.Name())
+}
+
+func TestBuildRegistryFromEnv_GitHub_SocketFallback(t *testing.T) {
+	clearGitHubEnv(t)
+	sockPath := filepath.Join(shortSocketDir(t), "sock")
+	t.Setenv(sandboxauth.SocketEnvVar, sockPath)
+	t.Setenv("GITHUB_REPO_OWNER", "octocat")
+	t.Setenv("GITHUB_REPO_NAME", "hello-world")
+
+	reg := BuildRegistryFromEnv(io.Discard)
+
+	src, err := reg.CodeReviewSource("github")
+	require.NoError(t, err, "_143_AUTH_SOCK + owner/repo should register the github source even without GITHUB_TOKEN")
+	require.Equal(t, "github", src.Name())
+}
+
+func TestBuildRegistryFromEnv_GitHub_NoCredsSkipsSource(t *testing.T) {
+	clearGitHubEnv(t)
+	// Owner/repo present but neither credential path — the source must NOT
+	// register, otherwise agents see github_* tools in the skills doc that
+	// fail at call time.
+	t.Setenv("GITHUB_REPO_OWNER", "octocat")
+	t.Setenv("GITHUB_REPO_NAME", "hello-world")
+
+	reg := BuildRegistryFromEnv(io.Discard)
+
+	_, err := reg.CodeReviewSource("github")
+	require.Error(t, err, "without creds, github must not register")
+}

--- a/internal/services/sandboxauth/protocol.go
+++ b/internal/services/sandboxauth/protocol.go
@@ -138,6 +138,22 @@ func NewClient(socketPath string) *Client {
 	return &Client{SocketPath: socketPath}
 }
 
+// GetAPIToken asks the host for a fresh API-scoped GitHub token and returns
+// just the token string. Wraps Get(ctx, ActionAPI) with the response-error
+// check that every API caller has to do anyway, so consumers (e.g. the
+// 143-tools GitHub source) can pass this method directly as a token-getter
+// callback without re-implementing the same boilerplate at every site.
+func (c *Client) GetAPIToken(ctx context.Context) (string, error) {
+	resp, err := c.Get(ctx, ActionAPI)
+	if err != nil {
+		return "", err
+	}
+	if resp.Error != "" {
+		return "", fmt.Errorf("auth socket: %s", resp.Error)
+	}
+	return resp.Token, nil
+}
+
 // Get asks the host to resolve a fresh GitHub credential for the given
 // action. Returns the response payload (which may carry a non-empty Error
 // field) and any transport error.

--- a/internal/services/sandboxauth/protocol_test.go
+++ b/internal/services/sandboxauth/protocol_test.go
@@ -27,6 +27,47 @@ func TestClient_Get_UsesEarlierContextDeadline(t *testing.T) {
 	require.Equal(t, "tok", resp.Token, "Get should still decode the host response")
 }
 
+func TestClient_GetAPIToken(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns token", func(t *testing.T) {
+		t.Parallel()
+
+		sock := startSocketServer(t, func(conn net.Conn) {
+			var req Request
+			require.NoError(t, json.NewDecoder(conn).Decode(&req))
+			require.Equal(t, ActionAPI, req.Action, "GetAPIToken must request the api scope")
+			require.NoError(t, json.NewEncoder(conn).Encode(&Response{Token: "ghs_api"}))
+		})
+
+		tok, err := NewClient(sock).GetAPIToken(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, "ghs_api", tok)
+	})
+
+	t.Run("transport error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewClient("/does/not/exist.sock").GetAPIToken(context.Background())
+		require.Error(t, err, "missing socket should surface as a transport error")
+	})
+
+	t.Run("host error becomes go error", func(t *testing.T) {
+		t.Parallel()
+
+		sock := startSocketServer(t, func(conn net.Conn) {
+			var req Request
+			require.NoError(t, json.NewDecoder(conn).Decode(&req))
+			require.NoError(t, json.NewEncoder(conn).Encode(&Response{Error: "no installation for repo"}))
+		})
+
+		tok, err := NewClient(sock).GetAPIToken(context.Background())
+		require.Error(t, err, "Response.Error must surface as a Go error so callers don't quietly use an empty token")
+		require.Empty(t, tok)
+		require.Contains(t, err.Error(), "auth socket: no installation for repo")
+	})
+}
+
 func TestClient_Get_TransportErrorBranches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- In modern GitHub-App auth mode the orchestrator routes creds through the per-session Unix socket and does not inject `GITHUB_TOKEN`. `registry_builder.go` only looked at the env var, so `143-tools` advertised GitHub tools in the skills doc but every call failed with "unknown tool".
- Adds a `TokenFunc` to `GitHubCodeReviewSource` so the source can resolve a fresh API-scoped token from the host socket lazily on first use, with the result cached for the lifetime of the CLI process (one socket round-trip per `143-tools` invocation regardless of how many API calls it issues).
- New tests cover the cached-resolution path, error propagation, the empty-token guard, and the static-token-wins-over-func precedence.

## Test plan
- [x] `go test ./internal/services/integration/... ./internal/services/mcp/...`
- [x] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)