### PR TITLE
Surface real preview-start errors: middleware Unwrap, exit-127 hint, log NULL fix

### DIFF
--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -38,6 +38,18 @@ func (rw *responseWriter) Flush() {
 	}
 }
 
+// Unwrap exposes the underlying ResponseWriter so http.NewResponseController
+// can reach the raw net.Conn for SetWriteDeadline / SetReadDeadline. Without
+// this, clearWriteDeadline silently fails (Go's controller cannot punch
+// through a wrapper that doesn't implement Unwrap), and the server's 15s
+// WriteTimeout still drops long-running responses — preview start in
+// particular, where snapshot restore + readiness probes routinely run for
+// 60-100s. The downstream symptom is a 502 EOF at the API edge with the real
+// error code (PREVIEW_SERVICE_NOT_READY etc.) lost.
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 func (rw *responseWriter) SetResolvedIdentity(orgID, userID uuid.UUID) {
 	rw.orgID = orgID
 	rw.userID = userID

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -351,6 +352,56 @@ func TestResponseWriter_Unwrap(t *testing.T) {
 	unwrapper, ok := any(rw).(interface{ Unwrap() http.ResponseWriter })
 	require.True(t, ok, "responseWriter must implement Unwrap so http.NewResponseController can reach the underlying conn")
 	require.Equal(t, http.ResponseWriter(inner), unwrapper.Unwrap(), "Unwrap must return the wrapped ResponseWriter")
+}
+
+// TestMiddlewareChain_SetWriteDeadlineEscapesServerWriteTimeout is the
+// end-to-end regression guard for the prod incident: a real http.Server
+// with a tight WriteTimeout, the actual middleware chain (Logging wrapping
+// Metrics) in front of a slow handler that calls SetWriteDeadline. Without
+// Unwrap on both wrappers, http.NewResponseController would fail silently,
+// the server's WriteTimeout would still fire while the handler slept, and
+// the client would see a torn connection. With Unwrap in place, the
+// SetWriteDeadline reaches the underlying conn, the timeout is suppressed,
+// and the full response makes it back.
+func TestMiddlewareChain_SetWriteDeadlineEscapesServerWriteTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		writeTimeout = 100 * time.Millisecond
+		handlerSleep = 400 * time.Millisecond
+	)
+
+	slowHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Mirror handlers/helpers.go's clearWriteDeadline. If Unwrap is
+		// missing on either Logging or Metrics, http.NewResponseController
+		// returns ErrNotSupported and the handler keeps running with the
+		// server's WriteTimeout still armed.
+		require.NoError(t,
+			http.NewResponseController(w).SetWriteDeadline(time.Time{}),
+			"SetWriteDeadline must reach underlying conn through middleware chain",
+		)
+		time.Sleep(handlerSleep)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	})
+
+	chain := Logging(zerolog.Nop(), nil)(Metrics(slowHandler))
+	srv := httptest.NewUnstartedServer(chain)
+	srv.Config.WriteTimeout = writeTimeout
+	srv.Start()
+	defer srv.Close()
+
+	// Generous client timeout so the test fails on the server-side timeout
+	// (the bug we're guarding against) and not on a client-side cutoff.
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err, "client request should complete despite handler outliving WriteTimeout")
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, `{"ok":true}`, string(body))
 }
 
 type capturingReporter struct {

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -337,6 +337,22 @@ func TestRoutePattern_FallsBackToPathWhenUnavailable(t *testing.T) {
 	}
 }
 
