### PR TITLE
Fix Linear OAuth: form-encode token request and request write scope

### DIFF
--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -364,7 +364,7 @@ func (h *IntegrationHandler) StartLinearOAuth(w http.ResponseWriter, r *http.Req
 		"client_id":     {h.linearClientID},
 		"redirect_uri":  {h.linearRedirectURL()},
 		"response_type": {"code"},
-		"scope":         {"read"},
+		"scope":         {"read,write"},
 		"state":         {state},
 	}
 
@@ -1135,22 +1135,19 @@ func (h *IntegrationHandler) slackRedirectURL() string {
 // --- Linear token exchange ---
 
 func (h *IntegrationHandler) exchangeLinearCode(ctx context.Context, code string) (*linearTokenResponse, error) {
-	body, err := json.Marshal(map[string]string{
-		"grant_type":    "authorization_code",
-		"code":          code,
-		"redirect_uri":  h.linearRedirectURL(),
-		"client_id":     h.linearClientID,
-		"client_secret": h.linearSecret,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("marshal linear oauth request: %w", err)
+	data := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {h.linearRedirectURL()},
+		"client_id":     {h.linearClientID},
+		"client_secret": {h.linearSecret},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, linearTokenURL, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, linearTokenURL, bytes.NewBufferString(data.Encode()))
 	if err != nil {
 		return nil, fmt.Errorf("create linear oauth request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := h.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Linear's OAuth token endpoint rejected our request because we sent `application/json`. Switched to `application/x-www-form-urlencoded` per RFC 6749, matching the Sentry/Slack handlers in the same file.
- Broadened the requested OAuth scope from `read` to `read,write` so the PM agent's `LinearTaskManager` can create issues, post comments, and update state/labels (existing connected workspaces will need to disconnect and reconnect to upgrade their token).

## Test plan
- [ ] Set `LINEAR_OAUTH_CLIENT_ID` / `LINEAR_OAUTH_CLIENT_SECRET`, run the connect flow end-to-end against a real Linear app, confirm consent screen shows read+write and the callback succeeds.
- [ ] After connecting, exercise an `UpdateTask` (e.g. add a comment / change state) via the PM agent and confirm Linear accepts it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)