### PR TITLE
Capitalize “Pull Request” in MCP tool descriptions and add regression test

### DIFF
--- a/internal/services/mcp/tools.go
+++ b/internal/services/mcp/tools.go
@@ -174,7 +174,7 @@ func (tr *ToolRegistry) ListTools() []Tool {
 		tools = append(tools,
 			Tool{
 				Name:        prefix + "_list_recent_prs",
-				Description: fmt.Sprintf("List recently merged pull requests from %s. Returns PR summaries with titles, authors, review status, and change size.", prefix),
+				Description: fmt.Sprintf("List recently merged Pull Requests from %s. Returns PR summaries with titles, authors, review status, and change size.", prefix),
 				InputSchema: ToolSchema{
 					Type: "object",
 					Properties: map[string]SchemaProperty{
@@ -185,11 +185,11 @@ func (tr *ToolRegistry) ListTools() []Tool {
 			},
 			Tool{
 				Name:        prefix + "_get_pr_reviews",
-				Description: fmt.Sprintf("Get all reviews and inline review comments for a specific pull request from %s. Returns review decisions, comments, and code-level feedback.", prefix),
+				Description: fmt.Sprintf("Get all reviews and inline review comments for a specific Pull Request from %s. Returns review decisions, comments, and code-level feedback.", prefix),
 				InputSchema: ToolSchema{
 					Type: "object",
 					Properties: map[string]SchemaProperty{
-						"pr_number": {Type: "number", Description: "The pull request number"},
+						"pr_number": {Type: "number", Description: "The Pull Request number"},
 					},
 					Required: []string{"pr_number"},
 				},
@@ -230,7 +230,7 @@ func (tr *ToolRegistry) ListTools() []Tool {
 						"title":               {Type: "string", Description: "Project title (required)"},
 						"goal":                {Type: "string", Description: "What success looks like (required)"},
 						"scope":               {Type: "string", Description: "What is in and out of bounds (optional)"},
-						"completion_criteria":  {Type: "string", Description: "How to know when done (optional)"},
+						"completion_criteria": {Type: "string", Description: "How to know when done (optional)"},
 						"reasoning":           {Type: "string", Description: "Why this project should exist (required)"},
 						"source_issue_ids":    {Type: "string", Description: "Comma-separated motivating issue UUIDs (optional)"},
 						"priority":            {Type: "number", Description: "Priority 0-100, default 50 (optional)", Default: 50},
@@ -704,16 +704,16 @@ func (tr *ToolRegistry) callProjectProposer(ctx context.Context, pp integration.
 	switch method {
 	case "propose":
 		var p struct {
-			RepositoryID      string  `json:"repository_id"`
-			Title             string  `json:"title"`
-			Goal              string  `json:"goal"`
-			Scope             *string `json:"scope"`
+			RepositoryID       string  `json:"repository_id"`
+			Title              string  `json:"title"`
+			Goal               string  `json:"goal"`
+			Scope              *string `json:"scope"`
 			CompletionCriteria *string `json:"completion_criteria"`
-			Reasoning         string  `json:"reasoning"`
-			SourceIssueIDs    string  `json:"source_issue_ids"`
-			Priority          int     `json:"priority"`
-			Tasks             string  `json:"tasks"`
-			SimilarProjectIDs string  `json:"similar_project_ids"`
+			Reasoning          string  `json:"reasoning"`
+			SourceIssueIDs     string  `json:"source_issue_ids"`
+			Priority           int     `json:"priority"`
+			Tasks              string  `json:"tasks"`
+			SimilarProjectIDs  string  `json:"similar_project_ids"`
 		}
 		if err := json.Unmarshal(args, &p); err != nil {
 			return ErrorResult(fmt.Sprintf("invalid arguments: %s", err))
@@ -748,16 +748,16 @@ func (tr *ToolRegistry) callProjectProposer(ctx context.Context, pp integration.
 		}
 
 		params := integration.ProposeProjectParams{
-			RepositoryID:      p.RepositoryID,
-			Title:             p.Title,
-			Goal:              p.Goal,
-			Scope:             p.Scope,
+			RepositoryID:       p.RepositoryID,
+			Title:              p.Title,
+			Goal:               p.Goal,
+			Scope:              p.Scope,
 			CompletionCriteria: p.CompletionCriteria,
-			Reasoning:         p.Reasoning,
-			SourceIssueIDs:    sourceIssueIDs,
-			Priority:          priority,
-			Tasks:             tasks,
-			SimilarProjectIDs: similarProjectIDs,
+			Reasoning:          p.Reasoning,
+			SourceIssueIDs:     sourceIssueIDs,
+			Priority:           priority,
+			Tasks:              tasks,
+			SimilarProjectIDs:  similarProjectIDs,
 		}
 		result, err := pp.ProposeProject(ctx, params)
 		if err != nil {

--- a/internal/services/mcp/tools_test.go
+++ b/internal/services/mcp/tools_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/services/integration"
+	"github.com/stretchr/testify/require"
 )
 
 // mockErrorTracker is a minimal ErrorTracker for testing tool dispatch.
@@ -85,15 +86,15 @@ func TestListToolsWithIntegrations(t *testing.T) {
 
 	// Verify error tracker tools are prefixed correctly.
 	expected := map[string]bool{
-		"sentry_list_errors":        false,
-		"sentry_get_error":          false,
-		"sentry_get_error_trend":    false,
+		"sentry_list_errors":         false,
+		"sentry_get_error":           false,
+		"sentry_get_error_trend":     false,
 		"sentry_find_related_errors": false,
-		"linear_list_tasks":         false,
-		"linear_get_task":           false,
-		"linear_find_related_tasks": false,
-		"linear_update_task":        false,
-		"linear_create_task":        false,
+		"linear_list_tasks":          false,
+		"linear_get_task":            false,
+		"linear_find_related_tasks":  false,
+		"linear_update_task":         false,
+		"linear_create_task":         false,
 	}
 	for _, tool := range tools {
 		if _, ok := expected[tool.Name]; !ok {
@@ -115,6 +116,23 @@ func TestListToolsEmptyRegistry(t *testing.T) {
 	if len(tools) != 0 {
 		t.Errorf("expected 0 tools, got %d", len(tools))
 	}
+}
+
+func TestListToolsCodeReviewDescriptionsUseCapitalizedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	tr := NewToolRegistry(buildFullTestRegistry())
+	tools := tr.ListTools()
+
+	descriptions := make(map[string]string, len(tools))
+	for _, tool := range tools {
+		descriptions[tool.Name] = tool.Description
+	}
+
+	require.Contains(t, descriptions["github_list_recent_prs"], "Pull Requests", "github_list_recent_prs should describe Pull Requests with capitalized output")
+	require.NotContains(t, descriptions["github_list_recent_prs"], "pull requests", "github_list_recent_prs should not describe pull requests in lowercase")
+	require.Contains(t, descriptions["github_get_pr_reviews"], "Pull Request", "github_get_pr_reviews should describe Pull Request with capitalized output")
+	require.NotContains(t, descriptions["github_get_pr_reviews"], "pull request", "github_get_pr_reviews should not describe pull request in lowercase")
 }
 
 func TestCallToolErrorTrackerListErrors(t *testing.T) {
@@ -240,8 +258,8 @@ func TestParseDuration(t *testing.T) {
 		{"7d", 7 * 24 * time.Hour},
 		{"14d", 14 * 24 * time.Hour},
 		{"30m", 30 * time.Minute},
-		{"", 14 * 24 * time.Hour},           // default
-		{"invalid", 14 * 24 * time.Hour},     // default
+		{"", 14 * 24 * time.Hour},        // default
+		{"invalid", 14 * 24 * time.Hour}, // default
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Updated the shared MCP tool registry so GitHub-related tool descriptions consistently capitalize “Pull Request” (including parameter descriptions). Added a regression test to ensure these capitalization expectations don’t drift again.

## Changes
- **internal/services/mcp/tools.go**
  - Capitalized “Pull Requests” / “Pull Request” in tool `Description` strings (e.g., `_list_recent_prs`, `_get_pr_reviews`).
  - Capitalized “Pull Request” in the `pr_number` schema parameter description.
- **internal/services/mcp/tools_test.go**
  - Added/updated a regression test to validate the expected capitalization in the tool registry output.

## Test plan
- Ran the focused MCP tool tests (pass).
- Verified `go vet ./...` and `go build ./...` pass.
- Note: `go test ./...` has existing failures in `internal/services/sandboxauth/sandboxcli_test.go` unrelated to this change (mismatched auth socket connection error).

---
*Generated by [143.dev](https://143.dev) — [session 78d2920d](https://app.143.dev/sessions/78d2920d-4fc1-4de1-b927-eece904dbcb4)*
