### PR TITLE
Move Code Review button to Overview tab under PR details card

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2383,13 +2383,6 @@ export function SessionDetailContent({ id }: { id: string }) {
             </TabsList>
           </div>
           <div aria-label="Session detail actions" className="flex items-center gap-2 shrink-0 pl-2">
-            {canRequestReview && (
-              <ReviewButton
-                capabilities={reviewCapabilities}
-                pendingMode={pendingReviewMode}
-                onReview={(mode) => startReviewMutation.mutate(mode)}
-              />
-            )}
             {hasPR && prData?.data?.github_pr_url ? (
               <>
                 {prStatus === "closed" && (
@@ -2510,6 +2503,15 @@ export function SessionDetailContent({ id }: { id: string }) {
                 </div>
               </CardContent>
             </Card>
+          )}
+          {canRequestReview && (
+            <div className="flex">
+              <ReviewButton
+                capabilities={reviewCapabilities}
+                pendingMode={pendingReviewMode}
+                onReview={(mode) => startReviewMutation.mutate(mode)}
+              />
+            </div>
           )}
           <OverviewTab session={session} members={members} />
         </div>


### PR DESCRIPTION
## Summary
- Moves the "Code review" `ReviewButton` out of the session detail tab-header action row and into the Overview tab, rendering it directly under the PR details card (PR health / closed / merged) and above the rest of the Overview content.
- Header action group now contains only the PR-related actions ("View PR" / "Create PR" / "PR closed" badge), reducing button clutter in that row.

## Test plan
- [ ] Open a session with `canRequestReview` true and confirm the Code review button no longer appears in the tab header and instead renders at the top of the Overview tab.
- [ ] Verify the button still triggers `startReviewMutation` and shows the pending state correctly.
- [ ] Verify View PR / Create PR buttons still render in the header as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)