### PR TITLE
Resolve attached review comments atomically with the follow-up message

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3081,6 +3081,7 @@ describe('SessionDetailPage', () => {
 
   it('clears attached review comments after sending them to the agent', async () => {
     let postedMessage = '';
+    let postedResolveIDs: string[] | undefined;
     const idleSessionWithDiff: Session = {
       ...mockSessions[0],
       status: 'idle',
@@ -3090,7 +3091,7 @@ describe('SessionDetailPage', () => {
       diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);',
       diff_stats: { added: 1, removed: 0, files_changed: 1 },
     };
-    const comments: SessionReviewComment[] = [{
+    const comment: SessionReviewComment = {
       id: 'comment-1',
       session_id: idleSessionWithDiff.id,
       org_id: 'org-1',
@@ -3103,7 +3104,11 @@ describe('SessionDetailPage', () => {
       pass_number: 1,
       created_at: '2026-02-17T07:10:00Z',
       updated_at: '2026-02-17T07:10:00Z',
-    }];
+    };
+    // Mutable backing store: GET returns whatever state POST /messages
+    // transitions the comment to. Mirrors the real backend, which resolves
+    // attached comments in the same transaction as the message create.
+    let comments: SessionReviewComment[] = [comment];
 
     server.use(
       http.get('/api/v1/sessions/:id', () => {
@@ -3116,8 +3121,13 @@ describe('SessionDetailPage', () => {
         } satisfies ListResponse<SessionReviewComment>);
       }),
       http.post('/api/v1/sessions/:id/messages', async ({ request }) => {
-        const body = await request.json() as { message: string };
+        const body = await request.json() as { message: string; resolve_review_comment_ids?: string[] };
         postedMessage = body.message;
+        postedResolveIDs = body.resolve_review_comment_ids;
+        if (postedResolveIDs && postedResolveIDs.length > 0) {
+          const resolved = new Set(postedResolveIDs);
+          comments = comments.map((c) => (resolved.has(c.id) ? { ...c, resolved: true } : c));
+        }
         return HttpResponse.json({
           data: {
             id: 99,
@@ -3154,6 +3164,10 @@ describe('SessionDetailPage', () => {
       expect(postedMessage).toContain('"Handle the null edge case"');
       expect(postedMessage).toContain('Hello agent');
     });
+    // The send must include the comment ID so the backend can resolve it
+    // atomically with the message create. Without this, a page refresh
+    // would resurrect the attached comment.
+    expect(postedResolveIDs).toEqual([comment.id]);
 
     await waitFor(() => {
       expect(screen.queryByText('1 comment attached')).not.toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3175,6 +3175,84 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByText('Handle the null edge case')).not.toBeInTheDocument();
   });
 
+  it('caps attached review comments to the backend per-message resolve limit', async () => {
+    let postedResolveIDs: string[] | undefined;
+    const idleSessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);',
+      diff_stats: { added: 1, removed: 0, files_changed: 1 },
+    };
+    const originalComments: SessionReviewComment[] = Array.from({ length: 51 }, (_, index) => ({
+      id: `00000000-0000-4000-8000-${index.toString().padStart(12, '0')}`,
+      session_id: idleSessionWithDiff.id,
+      org_id: 'org-1',
+      user_id: mockMembers[0].id,
+      file_path: 'src/app.ts',
+      line_number: index + 1,
+      diff_side: 'new',
+      body: `Review comment ${index + 1}`,
+      resolved: false,
+      pass_number: 1,
+      created_at: '2026-02-17T07:10:00Z',
+      updated_at: '2026-02-17T07:10:00Z',
+    }));
+    let comments = originalComments;
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/review-comments', () => {
+        return HttpResponse.json({
+          data: comments,
+          meta: {},
+        } satisfies ListResponse<SessionReviewComment>);
+      }),
+      http.post('/api/v1/sessions/:id/messages', async ({ request }) => {
+        const body = await request.json() as { message: string; resolve_review_comment_ids?: string[] };
+        postedResolveIDs = body.resolve_review_comment_ids;
+        if (postedResolveIDs && postedResolveIDs.length > 0) {
+          const resolved = new Set(postedResolveIDs);
+          comments = comments.map((comment) => (resolved.has(comment.id) ? { ...comment, resolved: true } : comment));
+        }
+        return HttpResponse.json({
+          data: {
+            id: 99,
+            session_id: idleSessionWithDiff.id,
+            org_id: 'org-1',
+            user_id: 'user-1',
+            turn_number: 2,
+            role: 'user' as const,
+            content: body.message,
+            created_at: '2026-02-17T07:10:00Z',
+          },
+        } satisfies SingleResponse<SessionMessage>);
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const textarea = await screen.findByPlaceholderText('Send a follow-up message...');
+    expect(await screen.findByText('50 comments attached')).toBeInTheDocument();
+
+    await user.type(textarea, 'Please handle these');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(postedResolveIDs).toHaveLength(50);
+    });
+    expect(postedResolveIDs).toEqual(originalComments.slice(0, 50).map((comment) => comment.id));
+
+    await waitFor(() => {
+      expect(screen.getByText('1 comment attached')).toBeInTheDocument();
+    });
+  });
+
   it('scrolls the chat transcript back to the live edge after sending a follow-up message', async () => {
     let messageSent = false;
     const idleSession: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2178,20 +2178,15 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [composerCommands, setComposerCommands] = useState<SessionInputCommand[]>([]);
   const [composerIsUploading, setComposerIsUploading] = useState(false);
   const [composerUploadError, setComposerUploadError] = useState<string | null>(null);
-  const [dismissedAttachedReviewCommentIDs, setDismissedAttachedReviewCommentIDs] = useState<string[]>([]);
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null);
   const composerUploadInputRef = useRef<HTMLInputElement>(null);
   const chatPanelScrollToLiveEdgeRef = useRef<(() => void) | null>(null);
-  const openComments = useMemo(() => comments.filter((comment) => !comment.resolved), [comments]);
-  useEffect(() => {
-    setDismissedAttachedReviewCommentIDs((previous) =>
-      previous.filter((commentID) => openComments.some((comment) => comment.id === commentID))
-    );
-  }, [openComments]);
-  const attachedReviewComments = useMemo(
-    () => openComments.filter((comment) => !dismissedAttachedReviewCommentIDs.includes(comment.id)),
-    [dismissedAttachedReviewCommentIDs, openComments]
-  );
+  // Open comments are the source of truth for what gets attached to the next
+  // message — once a send succeeds, the backend marks them resolved in the
+  // same transaction, the comments query is invalidated below, and the next
+  // refetch flips them out of openComments. No local "dismissed" state is
+  // needed (and would be wrong: it wouldn't survive page reloads).
+  const attachedReviewComments = useMemo(() => comments.filter((comment) => !comment.resolved), [comments]);
   const composerCanSendMessage = session?.status !== "skipped" && session?.status !== "pending" && session?.sandbox_state !== "destroyed";
   const composerIsRunning = session?.status === "running";
   const composerIsSnapshotExpired = session?.sandbox_state === "destroyed";
@@ -2242,6 +2237,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         ? formatReviewMessage(attachedReviewComments, filteredFiles, draftMessage)
         : draftMessage;
       const isPlanRequest = opts.planMode ?? composerPlanMode;
+      const resolveReviewCommentIDs = attachedReviewComments.map((comment) => comment.id);
 
       return api.sessions.sendMessage(id, {
         message: formattedMessage,
@@ -2250,15 +2246,10 @@ export function SessionDetailContent({ id }: { id: string }) {
         commands: composerCommands.length > 0 ? composerCommands : undefined,
         planMode: isPlanRequest,
         model: composerSelectedModel || undefined,
-      });
+        resolveReviewCommentIDs: resolveReviewCommentIDs.length > 0 ? resolveReviewCommentIDs : undefined,
+      }).then((response) => ({ response, resolvedIDs: resolveReviewCommentIDs }));
     },
-    onSuccess: () => {
-      setDismissedAttachedReviewCommentIDs((previous) => {
-        if (attachedReviewComments.length === 0) {
-          return previous;
-        }
-        return Array.from(new Set([...previous, ...attachedReviewComments.map((comment) => comment.id)]));
-      });
+    onSuccess: ({ resolvedIDs }) => {
       setComposerMessage("");
       setComposerAttachments([]);
       setComposerReferences([]);
@@ -2273,6 +2264,26 @@ export function SessionDetailContent({ id }: { id: string }) {
       chatPanelScrollToLiveEdgeRef.current?.();
       queryClient.invalidateQueries({ queryKey: ["session", id] });
       queryClient.invalidateQueries({ queryKey: ["session", id, "timeline"] });
+      // Backend resolved the attached review comments inside the same tx as
+      // the message. Optimistically flip them to resolved=true in the cache
+      // so the "N comments attached" banner disappears immediately, then
+      // invalidate to reconcile with the canonical server state.
+      if (resolvedIDs.length > 0) {
+        const resolvedSet = new Set(resolvedIDs);
+        queryClient.setQueryData<ListResponse<SessionReviewComment>>(
+          ["session", id, "review-comments"],
+          (previous) => {
+            if (!previous) return previous;
+            return {
+              ...previous,
+              data: previous.data.map((comment) =>
+                resolvedSet.has(comment.id) ? { ...comment, resolved: true } : comment
+              ),
+            };
+          }
+        );
+      }
+      queryClient.invalidateQueries({ queryKey: ["session", id, "review-comments"] });
     },
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -120,6 +120,7 @@ const PREVIEW_ORIGIN_TEMPLATE =
 const FAILURE_CATEGORY_CODEX_AUTH = "codex_auth_expired";
 const PR_ERROR_TOAST_DURATION_MS = 10_000;
 const PR_ERROR_TOAST_MESSAGE = "PR creation failed";
+const MAX_RESOLVE_REVIEW_COMMENTS_PER_MESSAGE = 50;
 
 const statusConfig: Record<string, { color: string; label: string }> = {
   pending: { color: "bg-muted text-muted-foreground", label: "Pending" },
@@ -2186,7 +2187,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   // same transaction, the comments query is invalidated below, and the next
   // refetch flips them out of openComments. No local "dismissed" state is
   // needed (and would be wrong: it wouldn't survive page reloads).
-  const attachedReviewComments = useMemo(() => comments.filter((comment) => !comment.resolved), [comments]);
+  const attachedReviewComments = useMemo(
+    () => comments.filter((comment) => !comment.resolved).slice(0, MAX_RESOLVE_REVIEW_COMMENTS_PER_MESSAGE),
+    [comments],
+  );
   const composerCanSendMessage = session?.status !== "skipped" && session?.status !== "pending" && session?.sandbox_state !== "destroyed";
   const composerIsRunning = session?.status === "running";
   const composerIsSnapshotExpired = session?.sandbox_state === "destroyed";

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -341,7 +341,7 @@ export const api = {
       post<import('./types').SingleResponse<import('./types').Session>>('/api/v1/sessions/manual', body),
     getMessages: (sessionId: string) =>
       get<import('./types').ListResponse<import('./types').SessionMessage>>(`/api/v1/sessions/${sessionId}/messages`),
-    sendMessage: (sessionId: string, body: { message: string; images?: string[]; references?: import('./types').SessionInputReference[]; commands?: import('./types').SessionInputCommand[]; planMode?: boolean; model?: string }) =>
+    sendMessage: (sessionId: string, body: { message: string; images?: string[]; references?: import('./types').SessionInputReference[]; commands?: import('./types').SessionInputCommand[]; planMode?: boolean; model?: string; resolveReviewCommentIDs?: string[] }) =>
       post<import('./types').SingleResponse<import('./types').SessionMessage>>(
         `/api/v1/sessions/${sessionId}/messages`,
         {
@@ -351,6 +351,7 @@ export const api = {
           commands: body.commands && body.commands.length > 0 ? body.commands : undefined,
           plan_mode: body.planMode || undefined,
           ...(body.model ? { model: body.model } : {}),
+          resolve_review_comment_ids: body.resolveReviewCommentIDs && body.resolveReviewCommentIDs.length > 0 ? body.resolveReviewCommentIDs : undefined,
         },
       ),
     endSession: (sessionId: string) =>

--- a/internal/api/handlers/audit_helpers.go
+++ b/internal/api/handlers/audit_helpers.go
@@ -83,6 +83,62 @@ func emitUserAuditWithSession(emitter *db.AuditEmitter, r *http.Request, action 
 	emitter.EmitUserAction(r.Context(), params)
 }
 
+// userAuditEntry is a per-row payload for emitUserAuditsWithSession. The
+// shared per-request fields (orgID, userID, IP, request ID, user agent) are
+// pulled once at dispatch time, so callers only have to supply the bits that
+// vary across audit rows.
+type userAuditEntry struct {
+	Action       models.AuditAction
+	ResourceType models.AuditResourceType
+	ResourceID   *string
+	SessionID    *uuid.UUID
+	ProjectID    *uuid.UUID
+	Details      json.RawMessage
+}
+
+// emitUserAuditsWithSession is the batched form of emitUserAuditWithSession:
+// it extracts request context once and writes all entries in a single DB
+// round-trip via AuditEmitter.EmitUserActions. No-op when emitter or user
+// context is missing, mirroring the single-emit helpers.
+func emitUserAuditsWithSession(emitter *db.AuditEmitter, r *http.Request, entries []userAuditEntry) {
+	if emitter == nil || len(entries) == 0 {
+		return
+	}
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		return
+	}
+	orgID := middleware.OrgIDFromContext(r.Context())
+
+	var requestID *string
+	if reqID := chiMiddleware.GetReqID(r.Context()); reqID != "" {
+		requestID = &reqID
+	}
+	ipAddress := parseClientIP(r)
+	var userAgent *string
+	if ua := r.UserAgent(); ua != "" {
+		userAgent = &ua
+	}
+
+	paramsList := make([]db.UserActionParams, 0, len(entries))
+	for _, e := range entries {
+		paramsList = append(paramsList, db.UserActionParams{
+			OrgID:        orgID,
+			UserID:       user.ID,
+			Action:       e.Action,
+			ResourceType: e.ResourceType,
+			ResourceID:   e.ResourceID,
+			Details:      e.Details,
+			RequestID:    requestID,
+			IPAddress:    ipAddress,
+			UserAgent:    userAgent,
+			SessionID:    e.SessionID,
+			ProjectID:    e.ProjectID,
+		})
+	}
+	emitter.EmitUserActions(r.Context(), paramsList)
+}
+
 // parseClientIP extracts the client IP from the request as a netip.Prefix
 // suitable for PostgreSQL inet storage.
 func parseClientIP(r *http.Request) *netip.Prefix {

--- a/internal/api/handlers/audit_helpers_batch_test.go
+++ b/internal/api/handlers/audit_helpers_batch_test.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+	chiMiddleware "github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmitUserAuditsWithSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-ops without emitter", func(t *testing.T) {
+		t.Parallel()
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		emitUserAuditsWithSession(nil, req, []userAuditEntry{{Action: models.AuditActionSessionCreated}})
+	})
+
+	t.Run("no-ops without entries", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		emitter := db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+		emitUserAuditsWithSession(emitter, req, nil)
+		require.NoError(t, mock.ExpectationsWereMet(), "empty audit entry list should not write audit rows")
+	})
+
+	t.Run("no-ops without user context", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+		emitter := db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+		emitUserAuditsWithSession(emitter, req, []userAuditEntry{{Action: models.AuditActionSessionCreated}})
+		require.NoError(t, mock.ExpectationsWereMet(), "missing user context should not write audit rows")
+	})
+
+	t.Run("includes request metadata on emitted rows", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		sessionID := uuid.New()
+		resourceID := sessionID.String()
+
+		mock.ExpectQuery("INSERT INTO audit_logs").
+			WithArgs(
+				orgID,
+				models.AuditActorUser,
+				userID.String(),
+				&userID,
+				models.AuditActionSessionReviewCommentUpdated,
+				models.AuditResourceSessionReviewComment,
+				&resourceID,
+				json.RawMessage(`{"source":"test"}`),
+				pgxmock.AnyArg(),
+				pgxmock.AnyArg(),
+				pgxmock.AnyArg(),
+				&sessionID,
+				pgxmock.AnyArg(),
+			).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), time.Now()))
+
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		req.Header.Set("X-Forwarded-For", "203.0.113.10")
+		req.Header.Set("User-Agent", "unit-test-agent")
+		ctx := middleware.WithOrgID(req.Context(), orgID)
+		ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: "member"})
+		ctx = context.WithValue(ctx, chiMiddleware.RequestIDKey, "req-123")
+		req = req.WithContext(ctx)
+
+		emitter := db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+		emitUserAuditsWithSession(emitter, req, []userAuditEntry{{
+			Action:       models.AuditActionSessionReviewCommentUpdated,
+			ResourceType: models.AuditResourceSessionReviewComment,
+			ResourceID:   &resourceID,
+			SessionID:    &sessionID,
+			Details:      json.RawMessage(`{"source":"test"}`),
+		}})
+
+		require.NoError(t, mock.ExpectationsWereMet(), "batched helper should emit one enriched audit row")
+	})
+}

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -78,6 +78,7 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"SessionFileHandler.GetFileContext":        "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionComposerHandler.ListSlashCommands": "built-in catalog is not org-scoped; project discovery branch delegates to buildProjectSlashCommandGroup which uses OrgIDFromContext",
 		"SessionHandler.StreamLogs":                "EventSource cannot send X-Active-Org-ID; delegates to streamOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
+		"resolveCommentsError.write":               "internal error-rendering helper; org scoping happens upstream in SendMessage where the error was produced",
 		"UploadHandler.ServeUpload":                "<img>/<a> tag fetches cannot send X-Active-Org-ID; authorizes off the path-encoded org-id + UserFromContext membership check rather than active-org context",
 		"UsageHandler.ExportCSV":                   "window.open downloads cannot send X-Active-Org-ID; delegates to exportOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
 

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -48,23 +48,24 @@ type sessionMembershipStore interface {
 }
 
 type SessionHandler struct {
-	runStore         *db.SessionStore
-	logStore         *db.SessionLogStore
-	questionStore    *db.SessionQuestionStore
-	validationStore  *db.ValidationStore
-	pullRequestStore *db.PullRequestStore
-	issueStore       *db.IssueStore
-	repoStore        *db.RepositoryStore
-	orgStore         *db.OrganizationStore
-	jobStore         *db.JobStore
-	messageStore     *db.SessionMessageStore
-	linkStore        *db.SessionIssueLinkStore
-	issueSnapshots   *db.SessionTurnIssueSnapshotStore
-	threadStore      *db.SessionThreadStore
-	viewStore        *db.SessionViewStore
-	memberships      sessionMembershipStore
-	prCredentials    githubStatusCredentialStore
-	prAuthChecker    interface {
+	runStore           *db.SessionStore
+	logStore           *db.SessionLogStore
+	questionStore      *db.SessionQuestionStore
+	validationStore    *db.ValidationStore
+	pullRequestStore   *db.PullRequestStore
+	issueStore         *db.IssueStore
+	repoStore          *db.RepositoryStore
+	orgStore           *db.OrganizationStore
+	jobStore           *db.JobStore
+	messageStore       *db.SessionMessageStore
+	reviewCommentStore *db.SessionReviewCommentStore
+	linkStore          *db.SessionIssueLinkStore
+	issueSnapshots     *db.SessionTurnIssueSnapshotStore
+	threadStore        *db.SessionThreadStore
+	viewStore          *db.SessionViewStore
+	memberships        sessionMembershipStore
+	prCredentials      githubStatusCredentialStore
+	prAuthChecker      interface {
 		HasValidCredential(ctx context.Context, orgID, userID uuid.UUID) (bool, error)
 	}
 	snapshotStore    storage.SnapshotStore // optional — enables snapshot cleanup on archive
@@ -201,6 +202,13 @@ var (
 
 func (h *SessionHandler) SetIssueLinkStore(store *db.SessionIssueLinkStore) {
 	h.linkStore = store
+}
+
+// SetReviewCommentStore wires the review-comment store used by SendMessage to
+// resolve comments inline with the message create transaction. Optional: if
+// unset, requests with resolve_review_comment_ids are rejected with a 400.
+func (h *SessionHandler) SetReviewCommentStore(store *db.SessionReviewCommentStore) {
+	h.reviewCommentStore = store
 }
 
 // SetLinearLinker injects the Linear session-linking service. When unset,
@@ -1537,6 +1545,12 @@ func (h *SessionHandler) AnswerQuestion(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.SessionQuestion]{Data: question})
 }
 
+// maxReviewCommentResolveIDsPerMessage caps how many review comments a single
+// SendMessage call can resolve. Each resolved comment emits one audit row
+// after the tx commits, so the cap keeps the post-commit tail bounded even
+// under unusual client behavior. The realistic typical attached-count is 1–3.
+const maxReviewCommentResolveIDsPerMessage = 50
+
 // SendMessage handles POST /sessions/{id}/messages — sends a follow-up message
 // to an idle multi-turn session and enqueues a continue_session job.
 func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
@@ -1553,11 +1567,12 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		Message    string                         `json:"message"`
-		Images     []string                       `json:"images"`
-		References []models.SessionInputReference `json:"references"`
-		Commands   []models.SessionInputCommand   `json:"commands"`
-		PlanMode   bool                           `json:"plan_mode"`
+		Message                 string                         `json:"message"`
+		Images                  []string                       `json:"images"`
+		References              []models.SessionInputReference `json:"references"`
+		Commands                []models.SessionInputCommand   `json:"commands"`
+		PlanMode                bool                           `json:"plan_mode"`
+		ResolveReviewCommentIDs []string                       `json:"resolve_review_comment_ids"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
@@ -1578,6 +1593,43 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		if err := command.Validate(); err != nil {
 			writeError(w, r, http.StatusBadRequest, "INVALID_COMMANDS", err.Error())
 			return
+		}
+	}
+
+	// Parse and dedupe optional review-comment IDs to resolve atomically with
+	// the message create. Reject malformed UUIDs and overlong lists early so
+	// the SQL phase only sees clean input.
+	//
+	// Authorization: SendMessage allows resolving any comment in the session,
+	// regardless of authorship — the user is taking action on the comment by
+	// addressing it in their message. This intentionally diverges from PATCH
+	// /review-comments/{id}, which restricts edits to the comment's author.
+	// Both surfaces share the same audit action so a downstream consumer can
+	// still distinguish via the resolved_via_message flag in audit details.
+	var resolveCommentIDs []uuid.UUID
+	if len(body.ResolveReviewCommentIDs) > 0 {
+		if h.reviewCommentStore == nil {
+			writeError(w, r, http.StatusBadRequest, "REVIEW_COMMENTS_NOT_CONFIGURED", "review comment resolution is not configured for this server")
+			return
+		}
+		if len(body.ResolveReviewCommentIDs) > maxReviewCommentResolveIDsPerMessage {
+			writeError(w, r, http.StatusBadRequest, "TOO_MANY_REVIEW_COMMENT_IDS",
+				fmt.Sprintf("at most %d review comment ids may be resolved per message", maxReviewCommentResolveIDsPerMessage))
+			return
+		}
+		seen := make(map[uuid.UUID]struct{}, len(body.ResolveReviewCommentIDs))
+		resolveCommentIDs = make([]uuid.UUID, 0, len(body.ResolveReviewCommentIDs))
+		for _, raw := range body.ResolveReviewCommentIDs {
+			parsed, err := uuid.Parse(raw)
+			if err != nil {
+				writeError(w, r, http.StatusBadRequest, "INVALID_REVIEW_COMMENT_ID", "invalid review comment id: "+raw)
+				return
+			}
+			if _, dup := seen[parsed]; dup {
+				continue
+			}
+			seen[parsed] = struct{}{}
+			resolveCommentIDs = append(resolveCommentIDs, parsed)
 		}
 	}
 
@@ -1637,14 +1689,55 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		msg.Commands = body.Commands
 	}
 
-	// If the session is already running, just save the message — the coding
-	// agent will buffer it and process inline. No status change or job needed.
+	// Running-session fast path: no status change, no job, no question
+	// handling. When there are no review comments to resolve, skip the tx
+	// entirely so we don't take row locks on session_messages for the common
+	// follow-up case. When there ARE comments to resolve, wrap both the
+	// insert and the resolve in a tx so the two are atomic.
 	if session.Status == string(models.SessionStatusRunning) {
-		if err := h.messageStore.Create(r.Context(), msg); err != nil {
-			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
+		if len(resolveCommentIDs) == 0 {
+			if err := h.messageStore.Create(r.Context(), msg); err != nil {
+				writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
+				return
+			}
+			writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
 			return
 		}
 
+		tx, err := h.runStore.Begin(r.Context())
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, "TX_BEGIN_FAILED", "failed to begin session transaction", err)
+			return
+		}
+		committed := false
+		defer func() {
+			if committed {
+				return
+			}
+			if rollbackErr := tx.Rollback(r.Context()); rollbackErr != nil {
+				zerolog.Ctx(r.Context()).Error().Err(rollbackErr).Str("session_id", sessionID.String()).Msg("failed to rollback send message transaction")
+			}
+		}()
+		txMessageStore := db.NewSessionMessageStore(tx)
+		txReviewCommentStore := db.NewSessionReviewCommentStore(tx)
+
+		if err := txMessageStore.Create(r.Context(), msg); err != nil {
+			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
+			return
+		}
+		resolvedComments, rerr := resolveSessionReviewComments(
+			r.Context(), txReviewCommentStore, orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
+		if rerr != nil {
+			rerr.write(w, r)
+			return
+		}
+		if err := tx.Commit(r.Context()); err != nil {
+			writeError(w, r, http.StatusInternalServerError, "TX_COMMIT_FAILED", "failed to commit session follow-up", err)
+			return
+		}
+		committed = true
+
+		h.emitReviewCommentResolutionAudits(r, sessionID, msg.ID, resolvedComments)
 		writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
 		return
 	}
@@ -1664,8 +1757,13 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	txRunStore := db.NewSessionStore(tx)
 	txMessageStore := db.NewSessionMessageStore(tx)
+	var txReviewCommentStore *db.SessionReviewCommentStore
+	if len(resolveCommentIDs) > 0 {
+		txReviewCommentStore = db.NewSessionReviewCommentStore(tx)
+	}
+
+	txRunStore := db.NewSessionStore(tx)
 	txQuestionStore := db.NewSessionQuestionStore(tx)
 
 	// Try claiming an idle session first, then fall back to resuming a
@@ -1689,6 +1787,17 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	if err := txMessageStore.Create(r.Context(), msg); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 		return
+	}
+
+	var resolvedComments []models.SessionReviewComment
+	if txReviewCommentStore != nil {
+		var rerr *resolveCommentsError
+		resolvedComments, rerr = resolveSessionReviewComments(
+			r.Context(), txReviewCommentStore, orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
+		if rerr != nil {
+			rerr.write(w, r)
+			return
+		}
 	}
 
 	// If the session was paused on a clarifying question, treat the follow-up
@@ -1741,8 +1850,136 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		emitUserAuditWithSession(h.audit, r, models.AuditActionSessionQuestionAnswered, models.AuditResourceSession, &qIDStr, &sessionID, nil,
 			marshalAuditDetails(h.logger, questionDetails))
 	}
+	h.emitReviewCommentResolutionAudits(r, sessionID, msg.ID, resolvedComments)
 
 	writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
+}
+
+// currentResolutionPass returns the pass number to record on a comment that
+// is being resolved during the current request, matching the semantics used
+// by the PATCH /review-comments handler: the user's resolving action belongs
+// to the session's current turn (with a fallback to 1 for not-yet-started
+// sessions where CurrentTurn is still 0).
+func currentResolutionPass(session *models.Session) int {
+	if session == nil || session.CurrentTurn == 0 {
+		return 1
+	}
+	return session.CurrentTurn
+}
+
+// resolveCommentsError carries the HTTP shape of a failure inside the
+// resolve-comments helper, so the helper can stay pure (no http.ResponseWriter
+// dependency) and SendMessage controls when the response is written. underlying
+// is included only when there's a real error worth logging.
+type resolveCommentsError struct {
+	status     int
+	code       string
+	message    string
+	underlying error
+}
+
+func (e *resolveCommentsError) write(w http.ResponseWriter, r *http.Request) {
+	if e.underlying != nil {
+		writeError(w, r, e.status, e.code, e.message, e.underlying)
+		return
+	}
+	writeError(w, r, e.status, e.code, e.message)
+}
+
+// resolveSessionReviewComments validates that every requested ID belongs to
+// the session and resolves the still-open ones, returning the rows whose
+// state actually changed. Already-resolved IDs are silently skipped (the
+// underlying store filters on resolved=false). The helper is pure: it does
+// not write to the response, so the caller decides when (and whether) to
+// surface failures to the HTTP client and to abandon the surrounding tx.
+//
+// The store argument must already be tx-scoped — the validation lookup and
+// the resolve UPDATE share the same tx so other writers can't slip a comment
+// in between the existence check and the update.
+func resolveSessionReviewComments(
+	ctx context.Context,
+	store *db.SessionReviewCommentStore,
+	orgID, sessionID uuid.UUID,
+	ids []uuid.UUID,
+	resolvedByPass int,
+) ([]models.SessionReviewComment, *resolveCommentsError) {
+	if len(ids) == 0 || store == nil {
+		return nil, nil
+	}
+	existing, err := store.ListByIDs(ctx, orgID, sessionID, ids)
+	if err != nil {
+		return nil, &resolveCommentsError{
+			status: http.StatusInternalServerError, code: "REVIEW_COMMENT_LOOKUP_FAILED",
+			message: "failed to look up review comments", underlying: err,
+		}
+	}
+	if len(existing) != len(ids) {
+		// Surface the missing IDs (capped) so misbehaving clients can debug
+		// without leaking other tenants' data — IDs not scoped to this org+
+		// session are functionally indistinguishable from "doesn't exist".
+		found := make(map[uuid.UUID]struct{}, len(existing))
+		for _, c := range existing {
+			found[c.ID] = struct{}{}
+		}
+		const maxMissingInError = 5
+		missing := make([]string, 0, maxMissingInError)
+		for _, id := range ids {
+			if _, ok := found[id]; ok {
+				continue
+			}
+			if len(missing) == maxMissingInError {
+				break
+			}
+			missing = append(missing, id.String())
+		}
+		return nil, &resolveCommentsError{
+			status: http.StatusBadRequest, code: "INVALID_REVIEW_COMMENT_IDS",
+			message: "review comment ids do not belong to this session: " + strings.Join(missing, ", "),
+		}
+	}
+	resolved, err := store.ResolveByIDs(ctx, orgID, sessionID, ids, resolvedByPass)
+	if err != nil {
+		return nil, &resolveCommentsError{
+			status: http.StatusInternalServerError, code: "REVIEW_COMMENT_RESOLVE_FAILED",
+			message: "failed to resolve review comments", underlying: err,
+		}
+	}
+	return resolved, nil
+}
+
+// emitReviewCommentResolutionAudits records one audit row per comment whose
+// resolved state actually changed. Mirrors the audit shape emitted by the
+// direct PATCH /review-comments handler so audit consumers see consistent
+// before/after values regardless of which surface triggered the resolution.
+// The resolved_via_message flag lets consumers tell the two surfaces apart.
+func (h *SessionHandler) emitReviewCommentResolutionAudits(
+	r *http.Request,
+	sessionID uuid.UUID,
+	messageID int64,
+	resolved []models.SessionReviewComment,
+) {
+	if len(resolved) == 0 {
+		return
+	}
+	for _, c := range resolved {
+		resID := c.ID.String()
+		sid := sessionID
+		emitUserAuditWithSession(h.audit, r, models.AuditActionSessionReviewCommentUpdated, models.AuditResourceSessionReviewComment,
+			&resID, &sid, nil, marshalAuditDetails(h.logger, map[string]any{
+				"review_comment_id":    c.ID.String(),
+				"session_id":           sid.String(),
+				"file_path":            c.FilePath,
+				"line_number":          c.LineNumber,
+				"diff_side":            c.DiffSide,
+				"pass_number":          c.PassNumber,
+				"body_length":          len(c.Body),
+				"resolved_via_message": true,
+				"message_id":           messageID,
+				"changes": map[string]any{
+					"resolved": auditChange(false, true),
+				},
+			}))
+	}
 }
 
 // ListMessages handles GET /sessions/{id}/messages — returns the conversation messages.

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1961,11 +1961,16 @@ func (h *SessionHandler) emitReviewCommentResolutionAudits(
 	if len(resolved) == 0 {
 		return
 	}
+	entries := make([]userAuditEntry, 0, len(resolved))
 	for _, c := range resolved {
 		resID := c.ID.String()
 		sid := sessionID
-		emitUserAuditWithSession(h.audit, r, models.AuditActionSessionReviewCommentUpdated, models.AuditResourceSessionReviewComment,
-			&resID, &sid, nil, marshalAuditDetails(h.logger, map[string]any{
+		entries = append(entries, userAuditEntry{
+			Action:       models.AuditActionSessionReviewCommentUpdated,
+			ResourceType: models.AuditResourceSessionReviewComment,
+			ResourceID:   &resID,
+			SessionID:    &sid,
+			Details: marshalAuditDetails(h.logger, map[string]any{
 				"review_comment_id":    c.ID.String(),
 				"session_id":           sid.String(),
 				"file_path":            c.FilePath,
@@ -1978,8 +1983,12 @@ func (h *SessionHandler) emitReviewCommentResolutionAudits(
 				"changes": map[string]any{
 					"resolved": auditChange(false, true),
 				},
-			}))
+			}),
+		})
 	}
+	// One INSERT regardless of N — keeps post-commit latency O(1) in the
+	// number of attached comments.
+	emitUserAuditsWithSession(h.audit, r, entries)
 }
 
 // ListMessages handles GET /sessions/{id}/messages — returns the conversation messages.

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -5275,6 +5275,27 @@ func TestSessionHandler_SendMessage_ResolvesReviewComments(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("rejects resolve IDs when review comment store is not configured", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.SetReviewCommentStore(nil)
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"hello","resolve_review_comment_ids":[%q]}`, commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code, "handler should reject resolve IDs when review comments are disabled")
+		require.Contains(t, w.Body.String(), "REVIEW_COMMENTS_NOT_CONFIGURED", "response should explain the missing review-comment store")
+		require.NoError(t, mock.ExpectationsWereMet(), "request should fail before DB access")
+	})
+
 	t.Run("rejects ID that does not belong to the session", func(t *testing.T) {
 		t.Parallel()
 		mock, err := pgxmock.NewPool()
@@ -5421,6 +5442,55 @@ func TestSessionHandler_SendMessage_ResolvesReviewComments(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("deduplicates repeated IDs before lookup and resolve", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentUserID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(4), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						9, "right", "dedupe me", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						9, "right", "dedupe me", true, &now, srcIntPtr(1),
+						1, now, now),
+			)
+		mock.ExpectCommit()
+		mock.ExpectQuery("INSERT INTO audit_logs").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"dedupe","resolve_review_comment_ids":[%q,%q]}`, commentID.String(), commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, "duplicate IDs should be resolved once without failing validation")
+		require.NoError(t, mock.ExpectationsWereMet(), "deduplicated request should issue one lookup and one resolve")
+	})
+
 	t.Run("rejects request that exceeds the per-message resolve cap", func(t *testing.T) {
 		t.Parallel()
 		mock, err := pgxmock.NewPool()
@@ -5562,6 +5632,174 @@ func TestSessionHandler_SendMessage_ResolvesReviewComments(t *testing.T) {
 		handler.SendMessage(w, req)
 		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
 		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestCurrentResolutionPass(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		session  *models.Session
+		expected int
+	}{
+		{name: "nil session defaults to first pass", session: nil, expected: 1},
+		{name: "zero current turn defaults to first pass", session: &models.Session{}, expected: 1},
+		{name: "nonzero current turn is preserved", session: &models.Session{CurrentTurn: 3}, expected: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := currentResolutionPass(tt.session)
+			require.Equal(t, tt.expected, got, "currentResolutionPass should return the expected pass number")
+		})
+	}
+}
+
+func TestResolveCommentsError_Write(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        *resolveCommentsError
+		expectCode string
+	}{
+		{
+			name: "writes plain error",
+			err: &resolveCommentsError{
+				status: http.StatusBadRequest, code: "BAD_COMMENTS", message: "bad comments",
+			},
+			expectCode: "BAD_COMMENTS",
+		},
+		{
+			name: "writes underlying error",
+			err: &resolveCommentsError{
+				status: http.StatusInternalServerError, code: "COMMENT_LOOKUP_FAILED", message: "lookup failed", underlying: errors.New("db down"),
+			},
+			expectCode: "COMMENT_LOOKUP_FAILED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			w := httptest.NewRecorder()
+			tt.err.write(w, req)
+			require.Equal(t, tt.err.status, w.Code, "resolveCommentsError should write the configured HTTP status")
+			require.Contains(t, w.Body.String(), tt.expectCode, "response should include the configured error code")
+		})
+	}
+}
+
+func TestResolveSessionReviewComments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op for empty IDs or missing store", func(t *testing.T) {
+		t.Parallel()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		resolved, rerr := resolveSessionReviewComments(context.Background(), nil, orgID, sessionID, []uuid.UUID{uuid.New()}, 1)
+		require.Nil(t, rerr, "nil store should be a no-op")
+		require.Empty(t, resolved, "nil store should not resolve comments")
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		store := db.NewSessionReviewCommentStore(mock)
+		resolved, rerr = resolveSessionReviewComments(context.Background(), store, orgID, sessionID, nil, 1)
+		require.Nil(t, rerr, "empty ID list should be a no-op")
+		require.Empty(t, resolved, "empty ID list should not resolve comments")
+		require.NoError(t, mock.ExpectationsWereMet(), "empty ID list should not query the store")
+	})
+
+	t.Run("returns lookup errors", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		commentID := uuid.New()
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(errors.New("connection refused"))
+
+		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, []uuid.UUID{commentID}, 1)
+		require.Empty(t, resolved, "lookup failure should not return resolved comments")
+		require.NotNil(t, rerr, "lookup failure should return a structured error")
+		require.Equal(t, "REVIEW_COMMENT_LOOKUP_FAILED", rerr.code, "lookup failure should use the lookup error code")
+		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
+	})
+
+	t.Run("caps missing ID details", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		now := time.Now()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(ids[0], sessionID, orgID, userID, "main.go",
+						1, "right", "exists", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+
+		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, ids, 1)
+		require.Empty(t, resolved, "missing IDs should not resolve comments")
+		require.NotNil(t, rerr, "missing IDs should return a structured error")
+		require.Equal(t, "INVALID_REVIEW_COMMENT_IDS", rerr.code, "missing IDs should use the invalid IDs error code")
+		require.NotContains(t, rerr.message, ids[0].String(), "existing IDs should not be reported as missing")
+		require.Contains(t, rerr.message, ids[1].String(), "first missing ID should be reported")
+		require.Contains(t, rerr.message, ids[5].String(), "fifth missing ID should be reported")
+		require.NotContains(t, rerr.message, ids[6].String(), "missing ID details should be capped")
+		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
+	})
+
+	t.Run("returns resolve errors", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		now := time.Now()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentID := uuid.New()
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, userID, "main.go",
+						1, "right", "exists", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(errors.New("connection refused"))
+
+		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, []uuid.UUID{commentID}, 2)
+		require.Empty(t, resolved, "resolve failure should not return resolved comments")
+		require.NotNil(t, rerr, "resolve failure should return a structured error")
+		require.Equal(t, "REVIEW_COMMENT_RESOLVE_FAILED", rerr.code, "resolve failure should use the resolve error code")
+		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
 	})
 }
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -118,7 +118,7 @@ func (s *archiveTestSnapshotStore) Delete(_ context.Context, key string) error {
 
 func newSessionHandler(t *testing.T, mock pgxmock.PgxPoolIface) *SessionHandler {
 	t.Helper()
-	return NewSessionHandler(
+	h := NewSessionHandler(
 		db.NewSessionStore(mock),
 		db.NewSessionLogStore(mock),
 		db.NewSessionQuestionStore(mock),
@@ -133,6 +133,11 @@ func newSessionHandler(t *testing.T, mock pgxmock.PgxPoolIface) *SessionHandler 
 		nil, // llmClient — not needed in unit tests
 		zerolog.Nop(),
 	)
+	// SendMessage's optional resolve_review_comment_ids path requires the
+	// review-comment store. The store presence is just a feature gate; tx-
+	// scoped instances are created on demand inside the handler.
+	h.SetReviewCommentStore(db.NewSessionReviewCommentStore(mock))
+	return h
 }
 
 // sessionColumns is the standard column set for sessions queries.
@@ -4274,7 +4279,9 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							now,
 						),
 					)
-				// Create message — no ClaimIdle, no ClaimForResume, no Enqueue.
+				// Running session, no review-comment resolve requested:
+				// short-circuits to a single non-tx INSERT (no Begin, no
+				// Commit, no ClaimIdle, no ClaimForResume, no Enqueue).
 				mock.ExpectQuery("INSERT INTO session_messages").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
@@ -4322,12 +4329,10 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 							now,
 						),
 					)
-				// Running session — the message gets created in-place; the
-				// references and commands columns receive the persisted JSON.
-				// Running session — message gets persisted in-place with the
-				// references and commands JSON columns populated. Exact JSON
-				// shape is covered by the model unit tests; here we only
-				// confirm the handler routes both fields to the store.
+				// Running session, no review-comment resolve requested:
+				// message gets persisted in-place via the non-tx fast path.
+				// Exact JSON shape is covered by the model unit tests; here
+				// we only confirm the handler routes both fields to the store.
 				mock.ExpectQuery("INSERT INTO session_messages").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -5217,6 +5222,294 @@ func TestSessionHandler_SendMessage_InvalidID(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code, "should return 400 for invalid ID")
 	require.Contains(t, w.Body.String(), "INVALID_ID")
 }
+
+// TestSessionHandler_SendMessage_ResolvesReviewComments verifies that
+// resolve_review_comment_ids is honored end-to-end: malformed UUIDs and IDs
+// that don't belong to the session are rejected with descriptive 400s, and
+// valid IDs are looked up + flipped to resolved inside the same transaction
+// that creates the message — so a partial state ("message saved, comment
+// still open") is impossible.
+func TestSessionHandler_SendMessage_ResolvesReviewComments(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	idleSessionRow := func(rows *pgxmock.Rows, sessionID, orgID uuid.UUID, status string) *pgxmock.Rows {
+		return addSessionRow(rows,
+			sessionID, uuid.New(), orgID, "claude-code", status, "semi", "low",
+			nil, nil, nil, nil,
+			nil, false, &now, nil, nil,
+			nil, nil, nil, false,
+			nil, nil, nil, nil, nil,
+			nil, nil, nil, nil,
+			nil, nil,
+			nil, // triggered_by_user_id
+			nil, 1, now, "snapshotted", stringPtr("snapshots/test"),
+			nil, nil, nil, nil, nil, nil,
+			nil, nil,
+			nil,
+			"idle",
+			(*string)(nil),
+			nil,
+			now,
+		)
+	}
+
+	t.Run("rejects malformed comment ID", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		// No DB calls expected — validation rejects before any query.
+
+		req := newSendMessageRequest(sessionID, orgID, userID, `{"message":"hello","resolve_review_comment_ids":["not-a-uuid"]}`)
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "INVALID_REVIEW_COMMENT_ID")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects ID that does not belong to the session", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		// Session is idle, claim succeeds, message is created, then the lookup
+		// for the foreign comment ID returns zero rows → handler aborts the tx.
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "idle"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("UPDATE sessions SET status").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(reviewCommentColumns)) // no rows match → invalid
+		mock.ExpectRollback()
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"hello","resolve_review_comment_ids":[%q]}`, commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "INVALID_REVIEW_COMMENT_IDS")
+		require.Contains(t, w.Body.String(), commentID.String(),
+			"error should name the offending IDs so client can debug without leaking other tenants' data")
+		require.NoError(t, mock.ExpectationsWereMet(),
+			"the message insert and comment lookup must roll back when validation fails")
+	})
+
+	t.Run("resolves comments inside the same tx for an idle session", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentUserID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "idle"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("UPDATE sessions SET status").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						42, "right", "fix this", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						42, "right", "fix this", true, &now, srcIntPtr(2),
+						1, now, now),
+			)
+		mock.ExpectQuery("INSERT INTO jobs").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+		mock.ExpectCommit()
+		// audit emitter writes one row for the resolved comment.
+		mock.ExpectQuery("INSERT INTO audit_logs").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"address review","resolve_review_comment_ids":[%q]}`, commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("resolves comments inline for a running session without enqueuing a job", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentUserID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(2), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						5, "right", "consider X", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						5, "right", "consider X", true, &now, srcIntPtr(2),
+						1, now, now),
+			)
+		mock.ExpectCommit()
+		mock.ExpectQuery("INSERT INTO audit_logs").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"thanks for the catch","resolve_review_comment_ids":[%q]}`, commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rejects request that exceeds the per-message resolve cap", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		// Build a list one over the cap. Validation should reject before any
+		// DB query — keeps audit + resolve work bounded under client misuse.
+		ids := make([]string, 0, maxReviewCommentResolveIDsPerMessage+1)
+		for i := 0; i <= maxReviewCommentResolveIDsPerMessage; i++ {
+			ids = append(ids, uuid.New().String())
+		}
+		idsJSON, jerr := json.Marshal(ids)
+		require.NoError(t, jerr)
+		body := fmt.Sprintf(`{"message":"hello","resolve_review_comment_ids":%s}`, string(idsJSON))
+
+		req := newSendMessageRequest(sessionID, orgID, userID, body)
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.Contains(t, w.Body.String(), "TOO_MANY_REVIEW_COMMENT_IDS")
+		require.NoError(t, mock.ExpectationsWereMet(), "no DB queries should run when validation rejects upfront")
+	})
+
+	t.Run("idempotent: already-resolved IDs commit cleanly with no audit emission", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentUserID := uuid.New()
+		commentID := uuid.New()
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		// Validation finds the comment (it exists), the resolve UPDATE
+		// returns zero rows because the comment is already resolved, and
+		// the request still succeeds — no audit emission, idempotent.
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(3), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(reviewCommentColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						12, "right", "already addressed", true, &now, srcIntPtr(1),
+						1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(reviewCommentColumns)) // already resolved → no rows changed
+		mock.ExpectCommit()
+		// No ExpectQuery on audit_logs — idempotent path emits zero audit rows.
+
+		req := newSendMessageRequest(sessionID, orgID, userID, fmt.Sprintf(`{"message":"thanks","resolve_review_comment_ids":[%q]}`, commentID.String()))
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// newSendMessageRequest builds a *http.Request configured the way the chi
+// router does at runtime: URL params populated, org and user contexts set.
+func newSendMessageRequest(sessionID, orgID, userID uuid.UUID, body string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/messages", strings.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: "member"})
+	return req.WithContext(ctx)
+}
+
+// srcIntPtr is mirrored from the db package's test helper since handlers_test
+// can't import it. Both produce a *int suitable for resolved_by_pass.
+func srcIntPtr(i int) *int { return &i }
 
 // mockLLMClient is a test double for llm.Client.
 // The WaitGroup lets the test verify that the handler waits for the LLM call

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -5449,6 +5449,76 @@ func TestSessionHandler_SendMessage_ResolvesReviewComments(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "no DB queries should run when validation rejects upfront")
 	})
 
