### PR TITLE
Add live container resource metrics and tighten sandbox memory defaults

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -463,6 +463,14 @@ func main() {
 		reaper := agent.NewSessionReaper(sessionStore, snapshotStore, cfg.SessionMaxIdleAge, cfg.SessionMaxSnapshotAge, cfg.SessionReaperInterval, logger, reaperOpts...)
 		go reaper.Run(ctx)
 
+		// Runtime resource sampler — emits live memory/CPU histograms per
+		// running sandbox so operators can size SANDBOX_* limits against
+		// actual usage. nil when sampling is disabled (interval <= 0) or
+		// the provider doesn't expose stats.
+		if workerServices != nil && workerServices.RuntimeSampler != nil {
+			go workerServices.RuntimeSampler.Run(ctx)
+		}
+
 		// Upload reaper: clean up old uploaded files (local mode only; use S3 lifecycle rules for S3).
 		uploadStore := storage.NewFileUploadStore(cfg.UploadStorageDir, "")
 		uploadReaper := storage.NewUploadReaper(uploadStore, cfg.UploadMaxAge, cfg.SessionReaperInterval, logger)
@@ -1011,6 +1019,22 @@ func buildServices(
 	})
 	prService.SetLinearMilestoneEnqueuer(linear.MilestoneEnqueuerFor(jobStore, logger))
 
+	// Runtime resource sampler. Optional capability — only providers that
+	// implement RuntimeStatsProvider produce samples. Disabled when the
+	// interval is non-positive (operators can switch this off if the OTel
+	// pipeline isn't wired up yet). The runtime type assertion goes
+	// through an explicit any() conversion because Go only allows type
+	// assertions on interface static types, and sandboxProvider's static
+	// type is the concrete *DockerProvider here.
+	var runtimeSampler *agent.RuntimeSampler
+	if cfg.RuntimeStatsInterval > 0 {
+		if statsProvider, ok := any(sandboxProvider).(agent.RuntimeStatsProvider); ok {
+			runtimeSampler = agent.NewRuntimeSampler(usageTracker, statsProvider, billingMetrics, cfg.RuntimeStatsInterval, logger)
+		} else {
+			logger.Info().Msg("sandbox provider does not implement RuntimeStatsProvider; runtime sampler disabled")
+		}
+	}
+
 	svc := &worker.Services{
 		Orchestrator:    orchestrator,
 		Validation:      validationSvc,
@@ -1024,6 +1048,7 @@ func buildServices(
 		GitHub:          ghSvc,
 		TitleService:    titleService,
 		Linear:          linearService,
+		RuntimeSampler:  runtimeSampler,
 	}
 	if sandboxAuthServer != nil {
 		// Capture by value: the closure outlives buildServices, but the

--- a/deploy/scripts/worker_buckets.sh
+++ b/deploy/scripts/worker_buckets.sh
@@ -2,10 +2,12 @@
 
 # Shared worker bucket defaults for deploy/provision scripts.
 # Why these process counts?
-# - Default sandbox memory is 4096 MB, so memory is usually the hard ceiling.
-# - We set WORKER_PROCESS_COUNT to roughly min(vCPU, floor(RAM_GB / 4)).
+# - Default sandbox memory is 3072 MB (3 GB cgroup limit). Tmpfs at /tmp +
+#   /var/tmp uses ~768 MB of that worst-case, leaving ~2.25 GB for the agent.
+# - We set WORKER_PROCESS_COUNT to roughly min(vCPU, floor(RAM_GB / 3)).
 # - That is intentionally "full utilization" at default limits, not conservative.
-# - If you lower SANDBOX_MEMORY_LIMIT_MB, raise counts; if you raise memory, lower counts.
+# - If you lower SANDBOX_MEMORY_LIMIT_MB further, raise counts; if you raise it,
+#   lower counts.
 
 apply_worker_bucket_overrides() {
   local role="$1"
@@ -32,21 +34,21 @@ apply_worker_bucket_overrides() {
 
   case "$bucket" in
     # Hetzner CPX (shared CPU) buckets
-    hcloud-cpx11) : "${WORKER_PROCESS_COUNT:=1}" ;; # 2 vCPU / 2 GB
-    hcloud-cpx21) : "${WORKER_PROCESS_COUNT:=1}" ;; # 3 vCPU / 4 GB
-    hcloud-cpx31) : "${WORKER_PROCESS_COUNT:=2}" ;; # 4 vCPU / 8 GB
-    hcloud-cpx41) : "${WORKER_PROCESS_COUNT:=4}" ;; # 8 vCPU / 16 GB
-    hcloud-cpx51) : "${WORKER_PROCESS_COUNT:=8}" ;; # 16 vCPU / 32 GB
+    hcloud-cpx11) : "${WORKER_PROCESS_COUNT:=1}" ;;  # 2 vCPU / 2 GB  (RAM-bound)
+    hcloud-cpx21) : "${WORKER_PROCESS_COUNT:=1}" ;;  # 3 vCPU / 4 GB  (RAM-bound)
+    hcloud-cpx31) : "${WORKER_PROCESS_COUNT:=2}" ;;  # 4 vCPU / 8 GB
+    hcloud-cpx41) : "${WORKER_PROCESS_COUNT:=5}" ;;  # 8 vCPU / 16 GB
+    hcloud-cpx51) : "${WORKER_PROCESS_COUNT:=10}" ;; # 16 vCPU / 32 GB
     # Hetzner CCX (dedicated CPU) buckets
-    hcloud-ccx13) : "${WORKER_PROCESS_COUNT:=2}" ;;  # 2 vCPU / 8 GB
-    hcloud-ccx23) : "${WORKER_PROCESS_COUNT:=4}" ;;  # 4 vCPU / 16 GB
-    hcloud-ccx33) : "${WORKER_PROCESS_COUNT:=8}" ;;  # 8 vCPU / 32 GB
-    hcloud-ccx43) : "${WORKER_PROCESS_COUNT:=16}" ;; # 16 vCPU / 64 GB
-    hcloud-ccx53) : "${WORKER_PROCESS_COUNT:=32}" ;; # 32 vCPU / 128 GB
-    hcloud-ccx63) : "${WORKER_PROCESS_COUNT:=48}" ;; # 48 vCPU / 192 GB
+    hcloud-ccx13) : "${WORKER_PROCESS_COUNT:=2}" ;;  # 2 vCPU / 8 GB  (CPU-bound)
+    hcloud-ccx23) : "${WORKER_PROCESS_COUNT:=5}" ;;  # 4 vCPU / 16 GB
+    hcloud-ccx33) : "${WORKER_PROCESS_COUNT:=10}" ;; # 8 vCPU / 32 GB
+    hcloud-ccx43) : "${WORKER_PROCESS_COUNT:=21}" ;; # 16 vCPU / 64 GB
+    hcloud-ccx53) : "${WORKER_PROCESS_COUNT:=42}" ;; # 32 vCPU / 128 GB
+    hcloud-ccx63) : "${WORKER_PROCESS_COUNT:=64}" ;; # 48 vCPU / 192 GB
     # AWS EC2 buckets
-    ec2-t3.xlarge) : "${WORKER_PROCESS_COUNT:=4}" ;;   # 4 vCPU / 16 GB
-    ec2-c6i.2xlarge) : "${WORKER_PROCESS_COUNT:=6}" ;; # 8 vCPU / 16 GB
+    ec2-t3.xlarge) : "${WORKER_PROCESS_COUNT:=5}" ;;    # 4 vCPU / 16 GB
+    ec2-c6i.2xlarge) : "${WORKER_PROCESS_COUNT:=8}" ;;  # 8 vCPU / 16 GB
     ec2-c6i.4xlarge) : "${WORKER_PROCESS_COUNT:=10}" ;; # 16 vCPU / 32 GB
     *)
       : "${WORKER_PROCESS_COUNT:=4}" # default baseline
@@ -54,6 +56,6 @@ apply_worker_bucket_overrides() {
   esac
 
   : "${SANDBOX_CPU_LIMIT:=2}"
-  : "${SANDBOX_MEMORY_LIMIT_MB:=4096}"
+  : "${SANDBOX_MEMORY_LIMIT_MB:=3072}"
   : "${SANDBOX_DISK_LIMIT_GB:=10}"
 }

--- a/deploy/scripts/worker_buckets.sh
+++ b/deploy/scripts/worker_buckets.sh
@@ -4,8 +4,11 @@
 # Why these process counts?
 # - Default sandbox memory is 3072 MB (3 GB cgroup limit). Tmpfs at /tmp +
 #   /var/tmp uses ~768 MB of that worst-case, leaving ~2.25 GB for the agent.
-# - We set WORKER_PROCESS_COUNT to roughly min(vCPU, floor(RAM_GB / 3)).
-# - That is intentionally "full utilization" at default limits, not conservative.
+# - We reserve host RAM before sizing sandboxes: max(2 GB, 10% of node RAM).
+# - We set WORKER_PROCESS_COUNT to roughly:
+#   max(1, min(vCPU, floor((RAM_GB - reserve_GB) / 3))).
+# - That targets high utilization at default limits while leaving room for the
+#   worker process, Docker/gVisor overhead, kernel memory, and page cache.
 # - If you lower SANDBOX_MEMORY_LIMIT_MB further, raise counts; if you raise it,
 #   lower counts.
 
@@ -37,19 +40,19 @@ apply_worker_bucket_overrides() {
     hcloud-cpx11) : "${WORKER_PROCESS_COUNT:=1}" ;;  # 2 vCPU / 2 GB  (RAM-bound)
     hcloud-cpx21) : "${WORKER_PROCESS_COUNT:=1}" ;;  # 3 vCPU / 4 GB  (RAM-bound)
     hcloud-cpx31) : "${WORKER_PROCESS_COUNT:=2}" ;;  # 4 vCPU / 8 GB
-    hcloud-cpx41) : "${WORKER_PROCESS_COUNT:=5}" ;;  # 8 vCPU / 16 GB
-    hcloud-cpx51) : "${WORKER_PROCESS_COUNT:=10}" ;; # 16 vCPU / 32 GB
+    hcloud-cpx41) : "${WORKER_PROCESS_COUNT:=4}" ;;  # 8 vCPU / 16 GB
+    hcloud-cpx51) : "${WORKER_PROCESS_COUNT:=9}" ;;  # 16 vCPU / 32 GB
     # Hetzner CCX (dedicated CPU) buckets
     hcloud-ccx13) : "${WORKER_PROCESS_COUNT:=2}" ;;  # 2 vCPU / 8 GB  (CPU-bound)
-    hcloud-ccx23) : "${WORKER_PROCESS_COUNT:=5}" ;;  # 4 vCPU / 16 GB
-    hcloud-ccx33) : "${WORKER_PROCESS_COUNT:=10}" ;; # 8 vCPU / 32 GB
-    hcloud-ccx43) : "${WORKER_PROCESS_COUNT:=21}" ;; # 16 vCPU / 64 GB
-    hcloud-ccx53) : "${WORKER_PROCESS_COUNT:=42}" ;; # 32 vCPU / 128 GB
-    hcloud-ccx63) : "${WORKER_PROCESS_COUNT:=64}" ;; # 48 vCPU / 192 GB
+    hcloud-ccx23) : "${WORKER_PROCESS_COUNT:=4}" ;;  # 4 vCPU / 16 GB
+    hcloud-ccx33) : "${WORKER_PROCESS_COUNT:=8}" ;;  # 8 vCPU / 32 GB  (CPU-bound)
+    hcloud-ccx43) : "${WORKER_PROCESS_COUNT:=16}" ;; # 16 vCPU / 64 GB (CPU-bound)
+    hcloud-ccx53) : "${WORKER_PROCESS_COUNT:=32}" ;; # 32 vCPU / 128 GB (CPU-bound)
+    hcloud-ccx63) : "${WORKER_PROCESS_COUNT:=48}" ;; # 48 vCPU / 192 GB (CPU-bound)
     # AWS EC2 buckets
