### PR TITLE
Fix opaque preview-start failures with lazy infra image pulls and clearer errors

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -182,9 +182,23 @@ func main() {
 			// Build sandbox+preview provider so worker-capable modes can start,
 			// stop, and hydrate previews locally.
 			sandboxExec := providers.NewDockerProvider(apiDockerCli, logger, providers.WithResolvConf(cfg.SandboxResolvConf))
-			pvProvider = previewproviders.NewDockerPreviewProvider(apiDockerCli, sandboxExec, logger)
+			dockerPreviewProvider := previewproviders.NewDockerPreviewProvider(apiDockerCli, sandboxExec, logger)
+			pvProvider = dockerPreviewProvider
 			snapshotExec = sandboxExec
 			apiSandboxProvider = sandboxExec
+
+			// Pre-pull infrastructure template images in the background so
+			// the first preview start that needs e.g. postgres:17-alpine
+			// answers the HTTP request inside the server's WriteTimeout
+			// instead of timing out on a multi-minute cold pull. The
+			// provider's lazy-pull stays as a safety net for templates
+			// added after boot. Detached from the process ctx so a slow
+			// pull never blocks shutdown.
+			go func() {
+				prepullCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+				defer cancel()
+				dockerPreviewProvider.EnsureInfraImages(prepullCtx)
+			}()
 		} else {
 			logger.Warn().Err(dockerErr).Msg("Docker not available — file browsing and preview provider disabled")
 		}

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -731,6 +731,50 @@ describe("PreviewPanel component", () => {
     ).not.toBeInTheDocument();
   });
 
+  // Provider-side launch failures (image pull, infra health, init script,
+  // readiness) carry a backend-built message that names the failing image
+  // or service and the underlying cause. We pass it through verbatim — if
+  // anyone re-wraps it with the generic "Failed to start preview:" prefix,
+  // the actionable detail gets buried.
+  it.each([
+    [
+      "PREVIEW_INFRA_IMAGE_UNAVAILABLE",
+      "preview infrastructure image is not available on this worker. The image could not be pulled from its registry — check the worker's network egress and registry credentials. Details: provider start preview: provision infrastructure \"db\": preview infrastructure image unavailable: pull \"postgres:17-alpine\": registry unreachable",
+    ],
+    [
+      "PREVIEW_INFRA_UNHEALTHY",
+      "preview infrastructure container did not become healthy in time. The container started but its health check (e.g. pg_isready) never passed. Details: provider start preview: preview infrastructure container failed health check: infrastructure \"db\" (postgres-17): health check timed out after 60 seconds",
+    ],
+    [
+      "PREVIEW_SERVICE_NOT_READY",
+      "preview service did not pass its readiness probe. The service may have crashed at boot, taken too long to start, or be listening on a different port than declared in .143/preview.json. Details: provider start preview: preview service readiness probe failed: primary service \"app\" (port 3000): timeout",
+    ],
+  ])(
+    "passes backend message through verbatim for %s without the generic prefix",
+    async (code, backendMessage) => {
+      const user = userEvent.setup();
+      mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+      const err = new Error(backendMessage);
+      (err as Error & { code?: string }).code = code;
+      mockStart.mockRejectedValueOnce(err);
+
+      renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("No preview running")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: "Start Preview" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(backendMessage)).toBeInTheDocument();
+      });
+      expect(
+        screen.queryByText(`Failed to start preview: ${backendMessage}`)
+      ).not.toBeInTheDocument();
+    }
+  );
+
   it("dismisses mutation error banner when X is clicked", async () => {
     const user = userEvent.setup();
     mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -311,6 +311,21 @@ export function PreviewPanel({
         setMutationError(err.message);
         return;
       }
+      // Provider-side launch failures (image pull, infra health, init
+      // script, readiness probe). The backend builds a message that
+      // names the failing image / service and includes the underlying
+      // cause, so passing it through verbatim is more useful than
+      // re-wrapping with a generic prefix.
+      if (
+        code === PREVIEW_ERROR_CODES.INFRA_IMAGE_UNAVAILABLE ||
+        code === PREVIEW_ERROR_CODES.INFRA_START_FAILED ||
+        code === PREVIEW_ERROR_CODES.INFRA_UNHEALTHY ||
+        code === PREVIEW_ERROR_CODES.INIT_SCRIPT_FAILED ||
+        code === PREVIEW_ERROR_CODES.SERVICE_NOT_READY
+      ) {
+        setMutationError(err.message);
+        return;
+      }
       setMutationError(`Failed to start preview: ${err.message}`);
     },
   });

--- a/frontend/src/lib/preview-types.ts
+++ b/frontend/src/lib/preview-types.ts
@@ -36,6 +36,25 @@ export const PREVIEW_ERROR_CODES = {
   // didn't supply an explicit config, so the backend has nothing to launch.
   // User fix is to commit the config file (see docs/guides/previews.md).
   NO_CONFIG: "PREVIEW_NO_CONFIG",
+  // 422 — a preview infrastructure container's image is not on the worker
+  // and the on-demand pull failed (registry unreachable, image renamed,
+  // rate-limit, no egress). The user-visible message names the image so an
+  // operator can pull manually or fix registry access.
+  INFRA_IMAGE_UNAVAILABLE: "PREVIEW_INFRA_IMAGE_UNAVAILABLE",
+  // 422 — Docker accepted the create call but the container failed to
+  // start (resource limits, label conflict, daemon error).
+  INFRA_START_FAILED: "PREVIEW_INFRA_START_FAILED",
+  // 422 — the infrastructure container started but its health check
+  // (pg_isready, redis-cli ping, etc.) never passed within the timeout.
+  INFRA_UNHEALTHY: "PREVIEW_INFRA_UNHEALTHY",
+  // 422 — a user-supplied init script (seed SQL etc.) returned a non-zero
+  // exit code or could not be read from the workspace.
+  INIT_SCRIPT_FAILED: "PREVIEW_INIT_SCRIPT_FAILED",
+  // 422 — an application service was launched but its readiness probe
+  // never passed within the configured timeout. The service likely
+  // crashed at boot or is bound to a different port than it declares in
+  // .143/preview.json.
+  SERVICE_NOT_READY: "PREVIEW_SERVICE_NOT_READY",
 } as const;
 
 export type PreviewErrorCode =

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -425,6 +425,71 @@ func (h *PreviewHandler) requireInspector(w http.ResponseWriter, r *http.Request
 	return inspector, true
 }
 
