### PR TITLE
[codex] Fix mobile swipe archive

### DIFF
--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -1,3 +1,4 @@
+import { act } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, renderWithProviders, screen } from '@/test/test-utils';
 import { SwipeActionRow } from './swipe-action-row';
@@ -107,6 +108,151 @@ describe('SwipeActionRow', () => {
 
     fireEvent.touchEnd(surface!);
     expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the moving row surface opaque while the action is revealed', () => {
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={() => {}}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 220, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 120, clientY: 24 }],
+    });
+
+    expect(surface).toHaveClass('bg-background');
+  });
+
+  it('auto-fires on a deliberate mobile-width swipe before half-row travel', () => {
+    const onAction = vi.fn();
+
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={onAction}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+    Object.defineProperty(container!, 'offsetWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 320, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 170, clientY: 24 }],
+    });
+    fireEvent.touchEnd(surface!);
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-fires when touchend lands before React flushes the latest drag offset', () => {
+    const onAction = vi.fn();
+
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={onAction}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+    Object.defineProperty(container!, 'offsetWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    act(() => {
+      fireEvent.touchStart(surface!, {
+        touches: [{ clientX: 320, clientY: 20 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 170, clientY: 24 }],
+      });
+      fireEvent.touchEnd(surface!);
+    });
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('still completes the action when the haptic request fails', () => {
+    const onAction = vi.fn();
+    const originalVibrate = navigator.vibrate;
+    const originalConsoleError = console.error;
+    const consoleError = vi.fn();
+    Object.defineProperty(navigator, 'vibrate', {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new Error('blocked');
+      }),
+    });
+    console.error = consoleError;
+
+    try {
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={onAction}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+      expect(surface).not.toBeNull();
+
+      fireEvent.touchStart(surface!, {
+        touches: [{ clientX: 320, clientY: 20 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 100, clientY: 24 }],
+      });
+      fireEvent.touchEnd(surface!);
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(consoleError).toHaveBeenCalledWith(
+        'Failed to trigger swipe haptic feedback',
+        expect.any(Error),
+      );
+    } finally {
+      console.error = originalConsoleError;
+      if (originalVibrate) {
+        Object.defineProperty(navigator, 'vibrate', {
+          configurable: true,
+          value: originalVibrate,
+        });
+      } else {
+        Reflect.deleteProperty(navigator, 'vibrate');
+      }
+    }
   });
 
   it('does not auto-fire the action when a committed swipe is cancelled', () => {

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -14,7 +14,7 @@ const ACTION_WIDTH = 92;
 const OPEN_THRESHOLD = 44;
 const HORIZONTAL_LOCK_THRESHOLD = 12;
 const TOUCH_QUERY = "(pointer: coarse)";
-const COMMIT_THRESHOLD_RATIO = 0.5;
+const COMMIT_THRESHOLD_RATIO = 0.36;
 const MIN_COMMIT_THRESHOLD = 140;
 const COMMIT_ANIMATION_MS = 220;
 // Pre-measurement fallback when a gesture starts before the row has dimensions.
@@ -59,8 +59,8 @@ function vibrate(pattern: number | number[]) {
   if (typeof navigator.vibrate !== "function") return;
   try {
     navigator.vibrate(pattern);
-  } catch {
-    // ignore
+  } catch (error) {
+    console.error("Failed to trigger swipe haptic feedback", error);
   }
 }
 
@@ -89,6 +89,7 @@ export function SwipeActionRow({
   // Mirrors isCommitted for use inside touchmove handlers, where the rendered
   // closure can lag behind rapid state transitions.
   const committedRef = useRef(false);
+  const offsetRef = useRef(0);
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const [isCommitted, setIsCommitted] = useState(false);
@@ -107,6 +108,7 @@ export function SwipeActionRow({
   }, []);
 
   const close = () => {
+    offsetRef.current = 0;
     setOffset(0);
     setIsDragging(false);
     setIsCommitted(false);
@@ -115,6 +117,7 @@ export function SwipeActionRow({
   };
 
   const open = () => {
+    offsetRef.current = ACTION_WIDTH;
     setOffset(ACTION_WIDTH);
     setIsDragging(false);
     setIsCommitted(false);
@@ -127,6 +130,7 @@ export function SwipeActionRow({
   // timer. Fallback: caller keeps the row mounted, the timer snaps offset back.
   const commitAction = (width: number) => {
     setIsDragging(false);
+    offsetRef.current = width;
     setOffset(width);
     dragRef.current = null;
     committedRef.current = false;
@@ -136,6 +140,7 @@ export function SwipeActionRow({
       window.clearTimeout(commitTimerRef.current);
     }
     commitTimerRef.current = window.setTimeout(() => {
+      offsetRef.current = 0;
       setOffset(0);
       setIsCommitted(false);
       commitTimerRef.current = null;
@@ -184,7 +189,12 @@ export function SwipeActionRow({
 
     if (!drag.swiping) return;
 
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
     const nextOffset = Math.max(0, Math.min(drag.width, -deltaX));
+    offsetRef.current = nextOffset;
     setOffset(nextOffset);
 
     const willCommit = nextOffset >= commitThresholdFor(drag.width);
@@ -203,11 +213,12 @@ export function SwipeActionRow({
       dragRef.current?.width ??
       containerRef.current?.offsetWidth ??
       FALLBACK_ROW_WIDTH;
-    if (offset >= commitThresholdFor(width)) {
+    const latestOffset = offsetRef.current;
+    if (latestOffset >= commitThresholdFor(width)) {
       commitAction(width);
       return;
     }
-    if (offset >= OPEN_THRESHOLD) {
+    if (latestOffset >= OPEN_THRESHOLD) {
       open();
       return;
     }
@@ -231,6 +242,7 @@ export function SwipeActionRow({
     ? {
         className: cn(
           "relative z-10 touch-pan-y",
+          offset > 0 && "bg-background",
           !isDragging && "transition-transform duration-200 ease-out",
         ),
         style: { transform: `translateX(-${offset}px)` },


### PR DESCRIPTION
Fixes mobile session/project swipe rows by keeping the foreground surface opaque during archive reveal and making deliberate left swipes auto-commit at phone width.
Tracks the latest drag offset in a ref so touchend does not miss fast iPhone swipes before React flushes state, and prevents default while horizontally swiping.
Logs haptic failures while still completing the archive action.
Validated with targeted Vitest suites, typecheck, lint, and build.