### PR TITLE
Add disabled hover tooltips to session detail controls and align send disabled state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -135,6 +135,30 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByRole('button', { name: 'Review' })).toBeInTheDocument();
   });
 
+  it('shows a hover tooltip when the native Review button is disabled', async () => {
+    server.use(
+      http.get('/api/v1/sessions/:id/review-capabilities', () => {
+        return HttpResponse.json({
+          data: {
+            can_review: false,
+            reason: 'Code review is only available after the session finishes running.',
+            modes: ['default'],
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const reviewButton = await screen.findByRole('button', { name: 'Code review' });
+    expect(reviewButton).toBeDisabled();
+
+    await user.hover(reviewButton.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip', { name: 'Code review is only available after the session finishes running.' })).toBeInTheDocument();
+  });
+
   it('hides the native Review button for viewers even when the session is review-capable', async () => {
     server.use(
       http.get('/api/v1/auth/me', () => {
@@ -216,6 +240,21 @@ describe('SessionDetailPage', () => {
     await waitFor(() => {
       expect(screen.getByRole('heading', { level: 1, name: updatedTitle })).toBeInTheDocument();
     });
+  });
+
+  it('shows a hover tooltip when Save title is disabled', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await screen.findByRole('heading', { level: 1, name: 'Fixed TypeError by adding null check' });
+    await user.click(screen.getByRole('button', { name: 'Edit session title' }));
+
+    const saveButton = screen.getByRole('button', { name: 'Save title' });
+    expect(saveButton).toBeDisabled();
+
+    await user.hover(saveButton.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip', { name: 'Enter a different title to save your changes.' })).toBeInTheDocument();
   });
 
   it('seeds the title editor from the same title shown in the header', async () => {
@@ -1454,6 +1493,47 @@ describe('SessionDetailPage', () => {
     const alert = await screen.findByRole('alert');
     expect(alert).toHaveTextContent('Session snapshot expired');
     expect(alert).toHaveTextContent('This session snapshot expired before a PR could be created. Send a new message to rebuild the sandbox, then create the PR again.');
+  });
+
+  it('shows a hover tooltip when Create PR is disabled', async () => {
+    const sessionWithSnapshot: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithSnapshot } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.post('/api/v1/sessions/:id/pr', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return HttpResponse.json({ data: { status: 'queued' } });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const createPRButton = await screen.findByRole('button', { name: 'Create PR' });
+    await user.click(createPRButton);
+
+    const queueingButton = await screen.findByRole('button', { name: 'Queueing PR…' });
+    expect(queueingButton).toBeDisabled();
+
+    await user.hover(queueingButton.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip', { name: 'Sending the PR request to the queue' })).toBeInTheDocument();
   });
 
   it('matches the snapshot expiry notice horizontal margins to overview cards', async () => {
@@ -3193,6 +3273,10 @@ describe('SessionDetailPage', () => {
     // The detail panel toggle should be disabled during review
     const toggleButton = screen.getByTitle('File tree required during review');
     expect(toggleButton).toBeDisabled();
+
+    await user.hover(toggleButton.parentElement as HTMLElement);
+
+    expect(await screen.findByRole('tooltip', { name: 'File tree required during review' })).toBeInTheDocument();
   });
 
   it('exits review mode when clicking a non-changes tab', async () => {
@@ -3256,6 +3340,39 @@ describe('SessionDetailPage', () => {
     // The standard shared composer should remain present in review mode.
     expect(await screen.findByPlaceholderText('Send a follow-up message...')).toBeInTheDocument();
     expect(screen.getByTitle('Send message')).toBeInTheDocument();
+  });
+
+  it('shows hover tooltips for disabled composer actions when the session environment has expired', async () => {
+    const destroyedSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'destroyed',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: destroyedSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    const user = userEvent.setup();
+    const { container } = renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await screen.findByPlaceholderText('Session environment has expired and can no longer be continued');
+
+    const attachButton = container.querySelector('button[title="Attach files or images"]') as HTMLButtonElement | null;
+    expect(attachButton).not.toBeNull();
+    expect(attachButton).toBeDisabled();
+    await user.hover(attachButton?.parentElement as HTMLElement);
+    expect(await screen.findByRole('tooltip', { name: 'Session environment has expired and can no longer be continued.' })).toBeInTheDocument();
+
+    const sendButton = container.querySelector('button[title="Send message"]') as HTMLButtonElement | null;
+    expect(sendButton).not.toBeNull();
+    expect(sendButton).toBeDisabled();
+    await user.hover(sendButton?.parentElement as HTMLElement);
+    expect(await screen.findByRole('tooltip', { name: 'Session environment has expired and can no longer be continued.' })).toBeInTheDocument();
   });
 
   it('keeps the expired sandbox warning visible in review mode with the shared composer', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -34,6 +34,7 @@ import { notify as toast } from "@/lib/notify";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
 import { Button } from "@/components/ui/button";
+import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { ErrorNotice } from "@/components/ui/error-notice";
 import {
   AlertDialog,
@@ -334,15 +335,17 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
                 )}
               </CardTitle>
               {session.failure_retry_advised && (
-                <Button
-                  size="xs"
-                  variant="outline"
-                  onClick={() => retryMutation.mutate()}
-                  disabled={retryMutation.isPending}
-                >
-                  <RefreshCw className={`mr-1.5 h-3 w-3 ${retryMutation.isPending ? "animate-spin" : ""}`} />
-                  {retryMutation.isPending ? "Retrying..." : "Retry"}
-                </Button>
+                <DisabledTooltip disabled={retryMutation.isPending} content="Retrying session...">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    onClick={() => retryMutation.mutate()}
+                    disabled={retryMutation.isPending}
+                  >
+                    <RefreshCw className={`mr-1.5 h-3 w-3 ${retryMutation.isPending ? "animate-spin" : ""}`} />
+                    {retryMutation.isPending ? "Retrying..." : "Retry"}
+                  </Button>
+                </DisabledTooltip>
               )}
             </div>
           </CardHeader>
@@ -890,6 +893,26 @@ function SessionComposer({
 
   const hasContent = message.trim() || attachments.length > 0 || openComments.length > 0;
   const sendDisabled = hasInvalidCommands || !hasContent || !canSendMessage || sendPending || isRunning;
+  const inactiveSessionMessage = isSnapshotExpired
+    ? "Session environment has expired and can no longer be continued."
+    : "Session is not active.";
+  const attachDisabledReason = isUploading
+    ? "Uploading attachments..."
+    : !canSendMessage
+      ? inactiveSessionMessage
+      : undefined;
+  const cancelDisabledReason = cancelPending ? "Cancelling session..." : undefined;
+  const sendDisabledReason = hasInvalidCommands
+    ? `${invalidCommandTokens.join(", ")} ${invalidCommandTokens.length === 1 ? "is" : "are"} not valid for this agent. Remove the chip${invalidCommandTokens.length === 1 ? "" : "s"} to continue.`
+    : !hasContent
+      ? "Add a message, attachment, or review comment before sending."
+      : !canSendMessage
+        ? inactiveSessionMessage
+        : sendPending
+          ? (planMode ? "Sending plan request..." : "Sending message...")
+          : isRunning
+            ? "Wait for the current agent response to finish before sending another message."
+            : undefined;
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
     setCaretPosition(e.currentTarget.selectionStart ?? message.length);
@@ -1112,17 +1135,19 @@ function SessionComposer({
           />
 
           <div className="flex items-center gap-1 px-2 pb-2">
-            <Button
-              type="button"
-              size="icon"
-              variant="ghost"
-              className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-              title="Attach files or images"
-              disabled={!canSendMessage || isUploading}
-              onClick={() => uploadInputRef.current?.click()}
-            >
-              {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
-            </Button>
+            <DisabledTooltip disabled={!canSendMessage || isUploading} content={attachDisabledReason}>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                title="Attach files or images"
+                disabled={!canSendMessage || isUploading}
+                onClick={() => uploadInputRef.current?.click()}
+              >
+                {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
+              </Button>
+            </DisabledTooltip>
             <input
               ref={uploadInputRef}
               type="file"
@@ -1166,33 +1191,37 @@ function SessionComposer({
 
             <div className="ml-auto flex items-center gap-1">
               {isRunning ? (
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className="h-8 w-8 shrink-0 rounded-lg"
-                  title="Cancel session"
-                  disabled={cancelPending}
-                  onClick={onCancelSession}
-                >
-                  <Square className="h-3 w-3" />
-                </Button>
+                <DisabledTooltip disabled={cancelPending} content={cancelDisabledReason}>
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    className="h-8 w-8 shrink-0 rounded-lg"
+                    title="Cancel session"
+                    disabled={cancelPending}
+                    onClick={onCancelSession}
+                  >
+                    <Square className="h-3 w-3" />
+                  </Button>
+                </DisabledTooltip>
               ) : (
-                <Button
-                  size="icon"
-                  variant={planMode ? "outline" : "default"}
-                  className={cn("h-8 w-8 shrink-0 rounded-lg", planMode && "border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-950/30")}
-                  title={planMode ? "Send plan request" : "Send message"}
-                  disabled={!hasContent || !canSendMessage || sendPending || isRunning}
-                  onClick={onSend}
-                >
-                  {sendPending ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : planMode ? (
-                    <ClipboardList className="h-4 w-4" />
-                  ) : (
-                    <ArrowUp className="h-4 w-4" />
-                  )}
-                </Button>
+                <DisabledTooltip disabled={sendDisabled} content={sendDisabledReason}>
+                  <Button
+                    size="icon"
+                    variant={planMode ? "outline" : "default"}
+                    className={cn("h-8 w-8 shrink-0 rounded-lg", planMode && "border-amber-300 dark:border-amber-700 text-amber-700 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-950/30")}
+                    title={planMode ? "Send plan request" : "Send message"}
+                    disabled={sendDisabled}
+                    onClick={onSend}
+                  >
+                    {sendPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : planMode ? (
+                      <ClipboardList className="h-4 w-4" />
+                    ) : (
+                      <ArrowUp className="h-4 w-4" />
+                    )}
+                  </Button>
+                </DisabledTooltip>
               )}
             </div>
           </div>
@@ -2356,6 +2385,19 @@ export function SessionDetailContent({ id }: { id: string }) {
   } : null;
   const trimmedDraftTitle = draftTitle.trim();
   const canSaveTitle = trimmedDraftTitle.length > 0 && trimmedDraftTitle !== currentTitle && !updateSessionMutation.isPending;
+  const saveTitleDisabledReason = updateSessionMutation.isPending
+    ? "Saving title..."
+    : trimmedDraftTitle.length === 0
+      ? "Enter a title before saving."
+      : trimmedDraftTitle === currentTitle
+        ? "Enter a different title to save your changes."
+        : undefined;
+  const titleEditPendingReason = updateSessionMutation.isPending ? "Saving title..." : undefined;
+  const detailToggleTitle = centerMode === "review" && showDetailPanel
+    ? "File tree required during review"
+    : showDetailPanel
+      ? "Hide details"
+      : "Show details";
 
   // Right-panel content. Rendered inline on desktop and inside a bottom sheet
   // on mobile — the same JSX in both places so tab state stays consistent.
@@ -2407,23 +2449,25 @@ export function SessionDetailContent({ id }: { id: string }) {
                 </a>
               </>
             ) : showPRAction && !prErrorNotice ? (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 text-xs gap-1.5"
-                disabled={prActionDisabled}
-                title={prActionTitle}
-                onClick={() => createPRMutation.mutate(undefined)}
-              >
-                {prActionSpinning ? (
-                  <Loader2 className="h-3 w-3 animate-spin" />
-                ) : prState === "failed" || localPRActionError ? (
-                  <AlertTriangle className="h-3 w-3" />
-                ) : (
-                  <GitPullRequest className="h-3 w-3" />
-                )}
-                {prActionLabel}
-              </Button>
+              <DisabledTooltip disabled={prActionDisabled} content={prActionTitle}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-xs gap-1.5"
+                  disabled={prActionDisabled}
+                  title={prActionTitle}
+                  onClick={() => createPRMutation.mutate(undefined)}
+                >
+                  {prActionSpinning ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : prState === "failed" || localPRActionError ? (
+                    <AlertTriangle className="h-3 w-3" />
+                  ) : (
+                    <GitPullRequest className="h-3 w-3" />
+                  )}
+                  {prActionLabel}
+                </Button>
+              </DisabledTooltip>
             ) : null}
           </div>
         </div>
@@ -2547,27 +2591,31 @@ export function SessionDetailContent({ id }: { id: string }) {
                   className="h-8 max-w-xl"
                   disabled={updateSessionMutation.isPending}
                 />
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  aria-label="Save title"
-                  disabled={!canSaveTitle}
-                  onClick={() => updateSessionMutation.mutate(trimmedDraftTitle)}
-                >
-                  <Check className="h-4 w-4" />
-                </Button>
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  aria-label="Cancel title"
-                  disabled={updateSessionMutation.isPending}
-                  onClick={() => {
-                    setDraftTitle(currentTitle);
-                    setIsEditingTitle(false);
-                  }}
-                >
-                  <X className="h-4 w-4" />
-                </Button>
+                <DisabledTooltip disabled={!canSaveTitle} content={saveTitleDisabledReason}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label="Save title"
+                    disabled={!canSaveTitle}
+                    onClick={() => updateSessionMutation.mutate(trimmedDraftTitle)}
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                </DisabledTooltip>
+                <DisabledTooltip disabled={updateSessionMutation.isPending} content={titleEditPendingReason}>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    aria-label="Cancel title"
+                    disabled={updateSessionMutation.isPending}
+                    onClick={() => {
+                      setDraftTitle(currentTitle);
+                      setIsEditingTitle(false);
+                    }}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </DisabledTooltip>
               </div>
             ) : (
               <>
@@ -2601,20 +2649,18 @@ export function SessionDetailContent({ id }: { id: string }) {
             )}
           </div>
           {/* Desktop toggle: hides/shows the inline right panel. */}
-          <Button
-            variant="ghost"
-            size="icon"
-            className={cn("hidden md:inline-flex h-8 w-8 shrink-0", centerMode === "review" && showDetailPanel && "opacity-30 cursor-not-allowed")}
-            disabled={centerMode === "review" && showDetailPanel}
-            onClick={() => setShowDetailPanel(!showDetailPanel)}
-            title={
-              centerMode === "review" && showDetailPanel
-                ? "File tree required during review"
-                : showDetailPanel ? "Hide details" : "Show details"
-            }
-          >
-            {showDetailPanel ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
-          </Button>
+          <DisabledTooltip disabled={centerMode === "review" && showDetailPanel} content={detailToggleTitle}>
+            <Button
+              variant="ghost"
+              size="icon"
+              className={cn("hidden md:inline-flex h-8 w-8 shrink-0", centerMode === "review" && showDetailPanel && "opacity-30 cursor-not-allowed")}
+              disabled={centerMode === "review" && showDetailPanel}
+              onClick={() => setShowDetailPanel(!showDetailPanel)}
+              title={detailToggleTitle}
+            >
+              {showDetailPanel ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+            </Button>
+          </DisabledTooltip>
           {/* Mobile toggle: opens the bottom sheet. */}
           <Button
             variant="ghost"

--- a/frontend/src/components/review-button.tsx
+++ b/frontend/src/components/review-button.tsx
@@ -4,6 +4,7 @@ import { ChevronDown, Loader2, Sparkles } from "lucide-react";
 
 import type { SessionReviewCapabilities, SessionReviewMode } from "@/lib/types";
 import { Button } from "@/components/ui/button";
+import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,24 +34,51 @@ export function ReviewButton({ capabilities, pendingMode, onReview }: ReviewButt
 
   const disabled = pendingMode !== null || !capabilities.can_review;
   const isPending = pendingMode !== null;
+  const disabledReason = isPending
+    ? "Review already in progress."
+    : !capabilities.can_review
+      ? capabilities.reason
+      : undefined;
 
   if (capabilities.modes.length === 1) {
     const [only] = capabilities.modes;
     return (
-      <Button
-        size="sm"
-        variant="outline"
-        disabled={disabled}
-        onClick={() => onReview(only)}
-        title={!capabilities.can_review ? capabilities.reason : undefined}
-      >
-        {isPending ? (
-          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-        ) : (
-          <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-        )}
-        {isPending ? "Reviewing…" : MODE_LABELS[only] ?? only}
-      </Button>
+      <DisabledTooltip disabled={disabled} content={disabledReason}>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={disabled}
+          onClick={() => onReview(only)}
+          title={disabledReason}
+        >
+          {isPending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isPending ? "Reviewing…" : MODE_LABELS[only] ?? only}
+        </Button>
+      </DisabledTooltip>
+    );
+  }
+
+  if (disabled) {
+    return (
+      <DisabledTooltip disabled content={disabledReason}>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled
+          title={disabledReason}
+        >
+          {isPending ? (
+            <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+          )}
+          {isPending ? "Reviewing…" : "Review"}
+        </Button>
+      </DisabledTooltip>
     );
   }
 
@@ -61,7 +89,7 @@ export function ReviewButton({ capabilities, pendingMode, onReview }: ReviewButt
           size="sm"
           variant="outline"
           disabled={disabled}
-          title={!capabilities.can_review ? capabilities.reason : undefined}
+          title={disabledReason}
         >
           {isPending ? (
             <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />

--- a/frontend/src/components/ui/disabled-tooltip.tsx
+++ b/frontend/src/components/ui/disabled-tooltip.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+type DisabledTooltipProps = {
+  children: React.ReactElement;
+  content?: React.ReactNode;
+  disabled?: boolean;
+};
+
+export function DisabledTooltip({ children, content, disabled = false }: DisabledTooltipProps) {
+  if (!disabled || !content) {
+    return children;
+  }
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex cursor-not-allowed" tabIndex={0}>
+            {children}
+          </span>
+        </TooltipTrigger>
+        <TooltipContent sideOffset={6}>
+          {content}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary
This update adds consistent hover tooltips for disabled controls on the session detail page, so users can see why an action isn’t available. It also aligns the “Send” button’s disabled state with the existing invalid-command guard to prevent mismatched UI behavior.

## Changes
- **Added** `frontend/src/components/ui/disabled-tooltip.tsx`
  - Provides a wrapper that renders hover tooltips for disabled elements (workaround for native disabled elements not firing hover events).
- **Updated** `frontend/src/components/review-button.tsx`
  - Wrapped the native **“Code review”** action so when review is disabled, hovering shows the server-provided reason.
- **Updated** `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Applied the disabled-tooltip wrapper to disabled session-detail controls, including:
    - PR action button
    - Title **Save/Cancel**
    - **Retry**
    - Detail panel toggle
    - **Attach**, **Send**, and **Cancel session**
  - Ensured **Send** disabled state matches the actual send logic by reusing the existing invalid-command guard.
- **Updated tests** `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Added coverage verifying tooltips appear when these controls are disabled:
    - Disabled **Review**
    - Disabled **Save title**
    - Disabled **Create PR**
    - **Detail toggle**
    - Expired-session composer actions (send/create flows)

## Test plan
- `npx vitest run src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 0fb35435](https://app.143.dev/sessions/0fb35435-75fe-4f55-83e6-0266620d2af4)*
