### PR TITLE
Add integration tests for core session lifecycle flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,15 @@ jobs:
           go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=180s
           go tool cover -func=coverage.out
 
+      # Integration tests run on every backend-test invocation (PR + push).
+      # They reuse the Postgres service this job already brings up — no new
+      # infra. Build-tag gating means they don't run during the unit-test
+      # step above, so we don't double-charge CI for the same code paths.
+      - name: Run integration tests
+        run: |
+          INTEGRATION_DATABASE_URL=$DATABASE_URL \
+          go test -tags=integration -timeout=120s ./internal/integration/...
+
       - name: Check backend coverage floor (main only)
         if: github.event_name == 'push'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging provision-redis deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging provision-redis deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -133,6 +133,14 @@ test-coverage-diff: test-pr
 test-main:
 	go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=180s
 	go tool cover -func=coverage.out
+
+# Integration tests against a real Postgres. Gated behind the `integration`
+# build tag so `make test` and `go test ./...` stay fast. Reuses DATABASE_URL
+# (the same env CI's backend-test job already exports), so locally:
+#   docker compose up -d postgres && make migrate-up && make test-integration
+test-integration:
+	INTEGRATION_DATABASE_URL=$${INTEGRATION_DATABASE_URL:-$$DATABASE_URL} \
+	go test -tags=integration -timeout=120s ./internal/integration/...
 
 migrate-up:
 	go run cmd/migrate/main.go up

--- a/internal/integration/fixtures.go
+++ b/internal/integration/fixtures.go
@@ -1,0 +1,192 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// seedOrg inserts a minimal Organization row and returns its ID. Settings is
+// an empty JSON object so OrgSettings parsing inside handlers (CreateManual)
+// gets sensible defaults instead of a NULL/parse error.
+func seedOrg(t *testing.T, pool *pgxpool.Pool) uuid.UUID {
+	t.Helper()
+	store := db.NewOrganizationStore(pool)
+	org := &models.Organization{
+		Name:     "integration-org-" + uuid.NewString()[:8],
+		Settings: json.RawMessage(`{}`),
+	}
+	if err := store.Create(context.Background(), org); err != nil {
+		t.Fatalf("seed org: %v", err)
+	}
+	return org.ID
+}
+
+// seedUser inserts a member-role user belonging to the given org. The user's
+// ID is what handlers like SendMessage stamp onto messages and audit events
+// via middleware.UserFromContext, so most tests want a real user even when
+// they don't authenticate. Inserts via raw SQL: UserStore.UpsertFromGitHub
+// requires a GitHub ID we don't want to fabricate, and Email-based register
+// flows go through the handler we'd rather not depend on transitively.
+func seedUser(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID) models.User {
+	t.Helper()
+	user := models.User{
+		OrgID: orgID,
+		Email: fmt.Sprintf("integration-%s@test.local", uuid.NewString()[:8]),
+		Name:  "Integration Test User",
+		Role:  "member",
+	}
+	err := pool.QueryRow(context.Background(), `
+		INSERT INTO users (org_id, email, name, role)
+		VALUES ($1, $2, $3, $4)
+		RETURNING id, created_at
+	`, user.OrgID, user.Email, user.Name, user.Role).Scan(&user.ID, &user.CreatedAt)
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	return user
+}
+
+// sessionOpts tunes which fields seedSession overrides on the default session
+// row. Zero-valued fields fall back to sensible defaults that make the
+// resulting row a plausible target for the handlers under test (manual
+// session, idle, ready to receive a follow-up).
+type sessionOpts struct {
+	Status       string
+	CurrentTurn  int
+	Origin       models.SessionOrigin
+	Interaction  models.SessionInteractionMode
+	Validation   models.SessionValidationPolicy
+	AgentType    models.AgentType
+	RepositoryID *uuid.UUID
+}
+
+// seedSession creates a session via the real SessionStore so any future
+// invariants enforced by Create (default origin, interaction mode, link
+// inserts) are honored. Returns the freshly persisted session — callers
+// should treat the returned struct as authoritative for ID / CreatedAt.
+func seedSession(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID, opts sessionOpts) models.Session {
+	t.Helper()
+	if opts.Status == "" {
+		opts.Status = string(models.SessionStatusIdle)
+	}
+	if opts.Origin == "" {
+		opts.Origin = models.SessionOriginManual
+	}
+	if opts.Interaction == "" {
+		opts.Interaction = models.SessionInteractionModeInteractive
+	}
+	if opts.Validation == "" {
+		opts.Validation = models.SessionValidationPolicyOnSessionEnd
+	}
+	if opts.AgentType == "" {
+		opts.AgentType = models.DefaultDefaultAgentType
+	}
+
+	title := "integration test session"
+	session := &models.Session{
+		OrgID:            orgID,
+		AgentType:        opts.AgentType,
+		Status:           opts.Status,
+		AutonomyLevel:    "semi",
+		TokenMode:        "low",
+		Origin:           opts.Origin,
+		InteractionMode:  opts.Interaction,
+		ValidationPolicy: opts.Validation,
+		Title:            &title,
+		PMApproach:       &title,
+		RepositoryID:     opts.RepositoryID,
+	}
+	store := db.NewSessionStore(pool)
+	if err := store.Create(context.Background(), session); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	// SessionStore.Create always inserts as 'pending' implicitly via the
+	// caller-supplied Status field — callers asking for non-pending need a
+	// follow-up update. CurrentTurn gets bumped by the orchestrator at
+	// runtime, so tests that need a specific turn (e.g. "send message to
+	// session that's already had two turns") set it via UPDATE here.
+	if session.Status != opts.Status || session.CurrentTurn != opts.CurrentTurn {
+		_, err := pool.Exec(context.Background(), `
+			UPDATE sessions
+			SET status = $1, current_turn = $2
+			WHERE id = $3 AND org_id = $4
+		`, opts.Status, opts.CurrentTurn, session.ID, orgID)
+		if err != nil {
+			t.Fatalf("seed session status update: %v", err)
+		}
+		session.Status = opts.Status
+		session.CurrentTurn = opts.CurrentTurn
+	}
+
+	return *session
+}
+
+// jobRow is the subset of the jobs row that integration tests assert against.
+// Reading the full models.Job pulls in lease/owner fields irrelevant to the
+// handler→DB seam we are testing.
+type jobRow struct {
+	ID       uuid.UUID
+	OrgID    uuid.UUID
+	Queue    string
+	JobType  string
+	Status   string
+	Priority int
+	Payload  json.RawMessage
+}
+
+// listJobs returns every job row for the given org, ordered oldest-first.
+// Tests assert exact counts and types; ordering keeps assertions deterministic.
+func listJobs(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID) []jobRow {
+	t.Helper()
+	rows, err := pool.Query(context.Background(), `
+		SELECT id, org_id, queue, job_type, status, priority, payload
+		FROM jobs
+		WHERE org_id = $1
+		ORDER BY created_at ASC, id ASC
+	`, orgID)
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	defer rows.Close()
+
+	var out []jobRow
+	for rows.Next() {
+		var j jobRow
+		if err := rows.Scan(&j.ID, &j.OrgID, &j.Queue, &j.JobType, &j.Status, &j.Priority, &j.Payload); err != nil {
+			t.Fatalf("scan job row: %v", err)
+		}
+		out = append(out, j)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate jobs: %v", err)
+	}
+	return out
+}
+
+// payloadField extracts a single string field from a job's JSON payload.
+// Fails the test if the field is missing or not a string — the handlers
+// under test always write string fields for session_id / org_id, so a missing
+// or wrong-typed field is a regression worth surfacing loudly.
+func payloadField(t *testing.T, payload json.RawMessage, key string) string {
+	t.Helper()
+	var m map[string]string
+	if err := json.Unmarshal(payload, &m); err != nil {
+		t.Fatalf("unmarshal job payload: %v (raw=%s)", err, string(payload))
+	}
+	val, ok := m[key]
+	if !ok {
+		t.Fatalf("job payload missing %q (raw=%s)", key, string(payload))
+	}
+	return val
+}

