### PR TITLE
Clear attached review comments from composer after sending message

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2950,7 +2950,7 @@ describe('SessionDetailPage', () => {
     });
   });
 
-  it('keeps unresolved review comments attached after returning to the main chat view', async () => {
+  it('clears attached review comments after sending them to the agent', async () => {
     let postedMessage = '';
     const idleSessionWithDiff: Session = {
       ...mockSessions[0],
@@ -3025,6 +3025,11 @@ describe('SessionDetailPage', () => {
       expect(postedMessage).toContain('"Handle the null edge case"');
       expect(postedMessage).toContain('Hello agent');
     });
+
+    await waitFor(() => {
+      expect(screen.queryByText('1 comment attached')).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText('Handle the null edge case')).not.toBeInTheDocument();
   });
 
   it('scrolls the chat transcript back to the live edge after sending a follow-up message', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2180,11 +2180,20 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [composerCommands, setComposerCommands] = useState<SessionInputCommand[]>([]);
   const [composerIsUploading, setComposerIsUploading] = useState(false);
   const [composerUploadError, setComposerUploadError] = useState<string | null>(null);
+  const [dismissedAttachedReviewCommentIDs, setDismissedAttachedReviewCommentIDs] = useState<string[]>([]);
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null);
   const composerUploadInputRef = useRef<HTMLInputElement>(null);
   const chatPanelScrollToLiveEdgeRef = useRef<(() => void) | null>(null);
   const openComments = useMemo(() => comments.filter((comment) => !comment.resolved), [comments]);
-  const attachedReviewComments = openComments;
+  useEffect(() => {
+    setDismissedAttachedReviewCommentIDs((previous) =>
+      previous.filter((commentID) => openComments.some((comment) => comment.id === commentID))
+    );
+  }, [openComments]);
+  const attachedReviewComments = useMemo(
+    () => openComments.filter((comment) => !dismissedAttachedReviewCommentIDs.includes(comment.id)),
+    [dismissedAttachedReviewCommentIDs, openComments]
+  );
   const composerCanSendMessage = session?.status !== "skipped" && session?.status !== "pending" && session?.sandbox_state !== "destroyed";
   const composerIsRunning = session?.status === "running";
   const composerIsSnapshotExpired = session?.sandbox_state === "destroyed";
@@ -2246,6 +2255,12 @@ export function SessionDetailContent({ id }: { id: string }) {
       });
     },
     onSuccess: () => {
+      setDismissedAttachedReviewCommentIDs((previous) => {
+        if (attachedReviewComments.length === 0) {
+          return previous;
+        }
+        return Array.from(new Set([...previous, ...attachedReviewComments.map((comment) => comment.id)]));
+      });
       setComposerMessage("");
       setComposerAttachments([]);
       setComposerReferences([]);


### PR DESCRIPTION
## Summary
When a user sends a message that includes attached unresolved review comments, the UI now clears those attachments after successful submit. This prevents previously-attached comment text from lingering in the composer and outbound payload.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Added `dismissedAttachedReviewCommentIDs` state to track which open review comments have been cleared.
  - Updated comment selection logic so `attachedReviewComments` excludes dismissed comment IDs.
  - Reset dismissed state when the set of open comments changes (e.g., comment resolved/removed).
  - On successful `onSuccess` of message send:
    - Mark currently attached review comments as dismissed.
    - Keep existing behavior of clearing `composerMessage`, attachments, and references.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Renamed the test to reflect the new behavior: clearing attached review comments after send.
  - Extended assertions to verify both the “comment attached” indicator and the comment text are no longer rendered after submission.

## Test plan
- Ran the updated session detail page tests, including the new/modified case in `page.test.tsx` that verifies the UI clears attached review comments after the first send.

---
*Generated by [143.dev](https://143.dev) — [session 45e3883b](https://app.143.dev/sessions/45e3883b-8639-4ad9-bb5b-4144a3cc0e65)*
