### PR TITLE
Add click-through and status-aware detail to automation runs list

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -2,16 +2,7 @@
 
 import { useMemo, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  RefreshCw,
-  Play,
-  Pause,
-  AlertTriangle,
-  CheckCircle2,
-  Clock,
-  Minus,
-  Loader2,
-} from "lucide-react";
+import { Play, Pause, Loader2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -29,9 +20,9 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { BranchPicker } from "@/components/branch-picker";
 import { api } from "@/lib/api";
-import { cn } from "@/lib/utils";
-import type { Automation, AutomationRun, AutomationRunStatus } from "@/lib/types";
+import type { Automation } from "@/lib/types";
 import { AutomationStatsCard } from "./automation-stats-card";
+import { RunsTab } from "./runs-tab";
 import {
   browserTimezone,
   formatRunAtWithTimezone,
@@ -48,133 +39,6 @@ const INTERVAL_UNITS = ["hours", "days", "weeks"] as const;
 type IntervalUnit = (typeof INTERVAL_UNITS)[number];
 const toIntervalUnit = (v: string, fallback: IntervalUnit): IntervalUnit =>
   (INTERVAL_UNITS as readonly string[]).includes(v) ? (v as IntervalUnit) : fallback;
-
-const runStatusConfig: Record<AutomationRunStatus, { icon: React.ComponentType<{ className?: string }>; label: string; color: string }> = {
-  pending: { icon: Clock, label: "Pending", color: "text-muted-foreground" },
-  running: { icon: RefreshCw, label: "Running", color: "text-blue-500" },
-  completed: { icon: CheckCircle2, label: "Completed", color: "text-green-500" },
-  completed_noop: { icon: Minus, label: "Not executed", color: "text-amber-600 dark:text-amber-500" },
-  failed: { icon: AlertTriangle, label: "Failed", color: "text-red-500" },
-  skipped: { icon: Minus, label: "Skipped", color: "text-muted-foreground" },
-};
-
-function RunCard({ run }: { run: AutomationRun }) {
-  const cfg = runStatusConfig[run.status] || runStatusConfig.pending;
-  const Icon = cfg.icon;
-  const isFailed = run.status === "failed";
-  const isNoop = run.status === "completed_noop";
-
-  return (
-    <div
-      className={cn(
-        "rounded-lg border p-4",
-        isFailed ? "border-red-200 bg-red-50/50 dark:border-red-900/30 dark:bg-red-950/20" :
-        isNoop ? "border-amber-200 bg-amber-50/50 dark:border-amber-900/30 dark:bg-amber-950/20" : "border-border bg-background"
-      )}
-    >
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <Icon className={cn("h-4 w-4", cfg.color)} />
-          <span className="text-sm font-medium">{cfg.label}</span>
-          <span className="text-xs text-muted-foreground">
-            {new Date(run.triggered_at).toLocaleString()}
-          </span>
-        </div>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          {run.triggered_by === "manual" && (
-            <span className="rounded-full bg-muted px-2 py-0.5 text-xs">Manual</span>
-          )}
-          {run.completed_at && (
-            <span>
-              {Math.round(
-                (new Date(run.completed_at).getTime() - new Date(run.triggered_at).getTime()) / 1000
-              )}s
-            </span>
-          )}
-        </div>
-      </div>
-      {run.result_summary && (
-        <p className="text-sm text-muted-foreground mt-1">{run.result_summary}</p>
-      )}
-    </div>
-  );
-}
-
-function RunsTab({ automationId }: { automationId: string }) {
-  // Pages are stored as a list of result pages so the polling refetch only
-  // replaces page 0 (latest runs) and any pages loaded via "Load more" persist
-  // across refetches. Using setState inside `select` would reset pagination on
-  // every poll tick.
-  const [extraPages, setExtraPages] = useState<AutomationRun[][]>([]);
-  const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>(undefined);
-
-  // Pause polling once the user paginates. If polling kept running while
-  // extra pages were loaded, any new run arriving at the top would shift the
-  // window and make the stored loadMoreCursor point into the middle of a
-  // now-different result set — producing skipped or duplicated runs on the
-  // next "Load more". Users who want fresh first-page runs can reload or
-  // re-navigate to the tab.
-  const isPaginated = extraPages.length > 0;
-
-  const { data, isLoading } = useQuery({
-    queryKey: ["automation-runs", automationId],
-    queryFn: () => api.automations.listRuns(automationId, { limit: 25 }),
-    refetchInterval: isPaginated ? false : 10000,
-  });
-
-  const firstPage = data?.data ?? [];
-  const firstPageCursor = data?.meta?.next_cursor || undefined;
-
-  // Before the user paginates, the cursor tracks the freshest first-page poll.
-  // Once extra pages exist, polling is disabled (see above) and the cursor
-  // comes from the most recent Load-more response.
-  const cursor = isPaginated ? loadMoreCursor : firstPageCursor;
-
-  const loadMoreMutation = useMutation({
-    mutationFn: () => api.automations.listRuns(automationId, { limit: 25, cursor }),
-    onSuccess: (res) => {
-      setExtraPages((prev) => [...prev, res.data ?? []]);
-      setLoadMoreCursor(res.meta?.next_cursor || undefined);
-    },
-  });
-
-  const allRuns = [firstPage, ...extraPages].flat();
-  const hasMore = !!cursor;
-
-  return (
-    <div className="space-y-3">
-      {isLoading && (
-        <div className="text-center py-8 text-sm text-muted-foreground">
-          Loading runs...
-        </div>
-      )}
-      {!isLoading && allRuns.length === 0 && (
-        <div className="text-center py-8 text-sm text-muted-foreground">
-          No runs yet. The first run will appear after the scheduled time.
-        </div>
-      )}
-      {allRuns.map((run) => (
-        <RunCard key={run.id} run={run} />
-      ))}
-      {loadMoreMutation.isError && (
-        <p className="text-center text-xs text-destructive">
-          Failed to load more runs. Please try again.
-        </p>
-      )}
-      {hasMore && (
-        <Button
-          variant="ghost"
-          size="sm"
-          className="w-full"
-          onClick={() => loadMoreMutation.mutate()}
-          disabled={loadMoreMutation.isPending}
-        >
-          {loadMoreMutation.isPending ? "Loading..." : "Load more"}
-        </Button>
-      )}
-    </div>
-  );
-}
 
 function SettingsTab({ automation }: { automation: Automation }) {
   const queryClient = useQueryClient();

--- a/frontend/src/app/(dashboard)/automations/[id]/run-card.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-card.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test/test-utils";
+
+import type { AutomationRun, AutomationRunStatus } from "@/lib/types";
+import { RunCard } from "./run-card";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: vi.fn() }),
+}));
+
+beforeEach(() => {
+  pushMock.mockClear();
+});
+
+function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
+  return {
+    id: "run-1",
+    automation_id: "auto-1",
+    triggered_at: "2026-04-30T00:00:00Z",
+    triggered_by: "schedule",
+    goal_snapshot: "g",
+    status: "completed" as AutomationRunStatus,
+    completed_at: "2026-04-30T00:00:30Z",
+    created_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:30Z",
+    ...overrides,
+  };
+}
+
+describe("RunCard click-through", () => {
+  it("navigates to /sessions/{id} when the card body is clicked", async () => {
+    const user = userEvent.setup();
+    const run = makeRun({
+      session: {
+        id: "sess-123",
+        title: "Refactor diff viewer",
+        status: "completed",
+        failure_retry_advised: false,
+        pr_creation_state: "succeeded",
+      },
+    });
+
+    renderWithProviders(<RunCard run={run} />);
+
+    // Click the card surface (not the inner action button) — the
+    // role="button" landing here is the whole-card affordance.
+    await user.click(screen.getByRole("button", { name: /open session for completed run/i }));
+
+    expect(pushMock).toHaveBeenCalledWith("/sessions/sess-123");
+  });
+
+  it("activates with Enter on the focused card", async () => {
+    const user = userEvent.setup();
+    const run = makeRun({
+      session: {
+        id: "sess-456",
+        status: "completed",
+        failure_retry_advised: false,
+        pr_creation_state: "idle",
+      },
+    });
+
+    renderWithProviders(<RunCard run={run} />);
+
+    const card = screen.getByRole("button", { name: /open session for completed run/i });
+    card.focus();
+    await user.keyboard("{Enter}");
+
+    expect(pushMock).toHaveBeenCalledWith("/sessions/sess-456");
+  });
+
+  it("Review PR link does not also fire whole-card navigation", async () => {
+    const user = userEvent.setup();
+    const run = makeRun({
+      session: {
+        id: "sess-789",
+        title: "Refactor",
+        status: "completed",
+        failure_retry_advised: false,
+        pr_creation_state: "succeeded",
+        pr: {
+          number: 1213,
+          url: "https://github.com/example/repo/pull/1213",
+          status: "open",
+          ci_status: "success",
+        },
+      },
+    });
+
+    renderWithProviders(<RunCard run={run} />);
+
+    const reviewLink = screen.getByRole("link", { name: /review pr/i });
+    expect(reviewLink).toHaveAttribute("href", "https://github.com/example/repo/pull/1213");
+    expect(reviewLink).toHaveAttribute("target", "_blank");
+    expect(reviewLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    await user.click(reviewLink);
+
+    // The card-level router.push should not fire — the click was
+    // handled by the anchor and stopPropagation prevents the wrapping
+    // div from also navigating.
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it("uses 'Reply to agent' as the CTA when the session is awaiting human guidance", () => {
+    const run = makeRun({
+      status: "failed",
+      session: {
+        id: "sess-help",
+        status: "needs_human_guidance",
+        failure_retry_advised: false,
+        pr_creation_state: "idle",
+      },
+    });
+
+    renderWithProviders(<RunCard run={run} />);
+
+    expect(screen.getByRole("button", { name: /reply to agent/i })).toBeInTheDocument();
+    // The headline copy should match the amber attention treatment, not
+    // the red "Failed" treatment — both the run.status (failed) and the
+    // session.status (needs_human_guidance) are present, and the linked
+    // session wins.
+    expect(screen.getByText(/needs your input/i)).toBeInTheDocument();
+  });
+
+  it("renders a non-interactive thin row for completed_noop without a session", () => {
+    const run = makeRun({ status: "completed_noop", completed_at: undefined });
+    renderWithProviders(<RunCard run={run} />);
+    // Quiet rows without a linked session should not be clickable —
+    // there's nowhere meaningful to navigate to.
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText(/no work needed/i)).toBeInTheDocument();
+  });
+
+  it("renders a non-interactive thin row for pending runs", () => {
+    const run = makeRun({ status: "pending", completed_at: undefined });
+    renderWithProviders(<RunCard run={run} />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(screen.getByText(/pending/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/[id]/run-card.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-card.tsx
@@ -17,7 +17,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import { cn, formatTimeAgo } from "@/lib/utils";
-import type { AutomationRun, AutomationRunStatus } from "@/lib/types";
+import type { AutomationRun, AutomationRunStatus, PRCreationState } from "@/lib/types";
 
 // "Quiet" runs — no work was needed (or the schedule fired while paused).
 // Treated as low-signal: rendered as thin dim rows individually and
@@ -70,11 +70,18 @@ interface RunCardProps {
 }
 
 export function RunCard({ run }: RunCardProps) {
+  // useRouter is hoisted here once and threaded down so the three nested
+  // components don't each re-subscribe to the router context.
+  const router = useRouter();
+  const navigateTo = (path: string) => router.push(path);
+
   const kind = classifyRun(run);
-  if (kind === "quiet") return <QuietRunRow run={run} />;
+  if (kind === "quiet") return <QuietRunRow run={run} navigateTo={navigateTo} />;
   if (kind === "pending") return <PendingRow run={run} />;
-  return <FullCard run={run} kind={kind} />;
+  return <FullCard run={run} kind={kind} navigateTo={navigateTo} />;
 }
+
+type Navigator = (path: string) => void;
 
 // ---------------------------------------------------------------------------
 // Full-card variants (running / completed / failed / needs_input)
@@ -83,12 +90,12 @@ export function RunCard({ run }: RunCardProps) {
 interface FullCardProps {
   run: AutomationRun;
   kind: FullCardKind;
+  navigateTo: Navigator;
 }
 
-function FullCard({ run, kind }: FullCardProps) {
-  const router = useRouter();
+function FullCard({ run, kind, navigateTo }: FullCardProps) {
   const sessionId = run.session?.id;
-  const navigate = sessionId ? () => router.push(`/sessions/${sessionId}`) : undefined;
+  const navigate = sessionId ? () => navigateTo(`/sessions/${sessionId}`) : undefined;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (!navigate) return;
@@ -125,7 +132,7 @@ function FullCard({ run, kind }: FullCardProps) {
         </div>
         <div className="flex shrink-0 items-center gap-2">
           <RowMeta run={run} kind={kind} />
-          <PrimaryAction run={run} kind={kind} />
+          <PrimaryAction run={run} kind={kind} navigateTo={navigateTo} />
           {navigate && (
             <ChevronRight
               aria-hidden
@@ -284,7 +291,11 @@ function primaryLine(run: AutomationRun, kind: FullCardKind): string | null {
 }
 
 function secondaryLine(run: AutomationRun, kind: FullCardKind): string | null {
-  if (kind === "failed") {
+  // Surface the agent's first suggested next step on both failure and
+  // needs-input rows — both states are blocked on the user, and the
+  // session's failure_next_steps is the same field powering the session
+  // page's guidance UI, so users see a consistent hint either place.
+  if (kind === "failed" || kind === "needs_input") {
     const next = run.session?.failure_next_steps?.[0];
     return next ? `Suggested next step: ${next}` : null;
   }
@@ -303,6 +314,7 @@ function secondaryLine(run: AutomationRun, kind: FullCardKind): string | null {
 function RowMeta({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
   const diff = run.session?.diff_stats;
   const pr = run.session?.pr;
+  const prState = run.session?.pr_creation_state;
   const hasDiff = diff && (diff.added > 0 || diff.removed > 0);
   const showInRow = kind === "completed_with_pr" || kind === "completed_no_pr";
   if (!showInRow) return null;
@@ -322,22 +334,71 @@ function RowMeta({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
           PR #{pr.number} · {pr.status}
         </Badge>
       ) : (
-        hasDiff && (
-          <Badge variant="outline" className="text-xs text-muted-foreground">
-            No PR yet
-          </Badge>
-        )
+        // No PR row joined — distinguish "in flight" (the worker is
+        // pushing a branch / opening the PR) from "PR creation failed"
+        // from the everyday "session done, user hasn't asked for a PR
+        // yet" case. All three conditions read off pr_creation_state,
+        // which is now a typed PRCreationState union so the branches
+        // are exhaustive.
+        <PRCreationPill prState={prState} hasDiff={!!hasDiff} />
       )}
     </div>
   );
+}
+
+function PRCreationPill({
+  prState,
+  hasDiff,
+}: {
+  prState: PRCreationState | undefined;
+  hasDiff: boolean;
+}) {
+  if (prState === "queued" || prState === "pushing") {
+    return (
+      <Badge
+        variant="outline"
+        className="gap-1 text-xs text-muted-foreground"
+        title="The worker is pushing the branch and opening a pull request."
+      >
+        <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
+        Creating PR…
+      </Badge>
+    );
+  }
+  if (prState === "failed") {
+    return (
+      <Badge
+        variant="outline"
+        className="border-red-500/40 text-xs text-red-700 dark:text-red-300"
+        title="PR creation failed. Open the session to retry."
+      >
+        PR creation failed
+      </Badge>
+    );
+  }
+  if (hasDiff) {
+    return (
+      <Badge variant="outline" className="text-xs text-muted-foreground">
+        No PR yet
+      </Badge>
+    );
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
 // Primary action button — varies by row state
 // ---------------------------------------------------------------------------
 
-function PrimaryAction({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
-  const router = useRouter();
+function PrimaryAction({
+  run,
+  kind,
+  navigateTo,
+}: {
+  run: AutomationRun;
+  kind: FullCardKind;
+  navigateTo: Navigator;
+}) {
   const sessionId = run.session?.id;
   // Stop card-level navigation from firing when the inner control handles
   // the click — otherwise the user lands on the session page after we
@@ -378,7 +439,7 @@ function PrimaryAction({ run, kind }: { run: AutomationRun; kind: FullCardKind }
       className="shrink-0"
       onClick={(e) => {
         stop(e);
-        router.push(`/sessions/${sessionId}`);
+        navigateTo(`/sessions/${sessionId}`);
       }}
       onKeyDown={stop}
     >
@@ -440,10 +501,15 @@ function PendingRow({ run }: { run: AutomationRun }) {
 // Quiet row — used both standalone and inside a quiet group
 // ---------------------------------------------------------------------------
 
-export function QuietRunRow({ run }: { run: AutomationRun }) {
-  const router = useRouter();
+export function QuietRunRow({
+  run,
+  navigateTo,
+}: {
+  run: AutomationRun;
+  navigateTo: Navigator;
+}) {
   const sessionId = run.session?.id;
-  const navigate = sessionId ? () => router.push(`/sessions/${sessionId}`) : undefined;
+  const navigate = sessionId ? () => navigateTo(`/sessions/${sessionId}`) : undefined;
   const headline = run.status === "skipped" ? "Skipped" : "No work needed";
   const summary = run.result_summary;
 

--- a/frontend/src/app/(dashboard)/automations/[id]/run-card.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-card.tsx
@@ -1,0 +1,479 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  CheckCircle2,
+  ChevronRight,
+  Loader2,
+  Minus,
+  MessageCircleWarning,
+  RefreshCw,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
+import { cn, formatTimeAgo } from "@/lib/utils";
+import type { AutomationRun, AutomationRunStatus } from "@/lib/types";
+
+// "Quiet" runs — no work was needed (or the schedule fired while paused).
+// Treated as low-signal: rendered as thin dim rows individually and
+// collapsed into a group when there are two or more in a row.
+export const QUIET_RUN_STATUSES: ReadonlyArray<AutomationRunStatus> = [
+  "completed_noop",
+  "skipped",
+];
+
+export function isQuietRun(run: AutomationRun): boolean {
+  return QUIET_RUN_STATUSES.includes(run.status);
+}
+
+// FullCardKind enumerates the variants that render as the rich row card
+// (header + body + meta + action). The dispatcher in RunCard handles the
+// other two row shapes — quiet and pending — separately, so the helpers
+// below never need to consider them.
+//
+// "needs_input" is a pseudo-status the dispatcher derives when the run
+// itself reports failed/completed but the linked session is actually
+// waiting on the user. The hook in internal/services/automations/hooks.go
+// maps needs_human_guidance → run failed, which is correct for accounting
+// but wrong for UX — those runs need an answer, not a retry.
+type FullCardKind =
+  | "running"
+  | "needs_input"
+  | "completed_with_pr"
+  | "completed_no_pr"
+  | "failed";
+
+type RowKind = FullCardKind | "pending" | "quiet";
+
+function classifyRun(run: AutomationRun): RowKind {
+  if (run.status === "running") return "running";
+  if (run.status === "pending") return "pending";
+  if (run.status === "failed") {
+    if (run.session?.status === "needs_human_guidance") return "needs_input";
+    return "failed";
+  }
+  if (run.status === "completed") {
+    if (run.session?.status === "needs_human_guidance") return "needs_input";
+    if (run.session?.pr) return "completed_with_pr";
+    return "completed_no_pr";
+  }
+  return "quiet";
+}
+
+interface RunCardProps {
+  run: AutomationRun;
+}
+
+export function RunCard({ run }: RunCardProps) {
+  const kind = classifyRun(run);
+  if (kind === "quiet") return <QuietRunRow run={run} />;
+  if (kind === "pending") return <PendingRow run={run} />;
+  return <FullCard run={run} kind={kind} />;
+}
+
+// ---------------------------------------------------------------------------
+// Full-card variants (running / completed / failed / needs_input)
+// ---------------------------------------------------------------------------
+
+interface FullCardProps {
+  run: AutomationRun;
+  kind: FullCardKind;
+}
+
+function FullCard({ run, kind }: FullCardProps) {
+  const router = useRouter();
+  const sessionId = run.session?.id;
+  const navigate = sessionId ? () => router.push(`/sessions/${sessionId}`) : undefined;
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!navigate) return;
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      navigate();
+    }
+  };
+
+  // Use the user-facing label (e.g. "Completed", "Failed", "Needs your
+  // input") rather than the internal kind string — screen readers
+  // shouldn't be reading "completed with pr" out loud.
+  const ariaLabel = navigate
+    ? `Open session for ${headlineFor(kind).label.toLowerCase()} run from ${formatTimeAgo(run.triggered_at)}`
+    : undefined;
+
+  return (
+    <div
+      role={navigate ? "button" : undefined}
+      tabIndex={navigate ? 0 : undefined}
+      aria-label={ariaLabel}
+      onClick={navigate}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "group relative rounded-lg border p-4 transition-colors",
+        navigate && "cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        cardSurfaceClass(kind),
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <Header run={run} kind={kind} />
+          <Body run={run} kind={kind} />
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <RowMeta run={run} kind={kind} />
+          <PrimaryAction run={run} kind={kind} />
+          {navigate && (
+            <ChevronRight
+              aria-hidden
+              className="hidden h-4 w-4 text-muted-foreground/60 transition-opacity opacity-0 group-hover:opacity-100 sm:block"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function cardSurfaceClass(kind: FullCardKind): string {
+  switch (kind) {
+    case "failed":
+      return "border-red-200 bg-red-50/40 dark:border-red-900/30 dark:bg-red-950/20";
+    case "needs_input":
+      return "border-amber-300/70 bg-amber-50/50 dark:border-amber-900/40 dark:bg-amber-950/20";
+    case "running":
+      return "border-blue-200/70 bg-blue-50/30 dark:border-blue-900/30 dark:bg-blue-950/20";
+    default:
+      return "border-border bg-background";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Header (icon + label + timestamp + optional category badge)
+// ---------------------------------------------------------------------------
+
+function Header({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
+  const headline = headlineFor(kind);
+  const Icon = headline.icon;
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <Icon
+        aria-hidden
+        className={cn("h-4 w-4 shrink-0", headline.iconClass, kind === "running" && "animate-spin")}
+      />
+      <span className={cn("text-sm font-medium", headline.labelClass)}>{headline.label}</span>
+      <span
+        className="text-xs text-muted-foreground"
+        title={new Date(run.triggered_at).toLocaleString()}
+      >
+        {formatTimeAgo(run.triggered_at)}
+      </span>
+      {kind === "running" && <LiveDuration startedAt={run.triggered_at} />}
+      {kind !== "running" && run.completed_at && (
+        <span className="text-xs text-muted-foreground">
+          · {formatDuration(run.triggered_at, run.completed_at)}
+        </span>
+      )}
+      {run.session?.failure_category && (kind === "failed" || kind === "needs_input") && (
+        <Badge
+          variant={kind === "failed" ? "destructive" : "outline"}
+          className={cn(
+            "text-xs uppercase tracking-wide",
+            kind === "needs_input" && "border-amber-500/40 text-amber-700 dark:text-amber-400",
+          )}
+        >
+          {run.session.failure_category.replaceAll("_", " ")}
+        </Badge>
+      )}
+      {run.triggered_by === "manual" && (
+        <Badge variant="outline" className="text-xs">
+          Manual
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+function headlineFor(kind: FullCardKind): {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  iconClass: string;
+  labelClass: string;
+} {
+  switch (kind) {
+    case "running":
+      return {
+        icon: RefreshCw,
+        label: "Running",
+        iconClass: "text-blue-500",
+        labelClass: "text-blue-700 dark:text-blue-300",
+      };
+    case "needs_input":
+      return {
+        icon: MessageCircleWarning,
+        label: "Needs your input",
+        iconClass: "text-amber-600 dark:text-amber-500",
+        labelClass: "text-amber-800 dark:text-amber-300",
+      };
+    case "completed_with_pr":
+    case "completed_no_pr":
+      return {
+        icon: CheckCircle2,
+        label: "Completed",
+        iconClass: "text-emerald-500",
+        labelClass: "text-emerald-700 dark:text-emerald-300",
+      };
+    case "failed":
+      return {
+        icon: AlertTriangle,
+        label: "Failed",
+        iconClass: "text-red-500",
+        labelClass: "text-red-700 dark:text-red-300",
+      };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Body (title + summary + suggested next step)
+// ---------------------------------------------------------------------------
+
+function Body({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
+  // The row's primary "what happened" line. Prefer session title when we
+  // have it, fall back to the run's result_summary, and finally to the
+  // session's failure_explanation for failed runs without a title.
+  const headline = primaryLine(run, kind);
+  const subline = secondaryLine(run, kind);
+  if (!headline && !subline) return null;
+  return (
+    <div className="space-y-0.5">
+      {headline && (
+        <p
+          className="line-clamp-2 text-sm text-foreground"
+          title={headline}
+        >
+          {headline}
+        </p>
+      )}
+      {subline && (
+        <p
+          className="line-clamp-2 text-xs text-muted-foreground"
+          title={subline}
+        >
+          {subline}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function primaryLine(run: AutomationRun, kind: FullCardKind): string | null {
+  if (kind === "needs_input") {
+    return run.session?.title || run.result_summary || "Agent paused, waiting for your guidance.";
+  }
+  if (kind === "failed") {
+    return run.session?.failure_explanation || run.result_summary || run.session?.title || "Run failed.";
+  }
+  if (kind === "running") {
+    return run.session?.title || "Working on it…";
+  }
+  // completed_with_pr | completed_no_pr
+  return run.session?.title || run.result_summary || null;
+}
+
+function secondaryLine(run: AutomationRun, kind: FullCardKind): string | null {
+  if (kind === "failed") {
+    const next = run.session?.failure_next_steps?.[0];
+    return next ? `Suggested next step: ${next}` : null;
+  }
+  if (kind === "completed_with_pr" || kind === "completed_no_pr") {
+    if (run.session?.title && run.result_summary && run.session.title !== run.result_summary) {
+      return run.result_summary;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Row meta (diff stats + PR pill) — sits next to the action button
+// ---------------------------------------------------------------------------
+
+function RowMeta({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
+  const diff = run.session?.diff_stats;
+  const pr = run.session?.pr;
+  const hasDiff = diff && (diff.added > 0 || diff.removed > 0);
+  const showInRow = kind === "completed_with_pr" || kind === "completed_no_pr";
+  if (!showInRow) return null;
+
+  return (
+    <div className="hidden items-center gap-2 sm:flex">
+      {hasDiff && <DiffStatsBadge added={diff.added} removed={diff.removed} />}
+      {pr ? (
+        <Badge
+          variant="outline"
+          className={cn(
+            "text-xs",
+            pr.status === "merged" && "border-purple-500/40 text-purple-700 dark:text-purple-300",
+            pr.status === "open" && "border-emerald-500/40 text-emerald-700 dark:text-emerald-300",
+          )}
+        >
+          PR #{pr.number} · {pr.status}
+        </Badge>
+      ) : (
+        hasDiff && (
+          <Badge variant="outline" className="text-xs text-muted-foreground">
+            No PR yet
+          </Badge>
+        )
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Primary action button — varies by row state
+// ---------------------------------------------------------------------------
+
+function PrimaryAction({ run, kind }: { run: AutomationRun; kind: FullCardKind }) {
+  const router = useRouter();
+  const sessionId = run.session?.id;
+  // Stop card-level navigation from firing when the inner control handles
+  // the click — otherwise the user lands on the session page after we
+  // already opened the PR in a new tab.
+  const stop = (e: React.MouseEvent | React.KeyboardEvent) => e.stopPropagation();
+
+  if (kind === "completed_with_pr" && run.session?.pr) {
+    // Real anchor (rather than window.open) so middle-click and "open in
+    // new tab" work as users expect, and popup blockers don't intercept
+    // the click. Button asChild gives us the same visual treatment.
+    return (
+      <Button asChild size="sm" variant="outline" className="shrink-0">
+        <a
+          href={run.session.pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={stop}
+          onKeyDown={stop}
+        >
+          Review PR
+          <ArrowUpRight className="ml-1.5 h-3.5 w-3.5" />
+        </a>
+      </Button>
+    );
+  }
+
+  if (!sessionId) return null;
+
+  let label = "Open session";
+  if (kind === "needs_input") label = "Reply to agent";
+  else if (kind === "running") label = "View live session";
+  else if (kind === "failed" && run.session?.failure_retry_advised) label = "Retry on session";
+
+  return (
+    <Button
+      size="sm"
+      variant={kind === "needs_input" ? "default" : "outline"}
+      className="shrink-0"
+      onClick={(e) => {
+        stop(e);
+        router.push(`/sessions/${sessionId}`);
+      }}
+      onKeyDown={stop}
+    >
+      {label}
+      <ChevronRight className="ml-1 h-3.5 w-3.5" />
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Live duration tick — only mounts while the run is running
+// ---------------------------------------------------------------------------
+
+function LiveDuration({ startedAt }: { startedAt: string }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  const elapsedMs = Math.max(0, now - new Date(startedAt).getTime());
+  return (
+    <span className="text-xs tabular-nums text-muted-foreground">
+      · {formatElapsed(elapsedMs)}
+    </span>
+  );
+}
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  if (totalSec < 60) return `${totalSec}s`;
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m < 60) return `${m}m ${s.toString().padStart(2, "0")}s`;
+  const h = Math.floor(m / 60);
+  const remM = m % 60;
+  return `${h}h ${remM.toString().padStart(2, "0")}m`;
+}
+
+function formatDuration(start: string, end: string): string {
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  if (!Number.isFinite(ms) || ms <= 0) return "<1s";
+  return formatElapsed(ms);
+}
+
+// ---------------------------------------------------------------------------
+// Pending — thin row, not clickable (no session yet)
+// ---------------------------------------------------------------------------
+
+function PendingRow({ run }: { run: AutomationRun }) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-dashed border-border/60 px-3 py-2 text-xs text-muted-foreground">
+      <Loader2 aria-hidden className="h-3.5 w-3.5 animate-spin" />
+      <span>Pending · queued {formatTimeAgo(run.triggered_at)}</span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quiet row — used both standalone and inside a quiet group
+// ---------------------------------------------------------------------------
+
+export function QuietRunRow({ run }: { run: AutomationRun }) {
+  const router = useRouter();
+  const sessionId = run.session?.id;
+  const navigate = sessionId ? () => router.push(`/sessions/${sessionId}`) : undefined;
+  const headline = run.status === "skipped" ? "Skipped" : "No work needed";
+  const summary = run.result_summary;
+
+  return (
+    <div
+      role={navigate ? "button" : undefined}
+      tabIndex={navigate ? 0 : undefined}
+      onClick={navigate}
+      onKeyDown={(e) => {
+        if (!navigate) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          navigate();
+        }
+      }}
+      className={cn(
+        "flex items-center gap-3 rounded-md border border-transparent px-3 py-1.5 text-xs text-muted-foreground transition-colors",
+        navigate && "cursor-pointer hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      )}
+    >
+      <Minus aria-hidden className="h-3.5 w-3.5 shrink-0" />
+      <span className="font-medium text-foreground/70">{headline}</span>
+      <span title={new Date(run.triggered_at).toLocaleString()}>
+        {formatTimeAgo(run.triggered_at)}
+      </span>
+      {summary && (
+        <span className="truncate" title={summary}>
+          · {summary}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/(dashboard)/automations/[id]/run-grouping.test.ts
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-grouping.test.ts
@@ -53,9 +53,11 @@ describe("groupRuns", () => {
     ];
     const groups = groupRuns(runs);
     expect(groups).toHaveLength(1);
+    // groupKey is the oldest run in the streak (last in DESC order) so
+    // the key stays stable as new runs land on top during polling.
     expect(groups[0]).toMatchObject({
       kind: "quiet",
-      firstId: "a",
+      groupKey: "c",
     });
     if (groups[0].kind === "quiet") {
       expect(groups[0].runs.map((r) => r.id)).toEqual(["a", "b", "c"]);
@@ -99,26 +101,24 @@ describe("groupRuns", () => {
     expect(groups).toHaveLength(1);
     if (groups[0].kind === "quiet") {
       expect(groups[0].runs).toHaveLength(4);
-      expect(groups[0].firstId).toBe("a");
+      expect(groups[0].groupKey).toBe("d");
     }
   });
 
-  it("uses the first run's id as the group key (stable across polling)", () => {
+  it("keys quiet groups by the oldest run id so the key is stable across polling", () => {
     const initial = [
       makeRun("a", "completed_noop"),
       makeRun("b", "completed_noop"),
     ];
-    const initialKey = (groupRuns(initial)[0] as { firstId: string }).firstId;
+    const initialKey = (groupRuns(initial)[0] as { groupKey: string }).groupKey;
 
     // Simulate a polling tick: a new quiet run lands on top, but the
-    // existing two stay. The firstId should now follow the new top run —
-    // the test guards against the contract change rather than asserting
-    // it stays equal: when the top changes, expanded state for the old
-    // group naturally retires, which is fine.
+    // existing two stay. The streak's oldest run is still "b", so the
+    // key — and therefore RunsTab's user-collapse state — survives.
     const after = [makeRun("z", "completed_noop"), ...initial];
-    const afterKey = (groupRuns(after)[0] as { firstId: string }).firstId;
-    expect(initialKey).toBe("a");
-    expect(afterKey).toBe("z");
+    const afterKey = (groupRuns(after)[0] as { groupKey: string }).groupKey;
+    expect(initialKey).toBe("b");
+    expect(afterKey).toBe("b");
   });
 
   it("preserves run order inside a quiet group", () => {

--- a/frontend/src/app/(dashboard)/automations/[id]/run-grouping.test.ts
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-grouping.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import type { AutomationRun, AutomationRunStatus } from "@/lib/types";
+
+import { groupRuns, isQuietStatus } from "./run-grouping";
+
+function makeRun(id: string, status: AutomationRunStatus): AutomationRun {
+  return {
+    id,
+    automation_id: "auto-1",
+    triggered_at: "2026-04-30T00:00:00Z",
+    triggered_by: "schedule",
+    goal_snapshot: "g",
+    status,
+    created_at: "2026-04-30T00:00:00Z",
+    updated_at: "2026-04-30T00:00:00Z",
+  };
+}
+
+describe("isQuietStatus", () => {
+  it.each<AutomationRunStatus>(["completed_noop", "skipped"])("classifies %s as quiet", (status) => {
+    expect(isQuietStatus(status)).toBe(true);
+  });
+
+  it.each<AutomationRunStatus>(["completed", "failed", "running", "pending"])(
+    "classifies %s as loud",
+    (status) => {
+      expect(isQuietStatus(status)).toBe(false);
+    },
+  );
+});
+
+describe("groupRuns", () => {
+  it("returns an empty list for no runs", () => {
+    expect(groupRuns([])).toEqual([]);
+  });
+
+  it("renders all-loud runs as singles", () => {
+    const runs = [
+      makeRun("a", "completed"),
+      makeRun("b", "failed"),
+      makeRun("c", "running"),
+    ];
+    const groups = groupRuns(runs);
+    expect(groups.map((g) => g.kind)).toEqual(["single", "single", "single"]);
+  });
+
+  it("groups ≥2 consecutive quiet runs into one quiet group", () => {
+    const runs = [
+      makeRun("a", "completed_noop"),
+      makeRun("b", "skipped"),
+      makeRun("c", "completed_noop"),
+    ];
+    const groups = groupRuns(runs);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      kind: "quiet",
+      firstId: "a",
+    });
+    if (groups[0].kind === "quiet") {
+      expect(groups[0].runs.map((r) => r.id)).toEqual(["a", "b", "c"]);
+    }
+  });
+
+  it("renders a lone quiet run as a single (never a group of one)", () => {
+    const runs = [
+      makeRun("a", "completed"),
+      makeRun("b", "completed_noop"),
+      makeRun("c", "completed"),
+    ];
+    const groups = groupRuns(runs);
+    expect(groups.map((g) => g.kind)).toEqual(["single", "single", "single"]);
+    expect(groups[1]).toMatchObject({ kind: "single", run: { id: "b" } });
+  });
+
+  it("collapses consecutive quiet runs but lets loud runs split groups", () => {
+    const runs = [
+      makeRun("a", "completed_noop"),
+      makeRun("b", "completed_noop"),
+      makeRun("c", "failed"),
+      makeRun("d", "skipped"),
+      makeRun("e", "skipped"),
+      makeRun("f", "completed"),
+    ];
+    const groups = groupRuns(runs);
+    expect(groups.map((g) => g.kind)).toEqual(["quiet", "single", "quiet", "single"]);
+    if (groups[0].kind === "quiet") expect(groups[0].runs.map((r) => r.id)).toEqual(["a", "b"]);
+    if (groups[2].kind === "quiet") expect(groups[2].runs.map((r) => r.id)).toEqual(["d", "e"]);
+  });
+
+  it("groups all-quiet input into a single block", () => {
+    const runs = [
+      makeRun("a", "completed_noop"),
+      makeRun("b", "skipped"),
+      makeRun("c", "completed_noop"),
+      makeRun("d", "completed_noop"),
+    ];
+    const groups = groupRuns(runs);
+    expect(groups).toHaveLength(1);
+    if (groups[0].kind === "quiet") {
+      expect(groups[0].runs).toHaveLength(4);
+      expect(groups[0].firstId).toBe("a");
+    }
+  });
+
+  it("uses the first run's id as the group key (stable across polling)", () => {
+    const initial = [
+      makeRun("a", "completed_noop"),
+      makeRun("b", "completed_noop"),
+    ];
+    const initialKey = (groupRuns(initial)[0] as { firstId: string }).firstId;
+
+    // Simulate a polling tick: a new quiet run lands on top, but the
+    // existing two stay. The firstId should now follow the new top run —
+    // the test guards against the contract change rather than asserting
+    // it stays equal: when the top changes, expanded state for the old
+    // group naturally retires, which is fine.
+    const after = [makeRun("z", "completed_noop"), ...initial];
+    const afterKey = (groupRuns(after)[0] as { firstId: string }).firstId;
+    expect(initialKey).toBe("a");
+    expect(afterKey).toBe("z");
+  });
+
+  it("preserves run order inside a quiet group", () => {
+    const runs = [
+      makeRun("first", "completed_noop"),
+      makeRun("second", "skipped"),
+      makeRun("third", "completed_noop"),
+    ];
+    const groups = groupRuns(runs);
+    if (groups[0].kind === "quiet") {
+      expect(groups[0].runs.map((r) => r.id)).toEqual(["first", "second", "third"]);
+    }
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/[id]/run-grouping.ts
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-grouping.ts
@@ -1,0 +1,54 @@
+import type { AutomationRun, AutomationRunStatus } from "@/lib/types";
+
+// Mirror of QUIET_RUN_STATUSES in run-card.tsx, kept here too so the
+// grouping helpers stay independent of the React component module (the
+// unit test imports just this file).
+const QUIET_STATUSES: ReadonlyArray<AutomationRunStatus> = ["completed_noop", "skipped"];
+
+export function isQuietStatus(status: AutomationRunStatus): boolean {
+  return QUIET_STATUSES.includes(status);
+}
+
+export type RunGroup =
+  | { kind: "single"; run: AutomationRun }
+  | { kind: "quiet"; runs: AutomationRun[]; firstId: string };
+
+// Collapse runs of consecutive quiet statuses into a single group.
+//
+// Rules (matched 1:1 in the UX spec):
+// - ≥2 consecutive quiet runs → one "quiet" group rendered as a thin
+//   collapsible bar with "N quiet runs" headline.
+// - A lone quiet run (sandwiched between two non-quiet ones, or at the
+//   ends of the list) renders as its own thin row (kind: "single") so we
+//   never show a group of one.
+// - Order is preserved — the input is expected DESC by triggered_at and
+//   the groups carry that ordering through.
+//
+// The function is intentionally pure / order-only so the same `firstId`
+// keys stay stable across polling refetches as long as the first run in a
+// quiet streak hasn't fallen off the page; that lets RunsTab persist
+// "expanded" state across polls without flicker.
+export function groupRuns(runs: AutomationRun[]): RunGroup[] {
+  const out: RunGroup[] = [];
+  let buf: AutomationRun[] = [];
+
+  const flushQuiet = () => {
+    if (buf.length >= 2) {
+      out.push({ kind: "quiet", runs: buf, firstId: buf[0].id });
+    } else if (buf.length === 1) {
+      out.push({ kind: "single", run: buf[0] });
+    }
+    buf = [];
+  };
+
+  for (const run of runs) {
+    if (isQuietStatus(run.status)) {
+      buf.push(run);
+    } else {
+      flushQuiet();
+      out.push({ kind: "single", run });
+    }
+  }
+  flushQuiet();
+  return out;
+}

--- a/frontend/src/app/(dashboard)/automations/[id]/run-grouping.ts
+++ b/frontend/src/app/(dashboard)/automations/[id]/run-grouping.ts
@@ -11,7 +11,7 @@ export function isQuietStatus(status: AutomationRunStatus): boolean {
 
 export type RunGroup =
   | { kind: "single"; run: AutomationRun }
-  | { kind: "quiet"; runs: AutomationRun[]; firstId: string };
+  | { kind: "quiet"; runs: AutomationRun[]; groupKey: string };
 
 // Collapse runs of consecutive quiet statuses into a single group.
 //
@@ -24,17 +24,18 @@ export type RunGroup =
 // - Order is preserved — the input is expected DESC by triggered_at and
 //   the groups carry that ordering through.
 //
-// The function is intentionally pure / order-only so the same `firstId`
-// keys stay stable across polling refetches as long as the first run in a
-// quiet streak hasn't fallen off the page; that lets RunsTab persist
-// "expanded" state across polls without flicker.
+// Group keying uses the *oldest* run in the streak (the last element,
+// since DESC ordering puts the oldest at the end). New quiet runs landing
+// on top of an existing streak grow the streak without changing its key,
+// so RunsTab's user-collapse state survives polling refetches. The key
+// only changes once the oldest run scrolls off the visible page entirely.
 export function groupRuns(runs: AutomationRun[]): RunGroup[] {
   const out: RunGroup[] = [];
   let buf: AutomationRun[] = [];
 
   const flushQuiet = () => {
     if (buf.length >= 2) {
-      out.push({ kind: "quiet", runs: buf, firstId: buf[0].id });
+      out.push({ kind: "quiet", runs: buf, groupKey: buf[buf.length - 1].id });
     } else if (buf.length === 1) {
       out.push({ kind: "single", run: buf[0] });
     }

--- a/frontend/src/app/(dashboard)/automations/[id]/runs-tab.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/runs-tab.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+
+import { RunsTab } from "./runs-tab";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+function makeQuietRun(id: string, hoursAgo: number) {
+  const t = new Date(Date.UTC(2026, 3, 30, 12 - hoursAgo, 0, 0)).toISOString();
+  return {
+    id,
+    automation_id: "auto-1",
+    triggered_at: t,
+    triggered_by: "schedule" as const,
+    goal_snapshot: "g",
+    status: "completed_noop" as const,
+    completed_at: t,
+    result_summary: "Repo had no new commits since last run.",
+    created_at: t,
+    updated_at: t,
+  };
+}
+
+describe("RunsTab quiet-group auto-expand", () => {
+  it("auto-expands the topmost quiet group when the entire visible list is quiet", async () => {
+    const runs = [
+      makeQuietRun("run-1", 1),
+      makeQuietRun("run-2", 2),
+      makeQuietRun("run-3", 3),
+    ];
+    server.use(
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: runs, meta: {} }),
+      ),
+    );
+
+    renderWithProviders(<RunsTab automationId="auto-1" />);
+
+    // The collapsible bar shows "3 quiet runs · last one …".
+    await screen.findByText(/3 quiet runs/i);
+
+    // When all-quiet, the topmost group should default to expanded so
+    // the page doesn't read as empty — each individual run is rendered.
+    await waitFor(() => {
+      expect(screen.getAllByText(/no work needed/i).length).toBeGreaterThanOrEqual(3);
+    });
+
+    // The toggle reflects the open state.
+    const toggle = screen.getByRole("button", { name: /3 quiet runs/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("respects user-driven collapse and keeps the group closed thereafter", async () => {
+    const user = userEvent.setup();
+    const runs = [makeQuietRun("a", 1), makeQuietRun("b", 2)];
+    server.use(
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: runs, meta: {} }),
+      ),
+    );
+
+    renderWithProviders(<RunsTab automationId="auto-1" />);
+
+    const toggle = await screen.findByRole("button", { name: /2 quiet runs/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Re-clicking toggles back open. The key behaviour we care about is
+    // that the user's explicit choice overrides the all-quiet
+    // auto-expand default — verified by the collapse working at all.
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("does not auto-expand when at least one loud run is in the page", async () => {
+    const t = "2026-04-30T12:00:00Z";
+    const loud = {
+      id: "loud-1",
+      automation_id: "auto-1",
+      triggered_at: t,
+      triggered_by: "schedule" as const,
+      goal_snapshot: "g",
+      status: "completed" as const,
+      completed_at: t,
+      created_at: t,
+      updated_at: t,
+      result_summary: "Made changes",
+      session: {
+        id: "sess-loud",
+        status: "completed",
+        failure_retry_advised: false,
+        pr_creation_state: "idle" as const,
+      },
+    };
+    const runs = [loud, makeQuietRun("q1", 1), makeQuietRun("q2", 2)];
+    server.use(
+      http.get("*/api/v1/automations/auto-1/runs*", () =>
+        HttpResponse.json({ data: runs, meta: {} }),
+      ),
+    );
+
+    renderWithProviders(<RunsTab automationId="auto-1" />);
+
+    const toggle = await screen.findByRole("button", { name: /2 quiet runs/i });
+    // Mixed page → quiet group stays collapsed by default so the loud
+    // run sits at the top of the page unobstructed.
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/[id]/runs-tab.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/runs-tab.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { ChevronRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -27,12 +28,11 @@ export function RunsTab({ automationId }: { automationId: string }) {
   // pagination on every poll tick.
   const [extraPages, setExtraPages] = useState<AutomationRun[][]>([]);
   const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>(undefined);
-  // Tracks user-driven toggle state for quiet groups, keyed by firstId.
-  // We deliberately store explicit (id → open) instead of "set of open
-  // ids" so we can distinguish "user hasn't touched this group" from
-  // "user collapsed it" and let the auto-expand fall-through only apply
-  // to the former. This avoids needing a setState-in-effect for the
-  // all-quiet auto-expand rule.
+  // Tracks user-driven toggle state for quiet groups, keyed by groupKey
+  // (the streak's oldest run id, stable across polling). We deliberately
+  // store explicit (key → open) instead of "set of open keys" so we can
+  // distinguish "user hasn't touched this group" from "user collapsed it"
+  // and let the auto-expand fall-through only apply to the former.
   const [userToggles, setUserToggles] = useState<Record<string, boolean>>({});
 
   // Pause polling once the user paginates. If polling kept running while
@@ -55,7 +55,12 @@ export function RunsTab({ automationId }: { automationId: string }) {
   const loadMoreMutation = useMutation({
     mutationFn: () => api.automations.listRuns(automationId, { limit: PAGE_SIZE, cursor }),
     onSuccess: (res) => {
-      setExtraPages((prev) => [...prev, res.data ?? []]);
+      // Skip empty pages so a "Load more" near the end of history doesn't
+      // permanently pause polling — extraPages.length stays 0 if the
+      // server returned no rows, and the standard 10s refetch resumes.
+      if (res.data && res.data.length > 0) {
+        setExtraPages((prev) => [...prev, res.data]);
+      }
       setLoadMoreCursor(res.meta?.next_cursor || undefined);
     },
   });
@@ -73,23 +78,26 @@ export function RunsTab({ automationId }: { automationId: string }) {
   // during render — no effect, no setState — so polling refetches don't
   // need to re-run it. Once the user clicks any group's toggle we honor
   // their explicit choice via userToggles.
-  const autoExpandedFirstId = useMemo(() => {
+  const autoExpandedKey = useMemo(() => {
     if (groups.length === 0) return null;
     const onlyQuiet = groups.every((g) => g.kind === "quiet");
     if (!onlyQuiet) return null;
     const topQuiet = groups.find(
       (g): g is Extract<RunGroup, { kind: "quiet" }> => g.kind === "quiet",
     );
-    return topQuiet?.firstId ?? null;
+    return topQuiet?.groupKey ?? null;
   }, [groups]);
 
-  const isGroupOpen = (firstId: string): boolean => {
-    if (firstId in userToggles) return userToggles[firstId];
-    return firstId === autoExpandedFirstId;
+  const isGroupOpen = (groupKey: string): boolean => {
+    if (groupKey in userToggles) return userToggles[groupKey];
+    return groupKey === autoExpandedKey;
   };
-  const setGroupOpen = (firstId: string, open: boolean) => {
-    setUserToggles((prev) => ({ ...prev, [firstId]: open }));
+  const setGroupOpen = (groupKey: string, open: boolean) => {
+    setUserToggles((prev) => ({ ...prev, [groupKey]: open }));
   };
+
+  const router = useRouter();
+  const navigateTo = (path: string) => router.push(path);
 
   if (isLoading) return <RunsSkeleton />;
   if (allRuns.length === 0) {
@@ -111,10 +119,11 @@ export function RunsTab({ automationId }: { automationId: string }) {
         }
         return (
           <QuietGroup
-            key={`${group.firstId}-${idx}`}
+            key={`${group.groupKey}-${idx}`}
             group={group}
-            open={isGroupOpen(group.firstId)}
-            onOpenChange={(open) => setGroupOpen(group.firstId, open)}
+            open={isGroupOpen(group.groupKey)}
+            onOpenChange={(open) => setGroupOpen(group.groupKey, open)}
+            navigateTo={navigateTo}
           />
         );
       })}
@@ -147,9 +156,10 @@ interface QuietGroupProps {
   group: Extract<RunGroup, { kind: "quiet" }>;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  navigateTo: (path: string) => void;
 }
 
-function QuietGroup({ group, open, onOpenChange }: QuietGroupProps) {
+function QuietGroup({ group, open, onOpenChange, navigateTo }: QuietGroupProps) {
   const newest = group.runs[0];
   const oldest = group.runs[group.runs.length - 1];
   const summary = `${group.runs.length} quiet runs`;
@@ -182,7 +192,7 @@ function QuietGroup({ group, open, onOpenChange }: QuietGroupProps) {
       <CollapsibleContent>
         <div className="space-y-1 px-2 pb-2 pt-1">
           {group.runs.map((run) => (
-            <QuietRunRow key={run.id} run={run} />
+            <QuietRunRow key={run.id} run={run} navigateTo={navigateTo} />
           ))}
         </div>
       </CollapsibleContent>

--- a/frontend/src/app/(dashboard)/automations/[id]/runs-tab.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/runs-tab.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { api } from "@/lib/api";
+import type { AutomationRun } from "@/lib/types";
+import { cn, formatTimeAgo } from "@/lib/utils";
+
+import { QuietRunRow, RunCard } from "./run-card";
+import { groupRuns, type RunGroup } from "./run-grouping";
+
+const PAGE_SIZE = 25;
+const POLL_MS = 10_000;
+
+export function RunsTab({ automationId }: { automationId: string }) {
+  // Pages are stored as a list of result pages so the polling refetch only
+  // replaces page 0 (latest runs) and any pages loaded via "Load more"
+  // persist across refetches. Using setState inside `select` would reset
+  // pagination on every poll tick.
+  const [extraPages, setExtraPages] = useState<AutomationRun[][]>([]);
+  const [loadMoreCursor, setLoadMoreCursor] = useState<string | undefined>(undefined);
+  // Tracks user-driven toggle state for quiet groups, keyed by firstId.
+  // We deliberately store explicit (id → open) instead of "set of open
+  // ids" so we can distinguish "user hasn't touched this group" from
+  // "user collapsed it" and let the auto-expand fall-through only apply
+  // to the former. This avoids needing a setState-in-effect for the
+  // all-quiet auto-expand rule.
+  const [userToggles, setUserToggles] = useState<Record<string, boolean>>({});
+
+  // Pause polling once the user paginates. If polling kept running while
+  // extra pages were loaded, any new run arriving at the top would shift
+  // the window and make the stored loadMoreCursor point into the middle of
+  // a now-different result set — producing skipped or duplicated runs on
+  // the next "Load more". Users who want fresh first-page runs can reload
+  // or re-navigate to the tab.
+  const isPaginated = extraPages.length > 0;
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["automation-runs", automationId],
+    queryFn: () => api.automations.listRuns(automationId, { limit: PAGE_SIZE }),
+    refetchInterval: isPaginated ? false : POLL_MS,
+  });
+
+  const firstPageCursor = data?.meta?.next_cursor || undefined;
+  const cursor = isPaginated ? loadMoreCursor : firstPageCursor;
+
+  const loadMoreMutation = useMutation({
+    mutationFn: () => api.automations.listRuns(automationId, { limit: PAGE_SIZE, cursor }),
+    onSuccess: (res) => {
+      setExtraPages((prev) => [...prev, res.data ?? []]);
+      setLoadMoreCursor(res.meta?.next_cursor || undefined);
+    },
+  });
+
+  const allRuns = useMemo(() => {
+    const firstPage = data?.data ?? [];
+    return [firstPage, ...extraPages].flat();
+  }, [data, extraPages]);
+  const groups = useMemo(() => groupRuns(allRuns), [allRuns]);
+  const hasMore = !!cursor;
+
+  // Auto-expand rule: if the entire visible list is quiet (a brand-new
+  // automation that has only no-op'd, or a slow stretch), default the
+  // topmost quiet group open so the page doesn't read as empty. Computed
+  // during render — no effect, no setState — so polling refetches don't
+  // need to re-run it. Once the user clicks any group's toggle we honor
+  // their explicit choice via userToggles.
+  const autoExpandedFirstId = useMemo(() => {
+    if (groups.length === 0) return null;
+    const onlyQuiet = groups.every((g) => g.kind === "quiet");
+    if (!onlyQuiet) return null;
+    const topQuiet = groups.find(
+      (g): g is Extract<RunGroup, { kind: "quiet" }> => g.kind === "quiet",
+    );
+    return topQuiet?.firstId ?? null;
+  }, [groups]);
+
+  const isGroupOpen = (firstId: string): boolean => {
+    if (firstId in userToggles) return userToggles[firstId];
+    return firstId === autoExpandedFirstId;
+  };
+  const setGroupOpen = (firstId: string, open: boolean) => {
+    setUserToggles((prev) => ({ ...prev, [firstId]: open }));
+  };
+
+  if (isLoading) return <RunsSkeleton />;
+  if (allRuns.length === 0) {
+    return (
+      <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-10 text-center">
+        <p className="text-sm font-medium text-foreground">No runs yet</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          The first run will appear here after the scheduled time, or when you click <span className="font-medium">Run now</span>.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {groups.map((group, idx) => {
+        if (group.kind === "single") {
+          return <RunCard key={group.run.id} run={group.run} />;
+        }
+        return (
+          <QuietGroup
+            key={`${group.firstId}-${idx}`}
+            group={group}
+            open={isGroupOpen(group.firstId)}
+            onOpenChange={(open) => setGroupOpen(group.firstId, open)}
+          />
+        );
+      })}
+
+      {loadMoreMutation.isError && (
+        <p className="text-center text-xs text-destructive">
+          Failed to load more runs. Please try again.
+        </p>
+      )}
+      {hasMore && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full"
+          onClick={() => loadMoreMutation.mutate()}
+          disabled={loadMoreMutation.isPending}
+        >
+          {loadMoreMutation.isPending ? "Loading…" : "Load more"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Quiet group — collapsible bar that hides ≥2 consecutive low-signal runs
+// ---------------------------------------------------------------------------
+
+interface QuietGroupProps {
+  group: Extract<RunGroup, { kind: "quiet" }>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function QuietGroup({ group, open, onOpenChange }: QuietGroupProps) {
+  const newest = group.runs[0];
+  const oldest = group.runs[group.runs.length - 1];
+  const summary = `${group.runs.length} quiet runs`;
+  const span = `last one ${formatTimeAgo(newest.triggered_at)}`;
+
+  return (
+    <Collapsible open={open} onOpenChange={onOpenChange} className="rounded-md border border-border/60">
+      <CollapsibleTrigger
+        className={cn(
+          "group flex w-full items-center justify-between gap-3 rounded-md px-3 py-1.5 text-xs text-muted-foreground transition-colors",
+          "hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+        )}
+        title={`${group.runs.length} runs from ${new Date(oldest.triggered_at).toLocaleString()} to ${new Date(newest.triggered_at).toLocaleString()}`}
+      >
+        <span className="flex items-center gap-2">
+          <ChevronRight
+            aria-hidden
+            className={cn(
+              "h-3.5 w-3.5 shrink-0 transition-transform",
+              open && "rotate-90",
+            )}
+          />
+          <span className="font-medium text-foreground/70">{summary}</span>
+          <span>· {span}</span>
+        </span>
+        <span className="text-xs uppercase tracking-wide text-muted-foreground/70">
+          {open ? "Hide" : "Show"}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="space-y-1 px-2 pb-2 pt-1">
+          {group.runs.map((run) => (
+            <QuietRunRow key={run.id} run={run} />
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Loading skeleton — alternates tall card and thin row to hint at the
+// status-aware row layout users will see once data lands.
+// ---------------------------------------------------------------------------
+
+function RunsSkeleton() {
+  return (
+    <div className="space-y-3" aria-busy aria-live="polite" aria-label="Loading runs">
+      <SkeletonCard tall />
+      <SkeletonRow />
+      <SkeletonCard />
+      <SkeletonRow />
+    </div>
+  );
+}
+
+function SkeletonCard({ tall = false }: { tall?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border/60 bg-muted/20 p-4",
+        tall ? "h-[88px]" : "h-[68px]",
+        "animate-pulse",
+      )}
+    />
+  );
+}
+
+function SkeletonRow() {
+  return <div className="h-6 animate-pulse rounded-md bg-muted/30" />;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1326,6 +1326,16 @@ export interface AutomationRun {
   session?: AutomationRunSession;
 }
 
+// Mirrors models.PRCreationState. Kept as a literal union so the row UI
+// gets exhaustiveness checks when branching on it (e.g. the "Creating PR…"
+// pill on completed_no_pr rows).
+export type PRCreationState =
+  | 'idle'
+  | 'queued'
+  | 'pushing'
+  | 'succeeded'
+  | 'failed';
+
 export interface AutomationRunSession {
   id: string;
   title?: string;
@@ -1338,7 +1348,7 @@ export interface AutomationRunSession {
   failure_category?: string;
   failure_next_steps?: string[];
   failure_retry_advised: boolean;
-  pr_creation_state: 'idle' | 'queued' | 'pushing' | 'succeeded' | 'failed' | string;
+  pr_creation_state: PRCreationState;
   pr?: PRSummary;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1319,6 +1319,27 @@ export interface AutomationRun {
   result_summary?: string;
   created_at: string;
   updated_at: string;
+  // Compact view of the session this run spawned. Populated by the list
+  // endpoint via a LATERAL join (see internal/db/automations.go); absent
+  // when the run hasn't spawned a session yet (pending/skipped, or
+  // mid-flight before the worker creates the session).
+  session?: AutomationRunSession;
+}
+
+export interface AutomationRunSession {
+  id: string;
+  title?: string;
+  // Mirrors models.SessionStatus values; the row UI keys off this
+  // (notably "needs_human_guidance") to choose between failure and
+  // attention treatments.
+  status: string;
+  diff_stats?: { added: number; removed: number; files_changed?: number };
+  failure_explanation?: string;
+  failure_category?: string;
+  failure_next_steps?: string[];
+  failure_retry_advised: boolean;
+  pr_creation_state: 'idle' | 'queued' | 'pushing' | 'succeeded' | 'failed' | string;
+  pr?: PRSummary;
 }
 
 export interface AutomationRunStatsBucket {

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -59,26 +59,6 @@ func automationRunTestColumns() []string {
 	}
 }
 
-// automationRunListTestColumns mirrors the enriched column shape returned
-// by AutomationRunStore.ListByAutomation: the base run columns plus a
-// LATERAL-joined session projection and its newest PR. Keep aligned with
-// listByAutomationSelectColumns in internal/db/automations.go.
-func automationRunListTestColumns() []string {
-	return []string{
-		"id", "automation_id", "org_id", "triggered_at", "triggered_by",
-		"triggered_by_user_id", "scheduled_time", "goal_snapshot", "config_snapshot",
-		"status", "completed_at", "result_summary", "created_at", "updated_at",
-		"session_id", "session_title", "session_status",
-		"session_diff_stats",
-		"session_failure_explanation",
-		"session_failure_category",
-		"session_failure_next_steps",
-		"session_failure_retry_advised",
-		"session_pr_creation_state",
-		"pr_number", "pr_url", "pr_status", "pr_ci_status",
-	}
-}
-
 func testAnyArgs(n int) []any {
 	out := make([]any, n)
 	for i := range out {
@@ -1314,9 +1294,9 @@ func TestAutomationHandler_ListRuns_OK(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM automation_runs ar.+LEFT JOIN LATERAL").
 		WithArgs(testAnyArgs(2)...).
 		WillReturnRows(
-			pgxmock.NewRows(automationRunListTestColumns()).AddRow(
+			pgxmock.NewRows(db.AutomationRunListColumns).AddRow(
 				uuid.New(), id, orgID, now, models.AutomationTriggeredBySchedule,
-				nil, nil, "goal", []byte(`{}`),
+				nil, nil, "goal",
 				models.AutomationRunStatusCompleted, nil, nil, now, now,
 				&sessionID, &title, &sessionStatus,
 				[]byte(`{"added":12,"removed":3}`),

--- a/internal/api/handlers/automations_test.go
+++ b/internal/api/handlers/automations_test.go
@@ -59,6 +59,26 @@ func automationRunTestColumns() []string {
 	}
 }
 
+// automationRunListTestColumns mirrors the enriched column shape returned
+// by AutomationRunStore.ListByAutomation: the base run columns plus a
+// LATERAL-joined session projection and its newest PR. Keep aligned with
+// listByAutomationSelectColumns in internal/db/automations.go.
+func automationRunListTestColumns() []string {
+	return []string{
+		"id", "automation_id", "org_id", "triggered_at", "triggered_by",
+		"triggered_by_user_id", "scheduled_time", "goal_snapshot", "config_snapshot",
+		"status", "completed_at", "result_summary", "created_at", "updated_at",
+		"session_id", "session_title", "session_status",
+		"session_diff_stats",
+		"session_failure_explanation",
+		"session_failure_category",
+		"session_failure_next_steps",
+		"session_failure_retry_advised",
+		"session_pr_creation_state",
+		"pr_number", "pr_url", "pr_status", "pr_ci_status",
+	}
+}
+
 func testAnyArgs(n int) []any {
 	out := make([]any, n)
 	for i := range out {
@@ -1273,7 +1293,9 @@ func TestAutomationHandler_ListRuns_OK(t *testing.T) {
 
 	orgID := uuid.New()
 	id := uuid.New()
+	sessionID := uuid.New()
 	now := time.Now()
+	title := "Refactor diff viewer"
 	a := models.Automation{
 		ID: id, OrgID: orgID, Name: "a", Goal: "g",
 		ExecutionMode: "sequential", BaseBranch: "main", ScheduleType: "interval",
@@ -1282,13 +1304,24 @@ func TestAutomationHandler_ListRuns_OK(t *testing.T) {
 	mock.ExpectQuery("SELECT .+ FROM automations WHERE id =").
 		WithArgs(testAnyArgs(2)...).
 		WillReturnRows(newAutomationRow(mock, a))
-	mock.ExpectQuery("SELECT .+ FROM automation_runs WHERE automation_id").
+	sessionStatus := string(models.SessionStatusCompleted)
+	retryAdvised := false
+	prCreationState := "succeeded"
+	prNumber := 1213
+	prURL := "https://github.com/example/repo/pull/1213"
+	prStatus := "open"
+	prCIStatus := "success"
+	mock.ExpectQuery("SELECT .+ FROM automation_runs ar.+LEFT JOIN LATERAL").
 		WithArgs(testAnyArgs(2)...).
 		WillReturnRows(
-			pgxmock.NewRows(automationRunTestColumns()).AddRow(
+			pgxmock.NewRows(automationRunListTestColumns()).AddRow(
 				uuid.New(), id, orgID, now, models.AutomationTriggeredBySchedule,
 				nil, nil, "goal", []byte(`{}`),
 				models.AutomationRunStatusCompleted, nil, nil, now, now,
+				&sessionID, &title, &sessionStatus,
+				[]byte(`{"added":12,"removed":3}`),
+				nil, nil, nil, &retryAdvised, &prCreationState,
+				&prNumber, &prURL, &prStatus, &prCIStatus,
 			),
 		)
 
@@ -1297,6 +1330,20 @@ func TestAutomationHandler_ListRuns_OK(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ListRuns(rr, req)
 	require.Equal(t, http.StatusOK, rr.Code)
+
+	// Confirm the response carries the embedded session payload — the
+	// frontend's clickable rows + diff/PR badges depend on this shape.
+	var resp models.ListResponse[models.AutomationRun]
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	got := resp.Data[0]
+	require.NotNil(t, got.Session)
+	require.Equal(t, sessionID, got.Session.ID)
+	require.Equal(t, "Refactor diff viewer", *got.Session.Title)
+	require.NotNil(t, got.Session.PR)
+	require.Equal(t, 1213, got.Session.PR.Number)
+	require.Equal(t, "https://github.com/example/repo/pull/1213", got.Session.PR.URL)
+
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/db/automations.go
+++ b/internal/db/automations.go
@@ -649,9 +649,62 @@ type AutomationRunFilters struct {
 	Cursor string
 }
 
+// listByAutomationSelectColumns extends automationRunColumns with a small
+// projection of the spawned session and its newest PR. Lateral joins keep
+// one row per run (preserving keyset pagination on triggered_at, id) while
+// avoiding an N+1 from the frontend's polling loop.
+//
+// Heavy session fields (diff_history, input_manifest, goal_snapshot blob)
+// are intentionally excluded — this query runs on a 10s poll for the open
+// automation page, so the row stays small.
+const listByAutomationSelectColumns = `ar.id, ar.automation_id, ar.org_id, ar.triggered_at, ar.triggered_by,
+	ar.triggered_by_user_id, ar.scheduled_time, ar.goal_snapshot, ar.config_snapshot,
+	ar.status, ar.completed_at, ar.result_summary, ar.created_at, ar.updated_at,
+	s.id AS session_id, s.title AS session_title, s.status AS session_status,
+	s.diff_stats AS session_diff_stats,
+	s.failure_explanation AS session_failure_explanation,
+	s.failure_category AS session_failure_category,
+	s.failure_next_steps AS session_failure_next_steps,
+	s.failure_retry_advised AS session_failure_retry_advised,
+	s.pr_creation_state AS session_pr_creation_state,
+	pr.github_pr_number AS pr_number, pr.github_pr_url AS pr_url,
+	pr.status AS pr_status, pr.ci_status AS pr_ci_status`
+
+// listByAutomationFromClause is the FROM + LATERAL JOINs used by
+// ListByAutomation. Pulled out as a const so the cursor variants can share
+// the same join shape and the query plan stays predictable.
+//
+// Multiplicity note: sessions.automation_run_id has no UNIQUE constraint
+// today (the design doc explicitly leaves room for multi-session fan-out
+// per run), so we collapse to the most recent session per run via the
+// LATERAL + LIMIT 1. The next PR per session likewise picks the most
+// recently created — sufficient for the row-level "Review PR →" CTA.
+const listByAutomationFromClause = `FROM automation_runs ar
+	LEFT JOIN LATERAL (
+		SELECT id, title, status, diff_stats,
+			failure_explanation, failure_category, failure_next_steps, failure_retry_advised,
+			pr_creation_state
+		FROM sessions
+		WHERE sessions.automation_run_id = ar.id AND sessions.org_id = ar.org_id
+		ORDER BY sessions.created_at DESC
+		LIMIT 1
+	) s ON true
+	LEFT JOIN LATERAL (
+		SELECT github_pr_number, github_pr_url, status, ci_status
+		FROM pull_requests
+		WHERE pull_requests.session_id = s.id AND pull_requests.org_id = ar.org_id
+		-- Prefer an open PR over a stale closed/merged one, then break
+		-- ties by recency. The ranked status case keeps the row's
+		-- "Review PR" CTA pointing at the actionable PR when a session
+		-- has been through revisions.
+		ORDER BY CASE pull_requests.status WHEN 'open' THEN 0 ELSE 1 END, pull_requests.created_at DESC
+		LIMIT 1
+	) pr ON true`
+
 func (s *AutomationRunStore) ListByAutomation(ctx context.Context, orgID, automationID uuid.UUID, filters AutomationRunFilters) ([]models.AutomationRun, error) {
-	query := fmt.Sprintf(`SELECT %s FROM automation_runs
-		WHERE automation_id = @automation_id AND org_id = @org_id`, automationRunColumns)
+	query := fmt.Sprintf(`SELECT %s %s
+		WHERE ar.automation_id = @automation_id AND ar.org_id = @org_id`,
+		listByAutomationSelectColumns, listByAutomationFromClause)
 	args := pgx.NamedArgs{
 		"automation_id": automationID,
 		"org_id":        orgID,
@@ -660,12 +713,12 @@ func (s *AutomationRunStore) ListByAutomation(ctx context.Context, orgID, automa
 	if filters.Cursor != "" {
 		cursorID, err := uuid.Parse(filters.Cursor)
 		if err == nil {
-			query += ` AND (triggered_at < (SELECT triggered_at FROM automation_runs WHERE id = @cursor_id) OR (triggered_at = (SELECT triggered_at FROM automation_runs WHERE id = @cursor_id) AND id < @cursor_id))`
+			query += ` AND (ar.triggered_at < (SELECT triggered_at FROM automation_runs WHERE id = @cursor_id) OR (ar.triggered_at = (SELECT triggered_at FROM automation_runs WHERE id = @cursor_id) AND ar.id < @cursor_id))`
 			args["cursor_id"] = cursorID
 		}
 	}
 
-	query += ` ORDER BY triggered_at DESC, id DESC`
+	query += ` ORDER BY ar.triggered_at DESC, ar.id DESC`
 
 	limit := filters.Limit
 	if limit <= 0 || limit > 100 {
@@ -678,7 +731,94 @@ func (s *AutomationRunStore) ListByAutomation(ctx context.Context, orgID, automa
 		return nil, fmt.Errorf("query automation runs: %w", err)
 	}
 	defer rows.Close()
-	return scanAutomationRuns(rows)
+	return scanAutomationRunsWithSession(rows)
+}
+
+// scanAutomationRunsWithSession decodes rows from the enriched
+// ListByAutomation query. Each row is one automation_run plus an optional
+// embedded session (and its optional embedded PR), all collapsed by
+// LATERAL JOINs upstream so we never have to dedupe runs here.
+func scanAutomationRunsWithSession(rows pgx.Rows) ([]models.AutomationRun, error) {
+	var runs []models.AutomationRun
+	for rows.Next() {
+		r, err := scanAutomationRunWithSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, r)
+	}
+	return runs, rows.Err()
+}
+
+func scanAutomationRunWithSession(row pgx.Row) (models.AutomationRun, error) {
+	var (
+		r models.AutomationRun
+
+		// Session columns. All nullable because the LEFT JOIN may produce
+		// NULL for runs that haven't spawned a session yet (pending,
+		// skipped, in-flight before the worker creates the session).
+		sessionID                  *uuid.UUID
+		sessionTitle               *string
+		sessionStatus              *string
+		sessionDiffStats           []byte
+		sessionFailureExplanation  *string
+		sessionFailureCategory     *string
+		sessionFailureNextSteps    []string
+		sessionFailureRetryAdvised *bool
+		sessionPRCreationState     *string
+
+		// PR columns. NULL when the session has no PullRequest row yet —
+		// the inner LATERAL is also a LEFT JOIN.
+		prNumber   *int
+		prURL      *string
+		prStatus   *string
+		prCIStatus *string
+	)
+
+	err := row.Scan(
+		&r.ID, &r.AutomationID, &r.OrgID, &r.TriggeredAt, &r.TriggeredBy,
+		&r.TriggeredByUserID, &r.ScheduledTime, &r.GoalSnapshot, &r.ConfigSnapshot,
+		&r.Status, &r.CompletedAt, &r.ResultSummary, &r.CreatedAt, &r.UpdatedAt,
+		&sessionID, &sessionTitle, &sessionStatus,
+		&sessionDiffStats,
+		&sessionFailureExplanation,
+		&sessionFailureCategory,
+		&sessionFailureNextSteps,
+		&sessionFailureRetryAdvised,
+		&sessionPRCreationState,
+		&prNumber, &prURL, &prStatus, &prCIStatus,
+	)
+	if err != nil {
+		return r, err
+	}
+
+	if sessionID != nil {
+		// status, failure_retry_advised, and pr_creation_state are NOT
+		// NULL on sessions, so a non-nil sessionID guarantees the rest of
+		// the session columns scanned non-nil — dereference directly.
+		// Same for pr.status / pr.ci_status when prNumber + prURL are set.
+		r.Session = &models.AutomationRunSession{
+			ID:                  *sessionID,
+			Title:               sessionTitle,
+			Status:              *sessionStatus,
+			DiffStats:           sessionDiffStats,
+			FailureExplanation:  sessionFailureExplanation,
+			FailureCategory:     sessionFailureCategory,
+			FailureNextSteps:    sessionFailureNextSteps,
+			FailureRetryAdvised: *sessionFailureRetryAdvised,
+			PRCreationState:     models.PRCreationState(*sessionPRCreationState),
+		}
+		if prNumber != nil && prURL != nil {
+			r.Session.PR = &models.PRSummary{
+				Number:   *prNumber,
+				URL:      *prURL,
+				Status:   *prStatus,
+				CIStatus: *prCIStatus,
+			}
+		}
+	}
+
+	return r, nil
 }
 
 // UpdateStatus updates a run's status. Scoped by org_id so a leaked run UUID

--- a/internal/db/automations.go
+++ b/internal/db/automations.go
@@ -560,18 +560,6 @@ func scanAutomationRun(row pgx.Row) (models.AutomationRun, error) {
 	return r, err
 }
 
-func scanAutomationRuns(rows pgx.Rows) ([]models.AutomationRun, error) {
-	var runs []models.AutomationRun
-	for rows.Next() {
-		r, err := scanAutomationRun(rows)
-		if err != nil {
-			return nil, err
-		}
-		runs = append(runs, r)
-	}
-	return runs, rows.Err()
-}
-
 // runInserter is the minimal QueryRow surface shared by pgxpool.Pool, pgx.Tx,
 // and pgxmock — all used here to insert automation runs. Unifying the pool and
 // tx paths through this interface lets CreateRun and CreateRunInTx delegate to

--- a/internal/db/automations.go
+++ b/internal/db/automations.go
@@ -649,16 +649,39 @@ type AutomationRunFilters struct {
 	Cursor string
 }
 
-// listByAutomationSelectColumns extends automationRunColumns with a small
-// projection of the spawned session and its newest PR. Lateral joins keep
-// one row per run (preserving keyset pagination on triggered_at, id) while
-// avoiding an N+1 from the frontend's polling loop.
+// AutomationRunListColumns is the post-projection column list returned by
+// ListByAutomation: the lean run columns (config_snapshot intentionally
+// dropped to keep the 10s polling row small — the row UI doesn't read it)
+// plus a small projection of the spawned session and its newest PR.
 //
-// Heavy session fields (diff_history, input_manifest, goal_snapshot blob)
-// are intentionally excluded — this query runs on a 10s poll for the open
-// automation page, so the row stays small.
+// Exported so tests in this package and downstream handler tests can build
+// pgxmock rows without redefining the list and silently drifting from the
+// SQL. Any change to listByAutomationSelectColumns must update this slice
+// in lockstep.
+var AutomationRunListColumns = []string{
+	"id", "automation_id", "org_id", "triggered_at", "triggered_by",
+	"triggered_by_user_id", "scheduled_time", "goal_snapshot",
+	"status", "completed_at", "result_summary", "created_at", "updated_at",
+	"session_id", "session_title", "session_status",
+	"session_diff_stats",
+	"session_failure_explanation",
+	"session_failure_category",
+	"session_failure_next_steps",
+	"session_failure_retry_advised",
+	"session_pr_creation_state",
+	"pr_number", "pr_url", "pr_status", "pr_ci_status",
+}
+
+// listByAutomationSelectColumns is the SQL projection matching
+// AutomationRunListColumns. Lateral joins keep one row per run (preserving
+// keyset pagination on triggered_at, id) while avoiding an N+1 from the
+// frontend's polling loop.
+//
+// Heavy session fields (diff_history, input_manifest) and the run's
+// config_snapshot blob are intentionally excluded — this query runs on a
+// 10s poll for the open automation page, so the row stays small.
 const listByAutomationSelectColumns = `ar.id, ar.automation_id, ar.org_id, ar.triggered_at, ar.triggered_by,
-	ar.triggered_by_user_id, ar.scheduled_time, ar.goal_snapshot, ar.config_snapshot,
+	ar.triggered_by_user_id, ar.scheduled_time, ar.goal_snapshot,
 	ar.status, ar.completed_at, ar.result_summary, ar.created_at, ar.updated_at,
 	s.id AS session_id, s.title AS session_title, s.status AS session_status,
 	s.diff_stats AS session_diff_stats,
@@ -777,7 +800,7 @@ func scanAutomationRunWithSession(row pgx.Row) (models.AutomationRun, error) {
 
 	err := row.Scan(
 		&r.ID, &r.AutomationID, &r.OrgID, &r.TriggeredAt, &r.TriggeredBy,
-		&r.TriggeredByUserID, &r.ScheduledTime, &r.GoalSnapshot, &r.ConfigSnapshot,
+		&r.TriggeredByUserID, &r.ScheduledTime, &r.GoalSnapshot,
 		&r.Status, &r.CompletedAt, &r.ResultSummary, &r.CreatedAt, &r.UpdatedAt,
 		&sessionID, &sessionTitle, &sessionStatus,
 		&sessionDiffStats,
@@ -794,28 +817,41 @@ func scanAutomationRunWithSession(row pgx.Row) (models.AutomationRun, error) {
 
 	if sessionID != nil {
 		// status, failure_retry_advised, and pr_creation_state are NOT
-		// NULL on sessions, so a non-nil sessionID guarantees the rest of
-		// the session columns scanned non-nil — dereference directly.
-		// Same for pr.status / pr.ci_status when prNumber + prURL are set.
-		r.Session = &models.AutomationRunSession{
-			ID:                  *sessionID,
-			Title:               sessionTitle,
-			Status:              *sessionStatus,
-			DiffStats:           sessionDiffStats,
-			FailureExplanation:  sessionFailureExplanation,
-			FailureCategory:     sessionFailureCategory,
-			FailureNextSteps:    sessionFailureNextSteps,
-			FailureRetryAdvised: *sessionFailureRetryAdvised,
-			PRCreationState:     models.PRCreationState(*sessionPRCreationState),
+		// NULL on sessions today, so a non-nil sessionID normally implies
+		// non-nil scans here. Fall back to zero values defensively so a
+		// future migration that relaxes one of those constraints can't
+		// turn this scanner into a nil-deref panic in the polling loop.
+		s := &models.AutomationRunSession{
+			ID:                 *sessionID,
+			Title:              sessionTitle,
+			DiffStats:          sessionDiffStats,
+			FailureExplanation: sessionFailureExplanation,
+			FailureCategory:    sessionFailureCategory,
+			FailureNextSteps:   sessionFailureNextSteps,
+		}
+		if sessionStatus != nil {
+			s.Status = *sessionStatus
+		}
+		if sessionFailureRetryAdvised != nil {
+			s.FailureRetryAdvised = *sessionFailureRetryAdvised
+		}
+		if sessionPRCreationState != nil {
+			s.PRCreationState = models.PRCreationState(*sessionPRCreationState)
 		}
 		if prNumber != nil && prURL != nil {
-			r.Session.PR = &models.PRSummary{
-				Number:   *prNumber,
-				URL:      *prURL,
-				Status:   *prStatus,
-				CIStatus: *prCIStatus,
+			pr := &models.PRSummary{
+				Number: *prNumber,
+				URL:    *prURL,
 			}
+			if prStatus != nil {
+				pr.Status = *prStatus
+			}
+			if prCIStatus != nil {
+				pr.CIStatus = *prCIStatus
+			}
+			s.PR = pr
 		}
+		r.Session = s
 	}
 
 	return r, nil

--- a/internal/db/automations_test.go
+++ b/internal/db/automations_test.go
@@ -572,30 +572,212 @@ func TestAutomationRunStore_GetByID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// listByAutomationColumnSlice mirrors the column list emitted by
+// listByAutomationSelectColumns. Kept here (rather than reusing
+// automationRunColumnSlice) because the enriched query joins sessions and
+// pull_requests onto each row — the test needs to feed pgxmock the same
+// shape the scanner expects, including all-NULL rows for runs without a
+// linked session.
+func listByAutomationColumnSlice() []string {
+	return []string{
+		"id", "automation_id", "org_id", "triggered_at", "triggered_by",
+		"triggered_by_user_id", "scheduled_time", "goal_snapshot", "config_snapshot",
+		"status", "completed_at", "result_summary", "created_at", "updated_at",
+		"session_id", "session_title", "session_status",
+		"session_diff_stats",
+		"session_failure_explanation",
+		"session_failure_category",
+		"session_failure_next_steps",
+		"session_failure_retry_advised",
+		"session_pr_creation_state",
+		"pr_number", "pr_url", "pr_status", "pr_ci_status",
+	}
+}
+
 func TestAutomationRunStore_ListByAutomation(t *testing.T) {
 	t.Parallel()
 
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
-	defer mock.Close()
-
-	store := NewAutomationRunStore(mock)
 	now := time.Now()
+	sessionID := uuid.New()
+	title := "Refactor diff viewer"
+	failureExplanation := "Three tests failed in orchestrator_test.go"
+	failureCategory := "tests-failing"
+	failureNextSteps := []string{"Re-run with --focus orchestrator", "Inspect logs in session"}
+	prURL := "https://github.com/example/repo/pull/1213"
 
-	mock.ExpectQuery("SELECT .+ FROM automation_runs WHERE automation_id").
-		WithArgs(anyArgs(2)...).
-		WillReturnRows(
-			pgxmock.NewRows(automationRunColumnSlice()).AddRow(
+	type prRow struct {
+		number   int
+		url      string
+		status   string
+		ciStatus string
+	}
+	type sessionRow struct {
+		id                  uuid.UUID
+		title               *string
+		status              string
+		diffStats           []byte
+		failureExplanation  *string
+		failureCategory     *string
+		failureNextSteps    []string
+		failureRetryAdvised bool
+		prCreationState     string
+		pr                  *prRow
+	}
+
+	cases := []struct {
+		name             string
+		runStatus        string
+		session          *sessionRow
+		assertEnrichment func(t *testing.T, got models.AutomationRun)
+	}{
+		{
+			name:      "completed run with session and PR",
+			runStatus: models.AutomationRunStatusCompleted,
+			session: &sessionRow{
+				id:              sessionID,
+				title:           &title,
+				status:          string(models.SessionStatusCompleted),
+				diffStats:       []byte(`{"added":128,"removed":23,"files_changed":4}`),
+				prCreationState: "succeeded",
+				pr: &prRow{
+					number:   1213,
+					url:      prURL,
+					status:   "open",
+					ciStatus: "success",
+				},
+			},
+			assertEnrichment: func(t *testing.T, got models.AutomationRun) {
+				t.Helper()
+				require.NotNil(t, got.Session)
+				require.Equal(t, sessionID, got.Session.ID)
+				require.Equal(t, "Refactor diff viewer", *got.Session.Title)
+				require.Equal(t, string(models.SessionStatusCompleted), got.Session.Status)
+				require.JSONEq(t, `{"added":128,"removed":23,"files_changed":4}`, string(got.Session.DiffStats))
+				require.NotNil(t, got.Session.PR)
+				require.Equal(t, 1213, got.Session.PR.Number)
+				require.Equal(t, prURL, got.Session.PR.URL)
+				require.Equal(t, "open", got.Session.PR.Status)
+				require.Equal(t, "success", got.Session.PR.CIStatus)
+			},
+		},
+		{
+			name:      "completed run with session but no PR",
+			runStatus: models.AutomationRunStatusCompleted,
+			session: &sessionRow{
+				id:              sessionID,
+				title:           &title,
+				status:          string(models.SessionStatusCompleted),
+				diffStats:       []byte(`{"added":12,"removed":3}`),
+				prCreationState: "idle",
+			},
+			assertEnrichment: func(t *testing.T, got models.AutomationRun) {
+				t.Helper()
+				require.NotNil(t, got.Session)
+				require.Nil(t, got.Session.PR)
+				require.Equal(t, models.PRCreationState("idle"), got.Session.PRCreationState)
+			},
+		},
+		{
+			name:      "failed run carries failure metadata",
+			runStatus: models.AutomationRunStatusFailed,
+			session: &sessionRow{
+				id:                  sessionID,
+				title:               nil,
+				status:              string(models.SessionStatusFailed),
+				failureExplanation:  &failureExplanation,
+				failureCategory:     &failureCategory,
+				failureNextSteps:    failureNextSteps,
+				failureRetryAdvised: true,
+				prCreationState:     "idle",
+			},
+			assertEnrichment: func(t *testing.T, got models.AutomationRun) {
+				t.Helper()
+				require.NotNil(t, got.Session)
+				require.Equal(t, failureExplanation, *got.Session.FailureExplanation)
+				require.Equal(t, failureCategory, *got.Session.FailureCategory)
+				require.Equal(t, failureNextSteps, got.Session.FailureNextSteps)
+				require.True(t, got.Session.FailureRetryAdvised)
+			},
+		},
+		{
+			name:      "pending run without a spawned session yet",
+			runStatus: models.AutomationRunStatusPending,
+			session:   nil,
+			assertEnrichment: func(t *testing.T, got models.AutomationRun) {
+				t.Helper()
+				require.Nil(t, got.Session)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			store := NewAutomationRunStore(mock)
+
+			cols := listByAutomationColumnSlice()
+			row := []any{
 				uuid.New(), uuid.New(), uuid.New(), now, models.AutomationTriggeredBySchedule,
 				nil, nil, "goal", []byte(`{}`),
-				models.AutomationRunStatusCompleted, nil, nil, now, now,
-			),
-		)
+				tc.runStatus, nil, nil, now, now,
+			}
+			if tc.session != nil {
+				// pgxmock matches scan kinds via reflection: a *T scan
+				// destination requires *T (or nil) as the AddRow value, so
+				// we wrap every non-NULL nullable column in a pointer.
+				// Address-takeable copies are needed because struct fields
+				// are not addressable through interface{} boxing.
+				sessionIDCopy := tc.session.id
+				sessionStatusCopy := tc.session.status
+				retryCopy := tc.session.failureRetryAdvised
+				prCreationCopy := tc.session.prCreationState
+				row = append(row,
+					&sessionIDCopy,
+					tc.session.title,
+					&sessionStatusCopy,
+					tc.session.diffStats,
+					tc.session.failureExplanation,
+					tc.session.failureCategory,
+					tc.session.failureNextSteps,
+					&retryCopy,
+					&prCreationCopy,
+				)
+				if tc.session.pr != nil {
+					prNumberCopy := tc.session.pr.number
+					prURLCopy := tc.session.pr.url
+					prStatusCopy := tc.session.pr.status
+					prCICopy := tc.session.pr.ciStatus
+					row = append(row, &prNumberCopy, &prURLCopy, &prStatusCopy, &prCICopy)
+				} else {
+					row = append(row, nil, nil, nil, nil)
+				}
+			} else {
+				// 9 session columns + 4 PR columns = 13 NULLs.
+				for i := 0; i < 13; i++ {
+					row = append(row, nil)
+				}
+			}
 
-	runs, err := store.ListByAutomation(context.Background(), uuid.New(), uuid.New(), AutomationRunFilters{Limit: 25})
-	require.NoError(t, err)
-	require.Len(t, runs, 1)
-	require.NoError(t, mock.ExpectationsWereMet())
+			mock.ExpectQuery("SELECT .+ FROM automation_runs ar.+LEFT JOIN LATERAL").
+				WithArgs(anyArgs(2)...).
+				WillReturnRows(
+					pgxmock.NewRows(cols).AddRow(row...),
+				)
+
+			runs, err := store.ListByAutomation(context.Background(), uuid.New(), uuid.New(), AutomationRunFilters{Limit: 25})
+			require.NoError(t, err)
+			require.Len(t, runs, 1)
+			require.Equal(t, tc.runStatus, runs[0].Status)
+			tc.assertEnrichment(t, runs[0])
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
 }
 
 func TestAutomationRunStore_UpdateStatus(t *testing.T) {

--- a/internal/db/automations_test.go
+++ b/internal/db/automations_test.go
@@ -572,28 +572,6 @@ func TestAutomationRunStore_GetByID(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
-// listByAutomationColumnSlice mirrors the column list emitted by
-// listByAutomationSelectColumns. Kept here (rather than reusing
-// automationRunColumnSlice) because the enriched query joins sessions and
-// pull_requests onto each row — the test needs to feed pgxmock the same
-// shape the scanner expects, including all-NULL rows for runs without a
-// linked session.
-func listByAutomationColumnSlice() []string {
-	return []string{
-		"id", "automation_id", "org_id", "triggered_at", "triggered_by",
-		"triggered_by_user_id", "scheduled_time", "goal_snapshot", "config_snapshot",
-		"status", "completed_at", "result_summary", "created_at", "updated_at",
-		"session_id", "session_title", "session_status",
-		"session_diff_stats",
-		"session_failure_explanation",
-		"session_failure_category",
-		"session_failure_next_steps",
-		"session_failure_retry_advised",
-		"session_pr_creation_state",
-		"pr_number", "pr_url", "pr_status", "pr_ci_status",
-	}
-}
-
 func TestAutomationRunStore_ListByAutomation(t *testing.T) {
 	t.Parallel()
 
@@ -721,10 +699,10 @@ func TestAutomationRunStore_ListByAutomation(t *testing.T) {
 
 			store := NewAutomationRunStore(mock)
 
-			cols := listByAutomationColumnSlice()
+			cols := AutomationRunListColumns
 			row := []any{
 				uuid.New(), uuid.New(), uuid.New(), now, models.AutomationTriggeredBySchedule,
-				nil, nil, "goal", []byte(`{}`),
+				nil, nil, "goal",
 				tc.runStatus, nil, nil, now, now,
 			}
 			if tc.session != nil {

--- a/internal/models/automation.go
+++ b/internal/models/automation.go
@@ -65,6 +65,39 @@ type AutomationRun struct {
 	ResultSummary     *string         `db:"result_summary"        json:"result_summary,omitempty"`
 	CreatedAt         time.Time       `db:"created_at"            json:"created_at"`
 	UpdatedAt         time.Time       `db:"updated_at"            json:"updated_at"`
+
+	// Session is a compact view of the session this run spawned, populated
+	// only by list/detail endpoints that join sessions (currently
+	// ListByAutomation). It is left nil by single-row fetches like GetByID
+	// and by writers (insertRun, scanAutomationRun for the bare table) so
+	// the on-the-wire shape stays additive: pre-existing consumers that
+	// don't read the field continue to work, and new consumers can rely on
+	// it to render row detail without an N+1.
+	Session *AutomationRunSession `json:"session,omitempty"`
+}
+
+// AutomationRunSession is the slice of the spawned session that the
+// automation runs list surfaces inline. Mirrors SessionListItem's PRSummary
+// pattern: a deliberately small projection so we can carry it on every
+// listed run without ballooning the payload during 10s polling.
+//
+// Fields here are read-only views of sessions / pull_requests rows; nothing
+// in this struct is persisted directly. The Session field on AutomationRun
+// is nil when no session has been spawned yet (pending/skipped runs).
+type AutomationRunSession struct {
+	ID                  uuid.UUID       `json:"id"`
+	Title               *string         `json:"title,omitempty"`
+	Status              string          `json:"status"`
+	DiffStats           json.RawMessage `json:"diff_stats,omitempty"`
+	FailureExplanation  *string         `json:"failure_explanation,omitempty"`
+	FailureCategory     *string         `json:"failure_category,omitempty"`
+	FailureNextSteps    []string        `json:"failure_next_steps,omitempty"`
+	FailureRetryAdvised bool            `json:"failure_retry_advised"`
+	PRCreationState     PRCreationState `json:"pr_creation_state"`
+	// PR is populated only when a PullRequest row exists for this session.
+	// Reuses models.PRSummary so the frontend can share rendering with the
+	// session list page.
+	PR *PRSummary `json:"pr,omitempty"`
 }
 
 // AutomationRunStatus constants.


### PR DESCRIPTION
## Summary

Each row in `/automations/[id]` now navigates to the session it spawned and renders a status-aware summary so users can triage a long history at a glance: failures show category and suggested next step, completed runs show diff stats and a Review PR link, sessions awaiting human guidance get an amber attention treatment, and consecutive no-op/skipped runs collapse into a single quiet group so signal is not buried.

`ListByAutomation` now uses LEFT JOIN LATERAL to embed a compact session + newest-PR projection on each run, so the polling list endpoint stays one query per tick with no N+1 from the frontend; the new `AutomationRun.session` field is additive on the wire.

## Test plan

- [x] `go test ./internal/db/ ./internal/api/handlers/ ./internal/models/`
- [x] `go vet ./...` and `lint-schema` / `lint-stores` tenancy guards
- [x] `npm run lint`, `npm run typecheck`, full `vitest run` (8 automations test files / 31 tests pass; new: `run-grouping.test.ts`, `run-card.test.tsx`, `runs-tab.test.tsx`)
- [ ] Manual smoke in the dashboard with a mix of completed/failed/no-op runs and a session in `needs_human_guidance`

🤖 Generated with [Claude Code](https://claude.com/claude-code)