### PR TITLE
Self-heal PR status drift when close webhook is dropped

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1023,30 +1023,38 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 		return nil
 	}
 
-	if event.PR.Merged {
-		// PR was merged.
-		if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "merged"); err != nil {
-			return fmt.Errorf("update PR status to merged: %w", err)
-		}
-		// Prefer the merge commit SHA so the deploy row reflects the commit
-		// that landed on the base branch (squash/rebase merges produce a new
-		// SHA distinct from the head). Fall back to head SHA if GitHub omitted
-		// merge_commit_sha for some reason.
-		commitSHA := event.PR.MergeCommitSHA
-		if commitSHA == "" {
-			commitSHA = event.PR.Head.SHA
-		}
-		s.runMergedPullRequestFollowUps(ctx, pr, commitSHA)
-	} else {
-		// PR was closed without merging.
-		if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "closed"); err != nil {
-			return fmt.Errorf("update PR status to closed: %w", err)
-		}
-		s.teardownPRPreview(ctx, pr, false)
-		s.maybeAutoArchiveSessionOnPRClose(ctx, pr, nil, false)
+	if err := s.applyClosedPRTransition(ctx, pr, event.PR.Merged, event.PR.MergeCommitSHA, event.PR.Head.SHA); err != nil {
+		return err
 	}
 
 	s.enqueuePullRequestStateSync(ctx, pr)
