### PR TITLE
Rehydrate sandbox auth listeners on worker boot

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -374,23 +374,6 @@ func main() {
 			LogsDays:    cfg.DataRetentionLogsDays,
 			JobsDays:    cfg.DataRetentionJobsDays,
 		}
-		processWorkers = startProcessWorkers(
-			ctx,
-			pool,
-			logger,
-			hostname,
-			workerCount,
-			stores,
-			services,
-			retentionCfg,
-			jobNotifier,
-			nodeManager,
-			previewCapable,
-			cfg.PreviewInternalBaseURL,
-		)
-
-		recoveryLoop := cluster.NewRecoveryLoop(nodeManager, jobStore, logger, 90*time.Second, 100)
-		go recoveryLoop.Start(ctx, 30*time.Second)
 
 		// Reconcile containers that leaked when the last server exited mid-turn
 		// or mid-Stop. Runs before the reaper starts so the reaper's Phase 2
@@ -431,6 +414,24 @@ func main() {
 				rehydrateCancel()
 			}
 		}
+
+		processWorkers = startProcessWorkers(
+			ctx,
+			pool,
+			logger,
+			hostname,
+			workerCount,
+			stores,
+			services,
+			retentionCfg,
+			jobNotifier,
+			nodeManager,
+			previewCapable,
+			cfg.PreviewInternalBaseURL,
+		)
+
+		recoveryLoop := cluster.NewRecoveryLoop(nodeManager, jobStore, logger, 90*time.Second, 100)
+		go recoveryLoop.Start(ctx, 30*time.Second)
 
 		usageRollupStore := db.NewUsageRollupStore(pool)
 		reaperOpts := []agent.SessionReaperOption{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -421,7 +421,11 @@ func main() {
 				if rehydrateErr != nil {
 					logger.Warn().Err(rehydrateErr).Msg("startup: rehydrating sandbox auth listeners failed; remaining sessions will retry on next turn boundary")
 				}
-				if services.SandboxAuthSweep != nil {
+				// Only sweep when rehydrate actually ran (keep != nil) — a nil
+				// keep means we don't know which sockets are live, so sweeping
+				// would clobber listeners the next turn boundary will rebind.
+				// See orch.RehydrateSandboxAuthListeners' return contract.
+				if keep != nil && services.SandboxAuthSweep != nil {
 					services.SandboxAuthSweep(keep)
 				}
 				rehydrateCancel()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -403,6 +403,31 @@ func main() {
 			reconcileCancel()
 		}
 
+		// Re-open the per-session GitHub credential socket listener for
+		// sessions whose containers survive a worker restart (preview holds
+		// keep them alive across the gap). Without this, in-sandbox `git push`
+		// dials a dead socket and fails with ECONNREFUSED until the next
+		// turn boundary calls Listen again. Runs after the reconciler so
+		// dead-container rows have already been cleared and we don't waste
+		// IsAlive probes on them. Best-effort: errors are logged, not fatal.
+		//
+		// services is guaranteed non-nil here (the Fatal above exits on nil)
+		// but staticcheck's flow analysis can't follow logger.Fatal — gate
+		// the rehydrate inside an explicit non-nil check to keep lint clean.
+		if services != nil {
+			if orch, ok := services.Orchestrator.(*agent.Orchestrator); ok {
+				rehydrateCtx, rehydrateCancel := context.WithTimeout(ctx, 2*time.Minute)
+				keep, rehydrateErr := orch.RehydrateSandboxAuthListeners(rehydrateCtx)
+				if rehydrateErr != nil {
+					logger.Warn().Err(rehydrateErr).Msg("startup: rehydrating sandbox auth listeners failed; remaining sessions will retry on next turn boundary")
+				}
+				if services.SandboxAuthSweep != nil {
+					services.SandboxAuthSweep(keep)
+				}
+				rehydrateCancel()
+			}
+		}
+
 		usageRollupStore := db.NewUsageRollupStore(pool)
 		reaperOpts := []agent.SessionReaperOption{
 			agent.WithOrphanCloser(db.NewContainerUsageStore(pool)),
@@ -951,6 +976,7 @@ func buildServices(
 		// *Server pointer is stable for the process lifetime.
 		s := sandboxAuthServer
 		svc.SandboxAuthShutdown = s.Shutdown
+		svc.SandboxAuthSweep = s.SweepStaleSessionDirs
 	}
 	return svc
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -255,8 +257,9 @@ func main() {
 
 	nodeManager := cluster.NewNodeManager(pool, logger, cfg.NodeID, cfg.Mode)
 	previewCapable := (cfg.Mode == "worker" || cfg.Mode == "all") && pvProvider != nil
+	var previewRoutingReady atomic.Bool
 	nodeManager.SetMetadataProvider(func() map[string]any {
-		return buildBaseMetadata(previewCapable, cfg.PreviewInternalBaseURL)
+		return buildBaseMetadata(previewCapable && previewRoutingReady.Load(), cfg.PreviewInternalBaseURL)
 	})
 	if err := nodeManager.Register(ctx, hostname); err != nil {
 		logger.Fatal().Err(err).Msg("failed to register cluster node")
@@ -428,6 +431,7 @@ func main() {
 			nodeManager,
 			previewCapable,
 			cfg.PreviewInternalBaseURL,
+			previewRoutingReady.Load,
 		)
 
 		recoveryLoop := cluster.NewRecoveryLoop(nodeManager, jobStore, logger, 90*time.Second, 100)
@@ -585,7 +589,15 @@ func main() {
 	}()
 
 	logger.Info().Int("port", cfg.Port).Str("mode", cfg.Mode).Msg("starting server")
-	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", cfg.Port))
+	if err != nil {
+		logger.Fatal().Err(err).Msg("server failed to bind listener")
+	}
+	previewRoutingReady.Store(true)
+	if err := nodeManager.HeartbeatOnce(ctx); err != nil {
+		logger.Warn().Err(err).Msg("failed to publish preview routing readiness; next heartbeat will retry")
+	}
+	if err := srv.Serve(ln); err != nil && err != http.ErrServerClosed {
 		logger.Fatal().Err(err).Msg("server failed")
 	}
 }
@@ -603,6 +615,7 @@ func startProcessWorkers(
 	nodeManager *cluster.NodeManager,
 	previewCapable bool,
 	previewInternalBaseURL string,
+	previewRoutingReady func() bool,
 ) []*worker.Worker {
 	workers := make([]*worker.Worker, 0, workerCount)
 	for i := 0; i < workerCount; i++ {
@@ -619,7 +632,7 @@ func startProcessWorkers(
 		})
 	}
 
-	nodeManager.SetMetadataProvider(buildWorkerMetadataProvider(workers, previewCapable, previewInternalBaseURL))
+	nodeManager.SetMetadataProvider(buildWorkerMetadataProvider(workers, previewCapable, previewInternalBaseURL, previewRoutingReady))
 
 	for i, w := range workers {
 		go w.Start(ctx)
@@ -646,9 +659,13 @@ func buildBaseMetadata(previewCapable bool, previewInternalBaseURL string) map[s
 	return metadata
 }
 
-func buildWorkerMetadataProvider(workers []*worker.Worker, previewCapable bool, previewInternalBaseURL string) func() map[string]any {
+func buildWorkerMetadataProvider(workers []*worker.Worker, previewCapable bool, previewInternalBaseURL string, previewRoutingReady func() bool) func() map[string]any {
 	return func() map[string]any {
-		metadata := buildBaseMetadata(previewCapable, previewInternalBaseURL)
+		advertisePreview := previewCapable
+		if previewRoutingReady != nil {
+			advertisePreview = advertisePreview && previewRoutingReady()
+		}
+		metadata := buildBaseMetadata(advertisePreview, previewInternalBaseURL)
 		metadata["active_job_count"] = totalActiveJobs(workers)
 		metadata["active_run_agent_count"] = totalActiveRunAgentJobs(workers)
 		return metadata

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -83,7 +83,7 @@ func TestBuildBaseMetadata(t *testing.T) {
 func TestBuildWorkerMetadataProvider_PreservesPreviewFields(t *testing.T) {
 	t.Parallel()
 
-	provider := buildWorkerMetadataProvider(nil, true, "http://worker-1:8080")
+	provider := buildWorkerMetadataProvider(nil, true, "http://worker-1:8080", func() bool { return true })
 
 	metadata := provider()
 
@@ -104,7 +104,7 @@ func TestBuildWorkerMetadataProvider_PreservesPreviewFields(t *testing.T) {
 func TestBuildWorkerMetadataProvider_NonPreviewCapable(t *testing.T) {
 	t.Parallel()
 
-	provider := buildWorkerMetadataProvider(nil, false, "")
+	provider := buildWorkerMetadataProvider(nil, false, "", func() bool { return true })
 
 	metadata := provider()
 
@@ -114,6 +114,21 @@ func TestBuildWorkerMetadataProvider_NonPreviewCapable(t *testing.T) {
 	if _, ok := metadata["preview_internal_base_url"]; ok {
 		t.Errorf("preview_internal_base_url should be omitted when not configured")
 	}
+}
+
+func TestBuildWorkerMetadataProvider_DelaysPreviewCapabilityUntilReady(t *testing.T) {
+	t.Parallel()
+
+	ready := false
+	provider := buildWorkerMetadataProvider(nil, true, "http://worker-1:8080", func() bool { return ready })
+
+	metadata := provider()
+	require.NotContains(t, metadata, "preview_capable", "preview_capable should be hidden until the HTTP listener is bound")
+	require.Equal(t, "http://worker-1:8080", metadata["preview_internal_base_url"], "preview internal URL should remain available in metadata")
+
+	ready = true
+	metadata = provider()
+	require.Equal(t, true, metadata["preview_capable"], "preview_capable should be advertised once routing is ready")
 }
 
 // TestMainStartupRunsRehydrateBeforeWorkers guards the sandbox-auth socket
@@ -132,6 +147,23 @@ func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
 	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
 	require.NotEqual(t, -1, rehydrate, "startup should still run sandbox auth rehydrate")
 	require.Less(t, rehydrate, startWorkers, "sandbox auth rehydrate/sweep must run before process workers can claim jobs")
+}
+
+func TestMainAdvertisesPreviewAfterHTTPListen(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("main.go")
+	require.NoError(t, err, "main.go should be readable for preview readiness ordering test")
+
+	body := string(src)
+	listen := strings.Index(body, "net.Listen(\"tcp\"")
+	ready := strings.Index(body, "previewRoutingReady.Store(true)")
+	serve := strings.Index(body, "srv.Serve(")
+	require.NotEqual(t, -1, listen, "startup should bind the HTTP listener explicitly")
+	require.NotEqual(t, -1, ready, "startup should mark preview routing ready explicitly")
+	require.NotEqual(t, -1, serve, "startup should serve the already-bound listener")
+	require.Less(t, listen, ready, "preview routing must not be advertised until the HTTP listener is bound")
+	require.Less(t, ready, serve, "preview routing should be advertised before serving blocks")
 }
 
 // fakeDrainer is a postPRSnapshotDrainer that blocks WaitForPostPRSnapshotUploads

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildBaseMetadata(t *testing.T) {
@@ -111,6 +114,24 @@ func TestBuildWorkerMetadataProvider_NonPreviewCapable(t *testing.T) {
 	if _, ok := metadata["preview_internal_base_url"]; ok {
 		t.Errorf("preview_internal_base_url should be omitted when not configured")
 	}
+}
+
+// TestMainStartupRunsRehydrateBeforeWorkers guards the sandbox-auth socket
+// sweep invariant: process workers must not be able to call Listen for a new
+// job while the boot-time rehydrate/sweep pass is still deciding which
+// session directories are stale.
+func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("main.go")
+	require.NoError(t, err, "main.go should be readable for startup ordering regression test")
+
+	body := string(src)
+	startWorkers := strings.Index(body, "\n\t\tprocessWorkers = startProcessWorkers(")
+	rehydrate := strings.Index(body, "orch.RehydrateSandboxAuthListeners(")
+	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
+	require.NotEqual(t, -1, rehydrate, "startup should still run sandbox auth rehydrate")
+	require.Less(t, rehydrate, startWorkers, "sandbox auth rehydrate/sweep must run before process workers can claim jobs")
 }
 
 // fakeDrainer is a postPRSnapshotDrainer that blocks WaitForPostPRSnapshotUploads

--- a/docs/design/48-worker-owned-preview-routing.md
+++ b/docs/design/48-worker-owned-preview-routing.md
@@ -1,6 +1,6 @@
 # Design: Worker-Owned Preview Routing
 
-> **Status:** Implemented | **Last reviewed:** 2026-04-22
+> **Status:** Implemented | **Last reviewed:** 2026-04-29
 
 This document records the deployed multi-node preview contract. It is the follow-on to [44-sandbox-preview-server.md](44-sandbox-preview-server.md) and describes how preview traffic and preview lifecycle are split between app nodes and worker nodes.
 
@@ -82,6 +82,10 @@ Preview-capable workers publish the following metadata through `nodes.metadata`:
 - `build_sha`
 
 `NODE_ID` must be stable in production so ownership written to the database remains routable across deploys and restarts.
+
+Workers only advertise `preview_capable = true` after boot-time local recovery work is complete and the HTTP listener is bound. This prevents app nodes from routing preview lifecycle calls to a worker that is registered in the cluster but not yet accepting internal preview RPC.
+
+Startup recovery is worker-scoped. A worker only rehydrates sandbox-auth sockets for preview-held sessions whose active `preview_instances.worker_node_id` matches its own `NODE_ID`; it must not scan or rebind sockets for containers owned by peer workers.
 
 ## Deployment Contract
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1692,8 +1692,8 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 	return sessions, nil
 }
 
-// ListContainerHoldingSessions returns sessions whose container_id is set and
-// a preview is currently holding the sandbox. Called on startup to rehydrate
+// ListContainerHoldingSessions returns sessions with a preview hold owned by
+// workerNodeID whose container_id is set. Called on startup to rehydrate
 // per-session GitHub credential socket listeners for containers that survive
 // a worker restart (preview holds keep them alive across the gap).
 //
@@ -1717,7 +1717,7 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 // so a degenerate state (probe failures, transient errors) doesn't trap the
 // caller in the same page.
 // lint:allow-no-orgid reason="startup rehydrate scans across all orgs by design"
-func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID, limit int) ([]models.Session, error) {
+func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, workerNodeID string, afterID uuid.UUID, limit int) ([]models.Session, error) {
 	if limit <= 0 {
 		limit = 1
 	}
@@ -1730,12 +1730,13 @@ func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID
 		    SELECT 1 FROM preview_instances p
 		    WHERE p.session_id = sessions.id
 		      AND p.org_id = sessions.org_id
+		      AND p.worker_node_id = @worker_node_id
 		      AND p.preview_holding_container = TRUE
 		  )
 		ORDER BY id ASC
 		LIMIT @limit`
 
-	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"after_id": afterID, "limit": limit})
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"worker_node_id": workerNodeID, "after_id": afterID, "limit": limit})
 	if err != nil {
 		return nil, fmt.Errorf("list container-holding sessions: %w", err)
 	}

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1712,12 +1712,15 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 // containers are *expected* to outlive the worker and need a proactive
 // re-Listen before any user action.
 //
-// Returns at most 100 rows per call, keyset-paginated by session id > afterID
-// and ordered by id ASC. Mirrors ListOrphanedContainers' pagination so a
-// degenerate state (probe failures, transient errors) doesn't trap the caller
-// in the same page.
+// Returns at most limit rows per call, keyset-paginated by session id >
+// afterID and ordered by id ASC. Mirrors ListOrphanedContainers' pagination
+// so a degenerate state (probe failures, transient errors) doesn't trap the
+// caller in the same page.
 // lint:allow-no-orgid reason="startup rehydrate scans across all orgs by design"
-func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID) ([]models.Session, error) {
+func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID, limit int) ([]models.Session, error) {
+	if limit <= 0 {
+		limit = 1
+	}
 	query := `
 		SELECT ` + sessionSelectColumns + `
 		FROM sessions
@@ -1730,9 +1733,9 @@ func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID
 		      AND p.preview_holding_container = TRUE
 		  )
 		ORDER BY id ASC
-		LIMIT 100`
+		LIMIT @limit`
 
-	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"after_id": afterID})
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"after_id": afterID, "limit": limit})
 	if err != nil {
 		return nil, fmt.Errorf("list container-holding sessions: %w", err)
 	}

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1692,6 +1692,50 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 	return sessions, nil
 }
 
+// ListContainerHoldingSessions returns sessions whose container_id is set and
+// a preview is currently holding the sandbox. Called on startup to rehydrate
+// per-session GitHub credential socket listeners for containers that survive
+// a worker restart (preview holds keep them alive across the gap).
+//
+// Without rehydration, a push from inside a held-alive sandbox dials a dead
+// socket and gets ECONNREFUSED until the next turn boundary calls Listen
+// again. The fresh listener uses the same on-disk path so the container's
+// directory bind-mount picks it up transparently.
+//
+// Returns at most 100 rows per call, keyset-paginated by session id > afterID
+// and ordered by id ASC. Mirrors ListOrphanedContainers' pagination so a
+// degenerate state (probe failures, transient errors) doesn't trap the caller
+// in the same page.
+// lint:allow-no-orgid reason="startup rehydrate scans across all orgs by design"
+func (s *SessionStore) ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID) ([]models.Session, error) {
+	query := `
+		SELECT ` + sessionSelectColumns + `
+		FROM sessions
+		WHERE container_id IS NOT NULL
+		  AND id > @after_id
+		  AND EXISTS (
+		    SELECT 1 FROM preview_instances p
+		    WHERE p.session_id = sessions.id
+		      AND p.org_id = sessions.org_id
+		      AND p.preview_holding_container = TRUE
+		  )
+		ORDER BY id ASC
+		LIMIT 100`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{"after_id": afterID})
+	if err != nil {
+		return nil, fmt.Errorf("list container-holding sessions: %w", err)
+	}
+	sessions, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		return nil, err
+	}
+	for i := range sessions {
+		hydrateSessionPolicy(&sessions[i])
+	}
+	return sessions, nil
+}
+
 // UpdateWorkingBranch sets the working branch name for a session.
 func (s *SessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessionID uuid.UUID, branch string) error {
 	query := `UPDATE sessions SET working_branch = @working_branch, last_activity_at = now() WHERE id = @id AND org_id = @org_id`

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1702,6 +1702,16 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 // again. The fresh listener uses the same on-disk path so the container's
 // directory bind-mount picks it up transparently.
 //
+// Why preview-only and not turn-or-preview: a turn_holding_container=TRUE
+// row at startup means a worker crashed mid-turn. Those rows go through
+// the orphan reconciler (ListOrphanedContainers), which IsAlive-probes
+// them and either CAS-clears the row (container gone) or leaves it for
+// the next turn boundary to re-Listen as part of normal flow. Adding
+// turn-held rows here would either double-process them with the reconciler
+// or race it. Preview-held rows, by contrast, are the only ones whose
+// containers are *expected* to outlive the worker and need a proactive
+// re-Listen before any user action.
+//
 // Returns at most 100 rows per call, keyset-paginated by session id > afterID
 // and ordered by id ASC. Mirrors ListOrphanedContainers' pagination so a
 // degenerate state (probe failures, transient errors) doesn't trap the caller

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1875,14 +1875,14 @@ func TestSessionStore_ListContainerHoldingSessions(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	now := time.Now()
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+LIMIT @limit`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).
 				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...),
 		)
 
-	sessions, err := store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	sessions, err := store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -1897,10 +1897,10 @@ func TestSessionStore_ListContainerHoldingSessions_QueryError(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL`).
-		WithArgs(pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("boom"))
 
-	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "list container-holding sessions")
 }