--- a/internal/integration/session_create_test.go
+++ b/internal/integration/session_create_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// TestIntegration_CreateManual_EnqueuesRunAgentJob covers the "user starts a
+// new manual session" entry point. A regression here means the entire
+// platform stops being able to create new sessions — every dashboard click
+// would 500 silently in unit tests but fail to commit a row here.
+//
+// Notably, this test deliberately does *not* pass a repository_id. Repos
+// require an upstream Integration row (FK), and exercising that wiring is
+// out of scope for the v1 integration suite. The orchestrator will choose to
+// run sandbox-less for repo-less manual sessions; that path still touches
+// every line we care about: org settings parse, session insert, message
+// insert, concurrency check, job enqueue.
+func TestIntegration_CreateManual_EnqueuesRunAgentJob(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+
+	handler := newTestSessionHandler(pool)
+
+	body := strings.NewReader(`{"message":"Refactor the cache key derivation in pkg/cache"}`)
+	req := buildAuthedRequest(http.MethodPost, "/api/v1/sessions/manual", body, orgID, &user, nil)
+
+	rec := httptest.NewRecorder()
+	handler.CreateManual(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, "create manual should return 201, body=%s", rec.Body.String())
+
+	var resp struct {
+		Data models.Session `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	createdID := resp.Data.ID
+	require.NotEqual(t, "", createdID.String())
+	require.Equal(t, "pending", resp.Data.Status, "newly-created manual session must be pending so the worker picks it up")
+	require.Equal(t, models.SessionOriginManual, resp.Data.Origin)
+	require.Equal(t, models.SessionInteractionModeInteractive, resp.Data.InteractionMode)
+	require.NotNil(t, resp.Data.TriggeredByUserID)
+	require.Equal(t, user.ID, *resp.Data.TriggeredByUserID)
+
+	// 1. Session row exists in DB and matches the response.
+	stored, err := db.NewSessionStore(pool).GetByID(context.Background(), orgID, createdID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", stored.Status)
+	require.Equal(t, models.SessionOriginManual, stored.Origin)
+
+	// 2. Initial turn-0 user message persisted (so attachments / commands
+	//    show up in the timeline alongside the prompt). A future refactor
+	//    that drops this on the floor would turn the chat history into a
+	//    list that starts at turn 1 — UX regression with no test signal
+	//    today.
+	msgs, err := db.NewSessionMessageStore(pool).ListBySession(context.Background(), orgID, createdID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, 0, msgs[0].TurnNumber)
+	require.Equal(t, models.MessageRoleUser, msgs[0].Role)
+	require.Equal(t, "Refactor the cache key derivation in pkg/cache", msgs[0].Content)
+
+	// 3. run_agent job in queue. The worker picks up by job_type — drift
+	//    here means the session sits in pending forever in production.
+	jobs := listJobs(t, pool, orgID)
+	require.Len(t, jobs, 1)
+	job := jobs[0]
+	require.Equal(t, "run_agent", job.JobType,
+		"job type drift will silently break new-session start")
+	require.Equal(t, "agent", job.Queue)
+	require.Equal(t, "pending", job.Status)
+	require.Equal(t, createdID.String(), payloadField(t, job.Payload, "session_id"))
+	require.Equal(t, orgID.String(), payloadField(t, job.Payload, "org_id"))
+}
+
+// TestIntegration_CreateManual_RejectsEmptyMessage anchors the input
+// validation contract. The handler trims whitespace then checks emptiness;
+// we intentionally exercise the "all whitespace" case rather than the empty
+// string because that's the more interesting failure mode (a frontend bug
+// that submits stray newlines should surface as MISSING_MESSAGE, not as a
+// session with no real prompt).
+func TestIntegration_CreateManual_RejectsEmptyMessage(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+
+	handler := newTestSessionHandler(pool)
+
+	body := strings.NewReader(`{"message":"   \n   "}`)
+	req := buildAuthedRequest(http.MethodPost, "/api/v1/sessions/manual", body, orgID, &user, nil)
+
+	rec := httptest.NewRecorder()
+	handler.CreateManual(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, rec.Body.String(), "MISSING_MESSAGE")
+
+	// Negative-space assertion: a rejected request must not commit anything.
+	jobs := listJobs(t, pool, orgID)
+	require.Empty(t, jobs)
+}

--- a/internal/integration/session_end_test.go
+++ b/internal/integration/session_end_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// TestIntegration_EndSession_EnqueuesOpenPRJob covers the "I'm done — open
+// the PR" terminal action. The default validation policy is "on session
+// end", so EndSession should transition the session to completed and
+// enqueue an `open_pr` job whose dedupe key keeps double-clicks from
+// producing duplicate PRs.
+//
+// A regression here would mean completed sessions never produce a PR — the
+// user finishes their work, hits End, and watches the result get silently
+// dropped on the floor.
+func TestIntegration_EndSession_EnqueuesOpenPRJob(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusIdle),
+		CurrentTurn: 2,
+		Validation:  models.SessionValidationPolicyOnSessionEnd,
+	})
+
+	handler := newTestSessionHandler(pool)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/end",
+		nil, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.EndSession(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "end session should return 200, body=%s", rec.Body.String())
+
+	// 1. Session transitioned to completed; pr_creation_state queued.
+	updated, err := db.NewSessionStore(pool).GetByID(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "completed", updated.Status)
+	require.Equal(t, models.PRCreationStateQueued, updated.PRCreationState,
+		"end-session must mark PR creation as queued so the UI shows the right state immediately")
+
+	// 2. open_pr job enqueued with the dedupe key the handler builds.
+	//    Dedupe is the only thing that prevents a double-click from
+	//    producing two PRs; the test asserts both type and dedupe behavior.
+	jobs := listJobs(t, pool, orgID)
+	require.Len(t, jobs, 1)
+	job := jobs[0]
+	require.Equal(t, "open_pr", job.JobType,
+		"validation policy `on_session_end` must enqueue open_pr (not validate)")
+	require.Equal(t, "default", job.Queue, "open_pr lives on the default queue (not agent), so non-sandbox workers can pick it up")
+	require.Equal(t, "pending", job.Status)
+	require.Equal(t, session.ID.String(), payloadField(t, job.Payload, "session_id"))
+	require.Equal(t, orgID.String(), payloadField(t, job.Payload, "org_id"))
+
+	// Dedupe assertion: re-end the same (now completed) session should be
+	// rejected because it's no longer idle, so we won't actually exercise
+	// dedupe here — but the dedupe_key column should be populated. Verify
+	// it via a direct query so a future refactor that drops the dedupe
+	// column from the INSERT is caught.
+	var dedupeKey *string
+	err = pool.QueryRow(context.Background(),
+		`SELECT dedupe_key FROM jobs WHERE id = $1`, job.ID).Scan(&dedupeKey)
+	require.NoError(t, err)
+	require.NotNil(t, dedupeKey, "open_pr enqueue must set a dedupe_key to suppress double-clicks")
+	require.Equal(t, "open_pr:"+session.ID.String(), *dedupeKey)
+}
+
+// TestIntegration_EndSession_RejectsNonIdleSession asserts the precondition:
+// only idle sessions can be ended. Ending a running or already-completed
+// session should 409 without enqueuing or transitioning anything.
+func TestIntegration_EndSession_RejectsNonIdleSession(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusRunning),
+		CurrentTurn: 1,
+	})
+
+	handler := newTestSessionHandler(pool)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/end",
+		nil, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.EndSession(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.Contains(t, rec.Body.String(), "NOT_IDLE")
+
+	stored, err := db.NewSessionStore(pool).GetByID(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "running", stored.Status, "rejected end-session must not mutate status")
+
+	jobs := listJobs(t, pool, orgID)
+	require.Empty(t, jobs)
+}

--- a/internal/integration/session_push_test.go
+++ b/internal/integration/session_push_test.go
@@ -1,0 +1,227 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/api/handlers"
+	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// TestIntegration_SendMessage_EnqueuesContinueSessionJob is the headline test
+// for the push-to-session flow. It exercises the same code path a frontend
+// chat reply hits in production: real SessionStore, SessionMessageStore, and
+// JobStore against a real Postgres, with the handler claiming the idle
+// session, persisting the user message, and enqueueing a continue_session
+// job — all in a single transaction.
+//
+// The assertions are structured to catch the exact regressions pgxmock-based
+// tests miss:
+//   - SQL typos / schema drift (real INSERTs run; bad columns fail loudly)
+//   - Transaction-boundary bugs (we read state *after* commit, so a
+//     mid-tx failure would leave the assertions to surface inconsistency)
+//   - Wrong job_type / queue / payload shape (the worker dispatches by
+//     these fields; a refactor that drifts the constants is silently broken
+//     in unit tests but caught here)
+func TestIntegration_SendMessage_EnqueuesContinueSessionJob(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusIdle),
+		CurrentTurn: 1,
+	})
+
+	handler := newTestSessionHandler(pool)
+
+	body := strings.NewReader(`{"message":"Please add tests for the new RPC handler."}`)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/messages",
+		body, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.SendMessage(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, "send message should return 201, body=%s", rec.Body.String())
+
+	// Assert the response carries the persisted message back to the client.
+	var resp struct {
+		Data models.SessionMessage `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, "Please add tests for the new RPC handler.", resp.Data.Content)
+	require.Equal(t, models.MessageRoleUser, resp.Data.Role)
+	require.Equal(t, session.CurrentTurn+1, resp.Data.TurnNumber, "turn number should advance one past the seeded value")
+	require.NotNil(t, resp.Data.UserID)
+	require.Equal(t, user.ID, *resp.Data.UserID)
+
+	// 1. messages — exactly the one row we just sent.
+	msgs, err := db.NewSessionMessageStore(pool).ListBySession(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, "Please add tests for the new RPC handler.", msgs[0].Content)
+	require.Equal(t, session.CurrentTurn+1, msgs[0].TurnNumber)
+
+	// 2. session — claimed and now running. Status transitions are part of
+	//    the contract: a future refactor that, say, leaves status='idle'
+	//    after ClaimIdle would produce frozen sessions in production.
+	updated, err := db.NewSessionStore(pool).GetByID(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, string(models.SessionStatusRunning), updated.Status,
+		"ClaimIdle should have transitioned the session to running")
+
+	// 3. jobs — exactly one continue_session job, queue=agent, payload
+	//    references this session. The whole reason we're testing this against
+	//    a real DB is that this assertion catches the case where the handler
+	//    or the JobStore drift apart on column names / payload shape.
+	jobs := listJobs(t, pool, orgID)
+	require.Len(t, jobs, 1, "expected exactly one job enqueued")
+	job := jobs[0]
+	require.Equal(t, "continue_session", job.JobType,
+		"job type drift will silently break push — worker dispatches by this field")
+	require.Equal(t, "agent", job.Queue)
+	require.Equal(t, "pending", job.Status)
+	require.Equal(t, 5, job.Priority)
+	require.Equal(t, session.ID.String(), payloadField(t, job.Payload, "session_id"))
+	require.Equal(t, orgID.String(), payloadField(t, job.Payload, "org_id"))
+}
+
+// TestIntegration_SendMessage_RunningSessionSkipsJob covers the second
+// branch of SendMessage: when the session is already running, the message is
+// buffered into session_messages but no continue_session job is enqueued
+// because the live agent will pick it up inline. A refactor that flips the
+// branch (enqueueing for running sessions) would cause duplicate runs in
+// production.
+func TestIntegration_SendMessage_RunningSessionSkipsJob(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusRunning),
+		CurrentTurn: 2,
+	})
+
+	handler := newTestSessionHandler(pool)
+
+	body := strings.NewReader(`{"message":"quick aside while you work"}`)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/messages",
+		body, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.SendMessage(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, "running-session reply should return 201, body=%s", rec.Body.String())
+
+	msgs, err := db.NewSessionMessageStore(pool).ListBySession(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1, "message should still be persisted")
+
+	jobs := listJobs(t, pool, orgID)
+	require.Empty(t, jobs, "no job should be enqueued for a running session — agent picks the message up inline")
+}
+
+// TestIntegration_SendMessage_RejectsDestroyedSnapshot guards the
+// SNAPSHOT_EXPIRED branch: a session whose sandbox was reaped after 30 days
+// cannot be resumed. The handler must reject before touching the message
+// store or the job queue, otherwise we'd accumulate orphan rows pointing at
+// runs that can never start.
+func TestIntegration_SendMessage_RejectsDestroyedSnapshot(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusCompleted),
+		CurrentTurn: 3,
+	})
+	// Mark the snapshot destroyed (the reaper does this in production).
+	_, err := pool.Exec(context.Background(),
+		`UPDATE sessions SET sandbox_state = 'destroyed' WHERE id = $1`, session.ID)
+	require.NoError(t, err)
+
+	handler := newTestSessionHandler(pool)
+
+	body := strings.NewReader(`{"message":"please resume"}`)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/messages",
+		body, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.SendMessage(rec, req)
+
+	require.Equal(t, http.StatusGone, rec.Code, "destroyed-snapshot should be 410 Gone")
+	require.Contains(t, rec.Body.String(), "SNAPSHOT_EXPIRED")
+
+	msgs, err := db.NewSessionMessageStore(pool).ListBySession(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Empty(t, msgs, "rejected request must not persist a message")
+
+	jobs := listJobs(t, pool, orgID)
+	require.Empty(t, jobs, "rejected request must not enqueue a job")
+}
+
+// newTestSessionHandler wires the production SessionHandler against the live
+// pool. Stores irrelevant to the flows under test (validation, PR, threads,
+// LLM client, audit emitter) are passed nil — the handlers we exercise check
+// for nil before using them, and we want a regression to the contrary to
+// surface as a panic during the test rather than be hidden behind a mock.
+//
+// Mirroring cmd/server/main.go's wiring is deliberate: if a future refactor
+// changes which stores SendMessage / CreateManual / RetrySession / EndSession
+// reach for, this helper must be updated in the same commit, which is itself
+// a useful refactor signal.
+func newTestSessionHandler(pool *pgxpool.Pool) *handlers.SessionHandler {
+	logger := zerolog.Nop()
+	return handlers.NewSessionHandler(
+		db.NewSessionStore(pool),
+		db.NewSessionLogStore(pool),
+		db.NewSessionQuestionStore(pool),
+		nil, // validationStore — only EndSession with validate-on-turn touches it; not tested here
+		nil, // pullRequestStore
+		nil, // issueStore — set to nil; CreateManual without RepositoryID won't call it
+		db.NewRepositoryStore(pool),
+		db.NewOrganizationStore(pool),
+		db.NewJobStore(pool),
+		db.NewSessionMessageStore(pool),
+		db.NewSessionThreadStore(pool),
+		nil, // llmClient — CreateManual treats nil as "skip title generation"
+		logger,
+	)
+}
+
+// buildAuthedRequest constructs an *http.Request as if it had passed the
+// auth + org-context middleware in production: the user is on the request
+// context, the active org is on the context, and chi route params are set
+// so chi.URLParam(r, "id") returns the right session ID.
+func buildAuthedRequest(method, target string, body io.Reader, orgID uuid.UUID, user *models.User, urlParams map[string]string) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	rctx := chi.NewRouteContext()
+	for k, v := range urlParams {
+		rctx.URLParams.Add(k, v)
+	}
+	ctx := req.Context()
+	ctx = context.WithValue(ctx, chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	if user != nil {
+		ctx = middleware.WithUser(ctx, user)
+	}
+	return req.WithContext(ctx)
+}