+	t.Run("batches audit emission into a single INSERT for many resolved comments", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentUserID := uuid.New()
+		const n = 4
+		commentIDs := make([]uuid.UUID, n)
+		for i := range commentIDs {
+			commentIDs[i] = uuid.New()
+		}
+		handler := newSessionHandler(t, mock)
+		handler.audit = db.NewAuditEmitter(db.NewAuditLogStore(mock), zerolog.Nop())
+
+		// Build the SELECT response: every requested ID exists, all unresolved.
+		selectRows := pgxmock.NewRows(reviewCommentColumns)
+		for i, id := range commentIDs {
+			selectRows.AddRow(id, sessionID, orgID, commentUserID, "main.go",
+				10+i, "right", "comment body", false, (*time.Time)(nil), (*int)(nil),
+				1, now, now)
+		}
+		// Build the UPDATE RETURNING response: all flip to resolved.
+		updateRows := pgxmock.NewRows(reviewCommentColumns)
+		for i, id := range commentIDs {
+			updateRows.AddRow(id, sessionID, orgID, commentUserID, "main.go",
+				10+i, "right", "comment body", true, &now, srcIntPtr(1),
+				1, now, now)
+		}
+
+		mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(idleSessionRow(pgxmock.NewRows(sessionColumns), sessionID, orgID, "running"))
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(7), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(selectRows)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(updateRows)
+		mock.ExpectCommit()
+		// CRITICAL: a single batched audit INSERT (Exec, not Query — the
+		// batch path skips RETURNING). If this asserts N times instead of
+		// once, the N+1 has regressed.
+		auditArgs := make([]any, 0, n*13)
+		for i := 0; i < n*13; i++ {
+			auditArgs = append(auditArgs, pgxmock.AnyArg())
+		}
+		mock.ExpectExec("INSERT INTO audit_logs").
+			WithArgs(auditArgs...).
+			WillReturnResult(pgxmock.NewResult("INSERT", n))
+
+		idsJSON := make([]string, n)
+		for i, id := range commentIDs {
+			idsJSON[i] = `"` + id.String() + `"`
+		}
+		body := fmt.Sprintf(`{"message":"addressing all of these","resolve_review_comment_ids":[%s]}`, strings.Join(idsJSON, ","))
+		req := newSendMessageRequest(sessionID, orgID, userID, body)
+		w := httptest.NewRecorder()
+		handler.SendMessage(w, req)
+		require.Equal(t, http.StatusCreated, w.Code, w.Body.String())
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
 	t.Run("idempotent: already-resolved IDs commit cleanly with no audit emission", func(t *testing.T) {
 		t.Parallel()
 		mock, err := pgxmock.NewPool()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -201,6 +201,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	sessionHandler.SetViewStore(sessionViewStore)
 	sessionHandler.SetIssueLinkStore(sessionIssueLinkStore)
 	sessionHandler.SetIssueSnapshotStore(sessionIssueSnapshotStore)
+	sessionHandler.SetReviewCommentStore(sessionReviewCommentStore)
 
 	// Linear session-linking: detection, primary resolution + context
 	// snapshotting, attachment/comment writes, state-sync transitions —

--- a/internal/db/audit_emitter.go
+++ b/internal/db/audit_emitter.go
@@ -47,6 +47,47 @@ func (e *AuditEmitter) EmitUserAction(ctx context.Context, params UserActionPara
 	}
 }
 
+// EmitUserActions logs multiple user-actor audits in a single DB round-trip.
+// Prefer this over a loop of EmitUserAction calls when emitting more than
+// one entry at a time: an N-row INSERT scales O(1) in network latency where
+// N separate INSERTs scale O(N). On error the whole batch is dropped — same
+// fire-and-forget contract as EmitUserAction, so callers don't need to
+// handle errors.
+//
+// All entries must share the same OrgID; mixed-org batches are rejected by
+// the underlying store. In practice this is naturally satisfied because a
+// batch emit comes from a single request, which has a single active org.
+func (e *AuditEmitter) EmitUserActions(ctx context.Context, paramsList []UserActionParams) {
+	if len(paramsList) == 0 {
+		return
+	}
+	orgID := paramsList[0].OrgID
+	entries := make([]*models.AuditLog, 0, len(paramsList))
+	for _, params := range paramsList {
+		userID := params.UserID
+		entries = append(entries, &models.AuditLog{
+			OrgID:        params.OrgID,
+			ActorType:    models.AuditActorUser,
+			ActorID:      userID.String(),
+			UserID:       &userID,
+			Action:       params.Action,
+			ResourceType: params.ResourceType,
+			ResourceID:   params.ResourceID,
+			Details:      params.Details,
+			RequestID:    params.RequestID,
+			IPAddress:    params.IPAddress,
+			UserAgent:    params.UserAgent,
+			SessionID:    params.SessionID,
+			ProjectID:    params.ProjectID,
+		})
+	}
+	if err := e.store.CreateBatch(ctx, orgID, entries); err != nil {
+		e.logger.Warn().Err(err).
+			Int("batch_size", len(entries)).
+			Msg("failed to emit audit log batch")
+	}
+}
+
 type UserActionParams struct {
 	OrgID        uuid.UUID
 	UserID       uuid.UUID

--- a/internal/db/audit_emitter_test.go
+++ b/internal/db/audit_emitter_test.go
@@ -105,3 +105,24 @@ func TestAuditEmitter_EmitUserActionsEmptyIsNoop(t *testing.T) {
 	emitter.EmitUserActions(context.Background(), nil)
 	require.NoError(t, mock.ExpectationsWereMet(), "no DB call should be made for an empty params slice")
 }
+
+func TestAuditEmitter_EmitUserActionsLogsAndDropsBatchErrors(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	emitter := NewAuditEmitter(NewAuditLogStore(mock), zerolog.Nop())
+
+	emitter.EmitUserActions(context.Background(), []UserActionParams{{
+		OrgID:        orgID,
+		UserID:       userID,
+		Action:       "invalid-action",
+		ResourceType: models.AuditResourceSession,
+	}})
+
+	require.NoError(t, mock.ExpectationsWereMet(), "invalid batch should be dropped without a DB call")
+}

--- a/internal/db/audit_emitter_test.go
+++ b/internal/db/audit_emitter_test.go
@@ -50,3 +50,58 @@ func TestAuditEmitter_EmitWebhookActionIncludesSessionAndProject(t *testing.T) {
 
 	require.NoError(t, mock.ExpectationsWereMet(), "webhook audit emit should persist session and project correlations")
 }
+
+func TestAuditEmitter_EmitUserActionsBatchesMultipleRows(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	emitter := NewAuditEmitter(NewAuditLogStore(mock), zerolog.Nop())
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	const n = 4
+
+	paramsList := make([]UserActionParams, 0, n)
+	for i := 0; i < n; i++ {
+		resID := uuid.New().String()
+		sid := sessionID
+		paramsList = append(paramsList, UserActionParams{
+			OrgID:        orgID,
+			UserID:       userID,
+			Action:       models.AuditActionSessionReviewCommentUpdated,
+			ResourceType: models.AuditResourceSessionReviewComment,
+			ResourceID:   &resID,
+			SessionID:    &sid,
+			Details:      json.RawMessage(`{}`),
+		})
+	}
+
+	// 4 rows × 13 columns = 52 args, in a single Exec.
+	argMatchers := make([]any, 0, n*13)
+	for i := 0; i < n*13; i++ {
+		argMatchers = append(argMatchers, pgxmock.AnyArg())
+	}
+	mock.ExpectExec("INSERT INTO audit_logs").
+		WithArgs(argMatchers...).
+		WillReturnResult(pgxmock.NewResult("INSERT", n))
+
+	emitter.EmitUserActions(context.Background(), paramsList)
+	require.NoError(t, mock.ExpectationsWereMet(),
+		"N user-action audits must collapse to a single Exec via CreateBatch")
+}
+
+func TestAuditEmitter_EmitUserActionsEmptyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	emitter := NewAuditEmitter(NewAuditLogStore(mock), zerolog.Nop())
+	emitter.EmitUserActions(context.Background(), nil)
+	require.NoError(t, mock.ExpectationsWereMet(), "no DB call should be made for an empty params slice")
+}

--- a/internal/db/audit_log_store.go
+++ b/internal/db/audit_log_store.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/models"
@@ -61,6 +62,71 @@ func (s *AuditLogStore) Create(ctx context.Context, entry *models.AuditLog) erro
 		"project_id":    entry.ProjectID,
 	})
 	return row.Scan(&entry.ID, &entry.CreatedAt)
