### PR TITLE
Replace PR synced pill with live inline sync time text and adaptive refresh

### DIFF
--- a/docs/design/implemented/61-pr-state-sync-and-repair-actions.md
+++ b/docs/design/implemented/61-pr-state-sync-and-repair-actions.md
@@ -180,7 +180,8 @@ When the PR needs attention:
 
 - show a short summary of the blocker
 - show the relevant repair button(s)
-- show the most recent GitHub sync timestamp
+- show the most recent GitHub sync timestamp as plain inline text, not a pill
+- keep the sync timestamp live relative to the current time (`Synced 15s ago`, `Synced 3m ago`) with an adaptive refresh cadence
 - keep the row visually compact so it reads like a lightweight action strip, not a large content block
 
 If the session is already showing a PR-related error notice, keep that notice as-is and render the PR health row directly below it as a separate element.

--- a/frontend/src/components/pr-health-banner-sync-copy.test.tsx
+++ b/frontend/src/components/pr-health-banner-sync-copy.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PullRequestHealthResponse } from "@/lib/types";
+import { renderWithProviders, screen } from "@/test/test-utils";
+
+import { PRHealthBanner } from "./pr-health-banner";
+
+const health: PullRequestHealthResponse = {
+  pull_request_id: "pr-123",
+  pull_request_number: 42,
+  repository: "acme/widgets",
+  url: "https://github.com/acme/widgets/pull/42",
+  status: "open",
+  head_sha: "head-sha",
+  base_sha: "base-sha",
+  health_version: 2,
+  merge_state: "clean",
+  has_conflicts: false,
+  failing_test_count: 0,
+  needs_agent_action: false,
+  github_state_synced_at: "2026-04-29T11:57:00.000Z",
+  summary: "PR #42 is healthy.",
+  checks: [],
+  can_resolve_conflicts: false,
+  can_fix_tests: false,
+  can_merge: false,
+  enrichment_status: "ready",
+  enrichment_requested: true,
+  enrichment_ready: true,
+  conflict_detail_available: false,
+  failing_test_detail_available: false,
+  obsolete_active_repair_sessions: false,
+};
+
+describe("PRHealthBanner sync copy", () => {
+  it("renders sync status as plain text instead of a badge pill", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={health}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/Synced/)).toBeInTheDocument();
+    expect(screen.queryByText(/Synced/, { selector: "[data-slot='badge']" })).toBeNull();
+  });
+});

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -3,11 +3,12 @@
 import { AlertTriangle, CheckCircle2, GitMerge, GitPullRequest, Loader2, Wrench } from "lucide-react";
 
 import type { PullRequestHealthResponse } from "@/lib/types";
-import { cn, formatTimeAgo } from "@/lib/utils";
+import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
+import { SyncTimeText } from "@/components/sync-time-text";
 
 // PRBannerAction names every action the banner can launch. The pending value
 // is shared across buttons so they can disable each other while one is in