-    ec2-t3.xlarge) : "${WORKER_PROCESS_COUNT:=5}" ;;    # 4 vCPU / 16 GB
-    ec2-c6i.2xlarge) : "${WORKER_PROCESS_COUNT:=8}" ;;  # 8 vCPU / 16 GB
-    ec2-c6i.4xlarge) : "${WORKER_PROCESS_COUNT:=10}" ;; # 16 vCPU / 32 GB
+    ec2-t3.xlarge) : "${WORKER_PROCESS_COUNT:=4}" ;;   # 4 vCPU / 16 GB
+    ec2-c6i.2xlarge) : "${WORKER_PROCESS_COUNT:=4}" ;; # 8 vCPU / 16 GB
+    ec2-c6i.4xlarge) : "${WORKER_PROCESS_COUNT:=9}" ;; # 16 vCPU / 32 GB
     *)
       : "${WORKER_PROCESS_COUNT:=4}" # default baseline
       ;;

--- a/deploy/scripts/worker_buckets_test.sh
+++ b/deploy/scripts/worker_buckets_test.sh
@@ -25,7 +25,7 @@ test_bucket_map_uses_bucket_then_host_with_colon_separator() {
   reset_worker_env
   WORKER_BUCKET_MAP="hcloud-ccx23:87.99.158.39,hcloud-cpx31:10.0.0.5"
   apply_worker_bucket_overrides worker "87.99.158.39"
-  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "bucket map should match bucket:host entries"
+  assert_eq "5" "${WORKER_PROCESS_COUNT:-}" "bucket map should match bucket:host entries"
 }
 
 test_bucket_map_does_not_override_other_hosts() {
@@ -48,7 +48,7 @@ test_bucket_map_sets_sandbox_defaults() {
   WORKER_BUCKET_MAP="hcloud-cpx31:87.99.158.39"
   apply_worker_bucket_overrides worker "87.99.158.39"
   assert_eq "2" "${SANDBOX_CPU_LIMIT:-}" "worker bucket overrides should set default sandbox CPU"
-  assert_eq "4096" "${SANDBOX_MEMORY_LIMIT_MB:-}" "worker bucket overrides should set default sandbox memory"
+  assert_eq "3072" "${SANDBOX_MEMORY_LIMIT_MB:-}" "worker bucket overrides should set default sandbox memory"
   assert_eq "10" "${SANDBOX_DISK_LIMIT_GB:-}" "worker bucket overrides should set default sandbox disk"
 }
 
@@ -63,7 +63,7 @@ test_bucket_map_uses_default_bucket_when_set() {
   reset_worker_env
   WORKER_DEFAULT_BUCKET="hcloud-ccx23"
   apply_worker_bucket_overrides worker "87.99.158.40"
-  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "default bucket should still work for unmapped workers"
+  assert_eq "5" "${WORKER_PROCESS_COUNT:-}" "default bucket should still work for unmapped workers"
 }
 
 test_bucket_map_uses_builtin_fallback_without_mapping() {

--- a/deploy/scripts/worker_buckets_test.sh
+++ b/deploy/scripts/worker_buckets_test.sh
@@ -25,7 +25,7 @@ test_bucket_map_uses_bucket_then_host_with_colon_separator() {
   reset_worker_env
   WORKER_BUCKET_MAP="hcloud-ccx23:87.99.158.39,hcloud-cpx31:10.0.0.5"
   apply_worker_bucket_overrides worker "87.99.158.39"
-  assert_eq "5" "${WORKER_PROCESS_COUNT:-}" "bucket map should match bucket:host entries"
+  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "bucket map should match bucket:host entries"
 }
 
 test_bucket_map_does_not_override_other_hosts() {
@@ -63,13 +63,42 @@ test_bucket_map_uses_default_bucket_when_set() {
   reset_worker_env
   WORKER_DEFAULT_BUCKET="hcloud-ccx23"
   apply_worker_bucket_overrides worker "87.99.158.40"
-  assert_eq "5" "${WORKER_PROCESS_COUNT:-}" "default bucket should still work for unmapped workers"
+  assert_eq "4" "${WORKER_PROCESS_COUNT:-}" "default bucket should still work for unmapped workers"
 }
 
 test_bucket_map_uses_builtin_fallback_without_mapping() {
   reset_worker_env
   apply_worker_bucket_overrides worker "87.99.158.40"
   assert_eq "2" "${WORKER_PROCESS_COUNT:-}" "builtin default bucket should apply when no mapping is configured"
+}
+
+test_builtin_bucket_counts_follow_reserved_ram_rule() {
+  local cases=(
+    "hcloud-cpx11:1"
+    "hcloud-cpx21:1"
+    "hcloud-cpx31:2"
+    "hcloud-cpx41:4"
+    "hcloud-cpx51:9"
+    "hcloud-ccx13:2"
+    "hcloud-ccx23:4"
+    "hcloud-ccx33:8"
+    "hcloud-ccx43:16"
+    "hcloud-ccx53:32"
+    "hcloud-ccx63:48"
+    "ec2-t3.xlarge:4"
+    "ec2-c6i.2xlarge:4"
+    "ec2-c6i.4xlarge:9"
+  )
+
+  local case bucket expected
+  for case in "${cases[@]}"; do
+    reset_worker_env
+    bucket="${case%%:*}"
+    expected="${case#*:}"
+    WORKER_DEFAULT_BUCKET="$bucket"
+    apply_worker_bucket_overrides worker "87.99.158.40"
+    assert_eq "$expected" "${WORKER_PROCESS_COUNT:-}" "$bucket should follow the reserved RAM sizing rule"
+  done
 }
 
 main() {
@@ -80,6 +109,7 @@ main() {
   test_bucket_map_ignores_non_worker_roles
   test_bucket_map_uses_default_bucket_when_set
   test_bucket_map_uses_builtin_fallback_without_mapping
+  test_builtin_bucket_counts_follow_reserved_ram_rule
 }
 
 main "$@"

--- a/docs/self-hosting/worker-capacity-tuning.md
+++ b/docs/self-hosting/worker-capacity-tuning.md
@@ -114,6 +114,8 @@ Workers emit OTel histograms (`container.memory.used`, `container.cpu.used`, `co
 
 **gVisor (runsc) caveat.** Production workers run gVisor by default. gVisor's stat surface is partial: `container.memory.used` is reported but with coarse granularity, and CPU throttling stats are zero. The histograms are still useful for relative comparison ("did p95 mem go up after the bucket bump?"), but treat absolute numbers as approximate. When in doubt, double-check on a runc dev worker.
 
+**Tick-budget caveat at high density.** The sampler fans out at most 8 concurrent stats calls per tick with a 5s per-call timeout, so a tick can take up to `ceil(WORKER_PROCESS_COUNT / 8) * 5s` worst-case (typical Docker `stats?stream=false` calls return in ~1s, well under that ceiling). On the largest bucket (`hcloud-ccx63`, 48 processes) the ceiling is exactly 30s — the same as the default `RUNTIME_STATS_INTERVAL`. If you provision dense nodes with `WORKER_PROCESS_COUNT > 40`, raise `RUNTIME_STATS_INTERVAL` to `60s` so a slow tick can't overrun the next one and silently drop samples.
+
 ## Migration notes
 
 The default `SANDBOX_MEMORY_LIMIT_MB` was lowered from `4096` to `3072` (paired with smaller tmpfs sizes so the agent's actual usable RAM went up, not down). Operators upgrading from earlier versions:

--- a/docs/self-hosting/worker-capacity-tuning.md
+++ b/docs/self-hosting/worker-capacity-tuning.md
@@ -39,10 +39,12 @@ Deploy/provision scripts now read bucket defaults from one shared file:
 
 How shared-CPU (CPX) counts were chosen:
 
-- Base sandbox memory default is 4096 MB.
-- The first-order limit is roughly `floor(node_ram_gb / 4)`.
+- Base sandbox memory default is 3072 MB (3 GB cgroup limit). Tmpfs at /tmp
+  (256 MiB) + /var/tmp (512 MiB) consumes up to ~768 MB of that, leaving
+  ~2.25 GB for the agent's actual heap.
+- The first-order limit is roughly `floor(node_ram_gb / 3)`.
 - We cap by available vCPU when that is lower.
-- In short: `WORKER_PROCESS_COUNT ~= min(vCPU, floor(RAM_GB / 4))`.
+- In short: `WORKER_PROCESS_COUNT ~= min(vCPU, floor(RAM_GB / 3))`.
 
 This is intentionally not ultra-conservative: it targets full utilization at the default sandbox memory size.
 
@@ -65,23 +67,23 @@ Built-in bucket presets used by deploy/provision scripts:
   - `hcloud-cpx11` → `WORKER_PROCESS_COUNT=1`
   - `hcloud-cpx21` → `WORKER_PROCESS_COUNT=1`
   - `hcloud-cpx31` → `WORKER_PROCESS_COUNT=2`
-  - `hcloud-cpx41` → `WORKER_PROCESS_COUNT=4`
-  - `hcloud-cpx51` → `WORKER_PROCESS_COUNT=8`
+  - `hcloud-cpx41` → `WORKER_PROCESS_COUNT=5`
+  - `hcloud-cpx51` → `WORKER_PROCESS_COUNT=10`
 - Hetzner CCX (dedicated CPU):
   - `hcloud-ccx13` → `WORKER_PROCESS_COUNT=2`
-  - `hcloud-ccx23` → `WORKER_PROCESS_COUNT=4`
-  - `hcloud-ccx33` → `WORKER_PROCESS_COUNT=8`
-  - `hcloud-ccx43` → `WORKER_PROCESS_COUNT=16`
-  - `hcloud-ccx53` → `WORKER_PROCESS_COUNT=32`
-  - `hcloud-ccx63` → `WORKER_PROCESS_COUNT=48`
-- `ec2-t3.xlarge` → `WORKER_PROCESS_COUNT=4`
-- `ec2-c6i.2xlarge` → `WORKER_PROCESS_COUNT=6`
+  - `hcloud-ccx23` → `WORKER_PROCESS_COUNT=5`
+  - `hcloud-ccx33` → `WORKER_PROCESS_COUNT=10`
+  - `hcloud-ccx43` → `WORKER_PROCESS_COUNT=21`
+  - `hcloud-ccx53` → `WORKER_PROCESS_COUNT=42`
+  - `hcloud-ccx63` → `WORKER_PROCESS_COUNT=64`
+- `ec2-t3.xlarge` → `WORKER_PROCESS_COUNT=5`
+- `ec2-c6i.2xlarge` → `WORKER_PROCESS_COUNT=8`
 - `ec2-c6i.4xlarge` → `WORKER_PROCESS_COUNT=10`
 
 Per-sandbox defaults are intentionally consistent across buckets unless you explicitly override:
 
 - `SANDBOX_CPU_LIMIT=2`
-- `SANDBOX_MEMORY_LIMIT_MB=4096`
+- `SANDBOX_MEMORY_LIMIT_MB=3072`
 - `SANDBOX_DISK_LIMIT_GB=10`
 
 `max_concurrent_runs` is a separate org-level execution policy in app settings, not a host-capacity bucket knob.
@@ -102,3 +104,16 @@ If a knob is omitted, runtime defaults still apply.
 - Increased p95/p99 run duration after increasing process count
 
 If you see these, lower `WORKER_PROCESS_COUNT` first, then lower per-sandbox CPU/memory limits if needed.
+
+## Verifying density with runtime metrics
+
+Workers emit OTel histograms (`container.memory.used`, `container.cpu.used`, `container.memory.utilization`, `container.cpu.utilization`) sampled every `RUNTIME_STATS_INTERVAL` (default 30s, set to `0` to disable). After bumping `WORKER_PROCESS_COUNT` or lowering `SANDBOX_MEMORY_LIMIT_MB`, watch p95 of `container.memory.utilization` for at least a week of real workload before treating the new size as proven. Sustained p95 above ~0.85 means you're one bad turn away from OOM kills; pull back.
+
+**gVisor (runsc) caveat.** Production workers run gVisor by default. gVisor's stat surface is partial: `container.memory.used` is reported but with coarse granularity, and CPU throttling stats are zero. The histograms are still useful for relative comparison ("did p95 mem go up after the bucket bump?"), but treat absolute numbers as approximate. When in doubt, double-check on a runc dev worker.
+
+## Migration notes
+
+The default `SANDBOX_MEMORY_LIMIT_MB` was lowered from `4096` to `3072` (paired with smaller tmpfs sizes so the agent's actual usable RAM went up, not down). Operators upgrading from earlier versions:
+
+- If you run workloads that genuinely need >3 GB cgroup headroom (large PM bootstraps on monorepos, agents that load big indices into memory), set `SANDBOX_MEMORY_LIMIT_MB=4096` explicitly to preserve old behavior.
+- If you also run with the old `WORKER_PROCESS_COUNT` and bump it per the new bucket presets, do it in one step per node — don't increase density and lower the per-sandbox limit at the same time on a node serving live traffic.

--- a/docs/self-hosting/worker-capacity-tuning.md
+++ b/docs/self-hosting/worker-capacity-tuning.md
@@ -42,11 +42,14 @@ How shared-CPU (CPX) counts were chosen:
 - Base sandbox memory default is 3072 MB (3 GB cgroup limit). Tmpfs at /tmp
   (256 MiB) + /var/tmp (512 MiB) consumes up to ~768 MB of that, leaving
   ~2.25 GB for the agent's actual heap.
-- The first-order limit is roughly `floor(node_ram_gb / 3)`.
-- We cap by available vCPU when that is lower.
-- In short: `WORKER_PROCESS_COUNT ~= min(vCPU, floor(RAM_GB / 3))`.
+- Reserve host RAM first: `max(2 GB, 10% of node RAM)`.
+- The first-order memory limit is roughly `floor((node_ram_gb - reserve_gb) / 3)`.
+- We cap by available vCPU when that is lower. `SANDBOX_CPU_LIMIT=2` is a
+  throttling ceiling, not a reservation, so this allows modest CPU overcommit
+  for LLM/network-bound runs without letting memory overcommit be the default.
+- In short: `WORKER_PROCESS_COUNT ~= max(1, min(vCPU, floor((RAM_GB - reserve_GB) / 3)))`.
 
-This is intentionally not ultra-conservative: it targets full utilization at the default sandbox memory size.
+This is intentionally not ultra-conservative: it targets high utilization at the default sandbox memory size while leaving room for the worker process, Docker/gVisor overhead, kernel memory, and page cache.
 
 ## Where to set these in production
 
@@ -67,18 +70,18 @@ Built-in bucket presets used by deploy/provision scripts:
   - `hcloud-cpx11` → `WORKER_PROCESS_COUNT=1`
   - `hcloud-cpx21` → `WORKER_PROCESS_COUNT=1`
   - `hcloud-cpx31` → `WORKER_PROCESS_COUNT=2`
-  - `hcloud-cpx41` → `WORKER_PROCESS_COUNT=5`
-  - `hcloud-cpx51` → `WORKER_PROCESS_COUNT=10`
+  - `hcloud-cpx41` → `WORKER_PROCESS_COUNT=4`
+  - `hcloud-cpx51` → `WORKER_PROCESS_COUNT=9`
 - Hetzner CCX (dedicated CPU):
   - `hcloud-ccx13` → `WORKER_PROCESS_COUNT=2`
-  - `hcloud-ccx23` → `WORKER_PROCESS_COUNT=5`
-  - `hcloud-ccx33` → `WORKER_PROCESS_COUNT=10`
-  - `hcloud-ccx43` → `WORKER_PROCESS_COUNT=21`
-  - `hcloud-ccx53` → `WORKER_PROCESS_COUNT=42`
-  - `hcloud-ccx63` → `WORKER_PROCESS_COUNT=64`
-- `ec2-t3.xlarge` → `WORKER_PROCESS_COUNT=5`
-- `ec2-c6i.2xlarge` → `WORKER_PROCESS_COUNT=8`
-- `ec2-c6i.4xlarge` → `WORKER_PROCESS_COUNT=10`
+  - `hcloud-ccx23` → `WORKER_PROCESS_COUNT=4`
+  - `hcloud-ccx33` → `WORKER_PROCESS_COUNT=8`
+  - `hcloud-ccx43` → `WORKER_PROCESS_COUNT=16`
+  - `hcloud-ccx53` → `WORKER_PROCESS_COUNT=32`
+  - `hcloud-ccx63` → `WORKER_PROCESS_COUNT=48`
+- `ec2-t3.xlarge` → `WORKER_PROCESS_COUNT=4`
+- `ec2-c6i.2xlarge` → `WORKER_PROCESS_COUNT=4`
+- `ec2-c6i.4xlarge` → `WORKER_PROCESS_COUNT=9`
 
 Per-sandbox defaults are intentionally consistent across buckets unless you explicitly override:
 

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -621,6 +621,51 @@ describe("PreviewPanel component", () => {
     expect(screen.getByText("Open the preview")).toBeInTheDocument();
   });
 
+  it("renders orphaned pending children as terminal when the parent preview failed", async () => {
+    mockGet.mockResolvedValue(
+      makePreviewStatus(
+        { status: "failed", error: "provider start preview failed" },
+        [
+          {
+            id: "svc-1",
+            preview_instance_id: "prev-1",
+            service_name: "web",
+            role: "primary",
+            status: "starting",
+            command: ["npm", "run", "dev"],
+            cwd: "",
+            port: 3000,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        [
+          {
+            id: "infra-1",
+            preview_instance_id: "prev-1",
+            infra_name: "postgres",
+            template: "postgres",
+            container_id: "ctr-1",
+            status: "provisioning",
+            host: "postgres",
+            port: 5432,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      ),
+    );
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Startup checklist")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("postgres did not finish provisioning")).toBeInTheDocument();
+    expect(screen.getByText("web did not finish starting")).toBeInTheDocument();
+    expect(screen.queryByText("postgres is provisioning")).not.toBeInTheDocument();
+    expect(screen.queryByText("web is starting")).not.toBeInTheDocument();
+  });
+
   /* ---------- Stop mutation ---------- */
 
   it("calls stop mutation when Stop button is clicked", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -291,6 +291,9 @@ export function PreviewPanel({
     status === "partially_ready" ||
     status === "starting";
   const isReady = status === "ready" || status === "partially_ready";
+  const hasStartupRows = services.length > 0 || infrastructure.length > 0;
+  const showStartupProgress =
+    (isActive && !isReady) || (status === "failed" && hasStartupRows);
 
   // Start preview
   const startMutation = useMutation({
@@ -509,10 +512,9 @@ export function PreviewPanel({
     startMutation.isPending ||
     stopMutation.isPending ||
     restartMutation.isPending;
-  const startupChecklist =
-    isActive && !isReady
-      ? buildStartupChecklist(status, services, infrastructure)
-      : [];
+  const startupChecklist = showStartupProgress
+    ? buildStartupChecklist(status, services, infrastructure)
+    : [];
 
   if (statusLoading) {
     return (
@@ -714,7 +716,7 @@ export function PreviewPanel({
       )}
 
       {/* Startup progress */}
-      {isActive && !isReady && (
+      {showStartupProgress && (
         <div className="space-y-2">
           <div className="rounded-lg border bg-muted/30 p-3">
             <p className="text-sm font-medium">Preview startup can take a few minutes.</p>

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,6 +190,11 @@ type Config struct {
 	// Telemetry (OpenTelemetry)
 	OTLPEndpoint string `env:"OTEL_EXPORTER_OTLP_ENDPOINT"` // e.g. "otel-collector:4318" or "https://otlp.grafana.net"
 	OTLPInsecure bool   `env:"OTEL_EXPORTER_OTLP_INSECURE" envDefault:"false"`
+	// RuntimeStatsInterval controls how often the worker samples per-container
+	// memory/CPU usage and emits container.{memory,cpu}.{used,utilization}
+	// histograms. Operators use these to size SANDBOX_* limits against actual
+	// consumption rather than allocation. Set to 0 to disable sampling.
+	RuntimeStatsInterval time.Duration `env:"RUNTIME_STATS_INTERVAL" envDefault:"30s"`
 
 	// Redis (optional)
 	RedisTopology   string `env:"REDIS_TOPOLOGY" envDefault:"standalone"`

--- a/internal/metrics/billing.go
+++ b/internal/metrics/billing.go
@@ -22,12 +22,16 @@ const meterName = "github.com/assembledhq/143/billing"
 // from attributes and rely on the container_usage_events DB table for
 // per-org queries.
 type BillingMetrics struct {
-	ContainerStartsTotal  otelmetric.Int64Counter
-	ContainerStopsTotal   otelmetric.Int64Counter
-	ContainerDurationSec  otelmetric.Float64Histogram
-	ContainerCPUAllocated otelmetric.Float64Histogram
-	ContainerMemAllocated otelmetric.Float64Histogram
-	ContainerMinutesTotal otelmetric.Float64Counter
+	ContainerStartsTotal    otelmetric.Int64Counter
+	ContainerStopsTotal     otelmetric.Int64Counter
+	ContainerDurationSec    otelmetric.Float64Histogram
+	ContainerCPUAllocated   otelmetric.Float64Histogram
+	ContainerMemAllocated   otelmetric.Float64Histogram
+	ContainerMinutesTotal   otelmetric.Float64Counter
+	ContainerMemUsed        otelmetric.Float64Histogram // sampled working-set memory (MiB)
+	ContainerCPUUsed        otelmetric.Float64Histogram // sampled CPU usage (cores)
+	ContainerMemUtilization otelmetric.Float64Histogram // sampled mem used / mem limit (0..1)
+	ContainerCPUUtilization otelmetric.Float64Histogram // sampled cpu used / cpu limit (0..1)
 	// containersActiveReg holds the registration so it can be cleaned up.
 	containersActiveReg otelmetric.Registration
 }
@@ -115,14 +119,54 @@ func NewBillingMetrics(activeCounter ActiveContainerCounter) (*BillingMetrics, e
 		return nil, err
 	}
 
+	memUsed, err := meter.Float64Histogram("container.memory.used",
+		otelmetric.WithDescription("Sampled working-set memory used by sandbox containers"),
+		otelmetric.WithUnit("MiBy"),
+		otelmetric.WithExplicitBucketBoundaries(64, 128, 256, 512, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 12288, 16384),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cpuUsed, err := meter.Float64Histogram("container.cpu.used",
+		otelmetric.WithDescription("Sampled CPU cores used by sandbox containers"),
+		otelmetric.WithUnit("{cores}"),
+		otelmetric.WithExplicitBucketBoundaries(0.05, 0.1, 0.25, 0.5, 1, 1.5, 2, 3, 4, 6, 8),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	memUtil, err := meter.Float64Histogram("container.memory.utilization",
+		otelmetric.WithDescription("Sampled memory used divided by memory limit (0..1)"),
+		otelmetric.WithUnit("1"),
+		otelmetric.WithExplicitBucketBoundaries(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1.0),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	cpuUtil, err := meter.Float64Histogram("container.cpu.utilization",
+		otelmetric.WithDescription("Sampled CPU used divided by CPU limit (0..1)"),
+		otelmetric.WithUnit("1"),
+		otelmetric.WithExplicitBucketBoundaries(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 1.0),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &BillingMetrics{
-		ContainerStartsTotal:  starts,
-		ContainerStopsTotal:   stops,
-		ContainerDurationSec:  duration,
-		ContainerCPUAllocated: cpu,
-		ContainerMemAllocated: mem,
-		ContainerMinutesTotal: minutes,
-		containersActiveReg:   activeReg,
+		ContainerStartsTotal:    starts,
+		ContainerStopsTotal:     stops,
+		ContainerDurationSec:    duration,
+		ContainerCPUAllocated:   cpu,
+		ContainerMemAllocated:   mem,
+		ContainerMinutesTotal:   minutes,
+		ContainerMemUsed:        memUsed,
+		ContainerCPUUsed:        cpuUsed,
+		ContainerMemUtilization: memUtil,
+		ContainerCPUUtilization: cpuUtil,
+		containersActiveReg:     activeReg,
 	}, nil
 }
 
@@ -154,4 +198,16 @@ func (m *BillingMetrics) RecordStop(ctx context.Context, orgID, exitReason strin
 	m.ContainerStopsTotal.Add(ctx, 1, reasonAttrs)
 	m.ContainerDurationSec.Record(ctx, durationSec, reasonAttrs)
 	m.ContainerMinutesTotal.Add(ctx, durationMin, orgAttr)
+}
+
+// RecordSample records a runtime resource-usage sample for one running
+// container. memMiB is sampled working-set memory in MiB, cpuCores is the
+// average CPU cores observed in the sample window, and the *Util values are
+// the corresponding fractions of the configured limit (clamped 0..1).
+func (m *BillingMetrics) RecordSample(ctx context.Context, orgID string, memMiB, cpuCores, memUtil, cpuUtil float64) {
+	attrs := otelmetric.WithAttributes(AttrOrgID.String(orgID))
+	m.ContainerMemUsed.Record(ctx, memMiB, attrs)
+	m.ContainerCPUUsed.Record(ctx, cpuCores, attrs)
+	m.ContainerMemUtilization.Record(ctx, memUtil, attrs)
+	m.ContainerCPUUtilization.Record(ctx, cpuUtil, attrs)
 }

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -293,7 +293,7 @@ const HandlerCleanupBuffer = 2 * time.Minute
 type SandboxConfig struct {
 	Image         string            // base image with agent CLI tools pre-installed
 	CPULimit      float64           // CPU cores (default: 2)
-	MemoryLimitMB int               // memory in MB (default: 4096)
+	MemoryLimitMB int               // memory in MB (default: 3072)
 	Timeout       time.Duration     // max execution time (default: DefaultSandboxTimeout)
 	NetworkPolicy string            // "restricted" — allow only LLM API endpoints
 	WorkDir       string            // path to the repo checkout inside the sandbox (e.g. /home/sandbox/<repo>)
@@ -334,7 +334,7 @@ func DefaultSandboxConfig() SandboxConfig {
 			cpuLimit = parsed
 		}
 	}
-	memoryLimitMB := 4096
+	memoryLimitMB := 3072
 	if v := os.Getenv("SANDBOX_MEMORY_LIMIT_MB"); v != "" {
 		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
 			memoryLimitMB = parsed

--- a/internal/services/agent/adapter_test.go
+++ b/internal/services/agent/adapter_test.go
@@ -65,7 +65,7 @@ func TestDefaultSandboxConfig_InvalidEnvironmentOverridesFallbackToDefaults(t *t
 	cfg := DefaultSandboxConfig()
 
 	require.Equal(t, 2.0, cfg.CPULimit, "DefaultSandboxConfig should fall back to default CPU limit for invalid SANDBOX_CPU_LIMIT")
-	require.Equal(t, 4096, cfg.MemoryLimitMB, "DefaultSandboxConfig should fall back to default memory limit for invalid SANDBOX_MEMORY_LIMIT_MB")
+	require.Equal(t, 3072, cfg.MemoryLimitMB, "DefaultSandboxConfig should fall back to default memory limit for invalid SANDBOX_MEMORY_LIMIT_MB")
 	require.Equal(t, 10, cfg.DiskLimitGB, "DefaultSandboxConfig should fall back to default disk limit for invalid SANDBOX_DISK_LIMIT_GB")
 }
 

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -207,7 +207,7 @@ type JobStore interface {
 // UsageRecorder tracks container lifecycle events for billing.
 type UsageRecorder interface {
 	ContainerStarted(ctx context.Context, orgID, sessionID uuid.UUID, sandbox *Sandbox, cfg SandboxConfig, startedAt time.Time) uuid.UUID
-	ContainerStopped(ctx context.Context, orgID, sessionID uuid.UUID, eventID uuid.UUID, startedAt time.Time, exitReason string)
+	ContainerStopped(ctx context.Context, orgID, sessionID uuid.UUID, eventID uuid.UUID, containerID string, startedAt time.Time, exitReason string)
 }
 
 // MemoryService provides scored memory context for agent prompts.
@@ -1292,7 +1292,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 			// the parent ctx was cancelled (timeout, shutdown).
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer stopCancel()
-			o.usageTracker.ContainerStopped(stopCtx, run.OrgID, run.ID, usageEventID, containerStartedAt, exitReason)
+			o.usageTracker.ContainerStopped(stopCtx, run.OrgID, run.ID, usageEventID, sandbox.ID, containerStartedAt, exitReason)
 		}
 		// Use a background context for cleanup since the run context may be cancelled.
 		destroyCtx := context.Background()
@@ -2019,7 +2019,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if o.usageTracker != nil {
 			stopCtx, stopCancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer stopCancel()
-			o.usageTracker.ContainerStopped(stopCtx, session.OrgID, session.ID, usageEventID, containerStartedAt, exitReason)
+			o.usageTracker.ContainerStopped(stopCtx, session.OrgID, session.ID, usageEventID, sandbox.ID, containerStartedAt, exitReason)
 		}
 		// Detached context so DB writes + destroy succeed even if ctx was
 		// cancelled (user cancel, timeout, shutdown).

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -44,6 +44,7 @@ type DockerClient interface {
 	ContainerStop(ctx context.Context, containerID string, options container.StopOptions) error
 	ContainerRemove(ctx context.Context, containerID string, options container.RemoveOptions) error
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
+	ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
 	ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
@@ -327,8 +328,15 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 			// and run it. /var/tmp is the exec-allowed scratch dir for tools
 			// that need to compile and exec in their tempdir; TMPDIR points
 			// here by default (see defaultScratchDir).
-			"/tmp":     "rw,noexec,nosuid,size=1073741824",
-			"/var/tmp": "rw,exec,nosuid,size=1073741824",
+			//
+			// Sizes count against the container's memory cgroup as soon as
+			// processes touch them, so they directly subtract from
+			// SANDBOX_MEMORY_LIMIT_MB. Keeping them small reserves more of
+			// that budget for the agent's actual heap. /var/tmp is the
+			// larger of the two because TMPDIR points there and most
+			// compile/test tooling churns scratch files there.
+			"/tmp":     "rw,noexec,nosuid,size=268435456", // 256 MiB
+			"/var/tmp": "rw,exec,nosuid,size=536870912",   // 512 MiB
 		},
 	}
 

--- a/internal/services/agent/providers/docker_stats.go
+++ b/internal/services/agent/providers/docker_stats.go
@@ -47,8 +47,11 @@ func (d *DockerProvider) Stats(ctx context.Context, sb *agent.Sandbox) (agent.Ru
 
 // memoryWorkingSet returns the working-set memory: usage minus the page cache
 // portion that the kernel can cheaply reclaim. This matches what `docker
-// stats` shows in the MEM USAGE column. Falls back to raw usage if neither
-// the cgroup-v2 ("inactive_file") nor cgroup-v1 ("cache") key is reported.
+// stats` shows in the MEM USAGE column. Tries cgroup v2's `inactive_file`
+// first, then cgroup v1's `total_inactive_file`, then a coarse `cache`
+// fallback. The `cache` branch over-subtracts (cache covers both active and
+// inactive page cache), so the result understates the true working set on
+// older runtimes that only report `cache`; treat it as a lower bound.
 func memoryWorkingSet(m container.MemoryStats) uint64 {
 	if m.Usage == 0 {
 		return 0

--- a/internal/services/agent/providers/docker_stats.go
+++ b/internal/services/agent/providers/docker_stats.go
@@ -1,0 +1,85 @@
+package providers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	cerrdefs "github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/container"
+
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+// Stats fetches a one-shot runtime sample for the given sandbox container via
+// the Docker stats API. Stream=false primes a 1s server-side delta so both
+// CPUStats and PreCPUStats are populated, which is what `docker stats` itself
+// uses to compute live CPU%.
+//
+// Returns an error that satisfies errors.Is(err, agent.ErrSandboxNotFound)
+// when Docker reports the container is gone, so the sampler can evict its
+// in-memory registry entry instead of polling forever.
+//
+// gVisor (runsc) caveat: under runsc, Docker can return zero values for
+// MemoryStats.Stats["inactive_file"] and ThrottlingData. memoryWorkingSet
+// falls back to MemoryStats.Usage in that case rather than over-subtracting.
+func (d *DockerProvider) Stats(ctx context.Context, sb *agent.Sandbox) (agent.RuntimeStats, error) {
+	resp, err := d.client.ContainerStats(ctx, sb.ID, false)
+	if err != nil {
+		if cerrdefs.IsNotFound(err) {
+			return agent.RuntimeStats{}, fmt.Errorf("container stats: %w: %w", agent.ErrSandboxNotFound, err)
+		}
+		return agent.RuntimeStats{}, fmt.Errorf("container stats: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var s container.StatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return agent.RuntimeStats{}, fmt.Errorf("decode stats: %w", err)
+	}
+
+	return agent.RuntimeStats{
+		MemoryBytes:      memoryWorkingSet(s.MemoryStats),
+		MemoryLimitBytes: s.MemoryStats.Limit,
+		CPUCores:         cpuCores(s.CPUStats, s.PreCPUStats),
+	}, nil
+}
+
+// memoryWorkingSet returns the working-set memory: usage minus the page cache
+// portion that the kernel can cheaply reclaim. This matches what `docker
+// stats` shows in the MEM USAGE column. Falls back to raw usage if neither
+// the cgroup-v2 ("inactive_file") nor cgroup-v1 ("cache") key is reported.
+func memoryWorkingSet(m container.MemoryStats) uint64 {
+	if m.Usage == 0 {
+		return 0
+	}
+	if v, ok := m.Stats["inactive_file"]; ok && v < m.Usage {
+		return m.Usage - v
+	}
+	if v, ok := m.Stats["total_inactive_file"]; ok && v < m.Usage {
+		return m.Usage - v
+	}
+	if v, ok := m.Stats["cache"]; ok && v < m.Usage {
+		return m.Usage - v
+	}
+	return m.Usage
+}
+
+// cpuCores converts a delta CPU sample into the average number of full cores
+// used during the window. Returns 0 when either delta is non-positive (e.g.
+// PreCPUStats was zeroed by a one-shot endpoint, or the container exited).
+func cpuCores(cur, prev container.CPUStats) float64 {
+	cpuDelta := float64(cur.CPUUsage.TotalUsage) - float64(prev.CPUUsage.TotalUsage)
+	sysDelta := float64(cur.SystemUsage) - float64(prev.SystemUsage)
+	if cpuDelta <= 0 || sysDelta <= 0 {
+		return 0
+	}
+	online := float64(cur.OnlineCPUs)
+	if online == 0 {
+		online = float64(len(cur.CPUUsage.PercpuUsage))
+	}
+	if online == 0 {
+		return 0
+	}
+	return (cpuDelta / sysDelta) * online
+}

--- a/internal/services/agent/providers/docker_stats_test.go
+++ b/internal/services/agent/providers/docker_stats_test.go
@@ -1,0 +1,148 @@
+package providers
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+func TestDockerProvider_Stats_DecodesAndReportsWorkingSet(t *testing.T) {
+	t.Parallel()
+
+	// Build a stats payload that exercises the working-set computation
+	// (Usage minus inactive_file) and the CPU% delta math.
+	const payload = `{
+		"cpu_stats": {
+			"cpu_usage": {"total_usage": 4000000000},
+			"system_cpu_usage": 8000000000,
+			"online_cpus": 4
+		},
+		"precpu_stats": {
+			"cpu_usage": {"total_usage": 2000000000},
+			"system_cpu_usage": 6000000000,
+			"online_cpus": 4
+		},
+		"memory_stats": {
+			"usage": 1073741824,
+			"limit": 4294967296,
+			"stats": {"inactive_file": 268435456}
+		}
+	}`
+
+	mock := &mockDockerClient{
+		containerStatsFn: func(ctx context.Context, id string, stream bool) (container.StatsResponseReader, error) {
+			require.Equal(t, "ctr-1", id)
+			require.False(t, stream, "Stats must use stream=false so PreCPUStats is primed")
+			return container.StatsResponseReader{Body: io.NopCloser(bytes.NewReader([]byte(payload)))}, nil
+		},
+	}
+	p := NewDockerProvider(mock, zerolog.Nop())
+
+	stats, err := p.Stats(context.Background(), &agent.Sandbox{ID: "ctr-1"})
+	require.NoError(t, err)
+
+	// Working set = 1 GiB - 256 MiB = 768 MiB.
+	require.Equal(t, uint64(1073741824-268435456), stats.MemoryBytes)
+	require.Equal(t, uint64(4294967296), stats.MemoryLimitBytes)
+
+	// CPU delta = 2s, system delta = 2s, online = 4 → 4.0 cores used.
+	require.InDelta(t, 4.0, stats.CPUCores, 1e-9)
+}
+
+func TestMemoryWorkingSet(t *testing.T) {
+	t.Parallel()
+	t.Run("subtracts inactive_file when present (cgroup v2)", func(t *testing.T) {
+		t.Parallel()
+		got := memoryWorkingSet(container.MemoryStats{
+			Usage: 1024,
+			Stats: map[string]uint64{"inactive_file": 256},
+		})
+		require.Equal(t, uint64(768), got)
+	})
+	t.Run("falls back to total_inactive_file (cgroup v1)", func(t *testing.T) {
+		t.Parallel()
+		got := memoryWorkingSet(container.MemoryStats{
+			Usage: 1024,
+			Stats: map[string]uint64{"total_inactive_file": 128},
+		})
+		require.Equal(t, uint64(896), got)
+	})
+	t.Run("falls back to cache when inactive keys missing", func(t *testing.T) {
+		t.Parallel()
+		got := memoryWorkingSet(container.MemoryStats{
+			Usage: 1024,
+			Stats: map[string]uint64{"cache": 512},
+		})
+		require.Equal(t, uint64(512), got)
+	})
+	t.Run("returns Usage when no breakdown available (gVisor)", func(t *testing.T) {
+		t.Parallel()
+		got := memoryWorkingSet(container.MemoryStats{Usage: 1024})
+		require.Equal(t, uint64(1024), got)
+	})
+	t.Run("returns 0 when usage is 0", func(t *testing.T) {
+		t.Parallel()
+		got := memoryWorkingSet(container.MemoryStats{})
+		require.Equal(t, uint64(0), got)
+	})
+}
+
+func TestCPUCores(t *testing.T) {
+	t.Parallel()
+	t.Run("computes cores from delta", func(t *testing.T) {
+		t.Parallel()
+		cur := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 3_000_000_000},
+			SystemUsage: 4_000_000_000,
+			OnlineCPUs:  4,
+		}
+		prev := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 1_000_000_000},
+			SystemUsage: 2_000_000_000,
+			OnlineCPUs:  4,
+		}
+		// (2 / 2) * 4 = 4 cores.
+		require.InDelta(t, 4.0, cpuCores(cur, prev), 1e-9)
+	})
+	t.Run("returns 0 when current matches previous (idle window)", func(t *testing.T) {
+		t.Parallel()
+		s := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 1_000_000_000},
+			SystemUsage: 2_000_000_000,
+			OnlineCPUs:  4,
+		}
+		require.Equal(t, 0.0, cpuCores(s, s))
+	})
+	t.Run("returns 0 when OnlineCPUs is unset and percpu is empty", func(t *testing.T) {
+		t.Parallel()
+		cur := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 3_000_000_000},
+			SystemUsage: 4_000_000_000,
+		}
+		prev := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 1_000_000_000},
+			SystemUsage: 2_000_000_000,
+		}
+		require.Equal(t, 0.0, cpuCores(cur, prev))
+	})
+	t.Run("derives core count from PercpuUsage length", func(t *testing.T) {
+		t.Parallel()
+		cur := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 3_000_000_000, PercpuUsage: []uint64{1, 2}},
+			SystemUsage: 4_000_000_000,
+		}
+		prev := container.CPUStats{
+			CPUUsage:    container.CPUUsage{TotalUsage: 1_000_000_000},
+			SystemUsage: 2_000_000_000,
+		}
+		// (2 / 2) * 2 = 2 cores.
+		require.InDelta(t, 2.0, cpuCores(cur, prev), 1e-9)
+	})
+}

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -33,6 +33,7 @@ type mockDockerClient struct {
 	containerStopFn        func(ctx context.Context, containerID string, options container.StopOptions) error
 	containerRemoveFn      func(ctx context.Context, containerID string, options container.RemoveOptions) error
 	containerInspectFn     func(ctx context.Context, containerID string) (container.InspectResponse, error)
+	containerStatsFn       func(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
 	containerExecCreateFn  func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	containerExecAttachFn  func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
 	containerExecInspectFn func(ctx context.Context, execID string) (container.ExecInspect, error)
@@ -86,6 +87,13 @@ func (m *mockDockerClient) ContainerInspect(ctx context.Context, containerID str
 			},
 		},
 	}, nil