+}
+
+// CreateBatch inserts multiple audit log entries in a single round-trip via
+// a multi-row VALUES INSERT. Use this when emitting more than one audit at
+// once (e.g. resolving N review comments inline with a message send) — at
+// LAN latency the cost of N separate INSERTs is dominated by per-query RTT.
+//
+// All entries must belong to orgID; cross-tenant batches are rejected so a
+// caller can't accidentally smear audit rows across orgs through a single
+// send. For a single entry the call falls through to Create so we don't pay
+// the cost of building a multi-row statement for the common case.
+func (s *AuditLogStore) CreateBatch(ctx context.Context, orgID uuid.UUID, entries []*models.AuditLog) error {
+	if len(entries) == 0 {
+		return nil
+	}
+	if len(entries) == 1 {
+		if entries[0].OrgID != orgID {
+			return fmt.Errorf("audit batch entry org_id %s does not match expected org_id %s", entries[0].OrgID, orgID)
+		}
+		return s.Create(ctx, entries[0])
+	}
+	for i, e := range entries {
+		if e.OrgID != orgID {
+			return fmt.Errorf("audit batch entry %d org_id %s does not match expected org_id %s", i, e.OrgID, orgID)
+		}
+		if err := e.ActorType.Validate(); err != nil {
+			return err
+		}
+		if err := e.Action.Validate(); err != nil {
+			return err
+		}
+		if err := e.ResourceType.Validate(); err != nil {
+			return err
+		}
+	}
+
+	// 13 placeholders per row, in the column order below.
+	const cols = 13
+	placeholders := make([]string, len(entries))
+	args := make([]any, 0, len(entries)*cols)
+	for i, e := range entries {
+		ph := make([]string, cols)
+		for j := 0; j < cols; j++ {
+			ph[j] = fmt.Sprintf("$%d", i*cols+j+1)
+		}
+		placeholders[i] = "(" + strings.Join(ph, ", ") + ")"
+		args = append(args,
+			e.OrgID, e.ActorType, e.ActorID, e.UserID,
+			e.Action, e.ResourceType, e.ResourceID,
+			e.Details, e.RequestID, e.IPAddress, e.UserAgent,
+			e.SessionID, e.ProjectID,
+		)
+	}
+
+	query := `INSERT INTO audit_logs (
+			org_id, actor_type, actor_id, user_id,
+			action, resource_type, resource_id,
+			details, request_id, ip_address, user_agent,
+			session_id, project_id
+		) VALUES ` + strings.Join(placeholders, ", ")
+
+	if _, err := s.db.Exec(ctx, query, args...); err != nil {
+		return fmt.Errorf("insert audit logs batch: %w", err)
+	}
+	return nil
 }
 
 // AuditLogFilters controls listing/search behavior.