@@ -1919,15 +1919,15 @@ func TestSessionStore_ListContainerHoldingSessions_ScanError(t *testing.T) {
 	store := NewSessionStore(mock)
 	now := time.Now()
 	scanErr := errors.New("simulated mid-row scan failure")
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS`).
-		WithArgs(pgxmock.AnyArg()).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+LIMIT @limit`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).
 				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...).
 				RowError(0, scanErr),
 		)
 
-	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
 	require.Error(t, err)
 	require.ErrorIs(t, err, scanErr, "scan errors must propagate to the caller so partial result sets aren't returned")
 }

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1875,14 +1875,14 @@ func TestSessionStore_ListContainerHoldingSessions(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	now := time.Now()
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+LIMIT @limit`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+p\.worker_node_id = @worker_node_id[\s\S]+LIMIT @limit`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).
 				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...),
 		)
 
-	sessions, err := store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
+	sessions, err := store.ListContainerHoldingSessions(context.Background(), "worker-a", uuid.Nil, 500)
 	require.NoError(t, err)
 	require.Len(t, sessions, 1)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -1897,10 +1897,10 @@ func TestSessionStore_ListContainerHoldingSessions_QueryError(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("boom"))
 
-	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
+	_, err = store.ListContainerHoldingSessions(context.Background(), "worker-a", uuid.Nil, 500)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "list container-holding sessions")
 }
@@ -1919,15 +1919,15 @@ func TestSessionStore_ListContainerHoldingSessions_ScanError(t *testing.T) {
 	store := NewSessionStore(mock)
 	now := time.Now()
 	scanErr := errors.New("simulated mid-row scan failure")
-	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+LIMIT @limit`).
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS[\s\S]+p\.worker_node_id = @worker_node_id[\s\S]+LIMIT @limit`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows(sessionTestColumns).
 				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...).
 				RowError(0, scanErr),
 		)
 
-	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil, 500)
+	_, err = store.ListContainerHoldingSessions(context.Background(), "worker-a", uuid.Nil, 500)
 	require.Error(t, err)
 	require.ErrorIs(t, err, scanErr, "scan errors must propagate to the caller so partial result sets aren't returned")
 }

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1861,6 +1861,50 @@ func TestSessionStore_ListOrphanedContainers_QueryError(t *testing.T) {
 	require.Contains(t, err.Error(), "list orphaned containers")
 }
 
+// TestSessionStore_ListContainerHoldingSessions is the rehydrate-side
+// counterpart to ListOrphanedContainers: same paging, opposite predicate
+// (EXISTS preview hold instead of NOT EXISTS). The query must filter by
+// preview_holding_container so we don't try to rehydrate listeners for
+// containers that aren't actually being kept alive across a worker restart.
+func TestSessionStore_ListContainerHoldingSessions(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	now := time.Now()
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...),
+		)
+
+	sessions, err := store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_ListContainerHoldingSessions_QueryError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnError(errors.New("boom"))
+
+	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "list container-holding sessions")
+}
+
 func TestSessionStore_BeginRuntime_PreservesRecoveringState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1905,6 +1905,33 @@ func TestSessionStore_ListContainerHoldingSessions_QueryError(t *testing.T) {
 	require.Contains(t, err.Error(), "list container-holding sessions")
 }
 