+}
+
+func (m *mockDockerClient) ContainerStats(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error) {
+	if m.containerStatsFn != nil {
+		return m.containerStatsFn(ctx, containerID, stream)
+	}
+	return container.StatsResponseReader{Body: io.NopCloser(bytes.NewReader([]byte("{}")))}, nil
 }
 
 func (m *mockDockerClient) ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
@@ -462,7 +470,7 @@ func TestDockerProvider_Create(t *testing.T) {
 
 		// Verify resource limits
 		require.Equal(t, int64(2e9), capturedHostConfig.Resources.NanoCPUs, "container should have 2 CPU cores")
-		require.Equal(t, int64(4096*1024*1024), capturedHostConfig.Resources.Memory, "container should have 4GB memory")
+		require.Equal(t, int64(3072*1024*1024), capturedHostConfig.Resources.Memory, "container should have 3GB memory")
 		require.NotNil(t, capturedHostConfig.Resources.PidsLimit, "container should have PID limit")
 		require.Equal(t, int64(256), *capturedHostConfig.Resources.PidsLimit, "container should have PID limit of 256")
 
@@ -1508,7 +1516,7 @@ func TestDefaultSandboxConfig(t *testing.T) {
 	cfg := agent.DefaultSandboxConfig()
 	require.Equal(t, "143-sandbox:latest", cfg.Image, "default image should be '143-sandbox:latest'")
 	require.Equal(t, float64(2), cfg.CPULimit, "default CPU limit should be 2")
-	require.Equal(t, 4096, cfg.MemoryLimitMB, "default memory limit should be 4096 MB")
+	require.Equal(t, 3072, cfg.MemoryLimitMB, "default memory limit should be 3072 MB")
 	require.Equal(t, "/workspace", cfg.WorkDir, "default work dir should be '/workspace'")
 	require.Equal(t, "restricted", cfg.NetworkPolicy, "default network policy should be 'restricted'")
 	require.Equal(t, 10, cfg.DiskLimitGB, "default disk limit should be 10GB")

--- a/internal/services/agent/runtime_sampler.go
+++ b/internal/services/agent/runtime_sampler.go
@@ -1,0 +1,150 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"runtime/debug"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/metrics"
+)
+
+// runtimeSamplerMaxConcurrency caps the number of in-flight stats calls so a
+// single tick can't fan out unboundedly when many containers are active.
+const runtimeSamplerMaxConcurrency = 8
+
+// runtimeSampleTimeout bounds one Stats call. Docker's stream=false primes
+// for ~1s server-side, so 5s leaves room for slow daemons without making the
+// whole tick slip when one container is wedged.
+const runtimeSampleTimeout = 5 * time.Second
+
+// RuntimeSampler periodically polls per-container resource usage and records
+// it against BillingMetrics. The sampler is host-local: it asks UsageTracker
+// for sandboxes started on this process, then asks the provider (when it
+// implements RuntimeStatsProvider) for a one-shot stats sample. Containers
+// owned by other workers are sampled by their own samplers.
+type RuntimeSampler struct {
+	tracker  *UsageTracker
+	provider RuntimeStatsProvider
+	metrics  *metrics.BillingMetrics
+	interval time.Duration
+	logger   zerolog.Logger
+}
+
+// NewRuntimeSampler builds a sampler that ticks every interval. interval <= 0
+// disables sampling. Pass a provider that implements RuntimeStatsProvider; if
+// the provider can't sample (e.g. e2b in the future), pass nil and the
+// sampler will no-op.
+func NewRuntimeSampler(
+	tracker *UsageTracker,
+	provider RuntimeStatsProvider,
+	m *metrics.BillingMetrics,
+	interval time.Duration,
+	logger zerolog.Logger,
+) *RuntimeSampler {
+	return &RuntimeSampler{
+		tracker:  tracker,
+		provider: provider,
+		metrics:  m,
+		interval: interval,
+		logger:   logger.With().Str("component", "runtime_sampler").Logger(),
+	}
+}
+
+// Run blocks until ctx is canceled, sampling every interval. Returns
+// immediately when sampling is disabled (interval <= 0, no provider, etc.)
+// so callers can wire it into errgroups unconditionally.
+func (s *RuntimeSampler) Run(ctx context.Context) {
+	if s.interval <= 0 || s.provider == nil || s.tracker == nil || s.metrics == nil {
+		s.logger.Info().Msg("runtime sampler disabled")
+		return
+	}
+	s.logger.Info().Dur("interval", s.interval).Msg("runtime sampler started")
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.tick(ctx)
+		}
+	}
+}
+
+func (s *RuntimeSampler) tick(ctx context.Context) {
+	active := s.tracker.Snapshot()
+	if len(active) == 0 {
+		return
+	}
+
+	sem := make(chan struct{}, runtimeSamplerMaxConcurrency)
+	var wg sync.WaitGroup
+	for _, c := range active {
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(c ActiveContainer) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			// A bug in the provider's Stats() must not bring down the
+			// worker. Recover so a single bad sample only loses one
+			// data point; the next tick keeps sampling other containers.
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger.Error().
+						Interface("panic", r).
+						Str("container_id", c.Sandbox.ID).
+						Bytes("stack", debug.Stack()).
+						Msg("runtime stats sample panicked")
+				}
+			}()
+			s.sampleOne(ctx, c)
+		}(c)
+	}
+	wg.Wait()
+}
+
+func (s *RuntimeSampler) sampleOne(ctx context.Context, c ActiveContainer) {
+	sampleCtx, cancel := context.WithTimeout(ctx, runtimeSampleTimeout)
+	defer cancel()
+
+	stats, err := s.provider.Stats(sampleCtx, c.Sandbox)
+	if err != nil {
+		// Containers race with stats sampling: a container that exits
+		// between Snapshot() and Stats() returns "no such container".
+		// That's expected, not actionable — log at debug. When the
+		// runtime tells us the container is gone, evict the entry from
+		// the registry so future ticks don't keep polling for a ghost.
+		if errors.Is(err, ErrSandboxNotFound) {
+			s.tracker.Forget(c.Sandbox.ID)
+		}
+		s.logger.Debug().Err(err).
+			Str("container_id", c.Sandbox.ID).
+			Msg("runtime stats sample failed")
+		return
+	}
+
+	memMiB := float64(stats.MemoryBytes) / (1024 * 1024)
+	memUtil := 0.0
+	if stats.MemoryLimitBytes > 0 {
+		memUtil = clamp01(float64(stats.MemoryBytes) / float64(stats.MemoryLimitBytes))
+	}
+	cpuUtil := 0.0
+	if c.CPULimit > 0 {
+		cpuUtil = clamp01(stats.CPUCores / c.CPULimit)
+	}
+	s.metrics.RecordSample(ctx, c.Sandbox.OrgID, memMiB, stats.CPUCores, memUtil, cpuUtil)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/internal/services/agent/runtime_sampler_test.go
+++ b/internal/services/agent/runtime_sampler_test.go
@@ -114,7 +114,7 @@ func TestRuntimeSampler_StoppedContainerIsNotSampled(t *testing.T) {
 
 	startedAt := time.Now()
 	eventID := tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, startedAt)
-	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, startedAt, "ok")
+	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, sb.ID, startedAt, "ok")
 
 	require.Empty(t, tracker.Snapshot(), "stopped container must be removed from registry")
 