--- a/internal/db/audit_log_store_test.go
+++ b/internal/db/audit_log_store_test.go
@@ -442,3 +442,157 @@ func TestAuditLogStore_GetByID(t *testing.T) {
 		})
 	}
 }
+
+func TestAuditLogStore_CreateBatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty batch is a no-op", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), uuid.New(), nil)
+		require.NoError(t, err, "empty batch should not error")
+		require.NoError(t, mock.ExpectationsWereMet(), "no query should run for an empty batch")
+	})
+
+	t.Run("single-entry batch falls through to Create", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		now := time.Now()
+		// Single-row path uses INSERT ... RETURNING (Query, not Exec).
+		mock.ExpectQuery("INSERT INTO audit_logs").
+			WithArgs(
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(),
+			).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+		entry := &models.AuditLog{
+			OrgID:        orgID,
+			ActorType:    models.AuditActorUser,
+			ActorID:      userID.String(),
+			UserID:       &userID,
+			Action:       models.AuditActionSessionCreated,
+			ResourceType: models.AuditResourceSession,
+		}
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), orgID, []*models.AuditLog{entry})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), entry.ID, "single-entry batch should populate ID via RETURNING")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("multi-entry batch issues a single Exec with all rows", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+
+		const n = 3
+		entries := make([]*models.AuditLog, 0, n)
+		for i := 0; i < n; i++ {
+			entries = append(entries, &models.AuditLog{
+				OrgID:        orgID,
+				ActorType:    models.AuditActorUser,
+				ActorID:      userID.String(),
+				UserID:       &userID,
+				Action:       models.AuditActionSessionReviewCommentUpdated,
+				ResourceType: models.AuditResourceSessionReviewComment,
+				Details:      json.RawMessage(`{"i":` + fmt.Sprint(i) + `}`),
+			})
+		}
+
+		// 3 rows × 13 columns = 39 args, all surfaced via the multi-row INSERT.
+		argMatchers := make([]any, 0, n*13)
+		for i := 0; i < n*13; i++ {
+			argMatchers = append(argMatchers, pgxmock.AnyArg())
+		}
+		mock.ExpectExec("INSERT INTO audit_logs.+ VALUES \\(\\$1, \\$2.+\\), \\(\\$14.+\\), \\(\\$27.+\\)$").
+			WithArgs(argMatchers...).
+			WillReturnResult(pgxmock.NewResult("INSERT", n))
+
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), orgID, entries)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet(),
+			"multi-row batch must issue exactly one Exec — regression risk for the per-comment audit N+1")
+	})
+
+	t.Run("validates every entry up front", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		good := &models.AuditLog{
+			OrgID: orgID, ActorType: models.AuditActorUser, ActorID: userID.String(),
+			UserID: &userID, Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession,
+		}
+		bad := &models.AuditLog{
+			OrgID: orgID, ActorType: "invalid", ActorID: userID.String(),
+			Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession,
+		}
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), orgID, []*models.AuditLog{good, bad})
+		require.Error(t, err, "should reject the batch when any entry is invalid")
+		require.NoError(t, mock.ExpectationsWereMet(), "no query should run when validation fails")
+	})
+
+	t.Run("rejects mixed-org batches", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		expectedOrg := uuid.New()
+		foreignOrg := uuid.New()
+		userID := uuid.New()
+		entries := []*models.AuditLog{
+			{OrgID: expectedOrg, ActorType: models.AuditActorUser, ActorID: userID.String(), UserID: &userID,
+				Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession},
+			{OrgID: foreignOrg, ActorType: models.AuditActorUser, ActorID: userID.String(), UserID: &userID,
+				Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession},
+		}
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), expectedOrg, entries)
+		require.Error(t, err, "must reject when an entry's org_id mismatches the batch org")
+		require.NoError(t, mock.ExpectationsWereMet(), "no query should run when tenancy check fails")
+	})
+
+	t.Run("propagates db errors", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		userID := uuid.New()
+		entries := []*models.AuditLog{
+			{OrgID: orgID, ActorType: models.AuditActorUser, ActorID: userID.String(), UserID: &userID,
+				Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession},
+			{OrgID: orgID, ActorType: models.AuditActorUser, ActorID: userID.String(), UserID: &userID,
+				Action: models.AuditActionSessionCreated, ResourceType: models.AuditResourceSession},
+		}
+		argMatchers := make([]any, 0, 2*13)
+		for i := 0; i < 2*13; i++ {
+			argMatchers = append(argMatchers, pgxmock.AnyArg())
+		}
+		mock.ExpectExec("INSERT INTO audit_logs").
+			WithArgs(argMatchers...).
+			WillReturnError(fmt.Errorf("connection refused"))
+
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), orgID, entries)
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}

