### PR TITLE
Fix /sessions/new model dropdown to include org Codex via coding-auths

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -69,6 +69,9 @@ const mocks = vi.hoisted(() => ({
       { provider: "pi", source: "personal" },
     ],
   }),
+  codingAuthsListMock: vi.fn().mockResolvedValue({
+    data: [],
+  }),
   codexAuthStatusMock: vi.fn().mockResolvedValue({ data: { status: "completed" } }),
   authMeMock: vi.fn().mockResolvedValue({
     data: {
@@ -103,6 +106,9 @@ vi.mock("@/lib/api", () => ({
     },
     userCredentials: {
       listResolved: mocks.resolvedCredsMock,
+    },
+    codingAuths: {
+      list: mocks.codingAuthsListMock,
     },
     codexAuth: {
       status: mocks.codexAuthStatusMock,
@@ -483,6 +489,52 @@ describe("ManualSessionCreatePageContent", () => {
     });
   });
 
+  it("shows org coding-auth models even when the user has no personal credentials", async () => {
+    const user = userEvent.setup();
+    mocks.settingsGetMock.mockResolvedValueOnce({
+      data: {
+        name: "Test Org",
+        settings: {
+          default_agent_type: "codex",
+        },
+      },
+    });
+    mocks.resolvedCredsMock.mockResolvedValueOnce({
+      data: [
+        { provider: "openai", source: "none" },
+        { provider: "anthropic", source: "none" },
+        { provider: "gemini", source: "none" },
+        { provider: "amp", source: "none" },
+        { provider: "pi", source: "none" },
+      ],
+    });
+    mocks.codexAuthStatusMock.mockResolvedValueOnce({ data: { status: "pending" } });
+    mocks.codingAuthsListMock.mockResolvedValueOnce({
+      data: [
+        {
+          id: "auth-1",
+          org_id: "org-1",
+          priority: 1,
+          agent: "codex",
+          auth_type: "api_key",
+          label: "Org Codex",
+          scope: "organization",
+          provider: "openai",
+          status: "healthy",
+          is_default: true,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    await user.click(await screen.findByRole("combobox", { name: /Model/i }));
+
+    expect(screen.getByRole("option", { name: "gpt-5.4" })).toBeInTheDocument();
+  });
+
   describe("draft persistence", () => {
     it("restores a stored prompt on mount", async () => {
       window.sessionStorage.setItem(
@@ -526,6 +578,89 @@ describe("ManualSessionCreatePageContent", () => {
           __v: 2,
           message: "draft in progress",
         });
+      });
+    });
+
+    it("does not clear a restored model that is available only through org coding auths", async () => {
+      type CodingAuthListResponse = {
+        data: Array<{
+          id: string;
+          org_id: string;
+          priority: number;
+          agent: string;
+          auth_type: string;
+          label: string;
+          scope: string;
+          provider: string;
+          status: string;
+          is_default: boolean;
+          created_at: string;
+          updated_at: string;
+        }>;
+      };
+      let resolveCodingAuths: ((value: CodingAuthListResponse) => void) | undefined;
+      mocks.resolvedCredsMock.mockResolvedValueOnce({
+        data: [
+          { provider: "openai", source: "none" },
+          { provider: "anthropic", source: "none" },
+          { provider: "gemini", source: "none" },
+          { provider: "amp", source: "none" },
+          { provider: "pi", source: "none" },
+        ],
+      });
+      mocks.codexAuthStatusMock.mockResolvedValueOnce({ data: { status: "pending" } });
+      mocks.codingAuthsListMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveCodingAuths = resolve;
+          }),
+      );
+      window.sessionStorage.setItem(
+        DRAFT_STORAGE_KEY,
+        JSON.stringify({
+          __v: 2,
+          message: "Restore my draft",
+          attachments: [],
+          references: [],
+          commands: [],
+          selectedModel: "gpt-5.4",
+          userSelectedRepoId: null,
+          branchByRepoId: {},
+          showImageInput: false,
+          imageURL: "",
+        }),
+      );
+
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const modelSelect = await screen.findByRole("combobox", { name: /Model/i });
+      await waitFor(() => {
+        expect(mocks.resolvedCredsMock).toHaveBeenCalledTimes(1);
+        expect(mocks.codexAuthStatusMock).toHaveBeenCalledTimes(1);
+      });
+
+      expect(resolveCodingAuths).toBeDefined();
+      resolveCodingAuths!({
+        data: [
+          {
+            id: "auth-1",
+            org_id: "org-1",
+            priority: 1,
+            agent: "codex",
+            auth_type: "api_key",
+            label: "Org Codex",
+            scope: "organization",
+            provider: "openai",
+            status: "healthy",
+            is_default: true,
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      await waitFor(() => {
+        expect(modelSelect).toHaveTextContent("gpt-5.4");
       });
     });
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -46,7 +46,7 @@ import { cn } from "@/lib/utils";
 import {
   AGENTS,
   agentTypeForModel,
-  isAgentConnected,
+  isAgentAvailable,
 } from "@/lib/agents";
 import { NoReposWarning } from "@/components/no-repos-warning";
 import { AgentKeyRequiredBanner } from "@/components/agent-key-required-banner";
@@ -62,7 +62,7 @@ import {
   supportsReasoningEffort,
   toCodingAgentReasoningEffort,
 } from "@/lib/coding-agent-reasoning";
-import type { OrgSettings, Organization, Repository, SingleResponse, ListResponse, ResolvedCredential, SessionInputCommand, SessionInputReference } from "@/lib/types";
+import type { CodingAuth, OrgSettings, Organization, Repository, SingleResponse, ListResponse, ResolvedCredential, SessionInputCommand, SessionInputReference } from "@/lib/types";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const triggerPickerIconClassName = "h-4 w-4 shrink-0";
@@ -281,6 +281,10 @@ export function ManualSessionCreatePageContent() {
     queryKey: queryKeys.codexAuth.status,
     queryFn: () => api.codexAuth.status(),
   });
+  const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
+    queryKey: ["coding-auths"],
+    queryFn: () => api.codingAuths.list(),
+  });
 
   // Auto-select: user's choice > last used repo > first repo.
   const selectedRepoId = useMemo(() => {
@@ -331,30 +335,31 @@ export function ManualSessionCreatePageContent() {
   };
 
   const codexAuthStatus = codexAuthResponse?.data;
+  const codingAuths = useMemo(() => codingAuthsResponse?.data ?? [], [codingAuthsResponse]);
   const modelGroups = useMemo(() => {
-    // Only show agents whose integrations are configured, so the picker matches
-    // what the user can actually run — same gating as AgentKeyRequiredBanner.
-    const integratedAgents = AGENTS.filter((agent) =>
-      isAgentConnected(agent.key, resolvedCredentials, codexAuthStatus),
+    // Show agents available from either the user-resolved credential path or
+    // the org coding-auth stack so the picker reflects both scopes.
+    const availableAgents = AGENTS.filter((agent) =>
+      isAgentAvailable(agent.key, resolvedCredentials, codexAuthStatus, codingAuths),
     );
     // Sort so the default agent type appears first, preserve original order otherwise.
-    return [...integratedAgents].sort((a, b) => {
+    return [...availableAgents].sort((a, b) => {
       if (a.key === defaultAgentType) return -1;
       if (b.key === defaultAgentType) return 1;
       return AGENTS.indexOf(a) - AGENTS.indexOf(b);
     });
-  }, [defaultAgentType, resolvedCredentials, codexAuthStatus]);
+  }, [codingAuths, defaultAgentType, resolvedCredentials, codexAuthStatus]);
 
   // Drop a previously selected model (from React state or restored draft) when
   // its agent is no longer integrated — keeps the picker value consistent with
-  // what's renderable. Only act once both credential queries have resolved so
+  // what's renderable. Only act once all availability queries have resolved so
   // a transient loading state doesn't nuke a valid choice.
   useEffect(() => {
-    if (!resolvedCredsResponse || !codexAuthResponse) return;
+    if (!resolvedCredsResponse || !codexAuthResponse || !codingAuthsResponse) return;
     if (!selectedModel) return;
     const stillAvailable = modelGroups.some((g) => g.models.includes(selectedModel));
     if (!stillAvailable) setSelectedModel("");
-  }, [modelGroups, selectedModel, resolvedCredsResponse, codexAuthResponse]);
+  }, [modelGroups, selectedModel, resolvedCredsResponse, codexAuthResponse, codingAuthsResponse]);
 
   // Determine which agent type would be used and whether credentials exist.
   const effectiveAgentType: string = selectedModel ? agentTypeForModel(selectedModel) ?? defaultAgentType : defaultAgentType;
@@ -364,7 +369,7 @@ export function ManualSessionCreatePageContent() {
   const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
   const submittedReasoningEffort = showReasoningSelector ? effectiveReasoningEffort : "";
   const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
-  const hasAgentCredentials = isAgentConnected(effectiveAgentType, resolvedCredentials, codexAuthStatus);
+  const hasAgentCredentials = isAgentAvailable(effectiveAgentType, resolvedCredentials, codexAuthStatus, codingAuths);
 
   const slashCommandsQuery = useSessionComposerSlashCommands({
     agentType: effectiveAgentType,

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -10,7 +10,7 @@ import {
   AVAILABLE_GEMINI_CLI_MODELS,
   AVAILABLE_PI_MODELS,
 } from "@/lib/model-constants";
-import type { CodexAuthStatus, ResolvedCredential } from "@/lib/types";
+import type { CodexAuthStatus, CodingAuth, ResolvedCredential } from "@/lib/types";
 
 export interface AgentEnvVar {
   name: string;
@@ -156,5 +156,21 @@ export function isAgentConnected(
   if (!agent) return false;
   return resolvedCredentials.some(
     (c) => c.provider === agent.providerKey && c.source !== "none",
+  );
+}
+
+function codingAuthStatusAllowsSelection(status: CodingAuth["status"]): boolean {
+  return status === "healthy" || status === "never_verified" || status === "rate_limited";
+}
+
+export function isAgentAvailable(
+  agentType: string,
+  resolvedCredentials: readonly ResolvedCredential[],
+  codexAuthStatus?: CodexAuthStatus | null,
+  codingAuths: readonly CodingAuth[] = [],
+): boolean {
+  if (isAgentConnected(agentType, resolvedCredentials, codexAuthStatus)) return true;
+  return codingAuths.some(
+    (row) => row.agent === agentType && codingAuthStatusAllowsSelection(row.status),
   );
 }


### PR DESCRIPTION
## Summary
Updated the `/sessions/new` manual session composer so the Model dropdown reflects models available through the user’s organization Coding-Auths, even when the user has no personal credentials. Added regression coverage to prevent this composer path from drifting.

## Changes
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx**
  - Updated model option composition to union in **org coding-auth** availability (not just personal credentials) when building the Model dropdown.
  - Ensured composer state handling keeps a restored/selected model if it’s available only via org coding-auths.
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx**
  - Added test verifying org coding-auth models show when user personal credentials are empty.
  - Added regression test verifying restored drafts don’t clear models available only through org coding-auths.
  - Extended API mocks to include `codingAuths.list`.
- **frontend/src/lib/agents.ts**
  - Adjusted agent/model availability logic to properly support the org Coding-Auth + Codex scenario used by the composer.

## Test plan
- Ran the updated unit tests for `manual-session-create-page-content` (including the new draft-race regression cases) to confirm the dropdown options include “gpt-5.4” from org “Org Codex” coding-auths and that restored selections remain valid.

---
*Generated by [143.dev](https://143.dev) — [session 5d7682c4](https://app.143.dev/sessions/5d7682c4-80c0-42ea-93b6-8b0842c31dfb)*