+// TestResponseWriter_Unwrap is the regression guard for the production EOF
+// that surfaced as 502 PREVIEW_WORKER_REQUEST_FAILED on long preview starts:
+// when this wrapper does not implement Unwrap(), http.NewResponseController
+// cannot reach the underlying conn, so handlers calling SetWriteDeadline
+// silently no-op and the server's 15s WriteTimeout drops the connection
+// mid-handler. Logging is the outermost server-mounted middleware, so the
+// preview-start handler always sees this wrapper at the top of the stack.
+func TestResponseWriter_Unwrap(t *testing.T) {
+	t.Parallel()
+	inner := httptest.NewRecorder()
+	rw := &responseWriter{ResponseWriter: inner, status: http.StatusOK}
+	unwrapper, ok := any(rw).(interface{ Unwrap() http.ResponseWriter })
+	require.True(t, ok, "responseWriter must implement Unwrap so http.NewResponseController can reach the underlying conn")
+	require.Equal(t, http.ResponseWriter(inner), unwrapper.Unwrap(), "Unwrap must return the wrapped ResponseWriter")
+}
+
 type capturingReporter struct {
 	requestErrors []observability.RequestErrorEvent
 	panicEvents   []panicEvent

--- a/internal/api/middleware/metrics.go
+++ b/internal/api/middleware/metrics.go
@@ -78,3 +78,11 @@ func (w *statusWriter) Flush() {
 		f.Flush()
 	}
 }
+
+// Unwrap exposes the underlying ResponseWriter to http.NewResponseController.
+// See logging.responseWriter.Unwrap for the rationale: without it, handlers
+// calling SetWriteDeadline (e.g. clearWriteDeadline for preview start) silently
+// no-op when this middleware sits between the chi router and the handler.
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}

--- a/internal/api/middleware/metrics_test.go
+++ b/internal/api/middleware/metrics_test.go
@@ -90,3 +90,19 @@ func TestStatusWriter(t *testing.T) {
 		})
 	}
 }
+
+// TestStatusWriter_Unwrap is the regression guard for the production EOF that
+// surfaced as 502 PREVIEW_WORKER_REQUEST_FAILED on long preview starts: when
+// this wrapper does not implement Unwrap(), http.NewResponseController cannot
+// see the underlying conn, so handlers calling SetWriteDeadline silently
+// no-op and the server's 15s WriteTimeout drops the connection mid-handler.
+// The same wrapper sits in the middleware chain in front of every preview
+// route, so this test pins the contract.
+func TestStatusWriter_Unwrap(t *testing.T) {
+	t.Parallel()
+	inner := httptest.NewRecorder()
+	sw := &statusWriter{ResponseWriter: inner, status: http.StatusOK}
+	unwrapper, ok := any(sw).(interface{ Unwrap() http.ResponseWriter })
+	require.True(t, ok, "statusWriter must implement Unwrap so http.NewResponseController can reach the underlying conn")
+	require.Equal(t, http.ResponseWriter(inner), unwrapper.Unwrap(), "Unwrap must return the wrapped ResponseWriter")
+}

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -1019,13 +1020,23 @@ func (s *PreviewStore) CreatePreviewLog(ctx context.Context, log *models.Preview
 		VALUES (@preview_instance_id, @org_id, @level, @step, @message, @metadata)
 		RETURNING %s`, previewLogColumns)
 
+	// metadata is NOT NULL in Postgres with a DEFAULT '{}'. Passing a nil
+	// json.RawMessage binds explicit NULL — which trips the not-null
+	// constraint because the DEFAULT only applies when the column is omitted
+	// from the INSERT. OnServiceFailed callers in particular pass an unset
+	// Metadata, and that silently dropped service-exit logs in production.
+	metadata := log.Metadata
+	if len(metadata) == 0 {
+		metadata = json.RawMessage(`{}`)
+	}
+
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"preview_instance_id": log.PreviewInstanceID,
 		"org_id":              log.OrgID,
 		"level":               log.Level,
 		"step":                log.Step,
 		"message":             log.Message,
-		"metadata":            log.Metadata,
+		"metadata":            metadata,
 	})
 	if err != nil {
 		return fmt.Errorf("insert preview log: %w", err)

--- a/internal/db/preview_store.go
+++ b/internal/db/preview_store.go
@@ -1021,10 +1021,12 @@ func (s *PreviewStore) CreatePreviewLog(ctx context.Context, log *models.Preview
 		RETURNING %s`, previewLogColumns)
 
 	// metadata is NOT NULL in Postgres with a DEFAULT '{}'. Passing a nil