--- a/internal/integration/session_retry_test.go
+++ b/internal/integration/session_retry_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// TestIntegration_RetrySession_ResetsAndReenqueues verifies the failure
+// recovery path: a user-clicked Retry on a failed session must (a) reset the
+// session row to pending, (b) clear the failure_* metadata, and (c) enqueue
+// a fresh run_agent job. A regression in any of these steps strands the
+// session: pending-with-no-job is the worst failure mode because it looks
+// fine in the UI but never makes progress.
+func TestIntegration_RetrySession_ResetsAndReenqueues(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusFailed),
+		CurrentTurn: 1,
+	})
+	// Stamp realistic failure metadata so the test verifies the reset
+	// actually clears it. A future refactor that drops a column from
+	// ResetForRetry's UPDATE list would surface here as leftover data.
+	expl := "agent ran out of context"
+	cat := "context_overflow"
+	_, err := pool.Exec(context.Background(), `
+		UPDATE sessions
+		SET failure_explanation = $1,
+		    failure_category = $2,
+		    failure_retry_advised = true,
+		    error = 'something went wrong'
+		WHERE id = $3
+	`, expl, cat, session.ID)
+	require.NoError(t, err)
+
+	handler := newTestSessionHandler(pool)
+
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/retry",
+		nil, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.RetrySession(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "retry should return 200, body=%s", rec.Body.String())
+
+	// 1. Session reset to pending with failure metadata cleared.
+	updated, err := db.NewSessionStore(pool).GetByID(context.Background(), orgID, session.ID)
+	require.NoError(t, err)
+	require.Equal(t, "pending", updated.Status)
+	require.Nil(t, updated.FailureExplanation, "failure_explanation must be cleared on retry")
+	require.Nil(t, updated.FailureCategory, "failure_category must be cleared on retry")
+	require.False(t, updated.FailureRetryAdvised, "failure_retry_advised must be reset on retry")
+	require.Nil(t, updated.Error, "error must be cleared on retry")
+	require.Nil(t, updated.StartedAt, "started_at must be cleared so the next run computes duration from a fresh start")
+	require.Nil(t, updated.CompletedAt, "completed_at must be cleared")
+
+	// 2. New run_agent job in queue.
+	jobs := listJobs(t, pool, orgID)
+	require.Len(t, jobs, 1, "retry must enqueue exactly one run_agent job")
+	job := jobs[0]
+	require.Equal(t, "run_agent", job.JobType)
+	require.Equal(t, "agent", job.Queue)
+	require.Equal(t, "pending", job.Status)
+	require.Equal(t, session.ID.String(), payloadField(t, job.Payload, "session_id"))
+	require.Equal(t, orgID.String(), payloadField(t, job.Payload, "org_id"))
+}
+
+// TestIntegration_RetrySession_RejectsNonFailedSession guards the inverse:
+// retrying an already-running or already-pending session must 409 without
+// touching the queue. Otherwise a double-click on Retry would enqueue two
+// jobs that race for the same session.
+func TestIntegration_RetrySession_RejectsNonFailedSession(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+	user := seedUser(t, pool, orgID)
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status:      string(models.SessionStatusRunning),
+		CurrentTurn: 1,
+	})
+
+	handler := newTestSessionHandler(pool)
+	req := buildAuthedRequest(http.MethodPost,
+		"/api/v1/sessions/"+session.ID.String()+"/retry",
+		nil, orgID, &user, map[string]string{"id": session.ID.String()})
+
+	rec := httptest.NewRecorder()
+	handler.RetrySession(rec, req)
+
+	require.Equal(t, http.StatusConflict, rec.Code)
+	require.Contains(t, rec.Body.String(), "NOT_FAILED")
+
+	jobs := listJobs(t, pool, orgID)
+	require.Empty(t, jobs, "rejected retry must not enqueue any job")
+}