+// classifyLaunchError converts a preview-launch error into the most specific
+// HTTP error code we can. Before this existed, every launch failure surfaced
+// as a generic 422 PREVIEW_START_FAILED with the message "failed to start
+// preview" — the actual cause (missing image, unhealthy container, init
+// script crash, readiness timeout) was logged but never reached the user, so
+// the frontend rendered the unhelpful "Failed to start preview: failed to
+// start preview".
+//
+// We pick out the provider sentinels from internal/services/preview/errors.go
+// and map each to a stable, debuggable error code. The user-visible message
+// always includes the underlying cause so an operator can act on it without
+// digging through Grafana.
+func classifyLaunchError(err error) *previewHTTPError {
+	if err == nil {
+		return nil
+	}
+	cause := err.Error()
+	switch {
+	case errors.Is(err, preview.ErrInfraImageUnavailable):
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_INFRA_IMAGE_UNAVAILABLE",
+			"preview infrastructure image is not available on this worker. The image could not be pulled from its registry — check the worker's network egress and registry credentials. Details: "+cause,
+			err,
+		)
+	case errors.Is(err, preview.ErrInfraStartFailed):
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_INFRA_START_FAILED",
+			"preview infrastructure container failed to start. Details: "+cause,
+			err,
+		)
+	case errors.Is(err, preview.ErrInfraUnhealthy):
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_INFRA_UNHEALTHY",
+			"preview infrastructure container did not become healthy in time. The container started but its health check (e.g. pg_isready) never passed. Details: "+cause,
+			err,
+		)
+	case errors.Is(err, preview.ErrInitScriptFailed):
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_INIT_SCRIPT_FAILED",
+			"preview init script failed. Check the script referenced in .143/preview.json. Details: "+cause,
+			err,
+		)
+	case errors.Is(err, preview.ErrServiceNotReady):
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_SERVICE_NOT_READY",
+			"preview service did not pass its readiness probe. The service may have crashed at boot, taken too long to start, or be listening on a different port than declared in .143/preview.json. Details: "+cause,
+			err,
+		)
+	default:
+		// Pass the underlying cause through as the message so the frontend
+		// shows something actionable instead of "failed to start preview".
+		return newPreviewHTTPError(
+			http.StatusUnprocessableEntity,
+			"PREVIEW_START_FAILED",
+			"failed to start preview: "+cause,
+			err,
+		)
+	}
+}
+
 // =============================================================================
 // POST /api/v1/sessions/{id}/preview — Start a preview
 // =============================================================================
