### PR TITLE
Use standard radio button layout for Autopilot execution mode options

### DIFF
--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -119,6 +119,8 @@ describe("AutopilotSettingsPage", () => {
     await waitFor(() => {
       expect(screen.getByLabelText("Max concurrent runs")).toHaveValue(5);
     });
+    expect(screen.getByLabelText("Suggest").parentElement).not.toHaveClass("rounded-lg", "border", "p-3");
+    expect(screen.getByLabelText("Conservative").parentElement).not.toHaveClass("rounded-lg", "border", "p-3");
   });
 
   it("autosaves a changed autonomy level immediately", async () => {

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -193,28 +193,35 @@ export default function AutopilotSettingsPage() {
                       },
                     })
                   }
+                  className="gap-4"
                 >
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="manual" aria-label="Suggest" />
-                    <div>
-                      <span className="text-xs font-medium">Suggest</span>
-                      <p className="text-xs text-muted-foreground">Autopilot recommends, you decide.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="auto_simple" aria-label="Act on low-risk" />
-                    <div>
-                      <span className="text-xs font-medium">Act on low-risk</span>
-                      <p className="text-xs text-muted-foreground">Auto-create sessions for bounded work.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="auto_all" aria-label="Operate broadly" />
-                    <div>
-                      <span className="text-xs font-medium">Operate broadly</span>
-                      <p className="text-xs text-muted-foreground">Autopilot runs automatically on eligible work.</p>
-                    </div>
-                  </label>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="manual" id="autonomy-manual" aria-label="Suggest" className="mt-0.5" />
+                    <Label htmlFor="autonomy-manual" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Suggest</span>
+                        <p className="text-xs text-muted-foreground">Autopilot recommends, you decide.</p>
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="auto_simple" id="autonomy-auto-simple" aria-label="Act on low-risk" className="mt-0.5" />
+                    <Label htmlFor="autonomy-auto-simple" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Act on low-risk</span>
+                        <p className="text-xs text-muted-foreground">Auto-create sessions for bounded work.</p>
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="auto_all" id="autonomy-auto-all" aria-label="Operate broadly" className="mt-0.5" />
+                    <Label htmlFor="autonomy-auto-all" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Operate broadly</span>
+                        <p className="text-xs text-muted-foreground">Autopilot runs automatically on eligible work.</p>
+                      </div>
+                    </Label>
+                  </div>
                 </RadioGroup>
               </div>
               <div className="space-y-2">
@@ -229,35 +236,44 @@ export default function AutopilotSettingsPage() {
                       settings: { execution_aggressiveness: parseInt(value, 10) },
                     })
                   }
+                  className="gap-4"
                 >
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="1" aria-label="Conservative" />
-                    <div>
-                      <span className="text-xs font-medium">Conservative</span>
-                      <p className="text-xs text-muted-foreground">Prefer smaller, lower-risk edits.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="2" aria-label="Moderate" />
-                    <div>
-                      <span className="text-xs font-medium">Moderate</span>
-                      <p className="text-xs text-muted-foreground">Balance scope and caution.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="3" aria-label="Aggressive" />
-                    <div>
-                      <span className="text-xs font-medium">Aggressive</span>
-                      <p className="text-xs text-muted-foreground">Allow broader changes when they stay coherent.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-center gap-3 rounded-lg border p-3">
-                    <RadioGroupItem value="4" aria-label="Maximum" />
-                    <div>
-                      <span className="text-xs font-medium">Maximum</span>
-                      <p className="text-xs text-muted-foreground">Optimize for throughput over caution.</p>
-                    </div>
-                  </label>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="1" id="execution-aggressiveness-1" aria-label="Conservative" className="mt-0.5" />
+                    <Label htmlFor="execution-aggressiveness-1" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Conservative</span>
+                        <p className="text-xs text-muted-foreground">Prefer smaller, lower-risk edits.</p>
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="2" id="execution-aggressiveness-2" aria-label="Moderate" className="mt-0.5" />
+                    <Label htmlFor="execution-aggressiveness-2" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Moderate</span>
+                        <p className="text-xs text-muted-foreground">Balance scope and caution.</p>
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="3" id="execution-aggressiveness-3" aria-label="Aggressive" className="mt-0.5" />
+                    <Label htmlFor="execution-aggressiveness-3" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Aggressive</span>
+                        <p className="text-xs text-muted-foreground">Allow broader changes when they stay coherent.</p>
+                      </div>
+                    </Label>
+                  </div>
+                  <div className="flex items-start gap-3">
+                    <RadioGroupItem value="4" id="execution-aggressiveness-4" aria-label="Maximum" className="mt-0.5" />
+                    <Label htmlFor="execution-aggressiveness-4" className="items-start gap-0">
+                      <div>
+                        <span className="text-xs font-medium">Maximum</span>
+                        <p className="text-xs text-muted-foreground">Optimize for throughput over caution.</p>
+                      </div>
+                    </Label>
+                  </div>
                 </RadioGroup>
               </div>
               <div className="space-y-2">

