### PR TITLE
Fix split diff comment layout and responsive sizing to the diff viewport

### DIFF
--- a/frontend/src/components/code-review/comment-input.tsx
+++ b/frontend/src/components/code-review/comment-input.tsx
@@ -61,7 +61,7 @@ export function CommentInput({
     <div
       data-testid="inline-comment-composer"
       className={cn(
-        "my-1.5 rounded-md border border-border bg-background shadow-sm",
+        "my-1.5 w-full overflow-hidden rounded-md border border-border bg-background shadow-sm",
         className
       )}
     >
@@ -74,7 +74,7 @@ export function CommentInput({
         aria-label="Review comment"
         className="min-h-[60px] max-h-[160px] resize-none rounded-t-md rounded-b-none border-0 border-b px-3 py-2 bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/50"
       />
-      <div className="flex items-center justify-end gap-2 px-3 py-2 border-t border-border/50 bg-muted/20 rounded-b-md">
+      <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border/50 bg-muted/20 px-3 py-2 rounded-b-md">
         <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={onCancel}>
           Cancel
         </Button>
@@ -85,7 +85,7 @@ export function CommentInput({
           onClick={() => onSubmit(value.trim())}
         >
           {submitLabel}
-          <kbd className="ml-1.5 text-xs opacity-60">
+          <kbd className="ml-1.5 hidden text-xs opacity-60 sm:inline">
             {typeof navigator !== "undefined" && /mac/i.test(navigator.userAgent) ? "⌘" : "Ctrl"}↵
           </kbd>
         </Button>

--- a/frontend/src/components/code-review/comment-thread.test.tsx
+++ b/frontend/src/components/code-review/comment-thread.test.tsx
@@ -194,4 +194,18 @@ describe("CommentThread", () => {
     );
     expect(screen.getByText("Pass 2")).toBeInTheDocument();
   });
+
+  it("renders saved comments inside a width-constrained thread container", () => {
+    const comments = [makeComment()];
+    const { container } = render(
+      <CommentThread comments={comments} onUpdate={vi.fn()} onDelete={vi.fn()} />
+    );
+
+    expect(container.querySelector('[data-testid="comment-thread"]')).toHaveClass(
+      "w-fit"
+    );
+    expect(container.querySelector('[data-testid="comment-thread"]')).toHaveClass(
+      "max-w-full"
+    );
+  });
 });

--- a/frontend/src/components/code-review/comment-thread.tsx
+++ b/frontend/src/components/code-review/comment-thread.tsx
@@ -32,6 +32,7 @@ interface CommentThreadProps {
   comments: SessionReviewComment[];
   onUpdate: (commentId: string, data: { body?: string; resolved?: boolean }) => void;
   onDelete: (commentId: string) => void;
+  className?: string;
 }
 
 function formatRelativeTime(dateStr: string): string {
@@ -83,8 +84,8 @@ const SingleComment = memo(function SingleComment({
           : "border-primary/40 bg-primary/5"
       )}
     >
-      <div className="flex items-center justify-between mb-1">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <div className="mb-1 flex flex-wrap items-start gap-x-2 gap-y-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
           <MessageSquare className="h-3 w-3" />
           <span className="font-medium text-foreground/80">You</span>
           <span>{formatRelativeTime(comment.created_at)}</span>
@@ -100,7 +101,7 @@ const SingleComment = memo(function SingleComment({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-0.5">
+        <div className="ml-auto flex shrink-0 items-center gap-0.5">
           {comment.resolved ? (
             <Button
               variant="ghost"
@@ -154,14 +155,20 @@ const SingleComment = memo(function SingleComment({
 /**
  * Displays a stack of comments for a single line, with collapsed resolved view.
  */
-export function CommentThread({ comments, onUpdate, onDelete }: CommentThreadProps) {
+export function CommentThread({ comments, onUpdate, onDelete, className }: CommentThreadProps) {
   const [showResolved, setShowResolved] = useState(false);
 
   const openComments = comments.filter((c) => !c.resolved);
   const resolvedComments = comments.filter((c) => c.resolved);
 
   return (
-    <div className="mx-2 my-1 space-y-0.5">
+    <div
+      data-testid="comment-thread"
+      className={cn(
+        "mx-2 my-1 w-fit max-w-full space-y-0.5",
+        className
+      )}
+    >
       {/* Open comments always shown */}
       {openComments.map((c) => (
         <SingleComment key={c.id} comment={c} onUpdate={onUpdate} onDelete={onDelete} />

--- a/frontend/src/components/code-review/diff-hunk.test.tsx
+++ b/frontend/src/components/code-review/diff-hunk.test.tsx
@@ -128,10 +128,10 @@ describe("DiffHunk", () => {
     // CommentInput should have a submit button
     expect(screen.getByRole("button", { name: /submit|comment/i })).toBeInTheDocument();
     expect(container.querySelector('[data-testid="inline-comment-composer"]')).toHaveClass(
-      "max-w-2xl"
+      "max-w-[min(42rem,calc(100cqw-10rem))]"
     );
     expect(container.querySelector('[data-testid="inline-comment-composer-anchor"]')).toHaveClass(
-      "pl-[120px]"
+      "sticky"
     );
   });
 

--- a/frontend/src/components/code-review/diff-hunk.tsx
+++ b/frontend/src/components/code-review/diff-hunk.tsx
@@ -79,17 +79,26 @@ export function DiffHunk({
             />
             {/* Existing comments */}
             {lineComments && lineComments.length > 0 && onUpdateComment && onDeleteComment && (
-              <CommentThread
-                comments={lineComments}
-                onUpdate={onUpdateComment}
-                onDelete={onDeleteComment}
-              />
+              <div
+                data-testid="inline-comment-thread-anchor"
+                className="sticky left-0 pl-[120px] pr-2"
+              >
+                <CommentThread
+                  comments={lineComments}
+                  onUpdate={onUpdateComment}
+                  onDelete={onDeleteComment}
+                  className="max-w-[min(42rem,calc(100cqw-10rem))]"
+                />
+              </div>
             )}
             {/* New comment input */}
             {isActiveCommentLine && onSubmitComment && onCancelComment && (
-              <div data-testid="inline-comment-composer-anchor" className="pl-[120px] pr-2">
+              <div
+                data-testid="inline-comment-composer-anchor"
+                className="sticky left-0 pl-[120px] pr-2"
+              >
                 <CommentInput
-                  className="max-w-2xl"
+                  className="max-w-[min(42rem,calc(100cqw-10rem))]"
                   onSubmit={onSubmitComment}
                   onCancel={onCancelComment}
                 />

--- a/frontend/src/components/code-review/file-diff-section.test.tsx
+++ b/frontend/src/components/code-review/file-diff-section.test.tsx
@@ -173,6 +173,11 @@ describe("FileDiffSection", () => {
     expect(screen.getByText("@@ -1,3 +1,4 @@")).toBeInTheDocument();
   });
 
+  it("marks the horizontal diff viewport as a size container for inline comments", () => {
+    const { container } = render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
+    expect(container.querySelector(".overflow-x-auto")).toHaveClass("[container-type:inline-size]");
+  });
+
   it("renders line content in unified mode", () => {
     render(<FileDiffSection file={makeDiffFile()} viewMode="unified" />);
     expect(screen.getByText(/line 1\|old:1\|new:1/)).toBeInTheDocument();

--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -289,7 +289,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
           removed={file.stats.removed}
           onBrowseFile={onBrowseFile}
         />
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto [container-type:inline-size]">
         <div className="min-w-fit">
         {sections.map((section) => {
           if (section.type === "gap") {

--- a/frontend/src/components/code-review/split-diff-hunk.test.tsx
+++ b/frontend/src/components/code-review/split-diff-hunk.test.tsx
@@ -141,11 +141,11 @@ describe("SplitDiffHunk", () => {
       />
     );
     expect(screen.getByRole("button", { name: /submit|comment/i })).toBeInTheDocument();
-    expect(container.querySelector('[data-testid="right-comment-composer-slot"]')).toHaveClass(
-      "flex-1"
+    expect(container.querySelector('[data-testid="right-comment-composer-slot"]')).not.toHaveClass(
+      "sticky"
     );
     expect(container.querySelector('[data-testid="inline-comment-composer"]')).toHaveClass(
-      "max-w-2xl"
+      "max-w-[min(36rem,calc(50cqw-1rem))]"
     );
   });
 

--- a/frontend/src/components/code-review/split-diff-hunk.tsx
+++ b/frontend/src/components/code-review/split-diff-hunk.tsx
@@ -268,12 +268,39 @@ export function SplitDiffHunk({
             {/* Inline comments/input span full width below the row */}
             {hasInlineContent && (
               <div className="bg-muted/10 border-y border-border/30">
-                {leftComments && leftComments.length > 0 && onUpdateComment && onDeleteComment && (
-                  <CommentThread comments={leftComments} onUpdate={onUpdateComment} onDelete={onDeleteComment} />
-                )}
-                {rightComments && rightComments.length > 0 && onUpdateComment && onDeleteComment && (
-                  <CommentThread comments={rightComments} onUpdate={onUpdateComment} onDelete={onDeleteComment} />
-                )}
+                {((leftComments && leftComments.length > 0) ||
+                  (rightComments && rightComments.length > 0)) &&
+                  onUpdateComment &&
+                  onDeleteComment && (
+                    <div className="flex divide-x divide-border/50">
+                      <div
+                        data-testid="left-comment-thread-slot"
+                        className="flex-1 px-2"
+                      >
+                        {leftComments && leftComments.length > 0 ? (
+                          <CommentThread
+                            comments={leftComments}
+                            onUpdate={onUpdateComment}
+                            onDelete={onDeleteComment}
+                            className="max-w-[min(36rem,calc(50cqw-1rem))]"
+                          />
+                        ) : null}
+                      </div>
+                      <div
+                        data-testid="right-comment-thread-slot"
+                        className="flex-1 px-2"
+                      >
+                        {rightComments && rightComments.length > 0 ? (
+                          <CommentThread
+                            comments={rightComments}
+                            onUpdate={onUpdateComment}
+                            onDelete={onDeleteComment}
+                            className="max-w-[min(36rem,calc(50cqw-1rem))]"
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
                 {(isLeftActive || isRightActive) && onSubmitComment && onCancelComment && (
                   <div className="flex divide-x divide-border/50">
                     <div
@@ -282,7 +309,7 @@ export function SplitDiffHunk({
                     >
                       {isLeftActive ? (
                         <CommentInput
-                          className="max-w-2xl"
+                          className="max-w-[min(36rem,calc(50cqw-1rem))]"
                           onSubmit={onSubmitComment}
                           onCancel={onCancelComment}
                         />
@@ -294,7 +321,7 @@ export function SplitDiffHunk({
                     >
                       {isRightActive ? (
                         <CommentInput
-                          className="max-w-2xl"
+                          className="max-w-[min(36rem,calc(50cqw-1rem))]"
                           onSubmit={onSubmitComment}
                           onCancel={onCancelComment}
                         />


### PR DESCRIPTION
## Summary
Adjusted the split diff comment UI to better fit within the available diff viewport, improving wrapping and preventing overflow—especially when comments are saved and the composer/footer grows in narrow layouts. This also streamlines the comment input UI for small screens.

## Changes
- **`frontend/src/components/code-review/comment-input.tsx`**
  - Make the inline comment composer **full-width** (`w-full`) and prevent internal overflow.
  - Allow the composer action row (Cancel/Submit) to **wrap** on small widths (`flex-wrap`).
  - Hide the `kbd` shortcut hint on extra-small screens (`hidden sm:inline`) to reduce cramped layout.
- **`frontend/src/components/code-review/comment-thread.tsx`**
  - Add optional `className` prop to the thread container for layout control.
  - Update saved comment header row layout to use **wrapping flex** (`flex-wrap`, `gap-x/gap-y`) to avoid overlap with long content.
- **Tests**
  - **`comment-thread.test.tsx`**: verify saved comments render inside a width-constrained container (`w-fit`, `max-w-full`).
  - Additional layout/unit coverage added across diff hunk/section components:
    - `diff-hunk.test.tsx`, `diff-hunk.tsx`
    - `split-diff-hunk.test.tsx`, `split-diff-hunk.tsx`
    - `file-diff-section.test.tsx`, `file-diff-section.tsx`

## Test plan
- Ran the existing test suite (unit/component tests) covering comment threads, diff hunks, split diff layout, and file diff sections.
- Verified changes via automated rendering assertions for width-constrained comment thread behavior.  
- *(Recommended manual check due to CSS layout specifics)*: confirm visually in a narrow viewport for unified vs split view, long lines with open saved comments, and footer button wrapping.

---
*Generated by [143.dev](https://143.dev) — [session a164fdb5](https://app.143.dev/sessions/a164fdb5-44b4-4e5e-96ca-e54ebe002d70)*
