### PR TITLE
Add mobile back navigation to automations detail view [VIR-56]

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -6,15 +6,70 @@ import AutomationDetailPage from "./page";
 
 const pushMock = vi.fn();
 
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<"a"> & { href: string }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "auto-1" }),
   useRouter: () => ({
     push: pushMock,
     replace: vi.fn(),
   }),
+  useSearchParams: () => new URLSearchParams("tab=paused"),
 }));
 
 describe("AutomationDetailPage", () => {
+  it("renders a back button to the automations list preserving query params", async () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    const backLink = await screen.findByLabelText("Back to automations");
+    expect(backLink).toHaveAttribute("href", "/automations?tab=paused");
+  });
+
   it("saves the selected base branch from the branch picker", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { MobileBackButton } from "@/components/mobile-back-button";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { BranchPicker } from "@/components/branch-picker";
@@ -253,8 +254,11 @@ export default function AutomationDetailPage() {
   if (isLoading) {
     return (
       <PageContainer size="default">
-        <div className="text-center py-12 text-sm text-muted-foreground">
-          Loading...
+        <div className="space-y-6">
+          <MobileBackButton to="/automations" label="Back to automations" />
+          <div className="text-center py-12 text-sm text-muted-foreground">
+            Loading...
+          </div>
         </div>
       </PageContainer>
     );
@@ -264,6 +268,7 @@ export default function AutomationDetailPage() {
     return (
       <PageContainer size="default">
         <div className="space-y-6">
+          <MobileBackButton to="/automations" label="Back to automations" />
           <PageHeader
             title="Automation not found"
             description="This automation does not exist or has been deleted."
@@ -298,6 +303,7 @@ export default function AutomationDetailPage() {
   return (
     <PageContainer size="default">
       <div className="space-y-6">
+        <MobileBackButton to="/automations" label="Back to automations" />
         <PageHeader
           title={automation.name}
           description={headerDescription}


### PR DESCRIPTION
## Summary
Implements `VIR-56` by adding a “Back to automations” affordance on the automations detail page. The back link is rendered in loading, not-found, and loaded states and preserves the current query params (e.g., active tab) when returning to the list.

## Changes
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Import and render `MobileBackButton` with `to="/automations"` and label `"Back to automations"`.
  - Show the back button in:
    - loading state
    - not-found state
    - loaded state
  - Wrap the loading UI with spacing so the back control is immediately visible.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Add test coverage asserting the back link points to `/automations?tab=paused` (query param preserved).
  - Mock `useSearchParams` to include `tab=paused`.

## Test plan
- Ran the updated unit/integration tests for `AutomationDetailPage`, including the new assertion for the back link URL with preserved query params.

---
*Generated by [143.dev](https://143.dev) — [session ca407392](https://143.dev/sessions/ca407392-da38-4e29-b4fa-94295fe5d086)*