+// TestSessionStore_ListContainerHoldingSessions_ScanError covers the path
+// where pgx.CollectRows fails mid-scan (a corrupt row, a column type
+// mismatch, or a transient driver fault). We surface the error verbatim
+// — the rehydrate caller then aborts the pass without a partial keep set.
+func TestSessionStore_ListContainerHoldingSessions_ScanError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	now := time.Now()
+	scanErr := errors.New("simulated mid-row scan failure")
+	mock.ExpectQuery(`FROM sessions\s+WHERE container_id IS NOT NULL\s+AND id > @after_id\s+AND EXISTS`).
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).
+				AddRow(newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...).
+				RowError(0, scanErr),
+		)
+
+	_, err = store.ListContainerHoldingSessions(context.Background(), uuid.Nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, scanErr, "scan errors must propagate to the caller so partial result sets aren't returned")
+}
+
 func TestSessionStore_BeginRuntime_PreservesRecoveringState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -174,6 +174,17 @@ type mockSessionStore struct {
 	acquireHoldCalls       int
 	releaseHoldCalls       int
 	finalizeCalls          int
+
+	// Programmable response for the rehydrate-pass query. Each call returns
+	// the next page; the field is used only by orchestrator-wrapper tests in
+	// sandbox_auth_rehydrate_test.go. Adding the method here means every
+	// orchestrator built with mockSessionStore satisfies
+	// ContainerHoldingSessionLister, so the wrapper's success path is
+	// reachable; the cast-fail path is exercised by a separate stub that
+	// deliberately omits the method.
+	containerHoldingPages [][]models.Session
+	containerHoldingErr   error
+	containerHoldingCalls int
 }
 
 type failureUpdate struct {
@@ -423,6 +434,25 @@ func (m *mockSessionStore) FinalizeContainerDestroy(ctx context.Context, orgID, 
 	}
 	// Default: CAS succeeds.
 	return true, nil
+}
+
+// ListContainerHoldingSessions returns the next pre-canned page from
+// containerHoldingPages. Used only by sandbox_auth_rehydrate_test.go to
+// exercise the orchestrator wrapper's success path; adding the method here
+// (rather than in a dedicated stub) means the wrapper's interface assertion
+// succeeds for every orchestrator built with mockSessionStore.
+func (m *mockSessionStore) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID) ([]models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.containerHoldingErr != nil {
+		return nil, m.containerHoldingErr
+	}
+	idx := m.containerHoldingCalls
+	m.containerHoldingCalls++
+	if idx >= len(m.containerHoldingPages) {
+		return nil, nil
+	}
+	return m.containerHoldingPages[idx], nil
 }
 
 func (m *mockSessionStore) getStatusUpdates() []string {
@@ -5022,4 +5052,60 @@ func TestContinueSession_AmpMissingAPIKeyFailsFast(t *testing.T) {
 		"assistant message should surface the actionable error text to the user")
 	require.Equal(t, session.CurrentTurn+1, assistantMessages[0].TurnNumber,
 		"assistant error message belongs on the attempted turn, not the prior one")
+}
+
+// TestOrchestrator_RehydrateSandboxAuth_NoSandboxAuth covers the orchestrator
+// wrapper's "skip when sandboxAuth is nil" bail path. defaultDeps doesn't
+// wire a SandboxAuth, so the wrapper must short-circuit at the first nil
+// check and return (nil, nil) without touching the session store.
+func TestOrchestrator_RehydrateSandboxAuth_NoSandboxAuth(t *testing.T) {
+	t.Parallel()
+	d := defaultDeps()
+	// Pre-seed the session store with a page so we can prove the wrapper
+	// never queried it (containerHoldingCalls stays at 0).
+	d.sessions.containerHoldingPages = [][]models.Session{{
+		models.Session{ID: uuid.New(), OrgID: uuid.New()},
+	}}
+	orch := buildOrchestrator(d)
+
+	keep, err := orch.RehydrateSandboxAuthListeners(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, keep, "the orchestrator wrapper must return a nil keep when sandboxAuth isn't wired so callers skip the sweep")
+	require.Equal(t, 0, d.sessions.containerHoldingCalls, "wrapper must short-circuit before touching the session store when sandboxAuth is nil")
+}
+
+// TestOrchestrator_RehydrateSandboxAuth_SuccessPath covers the wrapper's
+// happy path: with a non-nil SandboxAuth and a session store that satisfies
+// ContainerHoldingSessionLister, the wrapper plumbs through to the
+// freestanding helper and returns its keep set. MockSandboxProvider's
+// default IsAlive returns true, so the seeded row goes all the way through
+// — IsAlive → repo lookup → Listen — and lands in the keep set. That
+// exercises every line of the wrapper (213-231) plus most of the per-row
+// success path in the freestanding helper.
+func TestOrchestrator_RehydrateSandboxAuth_SuccessPath(t *testing.T) {
+	t.Parallel()
+	agent.SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { agent.SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	orgID := testOrg()
+	repoID := uuid.MustParse("00000000-0000-0000-0000-000000000099")
+	containerID := "container-rehydrate-success"
+	sessionID := uuid.New()
+	d := defaultDeps()
+	authStub := &fakeSandboxAuthServer{}
+	d.sandboxAuth = authStub
+	d.identityResolver = identity.NewResolver(d.github, zerolog.Nop())
+	d.users = fakeUserStore{}
+	cid := containerID
+	d.sessions.containerHoldingPages = [][]models.Session{{
+		models.Session{ID: sessionID, OrgID: orgID, ContainerID: &cid, RepositoryID: &repoID},
+	}}
+	orch := buildOrchestrator(d)
+
+	keep, err := orch.RehydrateSandboxAuthListeners(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, keep, "wrapper success path must return non-nil keep so the caller knows sweep is safe")
+	require.Contains(t, keep, sessionID, "the alive container's session must be Listen'd and added to the keep set")
+	require.GreaterOrEqual(t, d.sessions.containerHoldingCalls, 1, "wrapper must have queried the session store at least once")
+	require.Equal(t, 1, authStub.listenCalls, "Listen must have been called exactly once for the seeded session")
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -441,7 +441,7 @@ func (m *mockSessionStore) FinalizeContainerDestroy(ctx context.Context, orgID, 
 // exercise the orchestrator wrapper's success path; adding the method here
 // (rather than in a dedicated stub) means the wrapper's interface assertion
 // succeeds for every orchestrator built with mockSessionStore.
-func (m *mockSessionStore) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID, _ int) ([]models.Session, error) {
+func (m *mockSessionStore) ListContainerHoldingSessions(_ context.Context, _ string, _ uuid.UUID, _ int) ([]models.Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.containerHoldingErr != nil {
@@ -5092,6 +5092,7 @@ func TestOrchestrator_RehydrateSandboxAuth_SuccessPath(t *testing.T) {
 	containerID := "container-rehydrate-success"
 	sessionID := uuid.New()
 	d := defaultDeps()
+	d.nodeID = "worker-a"
 	authStub := &fakeSandboxAuthServer{}
 	d.sandboxAuth = authStub
 	d.identityResolver = identity.NewResolver(d.github, zerolog.Nop())

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -441,7 +441,7 @@ func (m *mockSessionStore) FinalizeContainerDestroy(ctx context.Context, orgID, 
 // exercise the orchestrator wrapper's success path; adding the method here
 // (rather than in a dedicated stub) means the wrapper's interface assertion
 // succeeds for every orchestrator built with mockSessionStore.
-func (m *mockSessionStore) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID) ([]models.Session, error) {
+func (m *mockSessionStore) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID, _ int) ([]models.Session, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.containerHoldingErr != nil {

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// rehydrateMaxBatches caps how many pages of 100 container-holding sessions
+// the rehydrate pass will work through at startup. Mirrors the reconciler's
+// safety valve: a healthy worker rarely has more than a handful of sessions
+// with live preview-held containers, so hitting the cap means something is
+// wrong (degenerate query, runaway preview accumulation) and we want to keep
+// startup moving rather than spin forever.
+const rehydrateMaxBatches = 20
+
+// ContainerHoldingSessionLister is the narrow subset of the session store
+// needed by the rehydrate pass. ListContainerHoldingSessions is keyset-
+// paginated by session id (pass uuid.Nil as the cursor for the first page)
+// and returns sessions where container_id is set and a preview hold is in
+// place — i.e. the ones whose containers survive worker restarts and whose
+// in-sandbox tooling will dial a dead socket until we Listen again.
+type ContainerHoldingSessionLister interface {
+	ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID) ([]models.Session, error)
+}
+
+// OrgSettingsLoader resolves an org's PR-authorship policy for the sandbox
+// auth resolver. Defined as a function type so callers can pass either the
+// orchestrator's existing helper (which surfaces parse errors) or a test
+// stub without dragging the full OrgStore into rehydrate. The captured
+// settings are pinned to the listener for its lifetime (see
+// sandboxauth.Server.Listen), so getting them right at rehydrate time
+// matters — a wrong value persists until the next turn boundary.
+type OrgSettingsLoader func(ctx context.Context, orgID uuid.UUID) (models.OrgSettings, error)
+
+// RehydrateSandboxAuthListeners is a one-shot startup pass that re-opens the
+// per-session GitHub credential socket listener for sessions whose containers
+// are still alive across a worker restart (preview holds keep them running).
+//
+// Why this exists: the host-side sandboxauth.Server holds its listeners in
+// process memory, so a worker restart leaves their sockets on disk with no
+// listener attached. The container's directory bind-mount survives the
+// restart, so the in-sandbox 143-tools helper keeps dialing the same path —
+// and gets ECONNREFUSED until the next turn boundary calls Listen again.
+// That gap can stretch indefinitely if the user is iterating in a preview
+// without sending a new turn (the common case for "I just want to push from
+// the held-alive sandbox"). Re-opening listeners proactively at startup
+// closes the gap to a single boot delay.
+//
+// Per session we:
+//  1. Probe IsAlive (cheap docker inspect). Containers that report dead are
+//     skipped — the orphan reconciler clears those rows separately.
+//  2. Load the repo + org settings the resolver needs.
+//  3. Call sandboxAuth.Listen, which removes any stale socket file at the
+//     deterministic path and binds a fresh one. The bind-mount inside the
+//     container resolves the new file at lookup time, so the next push
+//     succeeds without any container-side reconfiguration.
+//
+// Best-effort by design: per-session failures are logged and the loop
+// continues so a single bad row can't strand the startup pass. If sandboxAuth
+// or provider is nil (legacy GITHUB_TOKEN path or no docker), we bail early
+// — there's nothing to rehydrate.
+func RehydrateSandboxAuthListeners(
+	ctx context.Context,
+	sessions ContainerHoldingSessionLister,
+	repos RepositoryStore,
+	orgSettings OrgSettingsLoader,
+	provider SandboxProvider,
+	sandboxAuth SandboxAuthServer,
+	logger zerolog.Logger,
+) (map[uuid.UUID]struct{}, error) {
+	rehydrated := make(map[uuid.UUID]struct{})
+	if sandboxAuth == nil {
+		logger.Debug().Msg("rehydrate: sandbox auth server not configured; skipping")
+		return rehydrated, nil
+	}
+	if provider == nil {
+		logger.Debug().Msg("rehydrate: no sandbox provider configured; skipping")
+		return rehydrated, nil
+	}
+
+	var totalRehydrated, totalDead, totalErrored int
+	var cursor uuid.UUID
+	hitCap := true
+
+	for batch := 0; batch < rehydrateMaxBatches; batch++ {
+		page, err := sessions.ListContainerHoldingSessions(ctx, cursor)
+		if err != nil {
+			return rehydrated, fmt.Errorf("list container-holding sessions: %w", err)
+		}
+		if len(page) == 0 {
+			hitCap = false
+			break
+		}
+		// Advance the cursor before processing so a transient per-row failure
+		// can't cause us to re-read the same page on the next iteration.
+		cursor = page[len(page)-1].ID
+
+		for i := range page {
+			run := &page[i]
+			rowLog := logger.With().
+				Str("session_id", run.ID.String()).
+				Str("org_id", run.OrgID.String()).
+				Logger()
+
+			if run.ContainerID == nil || *run.ContainerID == "" {
+				continue
+			}
+			containerID := *run.ContainerID
+			sb := &Sandbox{ID: containerID, Provider: "docker"}
+
+			alive, aliveErr := probeAliveWithRetry(ctx, provider, sb, rowLog, run.ID, containerID)
+			if aliveErr != nil {
+				totalErrored++
+				continue
+			}
+			if !alive {
+				// Reconciler will clear this row in its own pass; nothing to
+				// rehydrate against a dead container.
+				totalDead++
+				continue
+			}
+
+			if run.RepositoryID == nil {
+				rowLog.Debug().Msg("rehydrate: skipping container-holding session with no repository linked")
+				continue
+			}
+			repo, err := repos.GetByID(ctx, run.OrgID, *run.RepositoryID)
+			if err != nil {
+				rowLog.Warn().Err(err).Msg("rehydrate: failed to load repository; leaving listener un-rehydrated for this session")
+				totalErrored++
+				continue
+			}
+
+			settings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+			if orgSettings != nil {
+				loaded, err := orgSettings(ctx, run.OrgID)
+				if err != nil {
+					rowLog.Warn().Err(err).Msg("rehydrate: failed to load org settings; leaving listener un-rehydrated for this session")
+					totalErrored++
+					continue
+				}
+				settings = loaded
+			}
+
+			if _, err := sandboxAuth.Listen(ctx, run.ID, run, &repo, settings); err != nil {
+				rowLog.Warn().Err(err).
+					Str("container_id", containerID).
+					Msg("rehydrate: failed to re-open sandbox auth socket; next turn boundary will retry")
+				totalErrored++
+				continue
+			}
+			rehydrated[run.ID] = struct{}{}
+			totalRehydrated++
+		}
+	}
+
+	if hitCap {
+		logger.Warn().
+			Int("batches", rehydrateMaxBatches).
+			Int("rows_per_batch", 100).
+			Msg("rehydrate: reached batch cap before draining container-holding sessions; remaining rows will retry on next turn boundary")
+	}
+
+	if totalRehydrated > 0 || totalDead > 0 || totalErrored > 0 {
+		logger.Info().
+			Int("rehydrated", totalRehydrated).
+			Int("dead_skipped", totalDead).
+			Int("errored", totalErrored).
+			Msg("rehydrate: sandbox auth listener rehydration complete")
+	} else {
+		logger.Debug().Msg("rehydrate: no container-holding sessions found")
+	}
+	return rehydrated, nil
+}
+
+// RehydrateSandboxAuthListeners runs the freestanding RehydrateSandboxAuthListeners
+// helper using the orchestrator's already-wired dependencies. Convenience for
+// callers (cmd/server/main.go) that already have an Orchestrator and would
+// otherwise have to rewire sessions/repos/orgs/provider/sandboxAuth into the
+// freestanding form.
+//
+// Returns nil and logs at debug if the orchestrator wasn't configured with a
+// sandbox auth server (legacy GITHUB_TOKEN env path, or local-dev with no
+// SANDBOX_AUTH_SOCKET_DIR). The sessions store must implement
+// ContainerHoldingSessionLister; if it doesn't (e.g., a stub in tests that
+// only implements the orchestrator-time methods), this returns nil with a
+// warn-level log so the boot path isn't fatal.
+func (o *Orchestrator) RehydrateSandboxAuthListeners(ctx context.Context) (map[uuid.UUID]struct{}, error) {
+	if o.sandboxAuth == nil {
+		o.logger.Debug().Msg("rehydrate: orchestrator has no sandbox auth server; skipping")
+		return nil, nil
+	}
+	lister, ok := o.sessions.(ContainerHoldingSessionLister)
+	if !ok {
+		o.logger.Warn().Msg("rehydrate: session store does not implement ContainerHoldingSessionLister; skipping")
+		return nil, nil
+	}
+	return RehydrateSandboxAuthListeners(
+		ctx,
+		lister,
+		o.repositories,
+		o.sandboxAuthOrgSettings,
+		o.provider,
+		o.sandboxAuth,
+		o.logger,
+	)
+}

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -27,14 +27,14 @@ const (
 )
 
 // ContainerHoldingSessionLister is the narrow subset of the session store
-// needed by the rehydrate pass. ListContainerHoldingSessions is keyset-
-// paginated by session id (pass uuid.Nil as the cursor for the first page)
-// with the caller-provided limit, and returns sessions where container_id is
-// set and a preview hold is in place — i.e. the ones whose containers survive
-// worker restarts and whose in-sandbox tooling will dial a dead socket until
-// we Listen again.
+// needed by the rehydrate pass. ListContainerHoldingSessions is scoped to the
+// local worker node, keyset-paginated by session id (pass uuid.Nil as the
+// cursor for the first page) with the caller-provided limit, and returns
+// sessions where container_id is set and a preview hold is in place — i.e.
+// the ones whose containers survive worker restarts and whose in-sandbox
+// tooling will dial a dead socket until we Listen again.
 type ContainerHoldingSessionLister interface {
-	ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID, limit int) ([]models.Session, error)
+	ListContainerHoldingSessions(ctx context.Context, workerNodeID string, afterID uuid.UUID, limit int) ([]models.Session, error)
 }
 
 // OrgSettingsLoader resolves an org's PR-authorship policy for the sandbox
@@ -86,6 +86,7 @@ func RehydrateSandboxAuthListeners(
 	ctx context.Context,
 	sessions ContainerHoldingSessionLister,
 	repos RepositoryStore,
+	workerNodeID string,
 	orgSettings OrgSettingsLoader,
 	provider SandboxProvider,
 	sandboxAuth SandboxAuthServer,
@@ -99,6 +100,10 @@ func RehydrateSandboxAuthListeners(
 		logger.Debug().Msg("rehydrate: no sandbox provider configured; skipping")
 		return nil, nil
 	}
+	if workerNodeID == "" {
+		logger.Warn().Msg("rehydrate: worker node id is empty; skipping to avoid cross-worker socket ownership")
+		return nil, nil
+	}
 
 	keep := make(map[uuid.UUID]struct{})
 	var totalRehydrated, totalDead, totalErrored int
@@ -106,7 +111,7 @@ func RehydrateSandboxAuthListeners(
 	hitCap := true
 
 	for batch := 0; batch < rehydrateMaxBatches; batch++ {
-		page, err := sessions.ListContainerHoldingSessions(ctx, cursor, rehydrateSessionPageLimit)
+		page, err := sessions.ListContainerHoldingSessions(ctx, workerNodeID, cursor, rehydrateSessionPageLimit)
 		if err != nil {
 			// Return nil keep (not the partial map) so callers don't sweep
 			// based on incomplete coverage — a partial keep would treat
@@ -241,6 +246,7 @@ func (o *Orchestrator) RehydrateSandboxAuthListeners(ctx context.Context) (map[u
 		ctx,
 		lister,
 		o.repositories,
+		o.nodeID,
 		o.sandboxAuthOrgSettings,
 		o.provider,
 		o.sandboxAuth,

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -65,13 +65,14 @@ type OrgSettingsLoader func(ctx context.Context, orgID uuid.UUID) (models.OrgSet
 // or provider is nil (legacy GITHUB_TOKEN path or no docker), we bail early
 // — there's nothing to rehydrate.
 //
-// Return contract: a nil map means "rehydrate did NOT run" (bail-out path);
-// a non-nil map (possibly empty) means "ran successfully and these are the
-// session IDs whose listeners are now live". Callers that want to
-// post-process with a sweep MUST distinguish these — sweeping on a nil keep
-// would treat every on-disk subdir as stale and clobber sockets we never
-// re-bound, regressing into ENOENT instead of the ECONNREFUSED this fix
-// is for.
+// Return contract: a nil map means "do NOT sweep" (rehydrate did not run, or
+// did not fully drain the candidate set); a non-nil map (possibly empty)
+// means "ran to completion and these session dirs must be preserved". The
+// preserve set includes sessions whose containers are live or whose liveness
+// could not be proven, even if Listen failed, because deleting a held
+// container's bind-mounted session dir is harder to recover from than a stale
+// socket. Callers that want to post-process with a sweep MUST distinguish
+// nil from empty.
 func RehydrateSandboxAuthListeners(
 	ctx context.Context,
 	sessions ContainerHoldingSessionLister,
@@ -90,7 +91,7 @@ func RehydrateSandboxAuthListeners(
 		return nil, nil
 	}
 
-	rehydrated := make(map[uuid.UUID]struct{})
+	keep := make(map[uuid.UUID]struct{})
 	var totalRehydrated, totalDead, totalErrored int
 	var cursor uuid.UUID
 	hitCap := true
@@ -126,6 +127,10 @@ func RehydrateSandboxAuthListeners(
 
 			alive, aliveErr := probeAliveWithRetry(ctx, provider, sb, rowLog, run.ID, containerID)
 			if aliveErr != nil {
+				// Unknown liveness is not safe to sweep: the preview hold may
+				// still have a bind-mounted session dir even though Docker was
+				// temporarily unavailable to the startup probe.
+				keep[run.ID] = struct{}{}
 				totalErrored++
 				continue
 			}
@@ -135,6 +140,10 @@ func RehydrateSandboxAuthListeners(
 				totalDead++
 				continue
 			}
+			// From this point on the container is known live. Preserve its
+			// session dir even if repo/settings/listen fails below; a later
+			// turn boundary can retry Listen against the same bind mount.
+			keep[run.ID] = struct{}{}
 
 			if run.RepositoryID == nil {
 				rowLog.Debug().Msg("rehydrate: skipping container-holding session with no repository linked")
@@ -165,7 +174,6 @@ func RehydrateSandboxAuthListeners(
 				totalErrored++
 				continue
 			}
-			rehydrated[run.ID] = struct{}{}
 			totalRehydrated++
 		}
 	}
@@ -186,7 +194,10 @@ func RehydrateSandboxAuthListeners(
 	} else {
 		logger.Debug().Msg("rehydrate: no container-holding sessions found")
 	}
-	return rehydrated, nil
+	if hitCap {
+		return nil, nil
+	}
+	return keep, nil
 }
 
 // RehydrateSandboxAuthListeners runs the package-level
@@ -196,13 +207,10 @@ func RehydrateSandboxAuthListeners(
 // sessions/repos/orgs/provider/sandboxAuth into the freestanding form.
 //
 // Return contract is the same as the freestanding helper: (nil, nil) means
-// "did NOT run" (bail-out — sandboxAuth not configured, or session store
-// doesn't satisfy ContainerHoldingSessionLister); (non-nil, nil) means "ran
-// successfully" with the rehydrated session IDs as the map keys (possibly
-// empty if no sessions matched). Callers that follow up with a sweep MUST
-// gate it on `keep != nil` — sweeping on a nil keep would treat every
-// on-disk session subdir as stale and clobber sockets the orchestrator
-// never re-bound.
+// "do NOT sweep" (bail-out or incomplete pagination); (non-nil, nil) means
+// "ran to completion" with the session IDs whose dirs must be preserved as
+// the map keys (possibly empty if no sessions matched). Callers that follow
+// up with a sweep MUST gate it on `keep != nil`.
 //
 // The interface assertion on o.sessions is defensive: production wires
 // *db.SessionStore which implements ContainerHoldingSessionLister, but a

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -64,6 +64,14 @@ type OrgSettingsLoader func(ctx context.Context, orgID uuid.UUID) (models.OrgSet
 // continues so a single bad row can't strand the startup pass. If sandboxAuth
 // or provider is nil (legacy GITHUB_TOKEN path or no docker), we bail early
 // — there's nothing to rehydrate.
+//
+// Return contract: a nil map means "rehydrate did NOT run" (bail-out path);
+// a non-nil map (possibly empty) means "ran successfully and these are the
+// session IDs whose listeners are now live". Callers that want to
+// post-process with a sweep MUST distinguish these — sweeping on a nil keep
+// would treat every on-disk subdir as stale and clobber sockets we never
+// re-bound, regressing into ENOENT instead of the ECONNREFUSED this fix
+// is for.
 func RehydrateSandboxAuthListeners(
 	ctx context.Context,
 	sessions ContainerHoldingSessionLister,
@@ -73,16 +81,16 @@ func RehydrateSandboxAuthListeners(
 	sandboxAuth SandboxAuthServer,
 	logger zerolog.Logger,
 ) (map[uuid.UUID]struct{}, error) {
-	rehydrated := make(map[uuid.UUID]struct{})
 	if sandboxAuth == nil {
 		logger.Debug().Msg("rehydrate: sandbox auth server not configured; skipping")
-		return rehydrated, nil
+		return nil, nil
 	}
 	if provider == nil {
 		logger.Debug().Msg("rehydrate: no sandbox provider configured; skipping")
-		return rehydrated, nil
+		return nil, nil
 	}
 
+	rehydrated := make(map[uuid.UUID]struct{})
 	var totalRehydrated, totalDead, totalErrored int
 	var cursor uuid.UUID
 	hitCap := true
@@ -90,7 +98,10 @@ func RehydrateSandboxAuthListeners(
 	for batch := 0; batch < rehydrateMaxBatches; batch++ {
 		page, err := sessions.ListContainerHoldingSessions(ctx, cursor)
 		if err != nil {
-			return rehydrated, fmt.Errorf("list container-holding sessions: %w", err)
+			// Return nil keep (not the partial map) so callers don't sweep
+			// based on incomplete coverage — a partial keep would treat
+			// unvisited live sessions as stale and clobber their sockets.
+			return nil, fmt.Errorf("list container-holding sessions: %w", err)
 		}
 		if len(page) == 0 {
 			hitCap = false
@@ -178,18 +189,27 @@ func RehydrateSandboxAuthListeners(
 	return rehydrated, nil
 }
 
-// RehydrateSandboxAuthListeners runs the freestanding RehydrateSandboxAuthListeners
-// helper using the orchestrator's already-wired dependencies. Convenience for
-// callers (cmd/server/main.go) that already have an Orchestrator and would
-// otherwise have to rewire sessions/repos/orgs/provider/sandboxAuth into the
-// freestanding form.
+// RehydrateSandboxAuthListeners runs the package-level
+// RehydrateSandboxAuthListeners helper using the orchestrator's already-wired
+// dependencies. Convenience for callers (cmd/server/main.go) that already
+// have an Orchestrator and would otherwise have to rewire
+// sessions/repos/orgs/provider/sandboxAuth into the freestanding form.
 //
-// Returns nil and logs at debug if the orchestrator wasn't configured with a
-// sandbox auth server (legacy GITHUB_TOKEN env path, or local-dev with no
-// SANDBOX_AUTH_SOCKET_DIR). The sessions store must implement
-// ContainerHoldingSessionLister; if it doesn't (e.g., a stub in tests that
-// only implements the orchestrator-time methods), this returns nil with a
-// warn-level log so the boot path isn't fatal.
+// Return contract is the same as the freestanding helper: (nil, nil) means
+// "did NOT run" (bail-out — sandboxAuth not configured, or session store
+// doesn't satisfy ContainerHoldingSessionLister); (non-nil, nil) means "ran
+// successfully" with the rehydrated session IDs as the map keys (possibly
+// empty if no sessions matched). Callers that follow up with a sweep MUST
+// gate it on `keep != nil` — sweeping on a nil keep would treat every
+// on-disk session subdir as stale and clobber sockets the orchestrator
+// never re-bound.
+//
+// The interface assertion on o.sessions is defensive: production wires
+// *db.SessionStore which implements ContainerHoldingSessionLister, but a
+// future refactor that narrows the SessionStore interface (or a test stub
+// that only implements the orchestrator-time methods) would degrade to
+// "rehydrate is unavailable" instead of failing boot. The warn log makes
+// that degradation visible to ops.
 func (o *Orchestrator) RehydrateSandboxAuthListeners(ctx context.Context) (map[uuid.UUID]struct{}, error) {
 	if o.sandboxAuth == nil {
 		o.logger.Debug().Msg("rehydrate: orchestrator has no sandbox auth server; skipping")

--- a/internal/services/agent/sandbox_auth_rehydrate.go
+++ b/internal/services/agent/sandbox_auth_rehydrate.go
@@ -10,22 +10,31 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
-// rehydrateMaxBatches caps how many pages of 100 container-holding sessions
-// the rehydrate pass will work through at startup. Mirrors the reconciler's
-// safety valve: a healthy worker rarely has more than a handful of sessions
-// with live preview-held containers, so hitting the cap means something is
-// wrong (degenerate query, runaway preview accumulation) and we want to keep
-// startup moving rather than spin forever.
-const rehydrateMaxBatches = 20
+const (
+	// rehydrateSessionPageLimit controls how many preview-held sessions the
+	// store returns per startup rehydrate page. With rehydrateMaxBatches, this
+	// lets one boot inspect up to 10k candidates before suppressing sweep.
+	rehydrateSessionPageLimit = 500
+
+	// rehydrateMaxBatches caps how many pages of container-holding sessions
+	// the rehydrate pass will work through at startup. Mirrors the
+	// reconciler's safety valve: a healthy worker rarely has more than a
+	// handful of sessions with live preview-held containers, so hitting the
+	// cap means something is wrong (degenerate query, runaway preview
+	// accumulation) and we want to keep startup moving rather than spin
+	// forever.
+	rehydrateMaxBatches = 20
+)
 
 // ContainerHoldingSessionLister is the narrow subset of the session store
 // needed by the rehydrate pass. ListContainerHoldingSessions is keyset-
 // paginated by session id (pass uuid.Nil as the cursor for the first page)
-// and returns sessions where container_id is set and a preview hold is in
-// place — i.e. the ones whose containers survive worker restarts and whose
-// in-sandbox tooling will dial a dead socket until we Listen again.
+// with the caller-provided limit, and returns sessions where container_id is
+// set and a preview hold is in place — i.e. the ones whose containers survive
+// worker restarts and whose in-sandbox tooling will dial a dead socket until
+// we Listen again.
 type ContainerHoldingSessionLister interface {
-	ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID) ([]models.Session, error)
+	ListContainerHoldingSessions(ctx context.Context, afterID uuid.UUID, limit int) ([]models.Session, error)
 }
 
 // OrgSettingsLoader resolves an org's PR-authorship policy for the sandbox
@@ -97,7 +106,7 @@ func RehydrateSandboxAuthListeners(
 	hitCap := true
 
 	for batch := 0; batch < rehydrateMaxBatches; batch++ {
-		page, err := sessions.ListContainerHoldingSessions(ctx, cursor)
+		page, err := sessions.ListContainerHoldingSessions(ctx, cursor, rehydrateSessionPageLimit)
 		if err != nil {
 			// Return nil keep (not the partial map) so callers don't sweep
 			// based on incomplete coverage — a partial keep would treat
@@ -181,7 +190,7 @@ func RehydrateSandboxAuthListeners(
 	if hitCap {
 		logger.Warn().
 			Int("batches", rehydrateMaxBatches).
-			Int("rows_per_batch", 100).
+			Int("rows_per_batch", rehydrateSessionPageLimit).
 			Msg("rehydrate: reached batch cap before draining container-holding sessions; remaining rows will retry on next turn boundary")
 	}
 

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -30,11 +30,13 @@ type rehydrateLister struct {
 	errAtCall int
 	calls     int
 	limits    []int
+	workers   []string
 }
 
-func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID, limit int) ([]models.Session, error) {
+func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, workerNodeID string, _ uuid.UUID, limit int) ([]models.Session, error) {
 	s.calls++
 	s.limits = append(s.limits, limit)
+	s.workers = append(s.workers, workerNodeID)
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -145,6 +147,7 @@ func TestRehydrate_SkipsWhenSandboxAuthNil(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{},
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		&rehydrateProvider{},
 		nil, // sandboxAuth is the nil-check we're testing
@@ -160,6 +163,7 @@ func TestRehydrate_SkipsWhenProviderNil(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{},
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		nil,
 		&rehydrateSandboxAuth{},
@@ -180,6 +184,7 @@ func TestRehydrate_NoSessionsReturnsNonNilEmptyMap(t *testing.T) {
 		context.Background(),
 		lister,
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		&rehydrateProvider{},
 		&rehydrateSandboxAuth{},
@@ -189,6 +194,7 @@ func TestRehydrate_NoSessionsReturnsNonNilEmptyMap(t *testing.T) {
 	require.NotNil(t, keep, "successful run with no sessions must return a non-nil empty map so the caller knows sweep is safe")
 	require.Empty(t, keep)
 	require.Equal(t, []int{rehydrateSessionPageLimit}, lister.limits, "rehydrate must request the configured page size from the session store")
+	require.Equal(t, []string{"worker-a"}, lister.workers, "rehydrate must scope the startup scan to the local worker node")
 }
 
 func TestRehydrate_RebindsLiveContainerOnly(t *testing.T) {
@@ -215,6 +221,7 @@ func TestRehydrate_RebindsLiveContainerOnly(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{live, dead}}},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -255,6 +262,7 @@ func TestRehydrate_PerSessionFailureDoesNotStopLoop(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{missing, good}}},
 		repos,
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -281,6 +289,7 @@ func TestRehydrate_ListenFailureCountsAsErrorButContinues(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{first}}},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -297,6 +306,7 @@ func TestRehydrate_ListErrorBubbles(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{err: listErr},
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		&rehydrateProvider{},
 		&rehydrateSandboxAuth{},
@@ -334,6 +344,7 @@ func TestRehydrate_PartialListErrorReturnsNilKeep(t *testing.T) {
 			errAtCall: 2,
 		},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -367,6 +378,7 @@ func TestRehydrate_OrgSettingsLoaderCalledPerSession(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{run}}},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		loader,
 		prov,
 		auth,
@@ -397,6 +409,7 @@ func TestRehydrate_SkipsRowsWithEmptyContainerID(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{withNilID, withEmptyID}}},
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -428,6 +441,7 @@ func TestRehydrate_IsAliveErrorIsCounted(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{flaky}}},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -459,6 +473,7 @@ func TestRehydrate_SkipsRowsWithNilRepositoryID(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{noRepo}}},
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		prov,
 		auth,
@@ -501,6 +516,7 @@ func TestRehydrate_OrgSettingsLoaderErrorIsPerRow(t *testing.T) {
 		context.Background(),
 		&rehydrateLister{pages: [][]models.Session{{failing, healthy}}},
 		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		"worker-a",
 		loader,
 		prov,
 		auth,
@@ -543,6 +559,7 @@ func TestRehydrate_HitsBatchCap(t *testing.T) {
 		context.Background(),
 		lister,
 		&rehydrateRepoStore{},
+		"worker-a",
 		nil,
 		prov,
 		auth,

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -258,7 +258,7 @@ func TestRehydrate_PerSessionFailureDoesNotStopLoop(t *testing.T) {
 	)
 	require.NoError(t, err, "list-page failures aside, per-row errors must not bubble up")
 	require.Equal(t, []uuid.UUID{good.ID}, auth.listened, "good session should still be rehydrated despite the prior repo lookup failure")
-	require.Equal(t, map[uuid.UUID]struct{}{good.ID: {}}, keep)
+	require.Equal(t, map[uuid.UUID]struct{}{missing.ID: {}, good.ID: {}}, keep, "live sessions must be preserved from sweep even when their listener rehydrate fails")
 }
 
 func TestRehydrate_ListenFailureCountsAsErrorButContinues(t *testing.T) {
@@ -283,7 +283,7 @@ func TestRehydrate_ListenFailureCountsAsErrorButContinues(t *testing.T) {
 		zerolog.Nop(),
 	)
 	require.NoError(t, err, "Listen errors are per-row; the loop must keep going")
-	require.Empty(t, keep, "a session whose Listen failed must not be reported as rehydrated (otherwise the sweep would think it's live)")
+	require.Equal(t, map[uuid.UUID]struct{}{first.ID: {}}, keep, "a live session whose Listen failed must still be preserved from sweep")
 }
 
 func TestRehydrate_ListErrorBubbles(t *testing.T) {
@@ -405,8 +405,9 @@ func TestRehydrate_SkipsRowsWithEmptyContainerID(t *testing.T) {
 }
 
 // TestRehydrate_IsAliveErrorIsCounted covers the per-row branch where
-// IsAlive's retries all fail. The row is skipped (no Listen, not in keep)
-// and counted as errored, but the loop continues to subsequent rows.
+// IsAlive's retries all fail. The row is skipped (no Listen) and counted as
+// errored, but it stays in the keep set because an unknown-liveness preview
+// hold is not safe to sweep.
 func TestRehydrate_IsAliveErrorIsCounted(t *testing.T) {
 	t.Parallel()
 	orgID := uuid.New()
@@ -430,7 +431,7 @@ func TestRehydrate_IsAliveErrorIsCounted(t *testing.T) {
 	)
 	require.NoError(t, err, "transient IsAlive failures are per-row; the loop must keep going")
 	require.NotNil(t, keep)
-	require.Empty(t, keep, "a row whose IsAlive probe failed must not be counted as rehydrated")
+	require.Equal(t, map[uuid.UUID]struct{}{flaky.ID: {}}, keep, "a row whose IsAlive probe failed must be preserved because it may still be live")
 	require.Empty(t, auth.listened, "Listen must not be called when IsAlive itself failed — the next turn boundary will retry from scratch")
 }
 
@@ -461,7 +462,7 @@ func TestRehydrate_SkipsRowsWithNilRepositoryID(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.NotNil(t, keep)
-	require.Empty(t, keep, "rows without a repository_id must be skipped — Listen needs a repo for the resolver closure")
+	require.Equal(t, map[uuid.UUID]struct{}{noRepo.ID: {}}, keep, "live rows without a repository_id must be skipped for Listen but preserved from sweep")
 	require.Empty(t, auth.listened, "Listen must not fire when the repo lookup is impossible (nil repository_id)")
 }
 
@@ -503,7 +504,7 @@ func TestRehydrate_OrgSettingsLoaderErrorIsPerRow(t *testing.T) {
 	)
 	require.NoError(t, err, "per-row loader failures must not bubble up — the loop must continue")
 	require.NotNil(t, keep)
-	require.NotContains(t, keep, failing.ID, "the failing-org row must be skipped")
+	require.Contains(t, keep, failing.ID, "the failing-org row must be preserved from sweep even though listener rehydrate failed")
 	require.Contains(t, keep, healthy.ID, "the healthy row must still be rehydrated despite the prior failure")
 }
 
@@ -544,7 +545,6 @@ func TestRehydrate_HitsBatchCap(t *testing.T) {
 		zerolog.Nop(),
 	)
 	require.NoError(t, err, "hitting the batch cap is non-fatal — the rest of the rows are deferred to the next turn boundary")
-	require.NotNil(t, keep)
-	require.Empty(t, keep, "all containers were dead; nothing should land in the keep set")
+	require.Nil(t, keep, "hitting the batch cap means pagination coverage is incomplete, so callers must skip sweep")
 	require.Equal(t, rehydrateMaxBatches, lister.calls, "the cap must stop pagination at exactly rehydrateMaxBatches calls")
 }

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -19,16 +19,25 @@ import (
 // pages[1] is the second, etc. An empty inner slice signals end-of-stream so
 // the caller breaks. Anything beyond the last page is also returned empty,
 // which keeps degenerate batch-cap tests well-defined.
+//
+// errAtCall (1-indexed) lets a test simulate a list failure on a specific
+// call number — useful for the partial-progress case where the first page
+// returns sessions and the second page errors. errAtCall == 0 means "never
+// error here"; the unconditional `err` field still applies.
 type rehydrateLister struct {
-	pages [][]models.Session
-	err   error
-	calls int
+	pages     [][]models.Session
+	err       error
+	errAtCall int
+	calls     int
 }
 
 func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID) ([]models.Session, error) {
 	s.calls++
 	if s.err != nil {
 		return nil, s.err
+	}
+	if s.errAtCall > 0 && s.calls == s.errAtCall {
+		return nil, errors.New("simulated mid-stream list failure")
 	}
 	if s.calls-1 >= len(s.pages) {
 		return nil, nil
@@ -140,7 +149,7 @@ func TestRehydrate_SkipsWhenSandboxAuthNil(t *testing.T) {
 		zerolog.Nop(),
 	)
 	require.NoError(t, err)
-	require.Empty(t, keep, "rehydrate should return an empty keep set when sandbox auth is disabled")
+	require.Nil(t, keep, "bail-out paths must return a nil keep so callers can distinguish 'didn't run' from 'ran with no sessions' and skip the sweep")
 }
 
 func TestRehydrate_SkipsWhenProviderNil(t *testing.T) {
@@ -155,6 +164,26 @@ func TestRehydrate_SkipsWhenProviderNil(t *testing.T) {
 		zerolog.Nop(),
 	)
 	require.NoError(t, err)
+	require.Nil(t, keep, "bail-out paths must return a nil keep so callers skip the sweep")
+}
+
+// TestRehydrate_NoSessionsReturnsNonNilEmptyMap is the negative-space partner
+// to the bail-out tests: when rehydrate actually ran (deps non-nil) but the
+// list returned no rows, the keep map must be non-nil so the caller knows it
+// can safely sweep — every UUID-named subdir on disk really is stale.
+func TestRehydrate_NoSessionsReturnsNonNilEmptyMap(t *testing.T) {
+	t.Parallel()
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{},
+		&rehydrateRepoStore{},
+		nil,
+		&rehydrateProvider{},
+		&rehydrateSandboxAuth{},
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, keep, "successful run with no sessions must return a non-nil empty map so the caller knows sweep is safe")
 	require.Empty(t, keep)
 }
 
@@ -271,7 +300,44 @@ func TestRehydrate_ListErrorBubbles(t *testing.T) {
 	)
 	require.Error(t, err)
 	require.ErrorIs(t, err, listErr, "a list-page failure must surface so ops can investigate; per-row failures are swallowed but page failures aren't")
-	require.Empty(t, keep)
+	require.Nil(t, keep, "list-page errors must return nil keep — a partial map would let the caller sweep based on incomplete coverage and clobber unvisited live sockets")
+}
+
+// TestRehydrate_PartialListErrorReturnsNilKeep verifies the contract that
+// a list-page failure mid-stream still yields a nil keep, not the partial
+// map of sessions we'd already processed. A partial keep would let the
+// caller sweep based on incomplete coverage and clobber sockets for the
+// (still-live) sessions we never visited.
+func TestRehydrate_PartialListErrorReturnsNilKeep(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	first := newSession(orgID, repoID, "container-first")
+
+	prov := &rehydrateProvider{alive: map[string]bool{"container-first": true}}
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	// First call returns one session (which gets Listen'd), second call
+	// errors. The function must return nil keep despite the partial
+	// progress.
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{
+			pages:     [][]models.Session{{first}},
+			errAtCall: 2,
+		},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.Error(t, err)
+	require.Nil(t, keep, "partial-progress + list error must return nil keep so the caller skips the sweep entirely")
+	require.Equal(t, []uuid.UUID{first.ID}, auth.listened, "the first-page Listen must have happened (proving 'partial progress' is real); we just don't trust the partial keep for sweep purposes")
 }
 
 func TestRehydrate_OrgSettingsLoaderCalledPerSession(t *testing.T) {

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -371,3 +371,180 @@ func TestRehydrate_OrgSettingsLoaderCalledPerSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, loaderCalls, "loader must be consulted exactly once per rehydrated session so the captured policy reflects org config at restart time")
 }
+
+// TestRehydrate_SkipsRowsWithEmptyContainerID covers the defensive guard
+// against rows where container_id is unset or empty. The query already
+// filters those out (WHERE container_id IS NOT NULL), but a future schema
+// change or a race that nulls the column mid-page must not deref a nil
+// pointer or call IsAlive with an empty ID.
+func TestRehydrate_SkipsRowsWithEmptyContainerID(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	withNilID := models.Session{ID: uuid.New(), OrgID: orgID, RepositoryID: &repoID}
+	emptyStr := ""
+	withEmptyID := models.Session{ID: uuid.New(), OrgID: orgID, ContainerID: &emptyStr, RepositoryID: &repoID}
+
+	auth := &rehydrateSandboxAuth{}
+	prov := &rehydrateProvider{} // no entries — IsAlive should never be called
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{withNilID, withEmptyID}}},
+		&rehydrateRepoStore{},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, keep)
+	require.Empty(t, keep, "rows with no container_id must be skipped silently — no IsAlive probe, no Listen, no errored-counter bump")
+	require.Empty(t, auth.listened, "Listen must not be called for rows with missing container_id")
+}
+
+// TestRehydrate_IsAliveErrorIsCounted covers the per-row branch where
+// IsAlive's retries all fail. The row is skipped (no Listen, not in keep)
+// and counted as errored, but the loop continues to subsequent rows.
+func TestRehydrate_IsAliveErrorIsCounted(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	flaky := newSession(orgID, repoID, "container-flaky")
+
+	prov := &rehydrateProvider{err: errors.New("docker daemon unavailable")}
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{flaky}}},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err, "transient IsAlive failures are per-row; the loop must keep going")
+	require.NotNil(t, keep)
+	require.Empty(t, keep, "a row whose IsAlive probe failed must not be counted as rehydrated")
+	require.Empty(t, auth.listened, "Listen must not be called when IsAlive itself failed — the next turn boundary will retry from scratch")
+}
+
+// TestRehydrate_SkipsRowsWithNilRepositoryID covers the defensive branch
+// for sessions whose repository_id is unset. The Listen call needs a repo
+// to capture in the resolver closure; without one, we skip the row rather
+// than fabricate a default that would later resolve to the wrong identity.
+func TestRehydrate_SkipsRowsWithNilRepositoryID(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	cid := "container-no-repo"
+	noRepo := models.Session{ID: uuid.New(), OrgID: orgID, ContainerID: &cid}
+
+	prov := &rehydrateProvider{alive: map[string]bool{"container-no-repo": true}}
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{noRepo}}},
+		&rehydrateRepoStore{},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, keep)
+	require.Empty(t, keep, "rows without a repository_id must be skipped — Listen needs a repo for the resolver closure")
+	require.Empty(t, auth.listened, "Listen must not fire when the repo lookup is impossible (nil repository_id)")
+}
+
+// TestRehydrate_OrgSettingsLoaderErrorIsPerRow covers the branch where the
+// loader fails for one session: that row is skipped and counted as
+// errored, but other sessions in the same page must still be processed.
+func TestRehydrate_OrgSettingsLoaderErrorIsPerRow(t *testing.T) {
+	t.Parallel()
+	failingOrg := uuid.New()
+	healthyOrg := uuid.New()
+	repoID := uuid.New()
+	failing := newSession(failingOrg, repoID, "container-failing-org")
+	healthy := newSession(healthyOrg, repoID, "container-healthy-org")
+
+	prov := &rehydrateProvider{alive: map[string]bool{
+		"container-failing-org": true,
+		"container-healthy-org": true,
+	}}
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	loader := func(_ context.Context, gotOrgID uuid.UUID) (models.OrgSettings, error) {
+		if gotOrgID == failingOrg {
+			return models.OrgSettings{}, errors.New("settings parse error")
+		}
+		return models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}, nil
+	}
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{failing, healthy}}},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		loader,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err, "per-row loader failures must not bubble up — the loop must continue")
+	require.NotNil(t, keep)
+	require.NotContains(t, keep, failing.ID, "the failing-org row must be skipped")
+	require.Contains(t, keep, healthy.ID, "the healthy row must still be rehydrated despite the prior failure")
+}
+
+// TestRehydrate_HitsBatchCap covers the safety-valve branch where the
+// pagination cursor never empties. A pathological query (or a runaway
+// preview accumulation) would otherwise spin forever; rehydrateMaxBatches
+// caps the work and emits a warn log so ops can spot it.
+func TestRehydrate_HitsBatchCap(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+
+	// Build rehydrateMaxBatches+1 non-empty pages, each with one session
+	// whose container reads as dead so per-row work stays cheap. The +1
+	// ensures the loop exits via the cap, not via empty-page break — which
+	// is the branch we're testing.
+	const overCap = rehydrateMaxBatches + 1
+	pages := make([][]models.Session, overCap)
+	for i := range pages {
+		pages[i] = []models.Session{
+			newSession(orgID, uuid.New(), "container-dead"),
+		}
+	}
+
+	prov := &rehydrateProvider{} // alive map empty → all containers dead → fast skip
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	lister := &rehydrateLister{pages: pages}
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		lister,
+		&rehydrateRepoStore{},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err, "hitting the batch cap is non-fatal — the rest of the rows are deferred to the next turn boundary")
+	require.NotNil(t, keep)
+	require.Empty(t, keep, "all containers were dead; nothing should land in the keep set")
+	require.Equal(t, rehydrateMaxBatches, lister.calls, "the cap must stop pagination at exactly rehydrateMaxBatches calls")
+}

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -1,0 +1,307 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// rehydrateLister is a programmable ContainerHoldingSessionLister. The pages
+// field is a list-of-lists keyed by call order: pages[0] is the first batch,
+// pages[1] is the second, etc. An empty inner slice signals end-of-stream so
+// the caller breaks. Anything beyond the last page is also returned empty,
+// which keeps degenerate batch-cap tests well-defined.
+type rehydrateLister struct {
+	pages [][]models.Session
+	err   error
+	calls int
+}
+
+func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID) ([]models.Session, error) {
+	s.calls++
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.calls-1 >= len(s.pages) {
+		return nil, nil
+	}
+	return s.pages[s.calls-1], nil
+}
+
+type rehydrateRepoStore struct {
+	repos map[uuid.UUID]models.Repository
+	err   error
+}
+
+func (s *rehydrateRepoStore) GetByID(_ context.Context, _, repoID uuid.UUID) (models.Repository, error) {
+	if s.err != nil {
+		return models.Repository{}, s.err
+	}
+	if r, ok := s.repos[repoID]; ok {
+		return r, nil
+	}
+	return models.Repository{}, errors.New("repo not found")
+}
+
+// rehydrateSandboxAuth records every Listen call so tests can assert exactly
+// which session IDs were rehydrated and in what order. Listens after listenErr
+// is set return that error to exercise the "leave un-rehydrated, keep going"
+// branch.
+type rehydrateSandboxAuth struct {
+	listened  []uuid.UUID
+	listenErr error
+}
+
+func (a *rehydrateSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *models.Session, _ *models.Repository, _ models.OrgSettings) (string, error) {
+	if a.listenErr != nil {
+		return "", a.listenErr
+	}
+	a.listened = append(a.listened, sessionID)
+	return "/tmp/rehydrate.sock", nil
+}
+
+func (a *rehydrateSandboxAuth) Close(_ uuid.UUID) {}
+
+// rehydrateProvider is a minimal SandboxProvider that only implements the
+// surface area RehydrateSandboxAuthListeners actually exercises (IsAlive).
+// Everything else returns sentinel errors so an accidental regression that
+// touches Create/Exec/etc inside rehydrate fails fast with an obvious
+// message.
+type rehydrateProvider struct {
+	alive map[string]bool
+	err   error
+}
+
+func (p *rehydrateProvider) Name() string { return "rehydrate-test" }
+func (p *rehydrateProvider) Create(context.Context, SandboxConfig) (*Sandbox, error) {
+	return nil, errors.New("rehydrate test provider should not Create")
+}
+func (p *rehydrateProvider) CloneRepo(context.Context, *Sandbox, string, string, string) error {
+	return errors.New("rehydrate test provider should not CloneRepo")
+}
+func (p *rehydrateProvider) Exec(context.Context, *Sandbox, string, io.Writer, io.Writer) (int, error) {
+	return 0, errors.New("rehydrate test provider should not Exec")
+}
+func (p *rehydrateProvider) ExecStream(context.Context, *Sandbox, string, func([]byte), io.Writer) (int, error) {
+	return 0, errors.New("rehydrate test provider should not ExecStream")
+}
+func (p *rehydrateProvider) ReadFile(context.Context, *Sandbox, string) ([]byte, error) {
+	return nil, errors.New("rehydrate test provider should not ReadFile")
+}
+func (p *rehydrateProvider) WriteFile(context.Context, *Sandbox, string, []byte) error {
+	return errors.New("rehydrate test provider should not WriteFile")
+}
+func (p *rehydrateProvider) Destroy(context.Context, *Sandbox) error {
+	return errors.New("rehydrate test provider should not Destroy")
+}
+func (p *rehydrateProvider) ConnectionInfo(context.Context, *Sandbox) (*SandboxConnectionInfo, error) {
+	return nil, errors.New("rehydrate test provider should not ConnectionInfo")
+}
+func (p *rehydrateProvider) Snapshot(context.Context, *Sandbox) (io.ReadCloser, error) {
+	return nil, errors.New("rehydrate test provider should not Snapshot")
+}
+func (p *rehydrateProvider) Restore(context.Context, *Sandbox, io.Reader) error {
+	return errors.New("rehydrate test provider should not Restore")
+}
+func (p *rehydrateProvider) IsAlive(_ context.Context, sb *Sandbox) (bool, error) {
+	if p.err != nil {
+		return false, p.err
+	}
+	return p.alive[sb.ID], nil
+}
+
+func newSession(orgID, repoID uuid.UUID, containerID string) models.Session {
+	cid := containerID
+	return models.Session{
+		ID:           uuid.New(),
+		OrgID:        orgID,
+		ContainerID:  &cid,
+		RepositoryID: &repoID,
+	}
+}
+
+func TestRehydrate_SkipsWhenSandboxAuthNil(t *testing.T) {
+	t.Parallel()
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{},
+		&rehydrateRepoStore{},
+		nil,
+		&rehydrateProvider{},
+		nil, // sandboxAuth is the nil-check we're testing
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.Empty(t, keep, "rehydrate should return an empty keep set when sandbox auth is disabled")
+}
+
+func TestRehydrate_SkipsWhenProviderNil(t *testing.T) {
+	t.Parallel()
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{},
+		&rehydrateRepoStore{},
+		nil,
+		nil,
+		&rehydrateSandboxAuth{},
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.Empty(t, keep)
+}
+
+func TestRehydrate_RebindsLiveContainerOnly(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	live := newSession(orgID, repoID, "container-live")
+	dead := newSession(orgID, repoID, "container-dead")
+
+	prov := &rehydrateProvider{
+		alive: map[string]bool{
+			"container-live": true,
+			"container-dead": false,
+		},
+	}
+	auth := &rehydrateSandboxAuth{}
+
+	// Drop reconciler retry backoff to zero so this test doesn't pay 500ms
+	// per IsAlive miss if the provider ever returns a transient error.
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{live, dead}}},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{live.ID}, auth.listened, "only the alive container's session should be Listen'd")
+	require.Contains(t, keep, live.ID)
+	require.NotContains(t, keep, dead.ID)
+}
+
+func TestRehydrate_PerSessionFailureDoesNotStopLoop(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	goodRepo := uuid.New()
+	missingRepo := uuid.New()
+	good := newSession(orgID, goodRepo, "container-good")
+	missing := newSession(orgID, missingRepo, "container-missing-repo")
+
+	prov := &rehydrateProvider{
+		alive: map[string]bool{
+			"container-good":         true,
+			"container-missing-repo": true,
+		},
+	}
+	auth := &rehydrateSandboxAuth{}
+
+	// Repo store knows about goodRepo but not missingRepo; rehydrate must
+	// still process `good` even though `missing`'s repo lookup fails.
+	repos := &rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{
+		goodRepo: {InstallationID: 1, FullName: "owner/good"},
+	}}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{missing, good}}},
+		repos,
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err, "list-page failures aside, per-row errors must not bubble up")
+	require.Equal(t, []uuid.UUID{good.ID}, auth.listened, "good session should still be rehydrated despite the prior repo lookup failure")
+	require.Equal(t, map[uuid.UUID]struct{}{good.ID: {}}, keep)
+}
+
+func TestRehydrate_ListenFailureCountsAsErrorButContinues(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	first := newSession(orgID, repoID, "container-first")
+
+	prov := &rehydrateProvider{alive: map[string]bool{"container-first": true}}
+	auth := &rehydrateSandboxAuth{listenErr: errors.New("address in use")}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{first}}},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		nil,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err, "Listen errors are per-row; the loop must keep going")
+	require.Empty(t, keep, "a session whose Listen failed must not be reported as rehydrated (otherwise the sweep would think it's live)")
+}
+
+func TestRehydrate_ListErrorBubbles(t *testing.T) {
+	t.Parallel()
+	listErr := errors.New("db down")
+	keep, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{err: listErr},
+		&rehydrateRepoStore{},
+		nil,
+		&rehydrateProvider{},
+		&rehydrateSandboxAuth{},
+		zerolog.Nop(),
+	)
+	require.Error(t, err)
+	require.ErrorIs(t, err, listErr, "a list-page failure must surface so ops can investigate; per-row failures are swallowed but page failures aren't")
+	require.Empty(t, keep)
+}
+
+func TestRehydrate_OrgSettingsLoaderCalledPerSession(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	repoID := uuid.New()
+	run := newSession(orgID, repoID, "container-x")
+
+	prov := &rehydrateProvider{alive: map[string]bool{"container-x": true}}
+	auth := &rehydrateSandboxAuth{}
+
+	SetIsAliveBackoffForTesting(0)
+	t.Cleanup(func() { SetIsAliveBackoffForTesting(500 * time.Millisecond) })
+
+	var loaderCalls int
+	loader := func(_ context.Context, gotOrgID uuid.UUID) (models.OrgSettings, error) {
+		loaderCalls++
+		require.Equal(t, orgID, gotOrgID, "loader must receive the session's org_id")
+		return models.OrgSettings{PRAuthorship: models.PRAuthorshipAppOnly}, nil
+	}
+
+	_, err := RehydrateSandboxAuthListeners(
+		context.Background(),
+		&rehydrateLister{pages: [][]models.Session{{run}}},
+		&rehydrateRepoStore{repos: map[uuid.UUID]models.Repository{repoID: {InstallationID: 1, FullName: "owner/repo"}}},
+		loader,
+		prov,
+		auth,
+		zerolog.Nop(),
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, loaderCalls, "loader must be consulted exactly once per rehydrated session so the captured policy reflects org config at restart time")
+}

