### PR TITLE
Raise preview worker RPC timeout to 10m and fix reaper FROM-alias bug

### DIFF
--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1766,13 +1766,16 @@ func (s *SessionStore) UpdateWorkingBranch(ctx context.Context, orgID, sessionID
 // failed with an explanatory error.
 // lint:allow-no-orgid reason="cross-org reaper scan for stuck pending sessions"
 func (s *SessionStore) ListStalePendingSessions(ctx context.Context, createdBefore time.Time) ([]models.Session, error) {
+	// No alias on `sessions`: sessionPrimaryIssueIDColumn references
+	// sessions.org_id / sessions.id literally, and a table alias would shadow
+	// the original name (Postgres 42P01).
 	query := `
 		SELECT ` + sessionListColumns + `
-		FROM sessions s
-		WHERE s.status = 'pending'
-		  AND s.deleted_at IS NULL
-		  AND s.created_at < @created_before
-		ORDER BY s.created_at ASC
+		FROM sessions
+		WHERE status = 'pending'
+		  AND deleted_at IS NULL
+		  AND created_at < @created_before
+		ORDER BY created_at ASC
 		LIMIT 100`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
@@ -1805,14 +1808,17 @@ func (s *SessionStore) ListStalePendingSessions(ctx context.Context, createdBefo
 // corrupted write path and needs investigation rather than reaping.
 // lint:allow-no-orgid reason="cross-org reaper scan for stuck running sessions"
 func (s *SessionStore) ListStaleRunningSessions(ctx context.Context, startedBefore time.Time) ([]models.Session, error) {
+	// No alias on `sessions`: sessionPrimaryIssueIDColumn references
+	// sessions.org_id / sessions.id literally, and a table alias would shadow
+	// the original name (Postgres 42P01).
 	query := `
 		SELECT ` + sessionListColumns + `
-		FROM sessions s
-		WHERE s.status = 'running'
-		  AND s.deleted_at IS NULL
-		  AND s.started_at IS NOT NULL
-		  AND s.started_at < @started_before
-		ORDER BY s.started_at ASC
+		FROM sessions
+		WHERE status = 'running'
+		  AND deleted_at IS NULL
+		  AND started_at IS NOT NULL
+		  AND started_at < @started_before
+		ORDER BY started_at ASC
 		LIMIT 100`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1290,7 +1290,10 @@ func TestSessionStore_ListStaleRunningSessions(t *testing.T) {
 
 	store := NewSessionStore(mock)
 
-	mock.ExpectQuery("SELECT .+ FROM sessions.+WHERE s.status = 'running'").
+	// The query must NOT alias `sessions` — sessionPrimaryIssueIDColumn
+	// hardcodes `sessions.org_id` / `sessions.id`, which Postgres rejects
+	// (42P01) when the outer FROM uses an alias.
+	mock.ExpectQuery("FROM sessions\\s+WHERE status = 'running'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(sessionTestColumns))
 
@@ -1309,13 +1312,34 @@ func TestSessionStore_ListStaleRunningSessions_QueryError(t *testing.T) {
 
 	store := NewSessionStore(mock)
 
-	mock.ExpectQuery("SELECT .+ FROM sessions.+WHERE s.status = 'running'").
+	mock.ExpectQuery("FROM sessions\\s+WHERE status = 'running'").
 		WithArgs(pgxmock.AnyArg()).
 		WillReturnError(errors.New("db down"))
 
 	_, err = store.ListStaleRunningSessions(context.Background(), time.Now().Add(-1*time.Hour))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "query stale running sessions")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSessionStore_ListStalePendingSessions(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+
+	// See TestSessionStore_ListStaleRunningSessions: the query must not
+	// alias `sessions`.
+	mock.ExpectQuery("FROM sessions\\s+WHERE status = 'pending'").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+
+	sessions, err := store.ListStalePendingSessions(context.Background(), time.Now().Add(-1*time.Hour))
+	require.NoError(t, err)
+	require.Len(t, sessions, 0)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/db/tenancy_test.go
+++ b/internal/db/tenancy_test.go
@@ -62,8 +62,8 @@ func TestMultiTenancyAudit(t *testing.T) {
 		{"sessions", "where token"},
 		{"sessions", "where user_id"},
 		{"sessions", "where status = 'idle'"},                  // ListStaleIdleSessions: system-wide cleanup across all orgs
-		{"sessions", "where s.status = 'pending'"},             // ListStalePendingSessions: system-wide cleanup across all orgs
-		{"sessions", "where s.status = 'running'"},             // ListStaleRunningSessions: system-wide cleanup across all orgs
+		{"sessions", "where status = 'pending'"},               // ListStalePendingSessions: system-wide cleanup across all orgs
+		{"sessions", "where status = 'running'"},               // ListStaleRunningSessions: system-wide cleanup across all orgs
 		{"sessions", "where sandbox_state"},                    // ListExpiredSnapshots: system-wide snapshot cleanup across all orgs
 		{"sessions", "where pending_snapshot_key is not null"}, // ReapStrandedPendingSnapshots: system-wide cross-org sweep run by leader-elected scheduler; per-org fanout adds no security and would require listing every org each tick
 		{"sessions", "diff_history"},                           // UpdateResult/UpdateTurnComplete: org_id is in a concatenated string fragment

--- a/internal/services/preview/worker_client.go
+++ b/internal/services/preview/worker_client.go
@@ -19,6 +19,12 @@ import (
 
 const previewWorkerTokenTTL = 30 * time.Second
 
+// previewWorkerHTTPTimeout caps app->worker preview RPCs. It must exceed the
+// worst-case launch budget (image pulls + infra startup + service readiness
+// probes, each defaulting to 90s) or the API gives up before the worker
+// finishes, surfacing as "context canceled" on a readiness probe.
+const previewWorkerHTTPTimeout = 10 * time.Minute
+
 // WorkerRequestError preserves structured worker error responses.
 type WorkerRequestError struct {
 	StatusCode int
@@ -87,7 +93,7 @@ func NewWorkerPreviewClient(secret string) *WorkerPreviewClient {
 	return &WorkerPreviewClient{
 		secret: secret,
 		httpClient: &http.Client{
-			Timeout: 90 * time.Second,
+			Timeout: previewWorkerHTTPTimeout,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- **Preview start failures.** `WorkerPreviewClient`'s 90s `http.Client.Timeout` was shorter than the worker's worst-case launch budget (image pulls + infra startup + per-service readiness probes that each default to 90s). Slow launches surfaced as "Failed to start preview" while the worker was still inside `waitForReadiness`. Bumped to 10m via a named constant with comment.
- **Reaper SQL 42P01.** `ListStalePendingSessions` / `ListStaleRunningSessions` used `FROM sessions s`, which shadowed the `sessions.org_id` / `sessions.id` references embedded in `sessionPrimaryIssueIDColumn`. Dropped the alias on both queries and added a comment so it is not reintroduced.
- Updated the tenancy-audit exemption patterns and the pgxmock matcher to the corrected SQL, and added the missing `TestSessionStore_ListStalePendingSessions` unit test.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./internal/db/ -short`
- [x] `go test ./internal/services/preview/...`
- [ ] After merge: confirm `make logs-query Q='"preview launch failed"'` no longer shows context-canceled readiness failures, and `make logs-query Q='"reaper: failed to list stale"'` is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
