### PR TITLE
Stop saving corrupt sandbox snapshots after agent crashes

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1427,7 +1427,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	}
 
 	// 11b. Snapshot workspace for multi-turn support (does not change session status).
-	snapshotKey, snapshotSize, snapshotErr := o.snapshotSession(ctx, run, sandbox, result)
+	snapshotKey, snapshotSize, snapshotErr := o.snapshotSessionOnTurnSuccess(ctx, run, sandbox, result, log)
 	if snapshotErr != nil {
 		log.Warn().Err(snapshotErr).Msg("failed to snapshot session, session will not support follow-up turns")
 	} else if snapshotKey != "" {
@@ -2218,7 +2218,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}
 
 	// 8. Snapshot again.
-	newSnapshotKey, snapshotSize, snapshotErr := o.snapshotSession(ctx, session, sandbox, result)
+	newSnapshotKey, snapshotSize, snapshotErr := o.snapshotSessionOnTurnSuccess(ctx, session, sandbox, result, log)
 	if snapshotErr != nil {
 		log.Warn().Err(snapshotErr).Msg("failed to snapshot session after continue")
 	} else if newSnapshotKey != "" {
@@ -2999,10 +2999,39 @@ func (o *Orchestrator) handleCancelledSession(ctx context.Context, session *mode
 	}
 }
 
+// snapshotSessionOnTurnSuccess wraps snapshotSession with the guard the
+// "normal completion" paths (RunAgent / ContinueSession success branches)
+// need: skip the snapshot when result.ExitCode != 0. That's the signal that
+// the agent CLI — and likely the sandbox runtime under it — crashed mid-turn,
+// leaving the workspace incoherent.
+//
+// The cancel and policy-stop paths intentionally do NOT use this wrapper:
+// their non-zero exits just mean the agent caught the signal and shut down
+// cleanly, so the workspace state is still valid. Calling this only on the
+// success path keeps both invariants:
+//   - graceful stops still produce a resumable checkpoint
+//   - a sandbox crash never overwrites a known-good prior snapshot with a
+//     truncated archive (incident: a 298-byte garbage upload bricked an
+//     active session for the rest of its lifetime)
+func (o *Orchestrator) snapshotSessionOnTurnSuccess(ctx context.Context, session *models.Session, sandbox *Sandbox, result *AgentResult, log zerolog.Logger) (string, int64, error) {
+	if result != nil && result.ExitCode != 0 {
+		log.Warn().
+			Int("exit_code", result.ExitCode).
+			Str("agent_error", truncateForLog(result.Error, 256)).
+			Msg("agent exited non-zero on the success path; skipping snapshot to preserve any prior good checkpoint")
+		return "", 0, nil
+	}
+	return o.snapshotSession(ctx, session, sandbox, result)
+}
+
 // snapshotSession snapshots the sandbox workspace to object storage for multi-turn support.
 // If snapshots are not configured, this is a no-op. This only saves the snapshot
 // and updates sandbox state — it does NOT change session status or call UpdateTurnComplete.
 // result is unused but kept in the signature for future extensibility (e.g. metadata).
