### PR TITLE
Fix preview start failing on every repo with auto-detect

### DIFF
--- a/deploy/vector.yaml
+++ b/deploy/vector.yaml
@@ -10,33 +10,69 @@ transforms:
     type: remap
     inputs: ["docker_logs"]
     source: |
-      # Extract Docker Compose service name
-      .service = .label."com.docker.compose.service" || "unknown"
+      # Stash docker-compose's service label under a non-colliding key so
+      # any zerolog `service` field on the actual log line wins after merge.
+      .compose_service = .label."com.docker.compose.service" || "unknown"
 
-      # Parse structured JSON logs from our Go services (zerolog output).
-      # Selectively extract known zerolog fields rather than merging the entire parsed
-      # object into root, which would clobber Vector metadata (source_type, container_name, etc.).
+      # Parse structured JSON logs from our Go services (zerolog output) and
+      # merge ALL parsed fields into the root, except a small denylist of
+      # vector-managed metadata that we don't want callers to be able to spoof
+      # or accidentally collide with. This used to be an allowlist, which
+      # silently dropped any new structured field a developer added (e.g.
+      # `exit_code`, `worker_node_id`, `preview_id`) until vector.yaml was
+      # also updated. Denylist is the right default: surface everything,
+      # protect only the keys vector needs to keep its own meaning.
+      #
+      # NOTE on Vector upgrades: the protected list below covers the
+      # docker_logs source's reserved metadata as of Vector 0.40. If you
+      # bump the Vector version, re-check
+      # https://vector.dev/docs/reference/configuration/sources/docker_logs/
+      # for new top-level fields that callers must not be able to spoof.
       parsed = parse_json(.message) ?? null
-      if parsed != null {
-        .message = string(parsed.message) ?? .message
-        .timestamp = string(parsed.time) ?? .timestamp
-        .level = string(parsed.level) ?? .level
-        .error = parsed.error
-        .caller = parsed.caller
-        .org_id = parsed.org_id
-        .agent_run_id = parsed.agent_run_id
-        .trace_id = parsed.trace_id
-        .request_id = parsed.request_id
-        .path = parsed.path
-        .status = parsed.status
-        .error_code = parsed.error_code
-        .error_message = parsed.error_message
-        .response_time_ms = parsed.response_time_ms
+      if is_object(parsed) {
+        # Snapshot vector/docker_logs metadata BEFORE merge so a malicious
+        # or accidentally-colliding zerolog field can't overwrite it.
+        protected_host = .host
+        protected_hostname = .hostname
+        protected_image = .image
+        protected_stream = .stream
+        protected_source_type = .source_type
+        protected_container_id = .container_id
+        protected_container_name = .container_name
+        protected_container_created_at = .container_created_at
+        protected_label = .label
+
+        # Merge first: every parsed field flows to root (and overwrites the
+        # raw .message that the docker_logs source wrote). Hoists / renames
+        # happen below so they can't be silently undone by the merge.
+        . = merge(., parsed) ?? .
+
+        # Rename .time → .timestamp (the only structural rename we apply to
+        # zerolog output; .message and .level keep their names).
+        .timestamp = string(.time) ?? .timestamp
+        del(.time)
+
+        # Restore protected metadata in case parsed contained a colliding key.
+        .host = protected_host
+        .hostname = protected_hostname
+        .image = protected_image
+        .stream = protected_stream
+        .source_type = protected_source_type
+        .container_id = protected_container_id
+        .container_name = protected_container_name
+        .container_created_at = protected_container_created_at
+        .label = protected_label
       }
 
       # Add server identity
       .server = get_env_var("SERVER_ROLE") ?? "unknown"
       .hostname, err = get_hostname()
+      # Preserve the docker compose service value at .service if the
+      # application log didn't supply its own — keeps existing dashboards /
+      # _stream_fields working unchanged for log lines that don't set it.
+      if !exists(.service) {
+        .service = .compose_service
+      }
 
   # Drop health check requests after JSON parsing so we can match on structured fields.
   # Filtering on .path avoids accidentally dropping app logs that mention health endpoints.

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -618,6 +618,34 @@ describe("PreviewPanel component", () => {
     });
   });
 