--- a/internal/db/audit_log_store_test.go
+++ b/internal/db/audit_log_store_test.go
@@ -490,6 +490,24 @@ func TestAuditLogStore_CreateBatch(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("single-entry batch rejects mismatched org", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "pgxmock pool should initialize")
+		defer mock.Close()
+
+		entry := &models.AuditLog{
+			OrgID:        uuid.New(),
+			ActorType:    models.AuditActorUser,
+			ActorID:      uuid.NewString(),
+			Action:       models.AuditActionSessionCreated,
+			ResourceType: models.AuditResourceSession,
+		}
+		err = NewAuditLogStore(mock).CreateBatch(context.Background(), uuid.New(), []*models.AuditLog{entry})
+		require.Error(t, err, "single-entry batch should reject a mismatched org before insert")
+		require.NoError(t, mock.ExpectationsWereMet(), "mismatched single-entry batch should not query")
+	})
+
 	t.Run("multi-entry batch issues a single Exec with all rows", func(t *testing.T) {
 		t.Parallel()
 		mock, err := pgxmock.NewPool()

--- a/internal/db/session_review_comment_store.go
+++ b/internal/db/session_review_comment_store.go
@@ -84,6 +84,63 @@ func (s *SessionReviewCommentStore) ListBySession(ctx context.Context, orgID, se
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionReviewComment])
 }
 
