### PR TITLE
Fix Jump to Latest affordance vertical offset in session chat

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2921,6 +2921,41 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('positions the jump-to-latest affordance close to the composer', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+    };
+
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockReturnValue(900);
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(200);
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    const { container } = renderWithProviders(<SessionDetailContent id={idleSession.id} />);
+
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    const scroller = getChatScroller(container);
+    await act(async () => {
+      scroller.scrollTop = 0;
+      scroller.dispatchEvent(new Event('scroll'));
+    });
+
+    const jumpButton = await screen.findByRole('button', { name: /Jump to latest/i });
+    const jumpContainer = jumpButton.parentElement;
+
+    expect(jumpContainer).not.toBeNull();
+    expect(jumpContainer).toHaveClass('bottom-4');
+    expect(jumpContainer).not.toHaveClass('bottom-24');
+  });
+
   it('opens review mode when clicking diff stats badge in footer', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1537,7 +1537,7 @@ function ChatPanel({
   return (
     <div className="relative flex flex-col h-full">
       {showJumpToLatest && (
-        <div className="absolute bottom-24 right-4 z-20">
+        <div className="absolute bottom-4 right-4 z-20">
           <Button
             type="button"
             size="sm"


### PR DESCRIPTION
## Summary

The high placement did not look intentional. The design note only calls for a subtle floating affordance when the user scrolls away from the live edge, with no guidance to keep it far above the composer; see [56-session-open-position.md](/home/sandbox/143/docs/design/future/56-session-open-position.md:84). In the implementation, the spacing came from a hard-coded `bottom-24` on the button wrapper, which is what made it sit oddly high in the chat pane.

I changed that offset to `bottom-4` in [session-detail-content.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx:1538), which puts the control much closer to the input/footer with a small gap. I also added a regression test in [page.test.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx:2924) so this doesn’t drift back upward.

Verification passed:
`npx vitest --run src/app/(dashboard)/sessions/[id]/page.test.tsx -t "positions the jump-to-latest affordance close to the composer"`
`npm run typecheck`
`npm run lint`
`npm run build`

Build note: `next build` still emits the existing workspace-root and deprecated `middleware` warnings, but the build succeeds.

## Test plan

Validated by automated agent run.

---
*Generated by [143.dev](https://143.dev) — [session d53af86a](https://app.143.dev/sessions/d53af86a-75d1-4ecb-b45c-f5f724ee23a8)*