-	// json.RawMessage binds explicit NULL — which trips the not-null
-	// constraint because the DEFAULT only applies when the column is omitted
-	// from the INSERT. OnServiceFailed callers in particular pass an unset
-	// Metadata, and that silently dropped service-exit logs in production.
+	// or empty json.RawMessage binds explicit NULL — which trips the
+	// not-null constraint because the DEFAULT only applies when the column
+	// is omitted from the INSERT. OnServiceFailed callers in particular
+	// pass an unset Metadata, and that silently dropped service-exit logs
+	// in production. Treat a zero-length value (nil slice or empty slice)
+	// as "use the column default".
 	metadata := log.Metadata
 	if len(metadata) == 0 {
 		metadata = json.RawMessage(`{}`)

--- a/internal/db/preview_store_test.go
+++ b/internal/db/preview_store_test.go
@@ -1046,6 +1046,54 @@ func TestPreviewStore_CreatePreviewLog(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+// TestPreviewStore_CreatePreviewLog_NilMetadataDefaultsToEmptyObject is the
+// regression guard for the production bug where OnServiceFailed silently
+// dropped service-exit logs because Metadata was unset → bound as SQL NULL →
+// rejected by the NOT NULL constraint on preview_logs.metadata. The store
+// must coerce a nil Metadata into a JSON empty-object so the column's DEFAULT
+// '{}' isn't bypassed.
+func TestPreviewStore_CreatePreviewLog_NilMetadataDefaultsToEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewPreviewStore(mock)
+	now := time.Now()
+	generatedID := uuid.New()
+	previewID := uuid.New()
+	orgID := uuid.New()
+
+	logEntry := &models.PreviewLog{
+		PreviewInstanceID: previewID,
+		OrgID:             orgID,
+		Level:             "error",
+		Step:              models.PreviewLogStepStart,
+		Message:           "service \"frontend\" failed",
+		// Metadata intentionally unset — mirrors managerServiceObserver.OnServiceFailed.
+	}
+
+	mock.ExpectQuery("INSERT INTO preview_logs").
+		WithArgs(
+			previewID,
+			orgID,
+			"error",
+			models.PreviewLogStepStart,
+			"service \"frontend\" failed",
+			json.RawMessage(`{}`),
+		).
+		WillReturnRows(
+			pgxmock.NewRows(previewLogTestCols).
+				AddRow(generatedID, previewID, orgID, "error", "start", "service \"frontend\" failed",
+					json.RawMessage(`{}`), now),
+		)
+
+	require.NoError(t, store.CreatePreviewLog(context.Background(), logEntry))
+	require.Equal(t, generatedID, logEntry.ID)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestPreviewStore_ListLogsByPreview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -867,6 +867,60 @@ func notifyServiceFailed(observer preview.ServiceObserver, name, errMsg string, 
 	observer.OnServiceFailed(name, errMsg, tail)
 }
 
+// formatServiceExitError builds a human-readable exit message from a service's
+// exit code plus the last few lines of its stdout/stderr. Bare "exited with
+// code N" — especially the POSIX "command not found" code 127 — leaves the
+// user staring at a number without any of the context the shell already
+// printed to stderr (e.g. "/bin/sh: 1: npm: not found"). Surfacing the tail
+// here lets that output reach the launch error returned to the API, not just
+// the preview_logs row.
+func formatServiceExitError(exitCode int, outputTail []string) string {
+	hint := ""
+	if exitCode == 127 {
+		hint = " (command not found — check that the executable exists on the sandbox's $PATH or use an absolute path in .143/preview.json)"
+	}
+	base := fmt.Sprintf("exited with code %d%s", exitCode, hint)
+	tail := truncatedTail(outputTail, 3, 200)
+	if tail == "" {
+		return base
+	}
+	return base + "; last output: " + tail
+}
+
+// truncatedTail joins the final maxLines of outputTail into a single
+// space-separated string, trimming each line and capping the joined result at
+// maxRunes runes so an unbounded log line can't blow up the surfacing error
+// message. Returns "" when outputTail has no usable content.
+func truncatedTail(outputTail []string, maxLines, maxRunes int) string {
+	if len(outputTail) == 0 || maxLines <= 0 {
+		return ""
+	}
+	start := len(outputTail) - maxLines
+	if start < 0 {
+		start = 0
+	}
+	parts := make([]string, 0, len(outputTail)-start)
+	for _, line := range outputTail[start:] {
+		trimmed := strings.TrimRight(line, "\r\n")
+		trimmed = strings.TrimSpace(trimmed)
+		if trimmed == "" {
+			continue
+		}
+		parts = append(parts, trimmed)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	joined := strings.Join(parts, " | ")
+	if maxRunes > 0 {
+		runes := []rune(joined)
+		if len(runes) > maxRunes {
+			joined = string(runes[:maxRunes]) + "…"
+		}
+	}
+	return joined
+}
+
 func (d *DockerPreviewProvider) startService(
 	ctx context.Context,
 	state *previewState,
@@ -960,7 +1014,7 @@ func (d *DockerPreviewProvider) startService(
 			if err != nil {
 				ss.err = err.Error()
 			} else {
-				ss.err = fmt.Sprintf("exited with code %d", exitCode)
+				ss.err = formatServiceExitError(exitCode, ss.outputTail)
 			}
 			tail = append([]string(nil), ss.outputTail...)
 		} else {

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -138,6 +138,20 @@ type serviceState struct {
 // service exits non-zero.
 const serviceTailLines = 200
 
+// serviceExitTailLines is the number of trailing non-blank stdout/stderr
+// lines folded into the user-visible exit error from formatServiceExitError.
+// Three is enough to capture a typical shell error like "/bin/sh: 1: npm:
+// not found" plus one or two contextual lines, while staying short enough
+// not to crowd the rest of the launch error in a UI banner.
+const serviceExitTailLines = 3
+
+// serviceExitTailRunes caps the rune length of the joined tail rendered
+// into a service-exit error so a runaway log line (a stack trace, a
+// minified JSON dump) cannot inflate the API response. Sized to leave
+// room for the wrapping "preview service did not pass its readiness probe…"
+// chrome that classifyLaunchError prepends.
+const serviceExitTailRunes = 200
+
 // DockerPreviewOption configures a DockerPreviewProvider.
 type DockerPreviewOption func(*DockerPreviewProvider)
 
@@ -880,29 +894,30 @@ func formatServiceExitError(exitCode int, outputTail []string) string {
 		hint = " (command not found — check that the executable exists on the sandbox's $PATH or use an absolute path in .143/preview.json)"
 	}
 	base := fmt.Sprintf("exited with code %d%s", exitCode, hint)
-	tail := truncatedTail(outputTail, 3, 200)
+	tail := truncatedTail(outputTail, serviceExitTailLines, serviceExitTailRunes)
 	if tail == "" {
 		return base
 	}
 	return base + "; last output: " + tail
 }
 
-// truncatedTail joins the final maxLines of outputTail into a single
-// space-separated string, trimming each line and capping the joined result at
-// maxRunes runes so an unbounded log line can't blow up the surfacing error
-// message. Returns "" when outputTail has no usable content.
+// truncatedTail returns up to the last maxLines non-blank lines of
+// outputTail joined into a single string, capped at maxRunes runes with an
+// ellipsis so a runaway log line can't blow up the surfacing error message.
+// Returns "" when outputTail has no usable content.
+//
+// Walks from the newest line back so trailing blank lines (a service that
+// ends with a flush of "\n\n" or pads its readiness logs with separators)
+// don't degrade the message into a useless tail. We still bound the scan at
+// the full ring buffer length, so an O(serviceTailLines) walk is the
+// worst case.
 func truncatedTail(outputTail []string, maxLines, maxRunes int) string {
 	if len(outputTail) == 0 || maxLines <= 0 {
 		return ""
 	}
-	start := len(outputTail) - maxLines
-	if start < 0 {
-		start = 0
-	}
-	parts := make([]string, 0, len(outputTail)-start)
-	for _, line := range outputTail[start:] {
-		trimmed := strings.TrimRight(line, "\r\n")
-		trimmed = strings.TrimSpace(trimmed)
+	parts := make([]string, 0, maxLines)
+	for i := len(outputTail) - 1; i >= 0 && len(parts) < maxLines; i-- {
+		trimmed := strings.TrimSpace(strings.TrimRight(outputTail[i], "\r\n"))
 		if trimmed == "" {
 			continue
 		}
@@ -910,6 +925,11 @@ func truncatedTail(outputTail []string, maxLines, maxRunes int) string {
 	}
 	if len(parts) == 0 {
 		return ""
+	}
+	// parts is newest-first from the reverse walk; flip to chronological so
+	// the joined message reads in the order the service actually printed.
+	for lo, hi := 0, len(parts)-1; lo < hi; lo, hi = lo+1, hi-1 {
+		parts[lo], parts[hi] = parts[hi], parts[lo]
 	}
 	joined := strings.Join(parts, " | ")
 	if maxRunes > 0 {

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -806,6 +806,121 @@ func TestStartService_TailRingBufferBoundedAtServiceTailLines(t *testing.T) {
 	require.Equal(t, fmt.Sprintf("line-%d", totalLines-1), failed[0].tail[len(failed[0].tail)-1])
 }
 
+// TestFormatServiceExitError covers the user-visible error built from a
+// service's non-zero exit. The bare exit number is opaque (especially the
+// POSIX 127 "command not found"), so the formatted message has to:
+//   - Decode 127 to a hint about $PATH / absolute paths in .143/preview.json.
+//   - Append the captured stdout/stderr tail so the user sees the real reason
+//     (e.g. "/bin/sh: 1: npm: not found") in the API response, not just an
+//     exit code.
+func TestFormatServiceExitError(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		exitCode int
+		tail     []string
+		want     []string // substrings we require to appear
+		notWant  []string // substrings we require to be absent
+	}{
+		{
+			name:     "code_127_includes_command_not_found_hint",
+			exitCode: 127,
+			tail:     []string{"/bin/sh: 1: npm: not found"},
+			want:     []string{"127", "command not found", "$PATH", "npm: not found"},
+		},
+		{
+			name:     "non_127_exit_omits_command_not_found_hint",
+			exitCode: 1,
+			tail:     []string{"crash boom"},
+			want:     []string{"exited with code 1", "crash boom"},
+			notWant:  []string{"command not found"},
+		},
+		{
+			name:     "no_tail_keeps_message_terse",
+			exitCode: 137,
+			tail:     nil,
+			want:     []string{"exited with code 137"},
+			notWant:  []string{"last output"},
+		},
+		{
+			name:     "tail_caps_to_last_three_lines",
+			exitCode: 1,
+			tail:     []string{"line-1", "line-2", "line-3", "line-4", "line-5"},
+			want:     []string{"line-3", "line-4", "line-5"},
+			notWant:  []string{"line-1", "line-2"},
+		},
+		{
+			name:     "blank_tail_lines_filtered",
+			exitCode: 1,
+			tail:     []string{"", "  ", "real error"},
+			want:     []string{"real error"},
+			notWant:  []string{"last output:  "},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatServiceExitError(tc.exitCode, tc.tail)
+			for _, s := range tc.want {
+				require.Contains(t, got, s, "want substring missing from %q", got)
+			}
+			for _, s := range tc.notWant {
+				require.NotContains(t, got, s, "unwanted substring present in %q", got)
+			}
+		})
+	}
+}
+
+// TestTruncatedTail_RuneCap guards the rune-based truncation: a single output
+// line longer than maxRunes should be cut down with an ellipsis instead of
+// flowing into the surfacing error message at full length, where it would
+// crowd out the rest of the message in a constrained UI banner.
+func TestTruncatedTail_RuneCap(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("x", 500)
+	got := truncatedTail([]string{long}, 3, 200)
+	runes := []rune(got)
+	require.LessOrEqual(t, len(runes), 201, "truncatedTail must respect maxRunes")
+	require.Contains(t, got, "…", "truncated tail should end with an ellipsis")
+}
+
+// TestStartService_Code127IncludesCommandNotFoundHint is the integration-level
+// regression guard: a service that exits 127 (the case that motivated this
+// change) must surface a hint about $PATH and the captured stderr tail
+// through the observer, so the user-visible launch error explains *why*
+// instead of stopping at "exited with code 127".
+func TestStartService_Code127IncludesCommandNotFoundHint(t *testing.T) {
+	t.Parallel()
+
+	exec := &fakeServiceExecutor{
+		execFn: func(_ context.Context, _ string) (int, error) { return 1, nil },
+		execStreamFn: func(_ context.Context, _ string, onLine func([]byte)) (int, error) {
+			onLine([]byte("/bin/sh: 1: npm: not found"))
+			return 127, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+	state := &previewState{
+		sandbox:  &agent.Sandbox{ID: "sb"},
+		services: map[string]*serviceState{},
+		cancelFn: func() {},
+	}
+
+	require.NoError(t, d.startService(
+		context.Background(), state, "frontend",
+		models.ServiceConfig{Command: []string{"npm", "run", "dev"}, Port: 3000},
+		nil, obs,
+	))
+	state.wg.Wait()
+
+	failed := obs.failed()
+	require.Len(t, failed, 1)
+	require.Contains(t, failed[0].errMsg, "127")
+	require.Contains(t, failed[0].errMsg, "command not found")
+	require.Contains(t, failed[0].errMsg, "npm: not found")
+}
+
 // TestWaitForReadiness_FailsFastWhenServiceStopped covers the second branch
 // of checkExited: a service that exited cleanly (Stopped, not Failed) before
 // becoming ready also short-circuits the loop.

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -856,6 +856,17 @@ func TestFormatServiceExitError(t *testing.T) {
 			want:     []string{"real error"},
 			notWant:  []string{"last output:  "},
 		},
+		{
+			// Trailing blanks must not degrade the surfacing error to a
+			// bare "exited with code N" — services that pad readiness
+			// output with blank-line separators (or end with a flushed
+			// "\n\n") still need to expose their last real lines.
+			name:     "trailing_blanks_look_back_for_real_content",
+			exitCode: 1,
+			tail:     []string{"line-A", "line-B", "real error", "", ""},
+			want:     []string{"line-A", "line-B", "real error"},
+			notWant:  []string{"last output: |"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Middleware**: add `Unwrap()` to `logging.responseWriter` and `metrics.statusWriter`. `clearWriteDeadline` (#676) was silently no-oping behind these wrappers because `http.NewResponseController` cannot punch through a wrapper that doesn't implement `Unwrap`, so the server's 15s `WriteTimeout` still cut 95s preview starts mid-write — prod logs show the worker writing a clean 422 `PREVIEW_SERVICE_NOT_READY` at 95.23s while Caddy logged 502 EOF.
- **Provider**: new `formatServiceExitError` decodes exit 127 to "command not found" with a `$PATH` / `.143/preview.json` hint and appends the last 3 lines of captured stderr (rune-capped) to the service-exit error so the actionable cause (e.g. `/bin/sh: 1: npm: not found`) reaches the API response, not just the `preview_logs` row.
- **Store**: coerce nil `Metadata` to `{}` before insert. `preview_logs.metadata` is `NOT NULL DEFAULT '{}'`, but binding nil `json.RawMessage` was sending explicit NULL and silently dropping every `OnServiceFailed` log row in production.

## Test plan

- [x] `go test ./internal/api/middleware/ ./internal/api/handlers/ ./internal/db/ ./internal/services/preview/...`
- [x] New regression guards: `TestResponseWriter_Unwrap`, `TestStatusWriter_Unwrap`, `TestFormatServiceExitError` (5 sub-cases), `TestTruncatedTail_RuneCap`, `TestStartService_Code127IncludesCommandNotFoundHint`, `TestPreviewStore_CreatePreviewLog_NilMetadataDefaultsToEmptyObject`
- [ ] After deploy: re-run preview start on session `fb255391-4cb0-48c0-ab24-166fc44a228f` and confirm the banner names "command not found" and shows the npm stderr line instead of the generic 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)