--- a/frontend/src/components/autopilot/autopilot-steering-sheet.test.tsx
+++ b/frontend/src/components/autopilot/autopilot-steering-sheet.test.tsx
@@ -26,6 +26,7 @@ describe("AutopilotSteeringSheet", () => {
     expect(screen.getByDisplayValue("Ship reliability first.")).toBeInTheDocument();
     expect(screen.getByDisplayValue("Payments hardening this quarter.")).toBeInTheDocument();
     expect(screen.getByDisplayValue("auth")).toBeInTheDocument();
+    expect(screen.getByLabelText("Suggest").parentElement).not.toHaveClass("rounded-lg", "border", "p-3");
   });
 
   it("autosaves the philosophy change with the merged product_context payload", async () => {

--- a/frontend/src/components/autopilot/autopilot-steering-sheet.tsx
+++ b/frontend/src/components/autopilot/autopilot-steering-sheet.tsx
@@ -185,28 +185,35 @@ function AutopilotSteeringSheetBody({
                 },
               })
             }
+            className="gap-4"
           >
-            <label className="flex items-center gap-3 rounded-lg border p-3">
-              <RadioGroupItem value="manual" aria-label="Suggest" />
-              <div>
-                <p className="text-sm font-medium">Suggest</p>
-                <p className="text-xs text-muted-foreground">Autopilot recommends, you decide.</p>
-              </div>
-            </label>
-            <label className="flex items-center gap-3 rounded-lg border p-3">
-              <RadioGroupItem value="auto_simple" aria-label="Act on low-risk" />
-              <div>
-                <p className="text-sm font-medium">Act on low-risk</p>
-                <p className="text-xs text-muted-foreground">Auto-create sessions for bounded work.</p>
-              </div>
-            </label>
-            <label className="flex items-center gap-3 rounded-lg border p-3">
-              <RadioGroupItem value="auto_all" aria-label="Operate broadly" />
-              <div>
-                <p className="text-sm font-medium">Operate broadly</p>
-                <p className="text-xs text-muted-foreground">Autopilot runs automatically on eligible work.</p>
-              </div>
-            </label>
+            <div className="flex items-start gap-3">
+              <RadioGroupItem value="manual" id="steering-autonomy-manual" aria-label="Suggest" className="mt-0.5" />
+              <Label htmlFor="steering-autonomy-manual" className="items-start gap-0">
+                <div>
+                  <p className="text-sm font-medium">Suggest</p>
+                  <p className="text-xs text-muted-foreground">Autopilot recommends, you decide.</p>
+                </div>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <RadioGroupItem value="auto_simple" id="steering-autonomy-auto-simple" aria-label="Act on low-risk" className="mt-0.5" />
+              <Label htmlFor="steering-autonomy-auto-simple" className="items-start gap-0">
+                <div>
+                  <p className="text-sm font-medium">Act on low-risk</p>
+                  <p className="text-xs text-muted-foreground">Auto-create sessions for bounded work.</p>
+                </div>
+              </Label>
+            </div>
+            <div className="flex items-start gap-3">
+              <RadioGroupItem value="auto_all" id="steering-autonomy-auto-all" aria-label="Operate broadly" className="mt-0.5" />
+              <Label htmlFor="steering-autonomy-auto-all" className="items-start gap-0">
+                <div>
+                  <p className="text-sm font-medium">Operate broadly</p>
+                  <p className="text-xs text-muted-foreground">Autopilot runs automatically on eligible work.</p>
+                </div>
+              </Label>
+            </div>
           </RadioGroup>
         </div>
         <div className="flex justify-end">


### PR DESCRIPTION
## Summary
Updated the Autopilot settings execution mode selector to use a standard radio + label structure instead of custom styled label wrappers. This improves semantic accessibility and prevents styling/layout classes from being applied to unintended parent containers.

## Changes
- **`frontend/src/app/(dashboard)/settings/autopilot/page.tsx`**
  - Refactored the execution mode options (“Suggest”, “Act on low-risk”, “Operate broadly”) from bordered/clickable label blocks to **radio inputs with explicit `id` + `Label htmlFor`**.
  - Adjusted spacing with `flex`/`gap` and small top alignment tweaks to keep the text aligned with the radio control.
- **`frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx`**
  - Strengthened assertions to ensure the “Suggest” and “Conservative” (existing wording in the test suite) option containers **do not** retain the old `rounded-lg border p-3` classes, validating the new layout behavior.

## Test plan
- Ran frontend test suite for the affected page/component:
  - `frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx`
  - `frontend/src/components/autopilot/autopilot-steering-sheet.test.tsx`
- Verified via `typecheck`, `lint`, and `build` in the pipeline.

---
*Generated by [143.dev](https://143.dev) — [session 0fc1d3da](https://143.dev/sessions/0fc1d3da-1191-46cc-bf7f-86a2887d1d59)*