--- a/internal/services/agent/sandbox_auth_rehydrate_test.go
+++ b/internal/services/agent/sandbox_auth_rehydrate_test.go
@@ -29,10 +29,12 @@ type rehydrateLister struct {
 	err       error
 	errAtCall int
 	calls     int
+	limits    []int
 }
 
-func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID) ([]models.Session, error) {
+func (s *rehydrateLister) ListContainerHoldingSessions(_ context.Context, _ uuid.UUID, limit int) ([]models.Session, error) {
 	s.calls++
+	s.limits = append(s.limits, limit)
 	if s.err != nil {
 		return nil, s.err
 	}
@@ -173,9 +175,10 @@ func TestRehydrate_SkipsWhenProviderNil(t *testing.T) {
 // can safely sweep — every UUID-named subdir on disk really is stale.
 func TestRehydrate_NoSessionsReturnsNonNilEmptyMap(t *testing.T) {
 	t.Parallel()
+	lister := &rehydrateLister{}
 	keep, err := RehydrateSandboxAuthListeners(
 		context.Background(),
-		&rehydrateLister{},
+		lister,
 		&rehydrateRepoStore{},
 		nil,
 		&rehydrateProvider{},
@@ -185,6 +188,7 @@ func TestRehydrate_NoSessionsReturnsNonNilEmptyMap(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, keep, "successful run with no sessions must return a non-nil empty map so the caller knows sweep is safe")
 	require.Empty(t, keep)
+	require.Equal(t, []int{rehydrateSessionPageLimit}, lister.limits, "rehydrate must request the configured page size from the session store")
 }
 
 func TestRehydrate_RebindsLiveContainerOnly(t *testing.T) {

--- a/internal/services/sandboxauth/server.go
+++ b/internal/services/sandboxauth/server.go
@@ -242,6 +242,66 @@ func (s *Server) Shutdown() {
 	}
 }
 
+// SweepStaleSessionDirs removes per-session subdirectories under socketDir
+// whose UUID isn't in keep. Called by the worker boot path after rehydrate
+// has re-Listen'd for every still-alive container, so anything left over is
+// either (a) a session whose container is dead (orphaned by a worker crash
+// before Close ran) or (b) a session whose row was already deleted. Either
+// way, the subdir is no longer load-bearing and accumulates indefinitely
+// without this sweep.
+//
+// Best-effort: a directory we can't read or remove is logged and skipped.
+// Subdirs in keep are left untouched even if they look empty — a freshly
+// rehydrated listener may not have written its socket file yet.
+//
+// Names that don't parse as UUIDs are also skipped: socketDir is shared with
+// no other writers by contract, but defending against a stray file (e.g. a
+// future tmpfile artifact, an op-team manual probe) is cheap and prevents
+// this sweep from accidentally deleting something it shouldn't.
+func (s *Server) SweepStaleSessionDirs(keep map[uuid.UUID]struct{}) {
+	if s.socketDir == "" {
+		return
+	}
+	entries, err := os.ReadDir(s.socketDir)
+	if err != nil {
+		s.logger.Warn().Err(err).Str("socket_dir", s.socketDir).Msg("sandboxauth: sweep failed to read socket dir")
+		return
+	}
+	var swept, kept, skipped int
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			skipped++
+			continue
+		}
+		id, err := uuid.Parse(entry.Name())
+		if err != nil {
+			skipped++
+			continue
+		}
+		if _, ok := keep[id]; ok {
+			kept++
+			continue
+		}
+		dirPath := filepath.Join(s.socketDir, entry.Name())
+		// RemoveAll because the subdir typically contains a leftover socket
+		// file (and possibly a stale lock or temp artifact). The contract
+		// for socketDir is "Server owns it" — nothing outside this package
+		// writes here, so removing the whole tree is safe.
+		if err := os.RemoveAll(dirPath); err != nil {
+			s.logger.Warn().Err(err).Str("session_dir", dirPath).Msg("sandboxauth: sweep failed to remove stale session dir")
+			continue
+		}
+		swept++
+	}
+	if swept > 0 || kept > 0 {
+		s.logger.Info().
+			Int("swept", swept).
+			Int("kept", kept).
+			Int("skipped", skipped).
+			Msg("sandboxauth: stale session dir sweep complete")
+	}
+}
+
 func (s *Server) detach(sessionID uuid.UUID) func() {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/services/sandboxauth/server.go
+++ b/internal/services/sandboxauth/server.go
@@ -250,6 +250,16 @@ func (s *Server) Shutdown() {
 // way, the subdir is no longer load-bearing and accumulates indefinitely
 // without this sweep.
 //
+// Boot-time sequencing assumption: this is called synchronously from the
+// worker boot path after RehydrateSandboxAuthListeners returns and BEFORE
+// processWorkers begin claiming jobs. Because of that ordering, no
+// concurrent Listen() can race the os.ReadDir → os.RemoveAll loop below —
+// the only Listens that could be in flight while sweep runs are the ones
+// rehydrate itself just made, and those session IDs are exactly what's in
+// `keep`. If a future refactor backgrounds rehydrate or moves the sweep
+// off the boot path, this assumption breaks and we'd need a per-session
+// mutex (or to read s.active under the server's lock).
+//
 // Best-effort: a directory we can't read or remove is logged and skipped.
 // Subdirs in keep are left untouched even if they look empty — a freshly
 // rehydrated listener may not have written its socket file yet.

--- a/internal/services/sandboxauth/server_test.go
+++ b/internal/services/sandboxauth/server_test.go
@@ -591,3 +591,62 @@ func TestServer_SweepStaleSessionDirs_EmptyKeep(t *testing.T) {
 	_, err := os.Stat(filepath.Join(dir, id.String()))
 	require.True(t, os.IsNotExist(err), "every UUID-named subdir should be swept when keep is empty")
 }
+
+// TestServer_SweepStaleSessionDirs_NoSocketDir is the early-return path:
+// when socketDir is unset (local-dev with no SANDBOX_AUTH_SOCKET_DIR), the
+// sweep must be a no-op rather than panicking on os.ReadDir("").
+func TestServer_SweepStaleSessionDirs_NoSocketDir(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(&stubResolver{}, "", zerolog.Nop())
+	require.NotPanics(t, func() {
+		srv.SweepStaleSessionDirs(map[uuid.UUID]struct{}{uuid.New(): {}})
+	}, "sweep must short-circuit on an unset socketDir without touching the filesystem")
+}
+
+// TestServer_SweepStaleSessionDirs_ReadDirFailure covers the branch where
+// ReadDir returns an error (e.g. socketDir was removed out from under us
+// between NewServer-time stat probe and the boot-time sweep). The function
+// must log and return cleanly — there's nothing useful to sweep against an
+// inaccessible directory.
+func TestServer_SweepStaleSessionDirs_ReadDirFailure(t *testing.T) {
+	t.Parallel()
+	// Point socketDir at a path under /tmp that exists at NewServer time
+	// (so the perms-probe doesn't fail) but gets deleted before sweep —
+	// ReadDir then returns a stat-like error.
+	dir, err := os.MkdirTemp("/tmp", "143a-sweep-readdir-*")
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(dir, 0o750))
+
+	srv := NewServer(&stubResolver{}, dir, zerolog.Nop())
+	require.NoError(t, os.RemoveAll(dir), "test setup: remove the dir so ReadDir fails")
+
+	require.NotPanics(t, func() {
+		srv.SweepStaleSessionDirs(nil)
+	}, "ReadDir failure must be swallowed — the sweep is best-effort hygiene, not a hard precondition for boot")
+}
+
+// TestServer_SweepStaleSessionDirs_NonUUIDDirectoryEntry exercises the
+// branch where a directory entry's name doesn't parse as a UUID. The sweep
+// must skip it (counted as `skipped`, not `swept`) so a stray dir from
+// future tooling or a manual ops probe survives — the contract is that the
+// sweep only owns UUID-named subdirs.
+func TestServer_SweepStaleSessionDirs_NonUUIDDirectoryEntry(t *testing.T) {
+	t.Parallel()
+	dir := shortSocketDir(t)
+
+	// A directory (not a file) with a non-UUID name. The earlier sweep test
+	// covers a non-UUID FILE, which short-circuits at the !IsDir check; this
+	// one specifically lands in the uuid.Parse error branch.
+	strayDir := filepath.Join(dir, "manual-ops-probe")
+	require.NoError(t, os.MkdirAll(strayDir, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(strayDir, "marker"), []byte("preserve me"), 0o600))
+
+	srv := NewServer(&stubResolver{}, dir, zerolog.Nop())
+	srv.SweepStaleSessionDirs(nil)
+
+	_, err := os.Stat(strayDir)
+	require.NoError(t, err, "non-UUID directory entries must survive sweep so future tooling/ops dirs aren't clobbered")
+	_, err = os.Stat(filepath.Join(strayDir, "marker"))
+	require.NoError(t, err, "the contents of a non-UUID dir must also be preserved")
+}

--- a/internal/services/sandboxauth/server_test.go
+++ b/internal/services/sandboxauth/server_test.go
@@ -533,3 +533,61 @@ func TestAssertParentDirPerms_ErrorPaths(t *testing.T) {
 		require.Contains(t, err.Error(), "is not a directory", "error should explain the type mismatch")
 	})
 }
+
+// TestServer_SweepStaleSessionDirs covers the post-rehydrate hygiene pass:
+// per-session subdirs whose UUIDs aren't in `keep` get removed, dirs that
+// are kept survive, and non-UUID entries are left alone (the contract is
+// that socketDir is single-writer, but the sweep should still defend against
+// stray files rather than blow them away).
+func TestServer_SweepStaleSessionDirs(t *testing.T) {
+	t.Parallel()
+	dir := shortSocketDir(t)
+
+	keepID := uuid.New()
+	staleID1 := uuid.New()
+	staleID2 := uuid.New()
+
+	for _, id := range []uuid.UUID{keepID, staleID1, staleID2} {
+		subdir := filepath.Join(dir, id.String())
+		require.NoError(t, os.MkdirAll(subdir, 0o750))
+		// Drop a leftover socket-shaped file inside each subdir to mimic the
+		// crash scenario this sweep is for: files left behind by a crashed
+		// orchestrator that didn't reach its Shutdown closer.
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, SocketFileName), []byte{}, 0o600))
+	}
+	// A non-UUID entry: must be left untouched even though it's not in keep,
+	// so the sweep can't clobber stray files dropped by ops/tooling.
+	strayPath := filepath.Join(dir, "not-a-uuid")
+	require.NoError(t, os.WriteFile(strayPath, []byte("manual probe"), 0o600))
+
+	srv := NewServer(&stubResolver{}, dir, zerolog.Nop())
+	srv.SweepStaleSessionDirs(map[uuid.UUID]struct{}{keepID: {}})
+
+	_, err := os.Stat(filepath.Join(dir, keepID.String()))
+	require.NoError(t, err, "kept session dir should still exist after sweep")
+
+	_, err = os.Stat(filepath.Join(dir, staleID1.String()))
+	require.True(t, os.IsNotExist(err), "stale session dir 1 should be removed")
+	_, err = os.Stat(filepath.Join(dir, staleID2.String()))
+	require.True(t, os.IsNotExist(err), "stale session dir 2 should be removed")
+
+	_, err = os.Stat(strayPath)
+	require.NoError(t, err, "non-UUID entries should be left alone")
+}
+
+// TestServer_SweepStaleSessionDirs_EmptyKeep verifies sweep with an empty
+// keep set removes every UUID-named subdir — the case where a worker boots
+// with no live preview-held containers.
+func TestServer_SweepStaleSessionDirs_EmptyKeep(t *testing.T) {
+	t.Parallel()
+	dir := shortSocketDir(t)
+
+	id := uuid.New()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, id.String()), 0o750))
+
+	srv := NewServer(&stubResolver{}, dir, zerolog.Nop())
+	srv.SweepStaleSessionDirs(nil)
+
+	_, err := os.Stat(filepath.Join(dir, id.String()))
+	require.True(t, os.IsNotExist(err), "every UUID-named subdir should be swept when keep is empty")
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -161,6 +161,12 @@ type Services struct {
 	// so listener goroutines and on-disk socket files don't outlive the
 	// process.
 	SandboxAuthShutdown func()
+	// SandboxAuthSweep removes per-session subdirs in the socket dir whose
+	// UUID isn't in the keep set. Called once at startup, after the
+	// rehydrate pass has re-Listen'd for every still-alive container, so
+	// leftover dirs from prior worker generations don't accumulate. nil
+	// when no SandboxAuthSocketDir is configured.
+	SandboxAuthSweep func(keep map[uuid.UUID]struct{})
 }
 
 type orchestratorService interface {


### PR DESCRIPTION
## Summary

Sessions whose containers survive a worker restart (preview-held) had no listener bound to their on-disk credential socket until the next turn boundary, so in-sandbox `git push` failed with ECONNREFUSED in the gap. This PR adds a startup pass that lists container-holding sessions, probes `IsAlive`, and re-`Listen`s for each live container, then sweeps leftover per-session subdirs so they don't accumulate across worker generations.

The fix covers all triggers: graceful deploys (clean shutdown removes sockets — rehydrate creates fresh ones), SIGKILL/panic crashes (stale files left behind — `Listen`'s existing pre-bind `os.Remove` cleans them), and any other restart cause.

The follow-up commit tightens the rehydrate→sweep contract: a nil keep means "rehydrate did not run" (skip sweep), a non-nil keep means "ran successfully" (sweep is safe). Mid-stream list errors return nil to prevent partial-keep-driven destructive sweeps.

## Test plan
- [ ] Verify sandbox `git push` works immediately after a worker restart without waiting for a new turn boundary
- [ ] Confirm boot logs show `rehydrate: ... rehydrated=N` for live preview-held sessions
- [ ] Confirm boot logs show `stale session dir sweep complete` after rehydrate
- [ ] Verify dead-container rows are skipped (reconciler clears them in its own pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
