### PR TITLE
Anchor session title prompt to original task to prevent title drift

### DIFF
--- a/internal/prompts/prompts_test.go
+++ b/internal/prompts/prompts_test.go
@@ -166,6 +166,19 @@ func TestCodingTaskPreamble(t *testing.T) {
 	assert.Contains(t, result, "risk_factors")
 }
 
+func TestSessionTitlePrompt(t *testing.T) {
+	t.Parallel()
+
+	result := SessionTitlePrompt(SessionTitlePromptData{
+		CurrentTitle: "Fix checkout timeout",
+	})
+
+	require.Contains(t, result, "The current title is: Fix checkout timeout", "prompt should include the current title for stability decisions")
+	require.Contains(t, result, "Keep the original task as the main thing", "prompt should anchor the title to the original task")
+	require.Contains(t, result, "Ignore routine follow-ups", "prompt should instruct the model to ignore incidental workflow chatter")
+	require.Contains(t, result, "Only change the title if the conversation clearly shifted to a new primary topic", "prompt should only allow retitling on real topic changes")
+}
+
 func TestLinkedIssuesContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/prompts/templates/session_title_prompt.template
+++ b/internal/prompts/templates/session_title_prompt.template
@@ -1,6 +1,11 @@
-You are generating a concise title for a coding session. Produce a short title (max 80 characters) that captures what was discussed and accomplished.
+You are generating a concise title for a coding session. Produce a short title (max 80 characters) that captures the session's primary task.
 
-If the conversation covers multiple topics, focus on the most recent or dominant theme. Use imperative or noun-phrase style (e.g., "Fix auth middleware null pointer", "Add pagination to user list API").
+Keep the original task as the main thing unless the conversation clearly pivoted to a different primary topic.
+Ignore routine follow-ups that do not change the underlying topic, including tests, CI fixes, merge conflicts, rebases, small cleanups, review back-and-forth, and similar implementation churn.
+Only change the title if the conversation clearly shifted to a new primary topic that would make the old title misleading.
+When in doubt, keep the existing title.
+
+Use imperative or noun-phrase style (e.g., "Fix auth middleware null pointer", "Add pagination to user list API").
 {{ if .CurrentTitle }}
 The current title is: {{ .CurrentTitle }}
 If it is still accurate, return it unchanged.

--- a/internal/services/session_title_test.go
+++ b/internal/services/session_title_test.go
@@ -88,8 +88,32 @@ func TestMaybeRegenerateTitle_RunsOnThirdTurn(t *testing.T) {
 
 	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
 	require.NoError(t, err)
-	assert.Equal(t, 1, llm.calls)
-	assert.Equal(t, "New title from LLM", sessions.updatedTitle)
+	require.Equal(t, 1, llm.calls, "should still consult the LLM on due turns for potential topic shifts")
+	require.Equal(t, "New title from LLM", sessions.updatedTitle, "should update the title when the model returns a new dominant topic")
+}
+
+func TestMaybeRegenerateTitle_FillsMissingTitleWhenDue(t *testing.T) {
+	t.Parallel()
+	llm := &mockLLM{response: "New title from LLM"}
+	sessions := &mockTitleSessionStore{
+		session: models.Session{CurrentTurn: 3},
+	}
+	messages := &mockTitleMessageStore{
+		messages: []models.SessionMessage{
+			{TurnNumber: 0, Role: models.MessageRoleUser, Content: "Fix the login bug"},
+			{TurnNumber: 0, Role: models.MessageRoleAssistant, Content: "I'll fix it"},
+			{TurnNumber: 1, Role: models.MessageRoleUser, Content: "Also update tests"},
+			{TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "Done"},
+			{TurnNumber: 2, Role: models.MessageRoleUser, Content: "Now refactor auth"},
+			{TurnNumber: 2, Role: models.MessageRoleAssistant, Content: "Refactored"},
+		},
+	}
+	svc := NewSessionTitleService(llm, sessions, messages)
+
+	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
+	require.NoError(t, err, "missing titles should still be generated on regeneration turns")
+	require.Equal(t, 1, llm.calls, "should call LLM when session title is missing")
+	require.Equal(t, "New title from LLM", sessions.updatedTitle, "should persist the generated title when session title is missing")
 }
 
 func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
@@ -107,9 +131,9 @@ func TestMaybeRegenerateTitle_SkipsUpdateWhenTitleUnchanged(t *testing.T) {
 	svc := NewSessionTitleService(llm, sessions, messages)
 
 	err := svc.MaybeRegenerateTitle(context.Background(), uuid.New(), uuid.New())
-	require.NoError(t, err)
-	assert.Equal(t, 1, llm.calls)
-	assert.Empty(t, sessions.updatedTitle, "should not update when title unchanged")
+	require.NoError(t, err, "unchanged titles should be accepted without updating")
+	require.Equal(t, 1, llm.calls, "should ask the LLM whether the title still fits")
+	require.Empty(t, sessions.updatedTitle, "should not update when the LLM keeps the existing title")
 }
 
 func TestMaybeRegenerateTitle_SkipsEmptyOrTooLong(t *testing.T) {


### PR DESCRIPTION
## Summary
Updated the session title prompt to keep the existing title anchored to the original task and only retitle when the conversation clearly pivots. Added prompt and service tests to lock in this stability behavior and prevent title drift over routine follow-ups.

## Changes
- **internal/prompts/templates/session_title_prompt.template**
  - Instruct the model to keep the original task as the main thing unless there’s a clear primary-topic shift.
  - Tell the model to ignore routine follow-ups (tests, CI fixes, rebases/merge churn, review back-and-forth, small cleanups).
  - Keep the “when in doubt, keep the existing title” rule.
- **internal/prompts/prompts_test.go**
  - Added `TestSessionTitlePrompt` to verify the prompt contains the anchoring and “ignore follow-ups / only retitle on clear shifts” guidance.
- **internal/services/session_title_test.go**
  - Strengthened `TestMaybeRegenerateTitle_RunsOnThirdTurn` assertions around LLM calls and title updates.
  - Added `TestMaybeRegenerateTitle_FillsMissingTitleWhenDue` to ensure missing titles are filled when due.

## Test plan
- Ran `go test ./...` to validate the updated prompt template behavior and the session title regeneration logic via unit tests.

---
*Generated by [143.dev](https://143.dev) — [session 3909dddc](https://app.143.dev/sessions/3909dddc-563c-4cbc-bfd1-a4abbca114b3)*
