### PR TITLE
Render /sessions with the same composer as /sessions/new and make mobile content-first

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import SessionsLayout from "./layout";
+
+const sidebarLayoutMock = vi.fn(
+  ({
+    mobileShow,
+    children,
+  }: {
+    mobileShow?: "sidebar" | "content";
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="sidebar-layout" data-mobile-show={mobileShow}>
+      {children}
+    </div>
+  ),
+);
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/sessions",
+}));
+
+vi.mock("@/components/sidebar-layout", () => ({
+  SidebarLayout: (props: {
+    sidebar: React.ReactNode;
+    children: React.ReactNode;
+    mobileShow?: "sidebar" | "content";
+  }) => sidebarLayoutMock(props),
+}));
+
+vi.mock("./session-sidebar", () => ({
+  SessionSidebar: () => <div data-testid="session-sidebar" />,
+}));
+
+describe("SessionsLayout", () => {
+  it("shows the content pane on mobile for the /sessions route", () => {
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("sidebar-layout")).toHaveAttribute("data-mobile-show", "content");
+  });
+});

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -1,17 +1,13 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { SessionSidebar } from "./session-sidebar";
 import { OptimisticSessionsProvider } from "@/contexts/optimistic-sessions";
 
 export default function SessionsLayout({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const mobileShow = pathname === "/sessions" ? "sidebar" : "content";
-
   return (
     <OptimisticSessionsProvider>
-      <SidebarLayout sidebar={<SessionSidebar />} mobileShow={mobileShow}>
+      <SidebarLayout sidebar={<SessionSidebar />} mobileShow="content">
         {children}
       </SidebarLayout>
     </OptimisticSessionsProvider>

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -1,8 +1,10 @@
+import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { http, HttpResponse } from 'msw';
 import { renderWithProviders, screen } from '@/test/test-utils';
 
 import { server } from '@/test/mocks/server';
+import SessionsPage from './page';
 import { SessionSidebar } from './session-sidebar';
 
 // Mock next/link to render a plain anchor
@@ -110,5 +112,17 @@ describe('SessionSidebar', () => {
     const newSessionTexts = screen.getAllByText('New session');
     // At least 2: the top "+ New session" link + the ghost entry in the list
     expect(newSessionTexts.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+vi.mock('./new/manual-session-create-page-content', () => ({
+  ManualSessionCreatePageContent: () => <div data-testid="manual-session-create-page" />,
+}));
+
+describe('SessionsPage', () => {
+  it('renders the same manual session composer entry point as /sessions/new', () => {
+    renderWithProviders(<SessionsPage />);
+
+    expect(screen.getByTestId('manual-session-create-page')).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/page.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.tsx
@@ -1,22 +1,5 @@
-import Link from "next/link";
-import { Plus } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ManualSessionCreatePageContent } from "./new/manual-session-create-page-content";
 
 export default function SessionsPage() {
-  return (
-    <div className="hidden md:flex h-full items-center justify-center p-8">
-      <div className="max-w-md text-center space-y-4">
-        <h1 className="text-lg font-semibold text-foreground">Sessions</h1>
-        <p className="text-sm text-muted-foreground">
-          Start a new session, or open one from the list to keep working.
-        </p>
-        <Button asChild>
-          <Link href="/sessions/new">
-            <Plus className="h-4 w-4" />
-            New session
-          </Link>
-        </Button>
-      </div>
-    </div>
-  );
+  return <ManualSessionCreatePageContent />;
 }


### PR DESCRIPTION
## Summary
`/sessions` now renders the same entry point as `/sessions/new` by reusing `ManualSessionCreatePageContent`, so users land directly in the “Let’s build” flow. I also updated the sessions layout to be content-first on mobile, and added tests to lock in the behavior.

## Changes
- **frontend/src/app/(dashboard)/sessions/page.tsx**
  - Replaced the `/sessions` CTA (“New session” link) with `ManualSessionCreatePageContent` so the composer is immediately visible.
- **frontend/src/app/(dashboard)/sessions/layout.tsx**
  - Removed pathname-based `mobileShow` logic and set `mobileShow="content"` so the main content is shown first on mobile regardless of route.
- **frontend/src/app/(dashboard)/sessions/page.test.tsx**
  - Added coverage asserting `/sessions` renders the same manual session composer entry point as the `/sessions/new` flow.
- **frontend/src/app/(dashboard)/sessions/layout.test.tsx**
  - Added coverage for the layout’s `mobileShow` behavior.

## Test plan
- `npx vitest run src/app/(dashboard)/sessions/page.test.tsx src/app/(dashboard)/sessions/layout.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 63d8d5b6](https://app.143.dev/sessions/63d8d5b6-d40e-4a53-ac01-c6ea1cc106a6)*