+//
+// Most callers should use snapshotSessionOnTurnSuccess; only the cancel and
+// policy-stop paths legitimately bypass the exit-code guard because they
+// know the non-zero exit was a graceful shutdown.
 func (o *Orchestrator) snapshotSession(ctx context.Context, session *models.Session, sandbox *Sandbox, result *AgentResult) (string, int64, error) {
 	if o.snapshots == nil {
 		return "", 0, nil
@@ -3037,6 +3066,22 @@ func (r *countingReadCloser) Read(p []byte) (int, error) {
 	n, err := r.ReadCloser.Read(p)
 	r.n += int64(n)
 	return n, err
+}
+
+// truncateForLog clips s to at most max bytes (rune-safe), appending "…"
+// when truncation occurs. Used when an unbounded user/CLI string is included
+// in a structured log field.
+func truncateForLog(s string, max int) string {
+	if max <= 0 || len(s) <= max {
+		return s
+	}
+	// Trim back to the previous rune boundary so we don't split a UTF-8
+	// codepoint when the cutoff lands mid-encoding.
+	cut := max
+	for cut > 0 && (s[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return s[:cut] + "…"
 }
 
 func (o *Orchestrator) handlePolicyStoppedSession(ctx context.Context, session *models.Session, sandbox *Sandbox, result *AgentResult, turnNumber int, reason StopReason, log zerolog.Logger) {

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -1,12 +1,16 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"sync/atomic"
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -420,4 +424,223 @@ func TestResolvePromptSeed_EarlyReturnAndErrors(t *testing.T) {
 		require.Error(t, err, "resolvePromptSeed should return primary issue fetch errors")
 		require.Contains(t, err.Error(), "fetch primary issue", "resolvePromptSeed should wrap primary issue fetch errors")
 	})
+}
+
+// snapshotSessionStubProvider is a no-op SandboxProvider whose only relevant
+// behavior is Snapshot — every other call panics so an unexpected provider
+// interaction shows up loudly in tests instead of returning silent zero values.
+type snapshotSessionStubProvider struct {
+	snapshotFn   func(ctx context.Context, sb *Sandbox) (io.ReadCloser, error)
+	snapshotCals int32
+}
+
+func (s *snapshotSessionStubProvider) Snapshot(ctx context.Context, sb *Sandbox) (io.ReadCloser, error) {
+	atomic.AddInt32(&s.snapshotCals, 1)
+	if s.snapshotFn != nil {
+		return s.snapshotFn(ctx, sb)
+	}
+	return io.NopCloser(bytes.NewReader(nil)), nil
+}
+func (s *snapshotSessionStubProvider) calls() int { return int(atomic.LoadInt32(&s.snapshotCals)) }
+
+func (s *snapshotSessionStubProvider) Name() string { return "stub" }
+func (s *snapshotSessionStubProvider) Create(context.Context, SandboxConfig) (*Sandbox, error) {
+	panic("snapshotSessionStubProvider.Create called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) CloneRepo(context.Context, *Sandbox, string, string, string) error {
+	panic("snapshotSessionStubProvider.CloneRepo called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) Exec(context.Context, *Sandbox, string, io.Writer, io.Writer) (int, error) {
+	panic("snapshotSessionStubProvider.Exec called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) ReadFile(context.Context, *Sandbox, string) ([]byte, error) {
+	panic("snapshotSessionStubProvider.ReadFile called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) WriteFile(context.Context, *Sandbox, string, []byte) error {
+	panic("snapshotSessionStubProvider.WriteFile called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) Destroy(context.Context, *Sandbox) error { return nil }
+func (s *snapshotSessionStubProvider) IsAlive(context.Context, *Sandbox) (bool, error) {
+	panic("snapshotSessionStubProvider.IsAlive called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) ConnectionInfo(context.Context, *Sandbox) (*SandboxConnectionInfo, error) {
+	panic("snapshotSessionStubProvider.ConnectionInfo called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) Restore(context.Context, *Sandbox, io.Reader) error {
+	panic("snapshotSessionStubProvider.Restore called unexpectedly")
+}
+func (s *snapshotSessionStubProvider) ExecStream(context.Context, *Sandbox, string, func([]byte), io.Writer) (int, error) {
+	panic("snapshotSessionStubProvider.ExecStream called unexpectedly")
+}
+
+// snapshotSessionRecordingStore is a SnapshotStore that records every
+// Save call so tests can assert that we did NOT save a corrupt archive.
+type snapshotSessionRecordingStore struct {
+	saves []string
+}
+
+func (s *snapshotSessionRecordingStore) Save(ctx context.Context, key string, reader io.Reader) error {
+	if _, err := io.Copy(io.Discard, reader); err != nil {
+		return err
+	}
+	s.saves = append(s.saves, key)
+	return nil
+}
+func (s *snapshotSessionRecordingStore) Load(context.Context, string, io.Writer) error {
+	return errors.New("not implemented")
+}
+func (s *snapshotSessionRecordingStore) Delete(context.Context, string) error { return nil }
+
+func TestSnapshotSessionOnTurnSuccess_SkipsWhenAgentExitedNonZero(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{}
+	store := &snapshotSessionRecordingStore{}
+	o := &Orchestrator{
+		provider:  provider,
+		snapshots: store,
+		logger:    zerolog.Nop(),
+	}
+
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	sandbox := &Sandbox{ID: "sandbox-1"}
+	result := &AgentResult{
+		ExitCode: 128,
+		Error:    `codex CLI exited with code 128: urpc method "containerManager.WaitPID" failed: EOF`,
+	}
+
+	key, size, err := o.snapshotSessionOnTurnSuccess(context.Background(), session, sandbox, result, zerolog.Nop())
+	require.NoError(t, err, "skipping should not surface as an error — callers log err and continue")
+	require.Empty(t, key, "no snapshot key should be returned when we skipped")
+	require.Zero(t, size)
+	require.Nil(t, session.SnapshotKey, "the prior snapshot pointer must not be touched")
+	require.Equal(t, 0, provider.calls(), "provider.Snapshot must not be called for a non-zero-exit run on the success path — that's exactly how the corrupt 298-byte archive was produced")
+	require.Empty(t, store.saves, "no Save call should reach storage")
+}
+
+func TestSnapshotSessionOnTurnSuccess_SnapshotsWhenAgentExitedClean(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{
+		snapshotFn: func(ctx context.Context, sb *Sandbox) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("archive-bytes"))), nil
+		},
+	}
+	store := &snapshotSessionRecordingStore{}
+	o := &Orchestrator{
+		provider:  provider,
+		snapshots: store,
+		logger:    zerolog.Nop(),
+	}
+
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	sandbox := &Sandbox{ID: "sandbox-1"}
+	result := &AgentResult{ExitCode: 0}
+
+	key, size, err := o.snapshotSessionOnTurnSuccess(context.Background(), session, sandbox, result, zerolog.Nop())
+	require.NoError(t, err)
+	require.Equal(t, 1, provider.calls())
+	require.Equal(t, []string{key}, store.saves)
+	require.NotNil(t, session.SnapshotKey)
+	require.Equal(t, key, *session.SnapshotKey)
+	require.Equal(t, int64(len("archive-bytes")), size)
+}
+
+func TestSnapshotSessionOnTurnSuccess_PassesNilResultThrough(t *testing.T) {
+	// nil result has no exit code to check; the wrapper must not block — the
+	// underlying snapshotSession is responsible for the rest.
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{
+		snapshotFn: func(ctx context.Context, sb *Sandbox) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("nil-result-archive"))), nil
+		},
+	}
+	store := &snapshotSessionRecordingStore{}
+	o := &Orchestrator{
+		provider:  provider,
+		snapshots: store,
+		logger:    zerolog.Nop(),
+	}
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+
+	key, _, err := o.snapshotSessionOnTurnSuccess(context.Background(), session, &Sandbox{ID: "sandbox-1"}, nil, zerolog.Nop())
+	require.NoError(t, err)
+	require.NotEmpty(t, key)
+	require.Equal(t, 1, provider.calls())
+}
+
+// TestSnapshotSession_AlwaysSnapshotsRegardlessOfExitCode pins the contract
+// that the cancel/policy paths rely on: snapshotSession itself is unconditional
+// once snapshots is configured. The exit-code guard lives only in the
+// snapshotSessionOnTurnSuccess wrapper so graceful stops (where the agent
+// exits non-zero on purpose because it caught a signal) still checkpoint.
+func TestSnapshotSession_AlwaysSnapshotsRegardlessOfExitCode(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{
+		snapshotFn: func(context.Context, *Sandbox) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("graceful-stop-archive"))), nil
+		},
+	}
+	store := &snapshotSessionRecordingStore{}
+	o := &Orchestrator{provider: provider, snapshots: store, logger: zerolog.Nop()}
+
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	gracefulResult := &AgentResult{ExitCode: 1, Summary: "Interrupted cleanly"}
+
+	key, _, err := o.snapshotSession(context.Background(), session, &Sandbox{ID: "sandbox-1"}, gracefulResult)
+	require.NoError(t, err)
+	require.NotEmpty(t, key, "policy/cancel paths must still get a checkpoint despite the non-zero exit")
+	require.Equal(t, 1, provider.calls())
+	require.Equal(t, []string{key}, store.saves)
+}
+
+func TestSnapshotSession_NilStoreIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{}
+	o := &Orchestrator{provider: provider, snapshots: nil, logger: zerolog.Nop()}
+
+	key, size, err := o.snapshotSession(context.Background(), &models.Session{ID: uuid.New(), OrgID: uuid.New()}, &Sandbox{ID: "sandbox-1"}, &AgentResult{ExitCode: 0})
+	require.NoError(t, err)
+	require.Empty(t, key)
+	require.Zero(t, size)
+	require.Equal(t, 0, provider.calls(), "no provider call should happen when snapshots store is unset")
+}
+
+func TestSnapshotSession_PropagatesProviderErrorWithoutUpdatingSession(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{
+		snapshotFn: func(context.Context, *Sandbox) (io.ReadCloser, error) {
+			return nil, errors.New("provider boom")
+		},
+	}
+	store := &snapshotSessionRecordingStore{}
+	o := &Orchestrator{provider: provider, snapshots: store, logger: zerolog.Nop()}
+
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	priorKey := "snapshots/prior/key"
+	session.SnapshotKey = &priorKey
+
+	_, _, err := o.snapshotSession(context.Background(), session, &Sandbox{ID: "sandbox-1"}, &AgentResult{ExitCode: 0})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "snapshot sandbox")
+	require.Equal(t, &priorKey, session.SnapshotKey, "the prior snapshot pointer must remain intact when Snapshot fails")
+	require.Empty(t, store.saves, "Save must not be called when Snapshot failed")
+}
+
+func TestTruncateForLog(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "hello", truncateForLog("hello", 10), "no truncation when under cap")
+	require.Equal(t, "hello", truncateForLog("hello", 5), "no truncation when exactly at cap")
+	require.Equal(t, "hell…", truncateForLog("hello there", 4), "should truncate and append ellipsis")
+	// UTF-8 boundary: "héllo" is 6 bytes (h é l l o, where é is 2 bytes).
+	// Cutting at byte 2 lands on the second byte of é; we should back up to
+	// byte 1 so we don't emit invalid UTF-8.
+	out := truncateForLog("héllo", 2)
+	require.Equal(t, "h…", out, "should rewind to a rune boundary before appending the ellipsis")
+	require.Equal(t, "x", truncateForLog("x", 0), "non-positive max disables truncation")
 }

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -629,8 +629,25 @@ func (d *DockerProvider) ConnectionInfo(ctx context.Context, sb *agent.Sandbox) 
 	}, nil
 }
 
