### PR TITLE
Preserve session diff across continue turns so Changes tab survives PR push

### DIFF
--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -817,6 +817,13 @@ func (s *SessionStore) UpdateResult(ctx context.Context, orgID, runID uuid.UUID,
 
 func (s *SessionStore) updateResultRow(ctx context.Context, db DBTX, orgID, runID uuid.UUID, status string, result *models.SessionResult, diffStats json.RawMessage) error {
 
+	// COALESCE on diff / diff_stats / diff_collected_at preserves the
+	// previously persisted authoritative diff when the current turn did not
+	// produce one (collection skipped or failed — sessiondiff.Collect returned
+	// ErrNoBaseCommitSHA, which the adapter logs and leaves result.Diff empty,
+	// which strPtr converts to nil here). Without this guard, an empty/NULL
+	// diff would overwrite the prior diff and blank out the Changes tab.
+	// diff_history's append SQL already no-ops when @diff IS NULL.
 	query := `
 		UPDATE sessions
 		SET status = @status,
@@ -828,10 +835,12 @@ func (s *SessionStore) updateResultRow(ctx context.Context, db DBTX, orgID, runI
 		    END,
 		    confidence_score = @confidence_score, confidence_reasoning = @confidence_reasoning,
 		    risk_factors = @risk_factors, token_usage = @token_usage,
-		    result_summary = @result_summary, diff = @diff, error = @error,
+		    result_summary = @result_summary,
+		    diff = COALESCE(@diff, diff),
+		    error = @error,
 		    base_commit_sha = COALESCE(@base_commit_sha, base_commit_sha),
-		    diff_collected_at = @diff_collected_at,
-		    diff_stats = @diff_stats,
+		    diff_collected_at = COALESCE(@diff_collected_at, diff_collected_at),
+		    diff_stats = COALESCE(@diff_stats, diff_stats),
 		    diff_history = ` + diffHistoryAppendSQL("COALESCE(current_turn, 0) + 1") + `
 		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
 
@@ -1190,6 +1199,12 @@ func (s *SessionStore) UpdateTurnComplete(ctx context.Context, orgID, sessionID 
 
 func (s *SessionStore) updateTurnCompleteRow(ctx context.Context, db DBTX, orgID, sessionID uuid.UUID, turn int, result *models.SessionResult, agentSessionID, snapshotKey string, diffStats json.RawMessage) error {
 
+	// COALESCE on diff / diff_stats / diff_collected_at: see updateResultRow
+	// for the full rationale. Briefly: when sessiondiff.Collect returns
+	// ErrNoBaseCommitSHA (or the agent produces no changes against base), the
+	// adapter leaves result.Diff empty → strPtr returns nil → @diff is NULL
+	// here. Falling back to the previously persisted diff is strictly better
+	// than clobbering the Changes tab with a blank value.
 	query := `
 		UPDATE sessions
 		SET status = 'idle', current_turn = @current_turn, last_activity_at = now(),
@@ -1198,10 +1213,12 @@ func (s *SessionStore) updateTurnCompleteRow(ctx context.Context, db DBTX, orgID
 		    pr_creation_state = 'idle', pr_creation_error = NULL,
 		    confidence_score = @confidence_score, confidence_reasoning = @confidence_reasoning,
 		    risk_factors = @risk_factors, token_usage = @token_usage,
-		    result_summary = @result_summary, diff = @diff, error = @error,
+		    result_summary = @result_summary,
+		    diff = COALESCE(@diff, diff),
+		    error = @error,
 		    base_commit_sha = COALESCE(@base_commit_sha, base_commit_sha),
-		    diff_collected_at = @diff_collected_at,
-		    diff_stats = @diff_stats,
+		    diff_collected_at = COALESCE(@diff_collected_at, diff_collected_at),
+		    diff_stats = COALESCE(@diff_stats, diff_stats),
 		    diff_history = ` + diffHistoryAppendSQL("@current_turn::int") + `
 		WHERE id = @id AND org_id = @org_id`
 

--- a/internal/db/session_store_diff_test.go
+++ b/internal/db/session_store_diff_test.go
@@ -179,6 +179,76 @@ func TestSessionStore_UpdateTurnComplete_WithDiffSnapshotInsertFailure(t *testin
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// TestSessionStore_UpdateResult_PreservesDiffWhenNil verifies that the
+// UPDATE sessions ... SET diff = COALESCE(@diff, diff) clause is in place,
+// so that a turn that did not collect a fresh diff (sessiondiff.Collect
+// returned ErrNoBaseCommitSHA, the agent produced no changes against the
+// base, etc. — strPtr converts the empty string to a nil *string) does not
+// blank out the previously persisted authoritative diff. This is the bug
+// users hit when pushing a PR or resolving conflicts: every clean-tree
+// continue turn used to overwrite the Changes tab with NULL.
+func TestSessionStore_UpdateResult_PreservesDiffWhenNil(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	collectedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// result.Diff is nil — the prior turn's diff must be preserved.
+	result := &models.SessionResult{}
+
+	// The SQL must contain `diff = COALESCE(@diff, diff)` so a NULL @diff
+	// leaves the existing value intact. Same for diff_stats and
+	// diff_collected_at to keep them consistent with the preserved diff.
+	mock.ExpectQuery(`UPDATE sessions[\s\S]+diff = COALESCE\(@diff, diff\)[\s\S]+diff_collected_at = COALESCE\(@diff_collected_at, diff_collected_at\)[\s\S]+diff_stats = COALESCE\(@diff_stats, diff_stats\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionTestColumns).AddRow(
+				newAgentSessionRow(sessionID, uuid.New(), orgID, collectedAt)...,
+			),
+		)
+
+	err = store.UpdateResult(context.Background(), orgID, sessionID, "completed", result)
+	require.NoError(t, err, "UpdateResult should succeed when diff is nil")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// TestSessionStore_UpdateTurnComplete_PreservesDiffWhenNil mirrors the
+// UpdateResult test for the continue-session write path — the same COALESCE
+// guard applies.
+func TestSessionStore_UpdateTurnComplete_PreservesDiffWhenNil(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	result := &models.SessionResult{}
+
+	mock.ExpectExec(`UPDATE sessions[\s\S]+SET status = 'idle'[\s\S]+diff = COALESCE\(@diff, diff\)[\s\S]+diff_collected_at = COALESCE\(@diff_collected_at, diff_collected_at\)[\s\S]+diff_stats = COALESCE\(@diff_stats, diff_stats\)`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateTurnComplete(context.Background(), orgID, sessionID, 2, result, "agent-123", "snap-key")
+	require.NoError(t, err, "UpdateTurnComplete should succeed when diff is nil")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_UpdateBaseCommitSHA(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -126,6 +126,10 @@ func (s *SessionThreadStore) UpdateStatus(ctx context.Context, orgID, threadID u
 }
 
 // UpdateResult persists agent results on a thread.
+//
+// COALESCE on diff preserves the prior thread diff when the current turn did
+// not produce one — same rationale as the session-level update; see
+// session_store.go updateResultRow for full details.
 func (s *SessionThreadStore) UpdateResult(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus, result *models.SessionResult) error {
 	query := `
 		UPDATE session_threads
@@ -137,7 +141,7 @@ func (s *SessionThreadStore) UpdateResult(ctx context.Context, orgID, threadID u
 		    END,
 		    confidence_score = @confidence_score,
 		    result_summary = @result_summary,
-		    diff = @diff,
+		    diff = COALESCE(@diff, diff),
 		    failure_explanation = @failure_explanation,
 		    failure_category = @failure_category
 		WHERE id = @id AND org_id = @org_id`
@@ -186,13 +190,15 @@ func (s *SessionThreadStore) ClaimIdle(ctx context.Context, orgID, threadID uuid
 }
 
 // UpdateTurnComplete sets the thread to idle and persists turn metadata.
+// COALESCE on diff: see UpdateResult above.
 func (s *SessionThreadStore) UpdateTurnComplete(ctx context.Context, orgID, threadID uuid.UUID, turn int, result *models.SessionResult, agentSessionID string) error {
 	query := `
 		UPDATE session_threads
 		SET status = 'idle', current_turn = @current_turn, last_activity_at = now(),
 		    agent_session_id = @agent_session_id,
 		    confidence_score = @confidence_score,
-		    result_summary = @result_summary, diff = @diff
+		    result_summary = @result_summary,
+		    diff = COALESCE(@diff, diff)
 		WHERE id = @id AND org_id = @org_id`
 
 	ct, err := s.db.Exec(ctx, query, pgx.NamedArgs{

--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -397,6 +397,14 @@ type Sandbox struct {
 	Purpose   string
 }
 
+// SandboxMetadataBaseCommitSHA is the well-known sandbox.Metadata key under
+// which the orchestrator stashes the immutable base commit captured at session
+// start. Adapters read it when collecting the authoritative session diff. The
+// constant lives in the agent package (rather than sessiondiff) so callers in
+// the agent package can reference it without creating an import cycle —
+// sessiondiff already imports agent for SandboxProvider/Sandbox.
+const SandboxMetadataBaseCommitSHA = "base_commit_sha"
+
 // SandboxConnectionInfo holds provider-specific connection details for local resume.
 type SandboxConnectionInfo struct {
 	Provider     string            // "docker" or "e2b"

--- a/internal/services/agent/adapters/amp_test.go
+++ b/internal/services/agent/adapters/amp_test.go
@@ -85,7 +85,7 @@ func TestAmpAdapter_Execute_StreamJSON(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 100)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "Fix it.",
 		UserPrompt:   "Null pointer.",
 		MaxTokens:    50_000,
@@ -137,7 +137,7 @@ func TestAmpAdapter_Execute_NonZeroExit(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x",
 		UserPrompt:   "y",
 		MaxTokens:    50_000,
@@ -163,7 +163,7 @@ func TestAmpAdapter_Execute_ContinuationUsesUserMessage(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		Continuation: true,
 		UserMessage:  "please continue where we left off",
 		MaxTokens:    50_000,
@@ -182,7 +182,7 @@ func TestAmpAdapter_Execute_MissingProvider(t *testing.T) {
 
 	adapter := NewAmpAdapter(zerolog.Nop())
 	logCh := make(chan agent.LogEntry, 10)
-	_, err := adapter.Execute(context.Background(), &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(context.Background(), &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -201,7 +201,7 @@ func TestAmpAdapter_Execute_WriteFileError(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -220,7 +220,7 @@ func TestAmpAdapter_Execute_ExecStreamError(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -242,7 +242,7 @@ func TestAmpAdapter_Execute_SummaryFromAssistantFallback(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.NoError(t, err)

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -792,6 +792,17 @@ func tryExtractConfidence(text string, result *agent.AgentResult) {
 // collectDiff runs git diff inside the sandbox to capture changes.
 // Returns an empty string (not an error) when the workspace is not a git repository,
 // which happens when no repository was configured for the issue.
+//
+// The base commit SHA is read from sandbox.Metadata, which the orchestrator
+// is responsible for populating both on the initial clone (RunAgent) and on
+// every continue path (ContinueSession). When the base SHA is missing,
+// sessiondiff.Collect returns ErrNoBaseCommitSHA — adapters log and leave
+// result.Diff unset so the persistence layer preserves the previous diff
+// rather than clobbering it with an empty string.
 func collectDiff(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox) (string, error) {
-	return sessiondiff.Collect(ctx, provider, sandbox)
+	baseCommitSHA := ""
+	if sandbox != nil && sandbox.Metadata != nil {
+		baseCommitSHA = sandbox.Metadata[sessiondiff.SandboxMetadataBaseCommitSHA]
+	}
+	return sessiondiff.Collect(ctx, provider, sandbox, baseCommitSHA)
 }

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -216,7 +216,7 @@ func TestClaudeCodeAdapter_Execute(t *testing.T) {
 			}
 
 			adapter := NewClaudeCodeAdapter(zerolog.Nop())
-			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
 				UserPrompt:   "Null pointer error.",
@@ -262,7 +262,7 @@ func TestClaudeCodeAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -282,7 +282,7 @@ func TestClaudeCodeAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -297,7 +297,7 @@ func TestClaudeCodeAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -328,7 +328,7 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please tighten the guard clause.",
 		MaxTokens:    50_000,
@@ -365,7 +365,7 @@ func TestClaudeCodeAdapter_Execute_IncludesReasoningEffortOverride(t *testing.T)
 	}
 
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		SystemPrompt:    "test",
 		UserPrompt:      "test",

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -651,7 +651,7 @@ func TestCodexAdapter_Execute(t *testing.T) {
 			}
 
 			adapter := NewCodexAdapter(zerolog.Nop())
-			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+			sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
 				UserPrompt:   "Null pointer error.",
@@ -697,7 +697,7 @@ func TestCodexAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -717,7 +717,7 @@ func TestCodexAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -732,7 +732,7 @@ func TestCodexAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -763,7 +763,7 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please tighten the test case.",
 		MaxTokens:    50_000,
@@ -800,7 +800,7 @@ func TestCodexAdapter_Execute_IncludesReasoningEffortOverride(t *testing.T) {
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		SystemPrompt:    "test",
 		UserPrompt:      "test",
@@ -837,7 +837,7 @@ func TestCodexAdapter_Execute_ContinuationWithResumeSessionIDIncludesReasoningEf
 	}
 
 	adapter := NewCodexAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		UserMessage:     "Please continue.",
 		MaxTokens:       50_000,

--- a/internal/services/agent/adapters/gemini_cli_test.go
+++ b/internal/services/agent/adapters/gemini_cli_test.go
@@ -214,9 +214,10 @@ func TestGeminiCLIAdapter_Execute(t *testing.T) {
 
 			adapter := NewGeminiCLIAdapter(zerolog.Nop())
 			sandbox := &agent.Sandbox{
-				ID:      "test-sandbox",
-				WorkDir: "/workspace",
-				HomeDir: "/home/sandbox",
+				ID:       "test-sandbox",
+				WorkDir:  "/workspace",
+				HomeDir:  "/home/sandbox",
+				Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"},
 			}
 			prompt := &agent.AgentPrompt{
 				SystemPrompt: "Fix the bug.",
@@ -261,7 +262,7 @@ func TestGeminiCLIAdapter_Execute_WriteFileError(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -284,7 +285,7 @@ func TestGeminiCLIAdapter_Execute_ExecError(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
@@ -299,7 +300,7 @@ func TestGeminiCLIAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	t.Parallel()
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "test", UserPrompt: "test", MaxTokens: 50_000}
 	logCh := make(chan agent.LogEntry, 10)
 
@@ -650,7 +651,7 @@ func TestGeminiCLIAdapter_Execute_StreamingOutput(t *testing.T) {
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test-sandbox", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{SystemPrompt: "Fix the bug.", UserPrompt: "Null pointer error.", MaxTokens: 50_000}
 
 	logCh := make(chan agent.LogEntry, 100)
@@ -700,7 +701,7 @@ func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *
 	}
 
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
-	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
 		UserMessage:  "Please include a regression test.",
 		MaxTokens:    50_000,

--- a/internal/services/agent/adapters/pi_test.go
+++ b/internal/services/agent/adapters/pi_test.go
@@ -79,7 +79,7 @@ func TestPiAdapter_Execute_StreamJSON(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 100)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "Fix it.",
 		UserPrompt:   "Bug.",
 		MaxTokens:    50_000,
@@ -124,7 +124,7 @@ func TestPiAdapter_Execute_NonZeroExit(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x",
 		UserPrompt:   "y",
 		MaxTokens:    50_000,
@@ -150,7 +150,7 @@ func TestPiAdapter_Execute_ContinuationUsesUserMessage(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		Continuation: true,
 		UserMessage:  "follow-up instruction",
 		MaxTokens:    50_000,
@@ -169,7 +169,7 @@ func TestPiAdapter_Execute_MissingProvider(t *testing.T) {
 
 	adapter := NewPiAdapter(zerolog.Nop())
 	logCh := make(chan agent.LogEntry, 10)
-	_, err := adapter.Execute(context.Background(), &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(context.Background(), &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -188,7 +188,7 @@ func TestPiAdapter_Execute_WriteFileError(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -207,7 +207,7 @@ func TestPiAdapter_Execute_ExecStreamError(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	_, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.Error(t, err)
@@ -227,7 +227,7 @@ func TestPiAdapter_Execute_SummaryFromAssistantFallback(t *testing.T) {
 	logCh := make(chan agent.LogEntry, 10)
 	ctx := WithSandboxProvider(context.Background(), provider)
 
-	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox"}, &agent.AgentPrompt{
+	result, err := adapter.Execute(ctx, &agent.Sandbox{ID: "t", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}, &agent.AgentPrompt{
 		SystemPrompt: "x", UserPrompt: "y", MaxTokens: 50_000,
 	}, logCh)
 	require.NoError(t, err)

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1369,7 +1369,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 			if sandbox.Metadata == nil {
 				sandbox.Metadata = make(map[string]string)
 			}
-			sandbox.Metadata["base_commit_sha"] = baseCommitSHA
+			sandbox.Metadata[SandboxMetadataBaseCommitSHA] = baseCommitSHA
 			run.BaseCommitSHA = &baseCommitSHA
 			if dbErr := o.sessions.UpdateBaseCommitSHA(ctx, run.OrgID, run.ID, baseCommitSHA); dbErr != nil {
 				log.Warn().Err(dbErr).Str("base_commit_sha", baseCommitSHA).Msg("failed to persist base commit sha")
@@ -1953,6 +1953,22 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			)
 			return fmt.Errorf("create sandbox: %w", err)
 		}
+	}
+	// Re-populate sandbox.Metadata["base_commit_sha"] from the DB so that
+	// sessiondiff.Collect can compute `git diff <base> -- .` (the cumulative
+	// session diff against the immutable base) instead of falling back to a
+	// plain `git diff` against the index. Without this, any continue turn
+	// run on a clean working tree (post-PR-push, post-merge) would collect
+	// an empty diff and overwrite the persisted authoritative diff, blanking
+	// out the Changes tab on the session page even though the PR clearly
+	// has changes. RunAgent sets this on the initial clone; the three setup
+	// branches above (reuse, hydrate, fresh-clone-on-continue) all leave
+	// Metadata empty, so we fix it here once for every continue path.
+	if session.BaseCommitSHA != nil && *session.BaseCommitSHA != "" {
+		if sandbox.Metadata == nil {
+			sandbox.Metadata = make(map[string]string)
+		}
+		sandbox.Metadata[SandboxMetadataBaseCommitSHA] = *session.BaseCommitSHA
 	}
 	// Record the turn hold. AcquireTurnHold uses COALESCE so it is idempotent
 	// when we reused a container (the row's container_id already matches our

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3442,6 +3442,72 @@ func TestContinueSession_ReusesExistingContainer(t *testing.T) {
 	require.GreaterOrEqual(t, d.sessions.releaseHoldCalls, 1)
 }
 
+// TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata is the
+// regression test for the "Changes tab goes blank after PR push / resolve
+// conflicts" bug. ContinueSession previously left sandbox.Metadata empty in
+// every setup branch (reuse / hydrate / fresh-clone), so sessiondiff.Collect
+// fell back to plain `git diff` and returned an empty string for any clean
+// working tree (post-push, post-merge). That empty diff overwrote the
+// authoritative session diff in the DB, blanking the Changes tab even
+// though the PR itself was healthy. With the fix, the orchestrator copies
+// session.BaseCommitSHA back onto sandbox.Metadata after every setup branch,
+// so the diff collector always has the immutable base SHA to compare
+// against. We exercise the reuse path here because it's the simplest setup
+// that goes through the post-switch metadata restore.
+func TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-base-sha"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	const expectedBaseSHA = "feedfacecafe1234"
+	baseSHA := expectedBaseSHA
+	session.BaseCommitSHA = &baseSHA
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "follow-up after PR push",
+		},
+	}
+
+	var observedBaseSHA string
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		require.NotNil(t, sandbox.Metadata, "ContinueSession must populate sandbox.Metadata before the agent runs")
+		observedBaseSHA = sandbox.Metadata[agent.SandboxMetadataBaseCommitSHA]
+		return &agent.AgentResult{
+			Summary:         "done",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+		}, nil
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("snap"))), nil
+	}
+
+	orch := buildOrchestrator(d)
+	require.NoError(t, orch.ContinueSession(context.Background(), session))
+
+	require.Equal(t, expectedBaseSHA, observedBaseSHA,
+		"ContinueSession must restore session.BaseCommitSHA onto sandbox.Metadata so sessiondiff.Collect can run `git diff <base> -- .` instead of falling back to plain `git diff`")
+}
+
 // TestContinueSession_ReusedContainerReopensAuthListener locks in the
 // regression: when a preview is holding the container alive across turns,
 // ContinueSession must (re)open the per-session credential listener even

--- a/internal/services/sessiondiff/service.go
+++ b/internal/services/sessiondiff/service.go
@@ -3,18 +3,35 @@ package sessiondiff
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/assembledhq/143/internal/services/agent"
 )
 
-const SandboxMetadataBaseCommitSHA = "base_commit_sha"
+// SandboxMetadataBaseCommitSHA is re-exported from the agent package so
+// existing callers (adapters, etc.) that referenced sessiondiff.SandboxMetadataBaseCommitSHA
+// keep compiling. The canonical declaration lives in the agent package
+// (agent.SandboxMetadataBaseCommitSHA) — see the rationale there.
+const SandboxMetadataBaseCommitSHA = agent.SandboxMetadataBaseCommitSHA
+
+// ErrNoBaseCommitSHA is returned by Collect when the caller does not supply a
+// base commit SHA. The previous behavior — falling back to plain `git diff`
+// against the index — silently produced misleading results once the agent had
+// committed its work (e.g. after a PR push), because a clean working tree
+// would yield an empty diff and overwrite the previously persisted authoritative
+// diff. Returning this sentinel forces callers to handle the missing-base case
+// explicitly (typically by skipping the persistence write so the prior diff
+// is preserved).
+var ErrNoBaseCommitSHA = errors.New("sessiondiff: base commit sha is required")
 
 // Collect returns the authoritative session diff: the current workspace
 // compared against the immutable recorded base commit, plus synthetic additions
-// for any untracked files.
-func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox) (string, error) {
+// for any untracked files. baseCommitSHA must be non-empty — Collect refuses
+// to fall back to plain `git diff` so that callers cannot inadvertently store
+// an empty diff after the workspace has been committed (post-push, post-merge).
+func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, baseCommitSHA string) (string, error) {
 	var checkStdout, checkStderr bytes.Buffer
 	checkExit, err := provider.Exec(ctx, sandbox, "git rev-parse --is-inside-work-tree", &checkStdout, &checkStderr)
 	if err != nil {
@@ -24,15 +41,11 @@ func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent
 		return "", nil
 	}
 
-	baseCommitSHA := ""
-	if sandbox.Metadata != nil {
-		baseCommitSHA = sandbox.Metadata[SandboxMetadataBaseCommitSHA]
+	if baseCommitSHA == "" {
+		return "", ErrNoBaseCommitSHA
 	}
 
-	diffCmd := "git diff"
-	if baseCommitSHA != "" {
-		diffCmd = fmt.Sprintf("git diff --find-renames --binary %s -- .", shellEscapeSingleQuote(baseCommitSHA))
-	}
+	diffCmd := fmt.Sprintf("git diff --find-renames --binary %s -- .", shellEscapeSingleQuote(baseCommitSHA))
 
 	var stdout, stderr bytes.Buffer
 	exitCode, err := provider.Exec(ctx, sandbox, diffCmd, &stdout, &stderr)

--- a/internal/services/sessiondiff/service_test.go
+++ b/internal/services/sessiondiff/service_test.go
@@ -15,16 +15,19 @@ func TestCollect(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		sandbox     *agent.Sandbox
-		execFn      func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error)
-		expected    string
-		expectedCmd []string
-		expectErr   string
+		name          string
+		sandbox       *agent.Sandbox
+		baseCommitSHA string
+		execFn        func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error)
+		expected      string
+		expectedCmd   []string
+		expectErr     string
+		expectErrIs   error
 	}{
 		{
-			name:    "returns empty when sandbox is not a git repo",
-			sandbox: &agent.Sandbox{ID: "sb"},
+			name:          "returns empty when sandbox is not a git repo",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				require.Equal(t, "git rev-parse --is-inside-work-tree", cmd, "git repo check should run first")
 				return 1, nil
@@ -35,8 +38,9 @@ func TestCollect(t *testing.T) {
 			},
 		},
 		{
-			name:    "collects git diff and untracked file patches with base commit",
-			sandbox: &agent.Sandbox{ID: "sb", Metadata: map[string]string{SandboxMetadataBaseCommitSHA: "abc123"}},
+			name:          "collects git diff and untracked file patches with base commit",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
@@ -68,21 +72,36 @@ func TestCollect(t *testing.T) {
 			},
 		},
 		{
-			name:    "returns error when repo check fails",
-			sandbox: &agent.Sandbox{ID: "sb"},
+			name:          "returns error when repo check fails",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				return 0, errors.New("boom")
 			},
 			expectErr: "check git repo",
 		},
 		{
-			name:    "returns error when git diff exits non zero",
-			sandbox: &agent.Sandbox{ID: "sb"},
+			name:          "refuses to compute a diff without a base commit sha",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				if cmd == "git rev-parse --is-inside-work-tree" {
+					return 0, nil
+				}
+				t.Fatalf("Collect should not run any git diff command when base sha is missing; got: %s", cmd)
+				return 0, nil
+			},
+			expectErrIs: ErrNoBaseCommitSHA,
+		},
+		{
+			name:          "returns error when git diff exits non zero",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git diff":
+				case "git diff --find-renames --binary abc123 -- .":
 					_, _ = io.WriteString(stderr, "bad diff")
 					return 2, nil
 				default:
@@ -93,13 +112,14 @@ func TestCollect(t *testing.T) {
 			expectErr: "git diff exited with code 2: bad diff",
 		},
 		{
-			name:    "returns error when listing untracked files fails",
-			sandbox: &agent.Sandbox{ID: "sb"},
+			name:          "returns error when listing untracked files fails",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git diff":
+				case "git diff --find-renames --binary abc123 -- .":
 					return 0, nil
 				case "git ls-files --others --exclude-standard -- .":
 					return 0, errors.New("ls failed")
@@ -111,13 +131,14 @@ func TestCollect(t *testing.T) {
 			expectErr: "list untracked files",
 		},
 		{
-			name:    "returns error when untracked diff exits with unexpected code",
-			sandbox: &agent.Sandbox{ID: "sb"},
+			name:          "returns error when untracked diff exits with unexpected code",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 				switch cmd {
 				case "git rev-parse --is-inside-work-tree":
 					return 0, nil
-				case "git diff":
+				case "git diff --find-renames --binary abc123 -- .":
 					return 0, nil
 				case "git ls-files --others --exclude-standard -- .":
 					_, _ = io.WriteString(stdout, "new.go\n")
@@ -145,7 +166,12 @@ func TestCollect(t *testing.T) {
 				return tt.execFn(ctx, sb, cmd, stdout, stderr)
 			}
 
-			diff, err := Collect(context.Background(), provider, tt.sandbox)
+			diff, err := Collect(context.Background(), provider, tt.sandbox, tt.baseCommitSHA)
+			if tt.expectErrIs != nil {
+				require.Error(t, err, "Collect should return an error")
+				require.ErrorIs(t, err, tt.expectErrIs, "Collect should return the expected sentinel error")
+				return
+			}
 			if tt.expectErr != "" {
 				require.Error(t, err, "Collect should return an error")
 				require.Contains(t, err.Error(), tt.expectErr, "Collect should return the expected error")


### PR DESCRIPTION
## Summary

Fixes the bug where the **Changes** tab on a session goes blank after pushing a PR or pressing **Resolve Conflicts**, even though the PR clearly contains commits.

Root cause: every `ContinueSession` setup branch (reuse / hydrate / fresh) left `sandbox.Metadata` empty, so `sessiondiff.Collect` fell back to plain `git diff` and returned an empty string for any clean working tree — the exact state every continue turn lands in post-push or post-merge — which then overwrote the persisted `sessions.diff`.

Three layered fixes:
- **Primary:** `ContinueSession` now copies `session.BaseCommitSHA` back onto `sandbox.Metadata` after sandbox setup, so `Collect` runs `git diff <base> -- .` against the immutable base.
- **Hardening #1:** `sessiondiff.Collect` takes `baseCommitSHA` explicitly and returns a new `ErrNoBaseCommitSHA` sentinel instead of falling back to plain `git diff`. SQL `UPDATE`s use `COALESCE(@diff, diff)` (and `@diff_stats` / `@diff_collected_at`) so a NULL diff preserves the previously persisted authoritative diff.
- **Hardening #2:** Constant moved to the `agent` package to break the import cycle the explicit-parameter change introduced.

Regression tests added at each layer.

## Test plan
- [x] `go test ./...` (all packages green)
- [x] `make lint` (0 issues)
- [ ] Manually verify: push a PR from a session, send a follow-up message, confirm Changes tab still shows the diff
- [ ] Manually verify: trigger Resolve Conflicts, confirm Changes tab still shows the diff after the repair turn completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)