### PR TITLE
Update Audit Log page UI: remove “Latest first” and switch pagination to “Load more”

### DIFF
--- a/frontend/src/app/(dashboard)/settings/audit-log/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/audit-log/page.test.tsx
@@ -177,7 +177,10 @@ describe('AuditLogPage', () => {
       expect(screen.getByText('created session')).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole('button', { name: 'Load older' }));
+    expect(screen.queryByText('Latest first')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Back to newest' })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
 
     await waitFor(() => {
       expect(screen.getByText('created session')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/settings/audit-log/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/audit-log/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useQueryState, parseAsString } from "nuqs";
 import { api } from "@/lib/api";
@@ -10,8 +10,7 @@ import { PageContainer } from "@/components/page-container";
 import { AuditLogEntry } from "@/components/audit/audit-log-entry";
 import { AuditLogDetailDrawer } from "@/components/audit/audit-log-detail-drawer";
 import { EmptyState } from "@/components/empty-state";
-import { Badge } from "@/components/ui/badge";
-import { ScrollText, ArrowUp, History } from "lucide-react";
+import { ScrollText, History } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -54,7 +53,6 @@ export default function AuditLogPage() {
   const [actionPrefix, setActionPrefix] = useQueryState("action_prefix", parseAsString);
   const [userId, setUserId] = useQueryState("user_id", parseAsString);
   const [selectedEntry, setSelectedEntry] = useState<AuditLog | null>(null);
-  const topRef = useRef<HTMLDivElement | null>(null);
 
   const isAdmin = user?.role === "admin";
 
@@ -79,7 +77,6 @@ export default function AuditLogPage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    hasLoadedHistory,
   } = useAuditLogFeed({
     filters,
     pageSize: 25,
@@ -184,14 +181,10 @@ export default function AuditLogPage() {
         {/* Entries */}
         <div className="rounded-lg border border-border bg-card shadow-sm">
           <div
-            ref={topRef}
             className="flex flex-col gap-3 border-b border-border/50 px-6 py-4 sm:flex-row sm:items-center sm:justify-between"
           >
             <div className="space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <Badge variant="secondary" className="rounded-full bg-muted/70 px-2.5 py-0.5 text-xs font-medium text-foreground">
-                  Latest first
-                </Badge>
                 <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                   <History className="h-3.5 w-3.5" />
                   {entries.length} event{entries.length === 1 ? "" : "s"} loaded
@@ -203,17 +196,6 @@ export default function AuditLogPage() {
                   : "Browse recent activity first, then extend the timeline without losing your place."}
               </p>
             </div>
-            {hasLoadedHistory && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 gap-1.5 self-start rounded-full px-3 text-xs sm:self-auto"
-                onClick={() => topRef.current?.scrollIntoView({ behavior: "smooth", block: "start" })}
-              >
-                <ArrowUp className="h-3.5 w-3.5" />
-                Back to newest
-              </Button>
-            )}
           </div>
           {error ? (
             <div className="rounded-md bg-destructive/10 px-3 py-2 text-xs text-destructive m-3">
@@ -250,7 +232,7 @@ export default function AuditLogPage() {
                     onClick={() => fetchNextPage()}
                     disabled={isFetchingNextPage}
                   >
-                    {isFetchingNextPage ? "Loading..." : "Load older"}
+                    {isFetchingNextPage ? "Loading..." : "Load more"}
                   </Button>
                 </div>
               )}


### PR DESCRIPTION
## Summary
Updated the settings audit log page controls to match the new UX: removed the “Latest first” badge and the “Back to newest” button, and changed the pagination button label to “Load more”. Updated the corresponding page test to assert the new UI and interaction flow.

## Changes
- `frontend/src/app/(dashboard)/settings/audit-log/page.tsx`
  - Removed the `Latest first` badge from the header.
  - Removed the `Back to newest` button and related scroll-to-top behavior.
  - Removed unused imports/state (`useRef`, `Badge`, and icon usage tied to the removed controls).
- `frontend/src/app/(dashboard)/settings/audit-log/page.test.tsx`
  - Added assertions that `Latest first` and `Back to newest` are not rendered.
  - Updated pagination interaction to click the `Load more` button instead of `Load older`.

## Test plan
- `npx vitest run src/app/(dashboard)/settings/audit-log/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 89b71a06](https://143.dev/sessions/89b71a06-db7f-490b-a850-8e4068d736c8)