### PR TITLE
Add Push changes button for follow-up commits to an open PR

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2091,6 +2091,137 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  // Regression: when the OAuth callback signs an `Action` claim into the
+  // resume token, the redirect forwards it as resume_action. The frontend
+  // must dispatch the matching mutation (push vs create) deterministically,
+  // even when the current PR state would otherwise lead to the opposite
+  // branch — e.g. another tab created the PR during the OAuth round-trip,
+  // so by the time we replay there's a PR but the original click was
+  // "Create PR". We trust the signed action over the live state.
+  it('auto-resumes Push changes when resume_action=push_changes is in the URL', async () => {
+    const createBodies: unknown[] = [];
+    const pushBodies: unknown[] = [];
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'succeeded',
+      pr_push_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json({
+          data: {
+            id: 'pr-1',
+            session_id: 'session-abcdef12-3456-7890',
+            org_id: sessionWithDiff.org_id,
+            github_pr_number: 42,
+            github_pr_url: 'https://github.com/example/repo/pull/42',
+            github_repo: 'example/repo',
+            title: 'Fix bug',
+            status: 'open',
+            review_status: 'pending',
+            authored_by: 'app',
+            ci_status: 'pending',
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        });
+      }),
+      http.get('/api/v1/users/me/github-status', () => {
+        return HttpResponse.json({
+          connected: true,
+          has_repo_scope: true,
+          github_login: 'alice',
+          pr_authorship_mode: 'user_preferred',
+          pr_draft_default: false,
+        });
+      }),
+      http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
+        createBodies.push(await request.json().catch(() => undefined));
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+      http.post('/api/v1/sessions/:id/pr/push', async ({ request }) => {
+        pushBodies.push(await request.json().catch(() => undefined));
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />, {
+      searchParams: { github_pr: 'connected', resume_pr: 'resume-push-1', resume_action: 'push_changes' },
+    });
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    await waitFor(() => {
+      expect(pushBodies).toEqual([{ author_mode: 'user', resume_token: 'resume-push-1' }]);
+    });
+    expect(createBodies).toEqual([]);
+  });
+
+  // Mirror of the push case: an explicit resume_action=create_pr must dispatch
+  // the create mutation even if a PR somehow appeared during the OAuth
+  // round-trip. The state-based fallback would route to push in that
+  // scenario; the signed action overrides.
+  it('auto-resumes Create PR when resume_action=create_pr is in the URL', async () => {
+    const createBodies: unknown[] = [];
+    const pushBodies: unknown[] = [];
+
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      pr_creation_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.get('/api/v1/users/me/github-status', () => {
+        return HttpResponse.json({
+          connected: true,
+          has_repo_scope: true,
+          github_login: 'alice',
+          pr_authorship_mode: 'user_preferred',
+          pr_draft_default: false,
+        });
+      }),
+      http.post('/api/v1/sessions/:id/pr', async ({ request }) => {
+        createBodies.push(await request.json().catch(() => undefined));
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+      http.post('/api/v1/sessions/:id/pr/push', async ({ request }) => {
+        pushBodies.push(await request.json().catch(() => undefined));
+        return HttpResponse.json({ status: 'queued' }, { status: 202 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />, {
+      searchParams: { github_pr: 'connected', resume_pr: 'resume-create-1', resume_action: 'create_pr' },
+    });
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    await waitFor(() => {
+      expect(createBodies).toEqual([{ author_mode: 'user', resume_token: 'resume-create-1' }]);
+    });
+    expect(pushBodies).toEqual([]);
+  });
+
   it('keeps a creating state until the pull request exists, then swaps to View PR', async () => {
     let sessionFetchCount = 0;
     const queuedSession: Session = {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -28,7 +28,6 @@ import {
   MessageSquare,
   Paperclip,
   Pencil,
-  Upload,
 } from "lucide-react";
 import { notify as toast } from "@/lib/notify";
 import { Badge } from "@/components/ui/badge";
@@ -2539,9 +2538,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   }
 
   // Push-changes button derived state. Mirrors the PR creation block above
-  // but operates on session.pr_push_state. Shown next to "View PR" when the
-  // session has an open PR; the backend exits cleanly with "no changes" if
-  // there is nothing to push, so we don't gate on a frontend-side dirty
+  // but operates on session.pr_push_state. Rendered inside the PR health
+  // banner alongside Resolve conflicts / Fix tests / Merge so all PR-level
+  // actions live in one place; the backend exits cleanly with "no changes"
+  // if there is nothing to push, so we don't gate on a frontend-side dirty
   // check.
   const pushAvailable = hasPR && prStatus === "open";
   const pushState = session.pr_push_state;
@@ -2657,27 +2657,6 @@ export function SessionDetailContent({ id }: { id: string }) {
                     PR closed
                   </Badge>
                 )}
-                {showPushAction && (
-                  <DisabledTooltip disabled={pushActionDisabled} content={pushActionTitle}>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 text-xs gap-1.5"
-                      disabled={pushActionDisabled}
-                      title={pushActionTitle}
-                      onClick={() => pushChangesMutation.mutate(undefined)}
-                    >
-                      {pushActionSpinning ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : pushState === "failed" || localPushActionError ? (
-                        <AlertTriangle className="h-3 w-3" />
-                      ) : (
-                        <Upload className="h-3 w-3" />
-                      )}
-                      {pushActionLabel}
-                    </Button>
-                  </DisabledTooltip>
-                )}
                 <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
                   <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
                     <ExternalLink className="h-3 w-3" />
@@ -2748,6 +2727,14 @@ export function SessionDetailContent({ id }: { id: string }) {
                 onFixTests={() => startRepairMutation.mutate("fix_tests")}
                 onResolveConflicts={() => startRepairMutation.mutate("resolve_conflicts")}
                 onMerge={handleMergeAction}
+                pushChanges={showPushAction ? {
+                  label: pushActionLabel,
+                  disabled: pushActionDisabled,
+                  spinning: pushActionSpinning,
+                  showError: pushState === "failed" || !!localPushActionError,
+                  title: pushActionTitle,
+                  onClick: () => pushChangesMutation.mutate(undefined),
+                } : undefined}
               />
             ) : isPRHealthLoading ? (
               <Card className="border-border/60">

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -28,6 +28,7 @@ import {
   MessageSquare,
   Paperclip,
   Pencil,
+  Upload,
 } from "lucide-react";
 import { notify as toast } from "@/lib/notify";
 import { Badge } from "@/components/ui/badge";
@@ -189,11 +190,12 @@ type PRAuthInterceptDetails = {
 
 // PRAuthPromptState is a discriminated union so merge prompts don't carry
 // create-PR-only fields (connect_url, resume_token, can_fallback_to_app).
-// create_pr prompts come from the backend's auth interception payload; merge
-// prompts are always synthesized client-side and connect via the hardcoded
-// /github/connect endpoint with no resume token and no fallback.
+// create_pr and push_changes prompts come from the backend's auth interception
+// payload; merge prompts are always synthesized client-side and connect via
+// the hardcoded /github/connect endpoint with no resume token and no fallback.
 type PRAuthPromptState =
   | ({ purpose: "create_pr" } & PRAuthInterceptDetails)
+  | ({ purpose: "push_changes" } & PRAuthInterceptDetails)
   | { purpose: "merge_pr" };
 
 type PRActionErrorState = {
@@ -1671,6 +1673,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [reviewParam, setReviewParam] = useQueryState("review");
   const [previewParam, setPreviewParam] = useQueryState("preview");
   const [resumePRParam, setResumePRParam] = useQueryState("resume_pr");
+  const [resumeActionParam, setResumeActionParam] = useQueryState("resume_action");
   const [githubPRParam, setGithubPRParam] = useQueryState("github_pr");
   const centerMode = reviewParam === "active" ? "review" : "chat";
   const [detailTab, setDetailTab] = useState<DetailTab>(
@@ -1746,6 +1749,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   }, [centerMode, exitReview, setPreviewParam]);
   const [localPRState, setLocalPRState] = useState<"idle" | "submitting" | "queued">("idle");
   const [localPRActionError, setLocalPRActionError] = useState<PRActionErrorState | null>(null);
+  const [localPushState, setLocalPushState] = useState<"idle" | "submitting" | "queued">("idle");
+  const [localPushActionError, setLocalPushActionError] = useState<PRActionErrorState | null>(null);
   const [pendingPRAction, setPendingPRAction] = useState<"fix_tests" | "resolve_conflicts" | "merge" | null>(null);
   const [repairActionError, setRepairActionError] = useState<string | null>(null);
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthPromptState | null>(null);
@@ -1762,12 +1767,16 @@ export function SessionDetailContent({ id }: { id: string }) {
       const waitingForServer = localPRState !== "idle" &&
         s.pr_creation_state !== "failed" &&
         s.pr_creation_state !== "succeeded";
+      const pushInFlight = s.pr_push_state === "queued" || s.pr_push_state === "pushing";
+      const waitingForPushServer = localPushState !== "idle" &&
+        s.pr_push_state !== "failed" &&
+        s.pr_push_state !== "succeeded";
 
-      // Poll while PR creation is in flight so the state machine advances
-      // without waiting for the user to navigate. Keep polling during the
-      // optimistic local phases too, since the best-effort queued write can
-      // legitimately lag the 202 response.
-      return serverInFlight || waitingForServer ? 2000 : false;
+      // Poll while PR creation OR push-changes is in flight so the state
+      // machine advances without waiting for the user to navigate. Keep
+      // polling during the optimistic local phases too, since the best-effort
+      // queued write can legitimately lag the 202 response.
+      return serverInFlight || waitingForServer || pushInFlight || waitingForPushServer ? 2000 : false;
     },
   });
 
@@ -1883,6 +1892,34 @@ export function SessionDetailContent({ id }: { id: string }) {
     }
     prevPRUrlRef.current = prUrl;
   }, [localPRState, prUrl, session?.pr_creation_state]);
+
+  // React to pr_push_state transitions with toast feedback. Mirrors the
+  // pr_creation_state effect above; kept separate so the two operations'
+  // success/error messages don't collide when both fire on the same render.
+  // Also clears localPushState when the server transitions out of in-flight
+  // so the button returns to "Push changes" promptly without waiting for the
+  // next polling tick.
+  const prevPRPushStateRef = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const prev = prevPRPushStateRef.current;
+    const current = session?.pr_push_state;
+    if (prev && current && prev !== current) {
+      if (current === "succeeded") {
+        queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
+        if (pullRequestId) {
+          queryClient.invalidateQueries({ queryKey: ["pull-request", pullRequestId, "health"] });
+        }
+        setLocalPushState("idle");
+        toast.success("Changes pushed to PR", prUrl ? {
+          action: { label: "View \u2197", onClick: () => window.open(prUrl, "_blank", "noopener,noreferrer") },
+        } : undefined);
+      } else if (current === "failed") {
+        setLocalPushState("idle");
+        toast.error(session?.pr_push_error || "Push to PR failed", { duration: PR_ERROR_TOAST_DURATION_MS });
+      }
+    }
+    prevPRPushStateRef.current = current;
+  }, [session?.pr_push_state, session?.pr_push_error, prUrl, queryClient, id, pullRequestId]);
   const startRepairMutation = useMutation({
     mutationFn: async (action: "fix_tests" | "resolve_conflicts") => {
       if (!pullRequestId) {
@@ -2045,10 +2082,11 @@ export function SessionDetailContent({ id }: { id: string }) {
 
   const clearPRResumeParams = useCallback(() => {
     void setResumePRParam(null);
+    void setResumeActionParam(null);
     if (githubPRParam === "connected") {
       void setGithubPRParam(null);
     }
-  }, [githubPRParam, setGithubPRParam, setResumePRParam]);
+  }, [githubPRParam, setGithubPRParam, setResumePRParam, setResumeActionParam]);
 
   const createPRMutation = useMutation({
     mutationFn: (options?: { draft?: boolean; authorMode?: PRAuthorMode; resumeToken?: string }) =>
@@ -2089,12 +2127,70 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
   });
 
+  const pushChangesMutation = useMutation({
+    mutationFn: (options?: { authorMode?: PRAuthorMode; resumeToken?: string }) =>
+      api.sessions.pushChangesToPR(id, options),
+    onMutate: () => {
+      setLocalPushActionError(null);
+      setLocalPushState("submitting");
+    },
+    onSuccess: (_data, options) => {
+      setLocalPushActionError(null);
+      setLocalPushState("queued");
+      if (options?.resumeToken) {
+        clearPRResumeParams();
+      }
+      queryClient.invalidateQueries({ queryKey: ["session", id] });
+    },
+    onError: (err, options) => {
+      if (err instanceof ApiError &&
+        (err.code === "GITHUB_PR_AUTHORSHIP_REQUIRED" || err.code === "GITHUB_PR_AUTHORSHIP_REAUTH_REQUIRED") &&
+        isPRAuthInterceptDetails(err.details)) {
+        setLocalPushState("idle");
+        setLocalPushActionError(null);
+        setPRAuthPrompt({ ...err.details, purpose: "push_changes" });
+        clearPRResumeParams();
+        return;
+      }
+      setLocalPushState("idle");
+      const msg = err instanceof Error ? err.message : "Push to PR failed";
+      setLocalPushActionError({
+        code: err instanceof ApiError ? err.code : undefined,
+        message: msg,
+      });
+      if (options?.resumeToken) {
+        clearPRResumeParams();
+      }
+      toast.error(msg, { duration: PR_ERROR_TOAST_DURATION_MS });
+    },
+  });
+
   useEffect(() => {
-    if (!canCreatePR || !resumePRParam) return;
+    if (!resumePRParam) return;
     if (resumeAttemptRef.current === resumePRParam) return;
+    // Prefer the action recorded in the resume_action URL param: it was
+    // signed into the resume token at the originating endpoint and forwarded
+    // by the OAuth callback, so the replay is deterministic regardless of
+    // any state change during the GitHub round-trip (e.g. another tab
+    // creating the PR, or the PR getting closed). Fall back to the current
+    // PR state for legacy tokens that predate the resume_action param.
+    const action: "create_pr" | "push_changes" =
+      resumeActionParam === "push_changes"
+        ? "push_changes"
+        : resumeActionParam === "create_pr"
+          ? "create_pr"
+          : hasPR && prStatus === "open"
+            ? "push_changes"
+            : "create_pr";
+    if (action === "push_changes") {
+      resumeAttemptRef.current = resumePRParam;
+      pushChangesMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
+      return;
+    }
+    if (!canCreatePR) return;
     resumeAttemptRef.current = resumePRParam;
     createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
-  }, [canCreatePR, createPRMutation, resumePRParam]);
+  }, [canCreatePR, createPRMutation, hasPR, prStatus, pushChangesMutation, resumeActionParam, resumePRParam]);
 
   const sessionDiff = session?.diff;
   const diffStats = useMemo(() => {
@@ -2442,6 +2538,51 @@ export function SessionDetailContent({ id }: { id: string }) {
     prActionTitle = "Connect your GitHub account to create PRs";
   }
 
+  // Push-changes button derived state. Mirrors the PR creation block above
+  // but operates on session.pr_push_state. Shown next to "View PR" when the
+  // session has an open PR; the backend exits cleanly with "no changes" if
+  // there is nothing to push, so we don't gate on a frontend-side dirty
+  // check.
+  const pushAvailable = hasPR && prStatus === "open";
+  const pushState = session.pr_push_state;
+  const queueingPush = localPushState === "submitting";
+  const pushingChanges =
+    (localPushState === "queued" && pushState !== "failed" && pushState !== "succeeded") ||
+    pushState === "queued" ||
+    pushState === "pushing";
+  const canPushChanges = pushAvailable && hasSnapshot && !isRunning;
+  const showPushAction = pushAvailable && (canPushChanges || queueingPush || pushingChanges || pushState === "failed" || localPushActionError);
+  let pushActionLabel = "Push changes";
+  let pushActionSpinning = false;
+  let pushActionDisabled = false;
+  let pushActionTitle: string | undefined;
+  if (queueingPush) {
+    pushActionLabel = "Queueing…";
+    pushActionSpinning = true;
+    pushActionDisabled = true;
+    pushActionTitle = "Sending the push request to the queue";
+  } else if (pushingChanges) {
+    pushActionLabel = "Pushing…";
+    pushActionSpinning = true;
+    pushActionDisabled = true;
+    pushActionTitle = "Pushing changes to the PR branch";
+  } else if (snapshotUnavailable) {
+    pushActionDisabled = true;
+    pushActionTitle = snapshotMessage;
+  } else if (localPushActionError) {
+    pushActionLabel = "Retry";
+    pushActionTitle = localPushActionError.message;
+  } else if (pushState === "failed") {
+    pushActionLabel = "Retry";
+    pushActionTitle = session.pr_push_error || "Push to PR failed";
+  } else if (ghBlocked) {
+    pushActionDisabled = true;
+    pushActionTitle = "Connect your GitHub account to push changes";
+  } else if (isRunning) {
+    pushActionDisabled = true;
+    pushActionTitle = "Wait for the session to finish before pushing";
+  }
+
   function handleMergeAction() {
     if (ghBlocked) {
       setPRAuthPrompt({ purpose: "merge_pr" });
@@ -2515,6 +2656,27 @@ export function SessionDetailContent({ id }: { id: string }) {
                   <Badge variant="secondary" className="h-7 px-2 text-xs">
                     PR closed
                   </Badge>
+                )}
+                {showPushAction && (
+                  <DisabledTooltip disabled={pushActionDisabled} content={pushActionTitle}>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7 text-xs gap-1.5"
+                      disabled={pushActionDisabled}
+                      title={pushActionTitle}
+                      onClick={() => pushChangesMutation.mutate(undefined)}
+                    >
+                      {pushActionSpinning ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : pushState === "failed" || localPushActionError ? (
+                        <AlertTriangle className="h-3 w-3" />
+                      ) : (
+                        <Upload className="h-3 w-3" />
+                      )}
+                      {pushActionLabel}
+                    </Button>
+                  </DisabledTooltip>
                 )}
                 <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
                   <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
@@ -2900,12 +3062,16 @@ export function SessionDetailContent({ id }: { id: string }) {
             <AlertDialogTitle>
               {prAuthPrompt?.purpose === "merge_pr"
                 ? "Merge this pull request as yourself?"
-                : "Open this pull request as yourself?"}
+                : prAuthPrompt?.purpose === "push_changes"
+                  ? "Push these changes as yourself?"
+                  : "Open this pull request as yourself?"}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {prAuthPrompt?.purpose === "merge_pr"
                 ? "Authorize GitHub once to merge pull requests as you."
-                : "Authorize GitHub once to open PRs as you. If you skip this, 143 can still open the PR as the app."}
+                : prAuthPrompt?.purpose === "push_changes"
+                  ? "Authorize GitHub once to push as you. If you skip this, 143 can still push the commits as the app."
+                  : "Authorize GitHub once to open PRs as you. If you skip this, 143 can still open the PR as the app."}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -2920,12 +3086,25 @@ export function SessionDetailContent({ id }: { id: string }) {
                 Create as 143
               </AlertDialogCancel>
             ) : null}
+            {prAuthPrompt?.purpose === "push_changes" && prAuthPrompt.can_fallback_to_app ? (
+              <AlertDialogCancel
+                onClick={(event) => {
+                  event.preventDefault();
+                  setPRAuthPrompt(null);
+                  pushChangesMutation.mutate({ authorMode: "app" });
+                }}
+              >
+                Push as 143
+              </AlertDialogCancel>
+            ) : null}
             <AlertDialogAction
               onClick={(event) => {
                 event.preventDefault();
                 if (!prAuthPrompt) return;
                 const resumeToken =
-                  prAuthPrompt.purpose === "create_pr" ? prAuthPrompt.resume_token : undefined;
+                  prAuthPrompt.purpose === "create_pr" || prAuthPrompt.purpose === "push_changes"
+                    ? prAuthPrompt.resume_token
+                    : undefined;
                 api.githubStatus.connect(resumeToken || undefined);
               }}
             >

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2182,6 +2182,14 @@ export function SessionDetailContent({ id }: { id: string }) {
             ? "push_changes"
             : "create_pr";
     if (action === "push_changes") {
+      // Mirror the canCreatePR gate on the create branch: don't fire the
+      // mutation until the session has a snapshot and isn't mid-turn.
+      // Without this, the OAuth callback firing while the session is still
+      // running would land an immediate 409 (or stale-snapshot error). The
+      // effect re-runs when these dependencies flip, so the replay still
+      // happens — just on the next tick when the session is actually ready.
+      const pushAvailable = hasPR && prStatus === "open";
+      if (!pushAvailable || !hasSnapshot || isRunning) return;
       resumeAttemptRef.current = resumePRParam;
       pushChangesMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
       return;
@@ -2189,7 +2197,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     if (!canCreatePR) return;
     resumeAttemptRef.current = resumePRParam;
     createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
-  }, [canCreatePR, createPRMutation, hasPR, prStatus, pushChangesMutation, resumeActionParam, resumePRParam]);
+  }, [canCreatePR, createPRMutation, hasPR, hasSnapshot, isRunning, prStatus, pushChangesMutation, resumeActionParam, resumePRParam]);
 
   const sessionDiff = session?.diff;
   const diffStats = useMemo(() => {

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -316,4 +316,83 @@ describe("PRHealthBanner", () => {
     expect(screen.getByRole("button", { name: "Resolve conflicts" })).toBeInTheDocument();
     expect(screen.queryByText(/^conflicts$/)).toBeNull();
   });
+
+  it("renders a Push changes button when pushChanges is provided and triggers onClick", async () => {
+    const onClick = vi.fn();
+    renderWithProviders(
+      <PRHealthBanner
+        health={baseHealth}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        pushChanges={{
+          label: "Push changes",
+          disabled: false,
+          spinning: false,
+          showError: false,
+          onClick,
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: "Push changes" });
+    expect(button).toBeEnabled();
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the Push changes button while another action is pending", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          can_resolve_conflicts: true,
+        }}
+        pendingAction="resolve_conflicts"
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        pushChanges={{
+          label: "Push changes",
+          disabled: false,
+          spinning: false,
+          showError: false,
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Push changes" })).toBeDisabled();
+  });
+
+  it("renders the Push changes button in spinning/Pushing state and disables it", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={baseHealth}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        pushChanges={{
+          label: "Pushing…",
+          disabled: true,
+          spinning: true,
+          showError: false,
+          onClick: vi.fn(),
+          title: "Pushing changes to the PR branch",
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /Pushing/ });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("title", "Pushing changes to the PR branch");
+  });
 });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, CheckCircle2, ExternalLink, GitMerge, GitPullRequest, Loader2, Wrench } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ExternalLink, GitMerge, GitPullRequest, Loader2, Upload, Wrench } from "lucide-react";
 
 import type { PullRequestHealthResponse } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,19 @@ import { SyncTimeText } from "@/components/sync-time-text";
 export type PRBannerAction = "fix_tests" | "resolve_conflicts" | "merge" | null;
 type PullRequestCheckStatus = NonNullable<PullRequestHealthResponse["checks"]>[number]["status"];
 