+  it("shows the backend message verbatim (no 'Failed to start preview:' prefix) when no .143/preview.json is committed", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+    const backendMessage =
+      "this repo has no .143/preview.json committed. Add one (see docs/guides/previews.md) so the preview knows what command to run.";
+    const err = new Error(backendMessage);
+    (err as Error & { code?: string }).code = "PREVIEW_NO_CONFIG";
+    mockStart.mockRejectedValueOnce(err);
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No preview running")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(backendMessage)).toBeInTheDocument();
+    });
+    // Guard against regression: if anyone wraps this code in the generic
+    // "Failed to start preview:" prefix, the backend's actionable message
+    // (which names the file the user must add) gets buried.
+    expect(
+      screen.queryByText(`Failed to start preview: ${backendMessage}`)
+    ).not.toBeInTheDocument();
+  });
+
   it("dismisses mutation error banner when X is clicked", async () => {
     const user = userEvent.setup();
     mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -194,6 +194,12 @@ export function PreviewPanel({
         );
         return;
       }
+      if (code === PREVIEW_ERROR_CODES.NO_CONFIG) {
+        // Backend message already names the file the user needs to add and
+        // points to the docs — pass it through verbatim.
+        setMutationError(err.message);
+        return;
+      }
       setMutationError(`Failed to start preview: ${err.message}`);
     },
   });

