### PR TITLE
Clean up preview startup UI to a calm preview-first canvas

### DIFF
--- a/docs/design/44-sandbox-preview-server.md
+++ b/docs/design/44-sandbox-preview-server.md
@@ -353,6 +353,8 @@ The reviewer sees screencasts in the session timeline alongside static screensho
 
 ## Preview Lifecycle
 
+The session preview tab should stay preview-first while startup is in progress. The primary surface is a calm unavailable-preview canvas with one status line and a compact Provisioning → Starting → Opening rail. Per-service and infrastructure diagnostics remain available in collapsed details by default so operators can inspect progress without making the normal waiting state feel busy.
+
 ### Startup Phases
 
 Even in MVP, preview startup should be modeled as three phases:

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -174,35 +174,67 @@ describe("PreviewPanel component", () => {
 
   /* ---------- Starting status ---------- */
 
-  it("shows Stop and Restart buttons and Building badge during starting status", async () => {
-    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
+  it("shows preview-first startup canvas and subtle controls during starting status", async () => {
+    mockGet.mockResolvedValue(
+      makePreviewStatus(
+        { status: "starting" },
+        [],
+        [
+          {
+            id: "infra-1",
+            preview_instance_id: "prev-1",
+            infra_name: "postgres",
+            template: "postgres",
+            container_id: "ctr-1",
+            status: "provisioning",
+            host: "postgres",
+            port: 5432,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      ),
+    );
 
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      // "Building" appears in both badge and progress label, use getAllByText
-      expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Stop")).toBeInTheDocument();
-    expect(screen.getByText("Restart")).toBeInTheDocument();
-    // Start button should NOT be visible
+    expect(screen.getByText("Provisioning postgres")).toBeInTheDocument();
+    expect(screen.getByText("Provisioning")).toBeInTheDocument();
+    expect(screen.getByText("Starting")).toBeInTheDocument();
+    expect(screen.getByText("Opening")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop preview" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart preview" })).toBeInTheDocument();
     expect(screen.queryByText("Start Preview")).not.toBeInTheDocument();
   });
 
-  it("renders progress bar status labels during starting status", async () => {
+  it("hides the Provisioning rail tile when the preview has no infrastructure", async () => {
     mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
 
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
     });
 
-    // Progress bar shows status labels from STATUS_ORDER
-    expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
-    // "Ready" appears in the progress bar status labels
-    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.queryByText("Provisioning")).not.toBeInTheDocument();
+    expect(screen.getByText("Starting")).toBeInTheDocument();
+    expect(screen.getByText("Opening")).toBeInTheDocument();
+  });
+
+  it("does not show duplicated startup guidance or checklist by default", async () => {
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Preview startup can take a few minutes.")).not.toBeInTheDocument();
+    expect(screen.queryByText("Startup checklist")).not.toBeInTheDocument();
   });
 
   /* ---------- Starting status (active controls) ---------- */
@@ -213,12 +245,11 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      // "Pending" appears in both badge and progress bar
-      expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Stop")).toBeInTheDocument();
-    expect(screen.getByText("Restart")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Stop preview" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restart preview" })).toBeInTheDocument();
   });
 
   /* ---------- Ready phase ---------- */
@@ -306,6 +337,23 @@ describe("PreviewPanel component", () => {
     });
 
     expect(screen.getByTitle("Preview")).toBeInTheDocument();
+  });
+
+  it("unmounts the startup canvas and restores top controls in partially_ready state", async () => {
+    mockGet.mockResolvedValue(
+      makePreviewStatus({ status: "partially_ready", id: "prev-1" }),
+    );
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Partially Ready")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Preparing preview")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Stop preview" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Stop/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Restart/ })).toBeInTheDocument();
   });
 
   /* ---------- Failed phase ---------- */
@@ -465,22 +513,16 @@ describe("PreviewPanel component", () => {
     expect(badge.className).toContain("text-destructive");
   });
 