--- a/internal/integration/testdb.go
+++ b/internal/integration/testdb.go
@@ -1,0 +1,178 @@
+//go:build integration
+
+// Package integration contains end-to-end tests that exercise the real
+// production code paths against a real Postgres database. They guard the
+// critical session lifecycle flows (push, create, retry, end) and the worker
+// dispatch path against refactor regressions that pgxmock-based unit tests
+// cannot catch (SQL typos, schema drift, transaction-boundary bugs, queue
+// pickup wiring).
+//
+// Tests are gated behind the `integration` build tag and require
+// INTEGRATION_DATABASE_URL pointing at a writable test database. The CI
+// `backend-test` job already provisions a Postgres 17 service container; this
+// suite reuses it via `make test-integration`.
+package integration
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/assembledhq/143/internal/db"
+)
+
+// integrationDatabaseURLEnv names the env var that points the integration test
+// suite at a writable Postgres. Distinct from DATABASE_URL so a developer who
+// runs `make test` against their dev DB doesn't accidentally have integration
+// tests truncate their dev data — they must opt in explicitly via the
+// integration target.
+const integrationDatabaseURLEnv = "INTEGRATION_DATABASE_URL"
+
+var (
+	poolOnce   sync.Once
+	poolErr    error
+	sharedPool *pgxpool.Pool
+)
+
+// requirePool returns a process-wide pgxpool.Pool against the integration
+// database, having run migrations exactly once. Tests should call this from
+// the top of each test function — it skips (rather than fails) when the env
+// var is unset so the suite is a no-op outside CI / `make test-integration`.
+func requirePool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	dbURL := os.Getenv(integrationDatabaseURLEnv)
+	if dbURL == "" {
+		t.Skipf("set %s to run integration tests (e.g. via `make test-integration`)", integrationDatabaseURLEnv)
+	}
+
+	poolOnce.Do(func() {
+		if err := runMigrations(dbURL); err != nil {
+			poolErr = err
+			return
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		_ = cancel // pool outlives the test binary; we deliberately don't cancel
+		pool, err := db.NewPool(ctx, dbURL)
+		if err != nil {
+			poolErr = err
+			return
+		}
+		sharedPool = pool
+	})
+
+	if poolErr != nil {
+		t.Fatalf("integration test pool unavailable: %v", poolErr)
+	}
+	return sharedPool
+}
+
+// runMigrations applies all up migrations against the test database. Run
+// once per process. ErrNoChange is treated as success — a freshly migrated DB
+// from a previous run is the common path.
+func runMigrations(dbURL string) error {
+	source, err := resolveMigrationSource()
+	if err != nil {
+		return err
+	}
+	m, err := migrate.New(source, dbURL)
+	if err != nil {
+		return err
+	}
+	defer m.Close()
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return err
+	}
+	return nil
+}
+
+// resolveMigrationSource finds the migrations directory by walking up from
+// the current working directory until it locates a `migrations/` folder.
+// Falls back to the binary-adjacent path for `go test -c` workflows. Mirrors
+// the lookup logic in cmd/migrate/main.go so the two stay in sync.
+func resolveMigrationSource() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, "migrations")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return "file://" + candidate, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return "", errors.New("could not locate migrations/ directory by walking up from " + cwd)
+}
+
+// truncatedTables lists every multi-tenant or test-relevant table that needs
+// resetting between integration tests. Truncating with CASCADE handles the
+// foreign-key web (sessions → session_messages, session_logs, etc.) without
+// us tracking dependency order by hand.
+//
+// schema_migrations is intentionally excluded — re-running migrations between
+// tests would dominate the wall-clock budget.
+var truncatedTables = []string{
+	"jobs",
+	"session_messages",
+	"session_logs",
+	"session_questions",
+	"session_threads",
+	"session_issue_links",
+	"session_turn_issue_snapshots",
+	"sessions",
+	"issues",
+	"repositories",
+	"integrations",
+	"auth_sessions",
+	"organization_memberships",
+	"users",
+	"organizations",
+}
+
+// resetDB truncates every test-relevant table so each test starts from a
+// clean slate. Called via t.Cleanup at the *start* of each test (so the next
+// test inherits a clean DB regardless of whether the prior one panicked).
+//
+// CASCADE traverses FK relationships — pgcrypto/uuid extensions and
+// schema_migrations are untouched. Wrapped in a single statement because
+// TRUNCATE acquires AccessExclusiveLock per table; one statement minimizes
+// the lock surface and is atomic in case the test process crashes mid-truncate.
+func resetDB(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	stmt := "TRUNCATE TABLE "
+	for i, table := range truncatedTables {
+		if i > 0 {
+			stmt += ", "
+		}
+		stmt += table
+	}
+	stmt += " RESTART IDENTITY CASCADE"
+	if _, err := pool.Exec(context.Background(), stmt); err != nil {
+		t.Fatalf("reset integration DB: %v", err)
+	}
+}
+
+// setup pairs requirePool + resetDB. Most tests want both: a live pool and a
+// clean slate. The Cleanup hook fires at end-of-test too so a crash mid-suite
+// doesn't leak data into the next file's tests.
+func setup(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := requirePool(t)
+	resetDB(t, pool)
+	t.Cleanup(func() { resetDB(t, pool) })
+	return pool
+}

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/worker"
+)
+
+// TestIntegration_WorkerDispatch_PicksUpAndCallsHandler closes the loop on
+// the queue → worker → handler seam. The session-side tests upstream prove
+// that pushing/creating/retrying/ending writes the right job row; this test
+// proves that an enqueued job actually reaches its handler. Together they
+// guarantee that a refactor of either side breaks at least one test before
+// it ships.
+//
+// Specifically guards:
+//   - Worker.ClaimNextRunnable wired through real SQL — schema/index drift
+//     surfaces here, not just in pgxmock.
+//   - Job-type → handler dispatch table — a typo in the registered key
+//     would silently dead-letter every job in production but passes
+//     pgxmock unit tests today.
+//   - Lease + ack lifecycle — the worker must transition `pending` →
+//     `running` (claim, attempts++) → `success` (mark succeeded with the
+//     fencing token). Each transition is real SQL.
+//
+// The test uses Worker.Wake() to short-circuit the 5s poll ticker so it
+// runs in <1s. We do not refactor the Worker to expose a single-tick
+// method — Wake() is already a public API, intended for exactly this kind
+// of "process now" signal.
+func TestIntegration_WorkerDispatch_PicksUpAndCallsHandler(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+
+	// Seed a session to anchor the foreign-key payload reference. The
+	// worker doesn't dereference session_id, but having one on hand keeps
+	// the payload realistic — exactly what production data looks like.
+	session := seedSession(t, pool, orgID, sessionOpts{
+		Status: "pending",
+	})
+
+	// Enqueue a continue_session job through the real JobStore — the
+	// same code path SendMessage uses in production. (We could insert via
+	// raw SQL, but going through the store catches a typo in either side.)
+	jobStore := db.NewJobStore(pool)
+	payload := map[string]string{
+		"session_id": session.ID.String(),
+		"org_id":     orgID.String(),
+	}
+	jobID, err := jobStore.Enqueue(context.Background(), orgID, "agent", "continue_session", payload, 5, nil)
+	require.NoError(t, err)
+	require.NotEqual(t, "", jobID.String())
+
+	// Build the worker with a recording handler. The `received` channel
+	// signals from the handler back to the test goroutine; using a
+	// 1-buffered channel avoids deadlocking if the handler runs before the
+	// test starts reading.
+	type recvJob struct {
+		JobType string
+		Payload json.RawMessage
+	}
+	received := make(chan recvJob, 1)
+	w := worker.New(pool, zerolog.Nop(), "test-node-"+jobID.String()[:8])
+	w.Register("continue_session", func(ctx context.Context, jobType string, payload json.RawMessage) error {
+		received <- recvJob{JobType: jobType, Payload: payload}
+		return nil
+	})
+
+	// Start the worker. context.WithCancel lets the test stop it cleanly
+	// once we've observed the dispatch — otherwise it would keep polling
+	// forever, holding goroutines past the test's lifetime.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+
+	// Wake() short-circuits the poll ticker — without it we'd wait up to
+	// 5s for the next tick, which is fine for production but turns this
+	// test into a flake on slow CI machines.
+	w.Wake()
+
+	// Wait for the handler invocation, with a generous-but-bounded timeout.
+	// 5s is the worker's own poll interval, so any longer means something
+	// is actually broken (not just slow CI).
+	select {
+	case got := <-received:
+		require.Equal(t, "continue_session", got.JobType,
+			"worker dispatched to the wrong handler — handler-table drift")
+		require.Equal(t, session.ID.String(), payloadField(t, got.Payload, "session_id"),
+			"worker delivered the wrong payload to the handler")
+		require.Equal(t, orgID.String(), payloadField(t, got.Payload, "org_id"))
+	case <-time.After(5 * time.Second):
+		t.Fatal("worker did not dispatch the job within 5s — claim or wake path is broken")
+	}
+
+	// After dispatch returns nil, the worker writes status=success on the
+	// job row asynchronously. Poll briefly for the terminal state — the
+	// alternative (an unconditional time.Sleep) is the kind of test
+	// flakiness this whole suite is supposed to prevent.
+	require.Eventually(t, func() bool {
+		var status string
+		err := pool.QueryRow(context.Background(),
+			`SELECT status FROM jobs WHERE id = $1`, jobID).Scan(&status)
+		if err != nil {
+			return false
+		}
+		return status == "success"
+	}, 3*time.Second, 25*time.Millisecond, "job did not transition to success after handler returned nil — ack/lease path is broken")
+}
+
+// TestIntegration_WorkerDispatch_UnknownJobTypeDeadLetters covers the
+// failure mode that drove the test's existence in the first place: a job
+// whose type has no registered handler should be promptly failed (not
+// silently swallowed). Otherwise a typo'd refactor of a job-type constant
+// turns into a sea of pending-forever rows.
+func TestIntegration_WorkerDispatch_UnknownJobTypeDeadLetters(t *testing.T) {
+	pool := setup(t)
+
+	orgID := seedOrg(t, pool)
+
+	jobStore := db.NewJobStore(pool)
+	payload := map[string]string{"org_id": orgID.String()}
+	jobID, err := jobStore.Enqueue(context.Background(), orgID, "agent", "no_such_handler", payload, 5, nil)
+	require.NoError(t, err)
+
+	w := worker.New(pool, zerolog.Nop(), "test-node-deadletter")
+	// Deliberately do *not* Register a handler for "no_such_handler".
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go w.Start(ctx)
+	w.Wake()
+
+	require.Eventually(t, func() bool {
+		var status string
+		var lastError *string
+		err := pool.QueryRow(context.Background(),
+			`SELECT status, last_error FROM jobs WHERE id = $1`, jobID).Scan(&status, &lastError)
+		if err != nil {
+			return false
+		}
+		return status == "failed" && lastError != nil && *lastError != ""
+	}, 5*time.Second, 25*time.Millisecond, "unknown job type must fail fast with an explanatory last_error — silent swallow is the worst outcome")
+}