+// tarStderrCap bounds how much stderr we keep from snapshot/restore tar
+// processes for diagnostic messages. Tar's error output is short by design;
+// 4 KiB leaves room for several wrapped messages without unbounded memory
+// growth on a tar that goes haywire (e.g. runaway warnings on a huge tree).
+const tarStderrCap = 4 * 1024
+
+// execPollInterval is how often we poll Docker to discover that an exec
+// process has finished. 50 ms keeps responsiveness without burning CPU on
+// idle sessions; matches the cadence Restore used historically.
+const execPollInterval = 50 * time.Millisecond
+
 // Snapshot tars the workspace and agent state directories from the container.
 // The returned reader streams a compressed tar archive; the caller must close it.
+//
+// Tar's exit status is checked after the stream completes — a non-zero exit
+// surfaces as an error from Read or Close on the returned ReadCloser. This
+// matters: an earlier version silently uploaded partial archives whenever tar
+// failed (e.g. when the gVisor runtime crashed mid-turn), which left sessions
+// permanently un-restorable. We now refuse to claim success on a broken tar.
 func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
 	d.logger.Info().
 		Str("container_id", sb.ID).
@@ -639,10 +656,14 @@ func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.Re
 	// Tar workspace + agent state dirs. --ignore-failed-read handles missing dirs gracefully.
 	// Agent state dirs (.claude/, .codex/, .gemini/) live under HomeDir, not WorkDir —
 	// HOME is set to the sandbox user's home so CLI configs resolve there.