--- a/frontend/src/lib/preview-types.ts
+++ b/frontend/src/lib/preview-types.ts
@@ -32,6 +32,10 @@ export const PREVIEW_ERROR_CODES = {
   // 500 — internal failure while hydrating (restore error, provider
   // outage, DB write failure). Generic; details in the underlying message.
   HYDRATE_FAILED: "PREVIEW_HYDRATE_FAILED",
+  // 422 — the repo has no committed .143/preview.json and the client
+  // didn't supply an explicit config, so the backend has nothing to launch.
+  // User fix is to commit the config file (see docs/guides/previews.md).
+  NO_CONFIG: "PREVIEW_NO_CONFIG",
 } as const;
 
 export type PreviewErrorCode =

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -27,6 +27,7 @@ type PreviewHandler struct {
 	manager         *preview.Manager
 	store           *db.PreviewStore
 	sessionStore    *db.SessionStore
+	repoStore       *db.RepositoryStore
 	fileReader      sandbox.FileReader
 	sandboxProvider agent.SandboxProvider
 	snapshots       storage.SnapshotStore
@@ -50,11 +51,12 @@ type PreviewHandler struct {
 // snapshot into it so the preview has a live workspace to run against.
 // Both may be nil in test builds; the handler falls back to
 // "NO_SANDBOX"/"SNAPSHOT_EXPIRED" errors in that case.
-func NewPreviewHandler(manager *preview.Manager, store *db.PreviewStore, sessionStore *db.SessionStore, fileReader sandbox.FileReader, sandboxProvider agent.SandboxProvider, snapshots storage.SnapshotStore, logger zerolog.Logger) *PreviewHandler {
+func NewPreviewHandler(manager *preview.Manager, store *db.PreviewStore, sessionStore *db.SessionStore, repoStore *db.RepositoryStore, fileReader sandbox.FileReader, sandboxProvider agent.SandboxProvider, snapshots storage.SnapshotStore, logger zerolog.Logger) *PreviewHandler {
 	return &PreviewHandler{
 		manager:         manager,
 		store:           store,
 		sessionStore:    sessionStore,
+		repoStore:       repoStore,
 		fileReader:      fileReader,
 		sandboxProvider: sandboxProvider,
 		snapshots:       snapshots,
@@ -246,6 +248,32 @@ type acquireSandboxResult struct {
 	Err error
 }
 
+// resolveSandboxWorkDir returns the absolute path inside the sandbox where
+// the session's repo is checked out. Mirrors orchestrator.go's logic
+// (HomeDir + "/" + slug) so file-reads against sb.WorkDir resolve to the same
+// place the agent uses. Falls back to /workspace when there's no attached
+// repo or the lookup fails — losing auto-detect is preferable to refusing to
+// hydrate at all.
+func (h *PreviewHandler) resolveSandboxWorkDir(ctx context.Context, session *models.Session) string {
+	defaults := agent.DefaultSandboxConfig()
+	if session.RepositoryID == nil || h.repoStore == nil {
+		return defaults.WorkDir
+	}
+	repo, err := h.repoStore.GetByID(ctx, session.OrgID, *session.RepositoryID)
+	if err != nil {
+		h.logger.Warn().Err(err).
+			Str("session_id", session.ID.String()).
+			Str("repository_id", session.RepositoryID.String()).
+			Msg("preview: repo lookup for sandbox WorkDir failed; falling back to default")
+		return defaults.WorkDir
+	}
+	slug := agent.SlugForRepo(repo.FullName)
+	if slug == "" {
+		return defaults.WorkDir
+	}
+	return defaults.HomeDir + "/" + slug
+}
+
 // acquireSandbox resolves a live sandbox for a preview start, picking between
 // three strategies:
 //   - Reuse: session.ContainerID is set; attach by ID.
@@ -254,6 +282,8 @@ type acquireSandboxResult struct {
 //   - Expired/Unavailable: no container and no usable snapshot; caller should
 //     return 410 only when the reaper explicitly expired the snapshot.
 func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, session *models.Session) acquireSandboxResult {
+	workDir := h.resolveSandboxWorkDir(ctx, session)
+
 	// Reuse is only safe when the row believes the container is actually
 	// running. A lingering container_id from a crashed worker or a session
 	// whose sandbox_state has since moved to 'snapshotted'/'destroyed' should
@@ -263,7 +293,7 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 		candidate := &agent.Sandbox{
 			ID:        *session.ContainerID,
 			Provider:  "docker",
-			WorkDir:   "/workspace",
+			WorkDir:   workDir,
 			SessionID: session.ID.String(),
 			OrgID:     session.OrgID.String(),
 			Purpose:   "preview",
@@ -317,13 +347,13 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 	}
 
 	// Hydrate: build a SandboxConfig matching what the orchestrator uses so
-	// the restored container has consistent resource limits and paths. Note
-	// that WorkDir deliberately stays as the default — the snapshot tar
-	// restores at absolute paths (it was taken with tar including abs
-	// paths), so WorkDir only affects where ad-hoc commands run, and a
-	// subsequent agent turn will wrap the sandbox with the repo-specific
-	// WorkDir before executing.
+	// the restored container has consistent resource limits and paths.
+	// WorkDir resolves from the session's repo (HomeDir + "/" + slug) so
+	// downstream sandbox commands — notably readWorkspacePreviewConfig's
+	// ReadFile against sb.WorkDir + "/.143/preview.json" — land in the same
+	// path the orchestrator uses, not the legacy /workspace default.
 	sandboxCfg := agent.DefaultSandboxConfig()
+	sandboxCfg.WorkDir = workDir
 	sandboxCfg.SessionID = session.ID.String()
 	sandboxCfg.OrgID = session.OrgID.String()
 	sandboxCfg.Purpose = "preview_hydrate"
@@ -405,13 +435,18 @@ type startPreviewRequest struct {
 	ProfileName   string                `json:"profile_name"`
 }
 
-func defaultPreviewConfig() *models.PreviewConfig {
+// reservationPlaceholderConfig returns a minimal valid config used solely to
+// satisfy ValidateConfig at reservation time when the client hasn't supplied
+// one. The real config (workspace .143/preview.json) is loaded after hydrate
+// and either replaces this placeholder or causes the reservation to abort
+// with PREVIEW_NO_CONFIG. This config is never executed.
+func reservationPlaceholderConfig() *models.PreviewConfig {
 	return &models.PreviewConfig{
-		Name:    "default",
+		Name:    "placeholder",
 		Primary: "app",
 		Services: map[string]models.ServiceConfig{
 			"app": {
-				Command: []string{"npm", "start"},
+				Command: []string{"true"},
 				Port:    3000,
 				Ready: models.ReadinessProbe{
 					HTTPPath: "/",
@@ -444,12 +479,14 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 	// container behind, and (b) acquires preview_holding_container=TRUE before
 	// hydrate publishes container_id, so a concurrent turn release's
 	// FinalizeContainerDestroy sees our hold and leaves the freshly-hydrated
-	// container alone. The config passed here is "initial" — if the client
-	// didn't supply one, we fall back to defaults and LaunchPreview will
-	// overwrite the row if workspace autodetect resolves something different.
+	// container alone. When the client didn't supply a config we reserve with
+	// a benign placeholder solely to satisfy ValidateConfig; the real config
+	// is loaded post-hydrate from the workspace and either replaces the
+	// placeholder before LaunchPreview or aborts the reservation with
+	// PREVIEW_NO_CONFIG. The placeholder is never executed.
 	initialConfig := body.Config
 	if initialConfig == nil {
-		initialConfig = defaultPreviewConfig()
+		initialConfig = reservationPlaceholderConfig()
 	}
 	input := preview.StartPreviewInput{
 		SessionID:     sessionID,
@@ -506,25 +543,26 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 	}
 
 	if body.Config == nil {
-		// Auto-detect: first try to read .143/preview.json from the session's
-		// workspace so repos with a committed config just work. Fall back to a
-		// Node.js default (npm start, port 3000) only if no config is present.
+		// Auto-detect: read .143/preview.json from the session's workspace.
+		// We deliberately do NOT fall back to a generic "npm start on :3000"
+		// default — for any repo without that file, that fallback exits within
+		// seconds and the user waits ~90s for the readiness probe to give up.
+		// Returning a clear PREVIEW_NO_CONFIG error is strictly more useful.
 		cfg, err := h.readWorkspacePreviewConfig(ctx, sb, sessionID)
 		if err != nil {
-			// Infrastructure failure (docker exec, sandbox gone, etc.) — do
-			// not silently swap in Node.js defaults, which would start the
-			// wrong preview for a non-Node project and time out after minutes.
 			h.manager.AbortReservation(ctx, reservation, hydratedID, fmt.Sprintf("read workspace config: %v", err))
 			return nil, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_CONFIG_READ_FAILED", "failed to read preview config from workspace", err)
 		}
-		if cfg != nil {
-			input.Config = cfg
-		} else {
-			h.logger.Info().
-				Str("session_id", sessionID.String()).
-				Msg("no preview config provided or committed, using Node.js defaults (npm start, port 3000)")
-			// input.Config already holds defaults from the reservation.
+		if cfg == nil {
+			h.manager.AbortReservation(ctx, reservation, hydratedID, "no committed preview config")
+			return nil, newPreviewHTTPError(
+				http.StatusUnprocessableEntity,
+				"PREVIEW_NO_CONFIG",
+				"this repo has no .143/preview.json committed. Add one (see docs/guides/previews.md) so the preview knows what command to run.",
+				nil,
+			)
 		}
+		input.Config = cfg
 	}
 	input.Sandbox = sb
 

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -141,19 +141,21 @@ func TestPreviewHandler_StartPreview_InvalidBody(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestPreviewHandler_StartPreview_DefaultConfig(t *testing.T) {
+func TestPreviewHandler_ReservationPlaceholderConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := defaultPreviewConfig()
+	// reservationPlaceholderConfig only has to satisfy ValidateConfig so the
+	// reservation row is creatable when the client doesn't supply a config.
+	// The real config (workspace .143/preview.json) is loaded post-hydrate;
+	// this placeholder is never executed.
+	cfg := reservationPlaceholderConfig()
 
-	require.Equal(t, "default", cfg.Name, "default preview config should use the default profile name")
-	require.Equal(t, "app", cfg.Primary, "default preview config should set the primary service")
-	require.Equal(t, []string{"npm", "start"}, cfg.Services["app"].Command, "default preview config should run npm start")
-	require.Equal(t, 3000, cfg.Services["app"].Port, "default preview config should expose the default Node port")
-	require.Equal(t, "/", cfg.Services["app"].Ready.HTTPPath, "default preview config should include a readiness probe path")
+	require.Equal(t, "placeholder", cfg.Name)
+	require.Equal(t, "app", cfg.Primary)
+	require.NotEmpty(t, cfg.Services["app"].Command, "placeholder must define a command so ValidateConfig passes")
 
 	errs := preview.ValidateConfig(cfg)
-	require.Empty(t, errs, "default preview config should satisfy preview validation")
+	require.Empty(t, errs, "reservation placeholder must satisfy preview validation")
 }
 
 func TestPreviewHandler_ManagerNotConfigured(t *testing.T) {
@@ -419,6 +421,21 @@ func newPreviewHandlerWithMock(mock pgxmock.PgxPoolIface) *PreviewHandler {
 	}
 }
 
+// validWorkspaceConfigJSON is a minimal but well-formed .143/preview.json,
+// used by tests that need StartPreview to traverse past the post-hydrate
+// auto-detect step (PREVIEW_NO_CONFIG) and exercise the actual launch path.
+const validWorkspaceConfigJSON = `{
+  "name": "test-app",
+  "primary": "app",
+  "services": {
+    "app": {
+      "command": ["echo", "ok"],
+      "port": 3000,
+      "ready": {"http_path": "/"}
+    }
+  }
+}`
+
 // previewTestContextWithIDs creates a request context with specific org/user IDs and chi URL param.
 func previewTestContextWithIDs(r *http.Request, orgID, userID uuid.UUID, sessionID string) *http.Request {
 	ctx := middleware.WithUser(r.Context(), &models.User{
@@ -593,10 +610,115 @@ func TestNewPreviewHandler(t *testing.T) {
 	})
 
 	sessionStore := db.NewSessionStore(mock)
-	h := NewPreviewHandler(mgr, store, sessionStore, sandbox.NoOpFileReader{}, nil, nil, zerolog.Nop())
+	repoStore := db.NewRepositoryStore(mock)
+	h := NewPreviewHandler(mgr, store, sessionStore, repoStore, sandbox.NoOpFileReader{}, nil, nil, zerolog.Nop())
 	require.NotNil(t, h)
 	require.NotNil(t, h.manager)
 	require.NotNil(t, h.store)
+}
+
+// =============================================================================
+// resolveSandboxWorkDir tests
+// =============================================================================
+
+// repositoryRowColumns mirrors the SELECT projection of RepositoryStore.GetByID.
+// Keep in sync with internal/db/repositories.go.
+var repositoryRowColumns = []string{
+	"id", "org_id", "integration_id", "github_id", "full_name", "default_branch",
+	"private", "language", "description", "clone_url", "installation_id", "status",
+	"last_synced_at", "context_quality", "settings", "created_at", "updated_at",
+}
+
+// repoRow returns a minimal valid Repository row for pgxmock with the given
+// full_name. Other fields hold zero/default values — only full_name matters
+// for resolveSandboxWorkDir.
+func repoRow(repoID, orgID uuid.UUID, fullName string) []any {
+	now := time.Now()
+	return []any{
+		repoID, orgID, uuid.New(), int64(1), fullName, "main",
+		false, (*string)(nil), (*string)(nil), "https://example.invalid/x.git",
+		int64(1), "active",
+		(*time.Time)(nil), (*float64)(nil), json.RawMessage(`{}`), now, now,
+	}
+}
+
+func TestResolveSandboxWorkDir_NilRepoID(t *testing.T) {
+	t.Parallel()
+
+	h := &PreviewHandler{logger: zerolog.Nop()}
+	got := h.resolveSandboxWorkDir(context.Background(), &models.Session{ID: uuid.New(), OrgID: uuid.New()})
+	require.Equal(t, "/workspace", got, "missing RepositoryID must fall back to legacy /workspace default")
+}
+
+func TestResolveSandboxWorkDir_NilRepoStore(t *testing.T) {
+	t.Parallel()
+
+	// RepositoryID set but no repoStore wired (e.g. legacy/test handlers) —
+	// must not panic; falls back to default.
+	repoID := uuid.New()
+	h := &PreviewHandler{logger: zerolog.Nop()}
+	got := h.resolveSandboxWorkDir(context.Background(), &models.Session{
+		ID: uuid.New(), OrgID: uuid.New(), RepositoryID: &repoID,
+	})
+	require.Equal(t, "/workspace", got, "nil repoStore must fall back rather than panic")
+}
+
+func TestResolveSandboxWorkDir_LookupSuccess(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM repositories\\s+WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repositoryRowColumns).
+				AddRow(repoRow(repoID, orgID, "assembledhq/143")...),
+		)
+
+	h := &PreviewHandler{
+		logger:    zerolog.Nop(),
+		repoStore: db.NewRepositoryStore(mock),
+	}
+	got := h.resolveSandboxWorkDir(context.Background(), &models.Session{
+		ID: uuid.New(), OrgID: orgID, RepositoryID: &repoID,
+	})
+	// Slug for "assembledhq/143" is "143"; default HomeDir is "/home/sandbox".
+	// Must match orchestrator.go's per-session WorkDir derivation so
+	// readWorkspacePreviewConfig finds .143/preview.json on disk.
+	require.Equal(t, "/home/sandbox/143", got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestResolveSandboxWorkDir_LookupError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM repositories\\s+WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("db down"))
+
+	h := &PreviewHandler{
+		logger:    zerolog.Nop(),
+		repoStore: db.NewRepositoryStore(mock),
+	}
+	got := h.resolveSandboxWorkDir(context.Background(), &models.Session{
+		ID: uuid.New(), OrgID: orgID, RepositoryID: &repoID,
+	})
+	// Losing auto-detect for one preview start is preferable to refusing to
+	// hydrate at all when the DB has a transient hiccup.
+	require.Equal(t, "/workspace", got, "lookup error must fall back, not bubble up")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 // =============================================================================
@@ -605,21 +727,27 @@ func TestNewPreviewHandler(t *testing.T) {
 
 // fakeFileReader is a stub FileReader that returns canned ReadFile responses.
 // Unused methods panic so this test file fails loudly if something else grows
-// a dependency on them.
+// a dependency on them. lastWorkDir captures the workDir argument from the
+// most recent ReadFile call so tests can assert that the handler is asking the
+// reader to look in the right repo-rooted path (not the legacy /workspace).
 type fakeFileReader struct {
-	content string
-	err     error
+	content     string
+	err         error
+	lastWorkDir *string
 }
 
-func (f fakeFileReader) ListDir(context.Context, string, string, string) ([]sandbox.FileEntry, error) {
+func (f *fakeFileReader) ListDir(context.Context, string, string, string) ([]sandbox.FileEntry, error) {
 	panic("not used")
 }
 
-func (f fakeFileReader) ReadFile(_ context.Context, _, _, _ string) (string, bool, error) {
+func (f *fakeFileReader) ReadFile(_ context.Context, _, workDir, _ string) (string, bool, error) {
+	if f.lastWorkDir != nil {
+		*f.lastWorkDir = workDir
+	}
 	return f.content, false, f.err
 }
 
-func (f fakeFileReader) ReadFileContext(context.Context, string, string, string, int, int, int) (sandbox.FileContextResult, error) {
+func (f *fakeFileReader) ReadFileContext(context.Context, string, string, string, int, int, int) (sandbox.FileContextResult, error) {
 	panic("not used")
 }
 
@@ -639,7 +767,7 @@ func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
 	// returns sandbox.ErrFileNotFound (wrapped). Must NOT bubble up — caller
 	// falls back to built-in defaults.
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{err: fmt.Errorf("read file .143/preview.json: %w", sandbox.ErrFileNotFound)},
+		fileReader: &fakeFileReader{err: fmt.Errorf("read file .143/preview.json: %w", sandbox.ErrFileNotFound)},
 		logger:     zerolog.Nop(),
 	}
 	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
@@ -652,12 +780,12 @@ func TestReadWorkspacePreviewConfig_UnexpectedReadError(t *testing.T) {
 
 	// A non-ENOENT read error (docker exec failure, context cancel, sandbox
 	// gone) means we cannot tell whether a committed config exists. Returning
-	// (nil, err) makes StartPreview surface a 500 instead of silently swapping
-	// in Node.js defaults — which would start the wrong preview for non-Node
-	// projects and time out after minutes.
+	// (nil, err) makes StartPreview surface a 500 instead of guessing — the
+	// caller distinguishes this from "definitively absent" (which yields
+	// PREVIEW_NO_CONFIG, not 500).
 	wantErr := errors.New("docker exec failed: container not running")
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{err: wantErr},
+		fileReader: &fakeFileReader{err: wantErr},
 		logger:     zerolog.Nop(),
 	}
 	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
@@ -669,16 +797,17 @@ func TestReadWorkspacePreviewConfig_UnexpectedReadError(t *testing.T) {
 func TestReadWorkspacePreviewConfig_ParseError(t *testing.T) {
 	t.Parallel()
 
-	// Parse errors are a user authoring problem, not infrastructure. We still
-	// fall back to defaults (returning the 500 would make the preview strictly
-	// worse than just running the default), but log at Warn so the user sees
-	// why their committed config didn't take effect.
+	// Parse errors are a user authoring problem, not infrastructure. Returning
+	// (nil, nil) keeps the response shape identical to "file not present", so
+	// the caller surfaces PREVIEW_NO_CONFIG (the user fix is the same: commit
+	// a valid .143/preview.json) instead of a misleading 500. The Warn log
+	// emitted by readWorkspacePreviewConfig is the operator-side breadcrumb.
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{content: "{not valid json"},
+		fileReader: &fakeFileReader{content: "{not valid json"},
 		logger:     zerolog.Nop(),
 	}
 	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.NoError(t, err, "invalid JSON must fall through to defaults, not surface as a 500")
+	require.NoError(t, err, "invalid JSON must not surface as a 500")
 	require.Nil(t, cfg)
 }
 
@@ -700,7 +829,7 @@ func TestReadWorkspacePreviewConfig_ValidConfig(t *testing.T) {
 	}`
 
 	h := &PreviewHandler{
-		fileReader: fakeFileReader{content: raw},
+		fileReader: &fakeFileReader{content: raw},
 		logger:     zerolog.Nop(),
 	}
 	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
@@ -789,6 +918,20 @@ func sessionRowWithContainer(id, orgID uuid.UUID, containerID string) []interfac
 		nil, nil, nil, nil, nil,
 		nil, nil, nil, "idle", (*string)(nil), nil, nil, nil, nil, nil, time.Now(),
 	)
+}
+
+// sessionRowWithContainerAndRepo is sessionRowWithContainer plus a non-nil
+// repository_id, used by tests that need acquireSandbox to invoke the repo
+// lookup in resolveSandboxWorkDir.
+func sessionRowWithContainerAndRepo(id, orgID, repoID uuid.UUID, containerID string) []interface{} {
+	row := sessionRowWithContainer(id, orgID, containerID)
+	for i, name := range sessionRowColumns {
+		if name == "repository_id" {
+			row[i] = &repoID
+			return row
+		}
+	}
+	panic("repository_id column missing from sessionRowColumns")
 }
 
 // sessionRowReuseWithSnapshot builds a row that satisfies both the reuse
@@ -893,10 +1036,114 @@ func (f *fakeHydrateSnapshotStore) Load(_ context.Context, _ string, w io.Writer
 
 func (f *fakeHydrateSnapshotStore) Delete(context.Context, string) error { return nil }
 
+// TestPreviewHandler_StartPreview_NoWorkspaceConfig covers the common path where
+// the user clicks Start Preview on a repo that has no .143/preview.json
+// committed and supplies no explicit config. The handler must abort the
+// reservation and surface PREVIEW_NO_CONFIG (422) — there is no longer a silent
+// "npm start on :3000" fallback that wastes ~90s on a doomed readiness probe.
+func TestPreviewHandler_StartPreview_NoWorkspaceConfig(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowWithContainer(sessionID, orgID, "container-1")...),
+		)
+	expectReserveSuccess(mock, sessionID, orgID, userID)
+	// fileReader returns ENOENT → readWorkspacePreviewConfig yields (nil, nil)
+	// → handler aborts the reservation with PREVIEW_NO_CONFIG.
+	expectAbortReservationNoDestroy(mock)
+
+	h := newPreviewHandlerWithMock(mock)
+	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = &fakeFileReader{err: fmt.Errorf("read .143/preview.json: %w", sandbox.ErrFileNotFound)}
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+
+	h.StartPreview(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code, "missing workspace config must surface as 422")
+
+	var resp models.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	require.Equal(t, "PREVIEW_NO_CONFIG", resp.Error.Code)
+	require.Contains(t, resp.Error.Message, ".143/preview.json", "user-facing message should name the file they need to add")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPreviewHandler_StartPreview_AutoDetectUsesRepoSlugWorkDir is the
+// regression test for the production bug where preview start always failed
+// with PREVIEW_NO_CONFIG (or, before that, fell into the npm-start fallback)
+// because the handler asked the file reader to look in /workspace, but the
+// orchestrator actually checks the repo out at /home/sandbox/<slug>. This
+// test wires a sessionRow with a repository_id, mocks the repo lookup, and
+// asserts that the workDir argument fileReader.ReadFile receives matches
+// the orchestrator's per-session WorkDir derivation — not the legacy default.
+func TestPreviewHandler_StartPreview_AutoDetectUsesRepoSlugWorkDir(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	repoID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowWithContainerAndRepo(sessionID, orgID, repoID, "container-1")...),
+		)
+	expectReserveSuccess(mock, sessionID, orgID, userID)
+	// resolveSandboxWorkDir → repoStore.GetByID lookup.
+	mock.ExpectQuery("SELECT .+ FROM repositories\\s+WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(repositoryRowColumns).
+				AddRow(repoRow(repoID, orgID, "assembledhq/143")...),
+		)
+	// fileReader returns ENOENT → handler aborts with PREVIEW_NO_CONFIG.
+	// We don't care about the response here; we care about the workDir the
+	// reader was called with, captured below via lastWorkDir.
+	expectAbortReservationNoDestroy(mock)
+
+	var capturedWorkDir string
+	h := newPreviewHandlerWithMock(mock)
+	h.sessionStore = db.NewSessionStore(mock)
+	h.repoStore = db.NewRepositoryStore(mock)
+	h.fileReader = &fakeFileReader{
+		err:         fmt.Errorf("read .143/preview.json: %w", sandbox.ErrFileNotFound),
+		lastWorkDir: &capturedWorkDir,
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+	h.StartPreview(w, req)
+
+	require.Equal(t, "/home/sandbox/143", capturedWorkDir,
+		"file reader must be invoked with the repo-rooted WorkDir, not the legacy /workspace")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 // TestPreviewHandler_StartPreview_AutoDetectInfraError exercises the auto-detect
-// branch of StartPreview when the workspace file reader returns a non-ENOENT
-// error. The handler must surface a 500 instead of silently swapping in Node.js
-// defaults — see readWorkspacePreviewConfig's docstring for the rationale.
+// branch when the workspace file reader returns a non-ENOENT error. The handler
+// must surface a 500 instead of guessing — distinct from PREVIEW_NO_CONFIG,
+// which means the file is definitively absent.
 func TestPreviewHandler_StartPreview_AutoDetectInfraError(t *testing.T) {
 	t.Parallel()
 
@@ -926,7 +1173,7 @@ func TestPreviewHandler_StartPreview_AutoDetectInfraError(t *testing.T) {
 
 	h := newPreviewHandlerWithMock(mock)
 	h.sessionStore = db.NewSessionStore(mock)
-	h.fileReader = fakeFileReader{err: errors.New("docker exec failed: container not running")}
+	h.fileReader = &fakeFileReader{err: errors.New("docker exec failed: container not running")}
 
 	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
 	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
@@ -1269,6 +1516,9 @@ func TestPreviewHandler_StartPreview_HydrateReachesLaunch(t *testing.T) {
 
 	h := newPreviewHandlerWithMock(mock)
 	h.sessionStore = db.NewSessionStore(mock)
+	// fileReader returns a valid workspace config so the post-hydrate
+	// auto-detect doesn't short-circuit with PREVIEW_NO_CONFIG before Launch.
+	h.fileReader = &fakeFileReader{content: validWorkspaceConfigJSON}
 	sp := testutil.NewMockSandboxProvider()
 	// RestoreFn drains the io.Pipe reader so the Load goroutine's Write
 	// completes and HydrateSandboxFromSnapshot returns instead of deadlocking.
@@ -1483,6 +1733,7 @@ func TestPreviewHandler_StartPreview_ReuseZombieFallsThroughToHydrate(t *testing
 
 	h := newPreviewHandlerWithMock(mock)
 	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = &fakeFileReader{content: validWorkspaceConfigJSON}
 	sp := testutil.NewMockSandboxProvider()
 	sp.IsAliveFn = func(_ context.Context, sb *agent.Sandbox) (bool, error) {
 		require.Equal(t, "zombie-id", sb.ID)
@@ -1545,6 +1796,7 @@ func TestPreviewHandler_StartPreview_ReuseInspectErrorFallsThroughToHydrate(t *t
 
 	h := newPreviewHandlerWithMock(mock)
 	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = &fakeFileReader{content: validWorkspaceConfigJSON}
 	sp := testutil.NewMockSandboxProvider()
 	sp.IsAliveFn = func(_ context.Context, _ *agent.Sandbox) (bool, error) {
 		return false, errors.New("docker daemon flaked")
@@ -1602,6 +1854,7 @@ func TestPreviewHandler_StartPreview_ReuseAttachesWhenContainerAlive(t *testing.
 
 	h := newPreviewHandlerWithMock(mock)
 	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = &fakeFileReader{content: validWorkspaceConfigJSON}
 	sp := testutil.NewMockSandboxProvider()
 	sp.IsAliveFn = func(_ context.Context, sb *agent.Sandbox) (bool, error) {
 		require.Equal(t, "live-container", sb.ID)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -444,7 +444,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		}()
 	}
 
-	previewHandler := handlers.NewPreviewHandler(previewManager, previewStore, sessionStore, fileReader, sandboxProvider, snapshotStore, logger)
+	previewHandler := handlers.NewPreviewHandler(previewManager, previewStore, sessionStore, repoStore, fileReader, sandboxProvider, snapshotStore, logger)
 	previewHandler.SetAuditEmitter(auditEmitter)
 	previewHandler.SetWorkerRuntime(workerSelector, workerClient, cfg.NodeID)
 	internalPreviewHandler := handlers.NewInternalPreviewHandler(previewHandler, previewManager, cfg.NodeID, cfg.SessionSecret, logger)


### PR DESCRIPTION
## Summary

Diagnosed from a prod incident on session `79c1472b…` ("Failed to start preview"). `PreviewHandler.acquireSandbox` was hardcoding `sb.WorkDir = "/workspace"` while `orchestrator.go` actually checks repos out at `/home/sandbox/<slug>`, so `readWorkspacePreviewConfig` never found `.143/preview.json` and silently fell into an `npm start :3000` fallback that exits in seconds — users waited ~90s for a generic 502 (`preview worker request failed`) every time.

This PR (1) resolves `sb.WorkDir` from the session's repository slug to match the orchestrator, (2) removes the npm fallback in favor of an actionable `422 PREVIEW_NO_CONFIG` (frontend renders the backend message verbatim, naming the file the user must add), and (3) reworks `deploy/vector.yaml` from a field allowlist to a denylist merge so structured zerolog fields (`exit_code`, `preview_id`, `worker_node_id`, etc.) stop getting silently dropped — and the docker-compose `service` label stops clobbering the zerolog `service` field. New unit tests cover all 4 branches of `resolveSandboxWorkDir`, an end-to-end test asserts the WorkDir actually flows to the file reader, and a frontend test guards the new `PREVIEW_NO_CONFIG` message.

## Test plan

- [x] `go test ./...` clean
- [x] `make lint` (golangci-lint v2.10.1) — 0 issues
- [x] Frontend `tsc --noEmit` + `eslint --max-warnings=0` clean
- [x] `vitest preview-panel.test.tsx` — 38/38 (1 added)
- [ ] Smoke-test `deploy/vector.yaml` against staging logging host before deploy (no local vector CLI to validate VRL syntax)
- [ ] After deploy, retry Start Preview on session `79c1472b-d1f3-4e3a-a8fb-cfdf762c4a1b` and confirm it now succeeds (or surfaces a clear error if `.143/preview.json` is genuinely missing)
- [ ] Spot-check Grafana for any panels keyed on `parsed.time` — that field is now removed post-merge in favor of `.timestamp` (which was already canonical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