@@ -216,9 +216,9 @@ func TestRuntimeSampler_PanicInStatsDoesNotCrashWorker(t *testing.T) {
 func TestRuntimeSampler_NotFoundEvictsRegistryEntry(t *testing.T) {
 	t.Parallel()
 	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
-	prov := &fakeStatsProvider{err: errors.New("wrap: " + agent.ErrSandboxNotFound.Error())}
-	// Use a real wrapping so errors.Is matches.
-	prov.err = wrapNotFound()
+	// Wrap ErrSandboxNotFound so errors.Is matches — same shape Stats()
+	// returns from real providers when Docker reports the container is gone.
+	prov := &fakeStatsProvider{err: wrapNotFound()}
 
 	orgID := uuid.New()
 	sessionID := uuid.New()

--- a/internal/services/agent/runtime_sampler_test.go
+++ b/internal/services/agent/runtime_sampler_test.go
@@ -1,0 +1,272 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/metrics"
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+type fakeStatsProvider struct {
+	mu       sync.Mutex
+	calls    []string
+	stats    agent.RuntimeStats
+	err      error
+	panicMsg string
+	delay    time.Duration
+	called   atomic.Int64
+}
+
+func (f *fakeStatsProvider) Stats(ctx context.Context, sb *agent.Sandbox) (agent.RuntimeStats, error) {
+	f.called.Add(1)
+	f.mu.Lock()
+	f.calls = append(f.calls, sb.ID)
+	d := f.delay
+	stats := f.stats
+	err := f.err
+	panicMsg := f.panicMsg
+	f.mu.Unlock()
+	if panicMsg != "" {
+		panic(panicMsg)
+	}
+	if d > 0 {
+		select {
+		case <-time.After(d):
+		case <-ctx.Done():
+			return agent.RuntimeStats{}, ctx.Err()
+		}
+	}
+	return stats, err
+}
+
+func newMetrics(t *testing.T) *metrics.BillingMetrics {
+	t.Helper()
+	m, err := metrics.NewBillingMetrics(nil)
+	require.NoError(t, err)
+	return m
+}
+
+func TestRuntimeSampler_RunDisabledByZeroInterval(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{}
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 0, zerolog.Nop())
+
+	// With a non-positive interval, Run should return immediately even
+	// without ctx cancellation.
+	done := make(chan struct{})
+	go func() {
+		s.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when interval <= 0")
+	}
+	require.Equal(t, int64(0), prov.called.Load())
+}
+
+func TestRuntimeSampler_SamplesActiveContainers(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{
+		stats: agent.RuntimeStats{
+			MemoryBytes:      512 * 1024 * 1024,
+			MemoryLimitBytes: 2048 * 1024 * 1024,
+			CPUCores:         0.75,
+		},
+	}
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1.5, MemoryLimitMB: 2048}
+	sb := &agent.Sandbox{ID: "ctr-A", Provider: "docker", OrgID: orgID.String()}
+	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 20*time.Millisecond, zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.Run(ctx)
+	require.Eventually(t, func() bool { return prov.called.Load() > 0 }, time.Second, 10*time.Millisecond)
+	cancel()
+
+	prov.mu.Lock()
+	defer prov.mu.Unlock()
+	require.Contains(t, prov.calls, "ctr-A")
+}
+
+func TestRuntimeSampler_StoppedContainerIsNotSampled(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{}
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1, MemoryLimitMB: 1024}
+	sb := &agent.Sandbox{ID: "ctr-B", Provider: "docker", OrgID: orgID.String()}
+
+	startedAt := time.Now()
+	eventID := tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, startedAt)
+	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, startedAt, "ok")
+
+	require.Empty(t, tracker.Snapshot(), "stopped container must be removed from registry")
+
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 5*time.Millisecond, zerolog.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	s.Run(ctx)
+	require.Equal(t, int64(0), prov.called.Load(), "stopped container must not be sampled")
+}
+
+func TestRuntimeSampler_StatsErrorDoesNotPanic(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{err: errors.New("no such container")}
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1, MemoryLimitMB: 1024}
+	sb := &agent.Sandbox{ID: "ctr-gone", Provider: "docker", OrgID: orgID.String()}
+	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	s.Run(ctx)
+	// Should have tried at least once and tolerated the error.
+	require.Greater(t, prov.called.Load(), int64(0))
+}
+
+func TestRuntimeSampler_RunDisabledByNilProvider(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	s := agent.NewRuntimeSampler(tracker, nil, newMetrics(t), 10*time.Millisecond, zerolog.Nop())
+	done := make(chan struct{})
+	go func() {
+		s.Run(context.Background())
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when provider is nil")
+	}
+}
+
+func TestRuntimeSampler_RunDisabledByNilTrackerOrMetrics(t *testing.T) {
+	t.Parallel()
+	prov := &fakeStatsProvider{}
+
+	// nil tracker.
+	s1 := agent.NewRuntimeSampler(nil, prov, newMetrics(t), 10*time.Millisecond, zerolog.Nop())
+	done1 := make(chan struct{})
+	go func() {
+		s1.Run(context.Background())
+		close(done1)
+	}()
+	select {
+	case <-done1:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when tracker is nil")
+	}
+
+	// nil metrics.
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	s2 := agent.NewRuntimeSampler(tracker, prov, nil, 10*time.Millisecond, zerolog.Nop())
+	done2 := make(chan struct{})
+	go func() {
+		s2.Run(context.Background())
+		close(done2)
+	}()
+	select {
+	case <-done2:
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return when metrics are nil")
+	}
+
+	require.Equal(t, int64(0), prov.called.Load(), "nil deps must short-circuit before any provider call")
+}
+
+func TestRuntimeSampler_PanicInStatsDoesNotCrashWorker(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{panicMsg: "boom"}
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1, MemoryLimitMB: 1024}
+	sb := &agent.Sandbox{ID: "ctr-panic", Provider: "docker", OrgID: orgID.String()}
+	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 80*time.Millisecond)
+	defer cancel()
+	// Recovered panics inside the sampler must let Run() return cleanly
+	// when ctx expires; if the recover were missing, the goroutine would
+	// crash the test binary instead.
+	s.Run(ctx)
+	require.Greater(t, prov.called.Load(), int64(0), "sampler should have attempted at least one panicking call")
+}
+
+func TestRuntimeSampler_NotFoundEvictsRegistryEntry(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{err: errors.New("wrap: " + agent.ErrSandboxNotFound.Error())}
+	// Use a real wrapping so errors.Is matches.
+	prov.err = wrapNotFound()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1, MemoryLimitMB: 1024}
+	sb := &agent.Sandbox{ID: "ctr-ghost", Provider: "docker", OrgID: orgID.String()}
+	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+	require.Len(t, tracker.Snapshot(), 1)
+
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 5*time.Millisecond, zerolog.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	s.Run(ctx)
+
+	require.Empty(t, tracker.Snapshot(), "ErrSandboxNotFound must evict the registry entry")
+}
+
+// wrapNotFound returns an error that errors.Is matches against
+// agent.ErrSandboxNotFound — same shape providers produce in production.
+func wrapNotFound() error {
+	return wrapErr("docker stats", agent.ErrSandboxNotFound)
+}
+
+func wrapErr(prefix string, err error) error {
+	return &wrappedErr{prefix: prefix, err: err}
+}
+
+type wrappedErr struct {
+	prefix string
+	err    error
+}
+
+func (w *wrappedErr) Error() string { return w.prefix + ": " + w.err.Error() }
+func (w *wrappedErr) Unwrap() error { return w.err }
+
+func TestUsageTrackerSnapshot_IsCopy(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 2, MemoryLimitMB: 4096}
+
+	for i := 0; i < 3; i++ {
+		sb := &agent.Sandbox{ID: "ctr-" + uuid.NewString(), OrgID: orgID.String()}
+		tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+	}
+	snap := tracker.Snapshot()
+	require.Len(t, snap, 3)
+	// Mutating the snapshot must not corrupt the tracker's state.
+	snap[0] = agent.ActiveContainer{}
+	require.Len(t, tracker.Snapshot(), 3)
+}