-  it("applies primary color class for starting status badge", async () => {
+  it("uses one primary starting label in the startup canvas", async () => {
     mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
 
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
     });
 
-    // The badge is inside a span with data-slot="badge"
-    const badges = screen.getAllByText("Starting");
-    const badgeEl = badges
-      .map((el) => el.closest("[data-slot='badge']"))
-      .find(Boolean);
-    expect(badgeEl).toBeTruthy();
-    expect(badgeEl!.className).toContain("text-primary");
+    expect(screen.getAllByText("Starting")).toHaveLength(1);
   });
 
   it("applies amber color class for partially_ready phase badge", async () => {
@@ -496,26 +538,6 @@ describe("PreviewPanel component", () => {
 
     const badge = screen.getByText("Partially Ready").closest("[class]")!;
     expect(badge.className).toContain("text-amber-600");
-  });
-
-  /* ---------- Progress bar values via style width ---------- */
-
-  it("renders progress bar at 50% for starting status", async () => {
-    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
-
-    const { container } = renderWithProviders(
-      <PreviewPanel {...DEFAULT_PROPS} />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getAllByText("Starting").length).toBeGreaterThanOrEqual(1);
-    });
-
-    // STATUS_ORDER = ["starting", "partially_ready", "ready"], so starting = (1/3)*100
-    const progressBar = container.querySelector(
-      ".bg-primary.rounded-full.transition-all",
-    );
-    expect(progressBar).toHaveStyle({ width: `${(1 / 3) * 100}%` });
   });
 
   /* ---------- Start mutation ---------- */
@@ -561,21 +583,8 @@ describe("PreviewPanel component", () => {
     expect(button.querySelector("svg.lucide-play")).not.toBeInTheDocument();
   });
 