+	//
+	// Stderr is intentionally NOT redirected to /dev/null inside the shell so
+	// diagnostic messages from a failing tar reach our caller via the docker
+	// multiplex stream. --ignore-failed-read keeps benign warnings silent.
 	workDirRel := strings.TrimPrefix(sb.WorkDir, "/")
 	homeDirRel := strings.TrimPrefix(sb.HomeDir, "/")
 	cmd := fmt.Sprintf(
-		"tar czf - --ignore-failed-read -C / '%s' '%s/.claude' '%s/.codex' '%s/.gemini' 2>/dev/null",
+		"tar czf - --ignore-failed-read -C / '%s' '%s/.claude' '%s/.codex' '%s/.gemini'",
 		workDirRel, homeDirRel, homeDirRel, homeDirRel,
 	)
 
@@ -662,19 +683,34 @@ func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.Re
 		return nil, fmt.Errorf("attach snapshot exec: %w", err)
 	}
 
-	// Docker multiplexes stdout/stderr. We pipe into a buffer via StdCopy
-	// and return a reader over the stdout portion.
+	// Docker multiplexes stdout/stderr over a single connection. StdCopy
+	// demuxes: tar's stdout (the archive) flows through the pipe to the
+	// caller; stderr is captured into a bounded buffer so a non-zero exit
+	// surfaces an actionable error rather than a bare "code 2".
 	pr, pw := io.Pipe()
 	go func() {
 		defer attachResp.Close()
-		_, err := stdcopy.StdCopy(pw, io.Discard, attachResp.Reader)
-		pw.CloseWithError(err)
+
+		stderrBuf := newCappedBuffer(tarStderrCap)
+		_, copyErr := stdcopy.StdCopy(pw, stderrBuf, attachResp.Reader)
+
+		// StdCopy returning means the connection drained, not that tar
+		// exited. Without this wait we'd accept a half-written gzip stream
+		// as a successful snapshot the moment the connection closed.
+		inspect, waitErr := waitForExecExit(ctx, d.client, execResp.ID)
+
+		pw.CloseWithError(snapshotExecError(copyErr, waitErr, inspect, stderrBuf))
 	}()
 
 	return pr, nil
 }
 
 // Restore extracts a snapshot tarball into the sandbox container.