--- a/internal/services/agent/runtime_stats.go
+++ b/internal/services/agent/runtime_stats.go
@@ -1,0 +1,32 @@
+package agent
+
+import (
+	"context"
+	"errors"
+)
+
+// RuntimeStats is a one-shot runtime resource usage sample for a sandbox.
+// CPUCores is the number of full cores observed during the sample window
+// (Docker's stream=false mode primes a 1s delta server-side). All fields are
+// best-effort: under gVisor (runsc) some kernels return 0 for memory or CPU
+// because gVisor's stat surface is partial; callers must tolerate zeroes.
+type RuntimeStats struct {
+	MemoryBytes      uint64  // working-set memory (usage minus inactive page cache)
+	MemoryLimitBytes uint64  // cgroup memory limit reported by the runtime
+	CPUCores         float64 // cores used during the sample window
+}
+
+// ErrSandboxNotFound signals that a sandbox the caller asked about no
+// longer exists in the underlying runtime (Docker returned 404, etc.).
+// Providers that implement RuntimeStatsProvider must return errors that
+// satisfy errors.Is(err, ErrSandboxNotFound) for this case so the sampler
+// can evict the entry from its registry instead of polling forever.
+var ErrSandboxNotFound = errors.New("sandbox not found")
+
+// RuntimeStatsProvider is an optional capability a SandboxProvider can expose
+// to support live resource sampling. The runtime sampler does a type
+// assertion against this interface; providers that don't implement it are
+// silently skipped instead of breaking the sampling loop.
+type RuntimeStatsProvider interface {
+	Stats(ctx context.Context, sb *Sandbox) (RuntimeStats, error)
+}

