### PR TITLE
Add external links to PR details hover-card checks when details_url is present

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1141,6 +1141,49 @@ describe('SessionDetailPage', () => {
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith('PR merged', expect.any(Object)));
   });
 
+  it('renders external links for CI checks shown from the PR details hover card', async () => {
+    server.use(
+      http.get('/api/v1/pull-requests/:id/health', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockPRHealth,
+            failing_test_count: 2,
+            can_fix_tests: true,
+            checks: [
+              {
+                name: 'unit tests',
+                category: 'test' as const,
+                status: 'failed' as const,
+                details_url: 'https://ci.example.com/unit-tests',
+              },
+              {
+                name: 'integration tests',
+                category: 'test' as const,
+                status: 'failed' as const,
+                details_url: 'https://ci.example.com/integration-tests',
+              },
+            ],
+          },
+        } satisfies SingleResponse<typeof mockPRHealth>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const user = userEvent.setup();
+    await user.hover(await screen.findByText('2/2 failed'));
+
+    const unitLink = await screen.findByRole('link', { name: /unit tests/i });
+    const integrationLink = screen.getByRole('link', { name: /integration tests/i });
+
+    expect(unitLink).toHaveAttribute('href', 'https://ci.example.com/unit-tests');
+    expect(unitLink).toHaveAttribute('target', '_blank');
+    expect(unitLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(integrationLink).toHaveAttribute('href', 'https://ci.example.com/integration-tests');
+    expect(integrationLink).toHaveAttribute('target', '_blank');
+    expect(integrationLink).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+  });
+
   it('shows merged PR state when a linked PR has already been merged', async () => {
     server.use(
       http.get('/api/v1/sessions/:id/pr', () => {

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -205,9 +205,9 @@ describe("PRHealthBanner", () => {
           ...baseHealth,
           failing_test_count: 1,
           checks: [
-            { name: "Unit tests", category: "test", status: "failed" },
-            { name: "E2E tests", category: "test", status: "pending" },
-            { name: "Lint", category: "lint", status: "passed" },
+            { name: "Unit tests", category: "test", status: "failed", details_url: "https://ci.example.com/unit-tests" },
+            { name: "E2E tests", category: "test", status: "pending", details_url: "https://ci.example.com/e2e-tests" },
+            { name: "Lint", category: "lint", status: "passed", details_url: "https://ci.example.com/lint" },
           ],
         }}
         pendingAction={null}
@@ -229,6 +229,40 @@ describe("PRHealthBanner", () => {
     expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
     expect(screen.getAllByText("pending").length).toBeGreaterThan(0);
     expect(screen.getAllByText("passed").length).toBeGreaterThan(0);
+  });
+
+  it("renders each hover-card check as an external link when details URLs are available", async () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          failing_test_count: 2,
+          checks: [
+            { name: "Unit tests", category: "test", status: "failed", details_url: "https://ci.example.com/unit-tests" },
+            { name: "E2E tests", category: "test", status: "failed", details_url: "https://ci.example.com/e2e-tests" },
+          ],
+        }}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+      />,
+    );
+
+    const user = userEvent.setup();
+    await user.hover(screen.getByText("2/2 failed"));
+
+    const unitLink = await screen.findByRole("link", { name: /Unit tests/i });
+    const e2eLink = screen.getByRole("link", { name: /E2E tests/i });
+
+    expect(unitLink).toHaveAttribute("href", "https://ci.example.com/unit-tests");
+    expect(unitLink).toHaveAttribute("target", "_blank");
+    expect(unitLink).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    expect(e2eLink).toHaveAttribute("href", "https://ci.example.com/e2e-tests");
+    expect(e2eLink).toHaveAttribute("target", "_blank");
+    expect(e2eLink).toHaveAttribute("rel", expect.stringContaining("noreferrer"));
   });
 
   it("shows failed-over-total summary and normalizes missing legacy statuses to pending", async () => {

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle2, GitMerge, GitPullRequest, Loader2, Wrench } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ExternalLink, GitMerge, GitPullRequest, Loader2, Wrench } from "lucide-react";
 
 import type { PullRequestHealthResponse } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -84,12 +84,30 @@ export function PRHealthBanner({
                         <div className="text-xs font-medium text-foreground">CI jobs</div>
                         <div className="space-y-1.5">
                           {orderedChecks.map((check) => (
-                            <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3">
-                              <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
-                              <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                {check.status}
-                              </Badge>
-                            </div>
+                            check.details_url ? (
+                              <a
+                                key={`${check.name}-${check.status}`}
+                                href={check.details_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex items-center justify-between gap-3 rounded-sm px-1 py-1 text-xs transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                              >
+                                <div className="flex min-w-0 items-center gap-1.5">
+                                  <span className="min-w-0 truncate text-foreground">{check.name}</span>
+                                  <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
+                                </div>
+                                <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                  {check.status}
+                                </Badge>
+                              </a>
+                            ) : (
+                              <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
+                                <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
+                                <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
+                                  {check.status}
+                                </Badge>
+                              </div>
+                            )
                           ))}
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
This change updates the PR health hover card to render each failed/pending CI check as an external link when a `details_url` is provided. Links open in a new tab with `noopener noreferrer` for safer navigation.

## Changes
- `frontend/src/components/pr-health-banner.tsx`
  - When rendering check rows in the PR details hover card, use `check.details_url` to render external links instead of static text (only when `details_url` exists).
  - Set `target="_blank"` and `rel="noopener noreferrer"` on these links.
- `frontend/src/components/pr-health-banner.test.tsx`
  - Extend test fixtures to include `details_url`.
  - Add coverage to assert each hover-card check becomes a link with correct `href`, `target`, and `rel`.
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Add an integration test that hovers the hover card and verifies the rendered check links match the mocked `details_url` values.

## Test plan
- `npx vitest run src/components/pr-health-banner.test.tsx src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

---
*Generated by [143.dev](https://143.dev) — [session 99febc00](https://app.143.dev/sessions/99febc00-496d-4ce2-8294-ab79b44c52f1)*
