### PR TITLE
Fix mobile SessionsLayout to show list first and return to list on back

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders, screen } from "@/test/test-utils";
 import SessionsLayout from "./layout";
 
@@ -17,8 +17,10 @@ const sidebarLayoutMock = vi.fn(
   ),
 );
 
+let mockPathname = "/sessions";
+
 vi.mock("next/navigation", () => ({
-  usePathname: () => "/sessions",
+  usePathname: () => mockPathname,
 }));
 
 vi.mock("@/components/sidebar-layout", () => ({
@@ -34,7 +36,35 @@ vi.mock("./session-sidebar", () => ({
 }));
 
 describe("SessionsLayout", () => {
-  it("shows the content pane on mobile for the /sessions route", () => {
+  beforeEach(() => {
+    mockPathname = "/sessions";
+  });
+
+  it("shows the sidebar pane on mobile for the /sessions route", () => {
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("sidebar-layout")).toHaveAttribute("data-mobile-show", "sidebar");
+  });
+
+  it("shows the content pane on mobile for the /sessions/new route", () => {
+    mockPathname = "/sessions/new";
+
+    renderWithProviders(
+      <SessionsLayout>
+        <div>Child content</div>
+      </SessionsLayout>,
+    );
+
+    expect(screen.getByTestId("sidebar-layout")).toHaveAttribute("data-mobile-show", "content");
+  });
+
+  it("shows the content pane on mobile for session detail routes", () => {
+    mockPathname = "/sessions/session-123";
+
     renderWithProviders(
       <SessionsLayout>
         <div>Child content</div>

--- a/frontend/src/app/(dashboard)/sessions/layout.tsx
+++ b/frontend/src/app/(dashboard)/sessions/layout.tsx
@@ -3,11 +3,15 @@
 import { SidebarLayout } from "@/components/sidebar-layout";
 import { SessionSidebar } from "./session-sidebar";
 import { OptimisticSessionsProvider } from "@/contexts/optimistic-sessions";
+import { usePathname } from "next/navigation";
 
 export default function SessionsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const mobileShow = pathname === "/sessions" ? "sidebar" : "content";
+
   return (
     <OptimisticSessionsProvider>
-      <SidebarLayout sidebar={<SessionSidebar />} mobileShow="content">
+      <SidebarLayout sidebar={<SessionSidebar />} mobileShow={mobileShow}>
         {children}
       </SidebarLayout>
     </OptimisticSessionsProvider>


### PR DESCRIPTION
## Summary
Updated the `SessionsLayout` to determine the mobile sidebar/content pane based on the current route. This restores the expected mobile behavior: `/sessions` shows the sessions list first, and navigating back from a session detail returns you to the list view.

## Changes
- **frontend/src/app/(dashboard)/sessions/layout.tsx**
  - Added `usePathname()` to read the current path.
  - Set `mobileShow` to:
    - `"sidebar"` for `/sessions` (list-first view)
    - `"content"` for `/sessions/new` and session detail routes (composer/detail-first view)
  - Passed the computed `mobileShow` into `SidebarLayout`.
- **frontend/src/app/(dashboard)/sessions/layout.test.tsx**
  - Enhanced mocks to allow changing `usePathname()` per test case.
  - Added/updated assertions for:
    - Mobile sidebar shown on `/sessions`
    - Mobile content shown on `/sessions/new`
    - Mobile content shown on session detail routes

## Test plan
- Ran the unit tests for the sessions layout (`layout.test.tsx`) to verify the correct `data-mobile-show` attribute is rendered for `/sessions`, `/sessions/new`, and session detail routes.

---
*Generated by [143.dev](https://143.dev) — [session a07da004](https://app.143.dev/sessions/a07da004-1153-46e4-a9c9-b885459f9625)*
