### PR TITLE
Keep /sessions/new prompt textarea at 16px on mobile to avoid iPhone zoom

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -174,6 +174,14 @@ describe("ManualSessionCreatePageContent", () => {
     });
   });
 
+  it("keeps the main message textarea at 16px on mobile", async () => {
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    const textarea = await screen.findByRole("textbox", { name: "Manual session prompt" });
+    expect(textarea).toHaveClass("text-base");
+    expect(textarea).toHaveClass("sm:text-xs");
+  });
+
   it("autofocuses the main message textarea", async () => {
     renderWithProviders(<ManualSessionCreatePageContent />);
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -951,7 +951,7 @@ export function ManualSessionCreatePageContent() {
                 placeholder="Tell the agent what to do..."
                 rows={1}
                 disabled={createManualSessionMutation.isPending}
-                className="min-h-[44px] resize-none border-none bg-transparent px-0 py-2 text-xs shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 disabled:opacity-60 disabled:cursor-not-allowed"
+                className="min-h-[44px] resize-none border-none bg-transparent px-0 py-2 shadow-none placeholder:text-muted-foreground/60 focus-visible:ring-0 disabled:opacity-60 disabled:cursor-not-allowed"
                 aria-label="Manual session prompt"
               />
 


### PR DESCRIPTION
## Summary
Updated the `/sessions/new` main prompt textarea styling so it no longer forces `text-xs` on mobile. This preserves the shared `Textarea` sizing (16px on small screens) to prevent iPhone zoom, while keeping the compact `sm:text-xs` sizing above the breakpoint.

## Changes
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx**
  - Removed the explicit `text-xs` class from the main prompt `<textarea>` so it inherits the correct responsive sizing.
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx**
  - Added a regression test asserting the prompt textarea has `text-base` and `sm:text-xs` classes.

## Test plan
- `npx vitest run src/app/\(dashboard\)/sessions/new/manual-session-create-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session b983738c](https://app.143.dev/sessions/b983738c-0bea-492d-8cba-725e4b3e53b9)*
