### PR TITLE
Add horizontal scroll to session detail tabs when tabs overflow

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1011,8 +1011,33 @@ describe('SessionDetailPage', () => {
     const actions = screen.getByLabelText('Session detail actions');
 
     expect(tabRail).toHaveClass('overflow-x-auto');
+    expect(tabRail).toHaveClass('scrollbar-hide');
     expect(actions).toHaveClass('shrink-0');
     expect(within(actions).getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+  });
+
+  it('shows the horizontal tab scrollbar only when tabs run into the action buttons', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const tabRail = await screen.findByLabelText('Session detail tabs');
+
+    Object.defineProperty(tabRail, 'clientWidth', {
+      configurable: true,
+      value: 140,
+    });
+    Object.defineProperty(tabRail, 'scrollWidth', {
+      configurable: true,
+      value: 360,
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    await waitFor(() => {
+      expect(tabRail).not.toHaveClass('scrollbar-hide');
+    });
+    expect(tabRail).toHaveClass('mask-fade-r');
   });
 
   it('renders the PR health banner at the top of Overview when a linked PR is open', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2299,6 +2299,50 @@ export function SessionDetailContent({ id }: { id: string }) {
     composerTextareaRef.current?.focus();
   }, []);
 
+  const changesCount = diffStats?.filesChanged;
+  const showValidationTab = !session?.triggered_by_user_id;
+  const detailTabsRef = useRef<HTMLDivElement>(null);
+  const [detailTabsOverflow, setDetailTabsOverflow] = useState(false);
+
+  const checkDetailTabsOverflow = useCallback(() => {
+    const el = detailTabsRef.current;
+    if (el) {
+      setDetailTabsOverflow(el.scrollWidth > el.clientWidth);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkDetailTabsOverflow();
+
+    const handleResize = () => checkDetailTabsOverflow();
+    window.addEventListener("resize", handleResize);
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => window.removeEventListener("resize", handleResize);
+    }
+
+    const observer = new ResizeObserver(() => {
+      checkDetailTabsOverflow();
+    });
+
+    if (detailTabsRef.current) {
+      observer.observe(detailTabsRef.current);
+    }
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", handleResize);
+    };
+  }, [
+    changesCount,
+    checkDetailTabsOverflow,
+    hasPR,
+    session?.id,
+    session?.pr_creation_error,
+    session?.pr_creation_state,
+    showValidationTab,
+  ]);
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center h-full">
@@ -2323,9 +2367,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   }
 
   const status = statusConfig[session.status] || statusConfig.pending;
-
-  const changesCount = diffStats?.filesChanged;
-  const showValidationTab = !session.triggered_by_user_id;
   const prState = session.pr_creation_state;
   const snapshotState = classifyPRSnapshotState({
     sessionSnapshotKey: session.snapshot_key,
@@ -2430,7 +2471,14 @@ export function SessionDetailContent({ id }: { id: string }) {
     >
       <div className="border-b border-border px-2 py-2 shrink-0">
         <div className="flex items-center gap-2 min-w-0">
-          <div aria-label="Session detail tabs" className="min-w-0 flex-1 overflow-x-auto scrollbar-hide">
+          <div
+            ref={detailTabsRef}
+            aria-label="Session detail tabs"
+            className={cn(
+              "min-w-0 flex-1 overflow-x-auto overflow-y-hidden",
+              detailTabsOverflow ? "mask-fade-r" : "scrollbar-hide",
+            )}
+          >
             <TabsList variant="line" size="sm" className="border-b-0 min-w-max">
               <TabsTrigger value="overview">Overview</TabsTrigger>
               <TabsTrigger value="changes">


### PR DESCRIPTION
## Summary
When the session detail tabs don’t fit alongside the action buttons, the tab rail now switches to an overflow/scrollable layout. This improves usability on narrow viewports by dynamically toggling the scrollbar/mask styling as space changes.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Added `detailTabsOverflow` state and `detailTabsRef` to detect `scrollWidth > clientWidth`.
  - Introduced `checkDetailTabsOverflow` and a resize strategy using both `window.resize` and `ResizeObserver` to update overflow state when layout changes.
  - Updated the tab rail styling behavior to reflect the overflow state (e.g., show appropriate mask/scroll affordances instead of permanently hiding the scrollbar).
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Extended existing expectations to assert the tab rail starts with `scrollbar-hide`.
  - Added a test covering the “overflow-on” case by mocking `clientWidth/scrollWidth`, dispatching a resize, and asserting the scrollbar is no longer hidden (and the right-side fade mask appears).

## Test plan
- Ran the updated unit tests in `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`.
- Validated the new overflow behavior via the added test that simulates tight layout using mocked element dimensions and a resize event.

---
*Generated by [143.dev](https://143.dev) — [session a7429b50](https://app.143.dev/sessions/a7429b50-26b6-450d-8e7d-6e61562fe01d)*