+//
+// Tar's stderr is captured (bounded) and included in the error returned
+// when tar exits non-zero. Without that, callers see only "exited with
+// code N" and have to guess whether the archive is corrupt, the path is
+// missing, or the container ran out of disk.
 func (d *DockerProvider) Restore(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
 	d.logger.Info().
 		Str("container_id", sb.ID).
@@ -706,31 +742,123 @@ func (d *DockerProvider) Restore(ctx context.Context, sb *agent.Sandbox, reader 
 	// does not affect the snapshot data already written.
 	_ = attachResp.CloseWrite()
 
-	// Drain stdout/stderr so the exec process can finish writing.
-	// Without this, the process may block on a full output buffer.
-	_, _ = stdcopy.StdCopy(io.Discard, io.Discard, attachResp.Reader)
+	// Drain stdout/stderr so the exec process can finish writing. Stderr is
+	// captured in a bounded buffer so a non-zero exit surfaces tar's actual
+	// complaint instead of just an exit code.
+	stderrBuf := newCappedBuffer(tarStderrCap)
+	_, _ = stdcopy.StdCopy(io.Discard, stderrBuf, attachResp.Reader)
 
-	// Poll until the exec process finishes. ContainerExecInspect may return
-	// Running=true if called immediately after CloseWrite.
-	ticker := time.NewTicker(50 * time.Millisecond)
+	inspect, err := waitForExecExit(ctx, d.client, execResp.ID)
+	if err != nil {
+		return fmt.Errorf("inspect restore exec: %w", err)
+	}
+	if inspect.ExitCode != 0 {
+		return fmt.Errorf("restore tar exited with code %d%s", inspect.ExitCode, formatStderrSuffix(stderrBuf))
+	}
+	return nil
+}
+
+// waitForExecExit polls until the given exec finishes and returns the
+// inspect snapshot. Polls at execPollInterval and respects ctx cancellation;
+// the only error returns are ctx.Err() and inspect transport failures.
+func waitForExecExit(ctx context.Context, client DockerClient, execID string) (container.ExecInspect, error) {
+	ticker := time.NewTicker(execPollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return container.ExecInspect{}, ctx.Err()
 		case <-ticker.C:
-			inspectResp, err := d.client.ContainerExecInspect(ctx, execResp.ID)
+			inspect, err := client.ContainerExecInspect(ctx, execID)
 			if err != nil {
-				return fmt.Errorf("inspect restore exec: %w", err)
+				return container.ExecInspect{}, err
 			}
-			if !inspectResp.Running {
-				if inspectResp.ExitCode != 0 {
-					return fmt.Errorf("restore tar exited with code %d", inspectResp.ExitCode)
-				}
-				return nil
+			if !inspect.Running {
+				return inspect, nil
 			}
 		}
 	}
+}
+
+// snapshotExecError rolls up the three failure modes of a snapshot tar — an
+// in-flight read error, a Docker inspect failure waiting for the exec to
+// finish, or a non-zero tar exit — into the single error that gets handed
+// to the caller via PipeWriter.CloseWithError. nil means clean EOF.
+func snapshotExecError(copyErr, waitErr error, inspect container.ExecInspect, stderr *cappedBuffer) error {
+	switch {
+	case copyErr != nil:
+		return fmt.Errorf("read snapshot stream: %w", copyErr)
+	case waitErr != nil:
+		return fmt.Errorf("wait for snapshot tar: %w", waitErr)
+	case inspect.ExitCode != 0:
+		return fmt.Errorf("snapshot tar exited with code %d%s", inspect.ExitCode, formatStderrSuffix(stderr))
+	default:
+		return nil
+	}
+}
+
+// formatStderrSuffix renders captured stderr into an error suffix like
+// `: tar: /workspace: Cannot stat: ...`, or "" if stderr was empty.
+// Whitespace (often a trailing newline) is trimmed for readability.
+func formatStderrSuffix(stderr *cappedBuffer) string {
+	if stderr == nil || stderr.Len() == 0 {
+		return ""
+	}
+	msg := strings.TrimSpace(stderr.String())
+	if msg == "" {
+		return ""
+	}
+	return ": " + msg
+}
+
+// cappedBuffer is a write-only sink that retains at most limit bytes and
+// silently drops the rest, while still reporting a "successful" Write.
+// Used for capturing diagnostic stderr without unbounded memory exposure
+// to a misbehaving process.
+//
+// Invariant: limit > 0 (enforced by newCappedBuffer). That means dropped
+// only ever flips to true after at least one byte has been buffered, so
+// `Len() == 0` reliably implies "no data captured" — callers can use Len
+// alone to gate empty-message handling without also having to consult
+// dropped.
+type cappedBuffer struct {
+	buf     bytes.Buffer
+	limit   int
+	dropped bool
+}
+
+func newCappedBuffer(limit int) *cappedBuffer {
+	if limit <= 0 {
+		// A zero/negative cap would let dropped flip to true with Len()==0,
+		// silently swallowing the [truncated] marker. Programmer error;
+		// loud panic beats a quiet diagnostic regression.
+		panic(fmt.Sprintf("newCappedBuffer: limit must be positive, got %d", limit))
+	}
+	return &cappedBuffer{limit: limit}
+}
+
+func (b *cappedBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	remaining := b.limit - b.buf.Len()
+	switch {
+	case remaining <= 0 && n > 0:
+		b.dropped = true
+	case n <= remaining:
+		b.buf.Write(p)
+	default:
+		b.buf.Write(p[:remaining])
+		b.dropped = true
+	}
+	return n, nil
+}
+
+func (b *cappedBuffer) Len() int { return b.buf.Len() }
+
+func (b *cappedBuffer) String() string {
+	if b.dropped {
+		return b.buf.String() + " [truncated]"
+	}
+	return b.buf.String()
 }
 
 // ExecStream runs a command inside the sandbox and calls onLine for each

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -155,6 +155,35 @@ func newMockHijackedResponse(data string) types.HijackedResponse {
 	}
 }
 