+	return nil
+}
+
+// applyClosedPRTransition flips a PR's status to merged/closed and runs the
+// matching follow-ups. Shared by the webhook handler and the periodic state
+// sync (which self-heals when a webhook is dropped). Prefers the merge commit
+// SHA so the deploy row reflects the commit that landed on the base branch
+// (squash/rebase merges produce a new SHA distinct from the head); falls back
+// to head SHA when GitHub omits merge_commit_sha.
+func (s *PRService) applyClosedPRTransition(ctx context.Context, pr models.PullRequest, merged bool, mergeCommitSHA, headSHA string) error {
+	if merged {
+		if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "merged"); err != nil {
+			return fmt.Errorf("update PR status to merged: %w", err)
+		}
+		commitSHA := mergeCommitSHA
+		if commitSHA == "" {
+			commitSHA = headSHA
+		}
+		s.runMergedPullRequestFollowUps(ctx, pr, commitSHA)
+		return nil
+	}
+
+	if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "closed"); err != nil {
+		return fmt.Errorf("update PR status to closed: %w", err)
+	}
+	s.teardownPRPreview(ctx, pr, false)
+	s.maybeAutoArchiveSessionOnPRClose(ctx, pr, nil, false)
 	return nil
 }
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -31,6 +31,8 @@ type gitHubPullRequestDetails struct {
 	Number         int    `json:"number"`
 	HTMLURL        string `json:"html_url"`
 	State          string `json:"state"`
+	Merged         bool   `json:"merged"`
+	MergeCommitSHA string `json:"merge_commit_sha"`
 	Mergeable      *bool  `json:"mergeable"`
 	MergeableState string `json:"mergeable_state"`
 	Head           struct {
@@ -199,6 +201,22 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 	if err != nil {
 		return err
 	}
+
+	// Self-heal: when GitHub reports the PR closed but our DB still has it
+	// open, the pull_request:closed webhook never landed (delivery failure,
+	// signature mismatch, app restart, etc.). Apply the same transition the
+	// webhook handler would have, then stop — a closed PR has no live health
+	// to track and re-running follow-ups would just churn idempotent work.
+	if strings.EqualFold(strings.TrimSpace(details.State), "closed") && pr.Status == "open" {
+		s.logger.Warn().
+			Str("pull_request_id", pullRequestID.String()).
+			Str("repo", pr.GitHubRepo).
+			Int("number", pr.GitHubPRNumber).
+			Bool("merged", details.Merged).
+			Msg("self-healing PR status drift during sync; closed-event webhook was likely dropped")
+		return s.applyClosedPRTransition(ctx, pr, details.Merged, details.MergeCommitSHA, details.Head.SHA)
+	}
+
 	checkRuns, err := s.listCheckRunsForRef(ctx, token, owner, repoName, details.Head.SHA)
 	if err != nil {
 		return err

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -420,6 +420,130 @@ func TestPRServiceSyncPullRequestState(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all sync expectations should be met")
 }
 
+// When GitHub reports a PR closed-and-merged but our DB still has it open, the
+// pull_request:closed webhook never landed. The sync must reconcile by flipping
+// status to "merged" itself; otherwise reconciliation just keeps refreshing
+// github_state_synced_at while leaving the PR row stuck on
+// status=open/merge_state=clean — surfaced as "synced just now" + a green
+// "Mergeable" badge for an already-merged PR.
+func TestPRServiceSyncPullRequestStateSelfHealsMergedDrift(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"closed","merged":true,"merge_commit_sha":"merge-commit-sha","mergeable":true,"mergeable_state":"clean","head":{"ref":"feature","sha":"head-sync"},"base":{"ref":"main","sha":"base-sync"}}`))
+		default:
+			t.Fatalf("self-heal path should not call %s; closed PRs skip the check_runs and snapshot writes", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	// Self-heal must run UpdateStatus("merged"). The merged-status branch sets
+	// merged_at = now() in the same statement (see PullRequestStore.UpdateStatus).
+	mock.ExpectExec("UPDATE pull_requests SET status = .+ merged_at = now").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID, "status": "merged"}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	// Service is wired with nil sessions/issues/deploys/jobs/orgs/previews so
+	// runMergedPullRequestFollowUps short-circuits — those side effects already
+	// have dedicated coverage in pr_handlers_test.go. This test focuses on the
+	// status-drift reconciliation that was missing before.
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+
+	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
+	require.NoError(t, err, "SyncPullRequestState should succeed when self-healing merged drift")
+	require.NoError(t, mock.ExpectationsWereMet(), "self-heal should issue UpdateStatus(merged) and skip the health snapshot path")
+}
+
+// Same drift, but the PR was closed without merging. Sync should flip status
+// to "closed" and skip the snapshot path. Distinct from the merged case
+// because the close branch runs different follow-ups (no deploy row, no
+// evaluate_experiment job).
+func TestPRServiceSyncPullRequestStateSelfHealsClosedWithoutMergeDrift(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/assembledhq/143/pulls/42":
+			_, _ = w.Write([]byte(`{"number":42,"html_url":"https://github.com/assembledhq/143/pull/42","state":"closed","merged":false,"mergeable":null,"mergeable_state":"unknown","head":{"ref":"feature","sha":"head-sync"},"base":{"ref":"main","sha":"base-sync"}}`))
+		default:
+			t.Fatalf("self-heal path should not call %s; closed PRs skip the check_runs and snapshot writes", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
+		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
+			repoID, orgID, integrationID, int64(1), "assembledhq/143", "main", false, nil, nil, "https://github.com/assembledhq/143.git", int64(123), "active", nil, nil, []byte(`{}`), now, now,
+		))
+	mock.ExpectExec("UPDATE pull_requests SET status").
+		WithArgs(pgx.NamedArgs{"id": pullRequestID, "org_id": orgID, "status": "closed"}).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	service := &PRService{
+		tokenProvider: &Service{cache: map[int64]*cachedToken{}},
+		pullRequests:  db.NewPullRequestStore(mock),
+		repos:         db.NewRepositoryStore(mock),
+		logger:        zerolog.New(io.Discard),
+		baseURL:       server.URL,
+		httpClient:    server.Client(),
+	}
+	service.tokenProvider.cache[123] = &cachedToken{Token: "install-token", ExpiresAt: time.Now().Add(time.Hour)}
+
+	err = service.SyncPullRequestState(context.Background(), orgID, pullRequestID)
+	require.NoError(t, err, "SyncPullRequestState should succeed when self-healing closed-without-merge drift")
+	require.NoError(t, mock.ExpectationsWereMet(), "self-heal should issue UpdateStatus(closed) and skip the health snapshot path")
+}
+
 // When GitHub returns mergeable=null while it recomputes (without an explicit
 // dirty/blocked label) on the same head SHA where we already know the PR is
 // conflicted, persisting the new snapshot would clobber has_conflicts=true


### PR DESCRIPTION
## Summary
- Reconcile `pull_requests.status` from GitHub's `state` field during `SyncPullRequestState` so a dropped `pull_request:closed` webhook no longer leaves a merged PR stuck on `status=open` (UI symptom: "synced just now" + green Mergeable badge for an already-merged PR).
- Extract the merge/close transition out of `HandlePullRequestEvent` into a shared `applyClosedPRTransition` helper called from both the webhook handler and the sync path; sync returns early after the transition since closed PRs have no live health to track.
- Add unit tests for both self-heal branches (merged and closed-without-merge), with HTTP handlers that fail the test if the closed-PR sync path tries to fetch `check-runs`.

## Test plan
- [x] `go test ./internal/services/github/...`
- [x] `make lint`
- [ ] After merge, watch logs for `msg="self-healing PR status drift"` to gauge how often webhooks are getting dropped in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