+// ListByIDs returns comments matching the given IDs scoped to the org+session.
+// Used to validate that requested comment IDs all belong to the session before
+// performing batch operations. Results are unordered; callers should compare
+// the returned set against the requested IDs to detect missing rows.
+func (s *SessionReviewCommentStore) ListByIDs(ctx context.Context, orgID, sessionID uuid.UUID, ids []uuid.UUID) ([]models.SessionReviewComment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	query := `
+		SELECT ` + sessionReviewCommentColumns + `
+		FROM session_review_comments
+		WHERE id = ANY(@ids) AND org_id = @org_id AND session_id = @session_id`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"ids":        ids,
+		"org_id":     orgID,
+		"session_id": sessionID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query session review comments by ids: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionReviewComment])
+}
+
+// ResolveByIDs marks the listed comments as resolved if they aren't already,
+// returning the rows whose state actually changed. Already-resolved comments
+// are silently skipped, which makes the operation idempotent: callers can
+// retry without flipping resolution timestamps. Scoping by org+session
+// prevents cross-tenant resolution even if a foreign ID slips through.
+func (s *SessionReviewCommentStore) ResolveByIDs(ctx context.Context, orgID, sessionID uuid.UUID, ids []uuid.UUID, resolvedByPass int) ([]models.SessionReviewComment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	query := `
+		UPDATE session_review_comments
+		SET resolved = true,
+		    resolved_at = now(),
+		    resolved_by_pass = @resolved_by_pass,
+		    updated_at = now()
+		WHERE id = ANY(@ids)
+		  AND org_id = @org_id
+		  AND session_id = @session_id
+		  AND resolved = false
+		RETURNING ` + sessionReviewCommentColumns
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"ids":              ids,
+		"org_id":           orgID,
+		"session_id":       sessionID,
+		"resolved_by_pass": resolvedByPass,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolve session review comments: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionReviewComment])
+}
+
 func (s *SessionReviewCommentStore) Update(ctx context.Context, orgID, sessionID, id uuid.UUID, body *string, resolved *bool, resolvedByPass *int) (models.SessionReviewComment, error) {
 	// Build dynamic SET clauses.
 	sets := "updated_at = now()"

--- a/internal/db/session_review_comment_store_test.go
+++ b/internal/db/session_review_comment_store_test.go
@@ -511,3 +511,144 @@ func TestSessionReviewCommentStore_MultiTenancy(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionReviewCommentStore_ListByIDs(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	id1 := uuid.New()
+	id2 := uuid.New()
+	now := time.Now()
+
+	t.Run("returns nothing for empty ID list without querying", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		got, err := store.ListByIDs(context.Background(), orgID, sessionID, nil)
+		require.NoError(t, err, "empty ID list should be a no-op, not an error")
+		require.Empty(t, got, "empty ID list should return zero rows")
+		require.NoError(t, mock.ExpectationsWereMet(), "no query should be issued when there are no IDs")
+	})
+
+	t.Run("scopes lookup to org and session", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY.+ AND org_id .+ AND session_id").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(newSessionReviewCommentRow(id1, sessionID, orgID, userID, now)...).
+					AddRow(newSessionReviewCommentRow(id2, sessionID, orgID, userID, now)...),
+			)
+
+		got, err := store.ListByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1, id2})
+		require.NoError(t, err)
+		require.Len(t, got, 2, "should return both matching comments")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("propagates db errors", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(fmt.Errorf("connection refused"))
+
+		_, err = store.ListByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1})
+		require.Error(t, err, "should propagate db errors")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSessionReviewCommentStore_ResolveByIDs(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+	id1 := uuid.New()
+	id2 := uuid.New()
+	now := time.Now()
+
+	t.Run("no-op for empty ID list", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		got, err := store.ResolveByIDs(context.Background(), orgID, sessionID, nil, 1)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.NoError(t, mock.ExpectationsWereMet(), "no query should be issued for empty ID list")
+	})
+
+	t.Run("returns rows that flipped to resolved", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true.+ WHERE id = ANY.+ AND org_id .+ AND session_id .+ AND resolved = false").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(id1, sessionID, orgID, userID, "main.go",
+						42, "right", "Please fix", true, &now, srcIntPtr(2),
+						1, now, now),
+			)
+
+		got, err := store.ResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1, id2}, 2)
+		require.NoError(t, err)
+		require.Len(t, got, 1, "only the unresolved row should appear in RETURNING")
+		require.True(t, got[0].Resolved, "returned row should now be marked resolved")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns empty when all targets are already resolved (idempotent)", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(srcColumns))
+
+		got, err := store.ResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1}, 5)
+		require.NoError(t, err, "already-resolved comments should not error")
+		require.Empty(t, got, "no rows changed → no rows returned")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("propagates db errors", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(fmt.Errorf("connection refused"))
+
+		_, err = store.ResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1}, 1)
+		require.Error(t, err, "should propagate db errors")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}