+// dockerStreamFrame builds a single Docker multiplexed stream frame.
+// stream is 1 (stdout) or 2 (stderr); the payload is wrapped with the
+// 8-byte header stdcopy expects.
+func dockerStreamFrame(stream byte, payload []byte) []byte {
+	if len(payload) > 0xFFFFFFFF {
+		panic("dockerStreamFrame: payload exceeds uint32 length")
+	}
+	frame := make([]byte, 8+len(payload))
+	frame[0] = stream
+	// bytes 1..3 are padding (zero)
+	size := uint32(len(payload))
+	frame[4] = byte(size >> 24)
+	frame[5] = byte(size >> 16)
+	frame[6] = byte(size >> 8)
+	frame[7] = byte(size)
+	copy(frame[8:], payload)
+	return frame
+}
+
+// dockerMultiplexed concatenates one stdout frame and one stderr frame —
+// the typical shape returned by `docker exec` once the tool has run.
+func dockerMultiplexed(stdout, stderr []byte) string {
+	out := dockerStreamFrame(1, stdout)
+	if len(stderr) > 0 {
+		out = append(out, dockerStreamFrame(2, stderr)...)
+	}
+	return string(out)
+}
+
 func newTestLogger() zerolog.Logger {
 	return zerolog.Nop()
 }
