### PR TITLE
Remove duplicate conflicts pill from PR health banner

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -197,4 +197,27 @@ describe("PRHealthBanner", () => {
     expect(screen.getByText("Legacy check")).toBeInTheDocument();
     expect(screen.getAllByText("pending").length).toBeGreaterThanOrEqual(2);
   });
+
+  it("does not render a separate conflicts badge when the summary already covers merge conflicts", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          has_conflicts: true,
+          can_resolve_conflicts: true,
+          summary: "PR #42 is blocked by merge conflicts.",
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("PR #42 is blocked by merge conflicts.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Resolve conflicts" })).toBeInTheDocument();
+    expect(screen.queryByText(/^conflicts$/)).toBeNull();
+  });
 });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -70,11 +70,6 @@ export function PRHealthBanner({
 
             <div className="flex flex-wrap items-center gap-2">
               <SyncTimeText syncedAt={health.github_state_synced_at} prefix="Synced" />
-              {health.has_conflicts && (
-                <Badge variant="secondary" className="bg-amber-50 text-amber-700 dark:bg-amber-950/30 dark:text-amber-400 text-xs">
-                  conflicts
-                </Badge>
-              )}
               {health.failing_test_count > 0 && (
                 orderedChecks.length > 0 ? (
                   <HoverCard openDelay={100} closeDelay={100}>


### PR DESCRIPTION
## Summary
Removed the extra standalone `conflicts` badge from the PR health banner to avoid duplicate/confusing indicators when the banner summary already covers merge conflicts. Kept the summary text and the existing “Resolve conflicts” action behavior unchanged.

## Changes
- **frontend/src/components/pr-health-banner.tsx**
  - Removed conditional rendering of the secondary `Badge` that displayed the standalone text **“conflicts”** when `health.has_conflicts` is true.
- **frontend/src/components/pr-health-banner.test.tsx**
  - Added a regression test asserting that when `has_conflicts` and `can_resolve_conflicts` are true, the component still renders:
    - the provided conflict summary text
    - the **“Resolve conflicts”** button
  - Also verifies there is **no separate** standalone `conflicts` badge rendered.

## Test plan
- `npx vitest run src/components/pr-health-banner.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session f7aee8d7](https://app.143.dev/sessions/f7aee8d7-d982-4dd0-8be9-a6025b48322b)*
