### PR TITLE
Apply text-xs body styling to PR details cards and update tests

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1143,7 +1143,8 @@ describe('SessionDetailPage', () => {
 
     expect(await screen.findByText('PR merged')).toBeInTheDocument();
     expect(screen.queryAllByText('PR merged')).toHaveLength(1);
-    expect(screen.getByText('PR #42 was merged successfully.')).toBeInTheDocument();
+    expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
+    expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('button', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-violet-700', 'dark:text-violet-400');
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2529,8 +2529,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </div>
                   <div className="min-w-0 space-y-1">
                     <div className="text-sm font-medium text-foreground">PR closed</div>
-                    <p className="text-sm text-foreground">{closedPRSummary}</p>
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-xs text-foreground">{closedPRSummary}</p>
+                    <p className="text-xs text-muted-foreground">
                       This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
                     </p>
                   </div>
@@ -2547,8 +2547,8 @@ export function SessionDetailContent({ id }: { id: string }) {
                   </div>
                   <div className="min-w-0 space-y-1">
                     <div className="text-sm font-medium text-foreground">PR merged</div>
-                    <p className="text-sm text-foreground">{mergedPRSummary}</p>
-                    <p className="text-sm text-muted-foreground">
+                    <p className="text-xs text-foreground">{mergedPRSummary}</p>
+                    <p className="text-xs text-muted-foreground">
                       This change has landed. Open a follow-up session if you need to make another revision.
                     </p>
                   </div>

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -33,7 +33,7 @@ const baseHealth: PullRequestHealthResponse = {
 };
 
 describe("PRHealthBanner", () => {
-  it("uses text-sm sizing for the header and metadata copy", () => {
+  it("uses text-sm for the header and text-xs for non-header copy", () => {
     renderWithProviders(
       <PRHealthBanner
         health={baseHealth}
@@ -47,7 +47,8 @@ describe("PRHealthBanner", () => {
     );
 
     expect(screen.getByText("PR health")).toHaveClass("text-sm");
-    expect(screen.getByText("PR #42 · acme/widgets")).toHaveClass("text-sm");
+    expect(screen.getByText("PR #42 · acme/widgets")).toHaveClass("text-xs");
+    expect(screen.getByText("PR #42 is healthy.")).toHaveClass("text-xs");
   });
 
   it("hides the Merge button when can_merge is false", () => {

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -60,13 +60,13 @@ export function PRHealthBanner({
               </div>
               <div className="min-w-0">
                 <div className="text-sm font-medium text-foreground">PR health</div>
-                <div className="text-sm text-muted-foreground">
+                <div className="text-xs text-muted-foreground">
                   PR #{health.pull_request_number} · {health.repository}
                 </div>
               </div>
             </div>
 
-            <p className="text-sm text-foreground">{health.summary}</p>
+            <p className="text-xs text-foreground">{health.summary}</p>
 
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant="secondary" className="text-xs">


### PR DESCRIPTION
## Summary
Updated the PR status UI so all non-header copy inside the session PR detail cards uses `text-xs`, aligning with the rest of the page. Kept card headers as `text-sm` and tightened tests to enforce the styling.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Updated **“PR closed”** and **“PR merged”** cards:
    - Changed summary + helper text from `text-sm` to `text-xs`
    - Left the header (“PR closed”/“PR merged”) as `text-sm`
- `frontend/src/components/pr-health-banner.tsx`
  - Updated the open-state **“PR health”** banner body/metadata to use `text-xs` while keeping the header `text-sm`
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Added assertions that PR merged summary + helper text have `text-xs`
- `frontend/src/components/pr-health-banner.test.tsx`
  - Strengthened assertions that PR health metadata and status copy have `text-xs` (header remains `text-sm`)

## Test plan
- Ran `npx vitest` for the affected tests
- Verified frontend checks: `npm run typecheck`, `npm run lint`, `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session fc0008a3](https://app.143.dev/sessions/fc0008a3-f9ee-4f33-899a-cbe0902ee701)*
