### PR TITLE
Add iOS-style full-swipe to auto-archive sessions

### DIFF
--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -102,7 +102,8 @@ describe('SwipeActionRow', () => {
       touches: [{ clientX: 100, clientY: 24 }],
     });
 
-    expect(surface!.closest('[data-swipe-state="committed"]')).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).toHaveAttribute('data-swipe-state', 'committed');
 
     fireEvent.touchEnd(surface!);
     expect(onAction).toHaveBeenCalledTimes(1);
@@ -133,7 +134,8 @@ describe('SwipeActionRow', () => {
     fireEvent.touchCancel(surface!);
 
     expect(onAction).not.toHaveBeenCalled();
-    expect(surface!.closest('[data-swipe-state="closed"]')).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).toHaveAttribute('data-swipe-state', 'closed');
   });
 
   it('does not open for mostly vertical movement', () => {

--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -108,6 +108,34 @@ describe('SwipeActionRow', () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it('does not auto-fire the action when a committed swipe is cancelled', () => {
+    const onAction = vi.fn();
+
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={onAction}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 320, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 100, clientY: 24 }],
+    });
+    fireEvent.touchCancel(surface!);
+
+    expect(onAction).not.toHaveBeenCalled();
+    expect(surface!.closest('[data-swipe-state="closed"]')).not.toBeNull();
+  });
+
   it('does not open for mostly vertical movement', () => {
     renderWithProviders(
       <SwipeActionRow

--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -79,6 +79,35 @@ describe('SwipeActionRow', () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it('auto-fires the action when released past the commit threshold', () => {
+    const onAction = vi.fn();
+
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={onAction}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 320, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 100, clientY: 24 }],
+    });
+
+    expect(surface!.closest('[data-swipe-state="committed"]')).not.toBeNull();
+
+    fireEvent.touchEnd(surface!);
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
   it('does not open for mostly vertical movement', () => {
     renderWithProviders(
       <SwipeActionRow

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useRef, useState, useSyncExternalStore, type ReactNode } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
@@ -8,6 +15,9 @@ const ACTION_WIDTH = 92;
 const OPEN_THRESHOLD = 44;
 const HORIZONTAL_LOCK_THRESHOLD = 12;
 const TOUCH_QUERY = "(pointer: coarse)";
+const COMMIT_THRESHOLD_RATIO = 0.5;
+const MIN_COMMIT_THRESHOLD = 140;
+const COMMIT_ANIMATION_MS = 220;
 
 type DragState = {
   startX: number;
@@ -40,6 +50,17 @@ function getTouchDeviceServerSnapshot(): boolean {
   return true;
 }
 
+function vibrate(pattern: number | number[]) {
+  if (typeof navigator === "undefined") return;
+  // iOS Safari does not implement the Vibration API; this is a no-op there.
+  if (typeof navigator.vibrate !== "function") return;
+  try {
+    navigator.vibrate(pattern);
+  } catch {
+    // ignore
+  }
+}
+
 export function SwipeActionRow({
   actionLabel,
   actionText,
@@ -55,25 +76,72 @@ export function SwipeActionRow({
   children: ReactNode;
   className?: string;
 }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
+  const commitTimerRef = useRef<number | null>(null);
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [isCommitted, setIsCommitted] = useState(false);
+  const [containerWidth, setContainerWidth] = useState(0);
   const isTouchDevice = useSyncExternalStore(
     subscribeTouchDevice,
     getTouchDeviceSnapshot,
     getTouchDeviceServerSnapshot,
   );
 
+  useLayoutEffect(() => {
+    const node = containerRef.current;
+    if (!node) return;
+    const update = () => setContainerWidth(node.offsetWidth);
+    update();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (commitTimerRef.current !== null) {
+        window.clearTimeout(commitTimerRef.current);
+      }
+    };
+  }, []);
+
+  const commitThreshold = Math.max(
+    MIN_COMMIT_THRESHOLD,
+    containerWidth * COMMIT_THRESHOLD_RATIO,
+  );
+  const maxOffset = containerWidth > 0 ? containerWidth : ACTION_WIDTH * 4;
+
   const close = () => {
     setOffset(0);
     setIsDragging(false);
+    setIsCommitted(false);
     dragRef.current = null;
   };
 
   const open = () => {
     setOffset(ACTION_WIDTH);
     setIsDragging(false);
+    setIsCommitted(false);
     dragRef.current = null;
+  };
+
+  const commitAction = () => {
+    setIsDragging(false);
+    setOffset(maxOffset);
+    dragRef.current = null;
+    vibrate([15, 30, 40]);
+    onAction();
+    if (commitTimerRef.current !== null) {
+      window.clearTimeout(commitTimerRef.current);
+    }
+    commitTimerRef.current = window.setTimeout(() => {
+      setOffset(0);
+      setIsCommitted(false);
+      commitTimerRef.current = null;
+    }, COMMIT_ANIMATION_MS);
   };
 
   const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
@@ -111,11 +179,24 @@ export function SwipeActionRow({
 
     if (!drag.swiping) return;
 
-    const nextOffset = Math.max(0, Math.min(ACTION_WIDTH, -deltaX));
+    const nextOffset = Math.max(0, Math.min(maxOffset, -deltaX));
     setOffset(nextOffset);
+
+    const willCommit = nextOffset >= commitThreshold;
+    if (willCommit !== isCommitted) {
+      setIsCommitted(willCommit);
+      if (willCommit) {
+        // Light tick when the user crosses into the auto-commit zone.
+        vibrate(8);
+      }
+    }
   };
 
   const handleTouchEnd = () => {
+    if (offset >= commitThreshold) {
+      commitAction();
+      return;
+    }
     if (offset >= OPEN_THRESHOLD) {
       open();
       return;
@@ -123,8 +204,14 @@ export function SwipeActionRow({
     close();
   };
 
-  const state = isTouchDevice && offset > 0 ? "open" : "closed";
+  const state =
+    isTouchDevice && offset > 0
+      ? isCommitted
+        ? "committed"
+        : "open"
+      : "closed";
   const trailingActionHidden = state === "closed";
+  const actionAreaWidth = Math.max(ACTION_WIDTH, offset);
 
   const swipeSurfaceProps = isTouchDevice
     ? {
@@ -148,22 +235,36 @@ export function SwipeActionRow({
 
   return (
     <div
+      ref={containerRef}
       className={cn("group relative overflow-hidden rounded-lg", className)}
       data-swipe-state={state}
     >
       {isTouchDevice && (
-        <div className="absolute inset-y-0 right-0 flex w-[92px] items-stretch justify-end">
+        <div
+          className="absolute inset-y-0 right-0"
+          style={{ width: `${actionAreaWidth}px` }}
+        >
           <Button
             aria-label={actionLabel}
             aria-hidden={trailingActionHidden}
             tabIndex={trailingActionHidden ? -1 : 0}
-            className="h-full w-full rounded-none rounded-r-lg bg-amber-500 px-0 text-white hover:bg-amber-600 active:bg-amber-600"
+            className={cn(
+              "h-full w-full rounded-none rounded-r-lg px-0 text-white transition-colors duration-150",
+              isCommitted
+                ? "bg-amber-600 hover:bg-amber-700 active:bg-amber-700"
+                : "bg-amber-500 hover:bg-amber-600 active:bg-amber-600",
+            )}
             onClick={() => {
               close();
               onAction();
             }}
           >
-            <span className="flex flex-col items-center justify-center gap-1 text-xs font-medium">
+            <span
+              className={cn(
+                "flex flex-col items-center justify-center gap-1 text-xs font-medium transition-transform duration-150",
+                isCommitted && "scale-110",
+              )}
+            >
               {actionIcon}
               <span>{actionText}</span>
             </span>

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -204,6 +204,10 @@ export function SwipeActionRow({
     close();
   };
 
+  const handleTouchCancel = () => {
+    close();
+  };
+
   const state =
     isTouchDevice && offset > 0
       ? isCommitted
@@ -223,7 +227,7 @@ export function SwipeActionRow({
         onTouchStart: handleTouchStart,
         onTouchMove: handleTouchMove,
         onTouchEnd: handleTouchEnd,
-        onTouchCancel: handleTouchEnd,
+        onTouchCancel: handleTouchCancel,
         onClickCapture: (event: React.MouseEvent<HTMLDivElement>) => {
           if (offset === 0) return;
           event.preventDefault();

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -2,7 +2,6 @@
 
 import {
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   useSyncExternalStore,
@@ -18,10 +17,14 @@ const TOUCH_QUERY = "(pointer: coarse)";
 const COMMIT_THRESHOLD_RATIO = 0.5;
 const MIN_COMMIT_THRESHOLD = 140;
 const COMMIT_ANIMATION_MS = 220;
+// Pre-measurement fallback when a gesture starts before the row has dimensions.
+// Real width is captured from offsetWidth at touchstart.
+const FALLBACK_ROW_WIDTH = ACTION_WIDTH * 4;
 
 type DragState = {
   startX: number;
   startY: number;
+  width: number;
   swiping: boolean;
   locked: boolean;
 };
@@ -61,6 +64,10 @@ function vibrate(pattern: number | number[]) {
   }
 }
 
+function commitThresholdFor(width: number) {
+  return Math.max(MIN_COMMIT_THRESHOLD, width * COMMIT_THRESHOLD_RATIO);
+}
+
 export function SwipeActionRow({
   actionLabel,
   actionText,
@@ -79,26 +86,17 @@ export function SwipeActionRow({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const commitTimerRef = useRef<number | null>(null);
+  // Mirrors isCommitted for use inside touchmove handlers, where the rendered
+  // closure can lag behind rapid state transitions.
+  const committedRef = useRef(false);
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const [isCommitted, setIsCommitted] = useState(false);
-  const [containerWidth, setContainerWidth] = useState(0);
   const isTouchDevice = useSyncExternalStore(
     subscribeTouchDevice,
     getTouchDeviceSnapshot,
     getTouchDeviceServerSnapshot,
   );
-
-  useLayoutEffect(() => {
-    const node = containerRef.current;
-    if (!node) return;
-    const update = () => setContainerWidth(node.offsetWidth);
-    update();
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(update);
-    ro.observe(node);
-    return () => ro.disconnect();
-  }, []);
 
   useEffect(() => {
     return () => {
@@ -108,16 +106,11 @@ export function SwipeActionRow({
     };
   }, []);
 
-  const commitThreshold = Math.max(
-    MIN_COMMIT_THRESHOLD,
-    containerWidth * COMMIT_THRESHOLD_RATIO,
-  );
-  const maxOffset = containerWidth > 0 ? containerWidth : ACTION_WIDTH * 4;
-
   const close = () => {
     setOffset(0);
     setIsDragging(false);
     setIsCommitted(false);
+    committedRef.current = false;
     dragRef.current = null;
   };
 
@@ -125,13 +118,18 @@ export function SwipeActionRow({
     setOffset(ACTION_WIDTH);
     setIsDragging(false);
     setIsCommitted(false);
+    committedRef.current = false;
     dragRef.current = null;
   };
 
-  const commitAction = () => {
+  // Slides the row fully off, fires onAction, then resets after the animation.
+  // Common case: onAction unmounts the row and the unmount effect clears the
+  // timer. Fallback: caller keeps the row mounted, the timer snaps offset back.
+  const commitAction = (width: number) => {
     setIsDragging(false);
-    setOffset(maxOffset);
+    setOffset(width);
     dragRef.current = null;
+    committedRef.current = false;
     vibrate([15, 30, 40]);
     onAction();
     if (commitTimerRef.current !== null) {
@@ -147,9 +145,16 @@ export function SwipeActionRow({
   const handleTouchStart = (event: React.TouchEvent<HTMLDivElement>) => {
     const touch = event.touches[0];
     if (!touch) return;
+    // Cancel a pending post-commit reset so a quick follow-up swipe isn't
+    // clobbered by the trailing setTimeout firing mid-gesture.
+    if (commitTimerRef.current !== null) {
+      window.clearTimeout(commitTimerRef.current);
+      commitTimerRef.current = null;
+    }
     dragRef.current = {
       startX: touch.clientX,
       startY: touch.clientY,
+      width: containerRef.current?.offsetWidth || FALLBACK_ROW_WIDTH,
       swiping: false,
       locked: false,
     };
@@ -179,11 +184,12 @@ export function SwipeActionRow({
 
     if (!drag.swiping) return;
 
-    const nextOffset = Math.max(0, Math.min(maxOffset, -deltaX));
+    const nextOffset = Math.max(0, Math.min(drag.width, -deltaX));
     setOffset(nextOffset);
 
-    const willCommit = nextOffset >= commitThreshold;
-    if (willCommit !== isCommitted) {
+    const willCommit = nextOffset >= commitThresholdFor(drag.width);
+    if (willCommit !== committedRef.current) {
+      committedRef.current = willCommit;
       setIsCommitted(willCommit);
       if (willCommit) {
         // Light tick when the user crosses into the auto-commit zone.
@@ -193,8 +199,12 @@ export function SwipeActionRow({
   };
 
   const handleTouchEnd = () => {
-    if (offset >= commitThreshold) {
-      commitAction();
+    const width =
+      dragRef.current?.width ??
+      containerRef.current?.offsetWidth ??
+      FALLBACK_ROW_WIDTH;
+    if (offset >= commitThresholdFor(width)) {
+      commitAction(width);
       return;
     }
     if (offset >= OPEN_THRESHOLD) {


### PR DESCRIPTION
## Summary
- Swipe a session past ~50% of the row width (min 140px) and release to auto-archive, matching iOS Mail. Sub-threshold swipes still snap open to the existing tap-to-archive button.
- Visual commit indication: the amber action area expands with the swipe, deepens (amber-500 to amber-600), and the icon/label scale to 110% once you cross the threshold.
- Haptics via `navigator.vibrate()` - a light tick on threshold cross and a pulse on commit. Works on Android Chrome/Edge/Firefox; iOS Safari does not implement the Web Vibration API, so it is a silent no-op there (the visual feedback carries the affordance).

## Test plan
- [x] `vitest run swipe-action-row` - 4 tests pass (added one for commit-on-release)
- [x] `eslint` + `tsc --noEmit` clean
- [ ] Manual: on a touch device, swipe a session row past halfway and release; row archives without tapping the button
- [ ] Manual: short swipe still reveals the Archive button and requires a tap
- [ ] Manual on Android: feel the vibration tick at threshold and pulse on commit

Generated with [Claude Code](https://claude.com/claude-code)
