### PR TITLE
Enable runsc --host-uds=open so sandbox git push can reach credential socket

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -46,7 +46,7 @@ runcmd:
   - curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
   - echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list
   - apt-get update && apt-get install -y runsc
-  - runsc install -- --ignore-cgroups
+  - runsc install -- --ignore-cgroups --host-uds=open
   - systemctl restart docker
 
   # Set up GHCR access (token written to file to avoid leaking in cloud-init logs)

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ if [ "$ROLE" = "worker" ]; then
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" \
       > /etc/apt/sources.list.d/gvisor.list
     apt-get update && apt-get install -y runsc
-    runsc install -- --ignore-cgroups
+    runsc install -- --ignore-cgroups --host-uds=open
     systemctl restart docker
   }
 fi

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -398,13 +398,20 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     done
   }
 
-  # Ensure gVisor runtime is configured with --ignore-cgroups so Docker
-  # handles cgroup management (prevents EOF errors from cgroup conflicts).
+  # Ensure gVisor runtime is configured with the flags the sandbox depends on:
+  #   --ignore-cgroups: Docker handles cgroup management (prevents EOF errors
+  #     from cgroup conflicts).
+  #   --host-uds=open: allow the in-sandbox 143-tools client to connect() to
+  #     the per-session GitHub credential socket bind-mounted from the host.
+  #     Default is "none", which makes connect() return ECONNREFUSED even
+  #     though the inode is visible inside the sandbox.
+  # Re-runs `runsc install` whenever either flag is missing so existing hosts
+  # get patched on the next deploy.
   if [ "$ROLE" = "worker" ] && command -v runsc &>/dev/null; then
     DAEMON_JSON="/etc/docker/daemon.json"
-    if [ -f "$DAEMON_JSON" ] && ! grep -q "ignore-cgroups" "$DAEMON_JSON"; then
-      echo "Patching runsc runtime to use --ignore-cgroups..."
-      sudo runsc install -- --ignore-cgroups
+    if [ ! -f "$DAEMON_JSON" ] || ! grep -q "ignore-cgroups" "$DAEMON_JSON" || ! grep -q "host-uds" "$DAEMON_JSON"; then
+      echo "Patching runsc runtime with --ignore-cgroups --host-uds=open..."
+      sudo runsc install -- --ignore-cgroups --host-uds=open
       sudo systemctl restart docker
       echo "Docker restarted with updated gVisor config."
     fi


### PR DESCRIPTION
## Summary
- Production sandbox agents were failing every `git push` with `sandboxauth: dial /run/143-auth/sock: connect: connection refused` even when the per-session listener was healthy. Root cause: `runsc` was installed with the default `--host-uds=none`, so gVisor refuses to bridge connections to host-bound AF_UNIX sockets — the bind-mounted socket inode is visible inside the sandbox but `connect()` returns ECONNREFUSED. The credential-socket model went live on Apr 27 (#583) without flipping this flag, so every sandbox push since has been broken.
- Add `--host-uds=open` to all three runsc-install paths: cloud-init worker provisioning, `bootstrap.sh`, and the `deploy.sh` self-healing patch. `open` is least-privilege — sandboxes are clients of the socket, never servers.
- Broaden `deploy.sh`'s idempotency check to also require `host-uds` in `daemon.json` so existing prod hosts (which already have `ignore-cgroups`) get re-patched on the next worker deploy.

## Test plan
- [ ] `make deploy ROLE=worker` rolls a worker host; observe the "Patching runsc runtime…" log and a docker restart.
- [ ] After deploy, verify `/etc/docker/daemon.json` on the worker shows `runtimeArgs: ["--ignore-cgroups", "--host-uds=open"]`.
- [ ] Run a fresh session that pushes a commit; confirm the push succeeds (no ECONNREFUSED in agent output, listener-started log present in worker logs).
- [ ] Re-run `make deploy ROLE=worker` a second time; the patch block should be skipped (no docker restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
