### PR TITLE
Defer Linear in-progress transition to session start

### DIFF
--- a/internal/db/linear_state_events.go
+++ b/internal/db/linear_state_events.go
@@ -16,6 +16,7 @@ type LinearStateEventKind string
 
 const (
 	LinearStateEventLinked   LinearStateEventKind = "linked"
+	LinearStateEventStarted  LinearStateEventKind = "started"
 	LinearStateEventPROpened LinearStateEventKind = "pr_opened"
 	LinearStateEventPRMerged LinearStateEventKind = "pr_merged"
 	LinearStateEventEnded    LinearStateEventKind = "ended"

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1026,6 +1026,14 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if err := o.sessions.UpdateStatus(ctx, run.OrgID, run.ID, "running"); err != nil {
 		return fmt.Errorf("update run status to running: %w", err)
 	}
+	// Fire the Linear state-transition signal exactly once per session, when
+	// the session actually starts running. Linking alone (paste a `ACS-1234`
+	// into the textarea) no longer moves the issue — the issue only flips to
+	// "in progress" once the orchestrator picks the session up and runs it.
+	// The fire-once unique constraint on (session_id, issue_id, "started")
+	// makes a re-entry from a resumed/retried run a no-op, so this call is
+	// safe on every RunAgent invocation.
+	o.enqueueLinearMilestone(ctx, run, string(linear.MilestoneStarted))
 	// runStartedAt is captured AFTER UpdateStatus, so the elapsed reported on
 	// a timeout excludes concurrency check + status write but includes
 	// everything from issue fetch onward (sandbox create, credential inject,

--- a/internal/services/linear/client.go
+++ b/internal/services/linear/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -362,12 +363,22 @@ func (c *graphQLClient) WorkflowStateForType(ctx context.Context, teamID string,
 	if err := c.do(ctx, query, map[string]any{"teamID": teamID}, &result); err != nil {
 		return nil, err
 	}
+	// Sort by position ascending so the no-preferences fallback is
+	// deterministic ("leftmost typed state in the team's UI"). Linear's
+	// workflowStates query has no orderBy argument, so default ordering is
+	// API-implementation-dependent — without this sort, two `started`-type
+	// states like "In Progress" and "In Review" could swap in API responses
+	// and silently land a session-start move on "In Review."
+	nodes := result.Data.WorkflowStates.Nodes
+	sort.SliceStable(nodes, func(i, j int) bool {
+		return nodes[i].Position < nodes[j].Position
+	})
 	preferred := make(map[string]bool, len(prefer))
 	for _, p := range prefer {
 		preferred[strings.ToLower(p)] = true
 	}
 	var fallback *WorkflowState
-	for _, n := range result.Data.WorkflowStates.Nodes {
+	for _, n := range nodes {
 		if n.Type != stateType {
 			continue
 		}

--- a/internal/services/linear/client_test.go
+++ b/internal/services/linear/client_test.go
@@ -373,6 +373,31 @@ func TestGraphQLClientWorkflowStateForType(t *testing.T) {
 	require.Error(t, err, "WorkflowStateForType should validate required inputs")
 }
 
+// TestGraphQLClientWorkflowStateForType_PositionOrderingDeterministic pins
+// the no-preferences fallback to "lowest position wins" regardless of the
+// order Linear returns the nodes. Without the client-side sort, a session
+// start could silently land on "In Review" instead of "In Progress" when
+// Linear's API reorders responses (the workflowStates query has no orderBy
+// argument, so server-side ordering is implementation-dependent).
+func TestGraphQLClientWorkflowStateForType_PositionOrderingDeterministic(t *testing.T) {
+	t.Parallel()
+
+	client := newGraphQLClientForTest(t, func(t *testing.T, req linearGraphQLRequest, w http.ResponseWriter) {
+		// Out-of-order on purpose: position-3 first, then position-2.
+		writeGraphQLResponse(t, w, `{
+			"data": {"workflowStates": {"nodes": [
+				{"id": "started-2", "name": "In Review", "type": "started", "position": 3},
+				{"id": "started-1", "name": "In Progress", "type": "started", "position": 2},
+				{"id": "backlog-1", "name": "Backlog", "type": "backlog", "position": 1}
+			]}}
+		}`)
+	})
+
+	got, err := client.WorkflowStateForType(context.Background(), "team-1", nil, "started")
+	require.NoError(t, err, "WorkflowStateForType should not error on unordered nodes")
+	require.Equal(t, &WorkflowState{ID: "started-1", Name: "In Progress", Type: "started"}, got, "no-preferences fallback must pick the lowest-position state of the requested type, regardless of API order")
+}
+
 func TestGraphQLClientIssueRecentHumanEdits(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/linear/handle_milestone_test.go
+++ b/internal/services/linear/handle_milestone_test.go
@@ -324,7 +324,8 @@ func TestMilestoneFormattingAndStateHelpers(t *testing.T) {
 		event    MilestoneEvent
 		expected db.LinearStateEventKind
 	}{
-		{event: MilestoneLinked, expected: db.LinearStateEventLinked},
+		{event: MilestoneLinked, expected: ""},
+		{event: MilestoneStarted, expected: db.LinearStateEventStarted},
 		{event: MilestonePROpened, expected: db.LinearStateEventPROpened},
 		{event: MilestonePRMerged, expected: db.LinearStateEventPRMerged},
 		{event: MilestoneEndedNoPR, expected: ""},
@@ -341,7 +342,8 @@ func TestMilestoneFormattingAndStateHelpers(t *testing.T) {
 		event    MilestoneEvent
 		expected string
 	}{
-		{event: MilestoneLinked, expected: "started"},
+		{event: MilestoneLinked, expected: ""},
+		{event: MilestoneStarted, expected: "started"},
 		{event: MilestonePROpened, expected: "started"},
 		{event: MilestonePRMerged, expected: "completed"},
 		{event: MilestoneFailed, expected: ""},
@@ -622,7 +624,7 @@ func TestHandleStateTransition_LinearStateSyncDisabledRecordsSkip(t *testing.T) 
 	session.LinearStateSyncDisabled = true
 
 	if err := svc.HandleStateTransition(context.Background(), MilestoneInput{
-		Event:      MilestoneLinked,
+		Event:      MilestoneStarted,
 		Session:    session,
 		Link:       link,
 		IssueID:    "linear-issue-id",
@@ -683,7 +685,7 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 		svc, _, events := buildTestService(t, newFakeLinearClient())
 		link := newPrimaryLink()
 		link.Role = models.SessionIssueLinkRoleRelated
-		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneLinked, Session: newSession(), Link: link, IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
+		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneStarted, Session: newSession(), Link: link, IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
 			t.Fatalf("related link skip should not error: %v", err)
 		}
 		if got := events.inserts[0].SkippedReason; got != db.LinearStateSkipNotPrimary {
@@ -702,7 +704,7 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 				},
 			}}, nil
 		}
-		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneLinked, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
+		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneStarted, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
 			t.Fatalf("per-team disabled skip should not error: %v", err)
 		}
 		if got := events.inserts[0].SkippedReason; got != db.LinearStateSkipPerTeamDisabled {
@@ -715,7 +717,7 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 		client := newFakeLinearClient()
 		client.humanEdited = true
 		svc, _, events := buildTestService(t, client)
-		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneLinked, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
+		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneStarted, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
 			t.Fatalf("human edit skip should not error: %v", err)
 		}
 		if got := events.inserts[0].SkippedReason; got != db.LinearStateSkipUserRecentEdit {
@@ -762,26 +764,26 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 		}
 	})
 
-	// Linked-event must NOT trip the coexistence guard — Linear's GitHub
+	// Session-start must NOT trip the coexistence guard — Linear's GitHub
 	// integration only runs on PR-lifecycle events, so suppressing our
-	// own "started" move on session-link would silently lose the only
+	// own "started" move on session-start would silently lose the only
 	// transition we own.
-	t.Run("session linked does not trip coexistence guard", func(t *testing.T) {
+	t.Run("session started does not trip coexistence guard", func(t *testing.T) {
 		t.Parallel()
 		client := newFakeLinearClient()
 		client.hasGitHubAttachment = true
 		svc, _, events := buildTestService(t, client)
-		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneLinked, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
-			t.Fatalf("linked transition should not error: %v", err)
+		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneStarted, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
+			t.Fatalf("started transition should not error: %v", err)
 		}
 		if client.updateStateCalls != 1 {
-			t.Fatalf("linked event must fire UpdateIssueState even when GitHub integration is present (got %d)", client.updateStateCalls)
+			t.Fatalf("started event must fire UpdateIssueState even when GitHub integration is present (got %d)", client.updateStateCalls)
 		}
 		if len(events.inserts) != 1 {
 			t.Fatalf("expected 1 transition event recorded, got %d", len(events.inserts))
 		}
 		if got := events.inserts[0].SkippedReason; got != "" {
-			t.Fatalf("linked event must record a real transition, not a skip (got SkippedReason=%q)", got)
+			t.Fatalf("started event must record a real transition, not a skip (got SkippedReason=%q)", got)
 		}
 	})
 
@@ -920,7 +922,7 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 		})
 
 		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{
-			Event:      MilestoneLinked,
+			Event:      MilestoneStarted,
 			Session:    newSession(),
 			Link:       link,
 			IssueID:    "linear-issue-id",
@@ -944,7 +946,7 @@ func TestHandleStateTransition_GuardsAndSkips(t *testing.T) {
 		client := newFakeLinearClient()
 		client.target = nil
 		svc, _, events := buildTestService(t, client)
-		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneLinked, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
+		if err := svc.HandleStateTransition(context.Background(), MilestoneInput{Event: MilestoneStarted, Session: newSession(), Link: newPrimaryLink(), IssueID: "linear-issue-id", IssueIdent: "ACS-1"}); err != nil {
 			t.Fatalf("nil target skip should not error: %v", err)
 		}
 		if got := events.inserts[0].SkippedReason; got != db.LinearStateSkipNoTargetState {
@@ -996,7 +998,7 @@ func TestHandleStateTransition_GuardLookupErrorsAreRetried(t *testing.T) {
 		svc, _, events := buildTestService(t, client)
 
 		err := svc.HandleStateTransition(context.Background(), MilestoneInput{
-			Event:      MilestoneLinked,
+			Event:      MilestoneStarted,
 			Session:    newSession(),
 			Link:       newPrimaryLink(),
 			IssueID:    "linear-issue-id",
@@ -1058,7 +1060,7 @@ func TestHandleStateTransition_FireOnceCollapseDuplicates(t *testing.T) {
 	link := newPrimaryLink()
 	session := newSession()
 	in := MilestoneInput{
-		Event:      MilestoneLinked,
+		Event:      MilestoneStarted,
 		Session:    session,
 		Link:       link,
 		IssueID:    "linear-issue-id",
@@ -1099,7 +1101,7 @@ func TestHandleStateTransition_PersistsPriorStateID(t *testing.T) {
 	link := newPrimaryLink()
 	session := newSession()
 	in := MilestoneInput{
-		Event:      MilestoneLinked,
+		Event:      MilestoneStarted,
 		Session:    session,
 		Link:       link,
 		IssueID:    "linear-issue-id",

--- a/internal/services/linear/writes.go
+++ b/internal/services/linear/writes.go
@@ -22,6 +22,7 @@ type MilestoneEvent string
 
 const (
 	MilestoneLinked    MilestoneEvent = "linked"
+	MilestoneStarted   MilestoneEvent = "started"
 	MilestonePROpened  MilestoneEvent = "pr_opened"
 	MilestonePRMerged  MilestoneEvent = "pr_merged"
 	MilestoneEndedNoPR MilestoneEvent = "ended_no_pr"
@@ -93,6 +94,13 @@ const botCommentPrefix = "🤖 143 automated update —"
 func (s *Service) HandleMilestone(ctx context.Context, in MilestoneInput) error {
 	if in.Session == nil {
 		return fmt.Errorf("nil session")
+	}
+	if in.Event == MilestoneStarted {
+		// `started` is the session-runtime trigger for HandleStateTransition
+		// only — the link-time `linked` milestone has already created the
+		// durable attachment and rolling comment, so re-touching them here
+		// would just churn the Linear UI on every session start.
+		return nil
 	}
 	if in.Link.Role != models.SessionIssueLinkRolePrimary {
 		// Related issues never get attachments or comments in v1.
@@ -815,8 +823,8 @@ func (s *Service) recordSkip(ctx context.Context, in MilestoneInput, kind db.Lin
 
 func stateEventKindFor(event MilestoneEvent) db.LinearStateEventKind {
 	switch event {
-	case MilestoneLinked:
-		return db.LinearStateEventLinked
+	case MilestoneStarted:
+		return db.LinearStateEventStarted
 	case MilestonePROpened:
 		return db.LinearStateEventPROpened
 	case MilestonePRMerged:
@@ -827,7 +835,7 @@ func stateEventKindFor(event MilestoneEvent) db.LinearStateEventKind {
 
 func stateTypeFor(event MilestoneEvent) string {
 	switch event {
-	case MilestoneLinked:
+	case MilestoneStarted:
 		return "started"
 	case MilestonePROpened:
 		return "started" // review states are typed `started` in Linear


### PR DESCRIPTION
## Summary
- Split the link-time and start-time Linear milestones: `MilestoneLinked` still creates the attachment + rolling comment, but no longer flips the issue's workflow state.
- New `MilestoneStarted` event fires from `Orchestrator.RunAgent` after the session transitions to `running`, and is the sole trigger for `HandleStateTransition` (typed `started` in Linear).
- Fire-once unique constraint on `(session_id, issue_id, "started")` makes resumed/retried runs a safe no-op, so the orchestrator can call it on every `RunAgent` invocation.

This means pasting `ACS-1234` into the textarea no longer moves the issue — the issue only flips to "In Progress" once the orchestrator actually picks the session up and runs it.

## Test plan
- [ ] `make lint`
- [ ] `go test ./internal/services/linear/... ./internal/services/agent/... ./internal/db/...`
- [ ] Manual: paste an issue ref, confirm Linear issue is unchanged; start the session, confirm it flips to In Progress exactly once
- [ ] Manual: retry a failed turn, confirm no duplicate state transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)
