### PR TITLE
Fix iPhone textarea auto-zoom by using mobile-safe font sizing in shared Textarea

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -1,6 +1,6 @@
 # Design: 143.dev
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-04-23
+> **Status:** Partially Implemented | **Last reviewed:** 2026-04-30
 
 [143.dev](http://143.dev) is an open-source platform that turns customer pain and production errors into safe, validated code fixes that ship automatically.
 
@@ -19,6 +19,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 - Explicit organization switches should persist across logins. The user-visible selection is still tab-local while browsing, but the system should remember the user's last explicitly selected org as the default seed for the next fresh login so multi-org users land back where they left off.
 - Audit log entries are expected to be self-describing. Every emitted audit event should include structured `details` with operator-useful context such as resource names, source/provenance, runtime choices, job IDs, related IDs, counts, and before/after changes. Audit details must not copy secrets, full document contents, large diffs, or access tokens; use booleans, lengths, hashes, masked summaries, and IDs instead.
 - Toast notifications should behave like platform-owned status surfaces rather than skinned third-party banners: success toasts are compact and auto-dismissing by default, error toasts align with the shared recoverable-error visual language, and dismiss controls only appear when needed in the top-right instead of the main content flow. Detailed design: [55-toast-notifications.md](55-toast-notifications.md).
+- Free-form form fields that can receive focus on phones, especially multi-line composers and settings textareas, must compute to at least `16px` on small screens to prevent iOS Safari auto-zoom while preserving denser desktop typography.
 
 ## Autopilot workspace UX
 

--- a/frontend/src/components/ui/textarea.test.tsx
+++ b/frontend/src/components/ui/textarea.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { renderWithProviders, screen } from "@/test/test-utils";
+
+import { Textarea } from "./textarea";
+
+describe("Textarea", () => {
+  it("uses a mobile-safe font size and keeps compact desktop sizing", () => {
+    renderWithProviders(<Textarea aria-label="Notes" />);
+
+    const textarea = screen.getByRole("textbox", { name: "Notes" });
+    expect(textarea).toHaveClass("text-base");
+    expect(textarea).toHaveClass("sm:text-xs");
+  });
+});

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -10,7 +10,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
       <textarea
         ref={ref}
         className={cn(
-          "flex min-h-[72px] w-full rounded-md border border-input bg-background px-2.5 py-1.5 text-xs",
+          "flex min-h-[72px] w-full rounded-md border border-input bg-background px-2.5 py-1.5 text-base sm:text-xs",
           "ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2",
           "focus-visible:ring-ring/40 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
           className


### PR DESCRIPTION
## Summary
Updated the shared `Textarea` component to ensure small screens render at least `16px`, preventing iOS Safari from auto-zooming focus on multi-line inputs. Desktop keeps the existing compact typography via responsive classes.

## Changes
- **`frontend/src/components/ui/textarea.tsx`**
  - Changed textarea font classes from `text-xs` to `text-base sm:text-xs` so mobile uses `16px` while `sm` and up remain compact.
- **`frontend/src/components/ui/textarea.test.tsx`**
  - Added a regression test asserting the textarea includes `text-base` and `sm:text-xs`.
- **`docs/design/overall.md`**
  - Recorded the design rule requiring free-form, focusable phone textareas to compute to at least `16px` to prevent iOS auto-zoom.

## Test plan
- `npx vitest run src/components/ui/textarea.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; existing Next.js warnings remained unchanged)

---
*Generated by [143.dev](https://143.dev) — [session 825b07a7](https://app.143.dev/sessions/825b07a7-db4f-4268-82d0-30681be0bae6)*
