### PR TITLE
Tidy coding-agent subscription sidesheet footer

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -509,31 +509,35 @@ export default function AgentPage() {
                   <div className="space-y-2">
                     <Label htmlFor="rename-auth">Name</Label>
                     <Input id="rename-auth" value={renameValue} onChange={(event) => setRenameValue(event.target.value)} />
-                    <Button
-                      onClick={() => renameMutation.mutate(renameValue.trim() || selected.label)}
-                      disabled={!renameValue.trim() || renameValue.trim() === selected.label}
-                    >
-                      Save name
-                    </Button>
                   </div>
 
-                  <div className="flex flex-wrap gap-2">
-                    <Button variant="outline" onClick={() => void reorderMutation.mutateAsync(moveRowToTop(rows, selected.id))} disabled={selected.priority === 1}>
-                      Set as default
-                    </Button>
-                    <Button variant="outline" onClick={() => void reorderMutation.mutateAsync(moveRows(rows, selected.id, "up"))} disabled={selected.priority === 1}>
-                      Move up
-                    </Button>
+                  <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-between">
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="outline"
+                        onClick={() => void reorderMutation.mutateAsync(moveRowToTop(rows, selected.id))}
+                        disabled={selected.priority === 1}
+                      >
+                        Set as default
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => deleteMutation.mutate(selected.id)}
+                      >
+                        <Trash2 className="mr-2 h-4 w-4" />
+                        Remove
+                      </Button>
+                    </div>
                     <Button
-                      variant="outline"
-                      onClick={() => void reorderMutation.mutateAsync(moveRows(rows, selected.id, "down"))}
-                      disabled={selected.priority === rows.length}
+                      onClick={() => renameMutation.mutate(renameValue.trim() || selected.label)}
+                      disabled={
+                        !renameValue.trim()
+                        || renameValue.trim() === selected.label
+                        || renameMutation.isPending
+                      }
                     >
-                      Move down
-                    </Button>
-                    <Button variant="destructive" onClick={() => deleteMutation.mutate(selected.id)}>
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      Remove
+                      Save
                     </Button>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Drop the **Move up** / **Move down** buttons from the edit-subscription sidesheet (drag-and-drop and "Set as default" already cover reordering).
- Replace the inline "Save name" button with a single sheet-level **Save** action.
- Re-lay the footer to match the canonical `DialogFooter` pattern used by `ProviderKeyDialog` — `Set as default` + ghost-styled `Remove` on the left, primary `Save` on the right, mobile-stacked via `flex flex-col-reverse sm:flex-row sm:justify-between`.

## Test plan
- [ ] Open Settings → Coding agents, click an auth row, confirm the sidesheet shows Set as default / Remove / Save and no Move buttons.
- [ ] Edit the name and confirm Save enables; click Save and confirm the rename persists.
- [ ] Confirm Set as default and Remove still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)