### PR TITLE
Add Tokens/session column and relabel Share to clarify breakdown basis

### DIFF
--- a/docs/design/implemented/46-billing-usage-dashboard.md
+++ b/docs/design/implemented/46-billing-usage-dashboard.md
@@ -269,6 +269,8 @@ Response:
 }
 ```
 
+**Breakdown share labeling:** The share column is only meaningful when the basis is explicit. The current breakdown share is defined as **share of total container hours** in the selected range, so the UI labels it `Share of Hours` with a tooltip instead of a generic `%`. This keeps the table interpretable when adjacent columns also show sessions, tokens, `Tokens/session`, and estimated cost. If we later support alternate share bases, the label must continue to name the basis directly (for example `Share of Tokens`) rather than reverting to a bare percentage sign.
+
 ### `GET /api/v1/usage/export`
 
 Returns a CSV download of usage data for the selected time range and filters.
@@ -514,7 +516,7 @@ The minimum viable usage page — summary cards and the main timeseries chart.
 
 The detailed breakdown view and cross-filtering between chart and table.
 
-- [ ] **`usage-breakdown-table.tsx`**: TanStack React Table showing per-user breakdown with columns: User, Minutes, Sessions, Tokens, Est. Cost, % Share. Dimension toggle for "By User" / "By Capacity" / "By Exit Reason". Calls `GET /api/v1/usage/breakdown`
+- [ ] **`usage-breakdown-table.tsx`**: TanStack React Table showing per-user breakdown with columns: User, Minutes, Sessions, Tokens, Est. Cost, Tokens/session, Share of Hours. Dimension toggle for "By User" / "By Capacity" / "By Exit Reason". Calls `GET /api/v1/usage/breakdown`
 - [ ] **`usage-capacity-bars.tsx`**: Horizontal stacked bar chart showing capacity tier distribution
 - [ ] **User filter on chart**: Dropdown populated from breakdown data — selecting a user filters the timeseries chart to that user's data via `user_id` query param
 - [ ] **Click-to-filter (table → chart)**: Clicking a row in the breakdown table filters the chart to that user/tier

--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -525,6 +525,9 @@ describe('UsageBreakdownTable', () => {
       expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     });
     expect(screen.getByText('1.0h')).toBeInTheDocument();
+    expect(screen.getByText('Tokens/session')).toBeInTheDocument();
+    expect(screen.getByText('2.3K')).toBeInTheDocument();
+    expect(screen.getByText('Share of Hours')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
@@ -56,6 +56,13 @@ export function UsageBreakdownTable({
 
   const rows = data?.data ?? [];
 
+  function formatTokensPerSession(totalTokens: number, totalSessions: number): string {
+    if (totalSessions <= 0) {
+      return "-";
+    }
+    return formatTokenCount(totalTokens / totalSessions);
+  }
+
   return (
     <Card>
       <CardContent className="p-4">
@@ -116,7 +123,18 @@ export function UsageBreakdownTable({
                       </TableHead>
                     </>
                   )}
-                  <TableHead className="text-xs text-right pr-4">%</TableHead>
+                  <TableHead className="text-xs text-right">Tokens/session</TableHead>
+                  <TableHead className="text-xs text-right pr-4">
+                    <Tooltip>
+                      <TooltipTrigger className="inline-flex items-center justify-end gap-1 w-full">
+                        Share of Hours
+                        <Info className="h-3 w-3 text-muted-foreground" />
+                      </TooltipTrigger>
+                      <TooltipContent className="max-w-[220px]">
+                        Percent of total container hours in the selected time range.
+                      </TooltipContent>
+                    </Tooltip>
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -148,6 +166,12 @@ export function UsageBreakdownTable({
                         </TableCell>
                       </>
                     )}
+                    <TableCell className="text-[13px] text-right tabular-nums">
+                      {formatTokensPerSession(
+                        row.total_input_tokens + row.total_output_tokens,
+                        row.total_sessions
+                      )}
+                    </TableCell>
                     <TableCell className="text-[13px] text-right tabular-nums pr-4">
                       <div className="flex items-center justify-end gap-2">
                         <div className="w-16 h-1.5 bg-muted rounded-full overflow-hidden">


### PR DESCRIPTION
## Summary
Updated the usage breakdown table to include a derived **Tokens/session** metric and improved the “share” column labeling to explicitly reflect its basis (“Share of Hours”). This makes the table easier to interpret alongside adjacent token/session/cost columns.

## Changes
- **frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx**
  - Added a derived `Tokens/session` column computed as `(input tokens + output tokens) / sessions`.
  - Render `-` when `sessions` is zero to avoid misleading infinite/undefined values.
  - Replaced the ambiguous `%` header with **Tokens/session** and updated the remaining share header/label to **Share of Hours** (with tooltip as applicable).
- **frontend/src/app/(dashboard)/settings/usage/page.test.tsx**
  - Extended assertions to cover the new table headers and the expected formatted `Tokens/session` value.
- **docs/design/implemented/46-billing-usage-dashboard.md**
  - Updated the design note to document why the share column is labeled by its explicit basis (e.g., “Share of Hours”) rather than a generic percentage sign.
  - Updated the feature checklist for `usage-breakdown-table.tsx` to reflect the new columns.

## Test plan
- `npx vitest --run src/app/(dashboard)/settings/usage/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 5d2cce20](https://app.143.dev/sessions/5d2cce20-484d-4a45-9946-2548dec75c8b)*
