### PR TITLE
Fix Automations mobile card layout to prevent overlapping detail rows

### DIFF
--- a/docs/design/implemented/48-automations-separation.md
+++ b/docs/design/implemented/48-automations-separation.md
@@ -398,6 +398,7 @@ Key design choices:
 - Grouped by enabled/paused — not by status lifecycle.
 - Each row shows: name, cadence, repo, last run summary, next run time.
 - "Paused by @john" — team audit trail built into the UI.
+- On narrow mobile viewports, automation cards must stack name, cadence, and timing metadata vertically, with wrapped text instead of truncating the details into overlapping rows. The overflow menu remains pinned as a separate trailing control so long names and schedules cannot collide with actions.
 
 ### 7.3 New automation page (`/automations/new`)
 

--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import AutomationsPage from "./page";
+
+describe("AutomationsPage", () => {
+  it("renders automation cards with mobile-friendly stacked details", async () => {
+    server.use(
+      http.get("*/api/v1/automations", () => HttpResponse.json({
+        data: [
+          {
+            id: "auto-enabled",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly release hardening sweep for mobile checkout reliability",
+            goal: "Keep the mobile checkout stable",
+            scope: "",
+            execution_mode: "async",
+            max_concurrent: 1,
+            base_branch: "main",
+            schedule_type: "interval",
+            interval_value: 2,
+            interval_unit: "weeks",
+            interval_run_at: "09:15",
+            timezone: "America/Los_Angeles",
+            next_run_at: "2026-05-01T09:15:00Z",
+            last_run_at: "2026-04-29T09:15:00Z",
+            enabled: true,
+            priority: 50,
+            created_at: "2026-04-01T00:00:00Z",
+            updated_at: "2026-04-01T00:00:00Z",
+          },
+          {
+            id: "auto-paused",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Dependency cleanup",
+            goal: "Clean stale dependencies",
+            scope: "",
+            execution_mode: "async",
+            max_concurrent: 1,
+            base_branch: "main",
+            schedule_type: "cron",
+            cron_expression: "0 9 * * 1",
+            timezone: "UTC",
+            enabled: false,
+            paused_at: "2026-04-29T12:00:00Z",
+            priority: 40,
+            created_at: "2026-04-01T00:00:00Z",
+            updated_at: "2026-04-01T00:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<AutomationsPage />);
+
+    const title = await screen.findByText("Weekly release hardening sweep for mobile checkout reliability");
+    expect(title).toHaveClass("break-words", "leading-5");
+
+    const schedule = screen.getByText(/every 2 weeks at/);
+    expect(schedule).toHaveClass("block", "break-words", "leading-5", "sm:max-w-[18rem]", "sm:text-right");
+
+    const detailRow = screen.getByText(/Last run:/).parentElement;
+    expect(detailRow).not.toBeNull();
+    expect(detailRow).toHaveClass("flex", "flex-col", "gap-1", "sm:flex-row", "sm:flex-wrap");
+
+    const menuButton = screen.getByRole("button", {
+      name: "More options for Weekly release hardening sweep for mobile checkout reliability",
+    });
+    expect(menuButton).toHaveClass("self-start", "shrink-0");
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -73,31 +73,35 @@ function AutomationCard({ automation }: { automation: Automation }) {
 
   return (
     <div className="rounded-lg border border-border bg-background transition-colors hover:bg-muted/30">
-      <div className="flex items-start justify-between gap-4 p-4">
+      <div className="flex items-start gap-3 p-4 sm:gap-4">
         <Link href={`/automations/${automation.id}`} className="flex-1 min-w-0">
-          <div className="flex items-center gap-2.5">
+          <div className="flex items-start gap-2.5">
             {automation.enabled ? (
               <RefreshCw className="h-4 w-4 text-blue-500 shrink-0" />
             ) : (
               <Pause className="h-4 w-4 text-muted-foreground shrink-0" />
             )}
-            <h3 className="text-sm font-medium text-foreground truncate">
-              {automation.name}
-            </h3>
-            <span className="text-xs text-muted-foreground shrink-0">
-              {formatSchedule(automation)}
-            </span>
-          </div>
-          <div className="mt-1 ml-6.5 flex items-center gap-3 text-xs text-muted-foreground">
-            {automation.last_run_at && (
-              <span>Last run: {formatTimeAgo(automation.last_run_at)}</span>
-            )}
-            {automation.next_run_at && automation.enabled && (
-              <span>Next: {new Date(automation.next_run_at).toLocaleString()}</span>
-            )}
-            {!automation.enabled && automation.paused_at && (
-              <span>Paused {formatTimeAgo(automation.paused_at)}</span>
-            )}
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="space-y-1 sm:flex sm:items-start sm:justify-between sm:gap-3 sm:space-y-0">
+                <h3 className="break-words text-sm font-medium leading-5 text-foreground">
+                  {automation.name}
+                </h3>
+                <span className="block break-words text-xs leading-5 text-muted-foreground sm:max-w-[18rem] sm:text-right">
+                  {formatSchedule(automation)}
+                </span>
+              </div>
+              <div className="flex flex-col gap-1 text-xs text-muted-foreground sm:flex-row sm:flex-wrap sm:gap-x-3 sm:gap-y-1">
+                {automation.last_run_at && (
+                  <span>Last run: {formatTimeAgo(automation.last_run_at)}</span>
+                )}
+                {automation.next_run_at && automation.enabled && (
+                  <span>Next: {new Date(automation.next_run_at).toLocaleString()}</span>
+                )}
+                {!automation.enabled && automation.paused_at && (
+                  <span>Paused {formatTimeAgo(automation.paused_at)}</span>
+                )}
+              </div>
+            </div>
           </div>
         </Link>
 
@@ -106,7 +110,7 @@ function AutomationCard({ automation }: { automation: Automation }) {
             <Button
               variant="ghost"
               size="icon"
-              className="h-8 w-8"
+              className="h-8 w-8 self-start shrink-0"
               aria-label={`More options for ${automation.name}`}
             >
               <MoreHorizontal className="h-4 w-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
Updated the Automations list UI so mobile cards render their name, schedule, and run-time metadata in a vertical, non-overlapping layout. This prevents long names/schedules from colliding with other content, aligning the implementation with the intended design.

## Changes
- **docs/design/implemented/48-automations-separation.md**
  - Added mobile-specific requirement: stack metadata vertically with wrapped text and keep the overflow menu as a separate trailing control to avoid collisions.
- **frontend/src/app/(dashboard)/automations/page.tsx**
  - Reworked `AutomationCard` markup/classes to:
    - Use vertical stacking on narrow viewports for name + schedule + timing metadata.
    - Enable text wrapping (`break-words`) rather than truncation that could lead to overlapping rows.
    - Keep the overflow/actions control visually separate from the card’s content to prevent layout collisions.
- **frontend/src/app/(dashboard)/automations/page.test.tsx**
  - Adjusted/added tests to match the updated card layout behavior.

## Test plan
- Ran frontend unit/component tests (`frontend/src/app/(dashboard)/automations/page.test.tsx`) to confirm rendering and layout-related expectations.
- Manually verified the Automations list at narrow/mobile viewport widths to ensure wrapped metadata no longer overlaps and the overflow control remains distinct.

---
*Generated by [143.dev](https://143.dev) — [session 72d68602](https://app.143.dev/sessions/72d68602-a525-4e79-9480-38d50bb43cd3)*