--- a/internal/services/agent/usage_tracker.go
+++ b/internal/services/agent/usage_tracker.go
@@ -110,8 +110,11 @@ func (t *UsageTracker) ContainerStarted(ctx context.Context, orgID, sessionID uu
 // ContainerStopped records that a container was destroyed. Must be called
 // exactly once per ContainerStarted call. sessionID is included in failure
 // logs so billing write failures can be traced back to the owning session
-// in Grafana.
-func (t *UsageTracker) ContainerStopped(ctx context.Context, orgID, sessionID uuid.UUID, eventID uuid.UUID, startedAt time.Time, exitReason string) {
+// in Grafana. containerID must match the sandbox.ID passed to ContainerStarted
+// so the in-memory sampler registry can drop the entry in O(1) without
+// iterating; pass "" if the caller no longer has it (the registry entry
+// will be reaped by Forget on the next failed Stats call).
+func (t *UsageTracker) ContainerStopped(ctx context.Context, orgID, sessionID uuid.UUID, eventID uuid.UUID, containerID string, startedAt time.Time, exitReason string) {
 	stoppedAt := time.Now()
 	orgIDStr := orgID.String()
 	durationSec := stoppedAt.Sub(startedAt).Seconds()
@@ -122,17 +125,14 @@ func (t *UsageTracker) ContainerStopped(ctx context.Context, orgID, sessionID uu
 		t.metrics.RecordStop(ctx, orgIDStr, exitReason, durationSec, durationMin)
 	}
 
-	// Remove from the in-memory registry. Iterate to find by event ID
-	// rather than container ID so callers don't need to thread the
-	// sandbox pointer through stop paths that already have eventID.
-	t.mu.Lock()
-	for id, ac := range t.active {
-		if ac.EventID == eventID {
-			delete(t.active, id)
-			break
-		}
+	// Remove from the in-memory registry. The map is keyed by container ID
+	// so this is an O(1) delete that's unambiguous even if RecordStart
+	// failure ever stops short-circuiting the registry insert.
+	if containerID != "" {
+		t.mu.Lock()
+		delete(t.active, containerID)
+		t.mu.Unlock()
 	}
-	t.mu.Unlock()
 
 	// DB persistence. Skip if eventID is Nil (start recording failed).
 	if t.store != nil && eventID != uuid.Nil {

--- a/internal/services/agent/usage_tracker.go
+++ b/internal/services/agent/usage_tracker.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,19 +18,39 @@ type ContainerUsageStore interface {
 	RecordStop(ctx context.Context, eventID uuid.UUID, stoppedAt time.Time, exitReason string) error
 }
 
+// ActiveContainer is an in-memory record of a sandbox known to be running on
+// this process. The runtime sampler uses Snapshot() to find them.
+type ActiveContainer struct {
+	EventID       uuid.UUID
+	Sandbox       *Sandbox
+	StartedAt     time.Time
+	CPULimit      float64
+	MemoryLimitMB int
+}
+
 // UsageTracker records container lifecycle events for billing observability.
 // It writes to both the database (for billing queries) and OTel metrics (for
-// real-time dashboards and alerting via any backend).
+// real-time dashboards and alerting via any backend). It also keeps an
+// in-memory registry of active containers so the runtime sampler can fetch
+// stats without round-tripping the DB on every tick.
 type UsageTracker struct {
 	store   ContainerUsageStore     // nil = DB tracking disabled
 	metrics *metrics.BillingMetrics // nil = metrics disabled
 	logger  zerolog.Logger
+
+	mu     sync.RWMutex
+	active map[string]ActiveContainer // keyed by sandbox container ID
 }
 
 // NewUsageTracker creates a UsageTracker. Pass nil store to disable DB tracking,
 // nil metrics to disable metric emission.
 func NewUsageTracker(store ContainerUsageStore, m *metrics.BillingMetrics, logger zerolog.Logger) *UsageTracker {
-	return &UsageTracker{store: store, metrics: m, logger: logger}
+	return &UsageTracker{
+		store:   store,
+		metrics: m,
+		logger:  logger,
+		active:  make(map[string]ActiveContainer),
+	}
 }
 
 // ContainerStarted records that a container was created and started.
@@ -44,6 +65,19 @@ func (t *UsageTracker) ContainerStarted(ctx context.Context, orgID, sessionID uu
 	if t.metrics != nil {
 		t.metrics.RecordStart(ctx, orgIDStr, sandbox.Provider, cfg.CPULimit, cfg.MemoryLimitMB)
 	}
+
+	// In-memory registry for the runtime sampler. Stored even when the DB
+	// path is disabled so self-hosters without persistence still get live
+	// resource metrics.
+	t.mu.Lock()
+	t.active[sandbox.ID] = ActiveContainer{
+		EventID:       eventID,
+		Sandbox:       sandbox,
+		StartedAt:     startedAt,
+		CPULimit:      cfg.CPULimit,
+		MemoryLimitMB: cfg.MemoryLimitMB,
+	}
+	t.mu.Unlock()
 
 	// DB persistence.
 	if t.store != nil {
@@ -86,6 +120,18 @@ func (t *UsageTracker) ContainerStopped(ctx context.Context, orgID, sessionID uu
 		t.metrics.RecordStop(ctx, orgIDStr, exitReason, durationSec, durationMin)
 	}
 
+	// Remove from the in-memory registry. Iterate to find by event ID
+	// rather than container ID so callers don't need to thread the
+	// sandbox pointer through stop paths that already have eventID.
+	t.mu.Lock()
+	for id, ac := range t.active {
+		if ac.EventID == eventID {
+			delete(t.active, id)
+			break
+		}
+	}
+	t.mu.Unlock()
+
 	// DB persistence. Skip if eventID is Nil (start recording failed).
 	if t.store != nil && eventID != uuid.Nil {
 		if err := t.store.RecordStop(ctx, eventID, stoppedAt, exitReason); err != nil {
@@ -98,4 +144,36 @@ func (t *UsageTracker) ContainerStopped(ctx context.Context, orgID, sessionID uu
 			ev.Msg("failed to record container stop for billing")
 		}
 	}
+}
+
+// Snapshot returns a copy of the currently active containers known to this
+// process. Used by the runtime sampler to walk live sandboxes; safe to call
+// concurrently with ContainerStarted/ContainerStopped.
+//
+// The Sandbox pointer inside each entry is shared (not deep-copied); callers
+// must treat it as read-only. Mutating it would race with code paths that
+// stash the sandbox elsewhere (orchestrator, preview manager).
+func (t *UsageTracker) Snapshot() []ActiveContainer {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make([]ActiveContainer, 0, len(t.active))
+	for _, ac := range t.active {
+		out = append(out, ac)
+	}
+	return out
+}
+
+// Forget removes a container from the in-memory registry without recording
+// a stop event. Intended for the runtime sampler to evict ghost entries
+// when Stats() reports a container is gone (e.g. a process crash skipped
+// the normal ContainerStopped path). This only affects sampling — the
+// billing DB row for the orphan is reconciled by ReconcileOrphanedContainers
+// at next startup.
+func (t *UsageTracker) Forget(containerID string) {
+	if containerID == "" {
+		return
+	}
+	t.mu.Lock()
+	delete(t.active, containerID)
+	t.mu.Unlock()
 }

--- a/internal/services/agent/usage_tracker.go
+++ b/internal/services/agent/usage_tracker.go
@@ -66,19 +66,6 @@ func (t *UsageTracker) ContainerStarted(ctx context.Context, orgID, sessionID uu
 		t.metrics.RecordStart(ctx, orgIDStr, sandbox.Provider, cfg.CPULimit, cfg.MemoryLimitMB)
 	}
 
-	// In-memory registry for the runtime sampler. Stored even when the DB
-	// path is disabled so self-hosters without persistence still get live
-	// resource metrics.
-	t.mu.Lock()
-	t.active[sandbox.ID] = ActiveContainer{
-		EventID:       eventID,
-		Sandbox:       sandbox,
-		StartedAt:     startedAt,
-		CPULimit:      cfg.CPULimit,
-		MemoryLimitMB: cfg.MemoryLimitMB,
-	}
-	t.mu.Unlock()
-
 	// DB persistence.
 	if t.store != nil {
 		event := &models.ContainerUsageEvent{
@@ -101,6 +88,21 @@ func (t *UsageTracker) ContainerStarted(ctx context.Context, orgID, sessionID uu
 			return uuid.Nil
 		}
 	}
+
+	// In-memory registry for the runtime sampler. Stored even when the DB
+	// path is disabled so self-hosters without persistence still get live
+	// resource metrics. When DB persistence is enabled, register only after
+	// RecordStart succeeds; otherwise the stop path receives uuid.Nil and
+	// cannot remove this entry by event ID.
+	t.mu.Lock()
+	t.active[sandbox.ID] = ActiveContainer{
+		EventID:       eventID,
+		Sandbox:       sandbox,
+		StartedAt:     startedAt,
+		CPULimit:      cfg.CPULimit,
+		MemoryLimitMB: cfg.MemoryLimitMB,
+	}
+	t.mu.Unlock()
 
 	return eventID
 }

--- a/internal/services/agent/usage_tracker_test.go
+++ b/internal/services/agent/usage_tracker_test.go
@@ -74,10 +74,11 @@ func TestUsageTracker_ContainerLifecycle(t *testing.T) {
 	require.Equal(t, 4096, store.startCalls[0].MemoryLimitMB)
 	require.Equal(t, startedAt, store.startCalls[0].StartedAt, "DB and caller should use the same timestamp")
 
-	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, startedAt, "completed")
+	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, sandbox.ID, startedAt, "completed")
 	require.Len(t, store.stopCalls, 1)
 	require.Equal(t, eventID, store.stopCalls[0].EventID)
 	require.Equal(t, "completed", store.stopCalls[0].ExitReason)
+	require.Empty(t, tracker.Snapshot(), "ContainerStopped must remove the entry from the sampler registry")
 }
 
 func TestUsageTracker_NilStoreAndMetrics(t *testing.T) {
@@ -93,7 +94,7 @@ func TestUsageTracker_NilStoreAndMetrics(t *testing.T) {
 
 	startedAt := time.Now()
 	eventID := tracker.ContainerStarted(context.Background(), orgID, sessionID, sandbox, cfg, startedAt)
-	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, startedAt, "completed")
+	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, sandbox.ID, startedAt, "completed")
 	// No panic = success.
 }
 
@@ -112,11 +113,11 @@ func TestUsageTracker_RecordStopFailureLogsSessionID(t *testing.T) {
 	startedAt := time.Now().Add(-time.Minute)
 
 	// Happy case: sessionID set — should include session_id in the error log.
-	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, startedAt, "failed")
+	tracker.ContainerStopped(context.Background(), orgID, sessionID, eventID, "ctr-fail-1", startedAt, "failed")
 	require.Len(t, store.stopCalls, 1, "RecordStop should be invoked even when it errors")
 
 	// Nil-session guard: RecordStop still called but session_id field skipped.
-	tracker.ContainerStopped(context.Background(), orgID, uuid.Nil, eventID, startedAt, "failed")
+	tracker.ContainerStopped(context.Background(), orgID, uuid.Nil, eventID, "ctr-fail-2", startedAt, "failed")
 	require.Len(t, store.stopCalls, 2)
 }
 
@@ -128,7 +129,7 @@ func TestUsageTracker_RecordStopSkippedOnNilEventID(t *testing.T) {
 	store := &mockContainerUsageStore{recordStopErr: fmt.Errorf("should not be called")}
 	tracker := agent.NewUsageTracker(store, testBillingMetrics(t), zerolog.Nop())
 
-	tracker.ContainerStopped(context.Background(), uuid.New(), uuid.New(), uuid.Nil, time.Now(), "failed")
+	tracker.ContainerStopped(context.Background(), uuid.New(), uuid.New(), uuid.Nil, "ctr-nil-event", time.Now(), "failed")
 	require.Empty(t, store.stopCalls, "RecordStop should be skipped when eventID is Nil")
 }
 

--- a/internal/services/agent/usage_tracker_test.go
+++ b/internal/services/agent/usage_tracker_test.go
@@ -17,9 +17,10 @@ import (
 
 // mockContainerUsageStore records calls for verification.
 type mockContainerUsageStore struct {
-	startCalls    []models.ContainerUsageEvent
-	stopCalls     []stopCall
-	recordStopErr error
+	startCalls     []models.ContainerUsageEvent
+	recordStartErr error
+	stopCalls      []stopCall
+	recordStopErr  error
 }
 
 type stopCall struct {
@@ -30,7 +31,7 @@ type stopCall struct {
 
 func (m *mockContainerUsageStore) RecordStart(_ context.Context, event *models.ContainerUsageEvent) error {
 	m.startCalls = append(m.startCalls, *event)
-	return nil
+	return m.recordStartErr
 }
 
 func (m *mockContainerUsageStore) RecordStop(_ context.Context, eventID uuid.UUID, stoppedAt time.Time, exitReason string) error {
@@ -129,4 +130,23 @@ func TestUsageTracker_RecordStopSkippedOnNilEventID(t *testing.T) {
 
 	tracker.ContainerStopped(context.Background(), uuid.New(), uuid.New(), uuid.Nil, time.Now(), "failed")
 	require.Empty(t, store.stopCalls, "RecordStop should be skipped when eventID is Nil")
+}
+
+func TestUsageTracker_RecordStartFailureDoesNotLeaveActiveContainer(t *testing.T) {
+	t.Parallel()
+
+	store := &mockContainerUsageStore{recordStartErr: fmt.Errorf("db down")}
+	tracker := agent.NewUsageTracker(store, testBillingMetrics(t), zerolog.Nop())
+
+	eventID := tracker.ContainerStarted(
+		context.Background(),
+		uuid.New(),
+		uuid.New(),
+		&agent.Sandbox{ID: "ctr-start-failed", Provider: "docker", WorkDir: "/workspace"},
+		agent.DefaultSandboxConfig(),
+		time.Now(),
+	)
+
+	require.Equal(t, uuid.Nil, eventID, "ContainerStarted should return Nil when DB start recording fails")
+	require.Empty(t, tracker.Snapshot(), "failed start recording should not leave a container in the sampler registry")
 }

--- a/internal/services/pm/bootstrap.go
+++ b/internal/services/pm/bootstrap.go
@@ -91,7 +91,7 @@ func (s *Service) runAgentInSandbox(ctx context.Context, params sandboxRunParams
 	}
 	cleanup := func() {
 		if s.usageTracker != nil {
-			s.usageTracker.ContainerStopped(ctx, params.orgID, uuid.Nil, usageEventID, containerStartedAt, exitReason)
+			s.usageTracker.ContainerStopped(ctx, params.orgID, uuid.Nil, usageEventID, sb.ID, containerStartedAt, exitReason)
 		}
 		if destroyErr := s.sandbox.Destroy(ctx, sb); destroyErr != nil {
 			s.logger.Warn().Err(destroyErr).Str("source", params.logName).Msg("failed to destroy sandbox")

--- a/internal/services/pm/bootstrap.go
+++ b/internal/services/pm/bootstrap.go
@@ -324,10 +324,13 @@ func (creds *integrationCredentials) connectedProviderNames() []string {
 }
 
 func bootstrapSandboxConfig() agent.SandboxConfig {
+	// Inherit SANDBOX_CPU_LIMIT / SANDBOX_MEMORY_LIMIT_MB from
+	// DefaultSandboxConfig so capacity-planning math (deploy/scripts/
+	// worker_buckets.sh) doesn't have to special-case bootstraps. Bootstrap
+	// only overrides the wall-clock timeout (repo clone + analysis is the
+	// long pole) and the network policy.
 	cfg := agent.DefaultSandboxConfig()
 	cfg.Timeout = 30 * time.Minute
-	cfg.CPULimit = 2
-	cfg.MemoryLimitMB = 4096
 	cfg.NetworkPolicy = "restricted"
 	return cfg
 }

--- a/internal/services/pm/bootstrap_test.go
+++ b/internal/services/pm/bootstrap_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/agent"
 )
 
 // --- mock pmDocumentStore ---
@@ -331,7 +332,11 @@ func TestBootstrapSandboxConfig(t *testing.T) {
 
 	cfg := bootstrapSandboxConfig()
 	require.Equal(t, 30*time.Minute, cfg.Timeout)
-	require.Equal(t, float64(2), cfg.CPULimit)
-	require.Equal(t, 4096, cfg.MemoryLimitMB)
 	require.Equal(t, "restricted", cfg.NetworkPolicy)
+	// CPULimit and MemoryLimitMB inherit from DefaultSandboxConfig so a
+	// single SANDBOX_* env-var change tunes both regular sessions and PM
+	// bootstraps. Pin to the same defaults DefaultSandboxConfig promises.
+	defaults := agent.DefaultSandboxConfig()
+	require.Equal(t, defaults.CPULimit, cfg.CPULimit)
+	require.Equal(t, defaults.MemoryLimitMB, cfg.MemoryLimitMB)
 }

--- a/internal/services/pm/project_analyze.go
+++ b/internal/services/pm/project_analyze.go
@@ -94,7 +94,7 @@ func (s *Service) AnalyzeProject(ctx context.Context, orgID, projectID uuid.UUID
 	}
 	defer func() {
 		if s.usageTracker != nil {
-			s.usageTracker.ContainerStopped(ctx, orgID, uuid.Nil, usageEventID, containerStartedAt, exitReason)
+			s.usageTracker.ContainerStopped(ctx, orgID, uuid.Nil, usageEventID, sb.ID, containerStartedAt, exitReason)
 		}
 		if destroyErr := s.sandbox.Destroy(ctx, sb); destroyErr != nil {
 			s.logger.Warn().Err(destroyErr).Msg("failed to destroy project PM sandbox")

--- a/internal/services/pm/review_fixes_test.go
+++ b/internal/services/pm/review_fixes_test.go
@@ -107,7 +107,7 @@ func (r *reviewUsageRecorder) ContainerStarted(_ context.Context, orgID, session
 	return uuid.New()
 }
 
-func (r *reviewUsageRecorder) ContainerStopped(_ context.Context, orgID, sessionID uuid.UUID, _ uuid.UUID, _ time.Time, exitReason string) {
+func (r *reviewUsageRecorder) ContainerStopped(_ context.Context, orgID, sessionID uuid.UUID, _ uuid.UUID, _ string, _ time.Time, exitReason string) {
 	r.stopped = append(r.stopped, reviewUsageStopped{orgID: orgID, sessionID: sessionID, exitReason: exitReason})
 }
 

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -415,7 +415,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	}
 	defer func() {
 		if s.usageTracker != nil {
-			s.usageTracker.ContainerStopped(ctx, orgID, sessionID, usageEventID, containerStartedAt, exitReason)
+			s.usageTracker.ContainerStopped(ctx, orgID, sessionID, usageEventID, sb.ID, containerStartedAt, exitReason)
 		}
 		if destroyErr := s.sandbox.Destroy(ctx, sb); destroyErr != nil {
 			s.logger.Warn().Err(destroyErr).Msg("failed to destroy PM sandbox")

--- a/internal/services/pm/service_helpers_test.go
+++ b/internal/services/pm/service_helpers_test.go
@@ -49,7 +49,7 @@ func (helperUsageTracker) ContainerStarted(context.Context, uuid.UUID, uuid.UUID
 	return uuid.New()
 }
 
-func (helperUsageTracker) ContainerStopped(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Time, string) {
+func (helperUsageTracker) ContainerStopped(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, time.Time, string) {
 }
 
 func TestResolveAgentType(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -177,6 +177,12 @@ type Services struct {
 	// leftover dirs from prior worker generations don't accumulate. nil
 	// when no SandboxAuthSocketDir is configured.
 	SandboxAuthSweep func(keep map[uuid.UUID]struct{})
+	// RuntimeSampler periodically polls per-container resource usage and
+	// records it as OTel histograms so operators can size SANDBOX_* limits
+	// against actual consumption rather than allocation. nil when sampling
+	// is disabled (interval <= 0 in config) or the provider can't report
+	// stats (e.g. a non-Docker provider in the future).
+	RuntimeSampler *agent.RuntimeSampler
 }
 
 type orchestratorService interface {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -359,10 +359,12 @@ func TestWorker_Poll_RunsDeadLetterHooksOnTerminalPaths(t *testing.T) {
 			lockToken := uuid.New()
 			orgID := uuid.New()
 			var fired int
+			var hookCtxErr error
 
 			w.Register("hook_job", func(ctx context.Context, jobType string, got json.RawMessage) error {
-				jobctx.RegisterDeadLetterHook(ctx, func(_ context.Context, err error) {
+				jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, err error) {
 					fired++
+					hookCtxErr = hookCtx.Err()
 				})
 				return tt.handlerErr()
 			})
@@ -382,6 +384,9 @@ func TestWorker_Poll_RunsDeadLetterHooksOnTerminalPaths(t *testing.T) {
 			w.poll(context.Background())
 
 			require.Equal(t, tt.expectHooks, fired, "dead-letter hooks should fire only on terminal give-up paths")
+			if tt.expectHooks > 0 {
+				require.NoError(t, hookCtxErr, "dead-letter hooks should receive a live context for terminal cleanup writes")
+			}
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds a periodic Docker stats sampler that emits per-container `container.{memory,cpu}.{used,utilization}` OTel histograms so operators can size `SANDBOX_*` limits against actual usage instead of just allocation. Sampler is host-local, fan-out is bounded, panics are recovered, and `ErrSandboxNotFound` self-heals ghost registry entries.
- Shrinks `/tmp` + `/var/tmp` tmpfs from 1 GiB each to 256 MiB / 512 MiB and lowers `SANDBOX_MEMORY_LIMIT_MB` from 4096 → 3072 (PM bootstrap now inherits this default). Net effect: more usable RAM per agent at less host memory cost.
- Recomputes `WORKER_PROCESS_COUNT` in `deploy/scripts/worker_buckets.sh` under the new `floor(RAM_GB / 3)` heuristic and updates the operator tuning doc with gVisor caveats, ramp-up guidance, and a migration note for self-hosters who want to keep the old 4 GB ceiling.

## Test plan

- [x] `make lint` clean
- [x] `go test ./internal/...` passes (new tests cover sampler lifecycle, panic recovery, not-found eviction, nil deps, working-set memory math, and CPU delta math)
- [x] `bash deploy/scripts/worker_buckets_test.sh` passes with updated bucket counts
- [ ] Deploy one worker with `RUNTIME_STATS_INTERVAL=30s`, watch `container.memory.utilization` p95 for a week before trusting the new bucket density

🤖 Generated with [Claude Code](https://claude.com/claude-code)