### PR TITLE
Debounce session draft writes to reduce sessions/new typing lag on mobile

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { ManualSessionCreatePageContent } from "./manual-session-create-page-content";
 
@@ -155,6 +155,10 @@ describe("ManualSessionCreatePageContent", () => {
     Object.values(mocks).forEach((m) => m.mockClear());
     mocks.searchParamGetMock.mockImplementation(() => null);
     window.sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("renders the session creation form", async () => {
@@ -563,21 +567,49 @@ describe("ManualSessionCreatePageContent", () => {
       });
     });
 
-    it("writes the prompt to sessionStorage as the user types", async () => {
+    it("debounces prompt writes to sessionStorage while the user types", async () => {
       renderWithProviders(<ManualSessionCreatePageContent />);
 
       const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
         "Tell the agent what to do...",
       );
+
+      vi.useFakeTimers();
       fireEvent.change(textarea, { target: { value: "draft in progress" } });
 
-      await waitFor(() => {
-        const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
-        expect(stored).not.toBeNull();
-        expect(JSON.parse(stored!)).toMatchObject({
-          __v: 2,
-          message: "draft in progress",
-        });
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+      vi.advanceTimersByTime(399);
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+      await vi.advanceTimersByTimeAsync(1);
+      const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toMatchObject({
+        __v: 2,
+        message: "draft in progress",
+      });
+    });
+
+    it("flushes the debounced draft immediately when the prompt blurs", async () => {
+      renderWithProviders(<ManualSessionCreatePageContent />);
+
+      const textarea = await screen.findByPlaceholderText<HTMLTextAreaElement>(
+        "Tell the agent what to do...",
+      );
+
+      vi.useFakeTimers();
+      fireEvent.change(textarea, { target: { value: "save on blur" } });
+
+      expect(window.sessionStorage.getItem(DRAFT_STORAGE_KEY)).toBeNull();
+
+      fireEvent.blur(textarea);
+
+      const stored = window.sessionStorage.getItem(DRAFT_STORAGE_KEY);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toMatchObject({
+        __v: 2,
+        message: "save on blur",
       });
     });
 

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -65,6 +65,7 @@ import {
 import type { CodingAuth, OrgSettings, Organization, Repository, SingleResponse, ListResponse, ResolvedCredential, SessionInputCommand, SessionInputReference } from "@/lib/types";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+const DRAFT_SAVE_DEBOUNCE_MS = 400;
 const triggerPickerIconClassName = "h-4 w-4 shrink-0";
 const directoryTriggerIcon = <FolderTree className={triggerPickerIconClassName} />;
 const fileTriggerIcon = <FileCode2 className={triggerPickerIconClassName} />;
@@ -101,6 +102,9 @@ export function ManualSessionCreatePageContent() {
   const messageInputRef = useRef<HTMLTextAreaElement>(null);
   const composerCardRef = useRef<HTMLDivElement>(null);
   const recognitionRef = useRef<BrowserSpeechRecognition | null>(null);
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingDraftRef = useRef<Parameters<typeof saveDraft>[0] | null>(null);
+  const resizeFrameRef = useRef<number | null>(null);
   // Synchronous guard: React Query's isPending flips on the next render, so
   // rapid Enter presses can all pass the isPending check in the same tick.
   const submittingRef = useRef(false);
@@ -216,7 +220,7 @@ export function ManualSessionCreatePageContent() {
   // confusing.
   useEffect(() => {
     if (!draftHydrated) return;
-    saveDraft({
+    const nextDraft = {
       message,
       attachments,
       references,
@@ -227,7 +231,18 @@ export function ManualSessionCreatePageContent() {
       branchByRepoId,
       showImageInput,
       imageURL,
-    });
+    };
+
+    pendingDraftRef.current = nextDraft;
+    if (draftSaveTimerRef.current) {
+      clearTimeout(draftSaveTimerRef.current);
+    }
+    draftSaveTimerRef.current = setTimeout(() => {
+      if (!pendingDraftRef.current) return;
+      saveDraft(pendingDraftRef.current);
+      pendingDraftRef.current = null;
+      draftSaveTimerRef.current = null;
+    }, DRAFT_SAVE_DEBOUNCE_MS);
   }, [
     draftHydrated,
     message,
@@ -241,6 +256,27 @@ export function ManualSessionCreatePageContent() {
     showImageInput,
     imageURL,
   ]);
+
+  function flushDraftSave() {
+    if (draftSaveTimerRef.current) {
+      clearTimeout(draftSaveTimerRef.current);
+      draftSaveTimerRef.current = null;
+    }
+    if (!pendingDraftRef.current) {
+      return;
+    }
+    saveDraft(pendingDraftRef.current);
+    pendingDraftRef.current = null;
+  }
+
+  useEffect(() => {
+    return () => {
+      flushDraftSave();
+      if (resizeFrameRef.current !== null) {
+        cancelAnimationFrame(resizeFrameRef.current);
+      }
+    };
+  }, []);
 
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
@@ -482,16 +518,23 @@ export function ManualSessionCreatePageContent() {
   }
 
   function resizeMessageInput() {
-    const element = messageInputRef.current;
-    if (!element) {
-      return;
+    if (resizeFrameRef.current !== null) {
+      cancelAnimationFrame(resizeFrameRef.current);
     }
 
-    const maxHeight = 240;
-    element.style.height = "auto";
-    const nextHeight = Math.min(element.scrollHeight, maxHeight);
-    element.style.height = `${nextHeight}px`;
-    element.style.overflowY = element.scrollHeight > maxHeight ? "auto" : "hidden";
+    resizeFrameRef.current = requestAnimationFrame(() => {
+      resizeFrameRef.current = null;
+      const element = messageInputRef.current;
+      if (!element) {
+        return;
+      }
+
+      const maxHeight = 240;
+      element.style.height = "auto";
+      const nextHeight = Math.min(element.scrollHeight, maxHeight);
+      element.style.height = `${nextHeight}px`;
+      element.style.overflowY = element.scrollHeight > maxHeight ? "auto" : "hidden";
+    });
   }
 
   useEffect(() => {
@@ -938,8 +981,8 @@ export function ManualSessionCreatePageContent() {
                 autoFocus
                 onChange={(event) => {
                   updateMessage(event.target.value, event.target.selectionStart ?? event.target.value.length);
-                  resizeMessageInput();
                 }}
+                onBlur={flushDraftSave}
                 onClick={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
                 onKeyUp={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}
                 onSelect={(event) => setCaretPosition(event.currentTarget.selectionStart ?? message.length)}


### PR DESCRIPTION
## Summary
Debounced writes of the manual-session prompt draft to `sessionStorage` to avoid blocking work on every keystroke, reducing typing lag on mobile. Also ensured the draft is flushed immediately when the textarea blurs so users don’t lose changes.

## Changes
- `frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx`
  - Added `DRAFT_SAVE_DEBOUNCE_MS = 400` and implemented debounced sessionStorage updates while typing.
  - Flushes the debounced draft immediately on textarea `blur` to preserve the latest input.
- `frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx`
  - Updated tests to verify debounced behavior during typing using fake timers.
  - Added coverage for immediate flush on blur.
  - Restored real timers after each test to prevent cross-test leakage.

## Test plan
- Ran the updated unit tests for `ManualSessionCreatePageContent` (Vitest), validating:
  - No `sessionStorage` draft write occurs until the debounce window elapses.
  - A blur event triggers an immediate draft write.

---
*Generated by [143.dev](https://143.dev) — [session 989a3b75](https://app.143.dev/sessions/989a3b75-0073-40d1-8d90-ebdcdff14ecf)*