--- a/internal/integration/worker_dispatch_test.go
+++ b/internal/integration/worker_dispatch_test.go
@@ -101,10 +101,11 @@ func TestIntegration_WorkerDispatch_PicksUpAndCallsHandler(t *testing.T) {
 		t.Fatal("worker did not dispatch the job within 5s — claim or wake path is broken")
 	}
 
-	// After dispatch returns nil, the worker writes status=success on the
-	// job row asynchronously. Poll briefly for the terminal state — the
-	// alternative (an unconditional time.Sleep) is the kind of test
-	// flakiness this whole suite is supposed to prevent.
+	// After dispatch returns nil, the worker writes status='succeeded' on
+	// the job row asynchronously (see MarkSucceededWithLease in jobs.go).
+	// Poll briefly for the terminal state — the alternative (an
+	// unconditional time.Sleep) is the kind of test flakiness this whole
+	// suite is supposed to prevent.
 	require.Eventually(t, func() bool {
 		var status string
 		err := pool.QueryRow(context.Background(),
@@ -112,8 +113,8 @@ func TestIntegration_WorkerDispatch_PicksUpAndCallsHandler(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return status == "success"
-	}, 3*time.Second, 25*time.Millisecond, "job did not transition to success after handler returned nil — ack/lease path is broken")
+		return status == "succeeded"
+	}, 3*time.Second, 25*time.Millisecond, "job did not transition to succeeded after handler returned nil — ack/lease path is broken")
 }
 
 // TestIntegration_WorkerDispatch_UnknownJobTypeDeadLetters covers the


### PR DESCRIPTION
## Summary

Adds a real-Postgres integration test suite (`//go:build integration`) covering the five highest-impact session lifecycle flows: SendMessage (push), CreateManual, RetrySession, EndSession, and Worker job dispatch. These guard against regressions that pgxmock unit tests cannot catch — SQL typos, schema drift, transaction-boundary bugs, and queue pickup wiring — by running real INSERTs through the production stores and asserting the exact `job_type` / queue / payload that production workers dispatch on.

Tests run in the existing `backend-test` CI job against the same Postgres 17 service container, so no new infra. Build-tag gating keeps `make test` and `go test ./...` unaffected.

## Test plan

- [x] `go vet -tags=integration ./internal/integration/...` clean
- [x] `go list ./...` does not include the integration package without the tag (existing `make test` unaffected)
- [x] `make lint-stores` and `make lint-schema` still pass
- [ ] CI green on this PR's `backend-test` job (validates the suite end-to-end against real Postgres)
- [ ] Local: `docker compose up -d postgres && make migrate-up && make test-integration`