@@ -889,6 +918,240 @@ func TestDockerProvider_Snapshot(t *testing.T) {
 		require.Contains(t, tarCmd, "'home/sandbox/.claude'", "tar should include the .claude dir under HomeDir")
 		require.Contains(t, tarCmd, "'home/sandbox/.codex'", "tar should include the .codex dir under HomeDir")
 		require.Contains(t, tarCmd, "'home/sandbox/.gemini'", "tar should include the .gemini dir under HomeDir")
+		require.NotContains(t, tarCmd, "2>/dev/null", "tar stderr must not be silenced — we capture it for diagnostics")
+	})
+
+	t.Run("returns error from Read when tar exits non-zero", func(t *testing.T) {
+		t.Parallel()
+
+		// Tar wrote one stdout chunk before failing, plus a stderr message.
+		// The pipe should yield the stdout bytes but then surface the failure
+		// to the caller — the "we silently uploaded a partial archive" bug.
+		stdoutPayload := []byte("partial-archive-bytes")
+		stderrPayload := []byte("tar: /workspace/missing: Cannot stat: No such file or directory\n")
+
+		mock := &mockDockerClient{}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			return newMockHijackedResponse(dockerMultiplexed(stdoutPayload, stderrPayload)), nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 2}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "snap-container", Provider: "docker", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+
+		rc, err := p.Snapshot(context.Background(), sb)
+		require.NoError(t, err, "Snapshot(start) should succeed; the failure surfaces during the read")
+		defer rc.Close()
+
+		var got bytes.Buffer
+		_, err = io.Copy(&got, rc)
+		require.Error(t, err, "draining the snapshot reader must surface tar's non-zero exit")
+		require.Contains(t, err.Error(), "snapshot tar exited with code 2")
+		require.Contains(t, err.Error(), "Cannot stat", "captured stderr should be in the error")
+		require.Equal(t, stdoutPayload, got.Bytes(), "the bytes that did stream through should be readable; the error appears at EOF")
+	})
+
+	t.Run("returns clean EOF when tar exits zero", func(t *testing.T) {
+		t.Parallel()
+
+		archive := []byte("\x1f\x8b\x08mock-gzip-bytes")
+		mock := &mockDockerClient{}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			return newMockHijackedResponse(dockerMultiplexed(archive, nil)), nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 0}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "snap-container", Provider: "docker", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+
+		rc, err := p.Snapshot(context.Background(), sb)
+		require.NoError(t, err)
+		defer rc.Close()
+
+		got, err := io.ReadAll(rc)
+		require.NoError(t, err, "a clean tar exit should not surface as an error")
+		require.Equal(t, archive, got)
+	})
+
+	t.Run("surfaces ctx error when tar never exits", func(t *testing.T) {
+		t.Parallel()
+
+		// Inspect always reports Running=true so waitForExecExit spins until
+		// ctx fires. Exercises the only way out when tar wedges inside the
+		// container — without ctx-respecting wait the consumer would block
+		// on the pipe forever.
+		mock := &mockDockerClient{}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: true}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "snap-container", Provider: "docker", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		rc, err := p.Snapshot(ctx, sb)
+		require.NoError(t, err, "Snapshot start should succeed; the ctx error surfaces during the read")
+		defer rc.Close()
+
+		_, err = io.Copy(io.Discard, rc)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wait for snapshot tar")
+		require.Contains(t, err.Error(), context.DeadlineExceeded.Error())
+	})
+}
+
+func TestDockerProvider_Restore(t *testing.T) {
+	t.Parallel()
+
+	t.Run("succeeds when tar exits zero", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockDockerClient{}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 0}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "restore-container", Provider: "docker", WorkDir: "/workspace"}
+
+		err := p.Restore(context.Background(), sb, bytes.NewReader([]byte("archive-bytes")))
+		require.NoError(t, err)
+	})
+
+	t.Run("error includes captured stderr when tar exits non-zero", func(t *testing.T) {
+		t.Parallel()
+
+		stderr := []byte("gzip: stdin: unexpected end of file\ntar: Child returned status 1\ntar: Error is not recoverable: exiting now\n")
+
+		mock := &mockDockerClient{}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			// Only stderr; tar didn't emit anything to stdout before dying.
+			return newMockHijackedResponse(dockerMultiplexed(nil, stderr)), nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: false, ExitCode: 2}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "restore-container", Provider: "docker", WorkDir: "/workspace"}
+
+		err := p.Restore(context.Background(), sb, bytes.NewReader([]byte("garbage-bytes")))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "restore tar exited with code 2")
+		require.Contains(t, err.Error(), "unexpected end of file", "tar's stderr should be in the error message — this is the diagnostic we lost before")
+	})
+
+	t.Run("returns ctx error when context is cancelled before exec exits", func(t *testing.T) {
+		t.Parallel()
+
+		// Inspect always reports Running=true so the wait loop spins until ctx
+		// fires. Without ctx-respecting wait this would hang the test.
+		mock := &mockDockerClient{}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{Running: true}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "restore-container", Provider: "docker", WorkDir: "/workspace"}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		err := p.Restore(ctx, sb, bytes.NewReader([]byte("archive")))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "inspect restore exec")
+	})
+}
+
+func TestCappedBuffer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("retains data under the cap and reports exact length", func(t *testing.T) {
+		t.Parallel()
+		b := newCappedBuffer(64)
+		n, err := b.Write([]byte("hello"))
+		require.NoError(t, err)
+		require.Equal(t, 5, n)
+		require.Equal(t, "hello", b.String())
+	})
+
+	t.Run("truncates writes that exceed the cap and marks dropped", func(t *testing.T) {
+		t.Parallel()
+		b := newCappedBuffer(8)
+		// Single oversize write — only the first 8 bytes are kept.
+		n, err := b.Write([]byte("0123456789"))
+		require.NoError(t, err)
+		require.Equal(t, 10, n, "Write should report success on the full payload so callers don't loop on a 'short write'")
+		require.Equal(t, "01234567 [truncated]", b.String())
+	})
+
+	t.Run("drops further writes once full", func(t *testing.T) {
+		t.Parallel()
+		b := newCappedBuffer(4)
+		_, _ = b.Write([]byte("ab"))
+		_, _ = b.Write([]byte("cdef"))
+		_, _ = b.Write([]byte("ghi"))
+		require.Equal(t, "abcd [truncated]", b.String())
+	})
+
+	t.Run("zero-length write is a no-op and does not flip dropped", func(t *testing.T) {
+		t.Parallel()
+		b := newCappedBuffer(4)
+		_, _ = b.Write(nil)
+		require.Equal(t, "", b.String(), "no data written should not produce a [truncated] marker")
+	})
+
+	t.Run("non-positive limit panics", func(t *testing.T) {
+		t.Parallel()
+		// A zero/negative cap would let dropped flip to true with Len()==0,
+		// silently swallowing the [truncated] marker downstream. We want a
+		// loud panic at construction rather than a quiet diagnostic regression.
+		require.PanicsWithValue(t,
+			"newCappedBuffer: limit must be positive, got 0",
+			func() { newCappedBuffer(0) })
+		require.Panics(t, func() { newCappedBuffer(-1) })
+	})
+}
+
+func TestSnapshotExecError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil all → nil", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, snapshotExecError(nil, nil, container.ExecInspect{ExitCode: 0}, newCappedBuffer(64)))
+	})
+
+	t.Run("copy error wins over wait error and exit code", func(t *testing.T) {
+		t.Parallel()
+		err := snapshotExecError(io.ErrUnexpectedEOF, fmt.Errorf("wait failed"), container.ExecInspect{ExitCode: 2}, newCappedBuffer(64))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "read snapshot stream")
+		require.Contains(t, err.Error(), io.ErrUnexpectedEOF.Error())
+	})
+
+	t.Run("wait error wins over exit code", func(t *testing.T) {
+		t.Parallel()
+		err := snapshotExecError(nil, fmt.Errorf("inspect: connection lost"), container.ExecInspect{ExitCode: 2}, newCappedBuffer(64))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "wait for snapshot tar")
+		require.Contains(t, err.Error(), "connection lost")
+	})
+
+	t.Run("non-zero exit includes captured stderr suffix", func(t *testing.T) {
+		t.Parallel()
+		stderr := newCappedBuffer(128)
+		_, _ = stderr.Write([]byte("tar: archive boom\n"))
+		err := snapshotExecError(nil, nil, container.ExecInspect{ExitCode: 2}, stderr)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "snapshot tar exited with code 2")
+		require.Contains(t, err.Error(), "tar: archive boom")
+		require.NotContains(t, err.Error(), "\n", "trailing whitespace should be trimmed")
+	})
+
+	t.Run("non-zero exit with empty stderr omits the suffix", func(t *testing.T) {
+		t.Parallel()
+		err := snapshotExecError(nil, nil, container.ExecInspect{ExitCode: 1}, newCappedBuffer(64))
+		require.Error(t, err)
+		require.Equal(t, "snapshot tar exited with code 1", err.Error())
 	})
 }
 


