### PR TITLE
Filter new-session model picker to integrated agents only

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -60,7 +60,15 @@ const mocks = vi.hoisted(() => ({
     file_name: "uploaded-shot.png",
     content_type: "image/png",
   }),
-  resolvedCredsMock: vi.fn().mockResolvedValue({ data: [] }),
+  resolvedCredsMock: vi.fn().mockResolvedValue({
+    data: [
+      { provider: "openai", source: "personal" },
+      { provider: "anthropic", source: "personal" },
+      { provider: "gemini", source: "personal" },
+      { provider: "amp", source: "personal" },
+      { provider: "pi", source: "personal" },
+    ],
+  }),
   codexAuthStatusMock: vi.fn().mockResolvedValue({ data: { status: "completed" } }),
   authMeMock: vi.fn().mockResolvedValue({
     data: {

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -45,8 +45,8 @@ import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 import {
   AGENTS,
-  AGENTS_BY_KEY,
   agentTypeForModel,
+  isAgentConnected,
 } from "@/lib/agents";
 import { NoReposWarning } from "@/components/no-repos-warning";
 import { AgentKeyRequiredBanner } from "@/components/agent-key-required-banner";
@@ -320,23 +320,31 @@ export function ManualSessionCreatePageContent() {
     setBranchByRepoId((prev) => ({ ...prev, [selectedRepoId]: branch }));
   };
 
-  const codexAuthCompleted = codexAuthResponse?.data?.status === "completed";
+  const codexAuthStatus = codexAuthResponse?.data;
   const modelGroups = useMemo(() => {
     // Only show agents whose integrations are configured, so the picker matches
     // what the user can actually run — same gating as AgentKeyRequiredBanner.
-    const integratedAgents = AGENTS.filter((agent) => {
-      if (agent.key === "codex" && codexAuthCompleted) return true;
-      return resolvedCredentials.some(
-        (c) => c.provider === agent.providerKey && c.source !== "none",
-      );
-    });
+    const integratedAgents = AGENTS.filter((agent) =>
+      isAgentConnected(agent.key, resolvedCredentials, codexAuthStatus),
+    );
     // Sort so the default agent type appears first, preserve original order otherwise.
     return [...integratedAgents].sort((a, b) => {
       if (a.key === defaultAgentType) return -1;
       if (b.key === defaultAgentType) return 1;
       return AGENTS.indexOf(a) - AGENTS.indexOf(b);
     });
-  }, [defaultAgentType, resolvedCredentials, codexAuthCompleted]);
+  }, [defaultAgentType, resolvedCredentials, codexAuthStatus]);
+
+  // Drop a previously selected model (from React state or restored draft) when
+  // its agent is no longer integrated — keeps the picker value consistent with
+  // what's renderable. Only act once both credential queries have resolved so
+  // a transient loading state doesn't nuke a valid choice.
+  useEffect(() => {
+    if (!resolvedCredsResponse || !codexAuthResponse) return;
+    if (!selectedModel) return;
+    const stillAvailable = modelGroups.some((g) => g.models.includes(selectedModel));
+    if (!stillAvailable) setSelectedModel("");
+  }, [modelGroups, selectedModel, resolvedCredsResponse, codexAuthResponse]);
 
   // Determine which agent type would be used and whether credentials exist.
   const effectiveAgentType: string = selectedModel ? agentTypeForModel(selectedModel) ?? defaultAgentType : defaultAgentType;
@@ -346,10 +354,7 @@ export function ManualSessionCreatePageContent() {
   const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
   const submittedReasoningEffort = showReasoningSelector ? effectiveReasoningEffort : "";
   const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
-  const requiredProvider = AGENTS_BY_KEY[effectiveAgentType]?.providerKey ?? "";
-  const hasAgentCredentials =
-    resolvedCredentials.some((c) => c.provider === requiredProvider && c.source !== "none")
-      || (effectiveAgentType === "codex" && codexAuthResponse?.data?.status === "completed");
+  const hasAgentCredentials = isAgentConnected(effectiveAgentType, resolvedCredentials, codexAuthStatus);
 
   const slashCommandsQuery = useSessionComposerSlashCommands({
     agentType: effectiveAgentType,

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -320,14 +320,23 @@ export function ManualSessionCreatePageContent() {
     setBranchByRepoId((prev) => ({ ...prev, [selectedRepoId]: branch }));
   };
 
+  const codexAuthCompleted = codexAuthResponse?.data?.status === "completed";
   const modelGroups = useMemo(() => {
+    // Only show agents whose integrations are configured, so the picker matches
+    // what the user can actually run — same gating as AgentKeyRequiredBanner.
+    const integratedAgents = AGENTS.filter((agent) => {
+      if (agent.key === "codex" && codexAuthCompleted) return true;
+      return resolvedCredentials.some(
+        (c) => c.provider === agent.providerKey && c.source !== "none",
+      );
+    });
     // Sort so the default agent type appears first, preserve original order otherwise.
-    return [...AGENTS].sort((a, b) => {
+    return [...integratedAgents].sort((a, b) => {
       if (a.key === defaultAgentType) return -1;
       if (b.key === defaultAgentType) return 1;
       return AGENTS.indexOf(a) - AGENTS.indexOf(b);
     });
-  }, [defaultAgentType]);
+  }, [defaultAgentType, resolvedCredentials, codexAuthCompleted]);
 
   // Determine which agent type would be used and whether credentials exist.
   const effectiveAgentType: string = selectedModel ? agentTypeForModel(selectedModel) ?? defaultAgentType : defaultAgentType;

--- a/frontend/src/components/autopilot/autopilot-helpers.ts
+++ b/frontend/src/components/autopilot/autopilot-helpers.ts
@@ -1,4 +1,4 @@
-import type { OrgSettings, PMDocument, PMPlan, PMStatus, CodexAuthStatus, ResolvedCredential } from "@/lib/types";
+import type { OrgSettings, PMDocument, PMPlan, PMStatus } from "@/lib/types";
 
 export const DEFAULT_PRIORITY_WEIGHTS: Required<NonNullable<OrgSettings["priority_weights"]>> = {
   customer_impact: 0.35,
@@ -6,30 +6,6 @@ export const DEFAULT_PRIORITY_WEIGHTS: Required<NonNullable<OrgSettings["priorit
   recency: 0.2,
   revenue_risk: 0.2,
 };
-
-export function isAgentConnected(
-  agentType: NonNullable<OrgSettings["default_agent_type"]>,
-  resolvedCredentials: readonly ResolvedCredential[],
-  codexAuthStatus?: CodexAuthStatus | null,
-): boolean {
-  const hasResolvedCredential = (provider: string) =>
-    resolvedCredentials.some((credential) => credential.provider === provider && credential.source !== "none");
-
-  switch (agentType) {
-    case "codex":
-      return codexAuthStatus?.status === "completed" || hasResolvedCredential("openai");
-    case "claude_code":
-      return hasResolvedCredential("anthropic");
-    case "gemini_cli":
-      return hasResolvedCredential("gemini");
-    case "amp":
-      return hasResolvedCredential("amp");
-    case "pi":
-      return hasResolvedCredential("pi");
-    default:
-      return false;
-  }
-}
 
 export type AutopilotHeroMode = "first_analysis" | "recommendation" | "attention";
 

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -17,8 +17,7 @@ import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { useDisconnectIntegration } from "@/hooks/use-disconnect-integration";
 import { useGitHubRepoSync } from "@/hooks/use-github-repo-sync";
 import { queryKeys } from "@/lib/query-keys";
-import { isAgentConnected } from "@/components/autopilot/autopilot-helpers";
-import { AGENTS_BY_KEY } from "@/lib/agents";
+import { AGENTS_BY_KEY, isAgentConnected } from "@/lib/agents";
 import {
   Select,
   SelectContent,

--- a/frontend/src/hooks/use-setup-status.ts
+++ b/frontend/src/hooks/use-setup-status.ts
@@ -3,7 +3,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
-import { isAgentConnected } from "@/components/autopilot/autopilot-helpers";
+import { isAgentConnected } from "@/lib/agents";
 import type { OrgSettings, Integration, Repository, ListResponse, Organization, SingleResponse } from "@/lib/types";
 
 export function useSetupStatus() {

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -10,6 +10,7 @@ import {
   AVAILABLE_GEMINI_CLI_MODELS,
   AVAILABLE_PI_MODELS,
 } from "@/lib/model-constants";
+import type { CodexAuthStatus, ResolvedCredential } from "@/lib/types";
 
 export interface AgentEnvVar {
   name: string;
@@ -138,4 +139,22 @@ export const AGENT_DISPLAY_LABELS: Readonly<Record<string, string>> = {
 // Resolve the agent type key for a given model string.
 export function agentTypeForModel(model: string): string | undefined {
   return AGENTS.find((a) => a.models.includes(model))?.key;
+}
+
+// True when the user has the credentials needed to run the given agent.
+// Codex can auth via OAuth (codexAuthStatus.completed) or an OPENAI_API_KEY
+// resolved credential; every other agent requires its provider's resolved
+// credential. Source of truth for the new-session picker filter, the
+// AgentKeyRequiredBanner gate, and setup-readiness checks.
+export function isAgentConnected(
+  agentType: string,
+  resolvedCredentials: readonly ResolvedCredential[],
+  codexAuthStatus?: CodexAuthStatus | null,
+): boolean {
+  if (agentType === "codex" && codexAuthStatus?.status === "completed") return true;
+  const agent = AGENTS_BY_KEY[agentType];
+  if (!agent) return false;
+  return resolvedCredentials.some(
+    (c) => c.provider === agent.providerKey && c.source !== "none",
+  );
 }


### PR DESCRIPTION
## Summary
- The model picker on `/sessions/new` previously listed every agent in `AGENTS` regardless of integration status, while the continue-session picker only shows models for the bound agent.
- Now filters to agents the user has actually configured: a resolved credential exists for the agent's `providerKey` (`source !== \"none\"`), or — for Codex specifically — `codexAuth.status === \"completed\"`. This is the same gating already used by `AgentKeyRequiredBanner`.
- The \"Default model\" option still renders unconditionally so users with no integrations aren't fully locked out, and the existing missing-credentials banner continues to surface.

## Test plan
- [ ] With only one provider's API key configured, open `/sessions/new` and confirm the model picker shows only that provider's models plus \"Default model\".
- [ ] Configure Codex via OAuth (no API key) and confirm Codex models appear.
- [ ] Remove all integrations and confirm only \"Default model\" is shown and the credential warning banner still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)