### PR TITLE
Dedupe initial-turn final assistant log against transcript message

### DIFF
--- a/internal/db/session_log_store_test.go
+++ b/internal/db/session_log_store_test.go
@@ -235,22 +235,22 @@ func TestSessionLogStore_MarkAssistantTranscriptDuplicate(t *testing.T) {
 		setupMock func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID)
 		expectErr string
 	}{
-			{
-				name: "success",
-				setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
-					mock.ExpectExec("UPDATE session_logs").
-						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
-						WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-				},
+		{
+			name: "success",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				mock.ExpectExec("UPDATE session_logs").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 			},
-			{
-				name: "database error",
-				setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
-					mock.ExpectExec("UPDATE session_logs").
-						WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
-						WillReturnError(context.DeadlineExceeded)
-				},
-				expectErr: "mark assistant transcript duplicate",
+		},
+		{
+			name: "database error",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID) {
+				mock.ExpectExec("UPDATE session_logs").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
+					WillReturnError(context.DeadlineExceeded)
+			},
+			expectErr: "mark assistant transcript duplicate",
 		},
 	}
 
@@ -278,6 +278,29 @@ func TestSessionLogStore_MarkAssistantTranscriptDuplicate(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+// Pins the NULLIF guard in MarkAssistantTranscriptDuplicate. Pre-fix
+// streamLogs persisted nil metadata as the JSONB value `null` (json.Marshal
+// of a nil map returns "null") instead of SQL NULL; on those legacy rows
+// `metadata || '{...}'::jsonb` resolves to `null` and would drop the
+// duplicate marker. The NULLIF coalesces both shapes into '{}' before the
+// merge. Removing the clause should fail this test.
+func TestSessionLogStore_MarkAssistantTranscriptDuplicate_NormalizesLegacyJSONBNullMetadata(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool without error")
+	defer mock.Close()
+
+	store := NewSessionLogStore(mock)
+	mock.ExpectExec(`COALESCE\(NULLIF\(metadata, 'null'::jsonb\), '\{\}'::jsonb\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), (*uuid.UUID)(nil), 3, "Final answer").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.MarkAssistantTranscriptDuplicate(context.Background(), uuid.New(), uuid.New(), nil, 3, "Final answer")
+	require.NoError(t, err, "MarkAssistantTranscriptDuplicate should succeed when the SQL normalizes legacy JSONB null metadata before the merge")
+	require.NoError(t, mock.ExpectationsWereMet(), "MarkAssistantTranscriptDuplicate SQL must contain the NULLIF guard against legacy JSONB null metadata")
 }
 
 func TestSessionLogStore_ListByThread(t *testing.T) {

--- a/internal/db/session_logs.go
+++ b/internal/db/session_logs.go
@@ -64,7 +64,7 @@ func (s *SessionLogStore) Create(ctx context.Context, log *models.SessionLog) er
 func (s *SessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error {
 	query := `
 		UPDATE session_logs
-		SET metadata = COALESCE(metadata, '{}'::jsonb) || '{"type":"assistant_final","duplicate_of_transcript":true}'::jsonb
+		SET metadata = COALESCE(NULLIF(metadata, 'null'::jsonb), '{}'::jsonb) || '{"type":"assistant_final","duplicate_of_transcript":true}'::jsonb
 		WHERE id = (
 			SELECT id
 			FROM session_logs

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1361,7 +1361,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, run.ID, run.OrgID, nil, run.CurrentTurn, logCh, runtimeTracker)
+		o.streamLogs(ctx, run.ID, run.OrgID, nil, turnNumber, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -1370,7 +1370,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Wait()
 
 	// 10b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, nil, run.CurrentTurn, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.ID, nil, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 11. Handle result.
 	stopReason := StopReasonNone
@@ -2492,10 +2492,14 @@ func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, t
 				tracker.Record(progressType, strength, entry.Timestamp)
 			}
 		}
-		metadata, err := json.Marshal(entry.Metadata)
-		if err != nil {
-			o.logger.Warn().Err(err).Str("run_id", runID.String()).Msg("failed to marshal log entry metadata")
-			metadata = nil
+		var metadata json.RawMessage
+		if entry.Metadata != nil {
+			var err error
+			metadata, err = json.Marshal(entry.Metadata)
+			if err != nil {
+				o.logger.Warn().Err(err).Str("run_id", runID.String()).Msg("failed to marshal log entry metadata")
+				metadata = nil
+			}
 		}
 
 		effectiveThreadID := threadID

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -114,4 +115,61 @@ func TestStreamLogs_CarriesThreadID(t *testing.T) {
 	require.Equal(t, 2, logs.logs[0].TurnNumber, "persisted log should keep the turn number")
 	require.Equal(t, "streamed message", logs.logs[0].Message, "persisted log should keep the message content")
 	require.Nil(t, logs.logs[0].Metadata, "persisted log should leave absent metadata as SQL null")
+}
+
+func TestStreamLogs_PersistsMetadataAsJSON(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	logs := &testInternalSessionLogStore{}
+	orch := &Orchestrator{
+		agentRunLogs: logs,
+		logger:       zerolog.Nop(),
+	}
+
+	logCh := make(chan LogEntry, 1)
+	logCh <- LogEntry{
+		Timestamp: time.Now(),
+		Level:     "output",
+		Message:   "with metadata",
+		Metadata:  map[string]interface{}{"step": "two"},
+	}
+	close(logCh)
+
+	orch.streamLogs(context.Background(), sessionID, orgID, nil, 1, logCh, nil)
+
+	require.Len(t, logs.logs, 1, "streamLogs should persist the log entry")
+	require.NotNil(t, logs.logs[0].Metadata, "non-nil metadata should be marshaled and persisted")
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(logs.logs[0].Metadata, &decoded), "persisted metadata should be valid JSON")
+	require.Equal(t, "two", decoded["step"], "persisted metadata should round-trip the entry payload")
+}
+
+func TestStreamLogs_DropsUnmarshalableMetadata(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	sessionID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	logs := &testInternalSessionLogStore{}
+	orch := &Orchestrator{
+		agentRunLogs: logs,
+		logger:       zerolog.Nop(),
+	}
+
+	logCh := make(chan LogEntry, 1)
+	logCh <- LogEntry{
+		Timestamp: time.Now(),
+		Level:     "output",
+		Message:   "bad metadata",
+		Metadata:  map[string]interface{}{"fn": func() {}},
+	}
+	close(logCh)
+
+	orch.streamLogs(context.Background(), sessionID, orgID, nil, 1, logCh, nil)
+
+	require.Len(t, logs.logs, 1, "streamLogs should still persist the log entry when metadata fails to marshal")
+	require.Nil(t, logs.logs[0].Metadata, "unmarshalable metadata should be dropped to nil rather than blocking the log")
 }

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -113,4 +113,5 @@ func TestStreamLogs_CarriesThreadID(t *testing.T) {
 	require.Equal(t, threadID, *logs.logs[0].ThreadID, "persisted log should use the provided thread id")
 	require.Equal(t, 2, logs.logs[0].TurnNumber, "persisted log should keep the turn number")
 	require.Equal(t, "streamed message", logs.logs[0].Message, "persisted log should keep the message content")
+	require.Nil(t, logs.logs[0].Metadata, "persisted log should leave absent metadata as SQL null")
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -531,6 +531,14 @@ func (m *mockSessionLogStore) getCount() int {
 	return m.count
 }
 
+func (m *mockSessionLogStore) getLogs() []models.SessionLog {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]models.SessionLog, len(m.logs))
+	copy(out, m.logs)
+	return out
+}
+
 func (m *mockSessionLogStore) MarkAssistantTranscriptDuplicate(ctx context.Context, orgID, sessionID uuid.UUID, threadID *uuid.UUID, turnNumber int, message string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -983,6 +991,9 @@ func TestRunAgent_MarksFinalOutputLogAsTranscriptDuplicate(t *testing.T) {
 	require.Equal(t, run.ID, d.logs.markedSessionID, "duplicate marker should use the session id")
 	require.Equal(t, 1, d.logs.markedTurnNumber, "duplicate marker should tag the first turn")
 	require.Equal(t, "Final answer", d.logs.markedMessage, "duplicate marker should target the final assistant summary")
+	logs := d.logs.getLogs()
+	require.Len(t, logs, 1, "RunAgent should persist the streamed final output log")
+	require.Equal(t, 1, logs[0].TurnNumber, "initial run logs should use the same first-turn number as the assistant transcript")
 }
 
 func TestRunAgent_ContinuesWhenAssistantMessageCreateFails(t *testing.T) {

--- a/internal/services/sessiontimeline/timeline.go
+++ b/internal/services/sessiontimeline/timeline.go
@@ -184,7 +184,12 @@ func duplicateTranscriptLogIDs(messages []models.SessionMessage, logs []models.S
 		if !ok {
 			continue
 		}
-		candidates := visibleByTranscript[key]
+		candidates := append([]models.SessionLog(nil), visibleByTranscript[key]...)
+		if key.turnNumber == 1 {
+			legacyInitialKey := key
+			legacyInitialKey.turnNumber = 0
+			candidates = append(candidates, visibleByTranscript[legacyInitialKey]...)
+		}
 		if len(candidates) == 0 {
 			continue
 		}

--- a/internal/services/sessiontimeline/timeline_test.go
+++ b/internal/services/sessiontimeline/timeline_test.go
@@ -102,6 +102,29 @@ func TestComposeTimeline_DedupesLegacyRowsWithoutMetadata(t *testing.T) {
 	require.Equal(t, models.SessionTimelineKindMessage, result[0].Kind, "assistant message should win for transcript rendering")
 }
 
+// Pins the legacy turn-0 fallback in duplicateTranscriptLogIDs: pre-fix
+// initial-run logs were tagged with turn 0 while the matching assistant
+// transcript message uses turn 1. The shim still dedupes those historical
+// rows. Removing the fallback should fail this test.
+func TestComposeTimeline_DedupesLegacyTurnZeroInitialRunLogAgainstTurnOneTranscript(t *testing.T) {
+	t.Parallel()
+
+	messages := []models.SessionMessage{
+		makeMessage(t, func(msg *models.SessionMessage) {
+			msg.TurnNumber = 1
+		}, "2026-01-01T00:00:03Z"),
+	}
+	logs := []models.SessionLog{
+		makeLog(t, func(log *models.SessionLog) {
+			log.TurnNumber = 0
+		}, "2026-01-01T00:00:02Z", "output", "assistant reply"),
+	}
+
+	result := Compose(messages, logs)
+	require.Len(t, result, 1, "legacy turn-0 initial-run log should dedupe against the turn-1 assistant transcript")
+	require.Equal(t, models.SessionTimelineKindMessage, result[0].Kind, "assistant transcript should remain visible after legacy log dedupe")
+}
+
 func TestComposeTimeline_SuppressesDuplicateAssistantOutputWithWhitespaceDifferences(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fix initial-turn final assistant message rendering twice in the timeline. `RunAgent` now passes `turnNumber` (= `CurrentTurn+1`) to `streamLogs` and `retryOnTokenExpired`, so initial log rows and the assistant transcript share a turn number.
- `streamLogs` skips `json.Marshal` for nil metadata (which used to persist as JSONB `null` and broke `metadata || jsonb` merges); `MarkAssistantTranscriptDuplicate` wraps with `NULLIF` to repair legacy rows already on disk.
- `duplicateTranscriptLogIDs` falls back to turn 0 when matching turn-1 transcript messages so historical sessions still dedupe.
- Both legacy shims are pinned by named tests (regex-pinned SQL for the `NULLIF`, explicit turn-0/turn-1 dedupe test for the timeline fallback) so removing either fails loudly.

## Test plan
- [ ] `go test ./internal/services/sessiontimeline/... ./internal/services/agent/... ./internal/db/...`
- [ ] Manually verify a fresh session no longer shows the duplicate final assistant entry in the timeline
- [ ] Spot-check a historical session (pre-fix data) still dedupes via the legacy fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)