### PR DESCRIPTION
## Summary
- A gVisor sandbox crash mid-turn caused the worker to upload a 298-byte truncated tar.gz as the session's canonical snapshot, bricking every future \`continue_session\` retry with a bare \`restore tar exited with code 2\`.
- \`Snapshot\` now waits for tar's exit code and surfaces non-zero exits (with captured stderr) as an error on the returned \`ReadCloser\`, so partial archives can no longer reach S3; \`Restore\` captures tar stderr so failures are diagnosable instead of just an exit code.
- A new \`snapshotSessionOnTurnSuccess\` wrapper refuses to snapshot when the agent exited non-zero on the success path, preserving any prior good checkpoint; cancel and policy-stop paths intentionally bypass the guard since those non-zero exits are graceful shutdowns.

## Test plan
- [x] \`go test -race ./internal/services/agent/...\` (12 new cases covering tar exit handling, ctx cancellation, stderr capture, the success-path skip, and \`cappedBuffer\` invariants)
- [x] Full \`go test -short ./internal/...\` clean
- [ ] Ops follow-up: clear \`snapshot_key\` / \`pending_snapshot_key\` on the bricked production session (\`f0a54f2c-ecca-49a8-ad42-9c7295b4a9fa\`) and delete the bad S3 object

🤖 Generated with [Claude Code](https://claude.com/claude-code)