### PR DESCRIPTION
## Summary

- Comments addressed in a session message were dismissed via local React state only, so they reappeared as "attached" on every reload and got re-sent in subsequent messages — visible in https://143.dev/sessions/989a3b75-0073-40d1-8d90-ebdcdff14ecf.
- `POST /sessions/:id/messages` now accepts `resolve_review_comment_ids` and flips them to `resolved=true` in the same transaction as the message insert, making resolution durable across reloads, navigation, and tabs.
- New `ListByIDs` / `ResolveByIDs` store methods (idempotent batch resolve via `WHERE resolved=false RETURNING`); pre-resolve validation that the IDs belong to the session, with capped per-request size and named offending IDs in the error response.
- Frontend drops the `dismissedAttachedReviewCommentIDs` state, optimistically flips the cache on success so the "N comment attached" banner clears immediately, and invalidates to reconcile.
- One audit row per newly-resolved comment, with `resolved_via_message: true` so audit consumers can distinguish from direct PATCH resolutions.

## Test plan

- [x] `make lint` clean (golangci-lint v2, lint-schema, lint-stores)
- [x] `go test ./internal/db/... ./internal/api/...` — all green, including new `ResolveByIDs` idempotency test and `SendMessage` sub-tests for the cap, malformed ID, foreign-ID rollback, idle/running happy paths, and zero-audit-emission idempotent path
- [x] `tsc --noEmit` + `eslint --max-warnings=0` clean
- [x] `vitest` 146/146 passing on the affected page test, with the existing "clears attached review comments" test extended to assert `resolve_review_comment_ids` is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)