### PR TITLE
Upsert session turn issue snapshots to unwedge failed-turn retries

### DIFF
--- a/internal/db/session_turn_issue_snapshots.go
+++ b/internal/db/session_turn_issue_snapshots.go
@@ -20,6 +20,13 @@ func NewSessionTurnIssueSnapshotStore(db DBTX) *SessionTurnIssueSnapshotStore {
 
 const sessionTurnIssueSnapshotColumns = `id, org_id, session_id, turn_number, linked_issues, created_at`
 
+// Create persists a per-turn issue snapshot, upserting on
+// (session_id, turn_number) so retries of an unfinished turn refresh the
+// linked-issue content instead of failing on the unique constraint. The row's
+// id and created_at are preserved from the first attempt — only linked_issues
+// is overwritten, so any job payload referencing the snapshot id remains valid
+// while the agent picks up edits the user (or external systems) made between
+// retries.
 func (s *SessionTurnIssueSnapshotStore) Create(ctx context.Context, snapshot *models.SessionTurnIssueSnapshot) error {
 	linkedIssues, err := json.Marshal(snapshot.LinkedIssues)
 	if err != nil {
@@ -28,6 +35,8 @@ func (s *SessionTurnIssueSnapshotStore) Create(ctx context.Context, snapshot *mo
 	query := `
 		INSERT INTO session_turn_issue_snapshots (org_id, session_id, turn_number, linked_issues)
 		VALUES (@org_id, @session_id, @turn_number, @linked_issues)
+		ON CONFLICT (session_id, turn_number) DO UPDATE
+		    SET linked_issues = EXCLUDED.linked_issues
 		RETURNING id, created_at`
 
 	if err := s.db.QueryRow(ctx, query, pgx.NamedArgs{

--- a/internal/db/session_turn_issue_snapshots_test.go
+++ b/internal/db/session_turn_issue_snapshots_test.go
@@ -50,6 +50,68 @@ func TestSessionTurnIssueSnapshotStore_Create(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// TestSessionTurnIssueSnapshotStore_Create_UpsertsOnTurnConflict guards the
+// regression that wedged sessions whose first turn attempt failed after the
+// snapshot insert but before UpdateTurnComplete bumped current_turn — every
+// retry then computed the same turn_number and tripped the unique constraint
+// on (session_id, turn_number) inside resolve issue context. Create must now
+// upsert: same id/created_at, refreshed linked_issues.
+func TestSessionTurnIssueSnapshotStore_Create_UpsertsOnTurnConflict(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionTurnIssueSnapshotStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	snapshotID := uuid.New()
+	createdAt := time.Now().UTC()
+
+	firstAttempt := &models.SessionTurnIssueSnapshot{
+		OrgID:      orgID,
+		SessionID:  sessionID,
+		TurnNumber: 3,
+		LinkedIssues: []models.SessionIssueSnapshotEntry{
+			{IssueID: uuid.New(), Role: models.SessionIssueLinkRolePrimary, Title: "first attempt"},
+		},
+	}
+	secondAttempt := &models.SessionTurnIssueSnapshot{
+		OrgID:      orgID,
+		SessionID:  sessionID,
+		TurnNumber: 3,
+		LinkedIssues: []models.SessionIssueSnapshotEntry{
+			{IssueID: uuid.New(), Role: models.SessionIssueLinkRolePrimary, Title: "retry with edited links"},
+		},
+	}
+
+	// The query must declare ON CONFLICT (session_id, turn_number) DO UPDATE so
+	// retries of an unfinished turn don't fail with SQLSTATE 23505.
+	upsertPattern := `(?s)INSERT INTO session_turn_issue_snapshots.+ON CONFLICT \(session_id, turn_number\) DO UPDATE.+SET linked_issues = EXCLUDED\.linked_issues`
+
+	mock.ExpectQuery(upsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(snapshotID, createdAt))
+	require.NoError(t, store.Create(context.Background(), firstAttempt), "first attempt should insert successfully")
+	require.Equal(t, snapshotID, firstAttempt.ID, "first attempt should populate id from RETURNING")
+
+	// Simulating retry of the same turn: ON CONFLICT path returns the original
+	// row's id and created_at via RETURNING. linked_issues on the row is now
+	// the second attempt's payload.
+	mock.ExpectQuery(upsertPattern).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(snapshotID, createdAt))
+	require.NoError(t, store.Create(context.Background(), secondAttempt), "retry must not return a unique-violation error")
+	require.Equal(t, snapshotID, secondAttempt.ID, "retry should resolve to the same row id (first-wins identity)")
+	require.Equal(t, createdAt, secondAttempt.CreatedAt, "retry should preserve the original created_at")
+
+	require.Contains(t, string(secondAttempt.RawLinkedIssues), "retry with edited links", "retry should persist the latest linked-issue payload (last-wins content)")
+	require.NotContains(t, string(secondAttempt.RawLinkedIssues), "first attempt", "retry should overwrite stale linked-issue payload")
+
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionTurnIssueSnapshotStore_Create_QueryError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

When a turn snapshot insert succeeded but `UpdateTurnComplete` did not run (sandbox failure, runtime crash, dead-letter retry, etc.), `current_turn` stayed put and every retry recomputed the same `turn_number`, tripping the unique key on `(session_id, turn_number)` and failing the run with `SQLSTATE 23505` inside `resolve issue context`. The session was effectively unrecoverable.

This switches `SessionTurnIssueSnapshotStore.Create` to `INSERT ... ON CONFLICT (session_id, turn_number) DO UPDATE SET linked_issues = EXCLUDED.linked_issues`. Retries refresh `linked_issues` with whatever the user (or Linear/GitHub sync) updated between attempts, while preserving the original `id` and `created_at` so any job payload that already references the snapshot id stays valid.

## Test plan

- [x] `go test ./internal/db/ ./internal/services/agent/...`
- [x] New regression: `TestSessionTurnIssueSnapshotStore_Create_UpsertsOnTurnConflict` pins the SQL to `ON CONFLICT (session_id, turn_number) DO UPDATE` and asserts a same-turn retry returns the original id/created_at while overwriting `linked_issues`.
- [ ] Manually unwedge any sessions stuck on the duplicate-key error (delete the orphan row at `current_turn + 1`, or bump `current_turn`).