### PR TITLE
Surface preview service failures fast and stream per-service status

### DIFF
--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -108,7 +108,7 @@ type internalPreviewTestProvider struct {
 	dialFn func(context.Context, string) (previewsvc.PreviewStream, error)
 }
 
-func (p internalPreviewTestProvider) StartPreview(context.Context, *agent.Sandbox, *models.PreviewConfig, map[string]string) (*previewsvc.PreviewHandle, error) {
+func (p internalPreviewTestProvider) StartPreview(context.Context, *agent.Sandbox, *models.PreviewConfig, map[string]string, previewsvc.ServiceObserver) (*previewsvc.PreviewHandle, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -387,7 +387,7 @@ type mockPreviewProvider struct {
 	startConfig *models.PreviewConfig
 }
 
-func (m *mockPreviewProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig, _ map[string]string) (*preview.PreviewHandle, error) {
+func (m *mockPreviewProvider) StartPreview(_ context.Context, _ *agent.Sandbox, cfg *models.PreviewConfig, _ map[string]string, _ preview.ServiceObserver) (*preview.PreviewHandle, error) {
 	m.startConfig = cfg
 	if m.startHandle != nil {
 		return m.startHandle, nil

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -394,8 +394,13 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 		}
 	}
 
-	// Start the preview via the provider.
-	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(instance.ID))
+	// Start the preview via the provider. The observer streams per-service
+	// Ready/Failed transitions into the DB as they happen, so the frontend's
+	// startup checklist sees progress instead of "all starting" until the
+	// whole launch returns. It also writes a preview_logs row with the tail
+	// of stdout/stderr when a service fails, so the user sees why.
+	observer := m.newServiceObserver(input.OrgID, instance.ID)
+	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(instance.ID), observer)
 	if err != nil {
 		return nil, fmt.Errorf("provider start preview: %w", err)
 	}
@@ -546,6 +551,72 @@ func (m *Manager) AbortReservation(parentCtx context.Context, instance *models.P
 			Str("preview_id", instance.ID.String()).
 			Str("container_id", hydratedContainerID).
 			Msg("abort reservation: destroy failed; container orphaned on host")
+	}
+}
+
+// newServiceObserver returns a preview.ServiceObserver that pumps per-service
+// Ready/Failed transitions into the DB as they happen during StartPreview,
+// and writes a preview_logs row with the tail of stdout/stderr when a service
+// fails. It uses fresh background contexts for each DB write so observer
+// callbacks fired after StartPreview returns (progressive support services,
+// the startService goroutine catching a non-zero exit) still land in the DB
+// even if the request context has already been canceled.
+func (m *Manager) newServiceObserver(orgID, previewID uuid.UUID) ServiceObserver {
+	return &managerServiceObserver{manager: m, orgID: orgID, previewID: previewID}
+}
+
+type managerServiceObserver struct {
+	manager   *Manager
+	orgID     uuid.UUID
+	previewID uuid.UUID
+}
+
+const observerWriteTimeout = 5 * time.Second
+
+func (o *managerServiceObserver) OnServiceReady(name string, port, pid int) {
+	ctx, cancel := context.WithTimeout(context.Background(), observerWriteTimeout)
+	defer cancel()
+	if err := o.manager.store.UpdateServiceStatus(ctx, o.orgID, o.previewID, name, models.PreviewServiceStatusReady, ""); err != nil {
+		o.manager.logger.Warn().Err(err).
+			Str("preview_id", o.previewID.String()).
+			Str("service", name).
+			Msg("observer: failed to mark service ready")
+	}
+	if pid > 0 {
+		if err := o.manager.store.UpdateServicePID(ctx, o.orgID, o.previewID, name, pid); err != nil {
+			o.manager.logger.Warn().Err(err).
+				Str("preview_id", o.previewID.String()).
+				Str("service", name).
+				Msg("observer: failed to record service PID")
+		}
+	}
+}
+
+func (o *managerServiceObserver) OnServiceFailed(name, errMsg string, tail []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), observerWriteTimeout)
+	defer cancel()
+	if err := o.manager.store.UpdateServiceStatus(ctx, o.orgID, o.previewID, name, models.PreviewServiceStatusFailed, errMsg); err != nil {
+		o.manager.logger.Warn().Err(err).
+			Str("preview_id", o.previewID.String()).
+			Str("service", name).
+			Msg("observer: failed to mark service failed")
+	}
+	msg := fmt.Sprintf("service %q failed: %s", name, errMsg)
+	if len(tail) > 0 {
+		msg += "\n--- last output ---\n" + strings.Join(tail, "\n")
+	}
+	logEntry := &models.PreviewLog{
+		PreviewInstanceID: o.previewID,
+		OrgID:             o.orgID,
+		Level:             "error",
+		Step:              models.PreviewLogStepStart,
+		Message:           msg,
+	}
+	if err := o.manager.store.CreatePreviewLog(ctx, logEntry); err != nil {
+		o.manager.logger.Warn().Err(err).
+			Str("preview_id", o.previewID.String()).
+			Str("service", name).
+			Msg("observer: failed to write preview log")
 	}
 }
 
