### PR TITLE
Fix "Unknown user" for GitHub accounts with no display name

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3806,6 +3806,38 @@ describe('SessionDetailPage', () => {
     expect(screen.getByText('Unknown user')).toBeInTheDocument();
   });
 
+  it('falls back to github_login when triggering member has no display name', async () => {
+    const memberWithoutName: User = {
+      id: 'user-no-name',
+      org_id: 'org-1',
+      email: '249349663+nisarg-assembled@users.noreply.github.com',
+      name: '',
+      role: 'admin',
+      github_login: 'nisarg-assembled',
+      created_at: '2026-01-01T00:00:00Z',
+    };
+    const sessionWithNamelessTrigger: Session = {
+      ...mockSessions[0],
+      triggered_by_user_id: memberWithoutName.id,
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithNamelessTrigger } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/team/members', () => {
+        return HttpResponse.json({
+          data: [memberWithoutName],
+          meta: {},
+        } satisfies ListResponse<User>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    expect(await screen.findByText('nisarg-assembled')).toBeInTheDocument();
+    expect(screen.queryByText('Unknown user')).not.toBeInTheDocument();
+  });
+
   it('calls retry API when Retry button is clicked on failed session', async () => {
     let retryCalled = false;
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -299,10 +299,13 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
   const status = statusConfig[session.status] || statusConfig.pending;
   const isActive = !terminalSessionStatuses.has(session.status);
 
+  const triggeredByMember = session.triggered_by_user_id
+    ? members.find((m) => m.id === session.triggered_by_user_id)
+    : undefined;
   const triggeredByLabel = session.pm_plan_id && !session.triggered_by_user_id
     ? "PM Agent"
     : session.triggered_by_user_id
-      ? members.find((m) => m.id === session.triggered_by_user_id)?.name || "Unknown user"
+      ? triggeredByMember?.name || triggeredByMember?.github_login || "Unknown user"
       : "System";
 
   return (

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -511,13 +511,21 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 		email = noreplyEmail
 	}
 
+	// GitHub returns "" for users who haven't set a public display name on
+	// their profile. Fall back to the login so every UI surface that renders
+	// users.name has something readable instead of an empty string.
+	displayName := ghUser.Name
+	if displayName == "" {
+		displayName = ghUser.Login
+	}
+
 	// Account linking: try GitHub ID → email → create new.
 	pendingInvite := readAndClearPendingInvitationCookie(w, r)
 
 	existingUser, err := h.userStore.GetByGitHubID(r.Context(), ghUser.ID)
 	if err == nil {
 		// Known GitHub user — update and sign in.
-		existingUser.Name = ghUser.Name
+		existingUser.Name = displayName
 		existingUser.Email = email
 		existingUser.GitHubLogin = &ghUser.Login
 		existingUser.AvatarURL = &ghUser.AvatarURL
@@ -553,7 +561,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			user := &models.User{
 				OrgID:              inv.OrgID,
 				Email:              email,
-				Name:               ghUser.Name,
+				Name:               displayName,
 				Role:               role,
 				GitHubID:           &ghUser.ID,
 				GitHubLogin:        &ghUser.Login,
@@ -587,7 +595,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	user := &models.User{
 		Email:              email,
-		Name:               ghUser.Name,
+		Name:               displayName,
 		GitHubID:           &ghUser.ID,
 		GitHubLogin:        &ghUser.Login,
 		GitHubNoreplyEmail: &noreplyEmail,

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -512,11 +512,11 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// GitHub returns "" for users who haven't set a public display name on
-	// their profile. Fall back to the login so every UI surface that renders
-	// users.name has something readable instead of an empty string.
-	displayName := ghUser.Name
-	if displayName == "" {
-		displayName = ghUser.Login
+	// their profile. Substitute the login here, before the account-linking
+	// branches consume ghUser.Name, so every persistence path (existing
+	// user, invited signup, new signup) writes a readable display value.
+	if ghUser.Name == "" {
+		ghUser.Name = ghUser.Login
 	}
 
 	// Account linking: try GitHub ID → email → create new.
@@ -525,7 +525,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	existingUser, err := h.userStore.GetByGitHubID(r.Context(), ghUser.ID)
 	if err == nil {
 		// Known GitHub user — update and sign in.
-		existingUser.Name = displayName
+		existingUser.Name = ghUser.Name
 		existingUser.Email = email
 		existingUser.GitHubLogin = &ghUser.Login
 		existingUser.AvatarURL = &ghUser.AvatarURL
@@ -561,7 +561,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			user := &models.User{
 				OrgID:              inv.OrgID,
 				Email:              email,
-				Name:               displayName,
+				Name:               ghUser.Name,
 				Role:               role,
 				GitHubID:           &ghUser.ID,
 				GitHubLogin:        &ghUser.Login,
@@ -595,7 +595,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	user := &models.User{
 		Email:              email,
-		Name:               displayName,
+		Name:               ghUser.Name,
 		GitHubID:           &ghUser.ID,
 		GitHubLogin:        &ghUser.Login,
 		GitHubNoreplyEmail: &noreplyEmail,

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -512,11 +512,11 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// GitHub returns "" for users who haven't set a public display name on
-	// their profile. Substitute the login here, before the account-linking
-	// branches consume ghUser.Name, so every persistence path (existing
-	// user, invited signup, new signup) writes a readable display value.
-	if ghUser.Name == "" {
-		ghUser.Name = ghUser.Login
+	// their profile. Fall back to the login so every UI surface that renders
+	// users.name has something readable instead of an empty string.
+	displayName := ghUser.Name
+	if displayName == "" {
+		displayName = ghUser.Login
 	}
 
 	// Account linking: try GitHub ID → email → create new.
@@ -525,7 +525,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	existingUser, err := h.userStore.GetByGitHubID(r.Context(), ghUser.ID)
 	if err == nil {
 		// Known GitHub user — update and sign in.
-		existingUser.Name = ghUser.Name
+		existingUser.Name = displayName
 		existingUser.Email = email
 		existingUser.GitHubLogin = &ghUser.Login
 		existingUser.AvatarURL = &ghUser.AvatarURL
@@ -561,7 +561,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 			user := &models.User{
 				OrgID:              inv.OrgID,
 				Email:              email,
-				Name:               ghUser.Name,
+				Name:               displayName,
 				Role:               role,
 				GitHubID:           &ghUser.ID,
 				GitHubLogin:        &ghUser.Login,
@@ -595,7 +595,7 @@ func (h *AuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 
 	user := &models.User{
 		Email:              email,
-		Name:               ghUser.Name,
+		Name:               displayName,
 		GitHubID:           &ghUser.ID,
 		GitHubLogin:        &ghUser.Login,
 		GitHubNoreplyEmail: &noreplyEmail,

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -765,6 +765,93 @@ func TestAuthHandler_Callback_EmptyGitHubNameFallsBackToLogin(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "name arg to UpsertFromGitHub must be the login when GitHub returned empty name")
 }
 
+// TestAuthHandler_Callback_NewSignupEmptyGitHubNameFallsBackToLogin pins the
+// same fallback in the new-signup branch (where GetByGitHubID and GetByEmail
+// both miss and we land in createSignupOrg). The existing-user test pins one
+// of three call sites; this one covers the fresh-account path so diff-cover
+// stays satisfied without the fallback drifting between branches over time.
+func TestAuthHandler_Callback_NewSignupEmptyGitHubNameFallsBackToLogin(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	userColumns := []string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "github_noreply_email", "avatar_url", "password_hash", "google_id", "created_at"}
+	newOrgID := uuid.New()
+	newUserID := uuid.New()
+	githubID := int64(99)
+
+	// No existing GitHub user, no email match — falls through to signup.
+	mock.ExpectQuery("SELECT .* FROM users WHERE github_id").
+		WithArgs(githubID).
+		WillReturnRows(pgxmock.NewRows(userColumns))
+	mock.ExpectQuery("(?s)SELECT .+ FROM users WHERE LOWER\\(email\\)").
+		WithArgs("99+nisarg-fresh@users.noreply.github.com").
+		WillReturnRows(pgxmock.NewRows(userColumns))
+
+	// createSignupOrg: org → user → membership → session → commit.
+	mock.ExpectBegin()
+	mock.ExpectQuery("INSERT INTO organizations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(newOrgID, now, now))
+	// Pin the name arg (3rd in UpsertFromGitHub's INSERT) to the login: with
+	// GitHub returning name:"" the handler must substitute ghUser.Login.
+	mock.ExpectQuery("INSERT INTO users .* ON CONFLICT .* RETURNING id, created_at").
+		WithArgs(
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			"nisarg-fresh",
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(newUserID, now))
+	mock.ExpectExec("INSERT INTO organization_memberships").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	expectUserLastOrgLookup(mock, newUserID, nil)
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), now))
+	mock.ExpectCommit()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_, _ = w.Write([]byte(`{"access_token":"ghu_token","token_type":"bearer","scope":"repo,user:email"}`))
+		case "/user":
+			_, _ = w.Write([]byte(`{"id":99,"login":"nisarg-fresh","name":"","email":"","avatar_url":"https://example.com/avatar.png"}`))
+		case "/user/emails":
+			_, _ = w.Write([]byte(`[{"email":"99+nisarg-fresh@users.noreply.github.com","verified":true}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewAuthHandler(
+		&config.Config{FrontendURL: "http://frontend.test"},
+		mock,
+		db.NewUserStore(mock),
+		db.NewAuthSessionStore(mock),
+		nil,
+		nil,
+	)
+	handler.SetGitHubURLsForTest(server.URL, server.URL, server.Client())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github/callback?state=valid-state&code=test-code", nil)
+	req.AddCookie(&http.Cookie{Name: "github_oauth_state", Value: "valid-state"})
+	w := httptest.NewRecorder()
+
+	handler.Callback(w, req)
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet(), "name arg to new-signup UpsertFromGitHub must be the login when GitHub returned empty name")
+}
+
 func TestAuthHandler_Providers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -685,6 +685,86 @@ func TestAuthHandler_Callback_ExistingGitHubUserAndEmailLink(t *testing.T) {
 	}
 }
 
+// TestAuthHandler_Callback_EmptyGitHubNameFallsBackToLogin pins the behavior
+// that protects "Unknown user" from leaking through the UI: GitHub's /user
+// API returns name:"" for users who haven't set a public display name, and
+// we must persist the login as the display name instead of the empty string.
+func TestAuthHandler_Callback_EmptyGitHubNameFallsBackToLogin(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	userColumns := []string{"id", "org_id", "email", "name", "role", "github_id", "github_login", "github_noreply_email", "avatar_url", "password_hash", "google_id", "created_at"}
+	userID := uuid.New()
+	orgID := uuid.New()
+	githubID := int64(42)
+	oldLogin := "nisarg-old"
+	oldNoreply := "42+nisarg-old@users.noreply.github.com"
+
+	mock.ExpectQuery("SELECT .* FROM users WHERE github_id").
+		WithArgs(githubID).
+		WillReturnRows(pgxmock.NewRows(userColumns).
+			AddRow(userID, orgID, "old@example.com", "" /* prior empty name */, "member", &githubID, &oldLogin, &oldNoreply, (*string)(nil), (*string)(nil), (*string)(nil), now))
+
+	// Args order matches the INSERT statement in UpsertFromGitHub:
+	// org_id, email, name, role, github_id, github_login, github_noreply_email, avatar_url.
+	// Pin the name arg to the login so the fallback is enforced by the test.
+	mock.ExpectQuery("INSERT INTO users .* ON CONFLICT .* RETURNING id, created_at").
+		WithArgs(
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			"nisarg-assembled",
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+			pgxmock.AnyArg(),
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(userID, now))
+
+	expectUserLastOrgLookup(mock, userID, nil)
+	mock.ExpectQuery("INSERT INTO auth_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(uuid.New(), now))
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/login/oauth/access_token":
+			_, _ = w.Write([]byte(`{"access_token":"ghu_token","token_type":"bearer","scope":"repo,user:email"}`))
+		case "/user":
+			// name:"" mirrors GitHub's response for users with no public
+			// display name. The handler must substitute the login.
+			_, _ = w.Write([]byte(`{"id":42,"login":"nisarg-assembled","name":"","email":"","avatar_url":"https://example.com/avatar.png"}`))
+		case "/user/emails":
+			_, _ = w.Write([]byte(`[{"email":"42+nisarg-assembled@users.noreply.github.com","verified":true}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewAuthHandler(
+		&config.Config{FrontendURL: "http://frontend.test"},
+		mock,
+		db.NewUserStore(mock),
+		db.NewAuthSessionStore(mock),
+		nil,
+		nil,
+	)
+	handler.SetGitHubURLsForTest(server.URL, server.URL, server.Client())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/auth/github/callback?state=valid-state&code=test-code", nil)
+	req.AddCookie(&http.Cookie{Name: "github_oauth_state", Value: "valid-state"})
+	w := httptest.NewRecorder()
+
+	handler.Callback(w, req)
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet(), "name arg to UpsertFromGitHub must be the login when GitHub returned empty name")
+}
+
 func TestAuthHandler_Providers(t *testing.T) {
 	t.Parallel()
 

--- a/migrations/000103_backfill_users_name_from_github_login.down.sql
+++ b/migrations/000103_backfill_users_name_from_github_login.down.sql
@@ -1,0 +1,5 @@
+-- No-op. The up migration heals empty users.name values by copying
+-- github_login into name; reverting would require knowing which rows
+-- were originally empty, which we don't track. Leaving names populated
+-- is the safer state to leave behind.
+SELECT 1;

--- a/migrations/000103_backfill_users_name_from_github_login.up.sql
+++ b/migrations/000103_backfill_users_name_from_github_login.up.sql
@@ -1,0 +1,15 @@
+-- Backfill users.name with the GitHub login for accounts whose name was
+-- persisted as an empty string during OAuth signup/login. GitHub's /user
+-- API returns name:"" for users who haven't set a public display name on
+-- their profile, and prior to this change we wrote that empty value
+-- through to the DB — which then surfaced as "Unknown user" anywhere the
+-- frontend rendered users.name (session attribution, audit logs, etc.).
+--
+-- The auth callback now substitutes the login at write time (see
+-- internal/api/handlers/auth.go), so this is a one-shot heal for rows
+-- that predate that fix. Idempotent: re-running selects nothing.
+UPDATE users
+SET name = github_login
+WHERE (name IS NULL OR name = '')
+  AND github_login IS NOT NULL
+  AND github_login <> '';


### PR DESCRIPTION
## Summary

- GitHub's `/user` API returns `name:""` for accounts that haven't set a public display name. The OAuth callback was persisting that empty string verbatim, so sessions triggered by those users rendered as "Unknown user" anywhere `users.name` was shown.
- Backend (`internal/api/handlers/auth.go`): substitute `ghUser.Login` when `ghUser.Name` is empty across all three persistence paths (existing-user upsert, invited signup, new signup).
- Frontend (`session-detail-content.tsx`): defensive fallback chain `name || github_login || "Unknown user"` so rows that already have an empty name still render readably until they re-login.
- Migration `000103` heals the 3 existing affected rows in prod by copying `github_login` into `name`; idempotent and write-only to matching rows.

## Test plan

- [x] `go test ./internal/api/handlers/ -run TestAuthHandler` (new `TestAuthHandler_Callback_EmptyGitHubNameFallsBackToLogin` pins the upsert's `name` arg to the login)
- [x] `npm run typecheck` and `npm test` for the new "falls back to github_login when triggering member has no display name" case
- [x] `lint-schema` clean against the new migration
- [ ] After merge: confirm in prod that nisarg-assembled / megan-assembled / assembled-albert show their logins instead of "Unknown user" on the sessions page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
