### PR TITLE
Remove leading slash icon from slash command chips in session composer textarea

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3511,6 +3511,57 @@ describe('SessionDetailPage', () => {
     expect(commandOverlay).toHaveStyle({ left: '48px', width: '640px' });
   });
 
+  it('renders slash command chips without a leading slash icon', async () => {
+    const resumableSession: Session = {
+      ...mockSessions[0],
+      agent_type: 'codex',
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      repository_id: 'repo-1',
+      target_branch: 'main',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: resumableSession } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/session-composer/slash-commands', () => {
+        return HttpResponse.json({
+          groups: [
+            {
+              source: 'builtin',
+              label: 'Codex commands',
+              items: [
+                {
+                  kind: 'command',
+                  agent_type: 'codex',
+                  name: 'review',
+                  token: '/review',
+                  display: '/review',
+                  description: 'Review pending changes',
+                  source: 'builtin',
+                },
+              ],
+            },
+          ],
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const composer = await screen.findByPlaceholderText('Send a follow-up message...') as HTMLTextAreaElement;
+    await user.type(composer, '/rev');
+    await user.click((await screen.findByText('/review')).closest('button') as HTMLButtonElement);
+
+    const chips = screen.getByLabelText('Selected references and commands');
+    expect(within(chips).getByText('/review')).toBeInTheDocument();
+    expect(chips.querySelector('svg.lucide-slash')).toBeNull();
+  });
+
   it('shows Gemini CLI agent type label', async () => {
     const geminiSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -17,7 +17,6 @@ import {
   RefreshCw,
   CheckCircle2,
   Check,
-  Slash,
   XCircle,
   X,
   MinusCircle,
@@ -1080,7 +1079,6 @@ function SessionComposer({
                     data-invalid={isInvalid || undefined}
                     title={isInvalid ? `${command.token} is a ${command.agent_type} command. Switch agent or remove it.` : undefined}
                   >
-                    <Slash className="h-3 w-3" />
                     <span className="max-w-[14rem] truncate">{command.token}</span>
                     <Button
                       type="button"


### PR DESCRIPTION
## Summary
Updated the session composer’s slash command “tag pills” to no longer render a leading slash icon, relying solely on the displayed command token (e.g., `/review`). Added/adjusted the regression test to target only the chip container, preventing unrelated future `Slash` icons from causing test failures.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Removed the `Slash` icon from the slash-command chip rendering (deleted the `<Slash className="h-3 w-3" />` element).
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added a focused test: **“renders slash command chips without a leading slash icon”**.
  - Scoped assertions to the chip container labeled **“Selected references and commands”** and verifies `svg.lucide-slash` is not present within it.

## Test plan
- `npx vitest --run src/app/'(dashboard)'/sessions/'[id]'/page.test.tsx -t "renders slash command chips without a leading slash icon"`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (build succeeds; existing Next.js workspace-root + deprecated middleware warnings remain)

---
*Generated by [143.dev](https://143.dev) — [session 98f85089](https://app.143.dev/sessions/98f85089-0c73-47c8-b32a-24a92bcc3333)*
