### PR TITLE
Cascade preview terminal status to child service/infra rows

### DIFF
--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -125,6 +125,14 @@ function buildStartupChecklist(
   services: PreviewService[],
   infrastructure: PreviewInfrastructure[],
 ): StartupChecklistStep[] {
+  // When the parent preview reaches a terminal state, force any child rows
+  // that were still pending to render as terminal too. The backend cascades
+  // these on terminal transitions; this defensive layer also covers
+  // historical rows from before the cascade landed.
+  const parentTerminal =
+    status === "failed" || status === "stopped" || status === "expired";
+  const parentFailed = status === "failed";
+
   const infraFailed = infrastructure.find(
     (item) => item.status === "failed" || item.status === "unhealthy",
   );
@@ -161,42 +169,58 @@ function buildStartupChecklist(
   const steps: StartupChecklistStep[] = [];
 
   if (infrastructure.length > 0) {
-    steps.push({
-      title: "Spin up infrastructure",
-      state: infraFailed
-        ? "failed"
-        : allInfraHealthy
-          ? "complete"
-          : infraProvisioning
-            ? "active"
-            : "pending",
-      detail: infraFailed
-        ? `${infraFailed.infra_name} failed to become healthy`
-        : allInfraHealthy
-          ? `${infrastructure.length === 1 ? infrastructure[0].infra_name : `${infrastructure.length} services`} ready`
-          : infraProvisioning
-            ? `${infraProvisioning.infra_name} is provisioning`
-            : "Waiting to start preview infrastructure.",
-    });
+    let infraState: StartupChecklistStepState;
+    let infraDetail: string;
+    if (infraFailed) {
+      infraState = "failed";
+      infraDetail = `${infraFailed.infra_name} failed to become healthy`;
+    } else if (allInfraHealthy) {
+      infraState = "complete";
+      infraDetail = `${
+        infrastructure.length === 1
+          ? infrastructure[0].infra_name
+          : `${infrastructure.length} services`
+      } ready`;
+    } else if (parentTerminal) {
+      infraState = parentFailed ? "failed" : "pending";
+      infraDetail = parentFailed
+        ? `${infraProvisioning?.infra_name ?? "Infrastructure"} did not finish provisioning`
+        : "Infrastructure was stopped before reaching ready.";
+    } else if (infraProvisioning) {
+      infraState = "active";
+      infraDetail = `${infraProvisioning.infra_name} is provisioning`;
+    } else {
+      infraState = "pending";
+      infraDetail = "Waiting to start preview infrastructure.";
+    }
+    steps.push({ title: "Spin up infrastructure", state: infraState, detail: infraDetail });
   }
 
-  steps.push({
-    title: "Start services",
-    state: serviceFailed
-      ? "failed"
-      : allServicesReady
-        ? "complete"
-        : serviceStarting
-          ? "active"
-          : "pending",
-    detail: serviceFailed
-      ? `${serviceFailed.service_name} failed to start`
-      : allServicesReady
-        ? `${services.length === 1 ? services[0]?.service_name ?? "App" : `${services.length} services`} ready`
-        : serviceStarting
-          ? `${serviceStarting.service_name} is starting`
-          : "Waiting for services to boot.",
-  });
+  let serviceState: StartupChecklistStepState;
+  let serviceDetail: string;
+  if (serviceFailed) {
+    serviceState = "failed";
+    serviceDetail = `${serviceFailed.service_name} failed to start`;
+  } else if (allServicesReady) {
+    serviceState = "complete";
+    serviceDetail = `${
+      services.length === 1
+        ? services[0]?.service_name ?? "App"
+        : `${services.length} services`
+    } ready`;
+  } else if (parentTerminal) {
+    serviceState = parentFailed ? "failed" : "pending";
+    serviceDetail = parentFailed
+      ? `${serviceStarting?.service_name ?? "Service"} did not finish starting`
+      : "Services were stopped before reaching ready.";
+  } else if (serviceStarting) {
+    serviceState = "active";
+    serviceDetail = `${serviceStarting.service_name} is starting`;
+  } else {
+    serviceState = "pending";
+    serviceDetail = "Waiting for services to boot.";
+  }
+  steps.push({ title: "Start services", state: serviceState, detail: serviceDetail });
 
   steps.push({
     title: "Open the preview",

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -544,15 +544,31 @@ func expectReserveSuccess(mock pgxmock.PgxPoolIface, sessionID, orgID, userID uu
 	return previewID
 }
 
+func previewAnyArgs(n int) []any {
+	args := make([]any, n)
+	for i := range args {
+		args[i] = pgxmock.AnyArg()
+	}
+	return args
+}
+
 // expectAbortReservationNoDestroy emits the pgxmock sequence for an Abort that
 // releases the hold without destroying a container (either the sandbox was
 // reused so hydratedContainerID is "", or the turn still holds it). Callers
 // that need the destroy path should build it inline.
 func expectAbortReservationNoDestroy(mock pgxmock.PgxPoolIface) {
-	// UpdatePreviewStatus: id, org_id, status, error (4 args).
+	// UpdatePreviewStatus(failed): parent status + child cascades in one transaction.
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectCommit()
 	// ReleasePreviewHold returns destroyNow=false because turn_holds=true.
 	mock.ExpectQuery("WITH released AS").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -2092,11 +2092,18 @@ func TestPreviewHandler_StopPreview_Success(t *testing.T) {
 				AddRow(newActivePreviewRow(previewID, sessionID, orgID, userID, now)...),
 		)
 
-	// StopPreview calls StopPreviewWithRevocation which does Begin + StopPreview + RevokeAll + Commit.
+	// StopPreview calls StopPreviewWithRevocation which does
+	// Begin + StopPreview (instance UPDATE + child cascades) + RevokeAll + Commit.
 	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -165,6 +165,41 @@ func (s *PreviewStore) GetActivePreviewForSession(ctx context.Context, orgID, se
 // and preview_infrastructure rows so the UI's startup checklist doesn't spin
 // forever on orphaned children.
 func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) error {
+	if status.IsTerminal() {
+		tx, err := s.db.Begin(ctx)
+		if err != nil {
+			return fmt.Errorf("begin terminal preview status transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		txStore := s.WithTx(tx)
+		rowsAffected, err := txStore.updatePreviewStatus(ctx, orgID, id, status, errMsg)
+		if err != nil {
+			return err
+		}
+		if rowsAffected == 0 {
+			return fmt.Errorf("preview instance not found")
+		}
+		if err := txStore.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
+			return err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return fmt.Errorf("commit terminal preview status transaction: %w", err)
+		}
+		return nil
+	}
+
+	rowsAffected, err := s.updatePreviewStatus(ctx, orgID, id, status, errMsg)
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("preview instance not found")
+	}
+	return nil
+}
+
+func (s *PreviewStore) updatePreviewStatus(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) (int64, error) {
 	var query string
 	if status.IsTerminal() {
 		query = `UPDATE preview_instances SET status = @status, error = @error, stopped_at = now(), updated_at = now()
@@ -177,17 +212,9 @@ func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.U
 		"id": id, "org_id": orgID, "status": status, "error": errMsg,
 	})
 	if err != nil {
-		return fmt.Errorf("update preview status: %w", err)
+		return 0, fmt.Errorf("update preview status: %w", err)
 	}
-	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("preview instance not found")
-	}
-	if status.IsTerminal() {
-		if err := s.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
-			return err
-		}
-	}
-	return nil
+	return tag.RowsAffected(), nil
 }
 
 // UpdatePreviewStatusIfActive atomically transitions a preview to the given
@@ -198,21 +225,51 @@ func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.U
 // When the new status is terminal, it also cascades the transition to
 // non-terminal child preview_services / preview_infrastructure rows.
 func (s *PreviewStore) UpdatePreviewStatusIfActive(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) (bool, error) {
+	if status.IsTerminal() {
+		tx, err := s.db.Begin(ctx)
+		if err != nil {
+			return false, fmt.Errorf("begin conditional terminal preview status transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+
+		txStore := s.WithTx(tx)
+		rowsAffected, err := txStore.updatePreviewStatusIfActive(ctx, orgID, id, status, errMsg)
+		if err != nil {
+			return false, err
+		}
+		if rowsAffected == 0 {
+			return false, nil
+		}
+		if err := txStore.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
+			return true, err
+		}
+		if err := tx.Commit(ctx); err != nil {
+			return true, fmt.Errorf("commit conditional terminal preview status transaction: %w", err)
+		}
+		return true, nil
+	}
+
+	rowsAffected, err := s.updatePreviewStatusIfActive(ctx, orgID, id, status, errMsg)
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected > 0, nil
+}
+
+func (s *PreviewStore) updatePreviewStatusIfActive(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) (int64, error) {
 	query := `UPDATE preview_instances SET status = @status, error = @error, updated_at = now()
 		WHERE id = @id AND org_id = @org_id AND status NOT IN ('stopped', 'failed', 'expired')`
+	if status.IsTerminal() {
+		query = `UPDATE preview_instances SET status = @status, error = @error, stopped_at = now(), updated_at = now()
+			WHERE id = @id AND org_id = @org_id AND status NOT IN ('stopped', 'failed', 'expired')`
+	}
 	tag, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id": id, "org_id": orgID, "status": status, "error": errMsg,
 	})
 	if err != nil {
-		return false, fmt.Errorf("conditional update preview status: %w", err)
+		return 0, fmt.Errorf("conditional update preview status: %w", err)
 	}
-	updated := tag.RowsAffected() > 0
-	if updated && status.IsTerminal() {
-		if err := s.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
-			return updated, err
-		}
-	}
-	return updated, nil
+	return tag.RowsAffected(), nil
 }
 
 // UpdatePreviewAccess updates the last_accessed_at timestamp.

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -160,7 +160,10 @@ func (s *PreviewStore) GetActivePreviewForSession(ctx context.Context, orgID, se
 }
 
 // UpdatePreviewStatus updates the status and optional error of a preview.
-// For terminal statuses (stopped, failed, expired), it also sets stopped_at.
+// For terminal statuses (stopped, failed, expired), it also sets stopped_at
+// and cascades the terminal transition to non-terminal child preview_services
+// and preview_infrastructure rows so the UI's startup checklist doesn't spin
+// forever on orphaned children.
 func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) error {
 	var query string
 	if status.IsTerminal() {
@@ -179,6 +182,11 @@ func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.U
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("preview instance not found")
 	}
+	if status.IsTerminal() {
+		if err := s.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -186,6 +194,9 @@ func (s *PreviewStore) UpdatePreviewStatus(ctx context.Context, orgID, id uuid.U
 // status only if its current status is not terminal (stopped, failed, expired).
 // Returns true if the update took effect, false if the preview was already
 // terminal (no error). This eliminates the TOCTOU window in RecyclePreview.
+//
+// When the new status is terminal, it also cascades the transition to
+// non-terminal child preview_services / preview_infrastructure rows.
 func (s *PreviewStore) UpdatePreviewStatusIfActive(ctx context.Context, orgID, id uuid.UUID, status models.PreviewStatus, errMsg string) (bool, error) {
 	query := `UPDATE preview_instances SET status = @status, error = @error, updated_at = now()
 		WHERE id = @id AND org_id = @org_id AND status NOT IN ('stopped', 'failed', 'expired')`
@@ -195,7 +206,13 @@ func (s *PreviewStore) UpdatePreviewStatusIfActive(ctx context.Context, orgID, i
 	if err != nil {
 		return false, fmt.Errorf("conditional update preview status: %w", err)
 	}
-	return tag.RowsAffected() > 0, nil
+	updated := tag.RowsAffected() > 0
+	if updated && status.IsTerminal() {
+		if err := s.cascadeChildrenToTerminal(ctx, orgID, id, status, errMsg); err != nil {
+			return updated, err
+		}
+	}
+	return updated, nil
 }
 
 // UpdatePreviewAccess updates the last_accessed_at timestamp.
@@ -234,7 +251,11 @@ func (s *PreviewStore) UpdateLastPath(ctx context.Context, orgID, id uuid.UUID, 
 	return nil
 }
 
-// StopPreview sets status to stopped and records the stop time.
+// StopPreview sets status to stopped and records the stop time. It also
+// cascades the terminal transition to non-terminal child preview_services
+// and preview_infrastructure rows so the UI's startup checklist reaches a
+// terminal state instead of spinning on orphaned children.
+//
 // This should be called within a transaction that also revokes access sessions.
 func (s *PreviewStore) StopPreview(ctx context.Context, orgID, id uuid.UUID) error {
 	tag, err := s.db.Exec(ctx,
@@ -248,6 +269,96 @@ func (s *PreviewStore) StopPreview(ctx context.Context, orgID, id uuid.UUID) err
 	if tag.RowsAffected() == 0 {
 		return fmt.Errorf("preview instance not found or already stopped")
 	}
+	if err := s.cascadeChildrenToTerminal(ctx, orgID, id, models.PreviewStatusStopped, ""); err != nil {
+		return err
+	}
+	return nil
+}
+
+// cascadeChildrenToTerminal flips non-terminal preview_services and
+// preview_infrastructure rows to a terminal state when their parent preview
+// transitions to terminal. Without this, the frontend's startup checklist
+// (which reads child statuses to drive spinner state) keeps spinning forever
+// when a launch is interrupted before the worker reaches its own terminal-
+// state writes — for example, when a rolling deploy kills the API process
+// after it reserved the rows but before the worker received the launch RPC.
+//
+// Mapping:
+//   - parent="failed": children still in starting/provisioning/unhealthy go to
+//     "failed" (they were the failure, by elimination); already-ready/healthy
+//     children go to "stopped" (they had reached health, so the failure was
+//     elsewhere).
+//   - parent="stopped"/"expired": all non-terminal children go to "stopped".
+//
+// The parent's error is propagated only into rows that were still pending
+// (starting/provisioning/unhealthy) and have no error of their own; rows
+// with their own captured error keep it.
+func (s *PreviewStore) cascadeChildrenToTerminal(ctx context.Context, orgID, previewID uuid.UUID, parentStatus models.PreviewStatus, parentErr string) error {
+	if !parentStatus.IsTerminal() {
+		return nil
+	}
+
+	// "stopped" / "expired" parent — everything still alive becomes "stopped".
+	// "failed" parent — pending children become "failed", ready/healthy become "stopped".
+	pendingTarget := string(models.PreviewServiceStatusStopped)
+	healthyTarget := string(models.PreviewServiceStatusStopped)
+	infraPendingTarget := string(models.PreviewInfraStatusStopped)
+	infraHealthyTarget := string(models.PreviewInfraStatusStopped)
+	if parentStatus == models.PreviewStatusFailed {
+		pendingTarget = string(models.PreviewServiceStatusFailed)
+		infraPendingTarget = string(models.PreviewInfraStatusFailed)
+	}
+
+	if _, err := s.db.Exec(ctx,
+		`UPDATE preview_services SET
+			status = CASE
+				WHEN status = 'starting' THEN @pending_target
+				WHEN status = 'ready' THEN @healthy_target
+				ELSE status
+			END,
+			error = CASE
+				WHEN status = 'starting' AND (error IS NULL OR error = '') THEN @parent_err
+				ELSE error
+			END
+		 WHERE preview_instance_id = @pid
+		   AND status NOT IN ('stopped', 'failed')
+		   AND preview_instance_id IN (SELECT id FROM preview_instances WHERE id = @pid AND org_id = @org_id)`,
+		pgx.NamedArgs{
+			"pid":            previewID,
+			"org_id":         orgID,
+			"pending_target": pendingTarget,
+			"healthy_target": healthyTarget,
+			"parent_err":     parentErr,
+		},
+	); err != nil {
+		return fmt.Errorf("cascade preview services to terminal: %w", err)
+	}
+
+	if _, err := s.db.Exec(ctx,
+		`UPDATE preview_infrastructure SET
+			status = CASE
+				WHEN status IN ('provisioning', 'unhealthy') THEN @pending_target
+				WHEN status = 'healthy' THEN @healthy_target
+				ELSE status
+			END,
+			error = CASE
+				WHEN status IN ('provisioning', 'unhealthy') AND (error IS NULL OR error = '') THEN @parent_err
+				ELSE error
+			END
+		 WHERE preview_instance_id = @pid
+		   AND status NOT IN ('stopped', 'failed')
+		   AND preview_instance_id IN (SELECT id FROM preview_instances WHERE id = @pid AND org_id = @org_id)`,
+		pgx.NamedArgs{
+			"pid":            previewID,
+			"org_id":         orgID,
+			"pending_target": infraPendingTarget,
+			"healthy_target": infraHealthyTarget,
+			"parent_err":     parentErr,
+		},
+	); err != nil {
+		return fmt.Errorf("cascade preview infrastructure to terminal: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -258,15 +258,86 @@ func TestPreviewStore_UpdatePreviewStatus(t *testing.T) {
 	}
 }
 
+func TestPreviewStore_UpdatePreviewStatus_TerminalCascadesChildren(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCascadesChildren(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectExec("UPDATE preview_instances SET status").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_NoCascadeWhenAlreadyTerminal(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	// Conditional update affects 0 rows (preview was already terminal).
+	mock.ExpectExec("UPDATE preview_instances SET status").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	// No cascade expected — children were already updated by the prior terminal write.
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.NoError(t, err)
+	require.False(t, updated)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPreviewStore_StopPreview(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		rows      int64
-		expectErr bool
+		name           string
+		rows           int64
+		expectErr      bool
+		expectCascades bool
 	}{
-		{name: "stops active preview", rows: 1},
+		{name: "stops active preview", rows: 1, expectCascades: true},
 		{name: "already stopped returns error", rows: 0, expectErr: true},
 	}
 
@@ -283,6 +354,14 @@ func TestPreviewStore_StopPreview(t *testing.T) {
 			mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 				WithArgs(previewAnyArgs(3)...).
 				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rows))
+			if tt.expectCascades {
+				mock.ExpectExec("UPDATE preview_services SET").
+					WithArgs(previewAnyArgs(5)...).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+				mock.ExpectExec("UPDATE preview_infrastructure SET").
+					WithArgs(previewAnyArgs(5)...).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+			}
 
 			err = store.StopPreview(context.Background(), uuid.New(), uuid.New())
 			if tt.expectErr {
@@ -1139,6 +1218,12 @@ func TestPreviewStore_StopPreviewWithRevocation(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(previewAnyArgs(3)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 2))

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -262,11 +262,12 @@ func TestPreviewStore_UpdatePreviewStatus_TerminalCascadesChildren(t *testing.T)
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
+	require.NoError(t, err, "pgxmock pool should be created")
 	defer mock.Close()
 
 	store := NewPreviewStore(mock)
 
+	mock.ExpectBegin()
 	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(previewAnyArgs(4)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -276,22 +277,48 @@ func TestPreviewStore_UpdatePreviewStatus_TerminalCascadesChildren(t *testing.T)
 	mock.ExpectExec("UPDATE preview_infrastructure SET").
 		WithArgs(previewAnyArgs(5)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectCommit()
 
 	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
-	require.NoError(t, err)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "terminal status update should cascade children")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatus_TerminalRollbackOnCascadeError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnError(errors.New("service cascade failed"))
+	mock.ExpectRollback()
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.Error(t, err, "terminal status update should fail when child cascade fails")
+	require.Contains(t, err.Error(), "service cascade failed", "terminal status error should include cascade failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCascadesChildren(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
+	require.NoError(t, err, "pgxmock pool should be created")
 	defer mock.Close()
 
 	store := NewPreviewStore(mock)
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(previewAnyArgs(4)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectExec("UPDATE preview_services SET").
@@ -300,32 +327,35 @@ func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCascadesChildren(t *te
 	mock.ExpectExec("UPDATE preview_infrastructure SET").
 		WithArgs(previewAnyArgs(5)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectCommit()
 
 	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
-	require.NoError(t, err)
-	require.True(t, updated)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "terminal conditional status update should cascade children")
+	require.True(t, updated, "conditional terminal status update should report the row was changed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewStore_UpdatePreviewStatusIfActive_NoCascadeWhenAlreadyTerminal(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
+	require.NoError(t, err, "pgxmock pool should be created")
 	defer mock.Close()
 
 	store := NewPreviewStore(mock)
 
+	mock.ExpectBegin()
 	// Conditional update affects 0 rows (preview was already terminal).
-	mock.ExpectExec("UPDATE preview_instances SET status").
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(previewAnyArgs(4)...).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	// No cascade expected — children were already updated by the prior terminal write.
+	mock.ExpectRollback()
 
 	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
-	require.NoError(t, err)
-	require.False(t, updated)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, err, "already-terminal conditional update should not error")
+	require.False(t, updated, "conditional update should report no row was changed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewStore_StopPreview(t *testing.T) {

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -227,10 +227,12 @@ func TestPreviewStore_UpdatePreviewStatus(t *testing.T) {
 	tests := []struct {
 		name      string
 		rows      int64
+		execErr   error
 		expectErr bool
 	}{
 		{name: "updates successfully", rows: 1},
 		{name: "not found returns error", rows: 0, expectErr: true},
+		{name: "update error returns error", execErr: errors.New("db down"), expectErr: true},
 	}
 
 	for _, tt := range tests {
@@ -245,7 +247,8 @@ func TestPreviewStore_UpdatePreviewStatus(t *testing.T) {
 
 			mock.ExpectExec("UPDATE preview_instances SET status").
 				WithArgs(previewAnyArgs(4)...).
-				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rows))
+				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rows)).
+				WillReturnError(tt.execErr)
 
 			err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusReady, "")
 			if tt.expectErr {
@@ -256,6 +259,23 @@ func TestPreviewStore_UpdatePreviewStatus(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestPreviewStore_UpdatePreviewStatus_TerminalBeginError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin().WillReturnError(errors.New("begin failed"))
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.Error(t, err, "terminal status update should return begin errors")
+	require.Contains(t, err.Error(), "begin failed", "terminal status error should include begin failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewStore_UpdatePreviewStatus_TerminalCascadesChildren(t *testing.T) {
@@ -284,6 +304,27 @@ func TestPreviewStore_UpdatePreviewStatus_TerminalCascadesChildren(t *testing.T)
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPreviewStore_UpdatePreviewStatus_TerminalUpdateError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnError(errors.New("update failed"))
+	mock.ExpectRollback()
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.Error(t, err, "terminal status update should return parent update errors")
+	require.Contains(t, err.Error(), "update failed", "terminal status error should include parent update failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestPreviewStore_UpdatePreviewStatus_TerminalRollbackOnCascadeError(t *testing.T) {
 	t.Parallel()
 
@@ -305,6 +346,121 @@ func TestPreviewStore_UpdatePreviewStatus_TerminalRollbackOnCascadeError(t *test
 	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
 	require.Error(t, err, "terminal status update should fail when child cascade fails")
 	require.Contains(t, err.Error(), "service cascade failed", "terminal status error should include cascade failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatus_TerminalRollbackOnInfraCascadeError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnError(errors.New("infra cascade failed"))
+	mock.ExpectRollback()
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.Error(t, err, "terminal status update should fail when infra cascade fails")
+	require.Contains(t, err.Error(), "infra cascade failed", "terminal status error should include infra cascade failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatus_TerminalCommitError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+
+	err = store.UpdatePreviewStatus(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "boom")
+	require.Error(t, err, "terminal status update should return commit errors")
+	require.Contains(t, err.Error(), "commit failed", "terminal status error should include commit failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_NonTerminal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		rows      int64
+		execErr   error
+		expected  bool
+		expectErr bool
+	}{
+		{name: "updates active preview", rows: 1, expected: true},
+		{name: "already terminal returns false", rows: 0, expected: false},
+		{name: "update error returns error", execErr: errors.New("db down"), expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should be created")
+			defer mock.Close()
+
+			store := NewPreviewStore(mock)
+
+			mock.ExpectExec("UPDATE preview_instances SET status").
+				WithArgs(previewAnyArgs(4)...).
+				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rows)).
+				WillReturnError(tt.execErr)
+
+			updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusReady, "")
+			if tt.expectErr {
+				require.Error(t, err, "conditional non-terminal update should return database errors")
+				require.False(t, updated, "conditional non-terminal update should not report updates on error")
+			} else {
+				require.NoError(t, err, "conditional non-terminal update should not error")
+				require.Equal(t, tt.expected, updated, "conditional non-terminal update should report whether the row changed")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalBeginError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin().WillReturnError(errors.New("begin failed"))
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.Error(t, err, "terminal conditional update should return begin errors")
+	require.False(t, updated, "terminal conditional update should not report updates on begin error")
+	require.Contains(t, err.Error(), "begin failed", "terminal conditional error should include begin failure")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -332,6 +488,81 @@ func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCascadesChildren(t *te
 	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
 	require.NoError(t, err, "terminal conditional status update should cascade children")
 	require.True(t, updated, "conditional terminal status update should report the row was changed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalUpdateError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnError(errors.New("update failed"))
+	mock.ExpectRollback()
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.Error(t, err, "terminal conditional update should return parent update errors")
+	require.False(t, updated, "terminal conditional update should not report updates when parent update fails")
+	require.Contains(t, err.Error(), "update failed", "terminal conditional error should include parent update failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCascadeError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnError(errors.New("service cascade failed"))
+	mock.ExpectRollback()
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.Error(t, err, "terminal conditional update should return cascade errors")
+	require.True(t, updated, "terminal conditional update should report parent row changed before cascade failed")
+	require.Contains(t, err.Error(), "service cascade failed", "terminal conditional error should include cascade failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_UpdatePreviewStatusIfActive_TerminalCommitError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectCommit().WillReturnError(errors.New("commit failed"))
+
+	updated, err := store.UpdatePreviewStatusIfActive(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusFailed, "")
+	require.Error(t, err, "terminal conditional update should return commit errors")
+	require.True(t, updated, "terminal conditional update should report parent row changed before commit failed")
+	require.Contains(t, err.Error(), "commit failed", "terminal conditional error should include commit failure")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
@@ -402,6 +633,42 @@ func TestPreviewStore_StopPreview(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestPreviewStore_StopPreview_CascadeError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
+		WithArgs(previewAnyArgs(3)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnError(errors.New("service cascade failed"))
+
+	err = store.StopPreview(context.Background(), uuid.New(), uuid.New())
+	require.Error(t, err, "stop preview should return cascade errors")
+	require.Contains(t, err.Error(), "service cascade failed", "stop preview error should include cascade failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPreviewStore_CascadeChildrenToTerminal_NonTerminalNoop(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+
+	err = store.cascadeChildrenToTerminal(context.Background(), uuid.New(), uuid.New(), models.PreviewStatusReady, "")
+	require.NoError(t, err, "non-terminal parent status should not cascade children")
+	require.NoError(t, mock.ExpectationsWereMet(), "no database statements should be executed")
 }
 
 func TestPreviewStore_CountActivePreviewsByOrg(t *testing.T) {

--- a/internal/services/preview/cleanup_test.go
+++ b/internal/services/preview/cleanup_test.go
@@ -117,6 +117,12 @@ func TestCleanupWorker_CleanupExpiredAndIdle(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -141,6 +147,12 @@ func TestCleanupWorker_CleanupExpiredAndIdle(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status.+stopped_at.+updated_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -1359,6 +1359,12 @@ func TestStopActivePreviewForSession_StopsActivePreview(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
@@ -1419,6 +1425,12 @@ func TestStopPreview_DestroysSandboxWhenTurnDoesNotHold(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
@@ -1481,6 +1493,12 @@ func TestStopPreview_LeavesSandboxWhenNewHolderAcquiredAfterRelease(t *testing.T
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
@@ -1541,6 +1559,12 @@ func TestStopPreview_LeavesSandboxWhenTurnStillHolds(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
@@ -1600,6 +1624,12 @@ func TestStopPreview_FinalizeErrorLeavesContainerForReconciler(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -1685,6 +1685,20 @@ func expectCreatePreviewInstance(mock pgxmock.PgxPoolIface, previewID, sessionID
 		)
 }
 
+func expectUpdatePreviewStatusFailed(mock pgxmock.PgxPoolIface) {
+	mock.ExpectBegin()
+	mock.ExpectExec("UPDATE preview_instances SET status").
+		WithArgs(previewAnyArgs(4)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(previewAnyArgs(5)...).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectCommit()
+}
+
 // previewAnyArgs matches the helper style in the db package tests.
 func previewAnyArgs(n int) []any {
 	args := make([]any, n)
@@ -1863,10 +1877,8 @@ func TestReservePreview_HoldErrorMarksFailed(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(fmt.Errorf("boom"))
 
-	// UpdatePreviewStatus failed.
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	// UpdatePreviewStatus(failed).
+	expectUpdatePreviewStatusFailed(mock)
 
 	_, err = mgr.ReservePreview(context.Background(), StartPreviewInput{
 		SessionID: sessionID,
@@ -2213,9 +2225,7 @@ func TestAbortReservation_ReleasesHoldAndDestroysHydratedContainer(t *testing.T)
 	}
 
 	// UpdatePreviewStatus(failed).
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 
 	// ReleasePreviewHold: destroyNow=true (container-1 and no turn).
 	mock.ExpectQuery(`WITH released AS`).
@@ -2266,9 +2276,7 @@ func TestAbortReservation_LeavesContainerWhenNotHydrated(t *testing.T) {
 		SessionID: uuid.New(),
 	}
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnRows(
@@ -2306,9 +2314,7 @@ func TestAbortReservation_LeavesContainerWhenSessionTracksDifferent(t *testing.T
 		SessionID: uuid.New(),
 	}
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	// Session reports a different container_id than the one we hydrated.
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
@@ -2346,9 +2352,7 @@ func TestAbortReservation_FinalizeNotClearedSkipsDestroy(t *testing.T) {
 		SessionID: uuid.New(),
 	}
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnRows(
@@ -2389,9 +2393,7 @@ func TestAbortReservation_FinalizeErrorSkipsDestroy(t *testing.T) {
 		SessionID: uuid.New(),
 	}
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnRows(
@@ -2431,9 +2433,7 @@ func TestAbortReservation_ReleaseHoldErrorLeavesContainer(t *testing.T) {
 		SessionID: uuid.New(),
 	}
 
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnError(fmt.Errorf("db down"))
@@ -2583,9 +2583,7 @@ func TestStartPreview_LaunchFailureAborts(t *testing.T) {
 		)
 
 	// AbortReservation: UpdatePreviewStatus(failed) + ReleasePreviewHold.
-	mock.ExpectExec("UPDATE preview_instances SET status").
-		WithArgs(previewAnyArgs(4)...).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	expectUpdatePreviewStatusFailed(mock)
 	mock.ExpectQuery(`WITH released AS`).
 		WithArgs(previewAnyArgs(2)...).
 		WillReturnRows(

--- a/internal/services/preview/worker_stopper_test.go
+++ b/internal/services/preview/worker_stopper_test.go
@@ -58,6 +58,12 @@ func TestWorkerStopper_StopPreview_LocalWorker(t *testing.T) {
 	mock.ExpectExec("UPDATE preview_instances SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+	mock.ExpectExec("UPDATE preview_infrastructure SET").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 	mock.ExpectExec("UPDATE preview_access_sessions SET revoked_at").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))

--- a/migrations/000104_cascade_orphan_preview_children.down.sql
+++ b/migrations/000104_cascade_orphan_preview_children.down.sql
@@ -1,0 +1,5 @@
+-- Cannot reliably restore the prior 'starting' / 'provisioning' / 'ready' /
+-- 'healthy' values: by definition the rows we touched belonged to terminal
+-- parents, so there is no signal to recover from. Leave the rows as the
+-- migration left them.
+SELECT 1;

--- a/migrations/000104_cascade_orphan_preview_children.up.sql
+++ b/migrations/000104_cascade_orphan_preview_children.up.sql
@@ -1,0 +1,51 @@
+-- Backfill orphaned preview_services / preview_infrastructure rows whose parent
+-- preview_instances row is already terminal. Without this, the frontend's
+-- startup checklist (which reads child statuses to drive spinner state) keeps
+-- spinning forever on previews where the parent flipped to stopped/failed/
+-- expired but the per-child rows were never updated — e.g. when a rolling
+-- deploy kills the API process between row reservation and the worker
+-- launch RPC.
+--
+-- Mapping:
+--   parent='failed'  -> still-trying children become 'failed' (carry the
+--                       parent error if their own error is empty), already-
+--                       ready/healthy children become 'stopped'.
+--   parent='stopped' / 'expired' -> all non-terminal children become 'stopped'.
+
+UPDATE preview_services ps
+SET
+    status = CASE
+        WHEN ps.status = 'starting' AND pi.status = 'failed' THEN 'failed'
+        WHEN ps.status = 'starting' THEN 'stopped'
+        WHEN ps.status = 'ready' THEN 'stopped'
+        ELSE ps.status
+    END,
+    error = CASE
+        WHEN ps.status = 'starting' AND pi.status = 'failed'
+             AND (ps.error IS NULL OR ps.error = '')
+        THEN pi.error
+        ELSE ps.error
+    END
+FROM preview_instances pi
+WHERE ps.preview_instance_id = pi.id
+  AND pi.status IN ('stopped', 'failed', 'expired')
+  AND ps.status NOT IN ('stopped', 'failed');
+
+UPDATE preview_infrastructure pinf
+SET
+    status = CASE
+        WHEN pinf.status IN ('provisioning', 'unhealthy') AND pi.status = 'failed' THEN 'failed'
+        WHEN pinf.status IN ('provisioning', 'unhealthy') THEN 'stopped'
+        WHEN pinf.status = 'healthy' THEN 'stopped'
+        ELSE pinf.status
+    END,
+    error = CASE
+        WHEN pinf.status IN ('provisioning', 'unhealthy') AND pi.status = 'failed'
+             AND (pinf.error IS NULL OR pinf.error = '')
+        THEN pi.error
+        ELSE pinf.error
+    END
+FROM preview_instances pi
+WHERE pinf.preview_instance_id = pi.id
+  AND pi.status IN ('stopped', 'failed', 'expired')
+  AND pinf.status NOT IN ('stopped', 'failed');


### PR DESCRIPTION
## Summary
- When a `preview_instances` row flips to a terminal status (stopped/failed/expired), also flip non-terminal `preview_services` and `preview_infrastructure` rows so the startup checklist UI reaches a terminal state instead of spinning forever on orphaned children — symptom seen when a rolling deploy killed the API between row reservation and the launch RPC.
- Adds a one-shot backfill migration (000104) for existing orphans, plus a defensive layer in the frontend `buildStartupChecklist` that treats child rows as terminal whenever the parent is terminal.
- Updates store/manager/handler/cleanup/worker-stopper test mocks to expect the new cascade SQL alongside the existing `preview_instances` and `preview_access_sessions` updates.

## Test plan
- [x] \`go test ./internal/...\` (db, preview, handlers, full internal suite)
- [x] \`make lint\` (lint-schema + lint-stores + golangci-lint v2)
- [x] \`npm run typecheck\` and \`npm run lint\` in \`frontend/\`
- [x] Migration dry-run against prod inside BEGIN/ROLLBACK: would update 9 service rows + 4 infra rows and leave zero orphans
- [ ] Start a preview from a session and confirm the startup checklist transitions cleanly on success and on a failed launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)