@@ -570,7 +635,7 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 	if err != nil {
 		h.manager.AbortReservation(ctx, reservation, hydratedID, fmt.Sprintf("launch: %v", err))
 		h.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("preview launch failed")
-		return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_START_FAILED", "failed to start preview", err)
+		return nil, classifyLaunchError(err)
 	}
 
 	if h.localNodeID != "" && (acq.Hydrated || (session.ContainerID != nil && *session.ContainerID != "")) {

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -1873,6 +1873,82 @@ func TestPreviewHandler_StartPreview_ReuseAttachesWhenContainerAlive(t *testing.
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestClassifyLaunchError verifies the error-code mapping that turns
+// preview-launch failures into actionable HTTP responses. Before this
+// existed, every launch failure became a generic 422 PREVIEW_START_FAILED
+// with the message "failed to start preview" — the actual cause never
+// reached the user, so the frontend rendered the unhelpful
+// "Failed to start preview: failed to start preview".
+func TestClassifyLaunchError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		err          error
+		wantCode     string
+		wantStatus   int
+		mustContain  string
+		mustContain2 string
+	}{
+		{
+			name:        "image unavailable",
+			err:         fmt.Errorf("provider start preview: provision infrastructure %q: %w: pull %q: registry unreachable", "db", preview.ErrInfraImageUnavailable, "postgres:17-alpine"),
+			wantCode:    "PREVIEW_INFRA_IMAGE_UNAVAILABLE",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "postgres:17-alpine",
+		},
+		{
+			name:        "infra start failed",
+			err:         fmt.Errorf("%w: create container: out of memory", preview.ErrInfraStartFailed),
+			wantCode:    "PREVIEW_INFRA_START_FAILED",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "out of memory",
+		},
+		{
+			name:        "infra unhealthy",
+			err:         fmt.Errorf("%w: infrastructure %q (postgres-17): health check timed out after 60 seconds", preview.ErrInfraUnhealthy, "db"),
+			wantCode:    "PREVIEW_INFRA_UNHEALTHY",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "health check timed out",
+		},
+		{
+			name:        "init script failed",
+			err:         fmt.Errorf("%w: infrastructure %q script %q: exit 1", preview.ErrInitScriptFailed, "db", "seed.sql"),
+			wantCode:    "PREVIEW_INIT_SCRIPT_FAILED",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "seed.sql",
+		},
+		{
+			name:        "service not ready",
+			err:         fmt.Errorf("%w: primary service %q (port 3000): timeout", preview.ErrServiceNotReady, "app"),
+			wantCode:    "PREVIEW_SERVICE_NOT_READY",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "port 3000",
+		},
+		{
+			name:        "unclassified surfaces underlying cause",
+			err:         errors.New("provider start preview: something weird happened"),
+			wantCode:    "PREVIEW_START_FAILED",
+			wantStatus:  http.StatusUnprocessableEntity,
+			mustContain: "something weird happened",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := classifyLaunchError(tc.err)
+			require.NotNil(t, got)
+			require.Equal(t, tc.wantStatus, got.status)
+			require.Equal(t, tc.wantCode, got.code)
+			require.Contains(t, got.message, tc.mustContain, "user-visible message must surface the underlying cause")
+			require.NotEqual(t, "failed to start preview", got.message, "must not regress to the opaque generic message")
+		})
+	}
+
+	require.Nil(t, classifyLaunchError(nil), "nil error must not produce a response")
+}
+
 func TestPreviewHandler_SetAuditEmitter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -16,9 +16,9 @@ import (
 
 // InfraTemplate describes a platform-provided infrastructure template.
 type InfraTemplate struct {
-	Image       string
-	DefaultPort int
-	HealthCmd   []string
+	Image        string
+	DefaultPort  int
+	HealthCmd    []string
 	DefaultMemMB int
 	DefaultCPU   float64
 	MaxMemMB     int
@@ -37,15 +37,37 @@ func LookupInfraTemplate(name string) (InfraTemplate, bool) {
 	return t, ok
 }
 
+// AllInfraImages returns the deduplicated set of Docker images used by every
+// supported infrastructure template. Worker boot calls this to pre-pull
+// images in the background, so the first preview that needs e.g.
+// postgres:17-alpine doesn't have to pay the cold-pull latency inside the
+// HTTP request handler (the server's WriteTimeout is far shorter than a
+// large image pull).
+func AllInfraImages() []string {
+	seen := make(map[string]struct{}, len(supportedTemplates))
+	out := make([]string, 0, len(supportedTemplates))
+	for _, t := range supportedTemplates {
+		if t.Image == "" {
+			continue
+		}
+		if _, ok := seen[t.Image]; ok {
+			continue
+		}
+		seen[t.Image] = struct{}{}
+		out = append(out, t.Image)
+	}
+	return out
+}
+
 // =============================================================================
 // Constraints
 // =============================================================================
 
 const (
-	MaxServicesPerConfig       = 4
-	MaxInfraPerConfig          = 2
-	MinPort                    = 1024
-	MaxPort                    = 65535
+	MaxServicesPerConfig = 4
+	MaxInfraPerConfig    = 2
+	MinPort              = 1024
+	MaxPort              = 65535
 )
 
 // =============================================================================
@@ -56,20 +78,20 @@ const (
 // It supports both single-service (top-level command/port) and multi-service
 // (services map) formats.
 type rawPreviewConfig struct {
-	Version     string                                `json:"version"`
-	Name        string                                `json:"name"`
-	Primary     string                                `json:"primary,omitempty"`
-	Services    map[string]models.ServiceConfig        `json:"services,omitempty"`
+	Version        string                                 `json:"version"`
+	Name           string                                 `json:"name"`
+	Primary        string                                 `json:"primary,omitempty"`
+	Services       map[string]models.ServiceConfig        `json:"services,omitempty"`
 	Infrastructure map[string]models.InfrastructureConfig `json:"infrastructure,omitempty"`
-	Credentials models.CredentialConfig                `json:"credentials"`
-	Network     models.NetworkConfig                  `json:"network"`
-	Progressive bool                                  `json:"progressive,omitempty"`
+	Credentials    models.CredentialConfig                `json:"credentials"`
+	Network        models.NetworkConfig                   `json:"network"`
+	Progressive    bool                                   `json:"progressive,omitempty"`
 
 	// Single-service top-level fields (mutually exclusive with Services).
-	Command []string          `json:"command,omitempty"`
-	Cwd     string            `json:"cwd,omitempty"`
-	Port    int               `json:"port,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
+	Command []string               `json:"command,omitempty"`
+	Cwd     string                 `json:"cwd,omitempty"`
+	Port    int                    `json:"port,omitempty"`
+	Env     map[string]string      `json:"env,omitempty"`
 	Ready   *models.ReadinessProbe `json:"ready,omitempty"`
 }
 
@@ -260,14 +282,14 @@ func validatePathInsideRepo(field, path string) []string {
 // the base branch.
 func ResolveConfig(baseCfg, diffCfg *models.PreviewConfig) *models.PreviewConfig {
 	resolved := &models.PreviewConfig{
-		Version:        baseCfg.Version,
-		Name:           baseCfg.Name,
-		Progressive:    baseCfg.Progressive,
+		Version:     baseCfg.Version,
+		Name:        baseCfg.Name,
+		Progressive: baseCfg.Progressive,
 
 		// Security-sensitive: always from base.
-		Primary:        baseCfg.Primary,
-		Credentials:    baseCfg.Credentials,
-		Network:        baseCfg.Network,
+		Primary:     baseCfg.Primary,
+		Credentials: baseCfg.Credentials,
+		Network:     baseCfg.Network,
 	}
 
 	// Infrastructure: structure from base, init_script from diff (unless connected).

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -657,6 +657,32 @@ func TestLookupInfraTemplate(t *testing.T) {
 	}
 }
 
+func TestAllInfraImages(t *testing.T) {
+	t.Parallel()
+
+	images := AllInfraImages()
+	if len(images) == 0 {
+		t.Fatal("every supported template must contribute an image so worker boot can pre-pull")
+	}
+
+	// No duplicates (postgres-17 / postgres-16 etc. happen to use distinct
+	// images today, but the contract is dedup regardless).
+	seen := map[string]struct{}{}
+	for _, img := range images {
+		if _, dup := seen[img]; dup {
+			t.Errorf("AllInfraImages must dedupe; saw %q twice", img)
+		}
+		seen[img] = struct{}{}
+	}
+
+	// Every template's image should be present.
+	for name, tmpl := range supportedTemplates {
+		if _, ok := seen[tmpl.Image]; !ok {
+			t.Errorf("image %q for template %q is missing from AllInfraImages", tmpl.Image, name)
+		}
+	}
+}
+
 func TestParseConfig_RoundTrip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/errors.go
+++ b/internal/services/preview/errors.go
@@ -1,0 +1,34 @@
+package preview
+
+import "errors"
+
+// Provider-side failure sentinels. The HTTP handler classifies preview-launch
+// errors via errors.Is so the frontend gets a specific code and message
+// instead of a generic "failed to start preview". Wrap with %w when adding
+// context (e.g. fmt.Errorf("%w: pull postgres:17-alpine: %v", ErrInfraImageUnavailable, err)).
+var (
+	// ErrInfraImageUnavailable means a preview infrastructure container could
+	// not be created because the requested image is not present locally and
+	// the on-demand pull failed (registry unreachable, image renamed/removed,
+	// rate limit, no network egress, etc.).
+	ErrInfraImageUnavailable = errors.New("preview infrastructure image unavailable")
+
+	// ErrInfraStartFailed means Docker accepted the create call but the
+	// container failed to start, or container creation itself failed for a
+	// reason other than missing image (resource limits, label conflict, etc.).
+	ErrInfraStartFailed = errors.New("preview infrastructure container failed to start")
+
+	// ErrInfraUnhealthy means the container started but its health check
+	// (pg_isready, redis-cli ping, etc.) did not pass within the timeout.
+	ErrInfraUnhealthy = errors.New("preview infrastructure container failed health check")
+
+	// ErrInitScriptFailed means a user-supplied init script (e.g. seed SQL)
+	// returned a non-zero exit code or could not be read from the workspace.
+	ErrInitScriptFailed = errors.New("preview init script failed")
+
+	// ErrServiceNotReady means an application service was launched but its
+	// readiness probe never passed within the configured timeout. The user's
+	// preview command likely crashed at boot or never bound to its declared
+	// port.
+	ErrServiceNotReady = errors.New("preview service readiness probe failed")
+)

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -2,8 +2,10 @@
 package providers
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -13,11 +15,15 @@ import (
 	"sync"
 	"time"
 
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -37,7 +43,18 @@ type DockerPreviewClient interface {
 	ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
+	// ImageInspect / ImagePull are used to lazy-pull preview infrastructure
+	// images on first use, so worker hosts don't need to pre-pull every
+	// supported template (postgres:17-alpine, redis:7-alpine, mysql:8, …).
+	ImageInspect(ctx context.Context, ref string, opts ...client.ImageInspectOption) (image.InspectResponse, error)
+	ImagePull(ctx context.Context, ref string, options image.PullOptions) (io.ReadCloser, error)
 }
+
+// imagePullTimeout bounds how long a single infrastructure image pull can
+// take before we give up. 5 minutes is generous for postgres-alpine over a
+// reasonable connection but stops a wedged registry from blocking the
+// preview start indefinitely.
+const imagePullTimeout = 5 * time.Minute
 
 // SandboxExecutor defines the exec interface needed from the sandbox provider
 // for running preview service processes inside the sandbox.
@@ -73,6 +90,11 @@ type DockerPreviewProvider struct {
 
 	mu       sync.RWMutex
 	previews map[string]*previewState // handle → state
+
+	// imagePulls deduplicates concurrent pulls of the same image ref. Two
+	// preview starts hitting an absent image at the same moment share a
+	// single pull instead of fanning out N redundant streams.
+	imagePulls singleflight.Group
 }
 
 // previewState tracks all running components of a preview.
@@ -189,7 +211,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		tmpl, _ := preview.LookupInfraTemplate(infraCfg.Template)
 		if err := d.waitForInfraHealth(ctx, ih.ContainerID, tmpl); err != nil {
 			d.cleanupState(handle)
-			return nil, fmt.Errorf("infrastructure %q health check failed: %w", name, err)
+			return nil, fmt.Errorf("%w: infrastructure %q (%s): %v", preview.ErrInfraUnhealthy, name, infraCfg.Template, err)
 		}
 		d.logger.Info().Str("infra", name).Str("template", infraCfg.Template).Msg("infrastructure healthy")
 	}
@@ -202,7 +224,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		ih := state.infra[name]
 		if err := d.runInitScript(ctx, sb, ih, infraCfg); err != nil {
 			d.cleanupState(handle)
-			return nil, fmt.Errorf("init script for %q failed: %w", name, err)
+			return nil, fmt.Errorf("%w: infrastructure %q script %q: %v", preview.ErrInitScriptFailed, name, infraCfg.InitScript, err)
 		}
 		d.logger.Info().Str("infra", name).Str("script", infraCfg.InitScript).Msg("init script completed")
 	}
@@ -249,7 +271,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			}
 			if err := d.waitForReadiness(ctx, sb, primaryCfg.Port, primaryCfg.Ready.HTTPPath, timeout); err != nil {
 				d.cleanupState(handle)
-				return nil, fmt.Errorf("readiness probe for primary %q failed: %w", cfg.Primary, err)
+				return nil, fmt.Errorf("%w: primary service %q (port %d): %v", preview.ErrServiceNotReady, cfg.Primary, primaryCfg.Port, err)
 			}
 			d.mu.Lock()
 			state.services[cfg.Primary].status = models.PreviewServiceStatusReady
@@ -299,7 +321,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			}
 			if err := d.waitForReadiness(ctx, sb, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
 				d.cleanupState(handle)
-				return nil, fmt.Errorf("readiness probe for %q failed: %w", name, err)
+				return nil, fmt.Errorf("%w: service %q (port %d): %v", preview.ErrServiceNotReady, name, svcCfg.Port, err)
 			}
 			d.mu.Lock()
 			state.services[name].status = models.PreviewServiceStatusReady
@@ -471,6 +493,15 @@ func (d *DockerPreviewProvider) provisionInfra(
 	}
 	containerName := fmt.Sprintf("preview-%s-%s", infraName, handlePrefix)
 
+	// Ensure the image is on the host before asking Docker to create the
+	// container. Worker hosts only pre-pull the 143-server / 143-sandbox /
+	// headless-shell images; infrastructure templates (postgres-N,
+	// redis-N, mysql-N) are pulled lazily on first use so adding a new
+	// template doesn't require re-provisioning workers.
+	if err := d.ensureImage(ctx, tmpl.Image); err != nil {
+		return nil, err
+	}
+
 	env := d.buildInfraEnv(infraCfg.Template, cred)
 	memLimit := int64(tmpl.DefaultMemMB) * 1024 * 1024
 	cpuNanos := int64(tmpl.DefaultCPU * 1e9)
@@ -497,7 +528,7 @@ func (d *DockerPreviewProvider) provisionInfra(
 		containerName,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("create container: %w", err)
+		return nil, fmt.Errorf("%w: create container for image %q: %v", preview.ErrInfraStartFailed, tmpl.Image, err)
 	}
 
 	if err := d.client.ContainerStart(ctx, resp.ID, container.StartOptions{}); err != nil {
@@ -507,7 +538,7 @@ func (d *DockerPreviewProvider) provisionInfra(
 		if rmErr := d.client.ContainerRemove(cleanCtx, resp.ID, container.RemoveOptions{Force: true}); rmErr != nil {
 			d.logger.Warn().Err(rmErr).Str("container_id", resp.ID).Msg("failed to remove container after start failure")
 		}
-		return nil, fmt.Errorf("start container: %w", err)
+		return nil, fmt.Errorf("%w: start container: %v", preview.ErrInfraStartFailed, err)
 	}
 
 	return &preview.InfraHandle{
@@ -518,6 +549,141 @@ func (d *DockerPreviewProvider) provisionInfra(
 		Port:        tmpl.DefaultPort,
 		Credential:  cred,
 	}, nil
+}
+
+// ensureImage makes sure the named image is present on the local Docker
+// host, pulling it from the registry on demand if it isn't. Concurrent
+// callers for the same image ref share a single pull (singleflight) so two
+// preview starts hitting a missing image don't fan out two redundant
+// streams.
+//
+// Failures are wrapped with preview.ErrInfraImageUnavailable so the HTTP
+// handler can map them to a specific error code that names the image, rather
+// than burying the cause inside a generic "failed to start preview".
+func (d *DockerPreviewProvider) ensureImage(ctx context.Context, ref string) error {
+	_, err, _ := d.imagePulls.Do(ref, func() (any, error) {
+		return nil, d.pullImage(ctx, ref)
+	})
+	return err
+}
+
+func (d *DockerPreviewProvider) pullImage(ctx context.Context, ref string) error {
+	if _, err := d.client.ImageInspect(ctx, ref); err == nil {
+		return nil
+	} else if !cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("%w: inspect %q: %v", preview.ErrInfraImageUnavailable, ref, err)
+	}
+
+	d.logger.Info().Str("image", ref).Msg("preview infra image missing on host; pulling from registry")
+	start := time.Now()
+
+	pullCtx, cancel := context.WithTimeout(ctx, imagePullTimeout)
+	defer cancel()
+
+	rc, err := d.client.ImagePull(pullCtx, ref, image.PullOptions{})
+	if err != nil {
+		return fmt.Errorf("%w: pull %q: %v", preview.ErrInfraImageUnavailable, ref, err)
+	}
+	defer rc.Close()
+
+	// Docker streams pull progress as one JSON object per line. Errors
+	// surface as `{"errorDetail": {...}, "error": "..."}` events that the
+	// daemon does NOT report via the ImagePull return value — if we just
+	// drain to /dev/null we lose the actual reason (auth failure, manifest
+	// unknown, rate limit) and only see "image not present after pull",
+	// which is useless for debugging.
+	if pullErr := scanPullStreamForError(rc); pullErr != nil {
+		return fmt.Errorf("%w: pull %q: %v", preview.ErrInfraImageUnavailable, ref, pullErr)
+	}
+
+	// Confirm the image actually landed. Catches the rare case where the
+	// stream finished cleanly but no errorDetail was emitted yet the image
+	// isn't present (e.g., daemon-side race during prune).
+	if _, err := d.client.ImageInspect(pullCtx, ref); err != nil {
+		return fmt.Errorf("%w: image %q not present after pull: %v", preview.ErrInfraImageUnavailable, ref, err)
+	}
+
+	d.logger.Info().Str("image", ref).Dur("elapsed", time.Since(start)).Msg("preview infra image pulled successfully")
+	return nil
+}
+
+// scanPullStreamForError reads Docker's pull-progress NDJSON stream, drains
+// it (the pull only completes once the daemon-side reader is done), and
+// returns the first errorDetail it sees (or nil for a clean pull). The
+// stream format is documented at
+// https://docs.docker.com/reference/api/engine/version/v1.45/#tag/Image/operation/ImageCreate
+// — each line is a JSON object with optional `status`, `progress`,
+// `errorDetail`, or `error` fields.
+func scanPullStreamForError(r io.Reader) error {
+	type pullEvent struct {
+		Error       string `json:"error"`
+		ErrorDetail struct {
+			Message string `json:"message"`
+		} `json:"errorDetail"`
+	}
+	var firstErr error
+	scanner := bufio.NewScanner(r)
+	// Pull progress events are short, but a Pulling-from line on a big
+	// image can stretch; bump the buffer ceiling well above bufio's
+	// default 64KiB so we never trip on it.
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		var ev pullEvent
+		if err := json.Unmarshal(line, &ev); err != nil {
+			// Malformed line; ignore and keep draining so the daemon
+			// finishes writing.
+			continue
+		}
+		if firstErr == nil {
+			switch {
+			case ev.ErrorDetail.Message != "":
+				firstErr = fmt.Errorf("%s", ev.ErrorDetail.Message)
+			case ev.Error != "":
+				firstErr = fmt.Errorf("%s", ev.Error)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil && firstErr == nil {
+		return fmt.Errorf("read pull stream: %w", err)
+	}
+	return firstErr
+}
+
+// EnsureInfraImages pre-pulls every supported infrastructure template image
+// in parallel, deduplicating via the same singleflight group as the
+// on-demand path. Best-effort: failures are logged but not returned, so a
+// transient registry hiccup doesn't block server startup. Worker boot calls
+// this in a background goroutine so the first preview that needs e.g.
+// postgres:17-alpine usually finds the image already on disk and answers
+// the HTTP request well within the server's WriteTimeout.
+//
+// Safe to call multiple times (singleflight collapses to one inspect each
+// after the first run).
+func (d *DockerPreviewProvider) EnsureInfraImages(ctx context.Context) {
+	images := preview.AllInfraImages()
+	if len(images) == 0 {
+		return
+	}
+	d.logger.Info().Strs("images", images).Msg("pre-pulling preview infra images in background")
+
+	var wg sync.WaitGroup
+	for _, ref := range images {
+		ref := ref
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := d.ensureImage(ctx, ref); err != nil {
+				d.logger.Warn().Err(err).Str("image", ref).Msg("preview infra image pre-pull failed; will retry on first preview start")
+				return
+			}
+		}()
+	}
+	wg.Wait()
+	d.logger.Info().Msg("preview infra image pre-pull pass complete")
 }
 
 func (d *DockerPreviewProvider) buildInfraEnv(template string, cred preview.InfraCredential) []string {

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -2,15 +2,21 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"io"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/preview"
+	cerrdefs "github.com/containerd/errdefs"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -20,6 +26,23 @@ type mockDockerPreviewClient struct {
 	createHostConfig       *container.HostConfig
 	createNetworkingConfig *network.NetworkingConfig
 	inspectResp            container.InspectResponse
+
+	// Image presence simulation:
+	// - imagesPresent[ref] == true means ImageInspect returns success.
+	// - imagePullCalls counts ImagePull invocations so tests can assert
+	//   the lazy-pull path was (or was not) taken.
+	// - imagePullErr, when set, makes ImagePull fail.
+	// - imagePullPopulates, when true, flips imagesPresent[ref]=true
+	//   after a successful pull so the post-pull verification inspect
+	//   succeeds.
+	// - imagePullBody, when set, replaces the default pull-stream payload
+	//   so tests can inject errorDetail events.
+	imagesPresent      map[string]bool
+	imagePullCalls     int
+	imagePullErr       error
+	imagePullPopulates bool
+	imagePullBody      string
+	imagePullMu        sync.Mutex
 }
 
 func (m *mockDockerPreviewClient) ContainerCreate(_ context.Context, _ *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, _ *ocispec.Platform, _ string) (container.CreateResponse, error) {
@@ -54,6 +77,49 @@ func (m *mockDockerPreviewClient) ContainerExecAttach(_ context.Context, _ strin
 
 func (m *mockDockerPreviewClient) ContainerExecInspect(_ context.Context, _ string) (container.ExecInspect, error) {
 	return container.ExecInspect{}, nil
+}
+
+func (m *mockDockerPreviewClient) ImageInspect(_ context.Context, ref string, _ ...client.ImageInspectOption) (image.InspectResponse, error) {
+	m.imagePullMu.Lock()
+	defer m.imagePullMu.Unlock()
+	if m.imagesPresent[ref] {
+		return image.InspectResponse{}, nil
+	}
+	return image.InspectResponse{}, cerrdefs.ErrNotFound
+}
+
+func (m *mockDockerPreviewClient) ImagePull(_ context.Context, ref string, _ image.PullOptions) (io.ReadCloser, error) {
+	m.imagePullMu.Lock()
+	m.imagePullCalls++
+	if m.imagePullErr != nil {
+		m.imagePullMu.Unlock()
+		return nil, m.imagePullErr
+	}
+	if m.imagePullPopulates {
+		if m.imagesPresent == nil {
+			m.imagesPresent = map[string]bool{}
+		}
+		m.imagesPresent[ref] = true
+	}
+	body := m.imagePullBody
+	m.imagePullMu.Unlock()
+	if body == "" {
+		body = `{"status":"Pulled"}`
+	}
+	return io.NopCloser(strings.NewReader(body)), nil
+}
+
+// gatedPullClient wraps the mock so ImagePull blocks on a shared channel —
+// the singleflight dedup test needs concurrent callers to all queue up on
+// the same key before any of them complete.
+type gatedPullClient struct {
+	*mockDockerPreviewClient
+	gate <-chan struct{}
+}
+
+func (g *gatedPullClient) ImagePull(ctx context.Context, ref string, opts image.PullOptions) (io.ReadCloser, error) {
+	<-g.gate
+	return g.mockDockerPreviewClient.ImagePull(ctx, ref, opts)
 }
 
 type noopSandboxExecutor struct{}
@@ -103,7 +169,8 @@ func TestNewDockerPreviewProvider_WithPreviewNetworkOverride(t *testing.T) {
 func TestProvisionInfra_UsesSandboxNetwork(t *testing.T) {
 	t.Parallel()
 
-	client := &mockDockerPreviewClient{
+	cli := &mockDockerPreviewClient{
+		imagesPresent: map[string]bool{"postgres:17": true},
 		inspectResp: container.InspectResponse{
 			ContainerJSONBase: &container.ContainerJSONBase{
 				HostConfig: &container.HostConfig{
@@ -117,7 +184,7 @@ func TestProvisionInfra_UsesSandboxNetwork(t *testing.T) {
 			},
 		},
 	}
-	provider := NewDockerPreviewProvider(client, &noopSandboxExecutor{}, zerolog.Nop())
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
 
 	handle, err := provider.provisionInfra(
 		context.Background(),
@@ -130,8 +197,203 @@ func TestProvisionInfra_UsesSandboxNetwork(t *testing.T) {
 
 	require.NoError(t, err, "provisionInfra should use the sandbox network when creating infra containers")
 	require.NotNil(t, handle, "provisionInfra should return a handle")
-	require.Equal(t, container.NetworkMode("143-sandbox-custom"), client.createHostConfig.NetworkMode, "infra containers should join the sandbox container network")
-	require.Contains(t, client.createNetworkingConfig.EndpointsConfig, "143-sandbox-custom", "network aliases should be attached to the sandbox network")
+	require.Equal(t, container.NetworkMode("143-sandbox-custom"), cli.createHostConfig.NetworkMode, "infra containers should join the sandbox container network")
+	require.Contains(t, cli.createNetworkingConfig.EndpointsConfig, "143-sandbox-custom", "network aliases should be attached to the sandbox network")
+	require.Zero(t, cli.imagePullCalls, "image is already present; ensureImage must not pull")
+}
+
+// TestProvisionInfra_PullsMissingImage verifies the lazy-pull behavior:
+// when the requested template image isn't on the host, provisionInfra
+// pulls it before creating the container, so workers don't need every
+// supported postgres/redis/mysql image pre-pulled at provision time.
+func TestProvisionInfra_PullsMissingImage(t *testing.T) {
+	t.Parallel()
+
+	cli := &mockDockerPreviewClient{
+		// Image starts absent; the pull populates it so the post-pull
+		// verification inspect succeeds.
+		imagesPresent:      map[string]bool{},
+		imagePullPopulates: true,
+		inspectResp: container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				HostConfig: &container.HostConfig{NetworkMode: container.NetworkMode("143-sandbox")},
+			},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{"143-sandbox": {IPAddress: "172.18.0.5"}},
+			},
+		},
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	_, err := provider.provisionInfra(
+		context.Background(),
+		&agent.Sandbox{ID: "sandbox-1"},
+		"preview-handle",
+		"db",
+		models.InfrastructureConfig{Template: "postgres-17"},
+		preview.InfraTemplate{Image: "postgres:17-alpine", DefaultMemMB: 128, DefaultCPU: 0.25, DefaultPort: 5432},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, cli.imagePullCalls, "missing image should trigger exactly one pull")
+}
+
+// TestProvisionInfra_PullFailureSurfacesAsImageUnavailable verifies that
+// when the registry pull fails, the caller receives ErrInfraImageUnavailable
+// (the sentinel the HTTP handler maps to PREVIEW_INFRA_IMAGE_UNAVAILABLE).
+// Bare network/registry errors must not bubble up unwrapped — that's what
+// produced the opaque "failed to start preview" message before this fix.
+func TestProvisionInfra_PullFailureSurfacesAsImageUnavailable(t *testing.T) {
+	t.Parallel()
+
+	cli := &mockDockerPreviewClient{
+		imagesPresent: map[string]bool{},
+		imagePullErr:  errors.New("registry unreachable"),
+		// Provide a usable inspect response so resolveSandboxNetwork
+		// succeeds; we want this test to fail in ensureImage, not earlier.
+		inspectResp: container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				HostConfig: &container.HostConfig{NetworkMode: container.NetworkMode("143-sandbox")},
+			},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{"143-sandbox": {IPAddress: "172.18.0.5"}},
+			},
+		},
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	_, err := provider.provisionInfra(
+		context.Background(),
+		&agent.Sandbox{ID: "sandbox-1"},
+		"preview-handle",
+		"db",
+		models.InfrastructureConfig{Template: "postgres-17"},
+		preview.InfraTemplate{Image: "postgres:17-alpine", DefaultMemMB: 128, DefaultCPU: 0.25, DefaultPort: 5432},
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, preview.ErrInfraImageUnavailable, "pull failures must wrap ErrInfraImageUnavailable so the handler can classify them")
+	require.Contains(t, err.Error(), "postgres:17-alpine", "error must name the image so the user can debug")
+	require.Contains(t, err.Error(), "registry unreachable", "error must include the underlying cause")
+}
+
+// TestProvisionInfra_PullStreamErrorDetailSurfaces verifies that registry
+// errors which Docker reports as JSON `errorDetail` events inside the pull
+// stream — rather than as an ImagePull return value — are surfaced to the
+// caller. Without parsing the stream the user sees the useless message
+// "image not present after pull"; with parsing they see the actual cause
+// (manifest unknown, unauthorized, rate limit, …).
+func TestProvisionInfra_PullStreamErrorDetailSurfaces(t *testing.T) {
+	t.Parallel()
+
+	cli := &mockDockerPreviewClient{
+		imagesPresent: map[string]bool{},
+		// Simulate Docker's NDJSON pull stream emitting an error event.
+		imagePullBody: `{"status":"Pulling from library/postgres"}` + "\n" +
+			`{"errorDetail":{"message":"manifest for postgres:99-alpine not found: manifest unknown"},"error":"manifest unknown"}` + "\n",
+		inspectResp: container.InspectResponse{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				HostConfig: &container.HostConfig{NetworkMode: container.NetworkMode("143-sandbox")},
+			},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{"143-sandbox": {IPAddress: "172.18.0.5"}},
+			},
+		},
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	_, err := provider.provisionInfra(
+		context.Background(),
+		&agent.Sandbox{ID: "sandbox-1"},
+		"preview-handle",
+		"db",
+		models.InfrastructureConfig{Template: "postgres-17"},
+		preview.InfraTemplate{Image: "postgres:99-alpine", DefaultMemMB: 128, DefaultCPU: 0.25, DefaultPort: 5432},
+	)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, preview.ErrInfraImageUnavailable)
+	require.Contains(t, err.Error(), "manifest for postgres:99-alpine not found", "errorDetail message must reach the user, not be swallowed by io.Discard")
+}
+
+// TestEnsureImage_SingleflightDedupes verifies that two concurrent
+// ensureImage calls for the same ref share one underlying ImagePull call.
+// Without dedup, every preview start that lands on a missing image would
+// fan out a separate pull stream against the daemon — wasteful and prone
+// to thundering-herd at boot.
+func TestEnsureImage_SingleflightDedupes(t *testing.T) {
+	t.Parallel()
+
+	// pullGate blocks ImagePull until the test releases it, giving
+	// concurrent callers time to all enter the singleflight before any
+	// of them complete. Without this gate the first caller could finish
+	// before the second arrives, defeating the dedup test.
+	pullGate := make(chan struct{})
+	cli := &gatedPullClient{
+		mockDockerPreviewClient: &mockDockerPreviewClient{
+			imagesPresent:      map[string]bool{},
+			imagePullPopulates: true,
+		},
+		gate: pullGate,
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	const callers = 5
+	errCh := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		go func() {
+			errCh <- provider.ensureImage(context.Background(), "postgres:17-alpine")
+		}()
+	}
+	// Release the pull and collect results.
+	close(pullGate)
+	for i := 0; i < callers; i++ {
+		require.NoError(t, <-errCh)
+	}
+	require.Equal(t, 1, cli.imagePullCalls, "%d concurrent ensureImage callers should share a single underlying pull", callers)
+}
+
+// TestEnsureInfraImages_PullsAllSupported verifies the worker-boot
+// pre-pull pass invokes the registry once per supported template image,
+// so the first preview start is a fast inspect rather than a multi-minute
+// cold pull that would blow through the HTTP server's WriteTimeout.
+func TestEnsureInfraImages_PullsAllSupported(t *testing.T) {
+	t.Parallel()
+
+	cli := &mockDockerPreviewClient{
+		imagesPresent:      map[string]bool{},
+		imagePullPopulates: true,
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	provider.EnsureInfraImages(context.Background())
+
+	require.Equal(t, len(preview.AllInfraImages()), cli.imagePullCalls, "every supported infra image should be pre-pulled")
+
+	// Second call is a no-op: every image is already present, so we hit
+	// the fast inspect path.
+	cli.imagePullCalls = 0
+	provider.EnsureInfraImages(context.Background())
+	require.Zero(t, cli.imagePullCalls, "second pass must not re-pull images that are already present")
+}
+
+// TestEnsureInfraImages_LogsAndContinuesOnFailure verifies that pre-pull
+// is best-effort: a registry failure for one image does not propagate up
+// or stop the others (and definitely doesn't block server boot). The
+// lazy-pull path stays as a safety net for whatever didn't pre-pull.
+func TestEnsureInfraImages_LogsAndContinuesOnFailure(t *testing.T) {
+	t.Parallel()
+
+	cli := &mockDockerPreviewClient{
+		imagesPresent: map[string]bool{},
+		imagePullErr:  errors.New("registry unreachable"),
+	}
+	provider := NewDockerPreviewProvider(cli, &noopSandboxExecutor{}, zerolog.Nop())
+
+	// Should not panic, should not block, should not return.
+	provider.EnsureInfraImages(context.Background())
+
+	require.Equal(t, len(preview.AllInfraImages()), cli.imagePullCalls, "every image should still be attempted even when the first one fails")
 }
 
 func TestBuildInfraEnv_Redis(t *testing.T) {


### PR DESCRIPTION
## Summary

Preview starts were failing with the unhelpful "Failed to start preview: failed to start preview" when a session needed an infra container (e.g. `postgres:17-alpine`) that wasn't on the worker — Docker returned "No such image" but the cause never reached the frontend because every launch failure collapsed into one opaque `PREVIEW_START_FAILED`.

This PR pre-pulls every supported infra template image at worker boot in a background goroutine (so the first preview start fits inside the 15s server WriteTimeout), keeps an on-demand pull as a singleflight-deduped safety net, parses Docker's NDJSON pull stream so registry errors like "manifest unknown" / "unauthorized" reach the user, and classifies launch errors via sentinels into specific HTTP codes (`PREVIEW_INFRA_IMAGE_UNAVAILABLE`, `PREVIEW_INFRA_UNHEALTHY`, `PREVIEW_INIT_SCRIPT_FAILED`, `PREVIEW_SERVICE_NOT_READY`, …) with messages that name the failing image / service. The frontend passes these messages through verbatim.

## Test plan

- [ ] `make lint` clean (golangci-lint v2: 0 issues)
- [ ] Go tests pass for `./internal/services/preview/...`, `./internal/api/handlers/...`, `./cmd/server/...`
- [ ] Frontend `vitest` passes for `preview-panel.test.tsx` (44 tests including new parametrized cases)
- [ ] Manually verify on prod: stop a preview, manually `docker rmi postgres:17-alpine` on the worker, restart the API server, confirm the next preview start succeeds (pre-pull warmed it) and that pulling-on-demand still works for an out-of-band-deleted image
- [ ] Manually verify error UX: trigger a `PREVIEW_INFRA_IMAGE_UNAVAILABLE` (e.g. block worker egress) and confirm the frontend shows the registry error, not "Failed to start preview"

🤖 Generated with [Claude Code](https://claude.com/claude-code)