### PR TITLE
Disable diff context expanders when session sandbox is gone

### DIFF
--- a/frontend/src/components/code-review/context-expander.test.tsx
+++ b/frontend/src/components/code-review/context-expander.test.tsx
@@ -3,16 +3,26 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ContextExpander } from "./context-expander";
 
-// Mock the api module
-vi.mock("@/lib/api", () => ({
-  api: {
-    sessions: {
-      getFileContext: vi.fn(),
+// Mock the api module. The ApiError class is defined inside the factory
+// because vi.mock is hoisted above any module-level declarations.
+vi.mock("@/lib/api", () => {
+  class MockApiError extends Error {
+    constructor(public code: string, message: string, public details?: unknown) {
+      super(message);
+      this.name = "ApiError";
+    }
+  }
+  return {
+    ApiError: MockApiError,
+    api: {
+      sessions: {
+        getFileContext: vi.fn(),
+      },
     },
-  },
-}));
+  };
+});
 
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 
 describe("ContextExpander", () => {
   it("returns null when hiddenLineCount <= 0", () => {
@@ -216,6 +226,76 @@ describe("ContextExpander", () => {
     expect(onExpand).not.toHaveBeenCalled();
     // Button should still be visible (not expanded)
     expect(screen.getByRole("button", { name: "Show 20 above" })).toBeInTheDocument();
+  });
+
+  it("calls onContextUnavailable on NO_SANDBOX response", async () => {
+    const onContextUnavailable = vi.fn();
+    vi.mocked(api.sessions.getFileContext).mockRejectedValue(
+      new ApiError("NO_SANDBOX", "session has no active sandbox container")
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={4}
+        sessionId="s1"
+        filePath="f.ts"
+        hiddenStart={1}
+        hiddenEnd={4}
+        onExpand={vi.fn()}
+        onContextUnavailable={onContextUnavailable}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show 20 above" }));
+    expect(onContextUnavailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onContextUnavailable on non-NO_SANDBOX errors", async () => {
+    const onContextUnavailable = vi.fn();
+    vi.mocked(api.sessions.getFileContext).mockRejectedValue(
+      new ApiError("INTERNAL", "boom")
+    );
+
+    const user = userEvent.setup();
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={4}
+        sessionId="s1"
+        filePath="f.ts"
+        hiddenStart={1}
+        hiddenEnd={4}
+        onExpand={vi.fn()}
+        onContextUnavailable={onContextUnavailable}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Show 20 above" }));
+    expect(onContextUnavailable).not.toHaveBeenCalled();
+  });
+
+  it("disables all controls and shows unavailable copy when contextUnavailable is true", () => {
+    render(
+      <ContextExpander
+        kind="middle"
+        hiddenLineCount={10}
+        sessionId="s1"
+        filePath="src/app.ts"
+        hiddenStart={6}
+        hiddenEnd={15}
+        onExpand={vi.fn()}
+        contextUnavailable
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Show 20 above" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Show 20 below" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Show all hidden lines" })).toBeDisabled();
+    expect(
+      screen.getByText("Additional file context unavailable for this session")
+    ).toBeInTheDocument();
   });
 
   it("disables above and below controls when the gap is fully revealed", () => {

--- a/frontend/src/components/code-review/context-expander.tsx
+++ b/frontend/src/components/code-review/context-expander.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, Loader2 } from "lucide-react";
-import { api } from "@/lib/api";
+import { ApiError, api } from "@/lib/api";
 import type { FileLine } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 
@@ -28,6 +28,10 @@ interface ContextExpanderProps {
   visibleEnd?: number;
   /** Callback when context lines are fetched */
   onExpand?: (direction: "above" | "below" | "all", lines: FileLine[], meta: ContextExpandResult) => void;
+  /** When true, disables expansion controls and shows an explicit unavailable message. */
+  contextUnavailable?: boolean;
+  /** Called when a fetch fails because the session has no live sandbox. */
+  onContextUnavailable?: () => void;
 }
 
 /**
@@ -44,12 +48,14 @@ export function ContextExpander({
   visibleStart,
   visibleEnd,
   onExpand,
+  contextUnavailable = false,
+  onContextUnavailable,
 }: ContextExpanderProps) {
   const [loading, setLoading] = useState(false);
 
   if (hiddenLineCount <= 0) return null;
 
-  const canExpand = sessionId && filePath && onExpand;
+  const canExpand = !contextUnavailable && sessionId && filePath && onExpand;
   const canExpandAbove = canExpand && (visibleStart == null || visibleStart > hiddenStart);
   const canExpandBelow = canExpand && (visibleEnd == null || visibleEnd < hiddenEnd);
   const canExpandAll = canExpand && (visibleStart !== hiddenStart || visibleEnd !== hiddenEnd);
@@ -96,17 +102,36 @@ export function ContextExpander({
           totalLines: resp.data.total_lines,
         });
       }
-    } catch {
-      // If context fetch fails (e.g., sandbox not running), silently ignore
+    } catch (err) {
+      // The session container is gone (completed sessions tear down their
+      // sandbox). Lift this signal so all expanders flip to the disabled
+      // state instead of silently swallowing repeated clicks.
+      if (err instanceof ApiError && err.code === "NO_SANDBOX") {
+        onContextUnavailable?.();
+      }
     } finally {
       setLoading(false);
     }
   }
 
+  const trailingText = contextUnavailable
+    ? "Additional file context unavailable for this session"
+    : kind === "top"
+    ? "Before change"
+    : kind === "bottom"
+    ? "After change"
+    : `Show ${hiddenLineCount} hidden lines`;
+
+  const titleText = contextUnavailable
+    ? "Additional file context unavailable for this session"
+    : canExpand
+    ? `Show ${hiddenLineCount} hidden lines`
+    : "Context expansion unavailable (sandbox not running)";
+
   return (
     <div
       className="flex items-center justify-center gap-2 px-3 py-2 text-xs text-muted-foreground/80 border-y border-border/40 bg-muted/15"
-      title={canExpand ? `Show ${hiddenLineCount} hidden lines` : "Context expansion unavailable (sandbox not running)"}
+      title={titleText}
     >
       {loading ? <Loader2 className="h-3 w-3 animate-spin" /> : <ChevronDown className="h-3 w-3" />}
       <Button
@@ -142,9 +167,7 @@ export function ContextExpander({
       >
         Show all
       </Button>
-      <span aria-label={`Show ${hiddenLineCount} hidden lines`}>
-        {kind === "top" ? "Before change" : kind === "bottom" ? "After change" : `Show ${hiddenLineCount} hidden lines`}
-      </span>
+      <span aria-label={trailingText}>{trailingText}</span>
     </div>
   );
 }

--- a/frontend/src/components/code-review/diff-pane.tsx
+++ b/frontend/src/components/code-review/diff-pane.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useCallback, useImperativeHandle, forwardRef, useEffect } from "react";
+import { useRef, useCallback, useImperativeHandle, forwardRef, useEffect, useState } from "react";
 import type { DiffFile } from "@/lib/diff-parser";
 import type { SessionReviewComment } from "@/lib/types";
 import type { CommentLineKey } from "@/hooks/use-review-comments";
@@ -56,6 +56,21 @@ export const DiffPane = forwardRef<DiffPaneHandle, DiffPaneProps>(
     const containerRef = useRef<HTMLDivElement>(null);
     const fileRefs = useRef<Map<number, HTMLDivElement>>(new Map());
     const lastReportedActiveFileIndexRef = useRef<number | null>(activeFileIndex ?? null);
+
+    // Once any expander hits a NO_SANDBOX response, the session container is
+    // gone for good — flip every expander on this pane into the disabled state
+    // so the user gets clear feedback instead of repeating the failed click.
+    // Reset on sessionId change using the "adjust state during render" pattern
+    // (https://react.dev/reference/react/useState#storing-information-from-previous-renders).
+    const [contextUnavailable, setContextUnavailable] = useState(false);
+    const [trackedSessionId, setTrackedSessionId] = useState(sessionId);
+    if (trackedSessionId !== sessionId) {
+      setTrackedSessionId(sessionId);
+      setContextUnavailable(false);
+    }
+    const handleContextUnavailable = useCallback(() => {
+      setContextUnavailable(true);
+    }, []);
 
     const setFileRef = useCallback(
       (index: number) => (el: HTMLDivElement | null) => {
@@ -189,6 +204,8 @@ export const DiffPane = forwardRef<DiffPaneHandle, DiffPaneProps>(
             onUpdateComment={onUpdateComment}
             onDeleteComment={onDeleteComment}
             onBrowseFile={onBrowseFile}
+            contextUnavailable={contextUnavailable}
+            onContextUnavailable={handleContextUnavailable}
           />
         ))}
       </div>

--- a/frontend/src/components/code-review/file-diff-section.tsx
+++ b/frontend/src/components/code-review/file-diff-section.tsx
@@ -32,6 +32,8 @@ interface FileDiffSectionProps {
   onUpdateComment?: (commentId: string, data: { body?: string; resolved?: boolean }) => void;
   onDeleteComment?: (commentId: string) => void;
   onBrowseFile?: (filePath: string) => void;
+  contextUnavailable?: boolean;
+  onContextUnavailable?: () => void;
 }
 
 type GapKind = "top" | "middle" | "bottom";
@@ -101,6 +103,8 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
     onUpdateComment,
     onDeleteComment,
     onBrowseFile,
+    contextUnavailable,
+    onContextUnavailable,
   }, ref) {
     // Collect all line contents across hunks for a single batch highlight call
     const allLineContents = useMemo(() => {
@@ -217,6 +221,8 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
             visibleStart={gapState.visibleStart}
             visibleEnd={gapState.visibleEnd}
             onExpand={makeHandleContextExpand(gapState)}
+            contextUnavailable={contextUnavailable}
+            onContextUnavailable={onContextUnavailable}
           />
           {expandedHunk ? (
             viewMode === "split" ? (
@@ -227,7 +233,7 @@ export const FileDiffSection = forwardRef<HTMLDivElement, FileDiffSectionProps>(
           ) : null}
         </div>
       );
-    }, [commonHunkProps, file.newPath, gapStates, makeHandleContextExpand, sessionId, viewMode]);
+    }, [commonHunkProps, file.newPath, gapStates, makeHandleContextExpand, sessionId, viewMode, contextUnavailable, onContextUnavailable]);
 
     const sections = useMemo(() => {
       const items: Array<{ type: "gap"; gap: ContextGapState } | { type: "hunk"; index: number; hunk: DiffFile["hunks"][number] }> = [];


### PR DESCRIPTION
## Summary
- Clicking `Show 20 above` / `Show 20 below` on a completed session silently failed because the file-context API returned 409 `NO_SANDBOX` (the session's Docker container had been torn down) and the frontend `catch` block swallowed the error.
- Detect the `NO_SANDBOX` `ApiError` in `ContextExpander`, lift the signal to `DiffPane`, and flip every expander on the pane into a disabled state with explicit "Additional file context unavailable for this session" copy — matching the existing design doc.
- Reset the unavailable flag when `sessionId` changes using the React "adjust state during render" pattern.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npx vitest run` for `context-expander`, `file-diff-section`, `diff-pane` (39 tests pass, including 3 new ones for NO_SANDBOX detection and the disabled UI)
- [ ] Manually click `Show 20 above` on a session whose sandbox is gone and confirm the expanders disable with the new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
