### PR TITLE
Scope sidebar swipe-to-archive overlay to touch devices

### DIFF
--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -1,6 +1,37 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, renderWithProviders, screen } from '@/test/test-utils';
 import { SwipeActionRow } from './swipe-action-row';
+
+function mockMatchMedia(coarse: boolean) {
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: query.includes('coarse') ? coarse : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+  return () => {
+    if (original) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        configurable: true,
+        value: original,
+      });
+    } else {
+      // jsdom defaults to no matchMedia — restore that.
+      // @ts-expect-error intentionally remove
+      delete window.matchMedia;
+    }
+  };
+}
 
 describe('SwipeActionRow', () => {
   it('keeps the hidden swipe action out of the accessibility tree while closed', () => {
@@ -72,5 +103,60 @@ describe('SwipeActionRow', () => {
 
     const action = screen.getAllByRole('button', { name: 'Archive item' })[0];
     expect(action.closest('[data-swipe-state="closed"]')).not.toBeNull();
+  });
+
+  describe('on non-touch (mouse) devices', () => {
+    let restoreMatchMedia: (() => void) | undefined;
+
+    afterEach(() => {
+      restoreMatchMedia?.();
+      restoreMatchMedia = undefined;
+    });
+
+    it('does not render the swipe overlay or transform the surface', () => {
+      restoreMatchMedia = mockMatchMedia(false);
+
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={() => {}}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      // Only the desktop hover icon button should remain.
+      expect(screen.getAllByRole('button', { name: 'Archive item' })).toHaveLength(1);
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]') as HTMLElement;
+      expect(surface).not.toBeNull();
+      // No inline transform on the surface so nothing slides on a stray touch.
+      expect(surface.style.transform).toBe('');
+    });
+
+    it('keeps state closed even if touch events fire', () => {
+      restoreMatchMedia = mockMatchMedia(false);
+
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={() => {}}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+      expect(surface).not.toBeNull();
+
+      fireEvent.touchStart(surface!, { touches: [{ clientX: 220, clientY: 20 }] });
+      fireEvent.touchMove(surface!, { touches: [{ clientX: 120, clientY: 24 }] });
+      fireEvent.touchEnd(surface!);
+
+      const action = screen.getByRole('button', { name: 'Archive item' });
+      expect(action.closest('[data-swipe-state="closed"]')).not.toBeNull();
+    });
   });
 });

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 const ACTION_WIDTH = 92;
 const OPEN_THRESHOLD = 44;
 const HORIZONTAL_LOCK_THRESHOLD = 12;
+const TOUCH_QUERY = "(pointer: coarse)";
 
 type DragState = {
   startX: number;
@@ -14,6 +15,30 @@ type DragState = {
   swiping: boolean;
   locked: boolean;
 };
+
+// Resolved synchronously on first client render via useSyncExternalStore so
+// non-touch desktops never paint the swipe overlay (which bleeds amber through
+// the row's translucent background). SSR and jsdom (no matchMedia) get the
+// touch-friendly variant — keeps tests passing without mocks.
+function subscribeTouchDevice(callback: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const mql = window.matchMedia(TOUCH_QUERY);
+  mql.addEventListener("change", callback);
+  return () => mql.removeEventListener("change", callback);
+}
+
+function getTouchDeviceSnapshot(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return true;
+  }
+  return window.matchMedia(TOUCH_QUERY).matches;
+}
+
+function getTouchDeviceServerSnapshot(): boolean {
+  return true;
+}
 
 export function SwipeActionRow({
   actionLabel,
@@ -33,20 +58,11 @@ export function SwipeActionRow({
   const dragRef = useRef<DragState | null>(null);
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
-  // Default to true so SSR and test environments (no matchMedia) get the
-  // touch-friendly variant — non-touch desktops flip to false in the effect.
-  const [isTouchDevice, setIsTouchDevice] = useState(true);
-
-  useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-      return;
-    }
-    const mql = window.matchMedia("(pointer: coarse)");
-    setIsTouchDevice(mql.matches);
-    const onChange = (event: MediaQueryListEvent) => setIsTouchDevice(event.matches);
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
+  const isTouchDevice = useSyncExternalStore(
+    subscribeTouchDevice,
+    getTouchDeviceSnapshot,
+    getTouchDeviceServerSnapshot,
+  );
 
   const close = () => {
     setOffset(0);
@@ -110,6 +126,26 @@ export function SwipeActionRow({
   const state = isTouchDevice && offset > 0 ? "open" : "closed";
   const trailingActionHidden = state === "closed";
 
+  const swipeSurfaceProps = isTouchDevice
+    ? {
+        className: cn(
+          "relative z-10 touch-pan-y",
+          !isDragging && "transition-transform duration-200 ease-out",
+        ),
+        style: { transform: `translateX(-${offset}px)` },
+        onTouchStart: handleTouchStart,
+        onTouchMove: handleTouchMove,
+        onTouchEnd: handleTouchEnd,
+        onTouchCancel: handleTouchEnd,
+        onClickCapture: (event: React.MouseEvent<HTMLDivElement>) => {
+          if (offset === 0) return;
+          event.preventDefault();
+          event.stopPropagation();
+          close();
+        },
+      }
+    : { className: "relative z-10" };
+
   return (
     <div
       className={cn("group relative overflow-hidden rounded-lg", className)}
@@ -135,25 +171,7 @@ export function SwipeActionRow({
         </div>
       )}
 
-      <div
-        data-swipe-surface="true"
-        className={cn(
-          "relative z-10",
-          isTouchDevice && "touch-pan-y",
-          isTouchDevice && !isDragging && "transition-transform duration-200 ease-out",
-        )}
-        style={isTouchDevice ? { transform: `translateX(-${offset}px)` } : undefined}
-        onTouchStart={isTouchDevice ? handleTouchStart : undefined}
-        onTouchMove={isTouchDevice ? handleTouchMove : undefined}
-        onTouchEnd={isTouchDevice ? handleTouchEnd : undefined}
-        onTouchCancel={isTouchDevice ? handleTouchEnd : undefined}
-        onClickCapture={(event) => {
-          if (offset === 0) return;
-          event.preventDefault();
-          event.stopPropagation();
-          close();
-        }}
-      >
+      <div data-swipe-surface="true" {...swipeSurfaceProps}>
         {children}
       </div>
 

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -33,6 +33,20 @@ export function SwipeActionRow({
   const dragRef = useRef<DragState | null>(null);
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  // Default to true so SSR and test environments (no matchMedia) get the
+  // touch-friendly variant — non-touch desktops flip to false in the effect.
+  const [isTouchDevice, setIsTouchDevice] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+    const mql = window.matchMedia("(pointer: coarse)");
+    setIsTouchDevice(mql.matches);
+    const onChange = (event: MediaQueryListEvent) => setIsTouchDevice(event.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
 
   const close = () => {
     setOffset(0);
@@ -93,7 +107,7 @@ export function SwipeActionRow({
     close();
   };
 
-  const state = offset > 0 ? "open" : "closed";
+  const state = isTouchDevice && offset > 0 ? "open" : "closed";
   const trailingActionHidden = state === "closed";
 
   return (
@@ -101,35 +115,38 @@ export function SwipeActionRow({
       className={cn("group relative overflow-hidden rounded-lg", className)}
       data-swipe-state={state}
     >
-      <div className="absolute inset-y-0 right-0 flex w-[92px] items-stretch justify-end">
-        <Button
-          aria-label={actionLabel}
-          aria-hidden={trailingActionHidden}
-          tabIndex={trailingActionHidden ? -1 : 0}
-          className="h-full w-full rounded-none rounded-r-lg bg-amber-500 px-0 text-white hover:bg-amber-600 active:bg-amber-600"
-          onClick={() => {
-            close();
-            onAction();
-          }}
-        >
-          <span className="flex flex-col items-center justify-center gap-1 text-xs font-medium">
-            {actionIcon}
-            <span>{actionText}</span>
-          </span>
-        </Button>
-      </div>
+      {isTouchDevice && (
+        <div className="absolute inset-y-0 right-0 flex w-[92px] items-stretch justify-end">
+          <Button
+            aria-label={actionLabel}
+            aria-hidden={trailingActionHidden}
+            tabIndex={trailingActionHidden ? -1 : 0}
+            className="h-full w-full rounded-none rounded-r-lg bg-amber-500 px-0 text-white hover:bg-amber-600 active:bg-amber-600"
+            onClick={() => {
+              close();
+              onAction();
+            }}
+          >
+            <span className="flex flex-col items-center justify-center gap-1 text-xs font-medium">
+              {actionIcon}
+              <span>{actionText}</span>
+            </span>
+          </Button>
+        </div>
+      )}
 
       <div
         data-swipe-surface="true"
         className={cn(
-          "relative z-10 touch-pan-y",
-          !isDragging && "transition-transform duration-200 ease-out",
+          "relative z-10",
+          isTouchDevice && "touch-pan-y",
+          isTouchDevice && !isDragging && "transition-transform duration-200 ease-out",
         )}
-        style={{ transform: `translateX(-${offset}px)` }}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
-        onTouchCancel={handleTouchEnd}
+        style={isTouchDevice ? { transform: `translateX(-${offset}px)` } : undefined}
+        onTouchStart={isTouchDevice ? handleTouchStart : undefined}
+        onTouchMove={isTouchDevice ? handleTouchMove : undefined}
+        onTouchEnd={isTouchDevice ? handleTouchEnd : undefined}
+        onTouchCancel={isTouchDevice ? handleTouchEnd : undefined}
         onClickCapture={(event) => {
           if (offset === 0) return;
           event.preventDefault();


### PR DESCRIPTION
## Summary
- The swipe-to-archive overlay added in #661 was rendering on desktop too: the absolute-positioned amber action button sat behind each row, and the row's `bg-muted/30` surface let it bleed through, making the sidebar look broken.
- `SwipeActionRow` now detects `(pointer: coarse)` via `matchMedia` and only renders the action overlay / attaches touch handlers on touch devices. Mouse-driven viewports keep the existing hover icon button as the sole archive affordance.
- State defaults to "touch" so SSR and Vitest's jsdom (no `matchMedia`) keep getting the swipeable variant — existing component and sidebar tests pass unchanged.

## Test plan
- [x] `vitest run src/components/swipe-action-row.test.tsx` (3 tests)
- [x] `vitest run src/app/(dashboard)/projects/project-sidebar.test.tsx src/app/(dashboard)/sessions/session-sidebar.test.tsx` (55 tests)
- [x] `tsc --noEmit`
- [ ] Manual: confirm desktop sidebar rows no longer show the amber overlay; confirm iOS swipe-to-archive still works on session and project sidebars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