@@ -1040,7 +1111,8 @@ func (m *Manager) RecyclePreview(ctx context.Context, orgID, previewID uuid.UUID
 
 	// Restart via provider with same sandbox and config. Use the existing
 	// instance ID so PREVIEW_ORIGIN stays stable across recycles.
-	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(previewID))
+	observer := m.newServiceObserver(orgID, previewID)
+	handle, err := m.provider.StartPreview(ctx, input.Sandbox, input.Config, m.platformEnv(previewID), observer)
 	if err != nil {
 		if statusErr := m.store.UpdatePreviewStatus(ctx, orgID, previewID, models.PreviewStatusFailed, err.Error()); statusErr != nil {
 			m.logger.Warn().Err(statusErr).Msg("recycle: failed to set failed status")

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -2676,3 +2676,154 @@ func TestManager_HMRWatcherGetter(t *testing.T) {
 	manager.hmrWatcher = watcher
 	require.Equal(t, watcher, manager.HMRWatcher(), "HMRWatcher should return the configured watcher")
 }
+
+// =============================================================================
+// managerServiceObserver tests
+//
+// The observer streams per-service Ready/Failed transitions into the DB while
+// StartPreview is still running, so the frontend's startup checklist sees
+// progress live. These tests exercise both methods including the PID-write
+// branch, the failure-path tail handling, and the warn-and-continue paths
+// when DB writes themselves fail.
+// =============================================================================
+
+func TestManagerServiceObserver_OnServiceReady_WithPID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	orgID := uuid.New()
+	previewID := uuid.New()
+	obs := mgr.newServiceObserver(orgID, previewID).(*managerServiceObserver)
+
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE preview_services SET pid").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	obs.OnServiceReady("web", 3000, 12345)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagerServiceObserver_OnServiceReady_NoPID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New()).(*managerServiceObserver)
+
+	// pid=0 must skip the second exec — the readiness probe runs before the
+	// PID-detection goroutine has had a chance to populate ss.pid for some
+	// services, and we don't want to clobber the column with 0.
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	obs.OnServiceReady("web", 3000, 0)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagerServiceObserver_OnServiceReady_DBErrorsLogged(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New()).(*managerServiceObserver)
+
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("status update boom"))
+	mock.ExpectExec("UPDATE preview_services SET pid").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("pid update boom"))
+
+	require.NotPanics(t, func() { obs.OnServiceReady("web", 3000, 99) })
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagerServiceObserver_OnServiceFailed_WithTail(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	orgID := uuid.New()
+	previewID := uuid.New()
+	obs := mgr.newServiceObserver(orgID, previewID).(*managerServiceObserver)
+
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	logID := uuid.New()
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(logID, previewID, orgID, "error", "start", "msg", json.RawMessage(`null`), time.Now()))
+
+	tail := []string{"line one", "line two: permission denied"}
+	obs.OnServiceFailed("server", "exited with code 126", tail)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagerServiceObserver_OnServiceFailed_NoTail(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	orgID := uuid.New()
+	previewID := uuid.New()
+	obs := mgr.newServiceObserver(orgID, previewID).(*managerServiceObserver)
+
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	logID := uuid.New()
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "preview_instance_id", "org_id", "level", "step", "message", "metadata", "created_at",
+		}).AddRow(logID, previewID, orgID, "error", "start", "msg", json.RawMessage(`null`), time.Now()))
+
+	obs.OnServiceFailed("web", "boom", nil)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestManagerServiceObserver_OnServiceFailed_DBErrorsLogged(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	mgr := newTestManager(mock, &mockProvider{})
+	obs := mgr.newServiceObserver(uuid.New(), uuid.New()).(*managerServiceObserver)
+
+	// Both DB writes fail; the observer must log and return without panicking
+	// so a flaky DB doesn't crash the worker mid-launch.
+	mock.ExpectExec("UPDATE preview_services SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("status boom"))
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(fmt.Errorf("log boom"))
+
+	require.NotPanics(t, func() { obs.OnServiceFailed("web", "boom", []string{"line"}) })
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -32,7 +32,7 @@ type mockProvider struct {
 	statusErr   error
 }
 
-func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, _ *models.PreviewConfig, _ map[string]string) (*PreviewHandle, error) {
+func (m *mockProvider) StartPreview(_ context.Context, _ *agent.Sandbox, _ *models.PreviewConfig, _ map[string]string, _ ServiceObserver) (*PreviewHandle, error) {
 	if m.startErr != nil {
 		return nil, m.startErr
 	}

--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -27,8 +27,13 @@ type PreviewCapableProvider interface {
 	// carry platform-level values (e.g. PREVIEW_ORIGIN) that must always be
 	// available and should win over user overrides.
 	//
+	// observer receives per-service Ready/Failed transitions as they happen,
+	// so callers (typically the manager) can persist per-service state to the
+	// DB without waiting for StartPreview to fully return. observer may be
+	// nil; provider implementations must tolerate it.
+	//
 	// The returned PreviewHandle contains connection details for DialPreview.
-	StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*PreviewHandle, error)
+	StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string, observer ServiceObserver) (*PreviewHandle, error)
 
 	// StopPreview gracefully stops all preview processes and tears down
 	// infrastructure containers. Safe to call multiple times.
@@ -101,6 +106,21 @@ type ServiceSnapshot struct {
 	PID    int
 	Port   int
 	Error  string
+}
+
+// ServiceObserver receives notifications when a preview service flips state
+// during StartPreview. It is invoked from both the calling goroutine and
+// background goroutines spawned by the provider, so implementations must be
+// safe for concurrent use and should return promptly. A nil observer is
+// allowed and is treated as a no-op.
+type ServiceObserver interface {
+	// OnServiceReady is invoked once a service has passed its readiness probe.
+	OnServiceReady(name string, port, pid int)
+	// OnServiceFailed is invoked when a service has crashed at boot, exited
+	// non-zero before becoming ready, or otherwise failed to come up. tail
+	// holds up to the last few hundred lines of stdout/stderr captured from
+	// the service process; it is best-effort and may be empty.
+	OnServiceFailed(name, errMsg string, tail []string)
 }
 
 // InfraSnapshot is the current state of a platform infrastructure container.

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -125,7 +125,18 @@ type serviceState struct {
 	port   int
 	status models.PreviewServiceStatus
 	err    string
+
+	// outputTail holds the last serviceTailLines stdout/stderr lines captured
+	// from the service process. It is appended to from the ExecStream onLine
+	// callback under d.mu and is surfaced to the observer when the service
+	// fails so the user can see why it exited.
+	outputTail []string
 }
+
+// serviceTailLines is the size of the per-service stdout/stderr ring buffer
+// that the provider keeps so it can replay the tail to the observer when a
+// service exits non-zero.
+const serviceTailLines = 200
 
 // DockerPreviewOption configures a DockerPreviewProvider.
 type DockerPreviewOption func(*DockerPreviewProvider)
@@ -161,7 +172,7 @@ func NewDockerPreviewProvider(
 // StartPreview
 // =============================================================================
 
-func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*preview.PreviewHandle, error) {
+func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string, observer preview.ServiceObserver) (*preview.PreviewHandle, error) {
 	handle, err := generateHandle()
 	if err != nil {
 		return nil, fmt.Errorf("generate preview handle: %w", err)
@@ -239,7 +250,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 		if name == cfg.Primary {
 			continue // primary starts last
 		}
-		if err := d.startService(svcCtx, state, name, svcCfg, svcEnvs[name]); err != nil {
+		if err := d.startService(svcCtx, state, name, svcCfg, svcEnvs[name], observer); err != nil {
 			d.cleanupState(handle)
 			return nil, fmt.Errorf("start service %q: %w", name, err)
 		}
@@ -247,7 +258,7 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 	// Start primary service.
 	if primaryCfg, ok := cfg.Services[cfg.Primary]; ok {
 		primaryPort = primaryCfg.Port
-		if err := d.startService(svcCtx, state, cfg.Primary, primaryCfg, svcEnvs[cfg.Primary]); err != nil {
+		if err := d.startService(svcCtx, state, cfg.Primary, primaryCfg, svcEnvs[cfg.Primary], observer); err != nil {
 			d.cleanupState(handle)
 			return nil, fmt.Errorf("start primary service %q: %w", cfg.Primary, err)
 		}
@@ -269,14 +280,16 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			if primaryCfg.Ready.TimeoutSeconds > 0 {
 				timeout = time.Duration(primaryCfg.Ready.TimeoutSeconds) * time.Second
 			}
-			if err := d.waitForReadiness(ctx, sb, primaryCfg.Port, primaryCfg.Ready.HTTPPath, timeout); err != nil {
+			if err := d.waitForReadiness(ctx, state, cfg.Primary, primaryCfg.Port, primaryCfg.Ready.HTTPPath, timeout); err != nil {
 				d.cleanupState(handle)
 				return nil, fmt.Errorf("%w: primary service %q (port %d): %v", preview.ErrServiceNotReady, cfg.Primary, primaryCfg.Port, err)
 			}
 			d.mu.Lock()
 			state.services[cfg.Primary].status = models.PreviewServiceStatusReady
+			pid := state.services[cfg.Primary].pid
 			d.mu.Unlock()
 			d.logger.Info().Str("service", cfg.Primary).Int("port", primaryCfg.Port).Msg("primary service ready (progressive)")
+			notifyServiceReady(observer, cfg.Primary, primaryCfg.Port, pid)
 			partiallyReady = true
 		}
 
@@ -293,21 +306,27 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 					timeout = time.Duration(svcCfg.Ready.TimeoutSeconds) * time.Second
 				}
 				bgCtx, cancel := context.WithTimeout(svcCtx, timeout)
-				if err := d.waitForReadiness(bgCtx, sb, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
+				if err := d.waitForReadiness(bgCtx, state, name, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
 					d.logger.Warn().Err(err).Str("service", name).Msg("support service readiness failed (progressive)")
 					d.mu.Lock()
+					var tail []string
 					if ss, ok := state.services[name]; ok {
 						ss.status = models.PreviewServiceStatusFailed
 						ss.err = err.Error()
+						tail = append([]string(nil), ss.outputTail...)
 					}
 					d.mu.Unlock()
+					notifyServiceFailed(observer, name, err.Error(), tail)
 				} else {
 					d.mu.Lock()
+					var pid int
 					if ss, ok := state.services[name]; ok {
 						ss.status = models.PreviewServiceStatusReady
+						pid = ss.pid
 					}
 					d.mu.Unlock()
 					d.logger.Info().Str("service", name).Int("port", svcCfg.Port).Msg("support service ready (progressive)")
+					notifyServiceReady(observer, name, svcCfg.Port, pid)
 				}
 				cancel()
 			}
@@ -319,14 +338,16 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 			if svcCfg.Ready.TimeoutSeconds > 0 {
 				timeout = time.Duration(svcCfg.Ready.TimeoutSeconds) * time.Second
 			}
-			if err := d.waitForReadiness(ctx, sb, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
+			if err := d.waitForReadiness(ctx, state, name, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
 				d.cleanupState(handle)
 				return nil, fmt.Errorf("%w: service %q (port %d): %v", preview.ErrServiceNotReady, name, svcCfg.Port, err)
 			}
 			d.mu.Lock()
 			state.services[name].status = models.PreviewServiceStatusReady
+			pid := state.services[name].pid
 			d.mu.Unlock()
 			d.logger.Info().Str("service", name).Int("port", svcCfg.Port).Msg("service ready")
+			notifyServiceReady(observer, name, svcCfg.Port, pid)
 		}
 	}
 
@@ -829,12 +850,30 @@ func (d *DockerPreviewProvider) runInitScript(
 // Service management
 // =============================================================================
 
+// notifyServiceReady invokes observer.OnServiceReady when observer is non-nil.
+// Centralised so callers can stay nil-safe without scattering checks.
+func notifyServiceReady(observer preview.ServiceObserver, name string, port, pid int) {
+	if observer == nil {
+		return
+	}
+	observer.OnServiceReady(name, port, pid)
+}
+
+// notifyServiceFailed invokes observer.OnServiceFailed when observer is non-nil.
+func notifyServiceFailed(observer preview.ServiceObserver, name, errMsg string, tail []string) {
+	if observer == nil {
+		return
+	}
+	observer.OnServiceFailed(name, errMsg, tail)
+}
+
 func (d *DockerPreviewProvider) startService(
 	ctx context.Context,
 	state *previewState,
 	name string,
 	svcCfg models.ServiceConfig,
 	env map[string]string,
+	observer preview.ServiceObserver,
 ) error {
 	// Build the command with environment variables and working directory.
 	var cmdParts []string
@@ -900,30 +939,60 @@ func (d *DockerPreviewProvider) startService(
 		}()
 
 		exitCode, err := d.executor.ExecStream(svcCtx, state.sandbox, cmd, func(line []byte) {
-			// Log output for diagnostics. In a full implementation this
-			// would be streamed to the preview log store.
-			d.logger.Debug().Str("service", name).Str("output", string(line)).Msg("service output")
+			// Append to the per-service ring buffer so we can replay the tail
+			// to the observer when the service fails. We copy the bytes
+			// because ExecStream reuses the slice across calls.
+			s := string(line)
+			d.mu.Lock()
+			if len(ss.outputTail) >= serviceTailLines {
+				ss.outputTail = ss.outputTail[1:]
+			}
+			ss.outputTail = append(ss.outputTail, s)
+			d.mu.Unlock()
+			d.logger.Debug().Str("service", name).Str("output", s).Msg("service output")
 		}, io.Discard)
 
 		d.mu.Lock()
-		defer d.mu.Unlock()
-		if err != nil || exitCode != 0 {
+		var tail []string
+		failed := err != nil || exitCode != 0
+		if failed {
 			ss.status = models.PreviewServiceStatusFailed
 			if err != nil {
 				ss.err = err.Error()
 			} else {
 				ss.err = fmt.Sprintf("exited with code %d", exitCode)
 			}
-			d.logger.Error().Str("service", name).Int("exit_code", exitCode).Err(err).Msg("service exited")
+			tail = append([]string(nil), ss.outputTail...)
 		} else {
 			ss.status = models.PreviewServiceStatusStopped
+		}
+		errMsg := ss.err
+		d.mu.Unlock()
+
+		if failed {
+			// Surface the tail at error level so it shows up in worker logs
+			// for ops debugging — the ExecStream callback only logs each line
+			// at debug, which is filtered out in production.
+			evt := d.logger.Error().Str("service", name).Int("exit_code", exitCode).Err(err)
+			if len(tail) > 0 {
+				evt = evt.Strs("output_tail", tail)
+			}
+			evt.Msg("service exited")
+			notifyServiceFailed(observer, name, errMsg, tail)
 		}
 	}()
 
 	return nil
 }
 
-func (d *DockerPreviewProvider) waitForReadiness(ctx context.Context, sb *agent.Sandbox, port int, httpPath string, timeout time.Duration) error {
+// readinessProbeAttemptTimeout caps how long a single curl-via-docker-exec
+// call inside the sandbox is allowed to take. Without this, a wedged docker
+// daemon can stretch the overall readiness budget far past its declared
+// timeout — the for-select can only react to deadline.C *between* probe
+// attempts, so a slow exec stalls the timer too.
+const readinessProbeAttemptTimeout = 5 * time.Second
+
+func (d *DockerPreviewProvider) waitForReadiness(ctx context.Context, state *previewState, name string, port int, httpPath string, timeout time.Duration) error {
 	deadline := time.NewTimer(timeout)
 	defer deadline.Stop()
 	tick := time.NewTicker(time.Second)
@@ -933,14 +1002,42 @@ func (d *DockerPreviewProvider) waitForReadiness(ctx context.Context, sb *agent.
 	// Shell-escape the path defensively even though ValidateConfig restricts characters.
 	cmd := fmt.Sprintf("curl -sf -o /dev/null %s", shellEscape(fmt.Sprintf("http://localhost:%d%s", port, httpPath)))
 
+	// Snapshot of the service status read each tick. If the goroutine
+	// running the service in startService has already set Failed/Stopped
+	// (i.e. the process exited before becoming ready), there is no point
+	// continuing to poll — bail immediately with the captured error.
+	checkExited := func() error {
+		d.mu.RLock()
+		defer d.mu.RUnlock()
+		ss, ok := state.services[name]
+		if !ok {
+			return nil
+		}
+		switch ss.status {
+		case models.PreviewServiceStatusFailed:
+			if ss.err != "" {
+				return fmt.Errorf("service %q exited before becoming ready: %s", name, ss.err)
+			}
+			return fmt.Errorf("service %q exited before becoming ready", name)
+		case models.PreviewServiceStatusStopped:
+			return fmt.Errorf("service %q stopped before becoming ready", name)
+		}
+		return nil
+	}
+
 	for {
+		if err := checkExited(); err != nil {
+			return err
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-deadline.C:
 			return fmt.Errorf("readiness probe timed out after %s", timeout)
 		case <-tick.C:
-			exitCode, _ := d.executor.Exec(ctx, sb, cmd, io.Discard, io.Discard)
+			execCtx, cancel := context.WithTimeout(ctx, readinessProbeAttemptTimeout)
+			exitCode, _ := d.executor.Exec(execCtx, state.sandbox, cmd, io.Discard, io.Discard)
+			cancel()
 			if exitCode == 0 {
 				return nil
 			}

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -606,6 +607,383 @@ func (h *hangingSandboxExecutor) Exec(ctx context.Context, _ *agent.Sandbox, _ s
 
 func (h *hangingSandboxExecutor) ReadFile(_ context.Context, _ *agent.Sandbox, _ string) ([]byte, error) {
 	return nil, nil
+}
+
+// recordingObserver captures Ready/Failed calls so tests can assert the
+// provider notified the observer at the right transitions. Safe for
+// concurrent use because progressive support and the startService goroutine
+// can both fire it at the same time.
+type recordingObserver struct {
+	mu          sync.Mutex
+	readyCalls  []recordedReady
+	failedCalls []recordedFailed
+}
+
+type recordedReady struct {
+	name string
+	port int
+	pid  int
+}
+
+type recordedFailed struct {
+	name   string
+	errMsg string
+	tail   []string
+}
+
+func (r *recordingObserver) OnServiceReady(name string, port, pid int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.readyCalls = append(r.readyCalls, recordedReady{name: name, port: port, pid: pid})
+}
+
+func (r *recordingObserver) OnServiceFailed(name, errMsg string, tail []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failedCalls = append(r.failedCalls, recordedFailed{
+		name:   name,
+		errMsg: errMsg,
+		tail:   append([]string(nil), tail...),
+	})
+}
+
+func (r *recordingObserver) ready() []recordedReady {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedReady(nil), r.readyCalls...)
+}
+
+func (r *recordingObserver) failed() []recordedFailed {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedFailed(nil), r.failedCalls...)
+}
+
+// fakeServiceExecutor lets a single test customize what each kind of exec
+// call returns. ExecStream simulates the long-running service process
+// (npm run dev / sh script.sh); Exec handles the readiness curl probes
+// and the per-service `lsof` PID detection.
+type fakeServiceExecutor struct {
+	execStreamFn func(ctx context.Context, cmd string, onLine func([]byte)) (int, error)
+	execFn       func(ctx context.Context, cmd string) (int, error)
+}
+
+func (f *fakeServiceExecutor) ExecStream(ctx context.Context, _ *agent.Sandbox, cmd string, onLine func(line []byte), _ io.Writer) (int, error) {
+	if f.execStreamFn != nil {
+		return f.execStreamFn(ctx, cmd, onLine)
+	}
+	return 0, nil
+}
+
+func (f *fakeServiceExecutor) Exec(ctx context.Context, _ *agent.Sandbox, cmd string, _, _ io.Writer) (int, error) {
+	if f.execFn != nil {
+		return f.execFn(ctx, cmd)
+	}
+	return 0, nil
+}
+
+func (f *fakeServiceExecutor) ReadFile(_ context.Context, _ *agent.Sandbox, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+// TestNotifyService_NilSafe verifies the helper functions tolerate a nil
+// observer — providers must work both when StartPreview is called from the
+// manager (with an observer) and when it's called from a context that
+// doesn't care about per-service updates.
+func TestNotifyService_NilSafe(t *testing.T) {
+	t.Parallel()
+	require.NotPanics(t, func() { notifyServiceReady(nil, "web", 3000, 42) })
+	require.NotPanics(t, func() { notifyServiceFailed(nil, "web", "boom", []string{"line"}) })
+}
+
+// TestNotifyService_InvokesObserver verifies the helpers forward arguments
+// faithfully when the observer is non-nil.
+func TestNotifyService_InvokesObserver(t *testing.T) {
+	t.Parallel()
+	obs := &recordingObserver{}
+	notifyServiceReady(obs, "web", 3000, 42)
+	notifyServiceFailed(obs, "server", "exited with code 126", []string{"hi", "bye"})
+
+	ready := obs.ready()
+	require.Len(t, ready, 1)
+	require.Equal(t, recordedReady{name: "web", port: 3000, pid: 42}, ready[0])
+
+	failed := obs.failed()
+	require.Len(t, failed, 1)
+	require.Equal(t, "server", failed[0].name)
+	require.Equal(t, "exited with code 126", failed[0].errMsg)
+	require.Equal(t, []string{"hi", "bye"}, failed[0].tail)
+}
+
+// TestStartService_FailureCapturesTailAndNotifies exercises the entire
+// startService failure path: the goroutine streams output through onLine
+// (which fills the ring buffer), then ExecStream returns a non-zero exit,
+// and the deferred section copies the tail and fires the observer. This
+// covers ~25 lines that previously had no test.
+func TestStartService_FailureCapturesTailAndNotifies(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeServiceExecutor{
+		execFn: func(_ context.Context, _ string) (int, error) {
+			// lsof for PID detection: pretend nothing's listening.
+			return 1, nil
+		},
+		execStreamFn: func(_ context.Context, _ string, onLine func([]byte)) (int, error) {
+			onLine([]byte("starting up"))
+			onLine([]byte("./bin/server: cannot execute"))
+			return 126, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+
+	state := &previewState{
+		sandbox:  &agent.Sandbox{ID: "sb"},
+		services: map[string]*serviceState{},
+		cancelFn: func() {},
+	}
+
+	err := d.startService(
+		context.Background(),
+		state,
+		"server",
+		models.ServiceConfig{Command: []string{"sh", "preview-start.sh"}, Port: 8080},
+		nil,
+		obs,
+	)
+	require.NoError(t, err)
+	state.wg.Wait()
+
+	failed := obs.failed()
+	require.Len(t, failed, 1, "observer should have been notified of the failure")
+	require.Equal(t, "server", failed[0].name)
+	require.Contains(t, failed[0].errMsg, "126")
+	require.Equal(t, []string{"starting up", "./bin/server: cannot execute"}, failed[0].tail)
+	require.Empty(t, obs.ready(), "should not see any Ready calls when the service exited non-zero")
+
+	// Service status flipped to Failed in-memory so waitForReadiness can
+	// fail-fast on it (covered by TestWaitForReadiness_FailsFastWhenServiceExited).
+	d.mu.RLock()
+	require.Equal(t, models.PreviewServiceStatusFailed, state.services["server"].status)
+	d.mu.RUnlock()
+}
+
+// TestStartService_TailRingBufferBoundedAtServiceTailLines verifies that
+// the per-service stdout/stderr ring buffer drops oldest lines after it
+// fills, so a chatty service can't OOM the worker before it dies.
+func TestStartService_TailRingBufferBoundedAtServiceTailLines(t *testing.T) {
+	t.Parallel()
+
+	totalLines := serviceTailLines + 50
+	exec := &fakeServiceExecutor{
+		execFn: func(_ context.Context, _ string) (int, error) { return 1, nil },
+		execStreamFn: func(_ context.Context, _ string, onLine func([]byte)) (int, error) {
+			for i := 0; i < totalLines; i++ {
+				onLine([]byte(fmt.Sprintf("line-%d", i)))
+			}
+			return 1, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+	state := &previewState{
+		sandbox:  &agent.Sandbox{},
+		services: map[string]*serviceState{},
+		cancelFn: func() {},
+	}
+
+	err := d.startService(context.Background(), state, "web",
+		models.ServiceConfig{Command: []string{"true"}, Port: 3000},
+		nil, obs)
+	require.NoError(t, err)
+	state.wg.Wait()
+
+	failed := obs.failed()
+	require.Len(t, failed, 1)
+	require.Len(t, failed[0].tail, serviceTailLines)
+	// First retained line should be the (totalLines - serviceTailLines)th input.
+	require.Equal(t, fmt.Sprintf("line-%d", totalLines-serviceTailLines), failed[0].tail[0])
+	require.Equal(t, fmt.Sprintf("line-%d", totalLines-1), failed[0].tail[len(failed[0].tail)-1])
+}
+
+// TestWaitForReadiness_FailsFastWhenServiceStopped covers the second branch
+// of checkExited: a service that exited cleanly (Stopped, not Failed) before
+// becoming ready also short-circuits the loop.
+func TestWaitForReadiness_FailsFastWhenServiceStopped(t *testing.T) {
+	t.Parallel()
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, &noopSandboxExecutor{}, zerolog.Nop())
+	state := &previewState{
+		sandbox:  &agent.Sandbox{},
+		services: map[string]*serviceState{},
+	}
+	state.services["web"] = &serviceState{
+		name:   "web",
+		port:   3000,
+		status: models.PreviewServiceStatusStopped,
+	}
+	err := d.waitForReadiness(context.Background(), state, "web", 3000, "/", 5*time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stopped before becoming ready")
+}
+
+// TestStartPreview_StandardMode_NotifiesObserverPerService runs StartPreview
+// to completion in standard mode with two services, both of which become
+// ready promptly, and asserts the observer received one OnServiceReady per
+// service. This covers Phase 5 (startService) and the standard branch of
+// Phase 6 (the readiness loop and notifyServiceReady call).
+func TestStartPreview_StandardMode_NotifiesObserverPerService(t *testing.T) {
+	t.Parallel()
+
+	// Each service's exec stream blocks until the test releases it.
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, cmd string) (int, error) {
+			// curl readiness probes return 0 (ready); lsof PID detection
+			// returns 1 (no listener). Distinguish by looking for "curl" in
+			// the command.
+			if strings.Contains(cmd, "curl") {
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+
+	cfg := &models.PreviewConfig{
+		Name:    "test-app",
+		Primary: "web",
+		Services: map[string]models.ServiceConfig{
+			"web":     {Command: []string{"npm", "run", "dev"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
+			"support": {Command: []string{"node", "worker.js"}, Port: 9000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
+		},
+	}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb"}, cfg, nil, obs)
+	require.NoError(t, err)
+	require.NotNil(t, handle)
+	require.Equal(t, 3000, handle.PrimaryPort)
+	require.False(t, handle.PartiallyReady)
+
+	ready := obs.ready()
+	require.Len(t, ready, 2)
+	names := []string{ready[0].name, ready[1].name}
+	require.ElementsMatch(t, []string{"web", "support"}, names)
+
+	// Cleanup.
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle))
+}
+
+// TestStartPreview_ProgressiveMode_NotifiesObserver covers Phase 6's
+// progressive branch — primary becomes ready first (synchronously), support
+// services come up in a background goroutine.
+func TestStartPreview_ProgressiveMode_NotifiesObserver(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, cmd string) (int, error) {
+			if strings.Contains(cmd, "curl") {
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+
+	cfg := &models.PreviewConfig{
+		Name:        "test-app",
+		Primary:     "web",
+		Progressive: true,
+		Services: map[string]models.ServiceConfig{
+			"web":     {Command: []string{"npm", "run", "dev"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
+			"support": {Command: []string{"node", "worker.js"}, Port: 9000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
+		},
+	}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb"}, cfg, nil, obs)
+	require.NoError(t, err)
+	require.True(t, handle.PartiallyReady)
+
+	// Primary should be ready synchronously — assert without waiting.
+	require.Eventually(t, func() bool {
+		for _, r := range obs.ready() {
+			if r.name == "web" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "primary service should fire OnServiceReady before StartPreview returns")
+
+	// Support service is polled in the background; allow time for it.
+	require.Eventually(t, func() bool {
+		for _, r := range obs.ready() {
+			if r.name == "support" {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 50*time.Millisecond, "support service should eventually fire OnServiceReady")
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle))
+}
+
+// TestStartPreview_NilObserver_DoesNotPanic verifies that providers tolerate
+// a nil observer — code paths in callers (e.g. tests, future internal
+// callers) shouldn't be forced to construct a no-op observer just to call
+// StartPreview.
+func TestStartPreview_NilObserver_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, _ func([]byte)) (int, error) {
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, cmd string) (int, error) {
+			if strings.Contains(cmd, "curl") {
+				return 0, nil
+			}
+			return 1, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+
+	cfg := &models.PreviewConfig{
+		Name:    "test-app",
+		Primary: "web",
+		Services: map[string]models.ServiceConfig{
+			"web": {Command: []string{"npm", "start"}, Port: 3000, Ready: models.ReadinessProbe{HTTPPath: "/"}},
+		},
+	}
+
+	handle, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb"}, cfg, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3000, handle.PrimaryPort)
+
+	close(release)
+	require.NoError(t, d.StopPreview(context.Background(), handle.Handle))
 }
 
 // TestWaitForReadiness_FailsFastWhenServiceExited verifies that the readiness

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
@@ -569,4 +570,100 @@ func TestTcpPreviewStream_NilClose(t *testing.T) {
 	t.Parallel()
 	s := &tcpPreviewStream{Conn: nil}
 	require.NoError(t, s.Close())
+}
+
+// hangingSandboxExecutor blocks Exec on a per-call channel so tests can prove
+// the readiness loop bounds each docker-exec attempt with a timeout instead
+// of letting a wedged daemon stall the whole probe.
+type hangingSandboxExecutor struct {
+	calls   chan struct{}
+	release chan struct{}
+}
+
+func (h *hangingSandboxExecutor) ExecStream(_ context.Context, _ *agent.Sandbox, _ string, _ func(line []byte), _ io.Writer) (int, error) {
+	return 0, nil
+}
+
+func (h *hangingSandboxExecutor) Exec(ctx context.Context, _ *agent.Sandbox, _ string, _, _ io.Writer) (int, error) {
+	if h.calls != nil {
+		select {
+		case h.calls <- struct{}{}:
+		default:
+		}
+	}
+	if h.release != nil {
+		select {
+		case <-h.release:
+		case <-ctx.Done():
+			return 1, ctx.Err()
+		}
+	} else {
+		<-ctx.Done()
+		return 1, ctx.Err()
+	}
+	return 1, nil
+}
+
+func (h *hangingSandboxExecutor) ReadFile(_ context.Context, _ *agent.Sandbox, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+// TestWaitForReadiness_FailsFastWhenServiceExited verifies that the readiness
+// loop bails immediately when the underlying service goroutine has set
+// status=Failed, instead of polling for the entire (long) probe timeout.
+// This was the worst part of the May 2026 16-minute preview-stuck incident:
+// the user's `server` exited 126 in seconds but waitForReadiness kept curling
+// a dead port for the full 4-minute budget.
+func TestWaitForReadiness_FailsFastWhenServiceExited(t *testing.T) {
+	t.Parallel()
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, &noopSandboxExecutor{}, zerolog.Nop())
+	state := &previewState{
+		sandbox:  &agent.Sandbox{},
+		services: map[string]*serviceState{},
+	}
+	state.services["server"] = &serviceState{
+		name:   "server",
+		port:   8080,
+		status: models.PreviewServiceStatusFailed,
+		err:    "exited with code 126",
+	}
+	// Use a generous timeout — the test asserts we return well before it.
+	err := d.waitForReadiness(context.Background(), state, "server", 8080, "/health", 5*time.Second)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exited before becoming ready")
+	require.Contains(t, err.Error(), "126")
+}
+
+// TestWaitForReadiness_BoundsExecPerAttempt verifies that each Exec call is
+// wrapped in a per-attempt timeout, so a wedged docker daemon can't stretch
+// the readiness budget. We give the loop a 2.5s overall timeout against an
+// Exec that hangs forever; without per-attempt bounding the loop would never
+// return because the deadline.C case can only fire between attempts.
+func TestWaitForReadiness_BoundsExecPerAttempt(t *testing.T) {
+	t.Parallel()
+	hung := &hangingSandboxExecutor{calls: make(chan struct{}, 4)}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, hung, zerolog.Nop())
+	state := &previewState{
+		sandbox:  &agent.Sandbox{},
+		services: map[string]*serviceState{},
+	}
+	state.services["web"] = &serviceState{
+		name:   "web",
+		port:   3000,
+		status: models.PreviewServiceStatusStarting,
+	}
+
+	// Overall budget shorter than a single hung Exec would take if unbounded.
+	// Per-attempt timeout (5s in production) is longer than this 2.5s overall
+	// budget, so the test really exercises the deadline.C path between
+	// attempts: the per-attempt timeout cancels the hung Exec, the loop
+	// re-enters select, and deadline.C fires.
+	start := time.Now()
+	err := d.waitForReadiness(context.Background(), state, "web", 3000, "/", 2500*time.Millisecond)
+	elapsed := time.Since(start)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "timed out")
+	// Generous upper bound so this isn't flaky on a loaded CI host but small
+	// enough to catch the regression where the loop stalls on a hung Exec.
+	require.Less(t, elapsed, 30*time.Second, "readiness loop didn't honor its timeout under a hung Exec")
 }

--- a/internal/services/preview/recycler_test.go
+++ b/internal/services/preview/recycler_test.go
@@ -27,9 +27,9 @@ func (p *countingProvider) StopPreview(ctx context.Context, handle string) error
 	return p.mockProvider.StopPreview(ctx, handle)
 }
 
-func (p *countingProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string) (*PreviewHandle, error) {
+func (p *countingProvider) StartPreview(ctx context.Context, sb *agent.Sandbox, cfg *models.PreviewConfig, extraEnv map[string]string, observer ServiceObserver) (*PreviewHandle, error) {
 	p.startCount++
-	return p.mockProvider.StartPreview(ctx, sb, cfg, extraEnv)
+	return p.mockProvider.StartPreview(ctx, sb, cfg, extraEnv, observer)
 }
 
 // newPreviewInstanceRowWithRecycleSchedule is like newPreviewInstanceRow but


### PR DESCRIPTION
## Summary
A preview whose support service exited with code 126 in seconds was leaving users waiting ~16 minutes for a "service not ready" error: the readiness loop kept polling a dead port for the full 240s timeout, the per-tick `docker exec` was unbounded so a wedged daemon stretched the budget further, and per-service status was only persisted after `StartPreview` fully returned so the UI showed "all starting" the whole time.

The provider now bails out of the readiness loop the moment the service goroutine sets `status=Failed`/`Stopped`, wraps each curl-via-docker-exec in a 5s per-attempt context, keeps a 200-line ring buffer of stdout/stderr, and emits per-service Ready/Failed events through a new `ServiceObserver`. The manager wires an observer that updates the `preview_services` row live and writes a `preview_logs` entry containing the tail when a service fails — so the user sees both live progress on the startup checklist and the actual reason their service died.

## Test plan
- [x] `go test ./internal/services/preview/... ./internal/api/handlers/...` passes
- [x] New unit tests `TestWaitForReadiness_FailsFastWhenServiceExited` and `TestWaitForReadiness_BoundsExecPerAttempt` pass
- [x] `make lint` clean
- [ ] Trigger a preview with an intentionally broken support service (`exit 126`) and confirm the failure surfaces in <30s with the script's last lines visible in the preview log feed
- [ ] Recheck a normal multi-service preview still reaches "ready" (regression check on the happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
