### PR TITLE
Add progressive slide-to-archive feedback for mobile session rows

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -1,6 +1,6 @@
 # Design: 143.dev
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-05-01
+> **Status:** Partially Implemented | **Last reviewed:** 2026-05-02
 
 [143.dev](http://143.dev) is an open-source platform that turns customer pain and production errors into safe, validated code fixes that ship automatically.
 
@@ -46,7 +46,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
     - The admins can specify product context (philosophy + direction + focus/avoid areas) to steer prioritization.
     - A **PM agent** now runs on a batch cadence, clusters related issues, produces a prioritized plan, and can propose new **repo-scoped projects** for human review when it finds a strategic opportunity (replacing per-issue auto-triggering for automation).
     - **Projects** are the primary long-term control surface. The canonical review surface for PM-proposed projects lives in `Projects`, while `Autopilot` shows lightweight PM proposal summaries and links users into that review flow. Each project can be `finite` (completes) or `evergreen` (continuous maintenance) with optional cadence-based execution and project-scoped quick actions.
-    - Session and project sidebars should feel native on phones: a left swipe reveals an archive action beneath the row, with an iOS-style icon-led affordance and tap-to-close behavior when the row is already open.
+    - Session and project sidebars should feel native on phones: a left swipe reveals an archive action beneath the row, with an iOS-style icon-led affordance, progressive fill/ready-state feedback as the user approaches the auto-archive threshold, and tap-to-close behavior when the row is already open.
 - Step 3: Execute a coding agent
     - Admins set a **confidence threshold** that controls which issues the system will auto-attempt. Issues below the threshold require manual triggering.
     - Recurring team automations should start from a **structured template library** rather than bare one-line prompts. The default templates are frontend-defined issue-style prompts with explicit sections for task framing, output requirements, and verification, plus a deeper `/automations/templates` browse page for less common workflows.

--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -110,6 +110,44 @@ describe('SwipeActionRow', () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it('shows progressive feedback before and after the auto-archive threshold', () => {
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={() => {}}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+    Object.defineProperty(container!, 'offsetWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 320, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 240, clientY: 24 }],
+    });
+
+    expect(screen.getByText('Keep swiping')).toBeInTheDocument();
+    expect(screen.queryByText('Release to archive')).not.toBeInTheDocument();
+
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 170, clientY: 24 }],
+    });
+
+    expect(screen.getByText('Release to archive')).toBeInTheDocument();
+    expect(container).toHaveAttribute('data-swipe-state', 'committed');
+  });
+
   it('keeps the moving row surface opaque while the action is revealed', () => {
     renderWithProviders(
       <SwipeActionRow

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -93,6 +93,7 @@ export function SwipeActionRow({
   const [offset, setOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const [isCommitted, setIsCommitted] = useState(false);
+  const [gestureWidth, setGestureWidth] = useState(FALLBACK_ROW_WIDTH);
   const isTouchDevice = useSyncExternalStore(
     subscribeTouchDevice,
     getTouchDeviceSnapshot,
@@ -156,10 +157,12 @@ export function SwipeActionRow({
       window.clearTimeout(commitTimerRef.current);
       commitTimerRef.current = null;
     }
+    const width = containerRef.current?.offsetWidth || FALLBACK_ROW_WIDTH;
+    setGestureWidth(width);
     dragRef.current = {
       startX: touch.clientX,
       startY: touch.clientY,
-      width: containerRef.current?.offsetWidth || FALLBACK_ROW_WIDTH,
+      width,
       swiping: false,
       locked: false,
     };
@@ -237,6 +240,12 @@ export function SwipeActionRow({
       : "closed";
   const trailingActionHidden = state === "closed";
   const actionAreaWidth = Math.max(ACTION_WIDTH, offset);
+  const commitThreshold = commitThresholdFor(gestureWidth);
+  const swipeProgress = Math.max(0, Math.min(1, offset / commitThreshold));
+  const progressFill = Math.max(0.18, swipeProgress);
+  const actionHint = isCommitted
+    ? `Release to ${actionText.toLowerCase()}`
+    : "Keep swiping";
 
   const swipeSurfaceProps = isTouchDevice
     ? {
@@ -267,15 +276,23 @@ export function SwipeActionRow({
     >
       {isTouchDevice && (
         <div
-          className="absolute inset-y-0 right-0"
+          className="absolute inset-y-0 right-0 overflow-hidden rounded-r-lg"
           style={{ width: `${actionAreaWidth}px` }}
         >
+          <div
+            aria-hidden="true"
+            className={cn(
+              "absolute inset-y-0 right-0 transition-all duration-150 ease-out",
+              isCommitted ? "bg-amber-700" : "bg-amber-500/80",
+            )}
+            style={{ width: `${progressFill * 100}%` }}
+          />
           <Button
             aria-label={actionLabel}
             aria-hidden={trailingActionHidden}
             tabIndex={trailingActionHidden ? -1 : 0}
             className={cn(
-              "h-full w-full rounded-none rounded-r-lg px-0 text-white transition-colors duration-150",
+              "relative h-full w-full rounded-none rounded-r-lg px-0 text-white transition-colors duration-150",
               isCommitted
                 ? "bg-amber-600 hover:bg-amber-700 active:bg-amber-700"
                 : "bg-amber-500 hover:bg-amber-600 active:bg-amber-600",
@@ -286,13 +303,34 @@ export function SwipeActionRow({
             }}
           >
             <span
+              aria-hidden="true"
               className={cn(
-                "flex flex-col items-center justify-center gap-1 text-xs font-medium transition-transform duration-150",
+                "absolute inset-y-2 right-0 rounded-l-full bg-white/16 transition-all duration-150 ease-out",
+                isCommitted ? "bg-white/22" : "bg-white/14",
+              )}
+              style={{ width: `${Math.max(24, progressFill * 100)}%` }}
+            />
+            <span
+              className={cn(
+                "relative flex flex-col items-center justify-center gap-1 text-xs font-medium transition-transform duration-150",
                 isCommitted && "scale-110",
               )}
             >
-              {actionIcon}
+              <span
+                className={cn(
+                  "flex h-9 w-9 items-center justify-center rounded-full border border-white/20 bg-black/10 transition-all duration-150",
+                  isCommitted && "scale-110 bg-black/20",
+                )}
+                style={{
+                  transform: `translateX(-${Math.round(swipeProgress * 12)}px) scale(${1 + swipeProgress * 0.08})`,
+                }}
+              >
+                {actionIcon}
+              </span>
               <span>{actionText}</span>
+              <span className="text-xs font-medium uppercase tracking-[0.14em] text-white/90">
+                {actionHint}
+              </span>
             </span>
           </Button>
         </div>


### PR DESCRIPTION
## Summary
Updated the swipe action row to provide progressive visual feedback as the user nears and passes the auto-archive threshold, making the mobile interaction feel more “native” and easier to understand. This complements the existing tap-to-close behavior when the row is already open.

## Changes
- **docs/design/overall.md**
  - Refined the mobile session/project sidebar behavior description to include progressive fill/ready-state feedback.
- **frontend/src/components/swipe-action-row.tsx**
  - Enhanced the slide-to-archive UI with layered fills/transforms tied to swipe progress.
  - Added/updated state signaling so the component reflects pre-threshold vs. threshold/committed behavior (via `data-swipe-state`).
- **frontend/src/components/swipe-action-row.test.tsx**
  - Added a test verifying progressive messaging and state changes before vs. after the auto-archive threshold during touch swipes.

## Test plan
- Ran `typecheck`, `lint`, and `build`.
- Executed the updated component test suite (including the new progressive threshold feedback test in `swipe-action-row.test.tsx`).

[143.dev](https://143.dev) | [session a6caac2c](https://143.dev/sessions/a6caac2c-b140-4104-ad04-e3f40ef406bf)