-  it("shows startup guidance while the preview is being created", async () => {
-    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
-
-    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Preview startup can take a few minutes.")).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText("You can stay here while we spin up the environment and bring services online."),
-    ).toBeInTheDocument();
-  });
-
-  it("renders a startup checklist from infrastructure and service state", async () => {
+  it("keeps infrastructure and service details collapsed until requested", async () => {
+    const user = userEvent.setup();
     mockGet.mockResolvedValue(
       makePreviewStatus(
         { status: "starting" },
@@ -611,8 +620,13 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Startup checklist")).toBeInTheDocument();
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
     });
+
+    expect(screen.queryByText("postgres is provisioning")).not.toBeInTheDocument();
+    expect(screen.queryByText("web is starting")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Details" }));
 
     expect(screen.getByText("Spin up infrastructure")).toBeInTheDocument();
     expect(screen.getByText("postgres is provisioning")).toBeInTheDocument();
@@ -622,6 +636,7 @@ describe("PreviewPanel component", () => {
   });
 
   it("renders orphaned pending children as terminal when the parent preview failed", async () => {
+    const user = userEvent.setup();
     mockGet.mockResolvedValue(
       makePreviewStatus(
         { status: "failed", error: "provider start preview failed" },
@@ -657,8 +672,10 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Startup checklist")).toBeInTheDocument();
+      expect(screen.getByText("Preview failed to start")).toBeInTheDocument();
     });
+
+    await user.click(screen.getByRole("button", { name: /Details/ }));
 
     expect(screen.getByText("postgres did not finish provisioning")).toBeInTheDocument();
     expect(screen.getByText("web did not finish starting")).toBeInTheDocument();
@@ -685,6 +702,23 @@ describe("PreviewPanel component", () => {
     });
   });
 
+  it("calls stop mutation from the starting preview canvas", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Stop preview" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Stop preview" }));
+
+    await waitFor(() => {
+      expect(mockStop).toHaveBeenCalledWith("sess-1");
+    });
+  });
+
   /* ---------- Restart mutation ---------- */
 
   it("calls restart mutation when Restart button is clicked", async () => {
@@ -698,6 +732,23 @@ describe("PreviewPanel component", () => {
     });
 
     await user.click(screen.getByText("Restart"));
+
+    await waitFor(() => {
+      expect(mockRestart).toHaveBeenCalledWith("sess-1");
+    });
+  });
+
+  it("calls restart mutation from the starting preview canvas", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "starting" }));
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Restart preview" })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Restart preview" }));
 
     await waitFor(() => {
       expect(mockRestart).toHaveBeenCalledWith("sess-1");

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -18,9 +18,15 @@ import {
   Palette,
   RefreshCw,
   X,
+  ChevronDown,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
   Tooltip,
   TooltipContent,
@@ -69,17 +75,7 @@ const STATUS_LABELS: Record<PreviewStatus, string> = {
   expired: "Expired",
 };
 
-const STATUS_ORDER: PreviewStatus[] = [
-  "starting",
-  "partially_ready",
-  "ready",
-];
-
-function statusProgress(status: PreviewStatus): number {
-  const idx = STATUS_ORDER.indexOf(status);
-  if (idx === -1) return 0;
-  return ((idx + 1) / STATUS_ORDER.length) * 100;
-}
+const STARTUP_PHASES = ["Provisioning", "Starting", "Opening"] as const;
 
 function statusColor(status: PreviewStatus): string {
   switch (status) {
@@ -244,6 +240,60 @@ function startupStepIcon(state: StartupChecklistStepState) {
   }
 }
 
+function getStartupSubtitle(
+  status: PreviewStatus | undefined,
+  services: PreviewService[],
+  infrastructure: PreviewInfrastructure[],
+): string {
+  const provisioning = infrastructure.find(
+    (item) => item.status === "provisioning",
+  );
+  if (provisioning) return `Provisioning ${provisioning.infra_name}`;
+
+  const starting = services.find((service) => service.status === "starting");
+  if (starting) return `Starting ${starting.service_name}`;
+
+  if (status === "partially_ready") {
+    return "Opening preview";
+  }
+
+  return "Starting services";
+}
+
+function startupPhaseState(
+  phase: (typeof STARTUP_PHASES)[number],
+  services: PreviewService[],
+  infrastructure: PreviewInfrastructure[],
+): StartupChecklistStepState {
+  const hasInfrastructure = infrastructure.length > 0;
+  const allInfrastructureHealthy =
+    hasInfrastructure && infrastructure.every((item) => item.status === "healthy");
+  const provisioning = infrastructure.some((item) => item.status === "provisioning");
+  const anyServiceReady = services.some((service) => service.status === "ready");
+  const anyServiceStarting = services.some((service) => service.status === "starting");
+  const allServicesReady =
+    services.length > 0 && services.every((service) => service.status === "ready");
+
+  if (phase === "Provisioning") {
+    if (!hasInfrastructure || allInfrastructureHealthy) return "complete";
+    if (provisioning) return "active";
+    return "pending";
+  }
+
+  if (phase === "Starting") {
+    if (allServicesReady) return "complete";
+    if (!hasInfrastructure || allInfrastructureHealthy || anyServiceStarting || anyServiceReady) {
+      return "active";
+    }
+    return "pending";
+  }
+
+  // "Opening" has no `complete` state inside this canvas — completion is
+  // signalled by the canvas unmounting once the parent transitions to
+  // partially_ready or ready.
+  if (allServicesReady) return "active";
+  return "pending";
+}
 
 export function PreviewPanel({
   sessionId,
@@ -283,8 +333,14 @@ export function PreviewPanel({
   });
 
   const instance = previewStatus?.instance;
-  const services = previewStatus?.services ?? [];
-  const infrastructure = previewStatus?.infrastructure ?? [];
+  const services = useMemo(
+    () => previewStatus?.services ?? [],
+    [previewStatus?.services],
+  );
+  const infrastructure = useMemo(
+    () => previewStatus?.infrastructure ?? [],
+    [previewStatus?.infrastructure],
+  );
   const status = instance?.status;
   const isActive =
     status === "ready" ||
@@ -531,9 +587,19 @@ export function PreviewPanel({
     startMutation.isPending ||
     stopMutation.isPending ||
     restartMutation.isPending;
-  const startupChecklist = showStartupProgress
-    ? buildStartupChecklist(status, services, infrastructure)
-    : [];
+  const showStartupCanvas = isActive && !isReady;
+  const startupChecklist = useMemo(
+    () =>
+      showStartupProgress
+        ? buildStartupChecklist(status, services, infrastructure)
+        : [],
+    [showStartupProgress, status, services, infrastructure],
+  );
+  const startupSubtitle = getStartupSubtitle(status, services, infrastructure);
+  const showTopControls = status !== "starting";
+  const visibleStartupPhases = STARTUP_PHASES.filter(
+    (phase) => phase !== "Provisioning" || infrastructure.length > 0,
+  );
 
   if (statusLoading) {
     return (
@@ -549,6 +615,7 @@ export function PreviewPanel({
   return (
     <div className="flex flex-col gap-3">
       {/* Controls bar */}
+      {showTopControls && (
       <div className="flex items-center gap-2 flex-wrap">
         {/* Start / Stop / Restart */}
         <div className="flex items-center gap-1">
@@ -581,9 +648,6 @@ export function PreviewPanel({
         {/* Status badge */}
         {status && (
           <Badge variant="secondary" className={cn(statusColor(status))}>
-            {status === "starting" && (
-              <Loader2 className="size-3 animate-spin" />
-            )}
             {status === "ready" && <CheckCircle2 className="size-3" />}
             {(status === "failed" || status === "unhealthy") && <AlertTriangle className="size-3" />}
             {STATUS_LABELS[status]}
@@ -594,7 +658,7 @@ export function PreviewPanel({
         {isReady && <ConsoleBadge sessionId={sessionId} />}
 
         {/* TTL Warning */}
-        {instance?.expires_at && isActive && (
+        {instance?.expires_at && isReady && (
           <TTLWarning
             expiresAt={instance.expires_at}
             sessionId={sessionId}
@@ -679,6 +743,7 @@ export function PreviewPanel({
           </TooltipProvider>
         )}
       </div>
+      )}
 
       {/* Mutation error banner */}
       {mutationError && (
@@ -718,7 +783,7 @@ export function PreviewPanel({
       )}
 
       {/* Service status indicators */}
-      {services.length > 1 && isActive && (
+      {services.length > 1 && isReady && (
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
           {services.map((svc) => (
             <div key={svc.service_name} className="flex items-center gap-1">
@@ -735,72 +800,114 @@ export function PreviewPanel({
       )}
 
       {/* Startup progress */}
-      {showStartupProgress && (
-        <div className="space-y-2">
-          <div className="rounded-lg border bg-muted/30 p-3">
-            <p className="text-sm font-medium">Preview startup can take a few minutes.</p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              You can stay here while we spin up the environment and bring services online.
-            </p>
-          </div>
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            {STATUS_ORDER.map((p, i) => {
-              const currentIdx = STATUS_ORDER.indexOf(
-                status as PreviewStatus
-              );
-              const isDone = i < currentIdx;
-              const isCurrent = i === currentIdx;
-              return (
-                <div
-                  key={p}
-                  className={cn(
-                    "flex items-center gap-1",
-                    isDone && "text-emerald-600 dark:text-emerald-400",
-                    isCurrent && "text-primary font-medium"
-                  )}
-                >
-                  {isDone ? (
-                    <CheckCircle2 className="size-3" />
-                  ) : isCurrent ? (
-                    <Loader2 className="size-3 animate-spin" />
-                  ) : (
-                    <Circle className="size-3" />
-                  )}
-                  {STATUS_LABELS[p]}
-                  {i < STATUS_ORDER.length - 1 && (
-                    <span className="text-muted-foreground/50 mx-1">
-                      &rarr;
-                    </span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-          <div className="h-1 rounded-full bg-muted overflow-hidden">
-            <div
-              className="h-full bg-primary rounded-full transition-all duration-500"
-              style={{ width: `${statusProgress(status as PreviewStatus)}%` }}
-            />
-          </div>
-          <div className="rounded-lg border bg-background/70 p-3">
-            <div className="mb-2 text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-              Startup checklist
+      {showStartupCanvas && (
+        <div className="rounded-lg border bg-muted/20 overflow-hidden">
+          <div className="relative bg-background">
+            <div className="absolute right-3 top-3 z-10 flex items-center gap-1">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="icon-sm"
+                      variant="ghost"
+                      aria-label="Stop preview"
+                      onClick={() => stopMutation.mutate()}
+                      disabled={isMutating}
+                      loading={stopMutation.isPending}
+                    >
+                      {!stopMutation.isPending && <Square className="size-3.5" />}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Stop preview</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      size="icon-sm"
+                      variant="ghost"
+                      aria-label="Restart preview"
+                      onClick={() => restartMutation.mutate()}
+                      disabled={isMutating}
+                      loading={restartMutation.isPending}
+                    >
+                      {!restartMutation.isPending && <RotateCw className="size-3.5" />}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Restart preview</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             </div>
-            <div className="space-y-2">
-              {startupChecklist.map((step) => (
-                <div
-                  key={step.title}
-                  className="flex items-start gap-2 rounded-md border border-border/60 bg-muted/20 px-2.5 py-2"
-                >
-                  <div className="mt-0.5">{startupStepIcon(step.state)}</div>
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium">{step.title}</div>
-                    <div className="text-xs text-muted-foreground">{step.detail}</div>
-                  </div>
-                </div>
-              ))}
+            <div className="flex min-h-[360px] flex-col items-center justify-center px-6 py-14 text-center">
+              <div className="mb-4 rounded-full border bg-card p-3 shadow-sm">
+                <Loader2 className="size-5 animate-spin text-primary" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-lg font-semibold text-foreground">Preparing preview</p>
+                <p className="text-sm text-muted-foreground">{startupSubtitle}</p>
+              </div>
+              <div
+                className={cn(
+                  "mt-8 grid w-full max-w-md gap-3",
+                  visibleStartupPhases.length === 3 ? "grid-cols-3" : "grid-cols-2",
+                )}
+              >
+                {visibleStartupPhases.map((phase) => {
+                  const phaseState = startupPhaseState(phase, services, infrastructure);
+                  return (
+                    <div
+                      key={phase}
+                      className={cn(
+                        "flex flex-col items-center gap-2 rounded-lg border bg-card/70 px-3 py-2.5 text-xs text-muted-foreground",
+                        phaseState === "active" && "border-primary/30 text-foreground shadow-sm",
+                        phaseState === "complete" && "text-emerald-600 dark:text-emerald-400",
+                      )}
+                    >
+                      {phaseState === "complete" ? (
+                        <CheckCircle2 className="size-3.5" />
+                      ) : phaseState === "active" ? (
+                        <Loader2 className="size-3.5 animate-spin text-primary" />
+                      ) : (
+                        <Circle className="size-3.5" />
+                      )}
+                      <span className={phaseState === "active" ? "font-medium" : undefined}>
+                        {phase}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           </div>
+          <Collapsible>
+            <div className="border-t bg-card/60 px-3 py-2">
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="group h-7 px-2 text-xs text-muted-foreground"
+                >
+                  Details
+                  <ChevronDown className="size-3.5 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="pt-2 pb-1">
+                <div className="space-y-1.5">
+                  {startupChecklist.map((step) => (
+                    <div
+                      key={step.title}
+                      className="flex items-start gap-2 rounded-md px-2 py-1.5 text-sm"
+                    >
+                      <div className="mt-0.5">{startupStepIcon(step.state)}</div>
+                      <div className="min-w-0">
+                        <div className="font-medium text-foreground">{step.title}</div>
+                        <div className="text-xs text-muted-foreground">{step.detail}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </div>
+          </Collapsible>
         </div>
       )}
 
@@ -824,6 +931,36 @@ export function PreviewPanel({
             <RefreshCw className="size-3.5" />
             Try Again
           </Button>
+          {hasStartupRows && (
+            <Collapsible>
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="group h-7 px-2 text-xs text-muted-foreground"
+                >
+                  Details
+                  <ChevronDown className="size-3.5 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="pt-2 pb-1">
+                <div className="space-y-1.5">
+                  {startupChecklist.map((step) => (
+                    <div
+                      key={step.title}
+                      className="flex items-start gap-2 rounded-md px-2 py-1.5 text-sm"
+                    >
+                      <div className="mt-0.5">{startupStepIcon(step.state)}</div>
+                      <div className="min-w-0">
+                        <div className="font-medium text-foreground">{step.title}</div>
+                        <div className="text-xs text-muted-foreground">{step.detail}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Replaces the busy starting-state UI (progress bar, three-step rail, always-expanded checklist) with a calm preview-first canvas: centered "Preparing preview" headline, a compact Provisioning → Starting → Opening rail, and a collapsed Details section behind a chevron toggle.
- Moves Stop/Restart into icon buttons inside the startup canvas while the preview is starting, hides the top control bar in that state, and narrows per-service indicators and the TTL warning to ready-only.
- Hides the Provisioning rail tile when the preview has no infrastructure so phases never claim to have completed work that didn't happen, and adds a one-paragraph design-doc note for the new lifecycle UX.

## Test plan
- [ ] `pnpm --filter frontend test --run preview-panel`
- [ ] Manual: trigger a preview start with infra and confirm the 3-tile rail, subtitle updates, Details collapses/expands, chevron rotates, and Stop/Restart work from the canvas.
- [ ] Manual: trigger a preview without infra and confirm the rail collapses to two tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
