### PR TITLE
Add diagnostic logging for sandbox GitHub auth socket bridge

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -821,6 +821,12 @@ func buildServices(
 	var sandboxAuthServer *sandboxauth.Server
 	if cfg.SandboxAuthSocketDir != "" {
 		sandboxAuthServer = sandboxauth.NewServer(identityResolver, cfg.SandboxAuthSocketDir, logger)
+		logger.Info().
+			Str("socket_dir", cfg.SandboxAuthSocketDir).
+			Msg("sandbox auth: per-session credential socket bridge enabled")
+	} else {
+		logger.Warn().
+			Msg("sandbox auth: SANDBOX_AUTH_SOCKET_DIR is empty; per-session credential socket disabled — sandbox `git push` will require GITHUB_TOKEN env fallback")
 	}
 
 	orchestrator := agent.NewOrchestrator(agent.OrchestratorConfig{

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -470,6 +470,12 @@ func (o *Orchestrator) prepareSandboxGitHubAuth(
 		}
 	}
 	if o.identityResolver == nil || o.sandboxAuth == nil {
+		log.Warn().
+			Bool("identity_resolver_nil", o.identityResolver == nil).
+			Bool("sandbox_auth_nil", o.sandboxAuth == nil).
+			Bool("fallback_token_present", fallbackToken != "").
+			Str("session_id", run.ID.String()).
+			Msg("sandbox auth socket bridge unavailable; falling back to env token (legacy path)")
 		if fallbackToken != "" {
 			sandboxCfg.Env["GITHUB_TOKEN"] = fallbackToken
 		}
@@ -502,8 +508,18 @@ func (o *Orchestrator) prepareSandboxGitHubAuth(
 	// the Server figures out which entry is current.
 	socketPath, err := o.sandboxAuth.Listen(ctx, run.ID, run, repo, orgSettings)
 	if err != nil {
+		log.Error().
+			Err(err).
+			Str("session_id", run.ID.String()).
+			Msg("sandbox auth: failed to open per-session credential socket; sandbox push will fail with ECONNREFUSED until next turn or restart")
 		return nil, fmt.Errorf("open sandbox auth socket: %w", err)
 	}
+	log.Info().
+		Str("session_id", run.ID.String()).
+		Str("socket_path", socketPath).
+		Str("identity_source", string(res.AuthoredBy())).
+		Bool("user_token", res.IsUserToken()).
+		Msg("sandbox auth: per-session credential socket wired into sandbox")
 	sandboxCfg.AuthSocketPath = socketPath
 	name, email := identity.CommitIdentity(res)
 	sandboxCfg.Env[sandboxauth.SocketEnvVar] = sandboxauth.SandboxSocketPath

--- a/internal/services/sandboxauth/server.go
+++ b/internal/services/sandboxauth/server.go
@@ -61,6 +61,16 @@ type activeListener struct {
 // Sockets are removed on session-end, but a stale socket from a crashed
 // orchestrator is detected and cleaned up by Listen on next use.
 func NewServer(resolver Resolver, socketDir string, logger zerolog.Logger) *Server {
+	probe := logger.Info().Str("socket_dir", socketDir)
+	if info, err := os.Stat(socketDir); err != nil {
+		probe = logger.Warn().Str("socket_dir", socketDir).Err(err)
+		probe.Msg("sandboxauth: socket dir stat failed at startup (will retry on first Listen via MkdirAll); ensure deploy/scripts/provision.sh ran on this host")
+	} else {
+		probe.
+			Str("mode", fmt.Sprintf("%#o", info.Mode().Perm())).
+			Bool("is_dir", info.IsDir()).
+			Msg("sandboxauth: socket dir present at startup (expected mode 0750 owned 1000:1000; see provision.sh)")
+	}
 	return &Server{
 		resolver:       resolver,
 		socketDir:      socketDir,
@@ -180,13 +190,14 @@ func (s *Server) Listen(
 				delete(s.active, sessionID)
 			}
 			s.mu.Unlock()
+			logger.Info().Msg("sandboxauth: listener closed")
 		})
 	}
 	entry.close = closeFn
 	s.mu.Lock()
 	s.active[sessionID] = entry
 	s.mu.Unlock()
-	logger.Debug().Msg("sandboxauth: listener started")
+	logger.Info().Msg("sandboxauth: listener started")
 	return sockPath, nil
 }
 


### PR DESCRIPTION
## Summary

Coding agents in sandboxes were hitting `dial /run/143-auth/sock: connect: connection refused` on `git push`, but worker logs gave no signal whether the per-session credential socket server was even initialized, whether the orchestrator was falling back to the legacy GITHUB_TOKEN env path, or whether `Listen` had failed.

This adds Info/Warn/Error logs across the three layers so a `grep sandboxauth` on worker logs tells the full lifecycle story:
- `cmd/server/main.go`: log socket-dir on init; warn if `SANDBOX_AUTH_SOCKET_DIR` is empty.
- `internal/services/sandboxauth/server.go`: stat-probe the socket dir at `NewServer`; promote listener-started from Debug to Info; add matching listener-closed line.
- `internal/services/agent/orchestrator.go`: warn on the resolver/server-nil fallback path with which dependency was nil; error loudly on `Listen` failure; info on the success path with the socket path and identity source.

No behavior change — diagnostic logging only.

## Test plan
- [ ] `make build` and unit tests pass (sandboxauth + agent packages green locally).
- [ ] Deploy to a worker host; confirm `sandbox auth: per-session credential socket bridge enabled` appears at startup.
- [ ] Trigger a session; confirm `sandboxauth: listener started` and (after turn end) `sandboxauth: listener closed` log lines.
- [ ] If sandbox push still fails, the new logs should disambiguate which of the four failure modes is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)