### PR TITLE
Improve Preview start UI with loading spinner, guidance, and startup checklist

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -70,6 +70,7 @@ const DEFAULT_PROPS = {
 function makePreviewStatus(
   overrides: Partial<PreviewStatusResponse["instance"]> = {},
   services: PreviewStatusResponse["services"] = [],
+  infrastructure: NonNullable<PreviewStatusResponse["infrastructure"]> = [],
 ): PreviewStatusResponse {
   return {
     instance: {
@@ -97,7 +98,7 @@ function makePreviewStatus(
       ...overrides,
     },
     services,
-    infrastructure: [],
+    infrastructure,
   };
 }
 
@@ -534,6 +535,90 @@ describe("PreviewPanel component", () => {
     await waitFor(() => {
       expect(mockStart).toHaveBeenCalledWith("sess-1");
     });
+  });
+
+  it("shows only the loading spinner while starting a preview from idle state", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+    mockStart.mockReturnValue(
+      new Promise<void>(() => {
+        // Keep the mutation pending so the loading state remains visible.
+      }),
+    );
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Start Preview" })).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole("button", { name: "Start Preview" });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(button.querySelector("[data-slot='button-spinner']")).toBeInTheDocument();
+    });
+    expect(button.querySelector("svg.lucide-play")).not.toBeInTheDocument();
+  });
+
+  it("shows startup guidance while the preview is being created", async () => {
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Preview startup can take a few minutes.")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText("You can stay here while we spin up the environment and bring services online."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a startup checklist from infrastructure and service state", async () => {
+    mockGet.mockResolvedValue(
+      makePreviewStatus(
+        { status: "starting" },
+        [
+          {
+            id: "svc-1",
+            preview_instance_id: "prev-1",
+            service_name: "web",
+            role: "primary",
+            status: "starting",
+            command: ["npm", "run", "dev"],
+            cwd: "",
+            port: 3000,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        [
+          {
+            id: "infra-1",
+            preview_instance_id: "prev-1",
+            infra_name: "postgres",
+            template: "postgres",
+            container_id: "ctr-1",
+            status: "provisioning",
+            host: "postgres",
+            port: 5432,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      ),
+    );
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Startup checklist")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Spin up infrastructure")).toBeInTheDocument();
+    expect(screen.getByText("postgres is provisioning")).toBeInTheDocument();
+    expect(screen.getByText("Start services")).toBeInTheDocument();
+    expect(screen.getByText("web is starting")).toBeInTheDocument();
+    expect(screen.getByText("Open the preview")).toBeInTheDocument();
   });
 
   /* ---------- Stop mutation ---------- */

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -32,6 +32,8 @@ import { api } from "@/lib/api";
 import {
   PREVIEW_ERROR_CODES,
   type PreviewStatus,
+  type PreviewInfrastructure,
+  type PreviewService,
 } from "@/lib/preview-types";
 import { ConsoleBadge } from "./console-badge";
 import { DesignModeOverlay } from "./design-mode-overlay";
@@ -110,6 +112,114 @@ function serviceStatusIcon(status: string) {
   }
 }
 
+type StartupChecklistStepState = "complete" | "active" | "pending" | "failed";
+
+interface StartupChecklistStep {
+  title: string;
+  state: StartupChecklistStepState;
+  detail: string;
+}
+
+function buildStartupChecklist(
+  status: PreviewStatus | undefined,
+  services: PreviewService[],
+  infrastructure: PreviewInfrastructure[],
+): StartupChecklistStep[] {
+  const infraFailed = infrastructure.find(
+    (item) => item.status === "failed" || item.status === "unhealthy",
+  );
+  const infraProvisioning = infrastructure.find(
+    (item) => item.status === "provisioning",
+  );
+  const allInfraHealthy =
+    infrastructure.length > 0 &&
+    infrastructure.every((item) => item.status === "healthy");
+
+  const serviceFailed = services.find((service) => service.status === "failed");
+  const serviceStarting = services.find((service) => service.status === "starting");
+  const allServicesReady =
+    services.length > 0 && services.every((service) => service.status === "ready");
+
+  const openPreviewState: StartupChecklistStepState =
+    status === "failed"
+      ? "failed"
+      : status === "ready" || status === "partially_ready"
+        ? "complete"
+        : status === "starting"
+          ? "active"
+          : "pending";
+
+  const openPreviewDetail =
+    status === "ready"
+      ? "Preview is ready to open."
+      : status === "partially_ready"
+        ? "Primary service is ready while background services finish."
+        : status === "failed"
+          ? "Preview startup failed before the app became reachable."
+          : "Waiting for the preview URL to become reachable.";
+
+  const steps: StartupChecklistStep[] = [];
+
+  if (infrastructure.length > 0) {
+    steps.push({
+      title: "Spin up infrastructure",
+      state: infraFailed
+        ? "failed"
+        : allInfraHealthy
+          ? "complete"
+          : infraProvisioning
+            ? "active"
+            : "pending",
+      detail: infraFailed
+        ? `${infraFailed.infra_name} failed to become healthy`
+        : allInfraHealthy
+          ? `${infrastructure.length === 1 ? infrastructure[0].infra_name : `${infrastructure.length} services`} ready`
+          : infraProvisioning
+            ? `${infraProvisioning.infra_name} is provisioning`
+            : "Waiting to start preview infrastructure.",
+    });
+  }
+
+  steps.push({
+    title: "Start services",
+    state: serviceFailed
+      ? "failed"
+      : allServicesReady
+        ? "complete"
+        : serviceStarting
+          ? "active"
+          : "pending",
+    detail: serviceFailed
+      ? `${serviceFailed.service_name} failed to start`
+      : allServicesReady
+        ? `${services.length === 1 ? services[0]?.service_name ?? "App" : `${services.length} services`} ready`
+        : serviceStarting
+          ? `${serviceStarting.service_name} is starting`
+          : "Waiting for services to boot.",
+  });
+
+  steps.push({
+    title: "Open the preview",
+    state: openPreviewState,
+    detail: openPreviewDetail,
+  });
+
+  return steps;
+}
+
+function startupStepIcon(state: StartupChecklistStepState) {
+  switch (state) {
+    case "complete":
+      return <CheckCircle2 className="size-3.5 text-emerald-500" />;
+    case "active":
+      return <Loader2 className="size-3.5 animate-spin text-primary" />;
+    case "failed":
+      return <AlertTriangle className="size-3.5 text-destructive" />;
+    default:
+      return <Circle className="size-3.5 text-muted-foreground" />;
+  }
+}
+
 
 export function PreviewPanel({
   sessionId,
@@ -150,6 +260,7 @@ export function PreviewPanel({
 
   const instance = previewStatus?.instance;
   const services = previewStatus?.services ?? [];
+  const infrastructure = previewStatus?.infrastructure ?? [];
   const status = instance?.status;
   const isActive =
     status === "ready" ||
@@ -353,6 +464,10 @@ export function PreviewPanel({
     startMutation.isPending ||
     stopMutation.isPending ||
     restartMutation.isPending;
+  const startupChecklist =
+    isActive && !isReady
+      ? buildStartupChecklist(status, services, infrastructure)
+      : [];
 
   if (statusLoading) {
     return (
@@ -556,6 +671,12 @@ export function PreviewPanel({
       {/* Startup progress */}
       {isActive && !isReady && (
         <div className="space-y-2">
+          <div className="rounded-lg border bg-muted/30 p-3">
+            <p className="text-sm font-medium">Preview startup can take a few minutes.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              You can stay here while we spin up the environment and bring services online.
+            </p>
+          </div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             {STATUS_ORDER.map((p, i) => {
               const currentIdx = STATUS_ORDER.indexOf(
@@ -594,6 +715,25 @@ export function PreviewPanel({
               className="h-full bg-primary rounded-full transition-all duration-500"
               style={{ width: `${statusProgress(status as PreviewStatus)}%` }}
             />
+          </div>
+          <div className="rounded-lg border bg-background/70 p-3">
+            <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+              Startup checklist
+            </div>
+            <div className="space-y-2">
+              {startupChecklist.map((step) => (
+                <div
+                  key={step.title}
+                  className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/20 px-2.5 py-2"
+                >
+                  <div className="mt-0.5">{startupStepIcon(step.state)}</div>
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium">{step.title}</div>
+                    <div className="text-xs text-muted-foreground">{step.detail}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       )}
@@ -690,9 +830,12 @@ export function PreviewPanel({
             disabled={isMutating}
             loading={startMutation.isPending}
           >
-            <Play className="size-3.5" />
+            {!startMutation.isPending && <Play className="size-3.5" />}
             Start Preview
           </Button>
+          <p className="text-xs text-muted-foreground">
+            Preview startup can take a few minutes once the environment begins booting.
+          </p>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Updated the PreviewPanel start flow UI to better reflect backend progress. When starting from idle, the Start button now shows only a spinner; during preview creation, users see startup guidance and a checklist derived from infrastructure and service state.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Refined the “Start Preview” button to display a loading spinner while the start mutation is pending (avoids showing the play icon).
  - Added a user-facing guidance message while the preview is in the **starting** state.
  - Implemented a **Startup checklist** UI that renders steps based on `infrastructure` and `services` statuses.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Extended `makePreviewStatus` to allow injecting `infrastructure` test data.
  - Added tests covering:
    - Spinner-only behavior when starting from `stopped`.
    - Display of startup guidance in `starting`.
    - Rendering of checklist items for both infrastructure and services.

## Test plan
- Ran the frontend unit tests for `PreviewPanel` (`preview-panel.test.tsx`), verifying the new loading, guidance, and checklist behaviors via mocked API responses and pending start mutation.

---
*Generated by [143.dev](https://143.dev) — [session c0414a28](https://app.143.dev/sessions/c0414a28-8a6d-49cb-9398-1ed66375a21e)*
