### PR TITLE
Diff session changes against merge-base instead of frozen base SHA

### DIFF
--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -405,6 +405,16 @@ type Sandbox struct {
 // sessiondiff already imports agent for SandboxProvider/Sandbox.
 const SandboxMetadataBaseCommitSHA = "base_commit_sha"
 
+// SandboxMetadataTargetBranch is the well-known sandbox.Metadata key under
+// which the orchestrator stashes the target branch (e.g. "main") for the
+// session — the branch the working branch will be PR'd into. sessiondiff.Collect
+// uses it to compute a dynamic merge-base diff (`origin/<target>...HEAD`) so
+// integrating the target branch back into the working branch (e.g.
+// `git pull origin main` or merging main to resolve PR conflicts) does not
+// inflate the diff with target-branch changes. Falls back to the immutable
+// base_commit_sha when missing or when the merge-base resolution fails.
+const SandboxMetadataTargetBranch = "target_branch"
+
 // SandboxConnectionInfo holds provider-specific connection details for local resume.
 type SandboxConnectionInfo struct {
 	Provider     string            // "docker" or "e2b"

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -243,7 +243,7 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	}
 
 	// Collect the git diff from the sandbox.
-	diff, err := collectDiff(ctx, provider, sandbox)
+	diff, err := collectDiff(ctx, provider, sandbox, a.logger)
 	if err != nil {
 		a.logger.Warn().Err(err).Msg("failed to collect git diff")
 	} else {
@@ -793,16 +793,27 @@ func tryExtractConfidence(text string, result *agent.AgentResult) {
 // Returns an empty string (not an error) when the workspace is not a git repository,
 // which happens when no repository was configured for the issue.
 //
-// The base commit SHA is read from sandbox.Metadata, which the orchestrator
-// is responsible for populating both on the initial clone (RunAgent) and on
-// every continue path (ContinueSession). When the base SHA is missing,
-// sessiondiff.Collect returns ErrNoBaseCommitSHA — adapters log and leave
-// result.Diff unset so the persistence layer preserves the previous diff
-// rather than clobbering it with an empty string.
-func collectDiff(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox) (string, error) {
+// The base commit SHA and target branch are read from sandbox.Metadata, which
+// the orchestrator is responsible for populating both on the initial clone
+// (RunAgent) and on every continue path (ContinueSession). The base SHA is the
+// immutable fallback; the target branch lets sessiondiff.Collect compute a
+// dynamic merge-base diff so integrating the target branch back into the
+// working branch (e.g. `git pull origin main` or merging main to resolve PR
+// conflicts) does not inflate the diff with target-branch changes. When the
+// base SHA is missing, sessiondiff.Collect returns ErrNoBaseCommitSHA —
+// adapters log and leave result.Diff unset so the persistence layer
+// preserves the previous diff rather than clobbering it with an empty string.
+//
+// logger is forwarded to Collect so merge-base fallbacks (transient fetch
+// failures, missing remote refs) show up in adapter-scoped logs at debug
+// level — making it diagnosable when a session's Changes tab silently
+// regresses to the inflated baseCommitSHA-snapshot view.
+func collectDiff(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, logger zerolog.Logger) (string, error) {
 	baseCommitSHA := ""
+	targetBranch := ""
 	if sandbox != nil && sandbox.Metadata != nil {
 		baseCommitSHA = sandbox.Metadata[sessiondiff.SandboxMetadataBaseCommitSHA]
+		targetBranch = sandbox.Metadata[sessiondiff.SandboxMetadataTargetBranch]
 	}
-	return sessiondiff.Collect(ctx, provider, sandbox, baseCommitSHA)
+	return sessiondiff.Collect(ctx, provider, sandbox, baseCommitSHA, targetBranch, logger)
 }

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -1383,7 +1383,7 @@ func TestCollectDiff(t *testing.T) {
 					"base_commit_sha": tt.baseCommitSHA,
 				},
 			}
-			diff, err := collectDiff(context.Background(), provider, sandbox)
+			diff, err := collectDiff(context.Background(), provider, sandbox, zerolog.Nop())
 			if tt.wantErr {
 				require.Error(t, err, "collectDiff should return an error")
 				return

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -154,7 +154,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	}
 
 	// Collect the git diff from the sandbox.
-	diff, err := collectDiff(ctx, provider, sandbox)
+	diff, err := collectDiff(ctx, provider, sandbox, a.logger)
 	if err != nil {
 		a.logger.Warn().Err(err).Msg("failed to collect git diff")
 	} else {

--- a/internal/services/agent/adapters/gemini_cli.go
+++ b/internal/services/agent/adapters/gemini_cli.go
@@ -137,7 +137,7 @@ func (a *GeminiCLIAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, 
 	}
 
 	// Collect the git diff from the sandbox.
-	diff, err := collectDiff(ctx, provider, sandbox)
+	diff, err := collectDiff(ctx, provider, sandbox, a.logger)
 	if err != nil {
 		a.logger.Warn().Err(err).Msg("failed to collect git diff")
 	} else {

--- a/internal/services/agent/adapters/stream_parser.go
+++ b/internal/services/agent/adapters/stream_parser.go
@@ -303,7 +303,7 @@ func runStreamingAgent(
 		}
 	}
 
-	diff, err := collectDiff(ctx, provider, sandbox)
+	diff, err := collectDiff(ctx, provider, sandbox, logger)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to collect git diff")
 	} else {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1376,6 +1376,23 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 			}
 		}
 
+		// Stamp the resolved target branch (the branch we just cloned from —
+		// repo default unless the session overrode it) onto sandbox.Metadata
+		// so sessiondiff.Collect can compute a merge-base diff against
+		// origin/<branch>. Without this the diff is taken against the frozen
+		// baseCommitSHA, which inflates by the entire delta from base to HEAD
+		// whenever the user integrates the target branch back into the working
+		// branch (e.g. `git pull origin main` or merging main to resolve PR
+		// conflicts). Empty branch is unexpected in this path (we just cloned
+		// from it) but we guard anyway — Collect treats empty target branch
+		// as "fall back to baseCommitSHA".
+		if branch != "" {
+			if sandbox.Metadata == nil {
+				sandbox.Metadata = make(map[string]string)
+			}
+			sandbox.Metadata[SandboxMetadataTargetBranch] = branch
+		}
+
 		// 8b. Create a working branch so the agent operates on a separate
 		// branch from the start, keeping the base branch clean.
 		workingBranch := designatedWorkingBranch
@@ -1816,6 +1833,12 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	integrationSkills := o.BuildIntegrationSkills(ctx, session.OrgID)
 	var authState *sandboxGitHubAuthState
 	var authErr error
+	// continueTargetBranch is the resolved target branch (repo default,
+	// overridden by session.TargetBranch) — captured during the repo lookup
+	// below and stamped onto sandbox.Metadata after sandbox setup so
+	// sessiondiff.Collect can compute a merge-base diff against
+	// origin/<branch>. Mirrors the branch resolved in RunAgent.
+	var continueTargetBranch string
 
 	// Wire the per-session GitHub credential helper for both fresh and
 	// reused containers. For reused containers (preview is holding the
@@ -1854,6 +1877,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 				"sandbox github auth",
 			)
 			return fmt.Errorf("fetch repository for auth: %w", repoErr)
+		}
+		continueTargetBranch = repo.DefaultBranch
+		if session.TargetBranch != nil && *session.TargetBranch != "" {
+			continueTargetBranch = *session.TargetBranch
 		}
 		var fallbackToken string
 		if !reusedExisting {
@@ -1964,11 +1991,22 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	// has changes. RunAgent sets this on the initial clone; the three setup
 	// branches above (reuse, hydrate, fresh-clone-on-continue) all leave
 	// Metadata empty, so we fix it here once for every continue path.
+	//
+	// Also re-stamp the resolved target branch so Collect can compute a
+	// merge-base diff against origin/<branch>. Without this the post-merge
+	// diff includes every commit pulled in from the target branch, inflating
+	// the Changes tab from the actual PR delta to the full base..HEAD range.
 	if session.BaseCommitSHA != nil && *session.BaseCommitSHA != "" {
 		if sandbox.Metadata == nil {
 			sandbox.Metadata = make(map[string]string)
 		}
 		sandbox.Metadata[SandboxMetadataBaseCommitSHA] = *session.BaseCommitSHA
+	}
+	if continueTargetBranch != "" {
+		if sandbox.Metadata == nil {
+			sandbox.Metadata = make(map[string]string)
+		}
+		sandbox.Metadata[SandboxMetadataTargetBranch] = continueTargetBranch
 	}
 	// Record the turn hold. AcquireTurnHold uses COALESCE so it is idempotent
 	// when we reused a container (the row's container_id already matches our

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3442,19 +3442,23 @@ func TestContinueSession_ReusesExistingContainer(t *testing.T) {
 	require.GreaterOrEqual(t, d.sessions.releaseHoldCalls, 1)
 }
 
-// TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata is the
+// TestContinueSession_RestoresDiffMetadataOntoSandboxMetadata is the
 // regression test for the "Changes tab goes blank after PR push / resolve
-// conflicts" bug. ContinueSession previously left sandbox.Metadata empty in
-// every setup branch (reuse / hydrate / fresh-clone), so sessiondiff.Collect
-// fell back to plain `git diff` and returned an empty string for any clean
-// working tree (post-push, post-merge). That empty diff overwrote the
-// authoritative session diff in the DB, blanking the Changes tab even
-// though the PR itself was healthy. With the fix, the orchestrator copies
-// session.BaseCommitSHA back onto sandbox.Metadata after every setup branch,
-// so the diff collector always has the immutable base SHA to compare
-// against. We exercise the reuse path here because it's the simplest setup
-// that goes through the post-switch metadata restore.
-func TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata(t *testing.T) {
+// conflicts" and "Changes tab inflates with target-branch commits after
+// merging main" bugs. ContinueSession previously left sandbox.Metadata
+// empty in every setup branch (reuse / hydrate / fresh-clone), so
+// sessiondiff.Collect fell back to plain `git diff` and returned an empty
+// string for any clean working tree (post-push, post-merge). That empty
+// diff overwrote the authoritative session diff in the DB, blanking the
+// Changes tab even though the PR itself was healthy. With the fix, the
+// orchestrator copies session.BaseCommitSHA AND the resolved target branch
+// back onto sandbox.Metadata after every setup branch, so the diff
+// collector has both the immutable base SHA (fallback) and the target
+// branch (for the merge-base-style diff that excludes commits brought in
+// by integrating the target branch back into the working branch). We
+// exercise the reuse path here because it's the simplest setup that goes
+// through the post-switch metadata restore.
+func TestContinueSession_RestoresDiffMetadataOntoSandboxMetadata(t *testing.T) {
 	t.Parallel()
 
 	orgID := testOrg()
@@ -3487,10 +3491,11 @@ func TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata(t *testing.T) 
 		},
 	}
 
-	var observedBaseSHA string
+	var observedBaseSHA, observedTargetBranch string
 	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
 		require.NotNil(t, sandbox.Metadata, "ContinueSession must populate sandbox.Metadata before the agent runs")
 		observedBaseSHA = sandbox.Metadata[agent.SandboxMetadataBaseCommitSHA]
+		observedTargetBranch = sandbox.Metadata[agent.SandboxMetadataTargetBranch]
 		return &agent.AgentResult{
 			Summary:         "done",
 			ConfidenceScore: 0.9,
@@ -3506,6 +3511,8 @@ func TestContinueSession_RestoresBaseCommitSHAOntoSandboxMetadata(t *testing.T) 
 
 	require.Equal(t, expectedBaseSHA, observedBaseSHA,
 		"ContinueSession must restore session.BaseCommitSHA onto sandbox.Metadata so sessiondiff.Collect can run `git diff <base> -- .` instead of falling back to plain `git diff`")
+	require.Equal(t, "main", observedTargetBranch,
+		"ContinueSession must stamp the resolved target branch onto sandbox.Metadata so sessiondiff.Collect can compute a merge-base diff against origin/<branch> instead of inflating the diff with target-branch changes after a merge")
 }
 
 // TestContinueSession_ReusedContainerReopensAuthListener locks in the

--- a/internal/services/sessiondiff/service.go
+++ b/internal/services/sessiondiff/service.go
@@ -5,7 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+
+	"github.com/rs/zerolog"
 
 	"github.com/assembledhq/143/internal/services/agent"
 )
