### PR TITLE
Fix purple proposal icon styling and add regression test

### DIFF
--- a/frontend/src/components/autopilot-proposal-card.test.tsx
+++ b/frontend/src/components/autopilot-proposal-card.test.tsx
@@ -87,4 +87,28 @@ describe("AutopilotProposalCard", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it("renders the proposal icon without a filled purple background", async () => {
+    server.use(
+      http.get("/api/v1/projects/proposals/summary", () =>
+        HttpResponse.json({ data: { count: 1 } }),
+      ),
+      http.get("/api/v1/projects", () =>
+        HttpResponse.json({
+          data: [{ id: "p-1", title: "Fix billing", status: "draft" }],
+        }),
+      ),
+    );
+
+    const { container } = renderWithProviders(<AutopilotProposalCard />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("PM found 1 strategic opportunity"),
+      ).toBeInTheDocument();
+    });
+
+    expect(container.querySelector(".bg-purple-100")).not.toBeInTheDocument();
+    expect(container.querySelector(".text-purple-600")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/autopilot-proposal-card.tsx
+++ b/frontend/src/components/autopilot-proposal-card.tsx
@@ -36,7 +36,7 @@ export function AutopilotProposalCard() {
       <CardContent className="py-3 px-4">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-3 min-w-0">
-            <div className="flex items-center justify-center h-8 w-8 rounded-full bg-purple-100 dark:bg-purple-900/50 shrink-0">
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center">
               <Lightbulb className="h-4 w-4 text-purple-600 dark:text-purple-400" />
             </div>
             <div className="min-w-0">


### PR DESCRIPTION
## Summary
Updated `AutopilotProposalCard` so the purple accent is applied to the icon (text/color) instead of rendering a filled purple circular background. Added a regression test to ensure the filled background classes don’t reappear.

## Changes
- **frontend/src/components/autopilot-proposal-card.tsx**
  - Removed the wrapper classes that created a filled background (`bg-purple-100` / `dark:bg-purple-900/50`)
  - Kept the icon color styling (`text-purple-600` / `dark:text-purple-400`) so the accent remains on the icon itself
- **frontend/src/components/autopilot-proposal-card.test.tsx**
  - Added test: `"renders the proposal icon without a filled purple background"`
  - Asserts `.bg-purple-100` is not present and `.text-purple-600` is present

## Test plan
- `npx vitest run src/components/autopilot-proposal-card.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Note: ran `npm ci` first because `frontend/node_modules` was missing.

---
*Generated by [143.dev](https://143.dev) — [session df822731](https://app.143.dev/sessions/df822731-c70d-4133-9f63-6622d61e8787)*
