### PR TITLE
Fix preview Start failing with opaque 502 when racing an active turn

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -6,7 +6,7 @@ import {
   PreviewPanel,
 } from "./preview-panel";
 import { renderWithProviders, screen, waitFor, userEvent } from "@/test/test-utils";
-import type { PreviewStatusResponse } from "@/lib/preview-types";
+import { PREVIEW_ERROR_CODES, type PreviewStatusResponse } from "@/lib/preview-types";
 
 /* ------------------------------------------------------------------ */
 /* Hoisted mocks                                                      */
@@ -709,7 +709,7 @@ describe("PreviewPanel component", () => {
     const err = new Error(
       "another process attached to this session's sandbox first; please retry"
     );
-    (err as Error & { code?: string }).code = "SANDBOX_BUSY";
+    (err as Error & { code?: string }).code = PREVIEW_ERROR_CODES.SANDBOX_BUSY;
     mockStart.mockRejectedValueOnce(err);
 
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
@@ -747,7 +747,7 @@ describe("PreviewPanel component", () => {
     // fall through to "Failed to start preview: preview worker request failed",
     // which buries the transient/retryable nature of the failure.
     const err = new Error("preview worker request failed");
-    (err as Error & { code?: string }).code = "PREVIEW_WORKER_REQUEST_FAILED";
+    (err as Error & { code?: string }).code = PREVIEW_ERROR_CODES.WORKER_REQUEST_FAILED;
     mockStart.mockRejectedValueOnce(err);
 
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -703,6 +703,73 @@ describe("PreviewPanel component", () => {
     });
   });
 
+  it("shows a retry-the-turn message when the sandbox is busy with a concurrent agent turn", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+    const err = new Error(
+      "another process attached to this session's sandbox first; please retry"
+    );
+    (err as Error & { code?: string }).code = "SANDBOX_BUSY";
+    mockStart.mockRejectedValueOnce(err);
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No preview running")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "The agent is currently using this session's sandbox. Wait for the current turn to finish, then try Start Preview again."
+        )
+      ).toBeInTheDocument();
+    });
+    // Guard against regression: the historical message conflated SANDBOX_BUSY
+    // with "Docker not configured" because both used to share the NO_SANDBOX
+    // code. Splitting the codes was the whole point — fail loudly if anyone
+    // re-merges them.
+    expect(
+      screen.queryByText(
+        "Preview is unavailable on this server (Docker not configured). Contact an admin."
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a transient-retry message when the API can't reach the preview worker", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+    // PREVIEW_WORKER_REQUEST_FAILED happens when the API's RPC to the worker
+    // EOFs (e.g. worker WriteTimeout overrun, or worker container restart).
+    // No structured error came back — without explicit handling it would
+    // fall through to "Failed to start preview: preview worker request failed",
+    // which buries the transient/retryable nature of the failure.
+    const err = new Error("preview worker request failed");
+    (err as Error & { code?: string }).code = "PREVIEW_WORKER_REQUEST_FAILED";
+    mockStart.mockRejectedValueOnce(err);
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No preview running")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Could not reach the preview worker (connection dropped). Try Start Preview again — if this keeps happening, the worker may be unhealthy."
+        )
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText("Failed to start preview: preview worker request failed")
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the backend message verbatim (no 'Failed to start preview:' prefix) when no .143/preview.json is committed", async () => {
     const user = userEvent.setup();
     mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -329,6 +329,25 @@ export function PreviewPanel({
         );
         return;
       }
+      if (code === PREVIEW_ERROR_CODES.SANDBOX_BUSY) {
+        // The agent is using the sandbox right now (running a turn). The
+        // backend already destroyed our half-built container; the user just
+        // needs to wait a beat and click again.
+        setMutationError(
+          "The agent is currently using this session's sandbox. Wait for the current turn to finish, then try Start Preview again."
+        );
+        return;
+      }
+      if (code === PREVIEW_ERROR_CODES.WORKER_REQUEST_FAILED) {
+        // Connection to the preview worker dropped mid-request — typically
+        // a timeout or a worker restart. No response body means no real
+        // error code; suggest retry rather than burying the cause under the
+        // generic "Failed to start preview:" prefix.
+        setMutationError(
+          "Could not reach the preview worker (connection dropped). Try Start Preview again — if this keeps happening, the worker may be unhealthy."
+        );
+        return;
+      }
       if (code === PREVIEW_ERROR_CODES.NO_CONFIG) {
         // Backend message already names the file the user needs to add and
         // points to the docs — pass it through verbatim.

--- a/frontend/src/lib/preview-types.ts
+++ b/frontend/src/lib/preview-types.ts
@@ -25,10 +25,19 @@ export const PREVIEW_ERROR_CODES = {
   // 409 — the session is not expired, but there is no restorable snapshot
   // available (for example snapshot persistence failed on the worker).
   SNAPSHOT_UNAVAILABLE: "SNAPSHOT_UNAVAILABLE",
-  // 409 — this worker has no sandbox provider / snapshot store wired, or
-  // a concurrent hydrate won the publish race. A retry may resolve the
-  // race-loss case; configuration needs admin attention.
+  // 409 — this worker has no sandbox provider / snapshot store wired.
+  // Configuration issue; needs admin attention.
   NO_SANDBOX: "NO_SANDBOX",
+  // 409 — a concurrent hydrate (typically a continue_session turn) won the
+  // sandbox attach race. Transient; a retry once the turn finishes
+  // resolves it.
+  SANDBOX_BUSY: "SANDBOX_BUSY",
+  // 502 — the API could not complete its RPC to the worker (EOF, network
+  // partition, or worker WriteTimeout overrun). Distinct from the worker
+  // returning a structured error: here we never got a response body, so
+  // there's no underlying code to surface — but the failure is transient
+  // and a retry will usually succeed.
+  WORKER_REQUEST_FAILED: "PREVIEW_WORKER_REQUEST_FAILED",
   // 500 — internal failure while hydrating (restore error, provider
   // outage, DB write failure). Generic; details in the underlying message.
   HYDRATE_FAILED: "PREVIEW_HYDRATE_FAILED",

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -81,6 +81,11 @@ func strPtr(s string) *string { return &s }
 // context's own deadline (driven by the client connection or the
 // worker_client's 10-minute timeout) still bounds the handler.
 //
+// Stop / StopActivePreviewForSession deliberately do NOT clear the
+// deadline: those paths only signal an existing container and complete
+// well within the 15s budget; keeping the default catches a genuinely
+// stuck stop instead of letting it hang the connection.
+//
 // Logs at Debug and returns silently on response writers that don't
 // support http.ResponseController — this is a perf/UX optimization, not
 // a correctness requirement, so degrading to the default WriteTimeout

--- a/internal/api/handlers/helpers.go
+++ b/internal/api/handlers/helpers.go
@@ -67,6 +67,30 @@ func clampListLimit(requested, defaultLimit, maxLimit int) int {
 
 func strPtr(s string) *string { return &s }
 
+// clearWriteDeadline disables the global http.Server WriteTimeout for a
+// single in-flight request. Use it at the top of handlers whose work can
+// legitimately exceed the server-wide WriteTimeout — preview start in
+// particular blends snapshot restore (~10s), infra image pull (~30s), and
+// readiness probes (90s default), and the 15s server WriteTimeout will
+// otherwise drop the connection mid-handler. The dropped connection
+// surfaces to the API caller as `EOF` and to the user as a 502 with no
+// usable error code, hiding the real failure.
+//
+// Scoped per-response: Go's http.Server re-arms WriteTimeout on the next
+// request that arrives on the same keep-alive connection. The request
+// context's own deadline (driven by the client connection or the
+// worker_client's 10-minute timeout) still bounds the handler.
+//
+// Logs at Debug and returns silently on response writers that don't
+// support http.ResponseController — this is a perf/UX optimization, not
+// a correctness requirement, so degrading to the default WriteTimeout
+// is acceptable for those cases.
+func clearWriteDeadline(w http.ResponseWriter, r *http.Request) {
+	if err := http.NewResponseController(w).SetWriteDeadline(time.Time{}); err != nil {
+		zerolog.Ctx(r.Context()).Debug().Err(err).Msg("could not clear write deadline; continuing with server default")
+	}
+}
+
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -69,6 +69,13 @@ func (h *InternalPreviewHandler) requireInspector(w http.ResponseWriter, r *http
 }
 
 func (h *InternalPreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
+	// startPreviewLocal can run snapshot restore + infra image pull +
+	// readiness probes. The server's 15s WriteTimeout will otherwise drop
+	// the connection mid-handler — the API caller then sees `EOF` and
+	// returns 502 PREVIEW_WORKER_REQUEST_FAILED to the browser, hiding
+	// the real error code (e.g. SANDBOX_BUSY). See helpers.go.
+	clearWriteDeadline(w, r)
+
 	claims, ok := h.authorize(w, r, "start")
 	if !ok {
 		return
@@ -126,6 +133,10 @@ func (h *InternalPreviewHandler) StopPreview(w http.ResponseWriter, r *http.Requ
 }
 
 func (h *InternalPreviewHandler) RecyclePreview(w http.ResponseWriter, r *http.Request) {
+	// Recycle = teardown + relaunch (image pulls + readiness probes); same
+	// WriteTimeout-overrun risk as StartPreview.
+	clearWriteDeadline(w, r)
+
 	previewID, err := uuid.Parse(chi.URLParam(r, "previewID"))
 	if err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_PREVIEW_ID", "invalid preview id")

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -346,14 +346,22 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 		}
 	}
 
-	// Pre-hydrate race check: re-read the session and bail early if a peer
-	// (typically a continue_session turn) has published a container_id since
-	// we read the row at the top of startPreviewLocal. Without this, hydrate
-	// runs the full snapshot restore + container create (~20s) before
-	// PublishHydratedContainerID's CAS detects the loss — and that work
-	// blows past the HTTP server's WriteTimeout on the worker, so the
-	// caller sees a 502 EOF instead of a clean 409 SANDBOX_BUSY.
-	fresh, freshErr := h.sessionStore.GetByID(ctx, orgID, session.ID)
+	// Pre-hydrate race check: re-read just container_id and bail early if a
+	// peer (typically a continue_session turn) has published one since we
+	// read `session` at the top of startPreviewLocal. This is a *latency*
+	// optimization layered on top of clearWriteDeadline (StartPreview):
+	// the deadline fix already prevents the slow path's 502 EOF, so the
+	// CAS inside PublishHydratedContainerID is sufficient for correctness.
+	// The peek's value is sub-100ms user feedback and avoiding ~20s of
+	// pointless snapshot restore + container create + destroy churn when
+	// we already know we'll lose.
+	//
+	// Only container_id is rechecked: sandbox_state and snapshot_key from
+	// the original `session` row are still trusted. A reaper expiring the
+	// snapshot in this window would slip past the peek and fail in
+	// HydrateSandboxFromSnapshot below — same behavior as before this peek
+	// existed, so out of scope for this fix.
+	winningID, freshErr := h.sessionStore.PeekContainerID(ctx, orgID, session.ID)
 	switch {
 	case freshErr != nil:
 		// Fail open: the CAS in PublishHydratedContainerID still catches the
@@ -363,10 +371,10 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 		h.logger.Warn().Err(freshErr).
 			Str("session_id", session.ID.String()).
 			Msg("preview hydrate: pre-hydrate peek failed; falling through to CAS race detection")
-	case fresh.ContainerID != nil && *fresh.ContainerID != "":
+	case winningID != "":
 		h.logger.Info().
 			Str("session_id", session.ID.String()).
-			Str("winning_container_id", *fresh.ContainerID).
+			Str("winning_container_id", winningID).
 			Msg("preview hydrate: peer published container_id before restore; returning SANDBOX_BUSY without hydrating")
 		return acquireSandboxResult{
 			ErrCode: "SANDBOX_BUSY",

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -239,9 +239,9 @@ type acquireSandboxResult struct {
 	// existing container (a turn still owns it — leave it alone on abort).
 	Hydrated bool
 	// ErrCode, when non-empty, is the HTTP error code to surface:
-	// "NO_SANDBOX" (409), "SNAPSHOT_UNAVAILABLE" (409), "SNAPSHOT_EXPIRED"
-	// (410). Empty for infrastructure failures that should map to
-	// 500 PREVIEW_HYDRATE_FAILED.
+	// "NO_SANDBOX" (409), "SANDBOX_BUSY" (409), "SNAPSHOT_UNAVAILABLE" (409),
+	// "SNAPSHOT_EXPIRED" (410). Empty for infrastructure failures that should
+	// map to 500 PREVIEW_HYDRATE_FAILED.
 	ErrCode string
 	// Err is the underlying error for logging and user messaging. Always
 	// non-nil when acquisition failed; always nil when Sandbox is non-nil.
@@ -346,6 +346,34 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 		}
 	}
 
+	// Pre-hydrate race check: re-read the session and bail early if a peer
+	// (typically a continue_session turn) has published a container_id since
+	// we read the row at the top of startPreviewLocal. Without this, hydrate
+	// runs the full snapshot restore + container create (~20s) before
+	// PublishHydratedContainerID's CAS detects the loss — and that work
+	// blows past the HTTP server's WriteTimeout on the worker, so the
+	// caller sees a 502 EOF instead of a clean 409 SANDBOX_BUSY.
+	fresh, freshErr := h.sessionStore.GetByID(ctx, orgID, session.ID)
+	switch {
+	case freshErr != nil:
+		// Fail open: the CAS in PublishHydratedContainerID still catches the
+		// race after restore. Log so a regression in the optimization is
+		// visible in prod (e.g. DB blips making us silently fall back to
+		// the slow path).
+		h.logger.Warn().Err(freshErr).
+			Str("session_id", session.ID.String()).
+			Msg("preview hydrate: pre-hydrate peek failed; falling through to CAS race detection")
+	case fresh.ContainerID != nil && *fresh.ContainerID != "":
+		h.logger.Info().
+			Str("session_id", session.ID.String()).
+			Str("winning_container_id", *fresh.ContainerID).
+			Msg("preview hydrate: peer published container_id before restore; returning SANDBOX_BUSY without hydrating")
+		return acquireSandboxResult{
+			ErrCode: "SANDBOX_BUSY",
+			Err:     fmt.Errorf("another process attached to this session's sandbox first; please retry"),
+		}
+	}
+
 	// Hydrate: build a SandboxConfig matching what the orchestrator uses so
 	// the restored container has consistent resource limits and paths.
 	// WorkDir resolves from the session's repo (HomeDir + "/" + slug) so
@@ -396,7 +424,7 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 			Str("losing_container_id", sandbox.ID).
 			Msg("preview hydrate lost race to another holder; destroyed local container")
 		return acquireSandboxResult{
-			ErrCode: "NO_SANDBOX",
+			ErrCode: "SANDBOX_BUSY",
 			Err:     fmt.Errorf("another process attached to this session's sandbox first; please retry"),
 		}
 	}
@@ -594,6 +622,8 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 			return nil, newPreviewHTTPError(http.StatusConflict, acq.ErrCode, acq.Err.Error(), acq.Err)
 		case "NO_SANDBOX":
 			return nil, newPreviewHTTPError(http.StatusConflict, acq.ErrCode, acq.Err.Error(), acq.Err)
+		case "SANDBOX_BUSY":
+			return nil, newPreviewHTTPError(http.StatusConflict, acq.ErrCode, acq.Err.Error(), acq.Err)
 		default:
 			return nil, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_HYDRATE_FAILED", "failed to hydrate sandbox for preview", acq.Err)
 		}
@@ -653,6 +683,12 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 }
 
 func (h *PreviewHandler) StartPreview(w http.ResponseWriter, r *http.Request) {
+	// Preview start can take ≫15s (snapshot restore + infra image pull +
+	// readiness probes). Clear the per-request write deadline so the
+	// server's 15s WriteTimeout doesn't kill the connection mid-handler
+	// and turn a real error code into a 502 EOF.
+	clearWriteDeadline(w, r)
+
 	if !h.requireManager(w, r) {
 		return
 	}
@@ -815,6 +851,10 @@ func (h *PreviewHandler) StopPreview(w http.ResponseWriter, r *http.Request) {
 // =============================================================================
 
 func (h *PreviewHandler) RestartPreview(w http.ResponseWriter, r *http.Request) {
+	// Recycle tears down + relaunches; same WriteTimeout-overrun risk as
+	// StartPreview (image pulls + readiness probes), so clear the deadline.
+	clearWriteDeadline(w, r)
+
 	if !h.requireManager(w, r) {
 		return
 	}

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -972,8 +972,9 @@ func sessionRowForHydrate(id, orgID uuid.UUID, snapshotKey *string, sandboxState
 // fakeHydrateSnapshotStore is a minimal SnapshotStore that writes a canned
 // payload on Load.
 type fakeHydrateSnapshotStore struct {
-	payload []byte
-	loadErr error
+	payload   []byte
+	loadErr   error
+	loadCalls int
 }
 
 func (f *fakeHydrateSnapshotStore) Save(context.Context, string, io.Reader) error {
@@ -981,6 +982,7 @@ func (f *fakeHydrateSnapshotStore) Save(context.Context, string, io.Reader) erro
 }
 
 func (f *fakeHydrateSnapshotStore) Load(_ context.Context, _ string, w io.Writer) error {
+	f.loadCalls++
 	if f.loadErr != nil {
 		return f.loadErr
 	}
@@ -1593,9 +1595,11 @@ func TestPreviewHandler_StartPreview_PublishContainerIDFails(t *testing.T) {
 }
 
 // TestPreviewHandler_StartPreview_PublishLosesRace covers the CAS-loss branch
-// of PublishHydratedContainerID: a concurrent orchestrator already published
-// a different container_id, so the preview must destroy its local sandbox and
-// surface a NO_SANDBOX error instructing the caller to retry.
+// of PublishHydratedContainerID: a concurrent orchestrator publishes a
+// different container_id while we're mid-restore (after our pre-hydrate peek
+// found the row clear), so the CAS detects the loss and the preview must
+// destroy its local sandbox and surface a SANDBOX_BUSY error instructing the
+// caller to retry.
 func TestPreviewHandler_StartPreview_PublishLosesRace(t *testing.T) {
 	t.Parallel()
 
@@ -1615,8 +1619,16 @@ func TestPreviewHandler_StartPreview_PublishLosesRace(t *testing.T) {
 				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
 		)
 	expectReserveSuccess(mock, sessionID, orgID, userID)
+	// Pre-hydrate peek re-reads the session and finds container_id still NULL
+	// (the orchestrator hasn't published yet) — hydrate proceeds.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
+		)
 	// COALESCE returns the orchestrator's pre-existing ID, proving our preview
-	// lost the race.
+	// lost the race during the snapshot restore window.
 	mock.ExpectQuery("UPDATE sessions\\s+SET container_id = COALESCE").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"coalesce"}).AddRow("orch-winner"))
@@ -1641,8 +1653,68 @@ func TestPreviewHandler_StartPreview_PublishLosesRace(t *testing.T) {
 	h.StartPreview(w, req)
 
 	require.Equal(t, http.StatusConflict, w.Code)
-	require.Contains(t, w.Body.String(), "NO_SANDBOX")
+	require.Contains(t, w.Body.String(), "SANDBOX_BUSY")
 	require.Equal(t, 1, sp.GetDestroyCalls(), "local container must be destroyed on race loss")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestPreviewHandler_StartPreview_PrehydratePeekShortCircuit covers the fast
+// path of race detection: the peer (typically a continue_session turn)
+// publishes container_id between our initial session read and the start of
+// hydrate. The pre-hydrate peek finds the row populated and returns
+// SANDBOX_BUSY without ever touching the snapshot store or sandbox provider.
+//
+// This avoids the historical failure where full restore + container create
+// (~20s) blew past the HTTP server's 15s WriteTimeout, surfacing as a 502
+// EOF on the API instead of a clean 409 SANDBOX_BUSY.
+func TestPreviewHandler_StartPreview_PrehydratePeekShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	key := "snap-key"
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
+		)
+	expectReserveSuccess(mock, sessionID, orgID, userID)
+	// Pre-hydrate peek finds container_id has been published since our first
+	// read — short-circuit out without restoring or creating a container.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(previewSessionRow(sessionID, orgID, strPtr("orch-winner"), &key, "running")...),
+		)
+	// hydratedID="" because we never created a container.
+	expectAbortReservationNoDestroy(mock)
+
+	h := newPreviewHandlerWithMock(mock)
+	h.sessionStore = db.NewSessionStore(mock)
+	sp := testutil.NewMockSandboxProvider()
+	h.sandboxProvider = sp
+	// Snapshot store presence required so we don't trip the NO_SANDBOX guard.
+	snaps := &fakeHydrateSnapshotStore{payload: []byte("snap")}
+	h.snapshots = snaps
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+
+	h.StartPreview(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.Contains(t, w.Body.String(), "SANDBOX_BUSY")
+	require.Equal(t, 0, snaps.loadCalls, "must not load the snapshot when peek detects the race")
+	require.Equal(t, 0, sp.GetDestroyCalls(), "no container to destroy when peek short-circuits")
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -1619,14 +1619,11 @@ func TestPreviewHandler_StartPreview_PublishLosesRace(t *testing.T) {
 				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
 		)
 	expectReserveSuccess(mock, sessionID, orgID, userID)
-	// Pre-hydrate peek re-reads the session and finds container_id still NULL
+	// Pre-hydrate peek (single-column COALESCE) finds container_id still NULL
 	// (the orchestrator hasn't published yet) — hydrate proceeds.
-	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+	mock.ExpectQuery("SELECT COALESCE\\(container_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(
-			pgxmock.NewRows(sessionRowColumns).
-				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
-		)
+		WillReturnRows(pgxmock.NewRows([]string{"container_id"}).AddRow(""))
 	// COALESCE returns the orchestrator's pre-existing ID, proving our preview
 	// lost the race during the snapshot restore window.
 	mock.ExpectQuery("UPDATE sessions\\s+SET container_id = COALESCE").
@@ -1686,14 +1683,12 @@ func TestPreviewHandler_StartPreview_PrehydratePeekShortCircuit(t *testing.T) {
 				AddRow(sessionRowForHydrate(sessionID, orgID, &key, "snapshotted")...),
 		)
 	expectReserveSuccess(mock, sessionID, orgID, userID)
-	// Pre-hydrate peek finds container_id has been published since our first
-	// read — short-circuit out without restoring or creating a container.
-	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+	// Pre-hydrate peek (single-column COALESCE) finds container_id has been
+	// published since our first read — short-circuit out without restoring
+	// or creating a container.
+	mock.ExpectQuery("SELECT COALESCE\\(container_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(
-			pgxmock.NewRows(sessionRowColumns).
-				AddRow(previewSessionRow(sessionID, orgID, strPtr("orch-winner"), &key, "running")...),
-		)
+		WillReturnRows(pgxmock.NewRows([]string{"container_id"}).AddRow("orch-winner"))
 	// hydratedID="" because we never created a container.
 	expectAbortReservationNoDestroy(mock)
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -1585,6 +1586,32 @@ func (s *SessionStore) ReleaseTurnHold(ctx context.Context, orgID, sessionID uui
 		return false, "", fmt.Errorf("release turn hold: %w", err)
 	}
 	return cid != "" && !previewHolds, cid, nil
+}
+
+// PeekContainerID returns the session's current container_id (empty when
+// NULL) using a single-column lookup. It exists for the preview hydrate
+// race-detection peek, which only needs to know whether a peer has
+// published a container_id since the caller last read the row — fetching
+// the full Session struct via GetByID would pull ~30 columns and hydrate
+// the policy JSON for no benefit. Returns the empty string for both
+// "no row" and "NULL container_id"; the caller cannot distinguish those
+// cases, but neither outcome should change the hydrate path's behavior.
+func (s *SessionStore) PeekContainerID(ctx context.Context, orgID, sessionID uuid.UUID) (string, error) {
+	query := `SELECT COALESCE(container_id, '')
+		FROM sessions
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
+	var containerID string
+	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	}).Scan(&containerID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", nil
+		}
+		return "", fmt.Errorf("peek container id: %w", err)
+	}
+	return containerID, nil
 }
 
 // PublishHydratedContainerID is the preview-hydrate CAS: a preview has just


### PR DESCRIPTION
## Summary
- Splits the preview hydrate race-loss out of `NO_SANDBOX` into a new `SANDBOX_BUSY` (409) so the frontend stops showing "Docker not configured" when the user just collided with a running turn.
- Adds a pre-hydrate peek that re-reads `container_id` and short-circuits with `SANDBOX_BUSY` in <100ms when a peer published — avoiding the ~22s restore/create dance that was overrunning the worker's 15s `WriteTimeout` and surfacing as a generic 502 EOF.
- `clearWriteDeadline` at handler entry on `StartPreview`, `RestartPreview`, `InternalStartPreview`, and `InternalRecyclePreview` so legitimately slow hydrate responses (image pulls, readiness probes) aren't dropped mid-write.
- Frontend wires both `SANDBOX_BUSY` and `PREVIEW_WORKER_REQUEST_FAILED` to clear retry-oriented messages instead of falling through to the generic `Failed to start preview:` prefix.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `npm run test` — 1577 frontend tests green
- [x] New Go test `PrehydratePeekShortCircuit` asserts the snapshot store's `Load` is never called when the peek detects the race
- [x] Updated `PublishLosesRace` for the extra `GetByID` and the new `SANDBOX_BUSY` code
- [x] Two new TS tests covering the new error-banner messages, including a regression guard against re-merging `SANDBOX_BUSY` into `NO_SANDBOX`
- [ ] After merge: verify on the original repro session that clicking Start Preview during an in-flight turn now shows the new banner instead of "Failed to start preview:"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
