### PR TITLE
Replace ImagePlus icon with link icon for “Add image URL”

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -2,7 +2,7 @@
 
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, Mic, Plus, ImagePlus, Paperclip, GitBranch, ChevronDown, FileCode2, FolderTree, Slash, X } from "lucide-react";
+import { ArrowUp, Mic, Plus, Link, Paperclip, GitBranch, ChevronDown, FileCode2, FolderTree, Slash, X } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -1050,7 +1050,7 @@ export function ManualSessionCreatePageContent() {
                     Upload files or photos
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => setShowImageInput(true)}>
-                    <ImagePlus className="mr-2 h-4 w-4" />
+                    <Link data-testid="add-image-url-link-icon" className="mr-2 h-4 w-4" />
                     Add image URL
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -80,6 +80,7 @@ describe('ManualSessionCreatePage', () => {
     renderWithProviders(<ManualSessionCreatePageContent />);
 
     await user.click(screen.getByRole('button', { name: 'Add files or photos' }));
+    expect(screen.getByTestId('add-image-url-link-icon')).toBeInTheDocument();
     await user.click(screen.getByRole('menuitem', { name: 'Add image URL' }));
     await user.type(screen.getByPlaceholderText('https://example.com/screenshot.png'), 'https://example.com/checkout-timeout.png');
     await user.click(screen.getByRole('button', { name: 'Add' }));

--- a/frontend/src/components/create-session-dialog.test.tsx
+++ b/frontend/src/components/create-session-dialog.test.tsx
@@ -241,6 +241,7 @@ describe("CreateSessionDialog", () => {
 
     // Open the attachment dropdown
     await user.click(screen.getByRole("button", { name: /Add files or photos/ }));
+    expect(screen.getByTestId("add-image-url-link-icon")).toBeInTheDocument();
     // Click "Add image URL"
     await user.click(screen.getByText("Add image URL"));
 

--- a/frontend/src/components/create-session-dialog.tsx
+++ b/frontend/src/components/create-session-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowUp, Loader2, GitBranch, ChevronDown, Paperclip, ImagePlus, Plus } from "lucide-react";
+import { ArrowUp, Loader2, GitBranch, ChevronDown, Paperclip, Link, Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import {
@@ -319,7 +319,7 @@ export function CreateSessionDialog({ open, onOpenChange }: CreateSessionDialogP
                 Upload files or photos
               </DropdownMenuItem>
               <DropdownMenuItem onClick={() => setShowImageInput(true)}>
-                <ImagePlus className="mr-2 h-4 w-4" />
+                <Link data-testid="add-image-url-link-icon" className="mr-2 h-4 w-4" />
                 Add image URL
               </DropdownMenuItem>
             </DropdownMenuContent>


### PR DESCRIPTION
## Summary
Updated the “Add image URL” dropdown action to use a link-style icon instead of `ImagePlus` in both the create-session dialog and the manual session creation page. Added test assertions to ensure the new icon renders, preventing regressions.

## Changes
- `frontend/src/components/create-session-dialog.tsx`
  - Replaced `ImagePlus` with `Link` for the “Add image URL” `DropdownMenuItem`.
- `frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx`
  - Replaced `ImagePlus` with `Link` for the “Add image URL” `DropdownMenuItem`.
- `frontend/src/components/create-session-dialog.test.tsx`
  - Added `data-testid="add-image-url-link-icon"` assertion after opening the attachment dropdown.
- `frontend/src/app/(dashboard)/sessions/new/page.test.tsx`
  - Added the same icon presence assertion before selecting “Add image URL”.

## Test plan
- Ran: `npx vitest run src/components/create-session-dialog.test.tsx 'src/app/(dashboard)/sessions/new/page.test.tsx'`
- Ran: `npm run typecheck`
- Ran: `npm run lint`
- Ran: `npm run build` (completed successfully; existing Next.js warnings remain)

---
*Generated by [143.dev](https://143.dev) — [session 5125149b](https://app.143.dev/sessions/5125149b-233a-49eb-b0ad-fb4d7878c1c4)*