+// PushChangesAction is the descriptor the parent passes when a push-to-PR
+// button should appear in the banner's action row. The parent owns the full
+// state machine (idle/queueing/pushing/failed/retry); the banner renders
+// what it's told. Nullish means the button is hidden — render nothing.
+export type PushChangesAction = {
+  label: string;
+  disabled: boolean;
+  spinning: boolean;
+  showError: boolean;
+  title?: string;
+  onClick: () => void;
+};
+
 type PRHealthBannerProps = {
   health: PullRequestHealthResponse;
   pendingAction: PRBannerAction;
@@ -25,6 +38,7 @@ type PRHealthBannerProps = {
   onFixTests: () => void;
   onResolveConflicts: () => void;
   onMerge: () => void;
+  pushChanges?: PushChangesAction;
 };
 
 export function PRHealthBanner({
@@ -35,13 +49,15 @@ export function PRHealthBanner({
   onFixTests,
   onResolveConflicts,
   onMerge,
+  pushChanges,
 }: PRHealthBannerProps) {
   const isHealthy = !health.can_fix_tests && !health.can_resolve_conflicts;
   const orderedChecks = [...(health.checks ?? [])]
     .map((check) => ({ ...check, status: normalizeCheckStatus(check.status) }))
     .sort((a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name));
   const canShowMergeButton = health.can_merge && checksAllowMerge(health.checks_confirmed, orderedChecks);
-  const hasActionableButton = health.can_resolve_conflicts || health.can_fix_tests || canShowMergeButton;
+  const hasActionableButton =
+    health.can_resolve_conflicts || health.can_fix_tests || canShowMergeButton || !!pushChanges;
   const failedChecks = orderedChecks.filter((check) => check.status === "failed").length;
   const failedSummaryLabel = orderedChecks.length > 0
     ? `${failedChecks}/${orderedChecks.length} failed`
@@ -179,6 +195,24 @@ export function PRHealthBanner({
                         <GitMerge className="mr-1.5 h-3.5 w-3.5" />
                       )}
                       {pendingAction === "merge" ? "Merging…" : "Merge"}
+                    </Button>
+                  )}
+                  {pushChanges && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={pushChanges.disabled || pendingAction !== null}
+                      title={pushChanges.title}
+                      onClick={pushChanges.onClick}
+                    >
+                      {pushChanges.spinning ? (
+                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                      ) : pushChanges.showError ? (
+                        <AlertTriangle className="mr-1.5 h-3.5 w-3.5" />
+                      ) : (
+                        <Upload className="mr-1.5 h-3.5 w-3.5" />
+                      )}
+                      {pushChanges.label}
                     </Button>
                   )}
                 </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -334,6 +334,11 @@ export const api = {
         ...(options.authorMode ? { author_mode: options.authorMode } : {}),
         ...(options.resumeToken ? { resume_token: options.resumeToken } : {}),
       } : undefined),