@@ -15,6 +18,10 @@ import (
 // keep compiling. The canonical declaration lives in the agent package
 // (agent.SandboxMetadataBaseCommitSHA) — see the rationale there.
 const SandboxMetadataBaseCommitSHA = agent.SandboxMetadataBaseCommitSHA
+
+// SandboxMetadataTargetBranch is re-exported from the agent package; see
+// agent.SandboxMetadataTargetBranch for the canonical declaration.
+const SandboxMetadataTargetBranch = agent.SandboxMetadataTargetBranch
 
 // ErrNoBaseCommitSHA is returned by Collect when the caller does not supply a
 // base commit SHA. The previous behavior — falling back to plain `git diff`
@@ -26,12 +33,26 @@ const SandboxMetadataBaseCommitSHA = agent.SandboxMetadataBaseCommitSHA
 // is preserved).
 var ErrNoBaseCommitSHA = errors.New("sessiondiff: base commit sha is required")
 
-// Collect returns the authoritative session diff: the current workspace
-// compared against the immutable recorded base commit, plus synthetic additions
-// for any untracked files. baseCommitSHA must be non-empty — Collect refuses
-// to fall back to plain `git diff` so that callers cannot inadvertently store
-// an empty diff after the workspace has been committed (post-push, post-merge).
-func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, baseCommitSHA string) (string, error) {
+// Collect returns the authoritative session diff: the working branch compared
+// against the most recent common ancestor with the target branch, plus
+// synthetic additions for any untracked files. baseCommitSHA must be non-empty —
+// it is the immutable fallback used when the dynamic merge-base resolution
+// fails (no network during fetch, missing remote ref, etc.).
+//
+// When targetBranch is supplied, Collect resolves the diff base dynamically
+// by best-effort `git fetch origin <targetBranch>` followed by
+// `git merge-base origin/<targetBranch> HEAD`. This makes the diff equivalent
+// to what GitHub renders for the PR: changes on the working branch only,
+// excluding anything pulled in by integrating the target branch back into the
+// working branch (e.g. `git pull origin main` or merging main to resolve PR
+// conflicts). When targetBranch is empty, or when fetch/merge-base fail,
+// Collect falls back to diffing against the immutable baseCommitSHA snapshot
+// captured at session creation.
+//
+// logger is used for Debug-level diagnostics when the merge-base path can't
+// be resolved and Collect falls back to baseCommitSHA. A zero zerolog.Logger
+// is acceptable (writes nowhere) for callers that don't have one.
+func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, baseCommitSHA, targetBranch string, logger zerolog.Logger) (string, error) {
 	var checkStdout, checkStderr bytes.Buffer
 	checkExit, err := provider.Exec(ctx, sandbox, "git rev-parse --is-inside-work-tree", &checkStdout, &checkStderr)
 	if err != nil {
@@ -45,7 +66,9 @@ func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent
 		return "", ErrNoBaseCommitSHA
 	}
 
-	diffCmd := fmt.Sprintf("git diff --find-renames --binary %s -- .", shellEscapeSingleQuote(baseCommitSHA))
+	diffBase := resolveDiffBase(ctx, provider, sandbox, baseCommitSHA, targetBranch, logger)
+
+	diffCmd := fmt.Sprintf("git diff --find-renames --binary %s -- .", shellEscapeSingleQuote(diffBase))
 
 	var stdout, stderr bytes.Buffer
 	exitCode, err := provider.Exec(ctx, sandbox, diffCmd, &stdout, &stderr)
@@ -61,6 +84,69 @@ func Collect(ctx context.Context, provider agent.SandboxProvider, sandbox *agent
 		return "", err
 	}
 	return stdout.String() + untrackedDiff, nil
+}
+
+// resolveDiffBase returns the SHA Collect should diff against. When targetBranch
+// is set, attempts to compute merge-base(origin/<targetBranch>, HEAD) — the same
+// base GitHub uses for the PR. Falls back to baseCommitSHA on any failure
+// (empty target branch, fetch error, missing remote ref, no common ancestor).
+//
+// The fetch is best-effort and intentionally swallows errors: a transient
+// network blip or auth glitch should degrade us to the (still-correct, just
+// possibly inflated post-merge) baseCommitSHA path rather than break the
+// Changes tab entirely. In the common case the working branch has not had
+// the target branch merged in, merge-base resolves to baseCommitSHA anyway,
+// so the two paths agree.
+//
+// The fetch must run on every Collect rather than once at sandbox setup —
+// long-running turns can outlive a fetch's freshness, and re-fetching
+// immediately before the diff guarantees the merge-base reflects the actual
+// state of origin/<branch> at diff time. The cost is one single-ref network
+// round-trip per turn (sub-second for typical repos), which is amortized
+// against the LLM call that just finished.
+func resolveDiffBase(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox, baseCommitSHA, targetBranch string, logger zerolog.Logger) string {
+	if targetBranch == "" {
+		return baseCommitSHA
+	}
+
+	escapedBranch := shellEscapeSingleQuote(targetBranch)
+
+	// Refresh origin/<targetBranch>. --quiet suppresses progress output;
+	// --no-tags avoids pulling unrelated tag refs. If this fails (no network,
+	// no auth, no remote) we fall through and use whatever local origin ref
+	// is present, which is still better than the frozen baseCommitSHA.
+	// stderr is buffered so we can surface auth/network failures via the
+	// debug log on the fallback path; stdout is discarded since fetch
+	// progress (suppressed by --quiet anyway) carries no signal.
+	var fetchErr bytes.Buffer
+	fetchCmd := fmt.Sprintf("git fetch --quiet --no-tags origin '%s'", escapedBranch)
+	fetchExit, fetchExecErr := provider.Exec(ctx, sandbox, fetchCmd, io.Discard, &fetchErr)
+
+	var mbOut, mbErr bytes.Buffer
+	mbCmd := fmt.Sprintf("git merge-base 'origin/%s' HEAD", escapedBranch)
+	exitCode, err := provider.Exec(ctx, sandbox, mbCmd, &mbOut, &mbErr)
+	if err != nil || exitCode != 0 {
+		logger.Debug().
+			Str("target_branch", targetBranch).
+			Str("fallback_base_commit_sha", baseCommitSHA).
+			Int("fetch_exit", fetchExit).
+			AnErr("fetch_exec_err", fetchExecErr).
+			Str("fetch_stderr", redactPossibleToken(strings.TrimSpace(fetchErr.String()))).
+			Int("merge_base_exit", exitCode).
+			AnErr("merge_base_exec_err", err).
+			Str("merge_base_stderr", strings.TrimSpace(mbErr.String())).
+			Msg("sessiondiff: merge-base unavailable, falling back to base_commit_sha snapshot")
+		return baseCommitSHA
+	}
+	mb := strings.TrimSpace(mbOut.String())
+	if mb == "" {
+		logger.Debug().
+			Str("target_branch", targetBranch).
+			Str("fallback_base_commit_sha", baseCommitSHA).
+			Msg("sessiondiff: merge-base returned empty output, falling back to base_commit_sha snapshot")
+		return baseCommitSHA
+	}
+	return mb
 }
 
 func collectUntrackedDiffs(ctx context.Context, provider agent.SandboxProvider, sandbox *agent.Sandbox) (string, error) {
@@ -97,4 +183,36 @@ func collectUntrackedDiffs(ctx context.Context, provider agent.SandboxProvider, 
 
 func shellEscapeSingleQuote(value string) string {
 	return strings.ReplaceAll(value, `'`, `'\''`)
+}
+
+// redactPossibleToken scrubs `x-access-token:<token>` patterns out of fetch
+// stderr before it lands in a structured log. CloneRepo strips the token
+// from .git/config after clone, so a healthy sandbox should never expose
+// it here — but a partially-configured remote (legacy GITHUB_TOKEN path,
+// reused container post-orchestrator-restart, etc.) could still surface
+// it in a fetch error message, so we redact defensively. The replacement
+// keeps the rest of the error text intact for diagnosis.
+func redactPossibleToken(s string) string {
+	const marker = "x-access-token:"
+	var b strings.Builder
+	rest := s
+	for {
+		idx := strings.Index(rest, marker)
+		if idx < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		// Emit everything up to and including the marker unchanged.
+		b.WriteString(rest[:idx+len(marker)])
+		// Token runs until the next '@' (URL terminator) or any whitespace.
+		// Advance past it on the input side so we never re-scan the
+		// REDACTED placeholder we're about to write — that's what caused
+		// the obvious infinite-loop bug in the in-place replace_all variant.
+		stop := idx + len(marker)
+		for stop < len(rest) && rest[stop] != '@' && rest[stop] != ' ' && rest[stop] != '\t' && rest[stop] != '\n' && rest[stop] != '\r' {
+			stop++
+		}
+		b.WriteString("REDACTED")
+		rest = rest[stop:]
+	}
 }

--- a/internal/services/sessiondiff/service_test.go
+++ b/internal/services/sessiondiff/service_test.go
@@ -6,9 +6,11 @@ import (
 	"io"
 	"testing"
 
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCollect(t *testing.T) {
@@ -18,6 +20,7 @@ func TestCollect(t *testing.T) {
 		name          string
 		sandbox       *agent.Sandbox
 		baseCommitSHA string
+		targetBranch  string
 		execFn        func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error)
 		expected      string
 		expectedCmd   []string
@@ -38,7 +41,7 @@ func TestCollect(t *testing.T) {
 			},
 		},
 		{
-			name:          "collects git diff and untracked file patches with base commit",
+			name:          "collects git diff and untracked file patches with base commit when no target branch",
 			sandbox:       &agent.Sandbox{ID: "sb"},
 			baseCommitSHA: "abc123",
 			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
@@ -69,6 +72,171 @@ func TestCollect(t *testing.T) {
 				"git ls-files --others --exclude-standard -- .",
 				"git diff --find-renames --binary --no-index -- /dev/null 'new file.txt'",
 				"git diff --find-renames --binary --no-index -- /dev/null 'quote'\\''file.go'",
+			},
+		},
+		{
+			name:          "diffs against merge-base when target branch is set",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
+			targetBranch:  "main",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				switch cmd {
+				case "git rev-parse --is-inside-work-tree":
+					return 0, nil
+				case "git fetch --quiet --no-tags origin 'main'":
+					return 0, nil
+				case "git merge-base 'origin/main' HEAD":
+					_, _ = io.WriteString(stdout, "deadbeef\n")
+					return 0, nil
+				case "git diff --find-renames --binary deadbeef -- .":
+					_, _ = io.WriteString(stdout, "merge-base diff\n")
+					return 0, nil
+				case "git ls-files --others --exclude-standard -- .":
+					return 0, nil
+				default:
+					t.Fatalf("unexpected command: %s", cmd)
+					return 0, nil
+				}
+			},
+			expected: "merge-base diff\n",
+			expectedCmd: []string{
+				"git rev-parse --is-inside-work-tree",
+				"git fetch --quiet --no-tags origin 'main'",
+				"git merge-base 'origin/main' HEAD",
+				"git diff --find-renames --binary deadbeef -- .",
+				"git ls-files --others --exclude-standard -- .",
+			},
+		},
+		{
+			name:          "falls back to baseCommitSHA when merge-base resolution fails",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
+			targetBranch:  "main",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				switch cmd {
+				case "git rev-parse --is-inside-work-tree":
+					return 0, nil
+				case "git fetch --quiet --no-tags origin 'main'":
+					_, _ = io.WriteString(stderr, "fatal: could not read from remote")
+					return 128, nil
+				case "git merge-base 'origin/main' HEAD":
+					_, _ = io.WriteString(stderr, "fatal: bad revision")
+					return 128, nil
+				case "git diff --find-renames --binary abc123 -- .":
+					_, _ = io.WriteString(stdout, "fallback diff\n")
+					return 0, nil
+				case "git ls-files --others --exclude-standard -- .":
+					return 0, nil
+				default:
+					t.Fatalf("unexpected command: %s", cmd)
+					return 0, nil
+				}
+			},
+			expected: "fallback diff\n",
+			expectedCmd: []string{
+				"git rev-parse --is-inside-work-tree",
+				"git fetch --quiet --no-tags origin 'main'",
+				"git merge-base 'origin/main' HEAD",
+				"git diff --find-renames --binary abc123 -- .",
+				"git ls-files --others --exclude-standard -- .",
+			},
+		},
+		{
+			name:          "falls back to baseCommitSHA when merge-base returns empty output",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
+			targetBranch:  "main",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				switch cmd {
+				case "git rev-parse --is-inside-work-tree":
+					return 0, nil
+				case "git fetch --quiet --no-tags origin 'main'":
+					return 0, nil
+				case "git merge-base 'origin/main' HEAD":
+					_, _ = io.WriteString(stdout, "\n")
+					return 0, nil
+				case "git diff --find-renames --binary abc123 -- .":
+					return 0, nil
+				case "git ls-files --others --exclude-standard -- .":
+					return 0, nil
+				default:
+					t.Fatalf("unexpected command: %s", cmd)
+					return 0, nil
+				}
+			},
+			expected: "",
+			expectedCmd: []string{
+				"git rev-parse --is-inside-work-tree",
+				"git fetch --quiet --no-tags origin 'main'",
+				"git merge-base 'origin/main' HEAD",
+				"git diff --find-renames --binary abc123 -- .",
+				"git ls-files --others --exclude-standard -- .",
+			},
+		},
+		{
+			name:          "tolerates a failing fetch when merge-base still resolves locally",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
+			targetBranch:  "main",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				switch cmd {
+				case "git rev-parse --is-inside-work-tree":
+					return 0, nil
+				case "git fetch --quiet --no-tags origin 'main'":
+					_, _ = io.WriteString(stderr, "fatal: network unreachable")
+					return 1, errors.New("exec failure")
+				case "git merge-base 'origin/main' HEAD":
+					_, _ = io.WriteString(stdout, "stalebase\n")
+					return 0, nil
+				case "git diff --find-renames --binary stalebase -- .":
+					_, _ = io.WriteString(stdout, "stale-base diff\n")
+					return 0, nil
+				case "git ls-files --others --exclude-standard -- .":
+					return 0, nil
+				default:
+					t.Fatalf("unexpected command: %s", cmd)
+					return 0, nil
+				}
+			},
+			expected: "stale-base diff\n",
+			expectedCmd: []string{
+				"git rev-parse --is-inside-work-tree",
+				"git fetch --quiet --no-tags origin 'main'",
+				"git merge-base 'origin/main' HEAD",
+				"git diff --find-renames --binary stalebase -- .",
+				"git ls-files --others --exclude-standard -- .",
+			},
+		},
+		{
+			name:          "shell escapes target branch with single quotes",
+			sandbox:       &agent.Sandbox{ID: "sb"},
+			baseCommitSHA: "abc123",
+			targetBranch:  "weird'branch",
+			execFn: func(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+				switch cmd {
+				case "git rev-parse --is-inside-work-tree":
+					return 0, nil
+				case "git fetch --quiet --no-tags origin 'weird'\\''branch'":
+					return 0, nil
+				case "git merge-base 'origin/weird'\\''branch' HEAD":
+					_, _ = io.WriteString(stdout, "mb\n")
+					return 0, nil
+				case "git diff --find-renames --binary mb -- .":
+					return 0, nil
+				case "git ls-files --others --exclude-standard -- .":
+					return 0, nil
+				default:
+					t.Fatalf("unexpected command: %s", cmd)
+					return 0, nil
+				}
+			},
+			expected: "",
+			expectedCmd: []string{
+				"git rev-parse --is-inside-work-tree",
+				"git fetch --quiet --no-tags origin 'weird'\\''branch'",
+				"git merge-base 'origin/weird'\\''branch' HEAD",
+				"git diff --find-renames --binary mb -- .",
+				"git ls-files --others --exclude-standard -- .",
 			},
 		},
 		{
@@ -166,7 +334,7 @@ func TestCollect(t *testing.T) {
 				return tt.execFn(ctx, sb, cmd, stdout, stderr)
 			}
 
-			diff, err := Collect(context.Background(), provider, tt.sandbox, tt.baseCommitSHA)
+			diff, err := Collect(context.Background(), provider, tt.sandbox, tt.baseCommitSHA, tt.targetBranch, zerolog.Nop())
 			if tt.expectErrIs != nil {
 				require.Error(t, err, "Collect should return an error")
 				require.ErrorIs(t, err, tt.expectErrIs, "Collect should return the expected sentinel error")
@@ -190,4 +358,47 @@ func TestShellEscapeSingleQuote(t *testing.T) {
 
 	require.Equal(t, "plain", shellEscapeSingleQuote("plain"), "strings without quotes should be unchanged")
 	require.Equal(t, "a'\\''b", shellEscapeSingleQuote("a'b"), "single quotes should be shell escaped")
+}
+
+func TestRedactPossibleToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "passes through plain text",
+			in:   "fatal: could not read from remote",
+			want: "fatal: could not read from remote",
+		},
+		{
+			name: "redacts token in URL",
+			in:   "fatal: unable to access 'https://x-access-token:ghs_abc123XYZ@github.com/org/repo.git/'",
+			want: "fatal: unable to access 'https://x-access-token:REDACTED@github.com/org/repo.git/'",
+		},
+		{
+			name: "redacts token without trailing @",
+			in:   "remote helper says x-access-token:ghs_secret died unexpectedly",
+			want: "remote helper says x-access-token:REDACTED died unexpectedly",
+		},
+		{
+			name: "redacts multiple occurrences",
+			in:   "tried x-access-token:aaa@host then x-access-token:bbb@host",
+			want: "tried x-access-token:REDACTED@host then x-access-token:REDACTED@host",
+		},
+		{
+			name: "leaves empty token marker as-is when nothing follows",
+			in:   "x-access-token:",
+			want: "x-access-token:REDACTED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, redactPossibleToken(tt.in))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- `sessiondiff.Collect` now resolves the diff base dynamically via best-effort `git fetch origin <target>` + `git merge-base origin/<target> HEAD`, falling back to the immutable `base_commit_sha` on failure. This collapses inflated session diffs (e.g. 4180e2fa showed 179 files / +9666 / -4360 for a PR whose actual delta is 9 files / +1025 / -311) when the user has merged the target branch back into the working branch.
- The orchestrator stamps the resolved target branch (repo default overridden by `session.TargetBranch`) onto `sandbox.Metadata` in both `RunAgent` and `ContinueSession`, mirroring the existing `base_commit_sha` plumbing.
- Adapters thread their `zerolog.Logger` through `collectDiff` so merge-base fallback events surface at debug level; fetch stderr is scrubbed of `x-access-token:` patterns before logging as defense-in-depth.

## Test plan
- [ ] Continue a session that has merged main into its working branch — Changes tab should match the GitHub PR view, not the inflated base..HEAD range.
- [ ] Continue a session that has not merged main — diff should be unchanged from current behavior (merge-base resolves to base_commit_sha).
- [ ] Confirm a session with no network access still produces a (now possibly inflated) diff via the base_commit_sha fallback rather than blanking the Changes tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)