@@ -36,7 +37,6 @@ export function PRHealthBanner({
   onMerge,
 }: PRHealthBannerProps) {
   const isHealthy = !health.can_fix_tests && !health.can_resolve_conflicts;
-  const syncedLabel = health.github_state_synced_at ? formatTimeAgo(health.github_state_synced_at) : "Syncing";
   const hasActionableButton = health.can_resolve_conflicts || health.can_fix_tests || health.can_merge;
   const orderedChecks = [...(health.checks ?? [])]
     .map((check) => ({ ...check, status: normalizeCheckStatus(check.status) }))
@@ -69,9 +69,7 @@ export function PRHealthBanner({
             <p className="text-sm text-foreground">{health.summary}</p>
 
             <div className="flex flex-wrap items-center gap-2">
-              <Badge variant="secondary" className="text-xs">
-                Synced {syncedLabel}
-              </Badge>
+              <SyncTimeText syncedAt={health.github_state_synced_at} prefix="Synced" />
               {health.has_conflicts && (
                 <Badge variant="secondary" className="bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 text-xs">
                   conflicts

--- a/frontend/src/components/sync-time-text.test.tsx
+++ b/frontend/src/components/sync-time-text.test.tsx
@@ -1,0 +1,63 @@
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen } from "@/test/test-utils";
+
+import { SyncTimeText } from "./sync-time-text";
+
+describe("SyncTimeText", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-29T12:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders seconds-ago copy for recent syncs and refreshes on a short cadence", () => {
+    renderWithProviders(
+      <SyncTimeText
+        syncedAt="2026-04-29T11:59:50.000Z"
+        prefix="Synced"
+      />,
+    );
+
+    expect(screen.getByText("Synced 10s ago")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(screen.getByText("Synced 15s ago")).toBeInTheDocument();
+  });
+
+  it("switches to minute-level copy and only refreshes when the minute boundary changes", () => {
+    renderWithProviders(
+      <SyncTimeText
+        syncedAt="2026-04-29T11:58:50.000Z"
+        prefix="Synced"
+      />,
+    );
+
+    expect(screen.getByText("Synced 1m ago")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(49000);
+    });
+
+    expect(screen.getByText("Synced 1m ago")).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("Synced 2m ago")).toBeInTheDocument();
+  });
+
+  it("falls back to syncing copy when no sync timestamp is available", () => {
+    renderWithProviders(<SyncTimeText syncedAt={undefined} prefix="Synced" fallback="Syncing" />);
+
+    expect(screen.getByText("Syncing")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/sync-time-text.tsx
+++ b/frontend/src/components/sync-time-text.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { cn, formatTimeAgo } from "@/lib/utils";
+
+type SyncTimeTextProps = {
+  syncedAt?: string | null;
+  prefix?: string;
+  fallback?: string;
+  className?: string;
+};
+
+type RelativeSyncLabel = {
+  label: string;
+  nextUpdateInMs: number | null;
+  title?: string;
+  includePrefix: boolean;
+};
+
+export function SyncTimeText({
+  syncedAt,
+  prefix,
+  fallback = "Syncing",
+  className,
+}: SyncTimeTextProps) {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const relativeLabel = useMemo(
+    () => formatRelativeSyncLabel(syncedAt, fallback, nowMs),
+    [fallback, nowMs, syncedAt],
+  );
+
+  useEffect(() => {
+    if (relativeLabel.nextUpdateInMs === null) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setNowMs(Date.now());
+    }, relativeLabel.nextUpdateInMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [relativeLabel.nextUpdateInMs]);
+
+  return (
+    <span
+      className={cn("text-xs text-muted-foreground", className)}
+      title={relativeLabel.title}
+    >
+      {prefix && relativeLabel.includePrefix ? `${prefix} ${relativeLabel.label}` : relativeLabel.label}
+    </span>
+  );
+}
+
+function formatRelativeSyncLabel(syncedAt: string | null | undefined, fallback: string, nowMs: number): RelativeSyncLabel {
+  if (!syncedAt) {
+    return { label: fallback, nextUpdateInMs: null, includePrefix: false };
+  }
+
+  const syncedDate = new Date(syncedAt);
+  if (Number.isNaN(syncedDate.getTime())) {
+    return { label: fallback, nextUpdateInMs: null, includePrefix: false };
+  }
+
+  const diffMs = Math.max(0, nowMs - syncedDate.getTime());
+  const title = syncedDate.toLocaleString();
+  const label = formatTimeAgo(syncedAt, { fallback, includeSeconds: true, nowMs });
+
+  if (diffMs < 60_000) {
+    return {
+      label,
+      nextUpdateInMs: millisecondsUntilNextBucket(diffMs, 5000),
+      title,
+      includePrefix: true,
+    };
+  }
+
+  if (diffMs < 3_600_000) {
+    return {
+      label,
+      nextUpdateInMs: millisecondsUntilNextBucket(diffMs, 60000),
+      title,
+      includePrefix: true,
+    };
+  }
+
+  if (diffMs < 86_400_000) {
+    return {
+      label,
+      nextUpdateInMs: millisecondsUntilNextBucket(diffMs, 3600000),
+      title,
+      includePrefix: true,
+    };
+  }
+
+  if (diffMs < 2_592_000_000) {
+    return {
+      label,
+      nextUpdateInMs: millisecondsUntilNextBucket(diffMs, 86400000),
+      title,
+      includePrefix: true,
+    };
+  }
+
+  return {
+    label,
+    nextUpdateInMs: null,
+    title,
+    includePrefix: true,
+  };
+}
+
+function millisecondsUntilNextBucket(diffMs: number, bucketMs: number) {
+  const remainder = diffMs % bucketMs;
+  return remainder === 0 ? bucketMs : bucketMs - remainder;
+}

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -40,9 +40,18 @@ describe("formatTimeAgo", () => {
     expect(formatTimeAgo(fiftyNineMinAgo)).toBe("59m ago");
   });
 
+  it("returns seconds ago when requested for very recent timestamps", () => {
+    const tenSecondsAgo = new Date(Date.now() - 10_000).toISOString();
+    expect(formatTimeAgo(tenSecondsAgo, { includeSeconds: true })).toBe("10s ago");
+  });
+
   it("returns '23h ago' just under a day", () => {
     const twentyThreeHoursAgo = new Date(Date.now() - 23 * 3_600_000).toISOString();
     expect(formatTimeAgo(twentyThreeHoursAgo)).toBe("23h ago");
+  });
+
+  it("returns a custom fallback when provided", () => {
+    expect(formatTimeAgo(undefined, { fallback: "Syncing" })).toBe("Syncing");
   });
 
   it("returns an em-dash for missing input (rollback safety)", () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -30,12 +30,24 @@ export function fileNameFromURL(url: string): string {
   return url.split("?")[0].split("#")[0].split("/").pop() || "file";
 }
 
-export function formatTimeAgo(dateStr: string | null | undefined): string {
-  if (!dateStr) return "—";
+type FormatTimeAgoOptions = {
+  fallback?: string;
+  includeSeconds?: boolean;
+  nowMs?: number;
+};
+
+export function formatTimeAgo(
+  dateStr: string | null | undefined,
+  options?: FormatTimeAgoOptions,
+): string {
+  const fallback = options?.fallback ?? "—";
+  if (!dateStr) return fallback;
   const date = new Date(dateStr);
-  if (Number.isNaN(date.getTime())) return "—";
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
+  if (Number.isNaN(date.getTime())) return fallback;
+  const diffMs = Math.max(0, (options?.nowMs ?? Date.now()) - date.getTime());
+  if (options?.includeSeconds && diffMs < 60_000) {
+    return `${Math.floor(diffMs / 1000)}s ago`;
+  }
   const diffMins = Math.floor(diffMs / 60000);
   if (diffMins < 1) return "just now";
   if (diffMins < 60) return `${diffMins}m ago`;


### PR DESCRIPTION
## Summary
Update the PR health banner to display the “Synced … ago” information as compact inline text (instead of a static pill) and keep it live relative to the current time. This also reuses the shared `formatTimeAgo` utility to avoid duplicating time-humanization logic.

## Changes
- **docs/design/implemented/61-pr-state-sync-and-repair-actions.md**
  - Adjusted the design spec to require inline text sync timestamps (not a pill) with live “Synced X ago” updates and adaptive refresh cadence.
- **frontend/src/components/pr-health-banner.tsx**
  - Replaced the `Badge`-based “Synced {formatTimeAgo(...)}` UI with the new `SyncTimeText` component.
  - Removed local `formatTimeAgo` usage in favor of the shared sync-time rendering component.
- **frontend/src/components/sync-time-text.tsx**
  - Implemented dynamic inline sync time rendering using the existing shared `formatTimeAgo` utility.
  - Drove refresh cadence from millisecond thresholds (removing redundant diffMinutes/diffHours/diffDays computations).
- **frontend/src/lib/utils.ts** / **frontend/src/lib/utils.test.ts**
  - Extended `formatTimeAgo` behavior (e.g., optional seconds support and fallback handling) and added corresponding tests.
- **frontend/src/components/sync-time-text.test.tsx** / **frontend/src/components/pr-health-banner-sync-copy.test.tsx**
  - Added/updated tests to cover the new inline sync time display and its copy behavior.

## Test plan
- Ran the frontend unit tests covering `formatTimeAgo`, `SyncTimeText`, and PR health banner sync copy:
  - `frontend/src/lib/utils.test.ts`
  - `frontend/src/components/sync-time-text.test.tsx`
  - `frontend/src/components/pr-health-banner-sync-copy.test.tsx`
- Verified the rendered banner uses `SyncTimeText` and that the timestamp text updates according to the adaptive cadence logic.

---
*Generated by [143.dev](https://143.dev) — [session c11f968b](https://app.143.dev/sessions/c11f968b-0581-4169-95ac-9d9b68ce6cee)*