+    pushChangesToPR: (sessionId: string, options?: { authorMode?: 'auto' | 'user' | 'app'; resumeToken?: string }) =>
+      post<{ status: string }>(`/api/v1/sessions/${sessionId}/pr/push`, options ? {
+        ...(options.authorMode ? { author_mode: options.authorMode } : {}),
+        ...(options.resumeToken ? { resume_token: options.resumeToken } : {}),
+      } : undefined),
     getQuestions: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions`),
     answerQuestion: (sessionId: string, questionId: string, answer: string) =>
       post<import('./types').SingleResponse<import('./types').SessionQuestion>>(`/api/v1/sessions/${sessionId}/questions/${questionId}/answer`, { answer }),

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -152,6 +152,8 @@ export interface Session {
   snapshot_key?: string;
   pr_creation_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
   pr_creation_error?: string;
+  pr_push_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
+  pr_push_error?: string;
   target_branch?: string;
   repository_id?: string;
   linked_issues?: Array<{

--- a/internal/api/handlers/github_status.go
+++ b/internal/api/handlers/github_status.go
@@ -230,7 +230,15 @@ func (h *GitHubStatusHandler) HandleConnectCallback(w http.ResponseWriter, r *ht
 	resumeCookieName := githubPRResumeCookiePrefix + r.URL.Query().Get("state")
 	if resumeCookie, err := r.Cookie(resumeCookieName); err == nil && resumeCookie.Value != "" && len(h.signingKey) > 0 {
 		if claims, tokenErr := parsePRAuthResumeToken(h.signingKey, resumeCookie.Value, time.Now()); tokenErr == nil {
+			// Forward the originating action ("create_pr" or "push_changes")
+			// the signed claim recorded so the frontend can dispatch the
+			// correct mutation deterministically. Older tokens without an
+			// action just omit the param; the frontend falls back to a
+			// state-based heuristic in that case.
 			redirectURL = fmt.Sprintf("%s/sessions/%s?github_pr=connected&resume_pr=%s", h.frontendURL, claims.SessionID, url.QueryEscape(resumeCookie.Value))
+			if claims.Action != "" {
+				redirectURL += "&resume_action=" + url.QueryEscape(claims.Action)
+			}
 		}
 	}
 	clearCookie(w, r, resumeCookieName)

--- a/internal/api/handlers/github_status_test.go
+++ b/internal/api/handlers/github_status_test.go
@@ -317,6 +317,60 @@ func TestGitHubStatusHandler_HandleConnectCallback_RedirectsBackToSessionResume(
 	require.Equal(t, "/sessions/"+sessionID.String(), parsed.Path, "callback should return to the originating session page")
 	require.Equal(t, "connected", parsed.Query().Get("github_pr"), "redirect should note successful GitHub PR auth")
 	require.NotEmpty(t, parsed.Query().Get("resume_pr"), "redirect should carry resume token back to the frontend")
+	require.Empty(t, parsed.Query().Get("resume_action"), "redirect should omit resume_action for legacy tokens without an Action claim")
+}
+
+func TestGitHubStatusHandler_HandleConnectCallback_ForwardsResumeAction(t *testing.T) {
+	t.Parallel()
+
+	// When the resume token's claims record an originating action, the
+	// callback must forward it as a resume_action URL param so the frontend
+	// dispatches deterministically (push vs create) regardless of any PR
+	// state change during the OAuth round-trip.
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+	handler := NewGitHubStatusHandler(
+		&stubGHCredentialStore{}, &stubGHOrgReader{},
+		"test-client-id", "test-secret", "https://app.143.dev", "https://app.143.dev",
+	)
+	handler.SetPRAuthFlow("test-signing-key-32bytes-minimum-length")
+	handler.appUserAuth = &stubGitHubAppUserAuthService{
+		exchangeCodeFunc: func(context.Context, string) (*models.GitHubAppUserConfig, error) {
+			return &models.GitHubAppUserConfig{
+				AccessToken:           "ghu_test",
+				TokenType:             "bearer",
+				ExpiresAt:             time.Now().Add(time.Hour),
+				RefreshToken:          "ghr_test",
+				RefreshTokenExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+			}, nil
+		},
+	}
+
+	resumeToken, err := signPRAuthResumeToken([]byte("test-signing-key-32bytes-minimum-length"), prAuthResumeClaims{
+		SessionID:  sessionID,
+		UserID:     userID,
+		OrgID:      orgID,
+		AuthorMode: "user",
+		Action:     string(prAuthActionPushChanges),
+		ExpiresAt:  time.Now().Add(5 * time.Minute).Unix(),
+	})
+	require.NoError(t, err, "resume token should sign")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/users/me/github/callback?state=ok&code=abc", nil)
+	req.AddCookie(&http.Cookie{Name: githubPRConnectStateCookie, Value: "ok"})
+	req.AddCookie(&http.Cookie{Name: githubPRResumeCookiePrefix + "ok", Value: resumeToken})
+	ctx := middleware.WithUser(req.Context(), &models.User{ID: userID, OrgID: orgID})
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	handler.HandleConnectCallback(rr, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, rr.Code, "callback should redirect back to the session page")
+	parsed, parseErr := url.Parse(rr.Header().Get("Location"))
+	require.NoError(t, parseErr, "redirect location should parse")
+	require.Equal(t, "push_changes", parsed.Query().Get("resume_action"), "callback should forward the action recorded in the signed claims")
 }
 
 func TestGitHubStatusHandler_HandleConnectCallback_UsesStateScopedResumeCookie(t *testing.T) {

--- a/internal/api/handlers/pr_auth_flow.go
+++ b/internal/api/handlers/pr_auth_flow.go
@@ -122,17 +122,30 @@ func parsePRAuthResumeToken(key []byte, token string, now time.Time) (prAuthResu
 	return claims, nil
 }
 
-// prAuthInterceptOpts customizes the user-facing copy and resume-claim payload
-// for requirePRAuthOrIntercept. ActionDescription is interpolated into the
-// "Authorize GitHub to <action> as you." message; ResumeExpiredMessage is
-// shown when the resume token decoded but expired (e.g. user took 10+ minutes
-// to complete the OAuth handshake). Draft is preserved in the resume claims so
-// the original Draft choice survives the GitHub round-trip — pass nil for
-// endpoints that don't expose a draft toggle. Action identifies the calling
-// endpoint and is signed into the claims so the OAuth callback can dispatch
-// the correct replay action regardless of any state change during the
-// handshake.
-type prAuthInterceptOpts struct {
+// prAuthInterceptParams bundles every input requirePRAuthOrIntercept needs.
+// SessionID/OrgID/Session/OrgSettings are session context; AuthorMode and
+// ResumeToken come from the request body; Action/ActionDescription/
+// ResumeExpiredMessage/Draft customize the user-facing copy and resume-claim
+// payload. Bundled into one struct because the helper otherwise grew a
+// nine-parameter signature that's hard to read at the call sites.
+//
+//   - Action identifies the calling endpoint and is signed into the resume
+//     claims so the OAuth callback can dispatch the correct replay action
+//     regardless of any state change during the handshake.
+//   - ActionDescription is interpolated into the "Authorize GitHub to
+//     <action> as you." message.
+//   - ResumeExpiredMessage is shown when the resume token decoded but
+//     expired (e.g. user took 10+ minutes to complete OAuth).
+//   - Draft is preserved in the resume claims so the original Draft choice
+//     survives the GitHub round-trip — leave nil for endpoints that don't
+//     expose a draft toggle.
+type prAuthInterceptParams struct {
+	SessionID            uuid.UUID
+	OrgID                uuid.UUID
+	Session              *models.Session
+	OrgSettings          models.OrgSettings
+	AuthorMode           prAuthorMode
+	ResumeToken          string
 	Action               prAuthAction
 	ActionDescription    string
 	ResumeExpiredMessage string
@@ -146,35 +159,26 @@ type prAuthInterceptOpts struct {
 // resume token expired → 409 PR_RESUME_EXPIRED, app-user-auth not configured →
 // 503, or an internal error). Single-source-of-truth for the auth flow so a
 // fix to the credential check or token-signing path lands in both endpoints.
-func (h *SessionHandler) requirePRAuthOrIntercept(
-	w http.ResponseWriter,
-	r *http.Request,
-	sessionID, orgID uuid.UUID,
-	session *models.Session,
-	orgSettings models.OrgSettings,
-	authorMode prAuthorMode,
-	resumeToken string,
-	opts prAuthInterceptOpts,
-) bool {
+func (h *SessionHandler) requirePRAuthOrIntercept(w http.ResponseWriter, r *http.Request, p prAuthInterceptParams) bool {
 	user := middleware.UserFromContext(r.Context())
-	if !shouldPromptForPRAuth(authorMode, orgSettings.PRAuthorship) ||
-		session.TriggeredByUserID == nil ||
+	if !shouldPromptForPRAuth(p.AuthorMode, p.OrgSettings.PRAuthorship) ||
+		p.Session.TriggeredByUserID == nil ||
 		user == nil ||
-		user.ID != *session.TriggeredByUserID {
+		user.ID != *p.Session.TriggeredByUserID {
 		return true
 	}
 
-	if resumeToken != "" {
+	if p.ResumeToken != "" {
 		if len(h.prAuthSigningKey) == 0 {
 			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
 			return false
 		}
-		claims, tokenErr := parsePRAuthResumeToken(h.prAuthSigningKey, resumeToken, time.Now())
-		if tokenErr != nil || claims.SessionID != sessionID || claims.UserID != user.ID || claims.OrgID != orgID {
+		claims, tokenErr := parsePRAuthResumeToken(h.prAuthSigningKey, p.ResumeToken, time.Now())
+		if tokenErr != nil || claims.SessionID != p.SessionID || claims.UserID != user.ID || claims.OrgID != p.OrgID {
 			writeJSON(w, http.StatusConflict, models.ErrorResponse{
 				Error: models.ErrorDetail{
 					Code:    "PR_RESUME_EXPIRED",
-					Message: opts.ResumeExpiredMessage,
+					Message: p.ResumeExpiredMessage,
 				},
 			})
 			return false
@@ -185,14 +189,14 @@ func (h *SessionHandler) requirePRAuthOrIntercept(
 	authUnavailable := h.prAuthChecker == nil
 	if h.prAuthChecker != nil {
 		var checkErr error
-		hasCredential, checkErr = h.prAuthChecker.HasValidCredential(r.Context(), orgID, user.ID)
+		hasCredential, checkErr = h.prAuthChecker.HasValidCredential(r.Context(), p.OrgID, user.ID)
 		if checkErr != nil {
 			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to verify GitHub PR authorization", checkErr)
 			return false
 		}
 	}
 	if authUnavailable && !hasCredential {
-		if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == prAuthorModeUser {
+		if p.OrgSettings.PRAuthorship == models.PRAuthorshipUserRequired || p.AuthorMode == prAuthorModeUser {
 			writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
 			return false
 		}
@@ -208,12 +212,12 @@ func (h *SessionHandler) requirePRAuthOrIntercept(
 		return false
 	}
 	signedToken, signErr := signPRAuthResumeToken(h.prAuthSigningKey, prAuthResumeClaims{
-		SessionID:  sessionID,
+		SessionID:  p.SessionID,
 		UserID:     user.ID,
-		OrgID:      orgID,
-		Draft:      opts.Draft,
+		OrgID:      p.OrgID,
+		Draft:      p.Draft,
 		AuthorMode: string(prAuthorModeUser),
-		Action:     string(opts.Action),
+		Action:     string(p.Action),
 		ExpiresAt:  time.Now().Add(prAuthResumeTokenTTL).Unix(),
 	})
 	if signErr != nil {
@@ -223,12 +227,12 @@ func (h *SessionHandler) requirePRAuthOrIntercept(
 	writeJSON(w, http.StatusConflict, models.ErrorResponse{
 		Error: models.ErrorDetail{
 			Code:    "GITHUB_PR_AUTHORSHIP_REQUIRED",
-			Message: fmt.Sprintf("Authorize GitHub to %s as you.", opts.ActionDescription),
+			Message: fmt.Sprintf("Authorize GitHub to %s as you.", p.ActionDescription),
 			Details: map[string]any{
-				"session_id":            sessionID.String(),
+				"session_id":            p.SessionID.String(),
 				"connect_url":           "/api/v1/users/me/github/connect?flow=pr_authorship",
 				"resume_token":          signedToken,
-				"can_fallback_to_app":   orgSettings.PRAuthorship != models.PRAuthorshipUserRequired,
+				"can_fallback_to_app":   p.OrgSettings.PRAuthorship != models.PRAuthorshipUserRequired,
 				"suggested_author_mode": string(prAuthorModeUser),
 			},
 		},

--- a/internal/api/handlers/pr_auth_flow.go
+++ b/internal/api/handlers/pr_auth_flow.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -31,13 +32,29 @@ const (
 	prAuthorModeApp  prAuthorMode = "app"
 )
 
+// prAuthAction identifies which endpoint signed a resume token. Encoded into
+// the signed claims and surfaced back to the frontend as a URL param after
+// the OAuth round-trip so the post-auth replay is deterministic — without it
+// the frontend would have to guess between "create PR" and "push changes"
+// based on current PR state, which can change during the handshake (tab/race).
+type prAuthAction string
+
+const (
+	prAuthActionCreatePR    prAuthAction = "create_pr"
+	prAuthActionPushChanges prAuthAction = "push_changes"
+)
+
 type prAuthResumeClaims struct {
 	SessionID  uuid.UUID `json:"session_id"`
 	UserID     uuid.UUID `json:"user_id"`
 	OrgID      uuid.UUID `json:"org_id"`
 	Draft      *bool     `json:"draft,omitempty"`
 	AuthorMode string    `json:"author_mode"`
-	ExpiresAt  int64     `json:"exp"`
+	// Action is the originating endpoint ("create_pr" or "push_changes").
+	// Empty for tokens signed before this field was added; readers should
+	// treat empty as "create_pr" for backward compatibility.
+	Action    string `json:"action,omitempty"`
+	ExpiresAt int64  `json:"exp"`
 }
 
 func parsePRAuthorMode(raw string) (prAuthorMode, error) {
@@ -103,6 +120,120 @@ func parsePRAuthResumeToken(key []byte, token string, now time.Time) (prAuthResu
 		return claims, errors.New("token expired")
 	}
 	return claims, nil
+}
+
+// prAuthInterceptOpts customizes the user-facing copy and resume-claim payload
+// for requirePRAuthOrIntercept. ActionDescription is interpolated into the
+// "Authorize GitHub to <action> as you." message; ResumeExpiredMessage is
+// shown when the resume token decoded but expired (e.g. user took 10+ minutes
+// to complete the OAuth handshake). Draft is preserved in the resume claims so
+// the original Draft choice survives the GitHub round-trip — pass nil for
+// endpoints that don't expose a draft toggle. Action identifies the calling
+// endpoint and is signed into the claims so the OAuth callback can dispatch
+// the correct replay action regardless of any state change during the
+// handshake.
+type prAuthInterceptOpts struct {
+	Action               prAuthAction
+	ActionDescription    string
+	ResumeExpiredMessage string
+	Draft                *bool
+}
+
+// requirePRAuthOrIntercept centralizes the GitHub user-auth interception that
+// CreatePR and PushChangesToPR share. Returns true if the caller should
+// proceed (auth not required, or the user is already authed); returns false if
+// a response was already written (auth required → 409 GITHUB_PR_AUTHORSHIP_REQUIRED,
+// resume token expired → 409 PR_RESUME_EXPIRED, app-user-auth not configured →
+// 503, or an internal error). Single-source-of-truth for the auth flow so a
+// fix to the credential check or token-signing path lands in both endpoints.
+func (h *SessionHandler) requirePRAuthOrIntercept(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionID, orgID uuid.UUID,
+	session *models.Session,
+	orgSettings models.OrgSettings,
+	authorMode prAuthorMode,
+	resumeToken string,
+	opts prAuthInterceptOpts,
+) bool {
+	user := middleware.UserFromContext(r.Context())
+	if !shouldPromptForPRAuth(authorMode, orgSettings.PRAuthorship) ||
+		session.TriggeredByUserID == nil ||
+		user == nil ||
+		user.ID != *session.TriggeredByUserID {
+		return true
+	}
+
+	if resumeToken != "" {
+		if len(h.prAuthSigningKey) == 0 {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
+			return false
+		}
+		claims, tokenErr := parsePRAuthResumeToken(h.prAuthSigningKey, resumeToken, time.Now())
+		if tokenErr != nil || claims.SessionID != sessionID || claims.UserID != user.ID || claims.OrgID != orgID {
+			writeJSON(w, http.StatusConflict, models.ErrorResponse{
+				Error: models.ErrorDetail{
+					Code:    "PR_RESUME_EXPIRED",
+					Message: opts.ResumeExpiredMessage,
+				},
+			})
+			return false
+		}
+	}
+
+	hasCredential := false
+	authUnavailable := h.prAuthChecker == nil
+	if h.prAuthChecker != nil {
+		var checkErr error
+		hasCredential, checkErr = h.prAuthChecker.HasValidCredential(r.Context(), orgID, user.ID)
+		if checkErr != nil {
+			writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to verify GitHub PR authorization", checkErr)
+			return false
+		}
+	}
+	if authUnavailable && !hasCredential {
+		if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == prAuthorModeUser {
+			writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
+			return false
+		}
+		// App-token fallback is allowed; let the caller proceed.
+		return true
+	}
+	if hasCredential {
+		return true
+	}
+
+	if len(h.prAuthSigningKey) == 0 {
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
+		return false
+	}
+	signedToken, signErr := signPRAuthResumeToken(h.prAuthSigningKey, prAuthResumeClaims{
+		SessionID:  sessionID,
+		UserID:     user.ID,
+		OrgID:      orgID,
+		Draft:      opts.Draft,
+		AuthorMode: string(prAuthorModeUser),
+		Action:     string(opts.Action),
+		ExpiresAt:  time.Now().Add(prAuthResumeTokenTTL).Unix(),
+	})
+	if signErr != nil {
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to prepare GitHub PR authorization", signErr)
+		return false
+	}
+	writeJSON(w, http.StatusConflict, models.ErrorResponse{
+		Error: models.ErrorDetail{
+			Code:    "GITHUB_PR_AUTHORSHIP_REQUIRED",
+			Message: fmt.Sprintf("Authorize GitHub to %s as you.", opts.ActionDescription),
+			Details: map[string]any{
+				"session_id":            sessionID.String(),
+				"connect_url":           "/api/v1/users/me/github/connect?flow=pr_authorship",
+				"resume_token":          signedToken,
+				"can_fallback_to_app":   orgSettings.PRAuthorship != models.PRAuthorshipUserRequired,
+				"suggested_author_mode": string(prAuthorModeUser),
+			},
+		},
+	})
+	return false
 }
 
 func clearCookie(w http.ResponseWriter, r *http.Request, name string) {

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -876,7 +876,7 @@ var sessionRowColumns = []string{
 	"target_branch", "working_branch",
 	"base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
-	"pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -917,6 +917,8 @@ func previewSessionRow(id, orgID uuid.UUID, containerID *string, snapshotKey *st
 		"recovery_attempt_count":         0,
 		"pr_creation_state":              "idle",
 		"pr_creation_error":              (*string)(nil),
+		"pr_push_state":                  "idle",
+		"pr_push_error":                  (*string)(nil),
 		"linear_private":                 false,
 		"linear_state_sync_disabled":     false,
 		"linear_identifier_hint":         (*string)(nil),

--- a/internal/api/handlers/session_files_test.go
+++ b/internal/api/handlers/session_files_test.go
@@ -82,7 +82,7 @@ var sessionColumnsForFiles = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -153,6 +153,8 @@ func setupSessionMock(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID, con
 				nil,            // automation_run_id
 				"idle",         // pr_creation_state
 				(*string)(nil), // pr_creation_error
+				"idle",         // pr_push_state
+				(*string)(nil), // pr_push_error
 				nil,            // diff_collected_at
 				nil,            // latest_diff_snapshot_id
 				nil,            // deleted_at

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1354,7 +1354,13 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if !h.requirePRAuthOrIntercept(w, r, sessionID, orgID, &session, orgSettings, authorMode, req.ResumeToken, prAuthInterceptOpts{
+	if !h.requirePRAuthOrIntercept(w, r, prAuthInterceptParams{
+		SessionID:            sessionID,
+		OrgID:                orgID,
+		Session:              &session,
+		OrgSettings:          orgSettings,
+		AuthorMode:           authorMode,
+		ResumeToken:          req.ResumeToken,
 		Action:               prAuthActionCreatePR,
 		ActionDescription:    "create this pull request",
 		ResumeExpiredMessage: "GitHub authorization completed, but the PR resume request expired. Please click Create PR again.",
@@ -1434,6 +1440,15 @@ func (h *SessionHandler) PushChangesToPR(w http.ResponseWriter, r *http.Request)
 		writeError(w, r, http.StatusConflict, "SNAPSHOT_PENDING", "a snapshot upload is still finishing; try again in a moment")
 		return
 	}
+	// Defense-in-depth against the frontend's isRunning gate: pushing while a
+	// turn is in flight would race the active sandbox and the snapshot we'd
+	// hydrate could be stale relative to commits the running turn is about
+	// to make. Reject server-side so a racing client (or a stale tab whose
+	// session.status hadn't refreshed) can't slip through.
+	if session.Status == string(models.SessionStatusRunning) {
+		writeError(w, r, http.StatusConflict, "SESSION_RUNNING", "wait for the session to finish before pushing")
+		return
+	}
 
 	switch session.PRPushState {
 	case models.PRPushStateQueued, models.PRPushStatePushing:
@@ -1480,8 +1495,17 @@ func (h *SessionHandler) PushChangesToPR(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	if !h.requirePRAuthOrIntercept(w, r, sessionID, orgID, &session, orgSettings, authorMode, req.ResumeToken, prAuthInterceptOpts{
-		Action:               prAuthActionPushChanges,
+	if !h.requirePRAuthOrIntercept(w, r, prAuthInterceptParams{
+		SessionID:   sessionID,
+		OrgID:       orgID,
+		Session:     &session,
+		OrgSettings: orgSettings,
+		AuthorMode:  authorMode,
+		ResumeToken: req.ResumeToken,
+		Action:      prAuthActionPushChanges,
+		// Draft is intentionally omitted: the push endpoint has no draft
+		// toggle, and the field has no meaning once the PR row already
+		// exists. Leaving it nil keeps the resume claim minimal.
 		ActionDescription:    "push these changes",
 		ResumeExpiredMessage: "GitHub authorization completed, but the resume request expired. Please click Push changes again.",
 	}) {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1354,80 +1354,15 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	user := middleware.UserFromContext(r.Context())
-	if shouldPromptForPRAuth(authorMode, orgSettings.PRAuthorship) &&
-		session.TriggeredByUserID != nil &&
-		user != nil &&
-		user.ID == *session.TriggeredByUserID {
-		if req.ResumeToken != "" {
-			if len(h.prAuthSigningKey) == 0 {
-				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
-				return
-			}
-			claims, tokenErr := parsePRAuthResumeToken(h.prAuthSigningKey, req.ResumeToken, time.Now())
-			if tokenErr != nil || claims.SessionID != sessionID || claims.UserID != user.ID || claims.OrgID != orgID {
-				writeJSON(w, http.StatusConflict, models.ErrorResponse{
-					Error: models.ErrorDetail{
-						Code:    "PR_RESUME_EXPIRED",
-						Message: "GitHub authorization completed, but the PR resume request expired. Please click Create PR again.",
-					},
-				})
-				return
-			}
-		}
-
-		hasCredential := false
-		authUnavailable := h.prAuthChecker == nil
-		if h.prAuthChecker != nil {
-			var checkErr error
-			hasCredential, checkErr = h.prAuthChecker.HasValidCredential(r.Context(), orgID, user.ID)
-			if checkErr != nil {
-				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to verify GitHub PR authorization", checkErr)
-				return
-			}
-		}
-		if authUnavailable && !hasCredential {
-			if orgSettings.PRAuthorship == models.PRAuthorshipUserRequired || authorMode == prAuthorModeUser {
-				writeError(w, r, http.StatusServiceUnavailable, "GITHUB_APP_USER_AUTH_NOT_CONFIGURED", "github app user auth is not configured")
-				return
-			}
-			goto enqueuePR
-		}
-		if !hasCredential {
-			if len(h.prAuthSigningKey) == 0 {
-				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "PR auth flow is not configured")
-				return
-			}
-			resumeToken, signErr := signPRAuthResumeToken(h.prAuthSigningKey, prAuthResumeClaims{
-				SessionID:  sessionID,
-				UserID:     user.ID,
-				OrgID:      orgID,
-				Draft:      req.Draft,
-				AuthorMode: string(prAuthorModeUser),
-				ExpiresAt:  time.Now().Add(prAuthResumeTokenTTL).Unix(),
-			})
-			if signErr != nil {
-				writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to prepare GitHub PR authorization", signErr)
-				return
-			}
-			writeJSON(w, http.StatusConflict, models.ErrorResponse{
-				Error: models.ErrorDetail{
-					Code:    "GITHUB_PR_AUTHORSHIP_REQUIRED",
-					Message: "Authorize GitHub to create this pull request as you.",
-					Details: map[string]any{
-						"session_id":            sessionID.String(),
-						"connect_url":           "/api/v1/users/me/github/connect?flow=pr_authorship",
-						"resume_token":          resumeToken,
-						"can_fallback_to_app":   orgSettings.PRAuthorship != models.PRAuthorshipUserRequired,
-						"suggested_author_mode": string(prAuthorModeUser),
-					},
-				},
-			})
-			return
-		}
+	if !h.requirePRAuthOrIntercept(w, r, sessionID, orgID, &session, orgSettings, authorMode, req.ResumeToken, prAuthInterceptOpts{
+		Action:               prAuthActionCreatePR,
+		ActionDescription:    "create this pull request",
+		ResumeExpiredMessage: "GitHub authorization completed, but the PR resume request expired. Please click Create PR again.",
+		Draft:                req.Draft,
+	}) {
+		return
 	}
 
-enqueuePR:
 	payload := map[string]any{
 		"session_id": sessionID.String(),
 		"org_id":     orgID.String(),
@@ -1459,6 +1394,136 @@ enqueuePR:
 	}
 	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionPRRequested, models.AuditResourceSession, &sessionIDStr, &session.ID, nil,
 		marshalAuditDetails(h.logger, prDetails))
+	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
+}
+
+// PushChangesToPR handles POST /sessions/{id}/pr/push — enqueues a job that
+// pushes any uncommitted/unpushed changes from the session sandbox up to the
+// existing PR's branch and updates the PR row's head_sha. The session must
+// have an open PR and a still-restorable snapshot. While a prior push attempt
+// is in flight (queued or pushing), returns 409 to prevent double-submits.
+//
+// Mirrors the validation, auth interception, and enqueue structure of CreatePR
+// so the two endpoints behave identically from a client perspective. The only
+// material differences are: (a) requires an existing PR (404 if none), (b)
+// rejects PRs that are not in the "open" state, and (c) the dedupe key,
+// queue/job names, and audit action are push-flavored.
+func (h *SessionHandler) PushChangesToPR(w http.ResponseWriter, r *http.Request) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	sessionID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_ID", "invalid session ID")
+		return
+	}
+
+	session, err := h.runStore.GetByID(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusNotFound, "NOT_FOUND", "session not found")
+		return
+	}
+
+	if session.SandboxState == string(models.SandboxStateDestroyed) {
+		writeError(w, r, http.StatusGone, "SNAPSHOT_EXPIRED", ghservice.SnapshotExpiredPRMessage)
+		return
+	}
+	if session.SnapshotKey == nil || *session.SnapshotKey == "" {
+		writeError(w, r, http.StatusConflict, "SNAPSHOT_NOT_CAPTURED", ghservice.SnapshotNotCapturedPRMessage)
+		return
+	}
+	if session.PendingSnapshotKey != nil && *session.PendingSnapshotKey != "" {
+		writeError(w, r, http.StatusConflict, "SNAPSHOT_PENDING", "a snapshot upload is still finishing; try again in a moment")
+		return
+	}
+
+	switch session.PRPushState {
+	case models.PRPushStateQueued, models.PRPushStatePushing:
+		writeError(w, r, http.StatusConflict, "PR_PUSH_IN_FLIGHT", "a push to this PR is already in progress")
+		return
+	}
+
+	pr, prErr := h.pullRequestStore.GetBySessionID(r.Context(), orgID, sessionID)
+	if prErr != nil {
+		if errors.Is(prErr, pgx.ErrNoRows) {
+			writeError(w, r, http.StatusNotFound, "NO_PR", "this session has no pull request to push to; create one first")
+			return
+		}
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to load pull request", prErr)
+		return
+	}
+	if pr.Status != models.PullRequestStatusOpen {
+		writeError(w, r, http.StatusConflict, "PR_CLOSED", "this pull request is no longer open")
+		return
+	}
+
+	var req struct {
+		AuthorMode  string `json:"author_mode,omitempty"`
+		ResumeToken string `json:"resume_token,omitempty"`
+	}
+	if r.Body != nil && r.ContentLength != 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+			writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
+			return
+		}
+	}
+	authorMode, err := parsePRAuthorMode(req.AuthorMode)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body", err)
+		return
+	}
+
+	orgSettings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	if h.orgStore != nil {
+		if org, orgErr := h.orgStore.GetByID(r.Context(), orgID); orgErr == nil {
+			if parsed, parseErr := models.ParseOrgSettings(org.Settings); parseErr == nil {
+				orgSettings = parsed
+			}
+		}
+	}
+
+	if !h.requirePRAuthOrIntercept(w, r, sessionID, orgID, &session, orgSettings, authorMode, req.ResumeToken, prAuthInterceptOpts{
+		Action:               prAuthActionPushChanges,
+		ActionDescription:    "push these changes",
+		ResumeExpiredMessage: "GitHub authorization completed, but the resume request expired. Please click Push changes again.",
+	}) {
+		return
+	}
+
+	payload := map[string]any{
+		"session_id": sessionID.String(),
+		"org_id":     orgID.String(),
+	}
+	if authorMode != prAuthorModeAuto {
+		payload["author_mode"] = string(authorMode)
+	}
+	dedupeKey := fmt.Sprintf("push_pr:%s", sessionID)
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "push_pr_changes", payload, 5, &dedupeKey); err != nil {
+		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue push job", err)
+		return
+	}
+
+	// Atomically transition pr_push_state from any non-in-flight state to
+	// 'queued'. The in-memory precheck above rejects the obvious case where
+	// the column is already queued/pushing, but two concurrent requests can
+	// both pass that check and reach this line. CAS resolves the race: the
+	// loser sees rows-affected=0 and returns 409 — the dedupeKey on the
+	// enqueue above already collapsed both requests onto a single worker
+	// job, so no duplicate work runs.
+	queued, err := h.runStore.TryMarkPRPushQueued(r.Context(), orgID, sessionID)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, "INTERNAL_ERROR", "failed to mark PR push as queued", err)
+		return
+	}
+	if !queued {
+		writeError(w, r, http.StatusConflict, "PR_PUSH_IN_FLIGHT", "a push to this PR is already in progress")
+		return
+	}
+
+	sessionIDStr := sessionID.String()
+	pushDetails := sessionAuditSnapshot(&session, nil, map[string]any{
+		"job_type": "push_pr_changes",
+	})
+	emitUserAuditWithSession(h.audit, r, models.AuditActionSessionPRPushRequested, models.AuditResourceSession, &sessionIDStr, &session.ID, nil,
+		marshalAuditDetails(h.logger, pushDetails))
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "queued"})
 }
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -7218,6 +7218,7 @@ type pushSessionRowOpts struct {
 	nilSnapshot        bool   // if true, snapshot_key is NULL
 	sandboxState       string // defaults to "none"
 	pushState          string // defaults to "idle"
+	status             string // defaults to "completed"
 }
 
 // pushSessionRow builds a fully-padded session row (matching sessionColumns
@@ -7249,6 +7250,10 @@ func pushSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time, opts pus
 	if pushState == "" {
 		pushState = "idle"
 	}
+	status := opts.status
+	if status == "" {
+		status = "completed"
+	}
 	primaryIssueID := &issueID
 	values := map[string]any{
 		"id":                             sessionID,
@@ -7258,7 +7263,7 @@ func pushSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time, opts pus
 		"interaction_mode":               string(models.SessionInteractionModeSingleRun),
 		"validation_policy":              string(models.SessionValidationPolicyOnSessionEnd),
 		"agent_type":                     string(models.AgentTypeClaudeCode),
-		"status":                         "completed",
+		"status":                         status,
 		"autonomy_level":                 "semi",
 		"token_mode":                     "low",
 		"complexity_tier":                nil,
@@ -7718,6 +7723,44 @@ func TestSessionHandler_PushChangesToPR_SessionNotFound(t *testing.T) {
 
 	require.Equal(t, http.StatusNotFound, w.Code, "should return 404 when session does not exist")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// Defense-in-depth: the frontend gates the push button on isRunning, but a
+// stale tab or a racing client could still POST while the session is mid-turn.
+// The handler must reject it server-side so the worker doesn't hydrate a
+// snapshot the active turn is about to invalidate.
+func TestSessionHandler_PushChangesToPR_RejectsRunningSession(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{
+			status: string(models.SessionStatusRunning),
+		}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "should return 409 when session is currently running")
+	require.Contains(t, w.Body.String(), "SESSION_RUNNING", "error code should distinguish running-session from other in-flight states")
+	require.NoError(t, mock.ExpectationsWereMet(), "handler should not query PRs or enqueue jobs while session is running")
 }
 
 // mockCanceller implements SessionCanceller for testing.

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -156,7 +156,7 @@ var sessionColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -237,9 +237,10 @@ func TestPreLinearSessionColumnsLenStaysInSync(t *testing.T) {
 	const pendingSnapshotFieldsAdded = 2
 	const linearFieldsAdded = 4
 	const identityFieldsAdded = 2
-	require.Equal(t, preLinearSessionColumnsLen+pendingSnapshotFieldsAdded+linearFieldsAdded+identityFieldsAdded, len(sessionColumns),
+	const prPushFieldsAdded = 2
+	require.Equal(t, preLinearSessionColumnsLen+pendingSnapshotFieldsAdded+linearFieldsAdded+identityFieldsAdded+prPushFieldsAdded, len(sessionColumns),
 		"sessionColumns shifted; bump preLinearSessionColumnsLen, pendingSnapshotFieldsAdded, "+
-			"linearFieldsAdded, or identityFieldsAdded if a new migration added more session columns")
+			"linearFieldsAdded, identityFieldsAdded, or prPushFieldsAdded if a new migration added more session columns")
 }
 
 // linearSessionDefaults returns the placeholder values for the four
@@ -277,7 +278,7 @@ func padLinearFields(values []interface{}) []interface{} {
 
 var sessionPullRequestColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 	"health_version", "merged_at", "created_at", "updated_at",
 }
@@ -296,6 +297,7 @@ func sessionPullRequestRow(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID
 		"pending",
 		"app",
 		"",
+		(*string)(nil),
 		(*string)(nil),
 		(*string)(nil),
 		models.PullRequestMergeStateUnknown,
@@ -562,7 +564,7 @@ func padSessionIdentityColumns(row []interface{}) []interface{} {
 	if len(row) >= len(sessionColumns) {
 		return row
 	}
-	if len(row) != len(sessionColumns)-4 {
+	if len(row) != len(sessionColumns)-6 {
 		// Some other length we don't recognize — let the row through
 		// unchanged so the AddRow call surfaces the real mismatch.
 		return row
@@ -573,10 +575,23 @@ func padSessionIdentityColumns(row []interface{}) []interface{} {
 	withPending = append(withPending, nil, nil) // pending_snapshot_key, pending_snapshot_set_at
 	withPending = append(withPending, row[pendingSnapshotKeyIndex:]...)
 
+	// Insert the pr_push pair right after pr_creation_error (and before
+	// diff_collected_at). In the post-pending row, diff_collected_at sits
+	// at index 74 (the +2 shift from the pre-pending layout where it was at
+	// index 72). The pr_push pair lands immediately before it. Use "idle"
+	// (not nil) for pr_push_state because the model's field is a non-pointer
+	// PRPushState — a NULL would fail pgx scanning. The migration mirrors
+	// this with NOT NULL DEFAULT 'idle'.
+	const prPushStateIndex = 74
+	withPRPush := make([]interface{}, 0, len(withPending)+2)
+	withPRPush = append(withPRPush, withPending[:prPushStateIndex]...)
+	withPRPush = append(withPRPush, "idle", (*string)(nil)) // pr_push_state, pr_push_error
+	withPRPush = append(withPRPush, withPending[prPushStateIndex:]...)
+
 	padded := make([]interface{}, 0, len(sessionColumns))
-	padded = append(padded, withPending[:len(withPending)-1]...)
+	padded = append(padded, withPRPush[:len(withPRPush)-1]...)
 	padded = append(padded, nil, nil)
-	padded = append(padded, withPending[len(withPending)-1])
+	padded = append(padded, withPRPush[len(withPRPush)-1])
 	return padded
 }
 
@@ -7191,6 +7206,517 @@ func TestSessionHandler_CreatePR_PRLookupDBError(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, w.Code, "should return 500 on PR lookup DB error")
 	require.Contains(t, w.Body.String(), "INTERNAL_ERROR", "error code should indicate internal error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// pushSessionRowOpts customizes pushSessionRow's defaults. The zero value
+// produces a completed, snapshot-backed session whose pr_push_state is "idle"
+// — i.e., a session that's ready to accept a "Push changes" request.
+type pushSessionRowOpts struct {
+	snapshotKey        string // explicit key; empty means generate, unless nilSnapshot
+	pendingSnapshotKey string // explicit pending upload key; empty means NULL
+	nilSnapshot        bool   // if true, snapshot_key is NULL
+	sandboxState       string // defaults to "none"
+	pushState          string // defaults to "idle"
+}
+
+// pushSessionRow builds a fully-padded session row (matching sessionColumns
+// in length and order) for push-changes handler tests. Built directly rather
+// than via addSessionRow because those test variants need to override
+// pr_push_state, which the auto-pad in padSessionIdentityColumns otherwise
+// forces to "idle" — and the dispatch by length doesn't have a slot for the
+// "explicit pr_push values" shape.
+func pushSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time, opts pushSessionRowOpts) *pgxmock.Rows {
+	snapshotKey := opts.snapshotKey
+	if snapshotKey == "" && !opts.nilSnapshot {
+		snapshotKey = "snap-push-" + sessionID.String()
+	}
+	var snapshotKeyArg any
+	if snapshotKey != "" {
+		snapshotKeyArg = &snapshotKey
+	} else {
+		snapshotKeyArg = nil
+	}
+	var pendingSnapshotKeyArg any
+	if opts.pendingSnapshotKey != "" {
+		pendingSnapshotKeyArg = &opts.pendingSnapshotKey
+	}
+	sandboxState := opts.sandboxState
+	if sandboxState == "" {
+		sandboxState = "none"
+	}
+	pushState := opts.pushState
+	if pushState == "" {
+		pushState = "idle"
+	}
+	primaryIssueID := &issueID
+	values := map[string]any{
+		"id":                             sessionID,
+		"primary_issue_id":               primaryIssueID,
+		"org_id":                         orgID,
+		"origin":                         string(models.SessionOriginIssueTrigger),
+		"interaction_mode":               string(models.SessionInteractionModeSingleRun),
+		"validation_policy":              string(models.SessionValidationPolicyOnSessionEnd),
+		"agent_type":                     string(models.AgentTypeClaudeCode),
+		"status":                         "completed",
+		"autonomy_level":                 "semi",
+		"token_mode":                     "low",
+		"complexity_tier":                nil,
+		"confidence_score":               nil,
+		"confidence_reasoning":           nil,
+		"risk_factors":                   nil,
+		"container_id":                   nil,
+		"worker_node_id":                 nil,
+		"turn_holding_container":         false,
+		"started_at":                     &now,
+		"completed_at":                   &now,
+		"token_usage":                    nil,
+		"failure_explanation":            nil,
+		"failure_category":               nil,
+		"failure_next_steps":             nil,
+		"failure_retry_advised":          false,
+		"parent_session_id":              nil,
+		"revision_context":               nil,
+		"error":                          nil,
+		"result_summary":                 nil,
+		"diff":                           nil,
+		"pm_plan_id":                     nil,
+		"title":                          nil,
+		"pm_approach":                    nil,
+		"pm_reasoning":                   nil,
+		"project_task_id":                nil,
+		"model_override":                 nil,
+		"reasoning_effort":               nil,
+		"triggered_by_user_id":           nil,
+		"agent_session_id":               nil,
+		"current_turn":                   0,
+		"last_activity_at":               now,
+		"sandbox_state":                  sandboxState,
+		"snapshot_key":                   snapshotKeyArg,
+		"pending_snapshot_key":           pendingSnapshotKeyArg,
+		"pending_snapshot_set_at":        nil,
+		"runtime_soft_deadline_at":       nil,
+		"runtime_hard_deadline_at":       nil,
+		"runtime_last_progress_at":       nil,
+		"runtime_last_progress_type":     "",
+		"runtime_last_progress_strength": "",
+		"runtime_extension_count":        0,
+		"runtime_extension_seconds":      0,
+		"runtime_stop_reason":            "",
+		"runtime_graceful_stop_at":       nil,
+		"checkpointed_at":                nil,
+		"checkpoint_kind":                "",
+		"checkpoint_capability":          "",
+		"checkpoint_size_bytes":          int64(0),
+		"checkpoint_error":               nil,
+		"recovery_state":                 "",
+		"recovery_queued_at":             nil,
+		"recovery_started_at":            nil,
+		"recovery_attempt_count":         0,
+		"target_branch":                  nil,
+		"working_branch":                 nil,
+		"base_commit_sha":                nil,
+		"repository_id":                  nil,
+		"diff_stats":                     nil,
+		"diff_history":                   nil,
+		"input_manifest":                 nil,
+		"archived_at":                    nil,
+		"archived_by_user_id":            nil,
+		"automation_run_id":              nil,
+		"pr_creation_state":              "idle",
+		"pr_creation_error":              (*string)(nil),
+		"pr_push_state":                  pushState,
+		"pr_push_error":                  (*string)(nil),
+		"diff_collected_at":              nil,
+		"latest_diff_snapshot_id":        nil,
+		"linear_private":                 false,
+		"linear_state_sync_disabled":     false,
+		"linear_identifier_hint":         (*string)(nil),
+		"linear_prepare_state":           string(models.LinearPrepareStateNone),
+		"deleted_at":                     nil,
+		"git_identity_source":            nil,
+		"git_identity_user_id":           nil,
+		"created_at":                     now,
+	}
+	row := make([]any, len(sessionColumns))
+	for i, col := range sessionColumns {
+		row[i] = values[col]
+	}
+	return pgxmock.NewRows(sessionColumns).AddRow(row...)
+}
+
+func TestSessionHandler_PushChangesToPR_Success(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	prID := uuid.New()
+	jobID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{}))
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionPullRequestColumns).
+				AddRow(sessionPullRequestRow(prID, &sessionID, orgID, "owner/repo", now)...),
+		)
+
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+	// CAS update from TryMarkPRPushQueued — 2 args (id, org_id) and rows-
+	// affected=1 to indicate the racing-winner branch.
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusAccepted, w.Code, "should return 202 Accepted")
+	require.Contains(t, w.Body.String(), `"status":"queued"`, "response should indicate job was queued")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_PushChangesToPR_CASLosesRaceReturnsConflict(t *testing.T) {
+	t.Parallel()
+
+	// Two concurrent submitters that both see pr_push_state='idle' will both
+	// pass the in-memory precheck. The CAS-on-mark-queued is the tiebreaker:
+	// the loser sees rows-affected=0 from TryMarkPRPushQueued and must
+	// return 409 PR_PUSH_IN_FLIGHT instead of 202. Simulate that by feeding
+	// the handler an idle row but mocking the UPDATE to affect zero rows.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	prID := uuid.New()
+	jobID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{}))
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionPullRequestColumns).
+				AddRow(sessionPullRequestRow(prID, &sessionID, orgID, "owner/repo", now)...),
+		)
+
+	// The job enqueue still runs (deduped by dedupeKey on the worker side).
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+	// CAS UPDATE matches no rows because a concurrent winner already moved
+	// pr_push_state to 'queued'.
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "CAS losing the race should produce a 409")
+	require.Contains(t, w.Body.String(), "PR_PUSH_IN_FLIGHT", "loser of the CAS race should see the in-flight code")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_PushChangesToPR_PendingSnapshotRejectsWithoutEnqueue(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{
+			pendingSnapshotKey: "snapshots/pending/post-pr.tar.zst",
+		}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "pending snapshot upload should block push enqueue")
+	require.Contains(t, w.Body.String(), `"code":"SNAPSHOT_PENDING"`, "response should expose a retryable pending-snapshot code")
+	require.NoError(t, mock.ExpectationsWereMet(), "handler should not query PRs or enqueue jobs while snapshot upload is pending")
+}
+
+func TestSessionHandler_PushChangesToPR_NoPR(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{}))
+
+	// PR lookup returns no rows — session has never had a PR opened.
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionPullRequestColumns))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "should return 404 when no PR exists for the session")
+	require.Contains(t, w.Body.String(), "NO_PR", "error code should distinguish missing-PR from session-not-found")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_PushChangesToPR_PRClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		prStatus  string
+		wantSlice string
+	}{
+		{name: "merged PR", prStatus: "merged", wantSlice: "PR_CLOSED"},
+		{name: "closed PR", prStatus: "closed", wantSlice: "PR_CLOSED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should be created")
+			defer mock.Close()
+
+			now := time.Now()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			issueID := uuid.New()
+			prID := uuid.New()
+			handler := newSessionHandler(t, mock)
+
+			mock.ExpectQuery("SELECT .+ FROM sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{}))
+
+			row := sessionPullRequestRow(prID, &sessionID, orgID, "owner/repo", now)
+			row[8] = tt.prStatus // status column
+			mock.ExpectQuery("SELECT .+ FROM pull_requests").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(sessionPullRequestColumns).AddRow(row...))
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", sessionID.String())
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+			ctx = middleware.WithOrgID(ctx, orgID)
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			handler.PushChangesToPR(w, req)
+
+			require.Equal(t, http.StatusConflict, w.Code, "should return 409 when PR is no longer open")
+			require.Contains(t, w.Body.String(), tt.wantSlice, "error code should indicate PR is closed/merged")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionHandler_PushChangesToPR_InFlightRejectsDuplicateSubmit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{name: "queued state rejects duplicate", state: "queued"},
+		{name: "pushing state rejects duplicate", state: "pushing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should be created")
+			defer mock.Close()
+
+			now := time.Now()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			issueID := uuid.New()
+			handler := newSessionHandler(t, mock)
+
+			mock.ExpectQuery("SELECT .+ FROM sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{pushState: tt.state}))
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("id", sessionID.String())
+			ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+			ctx = middleware.WithOrgID(ctx, orgID)
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			handler.PushChangesToPR(w, req)
+
+			require.Equal(t, http.StatusConflict, w.Code, "in-flight push should reject duplicate submits")
+			require.Contains(t, w.Body.String(), "PR_PUSH_IN_FLIGHT", "error code should indicate an in-flight push")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionHandler_PushChangesToPR_SnapshotExpired(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	// Sandbox destroyed simulates true retention expiry. The PR row may still
+	// exist but pushing requires a hydratable sandbox.
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{
+			sandboxState: "destroyed",
+			nilSnapshot:  true,
+		}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusGone, w.Code, "should return 410 when snapshot retention has expired")
+	require.Contains(t, w.Body.String(), "SNAPSHOT_EXPIRED", "error code should indicate snapshot expiry")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_PushChangesToPR_SnapshotNotCaptured(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{nilSnapshot: true}))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusConflict, w.Code, "should return 409 when no snapshot was captured")
+	require.Contains(t, w.Body.String(), "SNAPSHOT_NOT_CAPTURED", "error code should indicate missing checkpoint")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_PushChangesToPR_SessionNotFound(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	handler := newSessionHandler(t, mock)
+
+	mock.ExpectQuery("SELECT .+ FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(pgx.ErrNoRows)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.PushChangesToPR(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code, "should return 404 when session does not exist")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -769,6 +769,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/sessions/{id}/archive", sessionHandler.ArchiveSession)
 				r.Post("/api/v1/sessions/{id}/unarchive", sessionHandler.UnarchiveSession)
 				r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
+				r.Post("/api/v1/sessions/{id}/pr/push", sessionHandler.PushChangesToPR)
 				r.Post("/api/v1/pull-requests/{id}/repair/fix-tests", pullRequestHandler.FixTests)
 				r.Post("/api/v1/pull-requests/{id}/repair/resolve-conflicts", pullRequestHandler.ResolveConflicts)
 				r.Post("/api/v1/pull-requests/{id}/merge", pullRequestHandler.Merge)

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -32,7 +32,7 @@ var sessionColumns = []string{
 	"target_branch", "working_branch",
 	"base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
-	"pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -91,6 +91,8 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		nil,            // automation_run_id
 		"idle",         // pr_creation_state
 		(*string)(nil), // pr_creation_error
+		"idle",         // pr_push_state
+		(*string)(nil), // pr_push_error
 		nil,            // diff_collected_at
 		nil,            // latest_diff_snapshot_id
 		false,          // linear_private

--- a/internal/db/pull_request_store_test.go
+++ b/internal/db/pull_request_store_test.go
@@ -13,7 +13,7 @@ import (
 
 var prColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 	"health_version", "merged_at", "created_at", "updated_at",
 }
@@ -21,7 +21,7 @@ var prColumns = []string{
 func newPRRow(id, sessionID, orgID uuid.UUID, now time.Time) []any {
 	return []any{
 		id, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-		"Fix bug", (*string)(nil), "open", "pending", "app", "", (*string)(nil), (*string)(nil),
+		"Fix bug", (*string)(nil), "open", "pending", "app", "", (*string)(nil), (*string)(nil), (*string)(nil),
 		models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 	}
 }
@@ -51,7 +51,7 @@ func TestPullRequestStore_Create_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).
 				AddRow(generatedID, now, now),

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -92,7 +92,7 @@ func (s *PullRequestStore) GetBySessionID(ctx context.Context, orgID, sessionID 
 
 func (s *PullRequestStore) UpdateStatus(ctx context.Context, orgID, id uuid.UUID, status string) error {
 	query := `UPDATE pull_requests SET status = @status, updated_at = now() WHERE id = @id AND org_id = @org_id`
-	if status == "merged" {
+	if status == models.PullRequestStatusMerged {
 		query = `UPDATE pull_requests SET status = @status, merged_at = now(), updated_at = now() WHERE id = @id AND org_id = @org_id`
 	}
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -129,6 +129,10 @@ func (s *PullRequestStore) UpdateTitle(ctx context.Context, orgID, id uuid.UUID,
 // Stale signals are intentionally cleared rather than preserved so the UI
 // does not surface a misleading "needs action" banner against a commit that
 // no longer exists at HEAD.
+//
+// Returns pgx.ErrNoRows if no PR row matched (org_id/id mismatch or PR was
+// deleted between push and update). Callers can detect drift instead of
+// silently swallowing a no-op write.
 func (s *PullRequestStore) UpdateHeadSHA(ctx context.Context, orgID, id uuid.UUID, headSHA string) error {
 	query := `UPDATE pull_requests
 		SET head_sha = @head_sha,
@@ -140,13 +144,19 @@ func (s *PullRequestStore) UpdateHeadSHA(ctx context.Context, orgID, id uuid.UUI
 		    needs_agent_action = false,
 		    updated_at = now()
 		WHERE id = @id AND org_id = @org_id`
-	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+	res, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":          id,
 		"org_id":      orgID,
 		"head_sha":    headSHA,
 		"merge_state": models.PullRequestMergeStateUnknown,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	if res.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
 }
 
 // GetByRepoAndNumber looks up a PR by repo and number without org scoping.

--- a/internal/db/pull_requests.go
+++ b/internal/db/pull_requests.go
@@ -26,8 +26,8 @@ type PullRequestFilters struct {
 
 func (s *PullRequestStore) Create(ctx context.Context, pr *models.PullRequest) error {
 	query := `
-		INSERT INTO pull_requests (session_id, org_id, github_pr_number, github_pr_url, github_repo, title, body, status, review_status, authored_by, head_sha)
-		VALUES (@session_id, @org_id, @github_pr_number, @github_pr_url, @github_repo, @title, @body, @status, @review_status, @authored_by, @head_sha)
+		INSERT INTO pull_requests (session_id, org_id, github_pr_number, github_pr_url, github_repo, title, body, status, review_status, authored_by, head_sha, head_ref)
+		VALUES (@session_id, @org_id, @github_pr_number, @github_pr_url, @github_repo, @title, @body, @status, @review_status, @authored_by, @head_sha, @head_ref)
 		RETURNING id, created_at, updated_at`
 
 	authoredBy := pr.AuthoredBy
@@ -46,6 +46,7 @@ func (s *PullRequestStore) Create(ctx context.Context, pr *models.PullRequest) e
 		"review_status":    pr.ReviewStatus,
 		"authored_by":      authoredBy,
 		"head_sha":         pr.HeadSHA,
+		"head_ref":         pr.HeadRef,
 	}
 
 	row := s.db.QueryRow(ctx, query, args)
@@ -53,7 +54,7 @@ func (s *PullRequestStore) Create(ctx context.Context, pr *models.PullRequest) e
 }
 
 const prSelectColumns = `id, session_id, org_id, github_pr_number, github_pr_url, github_repo,
-		       title, body, status, review_status, authored_by, ci_status, head_sha, base_sha,
+		       title, body, status, review_status, authored_by, ci_status, head_sha, head_ref, base_sha,
 		       merge_state, has_conflicts, failing_test_count, needs_agent_action, github_state_synced_at,
 		       health_version, merged_at, created_at, updated_at`
 
@@ -108,6 +109,42 @@ func (s *PullRequestStore) UpdateTitle(ctx context.Context, orgID, id uuid.UUID,
 		"id":     id,
 		"org_id": orgID,
 		"title":  title,
+	})
+	return err
+}
+
+// UpdateHeadSHA persists the SHA of the most recent commit pushed to the PR's
+// head branch. Called after a "Push changes" follow-up push lands so the PR
+// row reflects the new HEAD without waiting for the GitHub webhook to round-
+// trip. Last-write-wins with the webhook is intentional — both writes carry
+// the same SHA after a successful push.
+//
+// Beyond head_sha, this also resets every column whose value was derived from
+// the *previous* HEAD: github_state_synced_at, health_version, merge_state,
+// has_conflicts, failing_test_count, and needs_agent_action. A fresh push
+// invalidates each of them — a previously-conflicted PR may now be clean,
+// previously-failing tests must re-run on the new SHA, and any pending
+// "agent action" tag (e.g. a fix-tests prompt) was scoped to the prior
+// commit. The next sync_pull_request_state job repopulates them from GitHub.
+// Stale signals are intentionally cleared rather than preserved so the UI
+// does not surface a misleading "needs action" banner against a commit that
+// no longer exists at HEAD.
+func (s *PullRequestStore) UpdateHeadSHA(ctx context.Context, orgID, id uuid.UUID, headSHA string) error {
+	query := `UPDATE pull_requests
+		SET head_sha = @head_sha,
+		    github_state_synced_at = NULL,
+		    health_version = 0,
+		    merge_state = @merge_state,
+		    has_conflicts = false,
+		    failing_test_count = 0,
+		    needs_agent_action = false,
+		    updated_at = now()
+		WHERE id = @id AND org_id = @org_id`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":          id,
+		"org_id":      orgID,
+		"head_sha":    headSHA,
+		"merge_state": models.PullRequestMergeStateUnknown,
 	})
 	return err
 }

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -188,6 +188,41 @@ func TestPullRequestStore_UpdateHeadSHA(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// Load-bearing regression: pr_health_service.go's currentMatchesHead
+// short-circuit treats `pr.HealthVersion != 0` as proof that UpdateHeadSHA
+// has not run since the cached health summary was written. If a future writer
+// stops resetting health_version to 0 here, that short-circuit will silently
+// surface stale "Resolve conflicts" / "Fix tests" banners after a fresh push.
+// Pin the literal `health_version = 0` substring so the test fails loudly if
+// the SET clause changes.
+//
+// Bumping the column to a non-zero default? Update pr_health_service.go's
+// currentMatchesHead at the same time so the SHA comparison becomes
+// unconditional, then update this regression to match.
+func TestPullRequestStore_UpdateHeadSHA_ResetsHealthVersionToZero(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+
+	// Anchor the literal SET fragment so accidental edits like
+	// `health_version = pr.health_version` or `health_version = @hv` fail
+	// the regex match instead of silently sliding past it.
+	mock.ExpectExec(`SET\s+head_sha = @head_sha,\s+github_state_synced_at = NULL,\s+health_version = 0,`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateHeadSHA(context.Background(), orgID, prID, "abc123def456")
+	require.NoError(t, err, "UpdateHeadSHA should reset health_version to 0 on every push to invalidate the cached health summary")
+	require.NoError(t, mock.ExpectationsWereMet(), "the SET clause must literally write health_version = 0 — see currentMatchesHead in pr_health_service.go")
+}
+
 // Drift detection: if the PR row was deleted between the push and the
 // follow-up UpdateHeadSHA, surface pgx.ErrNoRows so the worker dead-letters
 // and we can investigate instead of silently leaving GitHub with a new

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -184,5 +185,30 @@ func TestPullRequestStore_UpdateHeadSHA(t *testing.T) {
 
 	err = store.UpdateHeadSHA(context.Background(), orgID, prID, "abc123def456")
 	require.NoError(t, err, "UpdateHeadSHA should persist the new commit SHA and mark cached health stale")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// Drift detection: if the PR row was deleted between the push and the
+// follow-up UpdateHeadSHA, surface pgx.ErrNoRows so the worker dead-letters
+// and we can investigate instead of silently leaving GitHub with a new
+// commit no DB row tracks.
+func TestPullRequestStore_UpdateHeadSHA_NoRowReturnsErrNoRows(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+
+	mock.ExpectExec("UPDATE pull_requests[\\s\\S]*SET head_sha = @head_sha").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+
+	err = store.UpdateHeadSHA(context.Background(), orgID, prID, "abc123def456")
+	require.ErrorIs(t, err, pgx.ErrNoRows, "UpdateHeadSHA should report drift when no PR row matched")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/db/pull_requests_test.go
+++ b/internal/db/pull_requests_test.go
@@ -24,7 +24,7 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 
 	cols := []string{
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 		"health_version", "merged_at", "created_at", "updated_at",
 	}
@@ -39,7 +39,7 @@ func TestPullRequestStore_GetByRepoAndNumber(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", nil, nil,
+					"Fix bug", ptrStr("Description"), "open", "pending", "user1", "", nil, nil, nil,
 					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), nil, now, now),
 		)
 
@@ -82,7 +82,7 @@ func TestPullRequestStore_BatchGetBySessionIDs_Success(t *testing.T) {
 
 	cols := []string{
 		"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+		"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 		"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 		"health_version", "merged_at", "created_at", "updated_at",
 	}
@@ -97,7 +97,7 @@ func TestPullRequestStore_BatchGetBySessionIDs_Success(t *testing.T) {
 		WillReturnRows(
 			pgxmock.NewRows(cols).
 				AddRow(prID, &sessionID, orgID, 42, "https://github.com/org/repo/pull/42", "org/repo",
-					"Fix bug", ptrStr("body"), "open", "pending", "app", "success", nil, nil,
+					"Fix bug", ptrStr("body"), "open", "pending", "app", "success", nil, nil, nil,
 					models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), nil, now, now),
 		)
 
@@ -164,4 +164,25 @@ func TestPullRequestStore_UpdateTitle(t *testing.T) {
 	err = store.UpdateTitle(context.Background(), orgID, prID, "Updated PR title")
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPullRequestStore_UpdateHeadSHA(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+
+	orgID := uuid.New()
+	prID := uuid.New()
+
+	mock.ExpectExec("UPDATE pull_requests[\\s\\S]*SET head_sha = @head_sha[\\s\\S]*github_state_synced_at = NULL[\\s\\S]*health_version = 0[\\s\\S]*failing_test_count = 0").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateHeadSHA(context.Background(), orgID, prID, "abc123def456")
+	require.NoError(t, err, "UpdateHeadSHA should persist the new commit SHA and mark cached health stale")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -123,7 +123,7 @@ const sessionSelectColumns = `id,
 	runtime_extension_count, runtime_extension_seconds, runtime_stop_reason, runtime_graceful_stop_at,
 	checkpointed_at, checkpoint_kind, checkpoint_capability, checkpoint_size_bytes, checkpoint_error,
 	recovery_state, recovery_queued_at, recovery_started_at, recovery_attempt_count,
-	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, diff_collected_at, latest_diff_snapshot_id,
+	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, pr_push_state, pr_push_error, diff_collected_at, latest_diff_snapshot_id,
 	linear_private, linear_state_sync_disabled, linear_identifier_hint, linear_prepare_state,
 	deleted_at, git_identity_source, git_identity_user_id, created_at`
 
@@ -143,7 +143,7 @@ const sessionListColumns = `id,
 	runtime_extension_count, runtime_extension_seconds, runtime_stop_reason, runtime_graceful_stop_at,
 	checkpointed_at, checkpoint_kind, checkpoint_capability, checkpoint_size_bytes, checkpoint_error,
 	recovery_state, recovery_queued_at, recovery_started_at, recovery_attempt_count,
-	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, diff_collected_at, latest_diff_snapshot_id,
+	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, pr_push_state, pr_push_error, diff_collected_at, latest_diff_snapshot_id,
 	linear_private, linear_state_sync_disabled, linear_identifier_hint, linear_prepare_state,
 	deleted_at, git_identity_source, git_identity_user_id, created_at`
 
@@ -1196,6 +1196,12 @@ func (s *SessionStore) updateTurnCompleteRow(ctx context.Context, db DBTX, orgID
 		    agent_session_id = @agent_session_id, snapshot_key = @snapshot_key,
 		    sandbox_state = 'snapshotted',
 		    pr_creation_state = 'idle', pr_creation_error = NULL,
+		    -- Only reset pr_push_state when no push is currently in flight.
+		    -- A concurrent turn-complete from the orchestrator must never
+		    -- silently overwrite an active push (the handler's in-flight 409
+		    -- guard relies on this column being authoritative).
+		    pr_push_state = CASE WHEN pr_push_state IN ('queued', 'pushing') THEN pr_push_state ELSE 'idle' END,
+		    pr_push_error = CASE WHEN pr_push_state IN ('queued', 'pushing') THEN pr_push_error ELSE NULL END,
 		    confidence_score = @confidence_score, confidence_reasoning = @confidence_reasoning,
 		    risk_factors = @risk_factors, token_usage = @token_usage,
 		    result_summary = @result_summary, diff = @diff, error = @error,
@@ -1384,6 +1390,64 @@ func (s *SessionStore) UpdatePRCreationState(ctx context.Context, orgID, session
 		SET pr_creation_state = @state, pr_creation_error = @err
 		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
 		  AND pr_creation_state <> 'succeeded'`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+		"state":  string(state),
+		"err":    errArg,
+	})
+	return err
+}
+
+// TryMarkPRPushQueued atomically transitions pr_push_state from any non-in-
+// flight state ('idle', 'succeeded', 'failed') to 'queued', clearing any
+// previous error. Returns (true, nil) when the row was updated, (false, nil)
+// when a concurrent request already moved the column to 'queued' or 'pushing'.
+//
+// The push handler uses this instead of UpdatePRPushState to start a push so
+// two concurrent API requests that both pass the in-memory precheck cannot
+// both transition the column to 'queued'. The handler's job-enqueue dedupe
+// key collapses the worker side onto a single job; this CAS gives the API
+// side the matching guarantee that exactly one of the racing requests
+// returns 202 and the other returns 409.
+func (s *SessionStore) TryMarkPRPushQueued(ctx context.Context, orgID, sessionID uuid.UUID) (bool, error) {
+	query := `UPDATE sessions
+		SET pr_push_state = 'queued', pr_push_error = NULL
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
+		  AND pr_push_state NOT IN ('queued', 'pushing')`
+	res, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     sessionID,
+		"org_id": orgID,
+	})
+	if err != nil {
+		return false, err
+	}
+	return res.RowsAffected() > 0, nil
+}
+
+// UpdatePRPushState transitions pr_push_state and sets/clears pr_push_error
+// atomically. Mirrors UpdatePRCreationState but does not treat `succeeded` as
+// terminal — a session can have its changes pushed multiple times across
+// follow-up turns, so the column must be free to cycle through the state
+// machine. Each new turn complete resets the column to `idle` separately.
+//
+// To start a new push (idle → queued) prefer TryMarkPRPushQueued, which
+// rejects races between concurrent submitters; this method is for downstream
+// transitions (queued → pushing → succeeded/failed) where the worker is the
+// sole writer.
+func (s *SessionStore) UpdatePRPushState(ctx context.Context, orgID, sessionID uuid.UUID, state models.PRPushState, errMsg string) error {
+	if err := state.Validate(); err != nil {
+		return err
+	}
+	var errArg any
+	if state == models.PRPushStateFailed && errMsg != "" {
+		errArg = errMsg
+	} else {
+		errArg = nil
+	}
+	query := `UPDATE sessions
+		SET pr_push_state = @state, pr_push_error = @err
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -34,7 +34,7 @@ var sessionTestColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -92,6 +92,8 @@ func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []in
 		nil,            // automation_run_id
 		"idle",         // pr_creation_state
 		(*string)(nil), // pr_creation_error
+		"idle",         // pr_push_state
+		(*string)(nil), // pr_push_error
 		nil,            // diff_collected_at
 		nil,            // latest_diff_snapshot_id
 		false,          // linear_private
@@ -290,6 +292,52 @@ func TestSessionStore_UpdatePRCreationState(t *testing.T) {
 			}
 
 			require.NoError(t, err, "UpdatePRCreationState should persist valid state transitions")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionStore_TryMarkPRPushQueued(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		rowsAffected int64
+		wantQueued   bool
+	}{
+		{
+			name:         "rows affected returns true",
+			rowsAffected: 1,
+			wantQueued:   true,
+		},
+		{
+			name:         "no rows affected returns false (concurrent winner)",
+			rowsAffected: 0,
+			wantQueued:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewSessionStore(mock)
+			orgID := uuid.New()
+			sessionID := uuid.New()
+
+			// CAS update should pass exactly two args (id, org_id) and
+			// guard with a NOT IN ('queued','pushing') predicate.
+			mock.ExpectExec("UPDATE sessions[\\s\\S]*pr_push_state = 'queued'[\\s\\S]*pr_push_state NOT IN").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rowsAffected))
+
+			queued, err := store.TryMarkPRPushQueued(context.Background(), orgID, sessionID)
+			require.NoError(t, err, "TryMarkPRPushQueued should not error on a successful CAS attempt")
+			require.Equal(t, tt.wantQueued, queued, "TryMarkPRPushQueued should report whether the row transitioned")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}

--- a/internal/models/audit_enums.go
+++ b/internal/models/audit_enums.go
@@ -40,6 +40,7 @@ const (
 	AuditActionSessionReviewCommentUpdated AuditAction = "session.review_comment.updated"
 	AuditActionSessionReviewCommentDeleted AuditAction = "session.review_comment.deleted"
 	AuditActionSessionPRRequested          AuditAction = "session.pr_requested"
+	AuditActionSessionPRPushRequested      AuditAction = "session.pr_push_requested"
 	AuditActionSessionRetried              AuditAction = "session.retried"
 	AuditActionSessionArchived             AuditAction = "session.archived"
 	AuditActionSessionUnarchived           AuditAction = "session.unarchived"
@@ -122,7 +123,7 @@ func (a AuditAction) Validate() error {
 		AuditActionSessionFailed, AuditActionSessionCancelled, AuditActionSessionStatusChanged,
 		AuditActionSessionQuestionCreated, AuditActionSessionQuestionAnswered, AuditActionSessionResumedLocally,
 		AuditActionSessionReviewCommentCreated, AuditActionSessionReviewCommentUpdated, AuditActionSessionReviewCommentDeleted,
-		AuditActionSessionPRRequested, AuditActionSessionRetried,
+		AuditActionSessionPRRequested, AuditActionSessionPRPushRequested, AuditActionSessionRetried,
 		AuditActionSessionArchived, AuditActionSessionUnarchived,
 		AuditActionProjectCreated, AuditActionProjectUpdated, AuditActionProjectDeleted,
 		AuditActionProjectStarted, AuditActionProjectCompleted, AuditActionProjectArchived,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -267,10 +267,15 @@ type Session struct {
 	// PRCreationState drives the Create PR button's state machine. It is
 	// orthogonal to Status — a session can be `completed` with pr_creation_state
 	// `idle` (ready for user to click Create PR), `pushing` (in flight), etc.
-	PRCreationState      PRCreationState `db:"pr_creation_state" json:"pr_creation_state"`
-	PRCreationError      *string         `db:"pr_creation_error" json:"pr_creation_error,omitempty"`
-	DiffCollectedAt      *time.Time      `db:"diff_collected_at" json:"diff_collected_at,omitempty"`
-	LatestDiffSnapshotID *uuid.UUID      `db:"latest_diff_snapshot_id" json:"latest_diff_snapshot_id,omitempty"`
+	PRCreationState PRCreationState `db:"pr_creation_state" json:"pr_creation_state"`
+	PRCreationError *string         `db:"pr_creation_error" json:"pr_creation_error,omitempty"`
+	// PRPushState drives the "Push changes" button's state machine for sessions
+	// that already have an open PR. Independent from PRCreationState so a single
+	// session can show "PR opened" while a follow-up push is mid-flight.
+	PRPushState          PRPushState `db:"pr_push_state" json:"pr_push_state"`
+	PRPushError          *string     `db:"pr_push_error" json:"pr_push_error,omitempty"`
+	DiffCollectedAt      *time.Time  `db:"diff_collected_at" json:"diff_collected_at,omitempty"`
+	LatestDiffSnapshotID *uuid.UUID  `db:"latest_diff_snapshot_id" json:"latest_diff_snapshot_id,omitempty"`
 	// LinearPrivate suppresses every Linear write for this session. The agent
 	// still receives Linear context locally; nothing leaves 143. Frozen at
 	// session create — see design 62 §"Composer controls must express distinct
@@ -505,23 +510,40 @@ type Validation struct {
 	CreatedAt           time.Time       `db:"created_at" json:"created_at"`
 }
 
+// PullRequest.Status values. Stored as a free-form string for historical
+// reasons (the webhook used to forward GitHub's raw state field). New code
+// should compare against these constants rather than literal strings so
+// renames stay grep-friendly.
+const (
+	PullRequestStatusOpen   = "open"
+	PullRequestStatusClosed = "closed"
+	PullRequestStatusMerged = "merged"
+)
+
 // PullRequest represents a GitHub PR created by an agent run.
 // NOTE: SessionID is nullable (*uuid.UUID) because PRs can be created manually
 // without an associated session. API consumers should handle null session_id.
 type PullRequest struct {
-	ID                  uuid.UUID             `db:"id" json:"id"`
-	SessionID           *uuid.UUID            `db:"session_id" json:"session_id,omitempty"`
-	OrgID               uuid.UUID             `db:"org_id" json:"org_id"`
-	GitHubPRNumber      int                   `db:"github_pr_number" json:"github_pr_number"`
-	GitHubPRURL         string                `db:"github_pr_url" json:"github_pr_url"`
-	GitHubRepo          string                `db:"github_repo" json:"github_repo"`
-	Title               string                `db:"title" json:"title"`
-	Body                *string               `db:"body" json:"body,omitempty"`
-	Status              string                `db:"status" json:"status"`
-	ReviewStatus        string                `db:"review_status" json:"review_status"`
-	AuthoredBy          string                `db:"authored_by" json:"authored_by"`
-	CIStatus            string                `db:"ci_status" json:"ci_status"`
-	HeadSHA             *string               `db:"head_sha" json:"head_sha,omitempty"`
+	ID             uuid.UUID  `db:"id" json:"id"`
+	SessionID      *uuid.UUID `db:"session_id" json:"session_id,omitempty"`
+	OrgID          uuid.UUID  `db:"org_id" json:"org_id"`
+	GitHubPRNumber int        `db:"github_pr_number" json:"github_pr_number"`
+	GitHubPRURL    string     `db:"github_pr_url" json:"github_pr_url"`
+	GitHubRepo     string     `db:"github_repo" json:"github_repo"`
+	Title          string     `db:"title" json:"title"`
+	Body           *string    `db:"body" json:"body,omitempty"`
+	Status         string     `db:"status" json:"status"`
+	ReviewStatus   string     `db:"review_status" json:"review_status"`
+	AuthoredBy     string     `db:"authored_by" json:"authored_by"`
+	CIStatus       string     `db:"ci_status" json:"ci_status"`
+	HeadSHA        *string    `db:"head_sha" json:"head_sha,omitempty"`
+	// HeadRef is the branch name on GitHub the PR tracks. Captured at
+	// PR-creation time so the "Push changes" follow-up always targets the
+	// same ref even if the session's title or Linear identifier (which feed
+	// into formatBranchName) change later. Nullable for PRs created before
+	// migration 107 added the column — the push code falls back to
+	// recomputing in that case.
+	HeadRef             *string               `db:"head_ref" json:"head_ref,omitempty"`
 	BaseSHA             *string               `db:"base_sha" json:"base_sha,omitempty"`
 	MergeState          PullRequestMergeState `db:"merge_state" json:"merge_state"`
 	HasConflicts        bool                  `db:"has_conflicts" json:"has_conflicts"`

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -193,6 +193,33 @@ func (s PRCreationState) Validate() error {
 	}
 }
 
+// PRPushState mirrors PRCreationState but tracks the "Push changes" follow-up
+// action that pushes new commits to an already-open PR. Kept separate so the
+// two operations can be in flight independently and so the UI does not have to
+// disambiguate "succeeded" between "PR opened" and "changes pushed".
+type PRPushState string
+
+const (
+	PRPushStateIdle      PRPushState = "idle"
+	PRPushStateQueued    PRPushState = "queued"
+	PRPushStatePushing   PRPushState = "pushing"
+	PRPushStateSucceeded PRPushState = "succeeded"
+	PRPushStateFailed    PRPushState = "failed"
+)
+
+func (s PRPushState) Validate() error {
+	switch s {
+	case PRPushStateIdle,
+		PRPushStateQueued,
+		PRPushStatePushing,
+		PRPushStateSucceeded,
+		PRPushStateFailed:
+		return nil
+	default:
+		return fmt.Errorf("invalid PRPushState: %q", s)
+	}
+}
+
 // SandboxState tracks the lifecycle of a session's sandbox.
 type SandboxState string
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -584,6 +584,7 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 
 	authoredBy := resolution.AuthoredBy()
 	headSHA := pushed.HeadSHA
+	headRef := branchName
 	pr := &models.PullRequest{
 		SessionID:      &run.ID,
 		OrgID:          run.OrgID,
@@ -592,10 +593,11 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		GitHubRepo:     repo.FullName,
 		Title:          title,
 		Body:           &body,
-		Status:         "open",
+		Status:         models.PullRequestStatusOpen,
 		ReviewStatus:   "pending",
 		AuthoredBy:     authoredBy,
 		HeadSHA:        &headSHA,
+		HeadRef:        &headRef,
 	}
 	if err := s.pullRequests.Create(ctx, pr); err != nil {
 		return nil, fmt.Errorf("store pull request: %w", err)
@@ -645,6 +647,155 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 	}
 
 	return pr, nil
+}
+
+// ErrNoPullRequest is returned by PushChangesToPR when the session has no
+// associated PR row. The "Push changes" action is only meaningful when a PR
+// already exists; the caller should fall back to (or surface) Create PR.
+var ErrNoPullRequest = errors.New("no pull request exists for session")
+
+// ErrPRClosed is returned by PushChangesToPR when the session's PR is in a
+// terminal state (merged or closed) where pushing additional commits would not
+// take effect on the user's behalf. The caller should disable the button.
+var ErrPRClosed = errors.New("pull request is closed")
+
+// PushChangesToPR stages, commits, and pushes any uncommitted/unpushed changes
+// from the session's sandbox up to the existing PR's branch, then updates the
+// PR row's head_sha. Mirrors the push half of CreatePR (sandbox hydrate, git
+// script, snapshot capture, post-push snapshot upload) without re-running the
+// PR-row creation, content generation, label attachment, status transitions,
+// or Linear milestones — those side effects belong to PR creation only.
+//
+// Branch resolution: prefers the head_ref captured at PR-creation time so the
+// push always targets the same ref the original CreatePR landed on. Falls back
+// to recomputing via formatBranchName for PRs created before the head_ref
+// column was added (migration 107). This avoids a divergence where a session's
+// title or Linear identifier changes after CreatePR ran and a fresh
+// formatBranchName would point at a branch the PR doesn't track.
+//
+// Returns ErrNoPullRequest if the session has no PR row, ErrPRClosed if the
+// PR is merged/closed, ErrNoChanges when there is nothing to push, and the
+// same snapshot sentinels as CreatePR when the sandbox is unavailable.
+func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, params ...CreatePRParams) (*models.PullRequest, error) {
+	pr, err := s.pullRequests.GetBySessionID(ctx, run.OrgID, run.ID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrNoPullRequest
+		}
+		return nil, fmt.Errorf("load pull request: %w", err)
+	}
+	if pr.Status != models.PullRequestStatusOpen {
+		return nil, ErrPRClosed
+	}
+
+	if s.sandboxProvider == nil || s.snapshots == nil {
+		return nil, fmt.Errorf("PRService: sandbox push dependencies not configured")
+	}
+	if run.SnapshotKey == nil || *run.SnapshotKey == "" {
+		return nil, ErrSnapshotNotCaptured
+	}
+	if run.PendingSnapshotKey != nil && *run.PendingSnapshotKey != "" {
+		return nil, agent.ErrSnapshotPending
+	}
+	if run.RepositoryID == nil {
+		return nil, fmt.Errorf("session %s has no repository", run.ID)
+	}
+
+	var issue *models.Issue
+	if run.PrimaryIssueID != nil {
+		i, lookupErr := s.issues.GetByID(ctx, run.OrgID, *run.PrimaryIssueID)
+		if lookupErr == nil {
+			issue = &i
+		} else {
+			s.logger.Warn().Err(lookupErr).Str("issue_id", run.PrimaryIssueID.String()).Msg("PushChangesToPR: failed to look up issue, proceeding without it")
+		}
+	}
+
+	repo, err := s.repos.GetByID(ctx, run.OrgID, *run.RepositoryID)
+	if err != nil {
+		return nil, fmt.Errorf("get repository: %w", err)
+	}
+
+	orgSettings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
+	if s.orgs != nil {
+		if org, orgErr := s.orgs.GetByID(ctx, run.OrgID); orgErr == nil {
+			if parsed, parseErr := models.ParseOrgSettings(org.Settings); parseErr == nil {
+				orgSettings = parsed
+			}
+		}
+	}
+
+	var opts CreatePRParams
+	for _, param := range params {
+		if param.Draft != nil {
+			opts.Draft = param.Draft
+		}
+		if param.AuthorMode != "" {
+			opts.AuthorMode = param.AuthorMode
+		}
+	}
+
+	resolution, err := s.resolveToken(ctx, run, &repo, orgSettings, opts.AuthorMode)
+	if err != nil {
+		return nil, fmt.Errorf("resolve token: %w", err)
+	}
+	token := resolution.Token
+
+	// Prefer the persisted head_ref so the push targets the exact branch the
+	// original CreatePR landed on. Fall back to recomputing for PRs created
+	// before head_ref was captured.
+	var branchName string
+	if pr.HeadRef != nil && *pr.HeadRef != "" {
+		branchName = *pr.HeadRef
+	} else {
+		branchName = formatBranchName(run, issue)
+	}
+	commitMsg := formatCommitMessage(run, issue)
+	authorName, authorEmail := identity.CommitIdentity(resolution)
+	if !resolution.IsUserToken() && run.TriggeredByUserID != nil && s.users != nil {
+		if user, userErr := s.users.GetByID(ctx, run.OrgID, *run.TriggeredByUserID); userErr == nil {
+			if trailer := identity.CoAuthorTrailer(&user); trailer != "" {
+				commitMsg += "\n\n" + trailer
+			}
+		}
+	}
+
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, token, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	if err != nil {
+		return nil, err
+	}
+	// Mirror CreatePR's tempfile ownership invariant: the deferred Remove is a
+	// safety net for every error path between here and the snapshot-upload
+	// dispatch below; on success, dispatchPostPRSnapshotUpload zeroes
+	// CapturedSnapshotPath to transfer ownership to the goroutine.
+	defer func() {
+		if pushed != nil && pushed.CapturedSnapshotPath != "" {
+			_ = os.Remove(pushed.CapturedSnapshotPath)
+		}
+	}()
+
+	if err := s.pullRequests.UpdateHeadSHA(ctx, run.OrgID, pr.ID, pushed.HeadSHA); err != nil {
+		return nil, fmt.Errorf("update pull request head sha: %w", err)
+	}
+	pr.HeadSHA = &pushed.HeadSHA
+	s.enqueuePullRequestStateSync(ctx, pr)
+
+	if pushed.CapturedSnapshotErr != nil {
+		s.logger.Warn().
+			Err(pushed.CapturedSnapshotErr).
+			Str("session_id", run.ID.String()).
+			Msg("post-push sandbox snapshot capture failed; resume will see stale state")
+	} else if pushed.CapturedSnapshotPath != "" {
+		newSnapshotKey := fmt.Sprintf("snapshots/%s/%s/post-pr.tar.zst", run.OrgID, run.ID)
+		if setErr := s.sessions.SetPendingSnapshotKey(ctx, run.OrgID, run.ID, newSnapshotKey); setErr != nil {
+			s.logger.Warn().Err(setErr).Str("session_id", run.ID.String()).Msg("failed to set pending snapshot key")
+		} else {
+			s.dispatchPostPRSnapshotUpload(run.OrgID, run.ID, newSnapshotKey, pushed.CapturedSnapshotPath, pushed.CapturedSnapshotSize)
+			pushed.CapturedSnapshotPath = ""
+		}
+	}
+
+	return &pr, nil
 }
 
 // postPRSnapshotUploadTimeout bounds a single upload attempt. Deliberately

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -659,6 +659,16 @@ var ErrNoPullRequest = errors.New("no pull request exists for session")
 // take effect on the user's behalf. The caller should disable the button.
 var ErrPRClosed = errors.New("pull request is closed")
 
+// ErrLegacyPRMissingHeadRef is returned by PushChangesToPR when the PR row was
+// created before migration 107 added the head_ref column and therefore has no
+// persisted branch name. We refuse to silently push to a recomputed branch
+// name because formatBranchName is sensitive to the session's title and
+// Linear identifier — both of which can drift after CreatePR runs — so a
+// fallback push could land on a branch the PR doesn't track and silently
+// orphan the user's commits. The user should re-create the PR (or wait for a
+// future backfill migration) instead.
+var ErrLegacyPRMissingHeadRef = errors.New("pull request was created before head_ref was tracked; cannot determine push branch")
+
 // PushChangesToPR stages, commits, and pushes any uncommitted/unpushed changes
 // from the session's sandbox up to the existing PR's branch, then updates the
 // PR row's head_sha. Mirrors the push half of CreatePR (sandbox hydrate, git
@@ -666,15 +676,17 @@ var ErrPRClosed = errors.New("pull request is closed")
 // PR-row creation, content generation, label attachment, status transitions,
 // or Linear milestones — those side effects belong to PR creation only.
 //
-// Branch resolution: prefers the head_ref captured at PR-creation time so the
-// push always targets the same ref the original CreatePR landed on. Falls back
-// to recomputing via formatBranchName for PRs created before the head_ref
-// column was added (migration 107). This avoids a divergence where a session's
-// title or Linear identifier changes after CreatePR ran and a fresh
-// formatBranchName would point at a branch the PR doesn't track.
+// Branch resolution: requires the head_ref captured at PR-creation time so
+// the push always targets the same ref the original CreatePR landed on. PRs
+// created before migration 107 don't have head_ref persisted; in that case we
+// return ErrLegacyPRMissingHeadRef rather than recomputing via
+// formatBranchName, because the recomputed name is sensitive to the session's
+// title and Linear identifier (both of which can drift after CreatePR ran)
+// and a guess could silently push to a branch the PR doesn't track.
 //
 // Returns ErrNoPullRequest if the session has no PR row, ErrPRClosed if the
-// PR is merged/closed, ErrNoChanges when there is nothing to push, and the
+// PR is merged/closed, ErrLegacyPRMissingHeadRef for legacy PRs without a
+// persisted branch name, ErrNoChanges when there is nothing to push, and the
 // same snapshot sentinels as CreatePR when the sandbox is unavailable.
 func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, params ...CreatePRParams) (*models.PullRequest, error) {
 	pr, err := s.pullRequests.GetBySessionID(ctx, run.OrgID, run.ID)
@@ -686,6 +698,11 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 	}
 	if pr.Status != models.PullRequestStatusOpen {
 		return nil, ErrPRClosed
+	}
+	// Refuse legacy PRs early — before any sandbox hydrate or token resolution
+	// — so we don't burn work on a request that's guaranteed to fail.
+	if pr.HeadRef == nil || *pr.HeadRef == "" {
+		return nil, ErrLegacyPRMissingHeadRef
 	}
 
 	if s.sandboxProvider == nil || s.snapshots == nil {
@@ -741,15 +758,9 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 	}
 	token := resolution.Token
 
-	// Prefer the persisted head_ref so the push targets the exact branch the
-	// original CreatePR landed on. Fall back to recomputing for PRs created
-	// before head_ref was captured.
-	var branchName string
-	if pr.HeadRef != nil && *pr.HeadRef != "" {
-		branchName = *pr.HeadRef
-	} else {
-		branchName = formatBranchName(run, issue)
-	}
+	// Use the persisted head_ref captured at PR-creation time. Guarded by the
+	// ErrLegacyPRMissingHeadRef check above, so we know it's set here.
+	branchName := *pr.HeadRef
 	commitMsg := formatCommitMessage(run, issue)
 	authorName, authorEmail := identity.CommitIdentity(resolution)
 	if !resolution.IsUserToken() && run.TriggeredByUserID != nil && s.users != nil {
@@ -1231,7 +1242,7 @@ func (s *PRService) HandlePullRequestEvent(ctx context.Context, event PullReques
 // to head SHA when GitHub omits merge_commit_sha.
 func (s *PRService) applyClosedPRTransition(ctx context.Context, pr models.PullRequest, merged bool, mergeCommitSHA, headSHA string) error {
 	if merged {
-		if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "merged"); err != nil {
+		if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, models.PullRequestStatusMerged); err != nil {
 			return fmt.Errorf("update PR status to merged: %w", err)
 		}
 		commitSHA := mergeCommitSHA
@@ -1242,7 +1253,7 @@ func (s *PRService) applyClosedPRTransition(ctx context.Context, pr models.PullR
 		return nil
 	}
 
-	if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, "closed"); err != nil {
+	if err := s.pullRequests.UpdateStatus(ctx, pr.OrgID, pr.ID, models.PullRequestStatusClosed); err != nil {
 		return fmt.Errorf("update PR status to closed: %w", err)
 	}
 	// Tell the Linear linker the session ended without a merge so the

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -27,7 +27,7 @@ import (
 // If the store query changes its SELECT list, update this slice to match.
 var handlerPRColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 	"health_version", "merged_at", "created_at", "updated_at",
 }
@@ -49,7 +49,7 @@ var sessionColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -66,7 +66,7 @@ func newMockPool(t *testing.T) pgxmock.PgxPoolIface {
 func handlerPRRow(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID, repo string, now time.Time) []any {
 	return []any{
 		prID, sessionID, orgID, 42, "https://github.com/" + repo + "/pull/42", repo,
-		"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+		"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 		models.PullRequestMergeStateUnknown, false, 0, false, nil, int64(0), (*time.Time)(nil), now, now,
 	}
 }
@@ -211,6 +211,8 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 					nil,                           // automation_run_id
 					"idle",                        // pr_creation_state
 					(*string)(nil),                // pr_creation_error
+					"idle",                        // pr_push_state
+					(*string)(nil),                // pr_push_error
 					nil,                           // diff_collected_at
 					nil,                           // latest_diff_snapshot_id
 					false,                         // linear_private

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -131,22 +131,31 @@ func (s *PRService) buildPullRequestHealthResponse(ctx context.Context, pr model
 
 	current, err := s.pullRequests.GetHealthCurrent(ctx, pr.OrgID, pr.ID)
 	if err == nil {
+		currentMatchesHead := pr.HealthVersion != 0 || resp.HeadSHA == "" || current.HeadSHA == resp.HeadSHA
 		var summary models.PullRequestHealthSummary
-		if unmarshalErr := json.Unmarshal(current.SummaryJSON, &summary); unmarshalErr == nil {
-			normalizeStoredCheckSummaries(&summary)
-			resp.MergeState = summary.MergeState
-			resp.HasConflicts = summary.HasConflicts
-			resp.FailingTestCount = summary.FailingTestCount
-			resp.NeedsAgentAction = summary.NeedsAgentAction
-			resp.Checks = summary.Checks
-			resp.HealthVersion = current.Version
-			resp.HeadSHA = current.HeadSHA
-			resp.BaseSHA = current.BaseSHA
-			resp.ChecksConfirmed = true
-			resp.EnrichmentStatus = current.EnrichmentStatus
-			resp.EnrichmentRequested = current.EnrichmentStatus == models.PullRequestHealthEnrichmentStatusPending
-			resp.EnrichmentReady = current.EnrichmentStatus == models.PullRequestHealthEnrichmentStatusReady
-			derivePullRequestRepairActions(resp)
+		if currentMatchesHead {
+			if unmarshalErr := json.Unmarshal(current.SummaryJSON, &summary); unmarshalErr == nil {
+				normalizeStoredCheckSummaries(&summary)
+				resp.MergeState = summary.MergeState
+				resp.HasConflicts = summary.HasConflicts
+				resp.FailingTestCount = summary.FailingTestCount
+				resp.NeedsAgentAction = summary.NeedsAgentAction
+				resp.Checks = summary.Checks
+				resp.HealthVersion = current.Version
+				resp.HeadSHA = current.HeadSHA
+				resp.BaseSHA = current.BaseSHA
+				resp.ChecksConfirmed = true
+				resp.EnrichmentStatus = current.EnrichmentStatus
+				resp.EnrichmentRequested = current.EnrichmentStatus == models.PullRequestHealthEnrichmentStatusPending
+				resp.EnrichmentReady = current.EnrichmentStatus == models.PullRequestHealthEnrichmentStatusReady
+				derivePullRequestRepairActions(resp)
+			}
+		} else {
+			s.logger.Info().
+				Str("pull_request_id", pr.ID.String()).
+				Str("pr_head_sha", resp.HeadSHA).
+				Str("health_head_sha", current.HeadSHA).
+				Msg("skipping stale pull request health summary for newer PR head")
 		}
 
 		if resp.EnrichmentReady {

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -131,6 +131,15 @@ func (s *PRService) buildPullRequestHealthResponse(ctx context.Context, pr model
 
 	current, err := s.pullRequests.GetHealthCurrent(ctx, pr.OrgID, pr.ID)
 	if err == nil {
+		// currentMatchesHead suppresses the cached health summary when it
+		// describes a SHA the PR has already moved past (e.g. after a "Push
+		// changes" follow-up). The HealthVersion != 0 short-circuit relies
+		// on PullRequestStore.UpdateHeadSHA resetting health_version to 0
+		// on every push — if a future writer changes that invariant the
+		// SHA comparison must become unconditional, otherwise stale
+		// "Resolve conflicts"/"Fix tests" banners can survive a fresh push.
+		// resp.HeadSHA == "" preserves legacy behavior for PRs that never
+		// had a head SHA recorded; nothing to compare against.
 		currentMatchesHead := pr.HealthVersion != 0 || resp.HeadSHA == "" || current.HeadSHA == resp.HeadSHA
 		var summary models.PullRequestHealthSummary
 		if currentMatchesHead {

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -82,7 +82,7 @@ func (s *PRService) GetPullRequestHealth(ctx context.Context, orgID, pullRequest
 		return nil, err
 	}
 
-	if (pr.GitHubStateSyncedAt == nil || pr.HealthVersion == 0) && pr.Status == "open" {
+	if (pr.GitHubStateSyncedAt == nil || pr.HealthVersion == 0) && pr.Status == models.PullRequestStatusOpen {
 		if err := s.SyncPullRequestState(ctx, orgID, pullRequestID); err != nil {
 			s.logger.Warn().Err(err).Str("pull_request_id", pullRequestID.String()).Msg("failed to sync pull request health inline")
 		}
@@ -90,7 +90,7 @@ func (s *PRService) GetPullRequestHealth(ctx context.Context, orgID, pullRequest
 		if err != nil {
 			return nil, err
 		}
-	} else if pr.Status == "open" && pr.GitHubStateSyncedAt != nil && time.Since(*pr.GitHubStateSyncedAt) > prHealthStaleAfter {
+	} else if pr.Status == models.PullRequestStatusOpen && pr.GitHubStateSyncedAt != nil && time.Since(*pr.GitHubStateSyncedAt) > prHealthStaleAfter {
 		s.enqueuePullRequestStateSync(ctx, pr)
 	}
 
@@ -99,7 +99,7 @@ func (s *PRService) GetPullRequestHealth(ctx context.Context, orgID, pullRequest
 		return nil, err
 	}
 
-	if pr.Status == "open" && resp.FailingTestCount > 0 && !resp.EnrichmentReady && !resp.EnrichmentRequested {
+	if pr.Status == models.PullRequestStatusOpen && resp.FailingTestCount > 0 && !resp.EnrichmentReady && !resp.EnrichmentRequested {
 		s.enqueuePullRequestHealthEnrichment(ctx, pr, resp.HealthVersion)
 		resp.EnrichmentRequested = true
 	}
@@ -190,7 +190,7 @@ func derivePullRequestRepairActions(resp *models.PullRequestHealthResponse) {
 	// Once GitHub health has been loaded, zero checks means "no CI rules
 	// configured" and is mergeable. Before that health snapshot exists, zero
 	// checks remains ambiguous and we keep merge hidden.
-	resp.CanMerge = resp.Status == "open" &&
+	resp.CanMerge = resp.Status == models.PullRequestStatusOpen &&
 		resp.MergeState == models.PullRequestMergeStateClean &&
 		checksAllowMerge(resp.ChecksConfirmed, resp.Checks)
 }
@@ -233,7 +233,7 @@ func (s *PRService) SyncPullRequestState(ctx context.Context, orgID, pullRequest
 	// signature mismatch, app restart, etc.). Apply the same transition the
 	// webhook handler would have, then stop — a closed PR has no live health
 	// to track and re-running follow-ups would just churn idempotent work.
-	if strings.EqualFold(strings.TrimSpace(details.State), "closed") && pr.Status == "open" {
+	if strings.EqualFold(strings.TrimSpace(details.State), "closed") && pr.Status == models.PullRequestStatusOpen {
 		s.logger.Warn().
 			Str("pull_request_id", pullRequestID.String()).
 			Str("repo", pr.GitHubRepo).

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -319,7 +319,7 @@ func TestPRServiceGetPullRequestHealthEnqueuesSyncAndEnrichment(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, &stale, int64(2), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("INSERT INTO jobs").
@@ -392,7 +392,7 @@ func TestPRServiceSyncPullRequestState(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -499,7 +499,7 @@ func TestPRServiceSyncPullRequestStateSelfHealsMergedDrift(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -563,7 +563,7 @@ func TestPRServiceSyncPullRequestStateSelfHealsClosedWithoutMergeDrift(t *testin
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, (*uuid.UUID)(nil), orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -633,7 +633,7 @@ func TestPRServiceSyncPullRequestStateSkipsIndeterminateMergeRegression(t *testi
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Flaky PR", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Flaky PR", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateConflicted, true, 0, true, (*time.Time)(nil), int64(3), &now, now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -706,7 +706,7 @@ func TestPRServiceSyncPullRequestStateSkipsIndeterminateTestRegression(t *testin
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Tests rerun", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Tests rerun", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateClean, false, 2, true, (*time.Time)(nil), int64(4), &now, now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -766,7 +766,7 @@ func TestPRServiceEnrichPullRequestHealth(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 1, true, (*time.Time)(nil), int64(5), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -838,7 +838,7 @@ func TestPRServiceStartPullRequestRepairReusesExistingRun(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
 		))
 	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
@@ -1218,14 +1218,14 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -1287,7 +1287,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", strPtr("head-inline"), strPtr("base-inline"),
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", strPtr("head-inline"), nil, strPtr("base-inline"),
 				models.PullRequestMergeStateConflicted, true, 1, true, &now, int64(1), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
@@ -1337,7 +1337,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "closed", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "closed", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
@@ -1371,7 +1371,7 @@ func TestPRServiceGetPullRequestHealthInlineSyncAndStartRepairErrors(t *testing.
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
@@ -1420,14 +1420,14 @@ func TestPRServiceReconcileAndRepairBranchCoverage(t *testing.T) {
 			WithArgs(pgx.NamedArgs{"org_id": orgID, "before": pgxmock.AnyArg(), "limit": 10}).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 			WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 				prID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+				"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 				models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
 			))
 		mock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
@@ -1487,7 +1487,7 @@ func TestPRServiceReconcileAndRepairBranchCoverage(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 						pullRequestID, nil, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-						"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+						"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 						models.PullRequestMergeStateUnknown, false, 0, false, &now, int64(5), (*time.Time)(nil), now, now,
 					))
 				mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
@@ -1578,7 +1578,7 @@ var prHealthSessionColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -1601,7 +1601,7 @@ func newPRHealthSessionRow(sessionID, orgID uuid.UUID, now time.Time, status str
 		nil, "", "", int64(0), nil,
 		"", nil, nil, 0,
 		nil, nil, nil, nil, nil, nil, nil,
-		nil, nil, nil, "idle", (*string)(nil), nil, nil,
+		nil, nil, nil, "idle", (*string)(nil), "idle", (*string)(nil), nil, nil,
 		false, false, (*string)(nil), models.LinearPrepareStateNone,
 		nil, nil, nil, now,
 	}

--- a/internal/services/github/pr_merge.go
+++ b/internal/services/github/pr_merge.go
@@ -66,7 +66,7 @@ func (s *PRService) MergePullRequest(ctx context.Context, orgID, pullRequestID, 
 	if err != nil {
 		return nil, fmt.Errorf("load pull request: %w", err)
 	}
-	if pr.Status != "open" {
+	if pr.Status != models.PullRequestStatusOpen {
 		return nil, fmt.Errorf("%w: pull request status is %q", ErrPullRequestNotMergeable, pr.Status)
 	}
 
@@ -173,7 +173,7 @@ func (s *PRService) MergePullRequest(ctx context.Context, orgID, pullRequestID, 
 	// (deploys ON CONFLICT, set-to-merged status, set-to-fixed issue,
 	// dedupe-keyed evaluate_experiment job, snapshot cleanup, audit gated on
 	// archived=true), so the duplicate execution is intentional and safe.
-	if err := s.pullRequests.UpdateStatus(ctx, orgID, pullRequestID, "merged"); err != nil {
+	if err := s.pullRequests.UpdateStatus(ctx, orgID, pullRequestID, models.PullRequestStatusMerged); err != nil {
 		s.logger.Warn().Err(err).Str("pull_request_id", pullRequestID.String()).Msg("failed to persist merged status after successful merge")
 	}
 	s.runMergedPullRequestFollowUps(ctx, pr, mergeResp.SHA)

--- a/internal/services/github/pr_merge_test.go
+++ b/internal/services/github/pr_merge_test.go
@@ -310,14 +310,14 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 		))
 	prMock.ExpectQuery("SELECT .+ FROM pull_requests WHERE id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "", nil, nil, nil,
 			models.PullRequestMergeStateUnknown, false, 0, false, (*time.Time)(nil), int64(0), (*time.Time)(nil), now, now,
 		))
 
@@ -382,7 +382,7 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(
 			prID, &sessionID, orgID, 42, "https://github.com/assembledhq/143/pull/42", "assembledhq/143",
-			"Fix bug", (*string)(nil), "open", "pending", "app", "success", &headSHA, &baseSHA,
+			"Fix bug", (*string)(nil), "open", "pending", "app", "success", &headSHA, nil, &baseSHA,
 			models.PullRequestMergeStateClean, false, 0, false, &now, int64(1), (*time.Time)(nil), now, now,
 		))
 	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current").

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -63,7 +63,7 @@ var prTestUserColumns = []string{
 
 var prTestPullRequestColumns = []string{
 	"id", "session_id", "org_id", "github_pr_number", "github_pr_url", "github_repo",
-	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "base_sha",
+	"title", "body", "status", "review_status", "authored_by", "ci_status", "head_sha", "head_ref", "base_sha",
 	"merge_state", "has_conflicts", "failing_test_count", "needs_agent_action", "github_state_synced_at",
 	"health_version", "merged_at", "created_at", "updated_at",
 }
@@ -86,6 +86,7 @@ func newPRTestRowWithTitle(prID uuid.UUID, sessionID *uuid.UUID, orgID uuid.UUID
 		"pending",
 		"app",
 		"",
+		nil,
 		nil,
 		nil,
 		models.PullRequestMergeStateUnknown,
@@ -3193,6 +3194,233 @@ func TestCreatePR_ReturnsExistingPRBeforeCheckingSandboxDeps(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestPushChangesToPR_ReturnsErrNoPullRequestWhenSessionHasNoPR(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	// PR lookup returns ErrNoRows — no PR row exists for this session.
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns))
+
+	svc := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		logger:       zerolog.Nop(),
+	}
+
+	_, err = svc.PushChangesToPR(context.Background(), &models.Session{ID: sessionID, OrgID: orgID})
+	require.ErrorIs(t, err, ErrNoPullRequest, "PushChangesToPR should return ErrNoPullRequest when no PR row exists")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPushChangesToPR_ReturnsErrPRClosedForClosedOrMergedPR(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "merged PR", status: "merged"},
+		{name: "closed PR", status: "closed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create pgxmock pool")
+			defer mock.Close()
+
+			now := time.Now()
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			prID := uuid.New()
+			body := "body"
+
+			row := newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)
+			row[8] = tt.status // status column index in prTestPullRequestColumns
+			mock.ExpectQuery("SELECT .+ FROM pull_requests").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(row...))
+
+			svc := &PRService{
+				pullRequests: db.NewPullRequestStore(mock),
+				logger:       zerolog.Nop(),
+			}
+
+			_, err = svc.PushChangesToPR(context.Background(), &models.Session{ID: sessionID, OrgID: orgID})
+			require.ErrorIs(t, err, ErrPRClosed, "PushChangesToPR should refuse to push to a non-open PR")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestPushChangesToPR_ReturnsErrSnapshotNotCapturedWhenSnapshotKeyMissing(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	prID := uuid.New()
+	body := "body"
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+				newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)...,
+			),
+		)
+
+	svc := &PRService{
+		pullRequests:    db.NewPullRequestStore(mock),
+		sandboxProvider: &prTestSandboxProvider{},
+		snapshots:       &prTestSnapshotStore{},
+		logger:          zerolog.Nop(),
+	}
+
+	// SnapshotKey is nil — push must refuse to hydrate.
+	_, err = svc.PushChangesToPR(context.Background(), &models.Session{ID: sessionID, OrgID: orgID})
+	require.ErrorIs(t, err, ErrSnapshotNotCaptured, "PushChangesToPR should refuse to push without a captured snapshot")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPushChangesToPR_ReturnsErrSnapshotPendingWhenUploadInFlight(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	prID := uuid.New()
+	body := "body"
+	snapshotKey := "snapshots/session.tar"
+	pendingSnapshotKey := "snapshots/session/post-pr.tar.zst"
+
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestPullRequestColumns).AddRow(
+				newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)...,
+			),
+		)
+
+	svc := &PRService{
+		pullRequests:    db.NewPullRequestStore(mock),
+		sandboxProvider: &prTestSandboxProvider{},
+		snapshots:       &prTestSnapshotStore{},
+		logger:          zerolog.Nop(),
+	}
+
+	_, err = svc.PushChangesToPR(context.Background(), &models.Session{
+		ID:                 sessionID,
+		OrgID:              orgID,
+		SnapshotKey:        &snapshotKey,
+		PendingSnapshotKey: &pendingSnapshotKey,
+	})
+	require.ErrorIs(t, err, agent.ErrSnapshotPending, "PushChangesToPR should wait for pending snapshot uploads before hydrating")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	prID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	body := "body"
+	snapshotKey := "snapshots/session.tar"
+	headRef := "143/session/changes"
+	headSHA := "abc1234567890abcdef1234567890abcdef12345"
+
+	prRow := newPRTestRow(prID, &sessionID, orgID, "owner/repo", now, &body)
+	prRow[13] = &headRef
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(prRow...))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestRepoColumns).AddRow(
+				repoID, orgID, integrationID, int64(12345), "owner/repo", "main",
+				false, nil, nil, "https://github.com/owner/repo.git", int64(99),
+				"active", nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestOrganizationColumns).AddRow(
+				orgID, "Test Org", json.RawMessage(`{"pr_authorship":"app_only"}`), now, now,
+			),
+		)
+	mock.ExpectExec("UPDATE pull_requests SET head_sha").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      "default",
+			"job_type":   "sync_pull_request_state",
+			"payload":    pgxmock.AnyArg(),
+			"priority":   6,
+			"dedupe_key": pgxmock.AnyArg(),
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	provider := &prTestSandboxProvider{
+		execStdout:  pushHeadSHASentinel + headSHA + "\n",
+		snapshotErr: errors.New("test: skip post-push snapshot"),
+	}
+	svc := &PRService{
+		tokenProvider: &Service{
+			cache: map[int64]*cachedToken{
+				99: {Token: "app-token", ExpiresAt: time.Now().Add(time.Hour)},
+			},
+		},
+		pullRequests:    db.NewPullRequestStore(mock),
+		sessions:        db.NewSessionStore(mock),
+		repos:           db.NewRepositoryStore(mock),
+		orgs:            db.NewOrganizationStore(mock),
+		jobs:            db.NewJobStore(mock),
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		logger:          zerolog.Nop(),
+	}
+
+	pr, err := svc.PushChangesToPR(context.Background(), &models.Session{
+		ID:           sessionID,
+		OrgID:        orgID,
+		RepositoryID: &repoID,
+		SnapshotKey:  &snapshotKey,
+	})
+	require.NoError(t, err, "PushChangesToPR should succeed for a snapshot-backed session with an open PR")
+	require.Equal(t, headSHA, *pr.HeadSHA, "PushChangesToPR should return the just-pushed head SHA")
+	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/'"+headRef+"'", "PushChangesToPR should push to the persisted PR head ref")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestCreatePR_ReturnsPRLookupErrorBeforeCheckingSandboxDeps(t *testing.T) {
 	t.Parallel()
 
@@ -3991,7 +4219,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 			),
 		)
 	mock.ExpectQuery("INSERT INTO pull_requests").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
 	mock.ExpectQuery("UPDATE sessions SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -4137,7 +4365,7 @@ func TestCreatePR_SuccessDispatchesPostPRSnapshotUpload(t *testing.T) {
 			),
 		)
 	mock.ExpectQuery("INSERT INTO pull_requests").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
 	// SetPendingSnapshotKey: the synchronous write that records the
 	// post-PR upload in flight. pgx NamedArgs expand to positional args by

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3275,12 +3275,15 @@ func TestPushChangesToPR_ReturnsErrSnapshotNotCapturedWhenSnapshotKeyMissing(t *
 	prID := uuid.New()
 	body := "body"
 
+	prRow := newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)
+	// head_ref must be set so we don't short-circuit on ErrLegacyPRMissingHeadRef
+	// before reaching the snapshot check this test exercises.
+	headRef := "143/session/changes"
+	prRow[13] = &headRef
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(prTestPullRequestColumns).AddRow(
-				newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)...,
-			),
+			pgxmock.NewRows(prTestPullRequestColumns).AddRow(prRow...),
 		)
 
 	svc := &PRService{
@@ -3311,12 +3314,15 @@ func TestPushChangesToPR_ReturnsErrSnapshotPendingWhenUploadInFlight(t *testing.
 	snapshotKey := "snapshots/session.tar"
 	pendingSnapshotKey := "snapshots/session/post-pr.tar.zst"
 
+	prRow := newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)
+	// See TestPushChangesToPR_ReturnsErrSnapshotNotCapturedWhenSnapshotKeyMissing
+	// for why head_ref must be set on this fixture.
+	headRef := "143/session/changes"
+	prRow[13] = &headRef
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
-			pgxmock.NewRows(prTestPullRequestColumns).AddRow(
-				newPRTestRow(prID, &sessionID, orgID, "testorg/testrepo", now, &body)...,
-			),
+			pgxmock.NewRows(prTestPullRequestColumns).AddRow(prRow...),
 		)
 
 	svc := &PRService{
@@ -3421,10 +3427,13 @@ func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
-// Regression: PRs created before migration 107 don't have head_ref persisted,
-// so the push code must fall back to recomputing via formatBranchName. Without
-// the fallback, legacy PRs would error out (or worse, push to the wrong ref).
-func TestPushChangesToPR_FallsBackToFormatBranchNameWhenHeadRefIsNil(t *testing.T) {
+// PRs created before migration 107 don't have head_ref persisted. The push
+// code refuses to recompute via formatBranchName because the result is
+// sensitive to the session's title and Linear identifier — both of which can
+// drift after CreatePR runs — so a guess could land the push on a branch the
+// PR doesn't track. Surface ErrLegacyPRMissingHeadRef instead and let the
+// caller dead-letter / show a "create a new PR" message.
+func TestPushChangesToPR_RefusesLegacyPRWithoutHeadRef(t *testing.T) {
 	t.Parallel()
 
 	mock, err := pgxmock.NewPool()
@@ -3435,83 +3444,30 @@ func TestPushChangesToPR_FallsBackToFormatBranchNameWhenHeadRefIsNil(t *testing.
 	orgID := uuid.New()
 	sessionID := uuid.New()
 	prID := uuid.New()
-	repoID := uuid.New()
-	integrationID := uuid.New()
 	body := "body"
 	snapshotKey := "snapshots/session.tar"
-	headSHA := "abc1234567890abcdef1234567890abcdef12345"
-	// WorkingBranch makes formatBranchName deterministic without depending
-	// on slugify or the session's title fields, so the assertion below is
-	// stable across formatting changes elsewhere in the codebase.
-	workingBranch := "legacy-pr-branch"
 
 	prRow := newPRTestRow(prID, &sessionID, orgID, "owner/repo", now, &body)
-	// Leave prRow[13] (head_ref) at nil — that's the legacy condition the
-	// fallback must handle.
+	// prRow[13] (head_ref) is nil by default — that's the legacy condition we
+	// refuse rather than guess past.
 	mock.ExpectQuery("SELECT .+ FROM pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(prRow...))
-	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(
-			pgxmock.NewRows(prTestRepoColumns).AddRow(
-				repoID, orgID, integrationID, int64(12345), "owner/repo", "main",
-				false, nil, nil, "https://github.com/owner/repo.git", int64(99),
-				"active", nil, nil, json.RawMessage(`{}`), now, now,
-			),
-		)
-	mock.ExpectQuery("SELECT .+ FROM organizations").
-		WithArgs(pgxmock.AnyArg()).
-		WillReturnRows(
-			pgxmock.NewRows(prTestOrganizationColumns).AddRow(
-				orgID, "Test Org", json.RawMessage(`{"pr_authorship":"app_only"}`), now, now,
-			),
-		)
-	mock.ExpectExec("UPDATE pull_requests SET head_sha").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectQuery("INSERT INTO jobs").
-		WithArgs(pgx.NamedArgs{
-			"org_id":     orgID,
-			"queue":      "default",
-			"job_type":   "sync_pull_request_state",
-			"payload":    pgxmock.AnyArg(),
-			"priority":   6,
-			"dedupe_key": pgxmock.AnyArg(),
-		}).
-		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
-	provider := &prTestSandboxProvider{
-		execStdout:  pushHeadSHASentinel + headSHA + "\n",
-		snapshotErr: errors.New("test: skip post-push snapshot"),
-	}
 	svc := &PRService{
-		tokenProvider: &Service{
-			cache: map[int64]*cachedToken{
-				99: {Token: "app-token", ExpiresAt: time.Now().Add(time.Hour)},
-			},
-		},
-		pullRequests:    db.NewPullRequestStore(mock),
-		sessions:        db.NewSessionStore(mock),
-		repos:           db.NewRepositoryStore(mock),
-		orgs:            db.NewOrganizationStore(mock),
-		jobs:            db.NewJobStore(mock),
-		sandboxProvider: provider,
-		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
-		logger:          zerolog.Nop(),
+		pullRequests: db.NewPullRequestStore(mock),
+		// sandboxProvider/snapshots intentionally nil — the legacy refusal must
+		// fire before any sandbox or token work runs.
+		logger: zerolog.Nop(),
 	}
 
-	pr, err := svc.PushChangesToPR(context.Background(), &models.Session{
-		ID:            sessionID,
-		OrgID:         orgID,
-		RepositoryID:  &repoID,
-		SnapshotKey:   &snapshotKey,
-		WorkingBranch: &workingBranch,
+	_, err = svc.PushChangesToPR(context.Background(), &models.Session{
+		ID:          sessionID,
+		OrgID:       orgID,
+		SnapshotKey: &snapshotKey,
 	})
-	require.NoError(t, err, "PushChangesToPR should succeed for a legacy PR with no head_ref")
-	require.Equal(t, headSHA, *pr.HeadSHA, "PushChangesToPR should return the just-pushed head SHA")
-	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/'"+workingBranch+"'", "PushChangesToPR should fall back to formatBranchName when head_ref is nil")
-	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	require.ErrorIs(t, err, ErrLegacyPRMissingHeadRef, "PushChangesToPR should refuse legacy PRs without a persisted head_ref")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met (no sandbox/token work should run)")
 }
 
 func TestCreatePR_ReturnsPRLookupErrorBeforeCheckingSandboxDeps(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3421,6 +3421,99 @@ func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// Regression: PRs created before migration 107 don't have head_ref persisted,
+// so the push code must fall back to recomputing via formatBranchName. Without
+// the fallback, legacy PRs would error out (or worse, push to the wrong ref).
+func TestPushChangesToPR_FallsBackToFormatBranchNameWhenHeadRefIsNil(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	prID := uuid.New()
+	repoID := uuid.New()
+	integrationID := uuid.New()
+	body := "body"
+	snapshotKey := "snapshots/session.tar"
+	headSHA := "abc1234567890abcdef1234567890abcdef12345"
+	// WorkingBranch makes formatBranchName deterministic without depending
+	// on slugify or the session's title fields, so the assertion below is
+	// stable across formatting changes elsewhere in the codebase.
+	workingBranch := "legacy-pr-branch"
+
+	prRow := newPRTestRow(prID, &sessionID, orgID, "owner/repo", now, &body)
+	// Leave prRow[13] (head_ref) at nil — that's the legacy condition the
+	// fallback must handle.
+	mock.ExpectQuery("SELECT .+ FROM pull_requests").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(prTestPullRequestColumns).AddRow(prRow...))
+	mock.ExpectQuery("SELECT .+ FROM repositories WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestRepoColumns).AddRow(
+				repoID, orgID, integrationID, int64(12345), "owner/repo", "main",
+				false, nil, nil, "https://github.com/owner/repo.git", int64(99),
+				"active", nil, nil, json.RawMessage(`{}`), now, now,
+			),
+		)
+	mock.ExpectQuery("SELECT .+ FROM organizations").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(prTestOrganizationColumns).AddRow(
+				orgID, "Test Org", json.RawMessage(`{"pr_authorship":"app_only"}`), now, now,
+			),
+		)
+	mock.ExpectExec("UPDATE pull_requests SET head_sha").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":     orgID,
+			"queue":      "default",
+			"job_type":   "sync_pull_request_state",
+			"payload":    pgxmock.AnyArg(),
+			"priority":   6,
+			"dedupe_key": pgxmock.AnyArg(),
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	provider := &prTestSandboxProvider{
+		execStdout:  pushHeadSHASentinel + headSHA + "\n",
+		snapshotErr: errors.New("test: skip post-push snapshot"),
+	}
+	svc := &PRService{
+		tokenProvider: &Service{
+			cache: map[int64]*cachedToken{
+				99: {Token: "app-token", ExpiresAt: time.Now().Add(time.Hour)},
+			},
+		},
+		pullRequests:    db.NewPullRequestStore(mock),
+		sessions:        db.NewSessionStore(mock),
+		repos:           db.NewRepositoryStore(mock),
+		orgs:            db.NewOrganizationStore(mock),
+		jobs:            db.NewJobStore(mock),
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		logger:          zerolog.Nop(),
+	}
+
+	pr, err := svc.PushChangesToPR(context.Background(), &models.Session{
+		ID:            sessionID,
+		OrgID:         orgID,
+		RepositoryID:  &repoID,
+		SnapshotKey:   &snapshotKey,
+		WorkingBranch: &workingBranch,
+	})
+	require.NoError(t, err, "PushChangesToPR should succeed for a legacy PR with no head_ref")
+	require.Equal(t, headSHA, *pr.HeadSHA, "PushChangesToPR should return the just-pushed head SHA")
+	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/'"+workingBranch+"'", "PushChangesToPR should fall back to formatBranchName when head_ref is nil")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestCreatePR_ReturnsPRLookupErrorBeforeCheckingSandboxDeps(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -157,7 +157,7 @@ var sessionTestCols = []string{
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
-	"pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	// Migration 102 — Linear session-linking columns. Migration 100 — git
 	// identity audit columns. Mocks must include both so SessionStore.GetByID's
 	// row decode finds every selected field.
@@ -214,6 +214,8 @@ func newSessionRow(sessionID, orgID uuid.UUID, containerID *string, now time.Tim
 		"recovery_attempt_count":         0,
 		"pr_creation_state":              "idle",
 		"pr_creation_error":              (*string)(nil),
+		"pr_push_state":                  "idle",
+		"pr_push_error":                  (*string)(nil),
 		"linear_private":                 false,
 		"linear_state_sync_disabled":     false,
 		"linear_identifier_hint":         (*string)(nil),

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -62,6 +62,7 @@ func RegisterHandlers(w *Worker, stores *Stores, services *Services, retentionCf
 		w.Register("continue_session", newContinueSessionHandler(stores, services, logger))
 		w.Register("validate", newValidateHandler(stores, services, logger))
 		w.Register("open_pr", newOpenPRHandler(stores, services, logger))
+		w.Register("push_pr_changes", newPushPRChangesHandler(stores, services, logger))
 		w.Register("sync_pull_request_state", newSyncPullRequestStateHandler(services, logger))
 		w.Register("reconcile_pull_request_state", newReconcilePullRequestStateHandler(services, logger))
 		w.Register("enrich_pull_request_health", newEnrichPullRequestHealthHandler(services, logger))
@@ -138,6 +139,7 @@ type MemoryReinforcer interface {
 
 type prCreator interface {
 	CreatePR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error)
+	PushChangesToPR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error)
 	SyncPullRequestState(ctx context.Context, orgID, pullRequestID uuid.UUID) error
 	ReconcilePullRequestState(ctx context.Context, orgID uuid.UUID, limit int) error
 	EnrichPullRequestHealth(ctx context.Context, orgID, pullRequestID uuid.UUID, version int64) error
@@ -1278,8 +1280,111 @@ func userFacingPRError(err error) string {
 		return ghservice.SnapshotUnavailablePRMessage
 	case errors.Is(err, ghservice.ErrNoChanges):
 		return "No changes to push."
+	case errors.Is(err, ghservice.ErrNoPullRequest):
+		return "No pull request exists for this session."
+	case errors.Is(err, ghservice.ErrPRClosed):
+		return "This pull request is no longer open."
 	default:
 		return "Check GitHub access or repo permissions and try again."
+	}
+}
+
+// push_pr_changes handler pushes any uncommitted/unpushed sandbox changes up
+// to an existing PR's branch. Mirrors newOpenPRHandler but operates on a
+// session that already has a PR row — drives pr_push_state through pushing ->
+// succeeded/failed without touching pr_creation_state, and skips the Linear
+// "ended_no_pr" milestone (a PR already exists, so "no changes to push" is a
+// benign UI-only outcome).
+func newPushPRChangesHandler(stores *Stores, services *Services, logger zerolog.Logger) JobHandler {
+	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
+		var input struct {
+			SessionID  string `json:"session_id"`
+			OrgID      string `json:"org_id"`
+			AuthorMode string `json:"author_mode,omitempty"`
+		}
+		if err := json.Unmarshal(payload, &input); err != nil {
+			return fmt.Errorf("unmarshal push_pr_changes payload: %w", err)
+		}
+
+		orgID, err := parseOrgID(input.OrgID, ctx)
+		if err != nil {
+			return fmt.Errorf("parse org ID: %w", err)
+		}
+		runID, err := uuid.Parse(input.SessionID)
+		if err != nil {
+			return fmt.Errorf("parse session ID: %w", err)
+		}
+
+		run, err := stores.Sessions.GetByID(ctx, orgID, runID)
+		if err != nil {
+			return fmt.Errorf("fetch session: %w", err)
+		}
+		if run.PendingSnapshotKey != nil && *run.PendingSnapshotKey != "" {
+			logger.Info().
+				Str("session_id", runID.String()).
+				Str("pending_snapshot_key", *run.PendingSnapshotKey).
+				Msg("push_pr_changes waiting for post-PR snapshot upload to land")
+			return &RetryableError{Err: agent.ErrSnapshotPending}
+		}
+
+		if stores.SessionIssueLinks != nil {
+			links, err := stores.SessionIssueLinks.ListBySession(ctx, orgID, runID)
+			if err != nil {
+				return fmt.Errorf("hydrate linked issues for push_pr_changes: %w", err)
+			}
+			run.LinkedIssues = links
+		}
+
+		logger.Info().
+			Str("session_id", runID.String()).
+			Str("org_id", orgID.String()).
+			Msg("starting push_pr_changes job")
+
+		if err := stores.Sessions.UpdatePRPushState(ctx, orgID, runID, models.PRPushStatePushing, ""); err != nil {
+			logger.Error().Err(err).Msg("failed to mark PR push as pushing")
+		}
+
+		var params []ghservice.CreatePRParams
+		if input.AuthorMode != "" {
+			params = append(params, ghservice.CreatePRParams{AuthorMode: input.AuthorMode})
+		}
+
+		_, pushErr := services.PR.PushChangesToPR(ctx, &run, params...)
+		if pushErr != nil {
+			// ErrNoChanges is benign for push-changes: either the user clicked
+			// with a clean sandbox + nothing ahead of upstream, or this is a
+			// worker retry after a partial-success first attempt landed the
+			// push. In both cases the PR's branch already reflects the
+			// session's state, so mark succeeded rather than failed — pr_push_error
+			// stays empty and the head_sha on the PR row is the canonical
+			// source of truth. Distinguishes push from CreatePR, where
+			// ErrNoChanges is a real "nothing to ship" outcome with no PR row.
+			if errors.Is(pushErr, ghservice.ErrNoChanges) {
+				logger.Info().
+					Str("session_id", runID.String()).
+					Msg("push_pr_changes: nothing to push (already up to date)")
+				if stateErr := stores.Sessions.UpdatePRPushState(ctx, orgID, runID, models.PRPushStateSucceeded, ""); stateErr != nil {
+					logger.Error().Err(stateErr).Msg("failed to mark PR push as succeeded")
+				}
+				return nil
+			}
+			logger.Error().Err(pushErr).
+				Str("session_id", runID.String()).
+				Msg("push_pr_changes failed")
+			msg := userFacingPRError(pushErr)
+			if stateErr := stores.Sessions.UpdatePRPushState(ctx, orgID, runID, models.PRPushStateFailed, msg); stateErr != nil {
+				logger.Error().Err(stateErr).Msg("failed to mark PR push as failed")
+			}
+			if shouldDeadLetterPRError(pushErr) {
+				return &FatalError{Err: pushErr}
+			}
+			return pushErr
+		}
+
+		if stateErr := stores.Sessions.UpdatePRPushState(ctx, orgID, runID, models.PRPushStateSucceeded, ""); stateErr != nil {
+			logger.Error().Err(stateErr).Msg("failed to mark PR push as succeeded")
+		}
+		return nil
 	}
 }
 
@@ -1292,6 +1397,10 @@ func shouldDeadLetterPRError(err error) bool {
 	case errors.Is(err, ghservice.ErrSnapshotUnavailable):
 		return true
 	case errors.Is(err, ghservice.ErrNoChanges):
+		return true
+	case errors.Is(err, ghservice.ErrNoPullRequest):
+		return true
+	case errors.Is(err, ghservice.ErrPRClosed):
 		return true
 	default:
 		return false

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1284,6 +1284,8 @@ func userFacingPRError(err error) string {
 		return "No pull request exists for this session."
 	case errors.Is(err, ghservice.ErrPRClosed):
 		return "This pull request is no longer open."
+	case errors.Is(err, ghservice.ErrLegacyPRMissingHeadRef):
+		return "This PR predates branch tracking; create a new PR to push follow-up changes."
 	default:
 		return "Check GitHub access or repo permissions and try again."
 	}
@@ -1401,6 +1403,8 @@ func shouldDeadLetterPRError(err error) bool {
 	case errors.Is(err, ghservice.ErrNoPullRequest):
 		return true
 	case errors.Is(err, ghservice.ErrPRClosed):
+		return true
+	case errors.Is(err, ghservice.ErrLegacyPRMissingHeadRef):
 		return true
 	default:
 		return false

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1530,41 +1530,59 @@ func TestPushPRChangesHandler_NoChangesIsTreatedAsSuccess(t *testing.T) {
 func TestPushPRChangesHandler_TerminalErrorBecomesFatal(t *testing.T) {
 	t.Parallel()
 
-	stores, mock := newTestStores(t)
-	defer mock.Close()
-
-	orgID := uuid.New()
-	sessionID := uuid.New()
-	now := time.Now()
-	snapshotKey := "snap-push-pr-fatal"
-
-	mock.ExpectQuery("SELECT .* FROM sessions").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-	// pushing → failed.
-	mock.ExpectExec("UPDATE sessions").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-
-	services := &Services{
-		PR: &stubPRService{
-			pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
-				return nil, ghservice.ErrSnapshotExpired
-			},
-		},
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "snapshot expired", err: ghservice.ErrSnapshotExpired},
+		// Legacy PRs can never succeed at push time — no head_ref means we
+		// can't safely identify the branch — so the worker must dead-letter
+		// rather than retry forever. The user-facing message tells the user
+		// to create a new PR.
+		{name: "legacy PR missing head_ref", err: ghservice.ErrLegacyPRMissingHeadRef},
 	}
 
-	handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
-	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
-	err := handler(context.Background(), "push_pr_changes", payload)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	var fatalErr *FatalError
-	require.ErrorAs(t, err, &fatalErr, "push_pr_changes should dead-letter terminal errors instead of retrying")
-	require.ErrorIs(t, fatalErr, ghservice.ErrSnapshotExpired, "push_pr_changes should preserve the underlying terminal error")
-	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+			stores, mock := newTestStores(t)
+			defer mock.Close()
+
+			orgID := uuid.New()
+			sessionID := uuid.New()
+			now := time.Now()
+			snapshotKey := "snap-push-pr-fatal-" + tt.name
+
+			mock.ExpectQuery("SELECT .* FROM sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+			// pushing → failed.
+			mock.ExpectExec("UPDATE sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			mock.ExpectExec("UPDATE sessions").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+			services := &Services{
+				PR: &stubPRService{
+					pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+						return nil, tt.err
+					},
+				},
+			}
+
+			handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
+			payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+			err := handler(context.Background(), "push_pr_changes", payload)
+
+			var fatalErr *FatalError
+			require.ErrorAs(t, err, &fatalErr, "push_pr_changes should dead-letter terminal errors instead of retrying")
+			require.ErrorIs(t, fatalErr, tt.err, "push_pr_changes should preserve the underlying terminal error")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
 }
 
 func TestOpenPRHandler_TerminalPRErrorsBecomeFatal(t *testing.T) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -61,7 +61,7 @@ var workerSessionColumns = []string{
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
-	"archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -227,15 +227,17 @@ func workerSessionTestRow(values ...any) []any {
 // workerSessionTestRowDispatch with nil values for columns added after the
 // fixture conventions were settled: the pending-snapshot pair
 // (pending_snapshot_key + pending_snapshot_set_at, between snapshot_key and
-// runtime_soft_deadline_at) and the trailing git_identity_source /
-// git_identity_user_id pair (immediately before created_at). Existing
-// fixtures emit a "pre-pending, pre-identity" row; we pad it to the
-// current layout without touching every call site.
+// runtime_soft_deadline_at), the pr_push pair (pr_push_state + pr_push_error,
+// between pr_creation_error and diff_collected_at), and the trailing
+// git_identity_source / git_identity_user_id pair (immediately before
+// created_at). Existing fixtures emit a "pre-pending, pre-pr_push,
+// pre-identity" row; we pad it to the current layout without touching every
+// call site.
 func padWorkerIdentityNils(row []any) []any {
 	if len(row) >= len(workerSessionColumns) {
 		return row
 	}
-	if len(row) != len(workerSessionColumns)-4 {
+	if len(row) != len(workerSessionColumns)-6 {
 		return row
 	}
 	const pendingSnapshotKeyIndex = 42
@@ -244,10 +246,23 @@ func padWorkerIdentityNils(row []any) []any {
 	withPending = append(withPending, nil, nil) // pending_snapshot_key, pending_snapshot_set_at
 	withPending = append(withPending, row[pendingSnapshotKeyIndex:]...)
 
+	// Insert the pr_push pair right after pr_creation_error (and before
+	// diff_collected_at). In the post-pending row, diff_collected_at sits at
+	// index 74 (the +2 shift from the pre-pending layout where it was at 72).
+	// The pr_push pair lands immediately before it. Use "idle" (not nil) for
+	// pr_push_state because the model's field is a non-pointer PRPushState —
+	// a NULL would fail pgx scanning. The migration mirrors this with NOT
+	// NULL DEFAULT 'idle'.
+	const prPushStateIndex = 74
+	withPRPush := make([]any, 0, len(withPending)+2)
+	withPRPush = append(withPRPush, withPending[:prPushStateIndex]...)
+	withPRPush = append(withPRPush, "idle", (*string)(nil)) // pr_push_state, pr_push_error
+	withPRPush = append(withPRPush, withPending[prPushStateIndex:]...)
+
 	padded := make([]any, 0, len(workerSessionColumns))
-	padded = append(padded, withPending[:len(withPending)-1]...)
+	padded = append(padded, withPRPush[:len(withPRPush)-1]...)
 	padded = append(padded, nil, nil)
-	padded = append(padded, withPending[len(withPending)-1])
+	padded = append(padded, withPRPush[len(withPRPush)-1])
 	return padded
 }
 
@@ -1312,6 +1327,7 @@ type mockPMService struct {
 
 type stubPRService struct {
 	createPRFn                func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error)
+	pushChangesToPRFn         func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error)
 	syncPullRequestStateFn    func(context.Context, uuid.UUID, uuid.UUID) error
 	reconcilePullRequestFn    func(context.Context, uuid.UUID, int) error
 	enrichPullRequestHealthFn func(context.Context, uuid.UUID, uuid.UUID, int64) error
@@ -1320,6 +1336,13 @@ type stubPRService struct {
 func (s *stubPRService) CreatePR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
 	if s.createPRFn != nil {
 		return s.createPRFn(ctx, run, params...)
+	}
+	return nil, nil
+}
+
+func (s *stubPRService) PushChangesToPR(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+	if s.pushChangesToPRFn != nil {
+		return s.pushChangesToPRFn(ctx, run, params...)
 	}
 	return nil, nil
 }
@@ -1374,6 +1397,174 @@ func newWorkerSessionRow(sessionID, orgID uuid.UUID, now time.Time, snapshotKey 
 		nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, "queued", (*string)(nil), nil, nil, nil, now,
 	)
+}
+
+func TestPushPRChangesHandler_SuccessMarksPushingAndSucceeded(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-push-pr-success"
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+	// Two state-machine writes: pushing → succeeded.
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	called := false
+	services := &Services{
+		PR: &stubPRService{
+			pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				called = true
+				return &models.PullRequest{ID: uuid.New(), OrgID: orgID}, nil
+			},
+		},
+	}
+
+	handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "push_pr_changes", payload)
+
+	require.NoError(t, err, "push_pr_changes handler should succeed when PR push succeeds")
+	require.True(t, called, "push_pr_changes handler should invoke PRService.PushChangesToPR")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestPushPRChangesHandler_PendingSnapshotRetriesWithoutMarkingPushing(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-push-pr-pending"
+	pendingSnapshotKey := "snapshots/session/post-pr.tar.zst"
+	row := newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)
+	for i, col := range workerSessionColumns {
+		if col == "pending_snapshot_key" {
+			row[i] = &pendingSnapshotKey
+			break
+		}
+	}
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(row...))
+
+	called := false
+	services := &Services{
+		PR: &stubPRService{
+			pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				called = true
+				return nil, nil
+			},
+		},
+	}
+
+	handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "push_pr_changes", payload)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "pending snapshot should requeue push_pr_changes without consuming an attempt")
+	require.ErrorIs(t, retryable.Err, agent.ErrSnapshotPending, "retryable error should preserve the pending-snapshot sentinel")
+	require.False(t, called, "push_pr_changes handler should not invoke PRService while snapshot upload is pending")
+	require.NoError(t, mock.ExpectationsWereMet(), "handler should not write pushing state while snapshot upload is pending")
+}
+
+// Regression: a worker retry of a push that already landed re-runs the push
+// script which exits cleanly with ErrNoChanges (HEAD is ancestor of @{u}). The
+// handler must mark the operation succeeded so the user doesn't see a
+// misleading "failed" toast — pr_push_state = succeeded reflects the truth
+// that the PR's branch already has the session's commits.
+func TestPushPRChangesHandler_NoChangesIsTreatedAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-push-pr-no-changes"
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+	// pushing → succeeded (NOT failed, despite the error from the service).
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	services := &Services{
+		PR: &stubPRService{
+			pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				return nil, ghservice.ErrNoChanges
+			},
+		},
+	}
+
+	handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "push_pr_changes", payload)
+
+	require.NoError(t, err, "push_pr_changes handler should swallow ErrNoChanges as a benign no-op")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met (succeeded write must fire, not failed)")
+}
+
+func TestPushPRChangesHandler_TerminalErrorBecomesFatal(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-push-pr-fatal"
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+	// pushing → failed.
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	services := &Services{
+		PR: &stubPRService{
+			pushChangesToPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				return nil, ghservice.ErrSnapshotExpired
+			},
+		},
+	}
+
+	handler := newPushPRChangesHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(context.Background(), "push_pr_changes", payload)
+
+	var fatalErr *FatalError
+	require.ErrorAs(t, err, &fatalErr, "push_pr_changes should dead-letter terminal errors instead of retrying")
+	require.ErrorIs(t, fatalErr, ghservice.ErrSnapshotExpired, "push_pr_changes should preserve the underlying terminal error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestOpenPRHandler_TerminalPRErrorsBecomeFatal(t *testing.T) {

--- a/migrations/000107_session_pr_push_state.down.sql
+++ b/migrations/000107_session_pr_push_state.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE pull_requests DROP COLUMN IF EXISTS head_ref;
+ALTER TABLE sessions DROP CONSTRAINT IF EXISTS chk_sessions_pr_push_state;
+ALTER TABLE sessions DROP COLUMN IF EXISTS pr_push_error;
+ALTER TABLE sessions DROP COLUMN IF EXISTS pr_push_state;

--- a/migrations/000107_session_pr_push_state.up.sql
+++ b/migrations/000107_session_pr_push_state.up.sql
@@ -1,0 +1,22 @@
+-- Track the state of the "Push changes" follow-up action for sessions that
+-- already have an open PR. Independent from pr_creation_state so a session can
+-- show "PR opened" while a follow-up push is mid-flight without the two state
+-- machines interfering.
+ALTER TABLE sessions
+    ADD COLUMN pr_push_state text NOT NULL DEFAULT 'idle',
+    ADD COLUMN pr_push_error text;
+
+ALTER TABLE sessions
+    ADD CONSTRAINT chk_sessions_pr_push_state CHECK (pr_push_state IN (
+        'idle', 'queued', 'pushing', 'succeeded', 'failed'
+    )) NOT VALID;
+ALTER TABLE sessions VALIDATE CONSTRAINT chk_sessions_pr_push_state;
+
+-- Persist the PR's head branch name so subsequent pushes target the same ref
+-- the original CreatePR landed on, even if the session's title or Linear key
+-- changes (which would shift formatBranchName's deterministic output and
+-- otherwise create a divergent branch on GitHub that the PR doesn't track).
+-- Nullable because rows created before this migration didn't capture it; the
+-- push code falls back to recomputing via formatBranchName when NULL.
+ALTER TABLE pull_requests
+    ADD COLUMN head_ref text;


### PR DESCRIPTION
## Summary
- Adds a **Push changes** button next to **View PR** that pushes follow-up sandbox commits to an already-open PR without re-running the full Create PR flow. New `pr_push_state` column drives an independent state machine (idle → queued → pushing → succeeded/failed) so push and create can be in flight without colliding, and a new `pull_requests.head_ref` column locks the PR's branch at create time so subsequent pushes never drift.
- Wires `POST /sessions/{id}/pr/push`, the `push_pr_changes` worker job, and `PRService.PushChangesToPR` (mirrors the push half of `CreatePR` only — no PR row, body, labels, or Linear milestones). Concurrent submits are reconciled by a CAS on `pr_push_state` plus the existing worker dedupe key.
- Refactors GitHub user-auth interception out of `CreatePR` into a shared helper, signs the originating endpoint into the resume token, and forwards it back as `resume_action` after OAuth so the post-auth replay is deterministic regardless of any state change during the round-trip.

## Test plan
- [ ] `make lint` is clean.
- [ ] Go tests pass: `internal/db`, `internal/api/handlers`, `internal/worker`, `internal/services/github`.
- [ ] Frontend `vitest` and `tsc --noEmit` pass.
- [ ] Manual: complete a session, click **Create PR**, then make follow-up sandbox edits and click **Push changes** — the same PR branch should advance to the new HEAD.
- [ ] Manual: trigger the GitHub OAuth flow from **Push changes**, complete the handshake, and confirm replay lands the push (not a new Create PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
