### PR TITLE
Replace Postgres polling with Redis pub/sub SSE for PR / eval state

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -145,6 +145,13 @@ func main() {
 	}
 	sessionStreams := cache.NewSessionStreams(redisClient, logger, redisMetrics)
 	jobNotifier := cache.NewJobNotifier(redisClient, logger)
+	// Eval batch + bootstrap pub/sub fanout. Constructed once and shared
+	// between the API (for SSE handlers) and the worker (for publishing on
+	// state transitions) so a single connection pool drives both. nil-safe
+	// when redisClient is nil — the SSE returns 503 and the worker's
+	// publishEvalBatchSignal helper skips publish.
+	evalBatchStreams := cache.NewEvalBatchStreams(redisClient, logger)
+	evalBootstrapStreams := cache.NewEvalBootstrapStreams(redisClient, logger)
 
 	// Create codex auth service (shared between router and orchestrator).
 	var cryptoSvc *crypto.Service
@@ -370,6 +377,11 @@ func main() {
 				sessionMessageStore, automationRunStore, snapshotStore, billingMetrics, cancelRegistry, orgSettingsCache)
 			if services != nil {
 				sandboxAuthShutdown = services.SandboxAuthShutdown
+				// Wire eval pub/sub publishers so worker handlers can wake
+				// the API SSE subscribers on every state transition without
+				// the API having to poll Postgres.
+				services.EvalBatchStreams = evalBatchStreams
+				services.EvalBootstrapStreams = evalBootstrapStreams
 				workerServices = services
 			}
 		}

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1993,22 +1993,17 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
   });
 
-  // PR state for the detail-panel header button
+  // PR state for the detail-panel header button. Refetched on demand by the
+  // pr_creation_state and pr_push_state effects below when the session SSE
+  // reports a transition to `succeeded` (worker has written the PR row) or
+  // `failed`. The session status stream is the source of truth for the state
+  // machine, so a separate poll on this endpoint would just duplicate load on
+  // Postgres without any latency win — Redis pub/sub already pushes the
+  // transition within milliseconds, and the SSE polling fallback re-reads the
+  // session row on a 1s tick when Redis is unavailable.
   const { data: prData } = useQuery({
     queryKey: ["session", id, "pr"],
     queryFn: () => api.sessions.getPR(id),
-    refetchInterval: (q) => {
-      const serverState = data?.data?.pr_creation_state;
-      const optimisticWaitingForPR =
-        localPRState !== "idle" && serverState !== "failed" && serverState !== "succeeded";
-      const waitingForPR =
-        optimisticWaitingForPR ||
-        serverState === "queued" ||
-        serverState === "pushing" ||
-        serverState === "succeeded";
-
-      return waitingForPR && !q.state.data?.data ? 2000 : false;
-    },
   });
   const pullRequestId = prData?.data?.id;
   const { data: prHealthData, isLoading: isPRHealthLoading } = useQuery({

--- a/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
@@ -8,13 +8,13 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { getActiveOrgId } from "@/lib/active-org";
 import { buildEvalBatchStreamURL, SSE_EVENT } from "@/lib/sse";
-import { useEvalSSE } from "@/lib/use-eval-sse";
+import { shouldSubscribeToEvalBatchStream, useEvalSSE } from "@/lib/use-eval-sse";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
-import type { EvalBatchDetail, EvalRun, EvalTask, ListResponse } from "@/lib/types";
+import type { EvalBatchDetail, EvalRun, EvalTask, ListResponse, SingleResponse } from "@/lib/types";
 import { evalRunStatusConfig } from "@/lib/types";
 
 // Slow polling backstop while SSE is the primary update channel. Keeps the
@@ -30,6 +30,9 @@ export default function BatchDetailPage() {
   const params = useParams();
   const batchId = params.id as string;
   const queryClient = useQueryClient();
+  const cachedBatch = queryClient.getQueryData<SingleResponse<EvalBatchDetail>>(
+    queryKeys.evals.batch(batchId),
+  )?.data;
 
   // Per-batch SSE subscription. Invalidates the detail query on each event
   // so React Query refetches the full EvalBatchDetail (batch + runs). The
@@ -37,10 +40,10 @@ export default function BatchDetailPage() {
   // partial state into the cache because the matrix needs the full runs
   // array — a single GET keeps the rendering path simple.
   const sseURL = useMemo(() => {
-    if (!batchId) return null;
+    if (!batchId || !shouldSubscribeToEvalBatchStream(cachedBatch?.status)) return null;
     const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
     return buildEvalBatchStreamURL(apiBase, batchId, getActiveOrgId());
-  }, [batchId]);
+  }, [batchId, cachedBatch?.status]);
   const onBatchEvent = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: queryKeys.evals.batch(batchId) });
   }, [queryClient, batchId]);

--- a/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/batch/[id]/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
+import { getActiveOrgId } from "@/lib/active-org";
+import { buildEvalBatchStreamURL, SSE_EVENT } from "@/lib/sse";
+import { useEvalSSE } from "@/lib/use-eval-sse";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { PageContainer } from "@/components/page-container";
@@ -14,16 +17,46 @@ import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
 import type { EvalBatchDetail, EvalRun, EvalTask, ListResponse } from "@/lib/types";
 import { evalRunStatusConfig } from "@/lib/types";
 
+// Slow polling backstop while SSE is the primary update channel. Keeps the
+// matrix correct in the rare event a Redis publish is dropped (network
+// blip on the publish side, subscription disconnect that re-establishes
+// after the missed event) without doing anything close to the prior 5s
+// load on Postgres. When SSE itself is unavailable (Redis down) we drop
+// back to the original 5s cadence — see streamHealthy from useEvalSSE.
+const SSE_BACKSTOP_POLL_MS = 30_000;
+const SSE_DOWN_POLL_MS = 5_000;
+
 export default function BatchDetailPage() {
   const params = useParams();
   const batchId = params.id as string;
+  const queryClient = useQueryClient();
+
+  // Per-batch SSE subscription. Invalidates the detail query on each event
+  // so React Query refetches the full EvalBatchDetail (batch + runs). The
+  // event itself carries only batch_id + status, but we don't try to merge
+  // partial state into the cache because the matrix needs the full runs
+  // array — a single GET keeps the rendering path simple.
+  const sseURL = useMemo(() => {
+    if (!batchId) return null;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+    return buildEvalBatchStreamURL(apiBase, batchId, getActiveOrgId());
+  }, [batchId]);
+  const onBatchEvent = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: queryKeys.evals.batch(batchId) });
+  }, [queryClient, batchId]);
+  const { healthy: streamHealthy } = useEvalSSE({
+    url: sseURL,
+    event: SSE_EVENT.EVAL_BATCH_UPDATED,
+    onEvent: onBatchEvent,
+  });
 
   const { data: batchResponse, isLoading } = useQuery({
     queryKey: queryKeys.evals.batch(batchId),
     queryFn: () => api.evals.getBatch(batchId),
     refetchInterval: (query) => {
       const batch = query.state.data?.data;
-      return batch && batch.status !== "completed" ? 5000 : false;
+      if (!batch || batch.status === "completed") return false;
+      return streamHealthy ? SSE_BACKSTOP_POLL_MS : SSE_DOWN_POLL_MS;
     },
   });
 

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { api } from "@/lib/api";
@@ -38,7 +38,8 @@ import {
 import { FlaskConical, Plus, Loader2, GitPullRequest, AlertTriangle, Layers, CheckCircle2, XCircle, Eye, RotateCw } from "lucide-react";
 import type { EvalTask, EvalBatch, EvalTaskSource, EvalBootstrapRun, EvalBootstrapStatus, ListResponse, Repository, SessionLog } from "@/lib/types";
 import { evalComplexityConfig, evalSourceConfig } from "@/lib/types";
-import { addSSEListener, SSE_EVENT, buildSessionLogsStreamURL } from "@/lib/sse";
+import { addSSEListener, SSE_EVENT, buildEvalBootstrapStreamURL, buildSessionLogsStreamURL } from "@/lib/sse";
+import { useEvalSSE } from "@/lib/use-eval-sse";
 import { getActiveOrgId } from "@/lib/active-org";
 
 type SourceFilter = "all" | EvalTaskSource | "archived";
@@ -110,14 +111,35 @@ export default function EvalsSettingsPage() {
   })();
   const effectiveBootstrapRunId = activeBootstrapRunId ?? latestActiveId;
 
-  // Poll for active bootstrap run status.
+  // SSE-driven bootstrap status with a polling backstop. The SSE wakes the
+  // page on every state transition so the user sees progress within ms; the
+  // backstop only fires when SSE itself is unavailable (Redis down) or has
+  // briefly disconnected, in which case we fall back to the original 3s
+  // cadence so the UI still updates while Redis is recovering.
+  const bootstrapSSEURL = useMemo(() => {
+    if (!effectiveBootstrapRunId) return null;
+    const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+    return buildEvalBootstrapStreamURL(apiBase, effectiveBootstrapRunId, getActiveOrgId());
+  }, [effectiveBootstrapRunId]);
+  const onBootstrapEvent = useCallback(() => {
+    if (!effectiveBootstrapRunId) return;
+    queryClient.invalidateQueries({ queryKey: queryKeys.evals.bootstrapRun(effectiveBootstrapRunId) });
+  }, [queryClient, effectiveBootstrapRunId]);
+  const { healthy: bootstrapStreamHealthy } = useEvalSSE({
+    url: bootstrapSSEURL,
+    event: SSE_EVENT.EVAL_BOOTSTRAP_UPDATED,
+    onEvent: onBootstrapEvent,
+  });
+
   const { data: activeBootstrapResponse } = useQuery({
     queryKey: queryKeys.evals.bootstrapRun(effectiveBootstrapRunId ?? ""),
     queryFn: () => api.evals.getBootstrapCandidates({ bootstrap_run_id: effectiveBootstrapRunId! }),
     enabled: !!effectiveBootstrapRunId,
     refetchInterval: (query) => {
       const status = query.state.data?.data?.status;
-      return status && isBootstrapActive(status) ? 3000 : false;
+      if (!status || !isBootstrapActive(status)) return false;
+      // 30s backstop while SSE is healthy; 3s when SSE is down.
+      return bootstrapStreamHealthy ? 30_000 : 3_000;
     },
   });
   const activeBootstrap = activeBootstrapResponse?.data;

--- a/frontend/src/app/(dashboard)/settings/evals/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/evals/page.tsx
@@ -36,10 +36,10 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { FlaskConical, Plus, Loader2, GitPullRequest, AlertTriangle, Layers, CheckCircle2, XCircle, Eye, RotateCw } from "lucide-react";
-import type { EvalTask, EvalBatch, EvalTaskSource, EvalBootstrapRun, EvalBootstrapStatus, ListResponse, Repository, SessionLog } from "@/lib/types";
+import type { EvalTask, EvalBatch, EvalTaskSource, EvalBootstrapRun, EvalBootstrapStatus, ListResponse, Repository, SessionLog, SingleResponse } from "@/lib/types";
 import { evalComplexityConfig, evalSourceConfig } from "@/lib/types";
 import { addSSEListener, SSE_EVENT, buildEvalBootstrapStreamURL, buildSessionLogsStreamURL } from "@/lib/sse";
-import { useEvalSSE } from "@/lib/use-eval-sse";
+import { shouldSubscribeToEvalBootstrapStream, useEvalSSE } from "@/lib/use-eval-sse";
 import { getActiveOrgId } from "@/lib/active-org";
 
 type SourceFilter = "all" | EvalTaskSource | "archived";
@@ -110,6 +110,9 @@ export default function EvalsSettingsPage() {
     return latest && isBootstrapActive(latest.status) ? latest.id : null;
   })();
   const effectiveBootstrapRunId = activeBootstrapRunId ?? latestActiveId;
+  const cachedBootstrap = queryClient.getQueryData<SingleResponse<EvalBootstrapRun>>(
+    queryKeys.evals.bootstrapRun(effectiveBootstrapRunId ?? ""),
+  )?.data;
 
   // SSE-driven bootstrap status with a polling backstop. The SSE wakes the
   // page on every state transition so the user sees progress within ms; the
@@ -117,10 +120,15 @@ export default function EvalsSettingsPage() {
   // briefly disconnected, in which case we fall back to the original 3s
   // cadence so the UI still updates while Redis is recovering.
   const bootstrapSSEURL = useMemo(() => {
-    if (!effectiveBootstrapRunId) return null;
+    if (
+      !effectiveBootstrapRunId ||
+      !shouldSubscribeToEvalBootstrapStream(cachedBootstrap?.status)
+    ) {
+      return null;
+    }
     const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
     return buildEvalBootstrapStreamURL(apiBase, effectiveBootstrapRunId, getActiveOrgId());
-  }, [effectiveBootstrapRunId]);
+  }, [effectiveBootstrapRunId, cachedBootstrap?.status]);
   const onBootstrapEvent = useCallback(() => {
     if (!effectiveBootstrapRunId) return;
     queryClient.invalidateQueries({ queryKey: queryKeys.evals.bootstrapRun(effectiveBootstrapRunId) });

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,4 +1,10 @@
-import type { PullRequestUpdatedEvent, Session, SessionLog } from "./types";
+import type {
+  EvalBatchUpdatedEvent,
+  EvalBootstrapUpdatedEvent,
+  PullRequestUpdatedEvent,
+  Session,
+  SessionLog,
+} from "./types";
 import { captureError } from "./errors";
 
 // EventSource cannot send custom headers like X-Active-Org-ID. The backend
@@ -35,6 +41,36 @@ export function buildPullRequestStreamURL(
   return `${apiBase}/api/v1/pull-requests/stream${qs ? `?${qs}` : ""}`;
 }
 
+// Per-batch SSE that wakes whenever an eval batch or one of its runs flips
+// state. Replaces the prior 5s React Query poll on /evals/batch/{id}.
+export function buildEvalBatchStreamURL(
+  apiBase: string,
+  batchId: string,
+  activeOrgId: string | null,
+): string {
+  const searchParams = new URLSearchParams();
+  if (activeOrgId) {
+    searchParams.set("org_id", activeOrgId);
+  }
+  const qs = searchParams.toString();
+  return `${apiBase}/api/v1/evals/batch/${batchId}/stream${qs ? `?${qs}` : ""}`;
+}
+
+// Per-bootstrap-run SSE that wakes whenever a bootstrap run flips state.
+// Replaces the prior 3s React Query poll on /evals/bootstrap/candidates.
+export function buildEvalBootstrapStreamURL(
+  apiBase: string,
+  runId: string,
+  activeOrgId: string | null,
+): string {
+  const searchParams = new URLSearchParams();
+  if (activeOrgId) {
+    searchParams.set("org_id", activeOrgId);
+  }
+  const qs = searchParams.toString();
+  return `${apiBase}/api/v1/evals/bootstrap/${runId}/stream${qs ? `?${qs}` : ""}`;
+}
+
 /**
  * SSE event types emitted by the session log stream.
  * Must stay in sync with the backend sse.EventType constants.
@@ -48,6 +84,10 @@ export const SSE_EVENT = {
   DONE: "done",
   /** Sent when a pull request health snapshot is updated. */
   PULL_REQUEST_UPDATED: "pull_request.updated",
+  /** Sent when an eval batch or one of its runs changes state. */
+  EVAL_BATCH_UPDATED: "eval_batch.updated",
+  /** Sent when an eval bootstrap run changes state. */
+  EVAL_BOOTSTRAP_UPDATED: "eval_bootstrap.updated",
 } as const;
 
 export type SSEEventType = (typeof SSE_EVENT)[keyof typeof SSE_EVENT];
@@ -58,6 +98,8 @@ export interface SSEEventPayloads {
   [SSE_EVENT.STATUS]: Session;
   [SSE_EVENT.DONE]: Session;
   [SSE_EVENT.PULL_REQUEST_UPDATED]: PullRequestUpdatedEvent;
+  [SSE_EVENT.EVAL_BATCH_UPDATED]: EvalBatchUpdatedEvent;
+  [SSE_EVENT.EVAL_BOOTSTRAP_UPDATED]: EvalBootstrapUpdatedEvent;
 }
 
 /** Type-safe event listener adder for session SSE streams. */

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1215,6 +1215,27 @@ export interface EvalBootstrapRun {
   error_message?: string;
 }
 
+// Lightweight signal arriving over the per-batch SSE stream. Mirrors
+// models.EvalBatchUpdatedEvent. Consumers refetch the full EvalBatchDetail on
+// receipt rather than reading fields from the event itself, so payload size
+// stays bounded for large batches.
+export interface EvalBatchUpdatedEvent {
+  batch_id: string;
+  org_id: string;
+  status: EvalBatchStatus;
+  updated_at: string;
+}
+
+// Lightweight signal arriving over the per-bootstrap-run SSE stream. Mirrors
+// models.EvalBootstrapUpdatedEvent.
+export interface EvalBootstrapUpdatedEvent {
+  bootstrap_run_id: string;
+  org_id: string;
+  status: EvalBootstrapStatus;
+  session_id?: string;
+  updated_at: string;
+}
+
 export const evalComplexityConfig: Record<EvalComplexity, { color: string; label: string }> = {
   trivial: { color: "bg-muted text-muted-foreground", label: "Trivial" },
   simple: { color: "bg-emerald-500/10 text-emerald-700 dark:text-emerald-400", label: "Simple" },

--- a/frontend/src/lib/use-eval-sse.test.ts
+++ b/frontend/src/lib/use-eval-sse.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  shouldSubscribeToEvalBatchStream,
+  shouldSubscribeToEvalBootstrapStream,
+} from "./use-eval-sse";
+
+describe("eval SSE stream subscription gating", () => {
+  it("keeps batch streams only for active batch statuses", () => {
+    expect(shouldSubscribeToEvalBatchStream("pending")).toBe(true);
+    expect(shouldSubscribeToEvalBatchStream("running")).toBe(true);
+    expect(shouldSubscribeToEvalBatchStream("completed")).toBe(false);
+    expect(shouldSubscribeToEvalBatchStream("failed")).toBe(false);
+    expect(shouldSubscribeToEvalBatchStream(undefined)).toBe(false);
+  });
+
+  it("keeps bootstrap streams only for active bootstrap statuses", () => {
+    expect(shouldSubscribeToEvalBootstrapStream("pending")).toBe(true);
+    expect(shouldSubscribeToEvalBootstrapStream("running")).toBe(true);
+    expect(shouldSubscribeToEvalBootstrapStream("completed")).toBe(false);
+    expect(shouldSubscribeToEvalBootstrapStream("failed")).toBe(false);
+    expect(shouldSubscribeToEvalBootstrapStream(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/lib/use-eval-sse.ts
+++ b/frontend/src/lib/use-eval-sse.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { addSSEListener, type SSEEventPayloads } from "./sse";
+import type { EvalBatchStatus, EvalBootstrapStatus } from "./types";
 
 // Connect cadence shared between the two eval SSE consumers (batch detail
 // page + bootstrap detail sheet). Capped exponential backoff (1s → 2s → 4s
@@ -11,6 +12,14 @@ import { addSSEListener, type SSEEventPayloads } from "./sse";
 const SSE_INITIAL_RECONNECT_DELAY_MS = 1_000;
 const SSE_MAX_RECONNECT_DELAY_MS = 15_000;
 const SSE_MAX_RECONNECT_ATTEMPTS = 5;
+
+export function shouldSubscribeToEvalBatchStream(status: EvalBatchStatus | undefined): boolean {
+  return status === "pending" || status === "running";
+}
+
+export function shouldSubscribeToEvalBootstrapStream(status: EvalBootstrapStatus | undefined): boolean {
+  return status === "pending" || status === "running";
+}
 
 export interface UseEvalSSEOptions<K extends keyof SSEEventPayloads> {
   /**

--- a/frontend/src/lib/use-eval-sse.ts
+++ b/frontend/src/lib/use-eval-sse.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { addSSEListener, type SSEEventPayloads } from "./sse";
+
+// Connect cadence shared between the two eval SSE consumers (batch detail
+// page + bootstrap detail sheet). Capped exponential backoff (1s → 2s → 4s
+// → 8s → 15s ceiling) so a transient Redis outage doesn't burn into the
+// page lifecycle, but a sustained outage hands off to the polling backstop
+// in the calling component without retrying forever.
+const SSE_INITIAL_RECONNECT_DELAY_MS = 1_000;
+const SSE_MAX_RECONNECT_DELAY_MS = 15_000;
+const SSE_MAX_RECONNECT_ATTEMPTS = 5;
+
+export interface UseEvalSSEOptions<K extends keyof SSEEventPayloads> {
+  /**
+   * Fully-qualified SSE URL (typically built by buildEvalBatchStreamURL or
+   * buildEvalBootstrapStreamURL). Pass null when there's nothing to
+   * subscribe to (e.g. no active bootstrap run); the hook stays idle and
+   * the previous connection is torn down on transition.
+   */
+  url: string | null;
+  /** SSE event name to listen for, e.g. SSE_EVENT.EVAL_BATCH_UPDATED. */
+  event: K;
+  /**
+   * Fires on every received event. Typically just a queryClient.invalidate.
+   * Don't read fields off the payload to drive UI state — Redis pub/sub is
+   * at-most-once and unordered, so the canonical record fetched on
+   * invalidation is the source of truth.
+   */
+  onEvent: (payload: SSEEventPayloads[K]) => void;
+}
+
+export interface UseEvalSSEResult {
+  /**
+   * True after EventSource.onopen fires; flips to false on any error so
+   * callers can drive a faster polling backstop while Redis recovers.
+   * Never resets to true on its own when there's no URL — there's nothing
+   * to be healthy or unhealthy about, so the previous value sticks until
+   * the next subscription opens.
+   */
+  healthy: boolean;
+}
+
+/**
+ * useEvalSSE wires an EventSource for the eval batch / bootstrap SSE
+ * channels with capped exponential reconnect and stream-health tracking.
+ * Extracted so the batch detail page and the evals page share one
+ * implementation — see batch/[id]/page.tsx and settings/evals/page.tsx.
+ */
+export function useEvalSSE<K extends keyof SSEEventPayloads>({
+  url,
+  event,
+  onEvent,
+}: UseEvalSSEOptions<K>): UseEvalSSEResult {
+  const [healthy, setHealthy] = useState(true);
+
+  useEffect(() => {
+    if (!url) return;
+
+    let eventSource: EventSource | null = null;
+    let cancelled = false;
+    let reconnectAttempts = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    function connect() {
+      if (cancelled) return;
+      eventSource = new EventSource(url!, { withCredentials: true });
+
+      eventSource.onopen = () => {
+        reconnectAttempts = 0;
+        setHealthy(true);
+      };
+
+      addSSEListener(eventSource, event, onEvent);
+
+      eventSource.onerror = () => {
+        eventSource?.close();
+        setHealthy(false);
+        if (cancelled || reconnectAttempts >= SSE_MAX_RECONNECT_ATTEMPTS) {
+          return;
+        }
+        const delay = Math.min(
+          SSE_INITIAL_RECONNECT_DELAY_MS * 2 ** reconnectAttempts,
+          SSE_MAX_RECONNECT_DELAY_MS,
+        );
+        reconnectAttempts += 1;
+        reconnectTimer = setTimeout(connect, delay);
+      };
+    }
+
+    connect();
+
+    return () => {
+      cancelled = true;
+      eventSource?.close();
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+    };
+  }, [url, event, onEvent]);
+
+  return { healthy };
+}

--- a/internal/api/handlers/eval.go
+++ b/internal/api/handlers/eval.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,8 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/api/sse"
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
@@ -18,14 +21,32 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// evalMembershipStore is the org-membership lookup the eval SSE handlers use
+// to validate explicit ?org_id= query params from EventSource clients (which
+// can't send custom request headers). Mirrors pullRequestMembershipStore in
+// pull_requests.go — kept as a local interface so tests can stub it without
+// pulling in a full membership store implementation.
+type evalMembershipStore interface {
+	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
+}
+
+var (
+	errEvalStreamOrgInvalid   = errors.New("invalid eval stream org")
+	errEvalStreamOrgForbidden = errors.New("forbidden eval stream org")
+	errEvalStreamUnauthorized = errors.New("unauthorized eval stream request")
+)
+
 type EvalHandler struct {
-	taskStore      *db.EvalTaskStore
-	runStore       *db.EvalRunStore
-	batchStore     *db.EvalBatchStore
-	bootstrapStore *db.EvalBootstrapStore
-	jobStore       *db.JobStore
-	txStarter      db.TxStarter
-	audit          *db.AuditEmitter
+	taskStore        *db.EvalTaskStore
+	runStore         *db.EvalRunStore
+	batchStore       *db.EvalBatchStore
+	bootstrapStore   *db.EvalBootstrapStore
+	jobStore         *db.JobStore
+	txStarter        db.TxStarter
+	audit            *db.AuditEmitter
+	batchStreams     *cache.EvalBatchStreams
+	bootstrapStreams *cache.EvalBootstrapStreams
+	memberships      evalMembershipStore
 }
 
 func NewEvalHandler(taskStore *db.EvalTaskStore, runStore *db.EvalRunStore, batchStore *db.EvalBatchStore, bootstrapStore *db.EvalBootstrapStore, jobStore *db.JobStore, txStarter db.TxStarter) *EvalHandler {
@@ -41,6 +62,99 @@ func NewEvalHandler(taskStore *db.EvalTaskStore, runStore *db.EvalRunStore, batc
 
 func (h *EvalHandler) SetAuditEmitter(audit *db.AuditEmitter) {
 	h.audit = audit
+}
+
+// SetBatchStreams wires the Redis-backed batch update fanout. Setting nil
+// (or never calling this) disables the SSE endpoint and forces clients to
+// fall back to the existing polling path.
+func (h *EvalHandler) SetBatchStreams(streams *cache.EvalBatchStreams) {
+	h.batchStreams = streams
+}
+
+// SetBootstrapStreams is the bootstrap (PR-history scan) counterpart to
+// SetBatchStreams.
+func (h *EvalHandler) SetBootstrapStreams(streams *cache.EvalBootstrapStreams) {
+	h.bootstrapStreams = streams
+}
+
+// SetMembershipStore wires the org-membership store used by the SSE handlers
+// to validate explicit ?org_id= query params for multi-org users on
+// EventSource (which can't send X-Active-Org-ID).
+func (h *EvalHandler) SetMembershipStore(store evalMembershipStore) {
+	h.memberships = store
+}
+
+// publishBatchSignal exists separately from the worker's identical helper
+// because the API and the worker live in different packages and pass
+// different services structs through their call stacks. The worker uses
+// publishEvalBatchSignal in worker/handlers.go; this handler-side variant
+// fires from the StartBatch HTTP path so the user lands on the detail page
+// with an event already in flight rather than waiting for the first run
+// transition.
+func (h *EvalHandler) publishBatchSignal(ctx context.Context, orgID, batchID uuid.UUID, status models.EvalBatchStatus) {
+	if h.batchStreams == nil || batchID == uuid.Nil {
+		return
+	}
+	if err := h.batchStreams.PublishUpdated(ctx, models.EvalBatchUpdatedEvent{
+		BatchID:   batchID,
+		OrgID:     orgID,
+		Status:    status,
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).Str("batch_id", batchID.String()).Msg("failed to publish eval batch update event")
+	}
+}
+
+func (h *EvalHandler) publishBootstrapSignal(ctx context.Context, orgID, runID uuid.UUID, status models.EvalBootstrapStatus, sessionID *uuid.UUID) {
+	if h.bootstrapStreams == nil || runID == uuid.Nil {
+		return
+	}
+	if err := h.bootstrapStreams.PublishUpdated(ctx, models.EvalBootstrapUpdatedEvent{
+		BootstrapRunID: runID,
+		OrgID:          orgID,
+		Status:         status,
+		SessionID:      sessionID,
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).Str("bootstrap_run_id", runID.String()).Msg("failed to publish eval bootstrap update event")
+	}
+}
+
+// streamOrgIDFromRequest mirrors pull_requests.go:streamOrgIDFromRequest.
+// EventSource clients can't send X-Active-Org-ID headers, so multi-org users
+// pass ?org_id= as a query string and we membership-check it here. Without
+// this, a user whose session-hint last_org_id differs from their actively-
+// viewed org would 404 on the SSE handshake.
+func (h *EvalHandler) streamOrgIDFromRequest(r *http.Request) (uuid.UUID, error) {
+	orgID := middleware.OrgIDFromContext(r.Context())
+	requestedRaw := strings.TrimSpace(r.URL.Query().Get("org_id"))
+	if requestedRaw == "" {
+		return orgID, nil
+	}
+
+	requestedOrgID, err := uuid.Parse(requestedRaw)
+	if err != nil {
+		return uuid.Nil, errEvalStreamOrgInvalid
+	}
+	if requestedOrgID == orgID {
+		return requestedOrgID, nil
+	}
+
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		return uuid.Nil, errEvalStreamUnauthorized
+	}
+	if h.memberships == nil {
+		return uuid.Nil, errors.New("membership store not configured")
+	}
+	if _, err := h.memberships.Get(r.Context(), user.ID, requestedOrgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, errEvalStreamOrgForbidden
+		}
+		return uuid.Nil, err
+	}
+
+	return requestedOrgID, nil
 }
 
 // validGitSHA matches a hex string of 4-40 characters (short or full SHA).
@@ -737,6 +851,11 @@ func (h *EvalHandler) StartBatch(w http.ResponseWriter, r *http.Request) {
 			marshalAuditDetails(*zerolog.Ctx(r.Context()), evalBatchAuditDetails(&batch, req.TaskIDs, len(req.Configs))))
 	}
 
+	// Wake any in-flight detail-page SSE subscribers (e.g. the user who just
+	// hit "Start batch" and is being redirected) so they don't have to wait
+	// for the first run state transition before seeing the new batch.
+	h.publishBatchSignal(r.Context(), orgID, batch.ID, batch.Status)
+
 	writeJSON(w, http.StatusCreated, models.SingleResponse[models.EvalBatch]{Data: batch})
 }
 
@@ -791,6 +910,117 @@ func (h *EvalHandler) GetBatch(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.EvalBatchDetail]{Data: detail})
 }
 
+// StreamBatchUpdates serves a per-batch SSE stream that emits an event each
+// time an EvalBatchUpdatedEvent for this batch arrives over Redis pub/sub.
+// The frontend uses this to replace the prior 5s React Query poll on
+// /evals/batch/{batchId}; on receipt of an event the client invalidates its
+// detail-query cache, which fetches the full EvalBatchDetail (batch + runs).
+//
+// Authorization: the request goes through the org-scoped middleware chain.
+// EventSource clients can't send X-Active-Org-ID, so multi-org users pass
+// ?org_id= and we membership-check it via streamOrgIDFromRequest (mirrors
+// pull_requests.go). The batch is then verified to belong to the resolved
+// org via batchStore.GetByID before the SSE handshake completes — failing
+// fast keeps the error path symmetric with the REST GET handler and prevents
+// callers from probing other orgs' batch IDs over the SSE channel.
+//
+// Channel scoping: the Redis pub/sub channel is keyed per batch
+// (`{batch:UUID}:eval_batches`), so the subscription only receives events
+// for the batch this client is watching — no server-side filter required
+// and no cross-batch fanout cost.
+//
+// Connection lifetime: the auth check is one-shot at handshake. If the
+// batch is deleted mid-stream the connection stays open and the per-batch
+// pub/sub channel simply goes silent until the request context is canceled
+// (browser navigation, logout, or proxy idle timeout). Mirrors the pull-
+// request stream's behavior; revisit if/when batch deletion becomes a
+// surfaced UX action.
+//
+// Degraded mode: if streams are not configured (no Redis) or the circuit
+// breaker is open, this returns 503. The frontend treats 503 as "fall back
+// to polling" rather than a fatal error so the user still sees progress
+// while Redis is recovering.
+func (h *EvalHandler) StreamBatchUpdates(w http.ResponseWriter, r *http.Request) {
+	if h.batchStreams == nil || !h.batchStreams.Available() {
+		http.Error(w, "eval batch streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	// Satisfy the org-scoping lint (org_id_lint_test.go) — the real
+	// resolution happens inside streamOrgIDFromRequest below, which can
+	// promote a query-string ?org_id= for multi-org users on EventSource.
+	_ = middleware.OrgIDFromContext(r.Context())
+
+	batchID, err := uuid.Parse(chi.URLParam(r, "batchId"))
+	if err != nil {
+		http.Error(w, "invalid batch ID", http.StatusBadRequest)
+		return
+	}
+
+	orgID, err := h.streamOrgIDFromRequest(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errEvalStreamOrgInvalid):
+			http.Error(w, "invalid eval stream org", http.StatusBadRequest)
+		case errors.Is(err, errEvalStreamOrgForbidden):
+			http.Error(w, "forbidden eval stream org", http.StatusForbidden)
+		case errors.Is(err, errEvalStreamUnauthorized):
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		default:
+			http.Error(w, "failed to authorize eval stream", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if _, err := h.batchStore.GetByID(r.Context(), orgID, batchID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "eval batch not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to load eval batch", http.StatusInternalServerError)
+		return
+	}
+
+	sw := sse.NewWriter(w)
+	if sw == nil {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	sub, err := h.batchStreams.Subscribe(batchID)
+	if err != nil {
+		http.Error(w, "eval batch streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer sub.Close()
+
+	logger := zerolog.Ctx(r.Context())
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if err := sw.WriteHeartbeat(); err != nil {
+				logger.Warn().Err(err).Msg("failed to write eval batch stream heartbeat")
+				return
+			}
+			sw.Flush()
+		case event, ok := <-sub.C:
+			if !ok {
+				logger.Warn().Str("reason", sub.CloseReason()).Msg("eval batch update subscription closed")
+				return
+			}
+			if err := sw.WriteEvent(sse.EventType("eval_batch.updated"), event); err != nil {
+				logger.Warn().Err(err).Str("batch_id", event.BatchID.String()).Msg("failed to write eval batch update event")
+				return
+			}
+			sw.Flush()
+		}
+	}
+}
+
 // --- Bootstrap ---
 
 // Bootstrap triggers a PR history scan to discover eval task candidates.
@@ -831,6 +1061,10 @@ func (h *EvalHandler) Bootstrap(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue bootstrap job", err)
 		return
 	}
+
+	// Publish the initial pending event so the bootstrap detail sheet can
+	// render an empty-but-active state without polling for the first signal.
+	h.publishBootstrapSignal(r.Context(), orgID, run.ID, run.Status, run.SessionID)
 
 	writeJSON(w, http.StatusAccepted, models.SingleResponse[models.EvalBootstrapRun]{Data: run})
 }
@@ -880,6 +1114,90 @@ func (h *EvalHandler) GetBootstrapCandidates(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.EvalBootstrapRun]{Data: run})
+}
+
+// StreamBootstrapUpdates serves a per-bootstrap-run SSE stream that wakes
+// whenever an EvalBootstrapUpdatedEvent for this run arrives over Redis
+// pub/sub. Replaces the prior 3s React Query poll on the bootstrap detail
+// sheet. Same authorization, channel-scoping, lifetime, and degraded-mode
+// semantics as StreamBatchUpdates above.
+func (h *EvalHandler) StreamBootstrapUpdates(w http.ResponseWriter, r *http.Request) {
+	if h.bootstrapStreams == nil || !h.bootstrapStreams.Available() {
+		http.Error(w, "eval bootstrap streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	// See StreamBatchUpdates — same lint-satisfying pattern.
+	_ = middleware.OrgIDFromContext(r.Context())
+
+	runID, err := uuid.Parse(chi.URLParam(r, "runId"))
+	if err != nil {
+		http.Error(w, "invalid bootstrap run ID", http.StatusBadRequest)
+		return
+	}
+
+	orgID, err := h.streamOrgIDFromRequest(r)
+	if err != nil {
+		switch {
+		case errors.Is(err, errEvalStreamOrgInvalid):
+			http.Error(w, "invalid eval stream org", http.StatusBadRequest)
+		case errors.Is(err, errEvalStreamOrgForbidden):
+			http.Error(w, "forbidden eval stream org", http.StatusForbidden)
+		case errors.Is(err, errEvalStreamUnauthorized):
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		default:
+			http.Error(w, "failed to authorize eval stream", http.StatusInternalServerError)
+		}
+		return
+	}
+
+	if _, err := h.bootstrapStore.GetByID(r.Context(), orgID, runID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			http.Error(w, "bootstrap run not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, "failed to load bootstrap run", http.StatusInternalServerError)
+		return
+	}
+
+	sw := sse.NewWriter(w)
+	if sw == nil {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	sub, err := h.bootstrapStreams.Subscribe(runID)
+	if err != nil {
+		http.Error(w, "eval bootstrap streams unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	defer sub.Close()
+
+	logger := zerolog.Ctx(r.Context())
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-heartbeat.C:
+			if err := sw.WriteHeartbeat(); err != nil {
+				logger.Warn().Err(err).Msg("failed to write eval bootstrap stream heartbeat")
+				return
+			}
+			sw.Flush()
+		case event, ok := <-sub.C:
+			if !ok {
+				logger.Warn().Str("reason", sub.CloseReason()).Msg("eval bootstrap update subscription closed")
+				return
+			}
+			if err := sw.WriteEvent(sse.EventType("eval_bootstrap.updated"), event); err != nil {
+				logger.Warn().Err(err).Str("bootstrap_run_id", event.BootstrapRunID.String()).Msg("failed to write eval bootstrap update event")
+				return
+			}
+			sw.Flush()
+		}
+	}
 }
 
 // AcceptBootstrapCandidates creates eval tasks from selected bootstrap candidates.

--- a/internal/api/handlers/eval_test.go
+++ b/internal/api/handlers/eval_test.go
@@ -10,13 +10,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
 
@@ -2653,4 +2656,318 @@ func TestEvalHandler_StartBatch_Validation(t *testing.T) {
 		require.Contains(t, w.Body.String(), "MISSING_FIELD")
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
+
+// --- SSE: StreamBatchUpdates / StreamBootstrapUpdates ---
+
+// stubEvalMembershipStore lets the SSE handler tests exercise cross-org
+// validation without bringing up a real OrganizationMembershipStore. Mirrors
+// stubPullRequestMembershipStore in pull_requests_test.go.
+type stubEvalMembershipStore struct {
+	getFunc func(context.Context, uuid.UUID, uuid.UUID) (models.OrganizationMembership, error)
+}
+
+func (s *stubEvalMembershipStore) Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error) {
+	return s.getFunc(ctx, userID, orgID)
+}
+
+func newTestEvalStreams(t *testing.T) (*cache.EvalBatchStreams, *cache.EvalBootstrapStreams) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	metrics, err := cache.NewMetrics()
+	require.NoError(t, err, "Redis metrics should initialize for SSE tests")
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), metrics)
+	require.NotNil(t, client, "Redis client should initialize for SSE tests")
+	t.Cleanup(func() {
+		closeErr := client.Close()
+		if closeErr != nil && !strings.Contains(closeErr.Error(), "client is closed") {
+			require.NoError(t, closeErr, "eval stream test client should close cleanly")
+		}
+	})
+	return cache.NewEvalBatchStreams(client, zerolog.Nop()), cache.NewEvalBootstrapStreams(client, zerolog.Nop())
+}
+
+func TestEvalHandler_StreamBatchUpdates_AuthAndAvailability(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	otherOrgID := uuid.New()
+
+	tests := []struct {
+		name           string
+		setup          func(*EvalHandler, pgxmock.PgxPoolIface, uuid.UUID)
+		batchID        string
+		query          string
+		expectedCode   int
+		expectedSubstr string
+	}{
+		{
+			name:           "503 when streams missing",
+			setup:          func(h *EvalHandler, _ pgxmock.PgxPoolIface, _ uuid.UUID) {},
+			batchID:        uuid.New().String(),
+			expectedCode:   http.StatusServiceUnavailable,
+			expectedSubstr: "eval batch streams unavailable",
+		},
+		{
+			name: "400 invalid batch ID",
+			setup: func(h *EvalHandler, _ pgxmock.PgxPoolIface, _ uuid.UUID) {
+				batchStreams, _ := newTestEvalStreams(t)
+				h.SetBatchStreams(batchStreams)
+			},
+			batchID:        "not-a-uuid",
+			expectedCode:   http.StatusBadRequest,
+			expectedSubstr: "invalid batch ID",
+		},
+		{
+			name: "400 invalid org_id query string",
+			setup: func(h *EvalHandler, _ pgxmock.PgxPoolIface, _ uuid.UUID) {
+				batchStreams, _ := newTestEvalStreams(t)
+				h.SetBatchStreams(batchStreams)
+			},
+			batchID:        uuid.New().String(),
+			query:          "?org_id=not-a-uuid",
+			expectedCode:   http.StatusBadRequest,
+			expectedSubstr: "invalid eval stream org",
+		},
+		{
+			name: "403 when explicit cross-org membership rejected",
+			setup: func(h *EvalHandler, _ pgxmock.PgxPoolIface, _ uuid.UUID) {
+				batchStreams, _ := newTestEvalStreams(t)
+				h.SetBatchStreams(batchStreams)
+				h.SetMembershipStore(&stubEvalMembershipStore{
+					getFunc: func(context.Context, uuid.UUID, uuid.UUID) (models.OrganizationMembership, error) {
+						return models.OrganizationMembership{}, pgx.ErrNoRows
+					},
+				})
+			},
+			batchID:        uuid.New().String(),
+			query:          "?org_id=" + otherOrgID.String(),
+			expectedCode:   http.StatusForbidden,
+			expectedSubstr: "forbidden eval stream org",
+		},
+		{
+			name: "404 when batch not in resolved org",
+			setup: func(h *EvalHandler, mock pgxmock.PgxPoolIface, _ uuid.UUID) {
+				batchStreams, _ := newTestEvalStreams(t)
+				h.SetBatchStreams(batchStreams)
+				mock.ExpectQuery("SELECT .+ FROM eval_batches WHERE id").
+					WithArgs(anyArgs(2)...).
+					WillReturnRows(pgxmock.NewRows(evalBatchColumns))
+			},
+			batchID:        uuid.New().String(),
+			expectedCode:   http.StatusNotFound,
+			expectedSubstr: "eval batch not found",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should initialize")
+			defer mock.Close()
+
+			handler := newEvalHandler(mock)
+			tt.setup(handler, mock, orgID)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/evals/batch/"+tt.batchID+"/stream"+tt.query, nil)
+			req = req.WithContext(evalCtxWithChi(orgID, userID, map[string]string{"batchId": tt.batchID}))
+			w := httptest.NewRecorder()
+
+			handler.StreamBatchUpdates(w, req)
+
+			require.Equal(t, tt.expectedCode, w.Code, "StreamBatchUpdates should return the expected status")
+			require.Contains(t, w.Body.String(), tt.expectedSubstr, "StreamBatchUpdates should explain the failure mode in the body")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestEvalHandler_StreamBatchUpdates_DeliversPublishedEvent(t *testing.T) {
+	t.Parallel()
+
+	// End-to-end: subscribe via the SSE handler, publish via the cache helper,
+	// confirm the event reaches the response writer with the documented event
+	// type. Locks in the per-batch channel scoping by also publishing for an
+	// unrelated batch and asserting it doesn't leak into the response.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	batchID := uuid.New()
+	otherBatchID := uuid.New()
+	now := time.Now()
+
+	handler := newEvalHandler(mock)
+	batchStreams, _ := newTestEvalStreams(t)
+	handler.SetBatchStreams(batchStreams)
+
+	mock.ExpectQuery("SELECT .+ FROM eval_batches WHERE id").
+		WithArgs(anyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(evalBatchColumns).AddRow(newTestEvalBatchRow(batchID, orgID, &userID, now)...))
+
+	ctx, cancel := context.WithCancel(evalCtxWithChi(orgID, userID, map[string]string{"batchId": batchID.String()}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evals/batch/"+batchID.String()+"/stream", nil).WithContext(ctx)
+	rr := newLockedRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.StreamBatchUpdates(rr, req)
+	}()
+
+	event := models.EvalBatchUpdatedEvent{
+		BatchID:   batchID,
+		OrgID:     orgID,
+		Status:    models.EvalBatchStatusRunning,
+		UpdatedAt: time.Now().UTC(),
+	}
+	otherEvent := models.EvalBatchUpdatedEvent{
+		BatchID:   otherBatchID,
+		OrgID:     orgID,
+		Status:    models.EvalBatchStatusRunning,
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	require.Eventually(t, func() bool {
+		// Publish the cross-batch event first so we'd see it ahead of ours
+		// if the per-batch channel scoping ever regressed.
+		_ = batchStreams.PublishUpdated(context.Background(), otherEvent)
+		_ = batchStreams.PublishUpdated(context.Background(), event)
+		return strings.Contains(rr.BodyString(), "eval_batch.updated")
+	}, 2*time.Second, 20*time.Millisecond, "StreamBatchUpdates should write the per-batch event to the SSE response")
+
+	cancel()
+	<-done
+
+	body := rr.BodyString()
+	require.Contains(t, body, batchID.String(), "SSE response should include the published batch ID")
+	require.NotContains(t, body, otherBatchID.String(), "SSE response must not leak events scoped to other batches")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestEvalHandler_StreamBootstrapUpdates_AuthAndAvailability(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	tests := []struct {
+		name           string
+		setup          func(*EvalHandler, pgxmock.PgxPoolIface)
+		runID          string
+		query          string
+		expectedCode   int
+		expectedSubstr string
+	}{
+		{
+			name:           "503 when streams missing",
+			setup:          func(*EvalHandler, pgxmock.PgxPoolIface) {},
+			runID:          uuid.New().String(),
+			expectedCode:   http.StatusServiceUnavailable,
+			expectedSubstr: "eval bootstrap streams unavailable",
+		},
+		{
+			name: "400 invalid run ID",
+			setup: func(h *EvalHandler, _ pgxmock.PgxPoolIface) {
+				_, bs := newTestEvalStreams(t)
+				h.SetBootstrapStreams(bs)
+			},
+			runID:          "not-a-uuid",
+			expectedCode:   http.StatusBadRequest,
+			expectedSubstr: "invalid bootstrap run ID",
+		},
+		{
+			name: "404 when run not in resolved org",
+			setup: func(h *EvalHandler, mock pgxmock.PgxPoolIface) {
+				_, bs := newTestEvalStreams(t)
+				h.SetBootstrapStreams(bs)
+				mock.ExpectQuery("SELECT .+ FROM eval_bootstrap_runs WHERE id").
+					WithArgs(anyArgs(2)...).
+					WillReturnRows(pgxmock.NewRows(bootstrapRunColumns))
+			},
+			runID:          uuid.New().String(),
+			expectedCode:   http.StatusNotFound,
+			expectedSubstr: "bootstrap run not found",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
+
+			handler := newEvalHandler(mock)
+			tt.setup(handler, mock)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/evals/bootstrap/"+tt.runID+"/stream"+tt.query, nil)
+			req = req.WithContext(evalCtxWithChi(orgID, userID, map[string]string{"runId": tt.runID}))
+			w := httptest.NewRecorder()
+
+			handler.StreamBootstrapUpdates(w, req)
+			require.Equal(t, tt.expectedCode, w.Code)
+			require.Contains(t, w.Body.String(), tt.expectedSubstr)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
+}
+
+func TestEvalHandler_StreamBootstrapUpdates_DeliversPublishedEvent(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	repoID := uuid.New()
+	runID := uuid.New()
+	now := time.Now()
+
+	handler := newEvalHandler(mock)
+	_, bootstrapStreams := newTestEvalStreams(t)
+	handler.SetBootstrapStreams(bootstrapStreams)
+
+	mock.ExpectQuery("SELECT .+ FROM eval_bootstrap_runs WHERE id").
+		WithArgs(anyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(bootstrapRunColumns).
+			AddRow(newTestBootstrapRunRow(runID, orgID, repoID, &userID, "running", json.RawMessage(`null`), now)...))
+
+	ctx, cancel := context.WithCancel(evalCtxWithChi(orgID, userID, map[string]string{"runId": runID.String()}))
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/evals/bootstrap/"+runID.String()+"/stream", nil).WithContext(ctx)
+	rr := newLockedRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handler.StreamBootstrapUpdates(rr, req)
+	}()
+
+	event := models.EvalBootstrapUpdatedEvent{
+		BootstrapRunID: runID,
+		OrgID:          orgID,
+		Status:         models.EvalBootstrapStatusCompleted,
+		UpdatedAt:      time.Now().UTC(),
+	}
+
+	require.Eventually(t, func() bool {
+		_ = bootstrapStreams.PublishUpdated(context.Background(), event)
+		return strings.Contains(rr.BodyString(), "eval_bootstrap.updated")
+	}, 2*time.Second, 20*time.Millisecond, "StreamBootstrapUpdates should write the per-run event to the SSE response")
+
+	cancel()
+	<-done
+
+	require.Contains(t, rr.BodyString(), runID.String(), "SSE response should include the published bootstrap run ID")
+	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -137,6 +137,11 @@ func (h *SessionHandler) sseFallbackPollInterval() time.Duration {
 		return override
 	}
 	span := int64(sseFallbackPollMax - sseFallbackPollMin)
+	// #nosec G404 -- jitter is a load-shedding mechanism (decorrelate per-
+	// connection Postgres polling so an outage doesn't cause an N-client
+	// dogpile), not a security primitive. An attacker who could predict
+	// the interval gains nothing useful; crypto/rand would just burn
+	// entropy and CPU on a hot path.
 	return sseFallbackPollMin + time.Duration(rand.Int64N(span+1))
 }
 
@@ -152,6 +157,7 @@ func (h *SessionHandler) sseFallbackHeartbeatInterval() time.Duration {
 		return override * 5
 	}
 	span := int64(sseFallbackHeartbeatMax - sseFallbackHeartbeatMin)
+	// #nosec G404 -- non-security jitter; see sseFallbackPollInterval above.
 	return sseFallbackHeartbeatMin + time.Duration(rand.Int64N(span+1))
 }
 

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"regexp"
 	"strings"
@@ -86,6 +87,84 @@ type SessionHandler struct {
 	linearLinker atomic.Pointer[linearLinkerHolder]
 	// shutdownCh is closed on SIGTERM; see SetShutdownSignal.
 	shutdownCh <-chan struct{}
+	// pollOverride is non-zero in tests to lock the SSE polling fallback to
+	// a predictable interval. Production leaves it at zero so the per-
+	// connection interval is sampled from sseFallbackPoll{Min,Max} for
+	// every reconnect, which staggers Postgres queries across clients and
+	// avoids the synchronized N-client dogpile that follows a Redis outage
+	// when many SSE connections fail over at once. See SetPollIntervalForTest.
+	//
+	// Stored as nanoseconds in atomic.Int64 (not a plain time.Duration field)
+	// because parallel tests share the SessionHandler instance via
+	// newSessionHandler(t, mock) and read this field from request-serving
+	// goroutines while another test goroutine may still be calling the
+	// setter — the race detector would (correctly) flag a plain field even
+	// though the setter is conventionally called once per test before any
+	// requests fire.
+	pollOverrideNanos atomic.Int64
+}
+
+const (
+	// sseFallbackPollMin/Max bracket the per-connection polling interval used
+	// when the Redis-backed log stream is unavailable and we must serve
+	// updates from Postgres. The 1.0s value used here previously translated
+	// into N concurrent SSE clients × 1 query/sec on the runs+logs tables —
+	// fine for steady-state, problematic when a Redis outage drops every
+	// client onto this path simultaneously and they then reconnect in
+	// lockstep when Redis comes back. The min/max bracket plus
+	// sseFallbackPollInterval's uniform sample give each connection an
+	// independent phase, capping the worst-case query rate at ~0.5 N/sec
+	// while keeping the median responsiveness well under the 5s SLA the
+	// frontend's reconnect logic expects.
+	sseFallbackPollMin = 2000 * time.Millisecond
+	sseFallbackPollMax = 3500 * time.Millisecond
+	// sseFallbackHeartbeatMin/Max jitter the SSE keepalive interval for the
+	// same reason — synchronized heartbeats from many connections produce
+	// brief CPU/syscall spikes that don't matter at small N but do at large
+	// N. The 12-18s window stays well under typical proxy idle timeouts (30
+	// or 60s) and the 2× ratio between min and max is enough to break
+	// alignment after a few minutes of running connections.
+	sseFallbackHeartbeatMin = 12 * time.Second
+	sseFallbackHeartbeatMax = 18 * time.Second
+)
+
+// sseFallbackPollInterval returns a per-connection randomized polling interval
+// in [sseFallbackPollMin, sseFallbackPollMax]. The override path is reserved
+// for tests that need a sub-second interval to keep wall-clock test time
+// reasonable; production code never sets it.
+func (h *SessionHandler) sseFallbackPollInterval() time.Duration {
+	if override := time.Duration(h.pollOverrideNanos.Load()); override > 0 {
+		return override
+	}
+	span := int64(sseFallbackPollMax - sseFallbackPollMin)
+	return sseFallbackPollMin + time.Duration(rand.Int64N(span+1))
+}
+
+// sseFallbackHeartbeatInterval returns a per-connection randomized heartbeat
+// interval in [sseFallbackHeartbeatMin, sseFallbackHeartbeatMax]. Same
+// override-for-tests semantics as sseFallbackPollInterval.
+func (h *SessionHandler) sseFallbackHeartbeatInterval() time.Duration {
+	if override := time.Duration(h.pollOverrideNanos.Load()); override > 0 {
+		// In test mode, scale the heartbeat down proportionally so tests that
+		// exercise the heartbeat branch don't have to wait the production
+		// floor. 5x the poll interval is enough to keep the heartbeat from
+		// firing on every poll tick.
+		return override * 5
+	}
+	span := int64(sseFallbackHeartbeatMax - sseFallbackHeartbeatMin)
+	return sseFallbackHeartbeatMin + time.Duration(rand.Int64N(span+1))
+}
+
+// SetPollIntervalForTest pins the SSE polling-fallback interval for tests
+// that need deterministic, fast iteration. Calling with d <= 0 restores the
+// default randomized behavior. Safe to call concurrently with request-
+// serving goroutines via the underlying atomic store.
+func (h *SessionHandler) SetPollIntervalForTest(d time.Duration) {
+	if d <= 0 {
+		h.pollOverrideNanos.Store(0)
+		return
+	}
+	h.pollOverrideNanos.Store(int64(d))
 }
 
 // linearLinkerHolder wraps the linearSessionLinker interface so the field
@@ -1012,9 +1091,13 @@ func (h *SessionHandler) streamLogsViaPolling(ctx context.Context, sw *sse.Write
 	}
 	sw.Flush()
 
-	ticker := time.NewTicker(1 * time.Second)
+	// Per-connection randomized intervals — see the comment block above
+	// sseFallbackPollMin for why this isn't a fixed 1s anymore.
+	pollInterval := h.sseFallbackPollInterval()
+	heartbeatInterval := h.sseFallbackHeartbeatInterval()
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
-	heartbeat := time.NewTicker(15 * time.Second)
+	heartbeat := time.NewTicker(heartbeatInterval)
 	defer heartbeat.Stop()
 	shutdownCh := h.shutdownCh
 

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -3041,6 +3041,10 @@ func TestSessionHandler_StreamLogsViaPolling_ReplaysAndFinishes(t *testing.T) {
 	defer mock.Close()
 
 	handler := newSessionHandler(t, mock)
+	// Pin the polling interval so the test isn't sensitive to the jittered
+	// production range (2s–3.5s). Production uses jittered per-connection
+	// intervals to avoid a synchronized N-client dogpile when Redis recovers.
+	handler.SetPollIntervalForTest(20 * time.Millisecond)
 	orgID := uuid.New()
 	runID := uuid.New()
 	issueID := uuid.New()
@@ -3167,6 +3171,7 @@ func TestSessionHandler_StreamLogsViaPolling_ReloadFailureReturns(t *testing.T) 
 	defer mock.Close()
 
 	handler := newSessionHandler(t, mock)
+	handler.SetPollIntervalForTest(20 * time.Millisecond)
 	orgID := uuid.New()
 	runID := uuid.New()
 	issueID := uuid.New()
@@ -3275,6 +3280,7 @@ func TestSessionHandler_StreamLogsViaPolling_StatusAndDoneWriteFailures(t *testi
 				defer mock.Close()
 
 				handler := newSessionHandler(t, mock)
+				handler.SetPollIntervalForTest(20 * time.Millisecond)
 				orgID := uuid.New()
 				runID := uuid.New()
 				issueID := uuid.New()
@@ -3338,6 +3344,7 @@ func TestSessionHandler_StreamLogs_RedisFallbackToPolling(t *testing.T) {
 	issueID := uuid.New()
 	now := time.Now()
 	handler := newSessionHandler(t, mock)
+	handler.SetPollIntervalForTest(20 * time.Millisecond)
 	streams, _ := newSessionTestStreams(t)
 	handler.SetStreams(streams)
 	handler.SetShutdownSignal(make(chan struct{}))
@@ -3396,6 +3403,36 @@ func TestSessionHandler_StreamLogs_RedisFallbackToPolling(t *testing.T) {
 		t.Fatal("StreamLogs did not finish after falling back to polling")
 	}
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionHandler_SSEFallbackJitterRange(t *testing.T) {
+	t.Parallel()
+
+	// Locks in the dogpile-mitigation contract: every sampled interval must
+	// fall inside the documented bracket so a future change can't silently
+	// regress the worst-case Postgres query rate during a Redis outage.
+	// The test override path is also verified — if SetPollIntervalForTest is
+	// ever broken, every other test in this file would still pass on luck
+	// because the production sampler returns timing in the seconds range.
+	h := &SessionHandler{}
+
+	for i := 0; i < 200; i++ {
+		got := h.sseFallbackPollInterval()
+		require.GreaterOrEqual(t, got, sseFallbackPollMin, "production poll interval must respect the lower bound")
+		require.LessOrEqual(t, got, sseFallbackPollMax, "production poll interval must respect the upper bound")
+		hb := h.sseFallbackHeartbeatInterval()
+		require.GreaterOrEqual(t, hb, sseFallbackHeartbeatMin, "production heartbeat interval must respect the lower bound")
+		require.LessOrEqual(t, hb, sseFallbackHeartbeatMax, "production heartbeat interval must respect the upper bound")
+	}
+
+	h.SetPollIntervalForTest(75 * time.Millisecond)
+	require.Equal(t, 75*time.Millisecond, h.sseFallbackPollInterval(), "test override should pin the poll interval to the requested value")
+	require.Equal(t, 5*75*time.Millisecond, h.sseFallbackHeartbeatInterval(), "test override should derive the heartbeat from the same scale")
+
+	h.SetPollIntervalForTest(0)
+	got := h.sseFallbackPollInterval()
+	require.GreaterOrEqual(t, got, sseFallbackPollMin, "passing 0 to the override should restore the default randomized sampler")
+	require.LessOrEqual(t, got, sseFallbackPollMax, "passing 0 to the override should restore the default randomized sampler")
 }
 
 func TestSessionHandler_CreateManual(t *testing.T) {
@@ -3908,9 +3945,9 @@ func TestSessionHandler_EndSession_ManualSkipsValidation(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/end", nil)
 	rctx := chi.NewRouteContext()
@@ -6053,9 +6090,9 @@ func TestSessionHandler_CreatePR_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
 	rctx := chi.NewRouteContext()
@@ -6123,9 +6160,9 @@ func TestSessionHandler_CreatePR_DedupeConflict(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(pgx.ErrNoRows)
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", nil)
 	rctx := chi.NewRouteContext()
@@ -6446,9 +6483,9 @@ func TestSessionHandler_CreatePR_AppAuthorModeBypassesAuthIntercept(t *testing.T
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	body := strings.NewReader(`{"author_mode":"app"}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", body)
@@ -6597,9 +6634,9 @@ func TestSessionHandler_CreatePR_UserPreferredWithoutGitHubAppUserAuthFallsBackT
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr", strings.NewReader(`{"author_mode":"auto"}`))
 	rctx := chi.NewRouteContext()
@@ -6974,7 +7011,7 @@ func TestSessionHandler_CreatePR_UpdateStateErrorStillAccepted(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("write failed"))
 
@@ -7379,11 +7416,13 @@ func TestSessionHandler_PushChangesToPR_Success(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
-	// CAS update from TryMarkPRPushQueued — 2 args (id, org_id) and rows-
-	// affected=1 to indicate the racing-winner branch.
-	mock.ExpectExec("UPDATE sessions").
+	// CAS update from TryMarkPRPushQueued — 2 args (id, org_id). RETURNING +
+	// publishStatus replaced bare Exec so the SSE detail page sees the
+	// transition immediately; the test returns the post-CAS row (pr_push_state
+	// flipped to "queued") to mirror what Postgres would actually return.
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pushSessionRow(sessionID, issueID, orgID, now, pushSessionRowOpts{pushState: "queued"}))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
 	rctx := chi.NewRouteContext()
@@ -7436,10 +7475,11 @@ func TestSessionHandler_PushChangesToPR_CASLosesRaceReturnsConflict(t *testing.T
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
 	// CAS UPDATE matches no rows because a concurrent winner already moved
-	// pr_push_state to 'queued'.
-	mock.ExpectExec("UPDATE sessions").
+	// pr_push_state to 'queued'. RETURNING with empty rows triggers
+	// pgx.ErrNoRows in TryMarkPRPushQueued, which surfaces as (false, nil).
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
+		WillReturnRows(pgxmock.NewRows(sessionColumns))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/pr/push", nil)
 	rctx := chi.NewRouteContext()

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -358,6 +358,14 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	pmDocumentHandler.SetAuditEmitter(auditEmitter)
 	evalHandler := handlers.NewEvalHandler(evalTaskStore, evalRunStore, evalBatchStore, evalBootstrapStore, jobStore, pool)
 	evalHandler.SetAuditEmitter(auditEmitter)
+	// Redis-backed pub/sub for the eval batch + bootstrap detail SSEs. nil
+	// when redisClient is nil — handlers will return 503 and the frontend
+	// will continue to fall back to its existing polling path.
+	evalBatchStreams := cache.NewEvalBatchStreams(redisClient, logger)
+	evalBootstrapStreams := cache.NewEvalBootstrapStreams(redisClient, logger)
+	evalHandler.SetBatchStreams(evalBatchStreams)
+	evalHandler.SetBootstrapStreams(evalBootstrapStreams)
+	evalHandler.SetMembershipStore(membershipStore)
 	auditLogHandler := handlers.NewAuditLogHandler(auditLogStore)
 	sessionReviewCommentHandler := handlers.NewSessionReviewCommentHandler(sessionReviewCommentStore, sessionStore, logger)
 	sessionReviewCommentHandler.SetAuditEmitter(auditEmitter)
@@ -758,7 +766,9 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Get("/api/v1/evals/runs/{runId}", evalHandler.GetRun)
 				r.Get("/api/v1/evals/batch", evalHandler.ListBatches)
 				r.Get("/api/v1/evals/batch/{batchId}", evalHandler.GetBatch)
+				r.Get("/api/v1/evals/batch/{batchId}/stream", evalHandler.StreamBatchUpdates)
 				r.Get("/api/v1/evals/bootstrap/candidates", evalHandler.GetBootstrapCandidates)
+				r.Get("/api/v1/evals/bootstrap/{runId}/stream", evalHandler.StreamBootstrapUpdates)
 
 				// Personal credential management
 				r.Put("/api/v1/settings/credentials/personal/{provider}", userCredentialHandler.UpsertPersonal)

--- a/internal/cache/eval_streams.go
+++ b/internal/cache/eval_streams.go
@@ -1,0 +1,301 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// EvalBatchStreams publishes lightweight "something changed" signals for eval
+// batch progress over Redis pub/sub. The channel is keyed by batch ID so a
+// detail-page subscriber only wakes for events that actually concern its
+// batch — orgs with many in-flight batches don't fan out cross-batch noise to
+// every viewer. Events deliberately carry only the fields needed to identify
+// the change; clients fetch the full EvalBatchDetail via the existing GET
+// handler when they receive an event, which both keeps the payload bounded
+// for large batches and side-steps Redis pub/sub's at-most-once / unordered
+// delivery (the canonical state always lives in Postgres).
+type EvalBatchStreams struct {
+	client *Client
+	logger zerolog.Logger
+}
+
+type EvalBatchSubscription struct {
+	C <-chan models.EvalBatchUpdatedEvent
+
+	ch     chan models.EvalBatchUpdatedEvent
+	cancel context.CancelFunc
+	pubsub *redis.PubSub
+
+	mu          sync.Mutex
+	closeReason string
+}
+
+func (s *EvalBatchSubscription) setCloseReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeReason = reason
+}
+
+func NewEvalBatchStreams(client *Client, logger zerolog.Logger) *EvalBatchStreams {
+	if client == nil {
+		return nil
+	}
+	return &EvalBatchStreams{client: client, logger: logger}
+}
+
+func (s *EvalBatchStreams) Available() bool {
+	return s != nil && s.client != nil && s.client.Available()
+}
+
+// PublishUpdated fans out an event keyed on the batch ID embedded in the
+// event itself. Callers must populate event.BatchID before invoking.
+func (s *EvalBatchStreams) PublishUpdated(ctx context.Context, event models.EvalBatchUpdatedEvent) error {
+	if s == nil || s.client == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal eval batch update event: %w", err)
+	}
+
+	if err := s.client.doCommand(ctx, "publish", func() error {
+		return s.client.raw().Publish(ctx, evalBatchStreamChannel(event.BatchID), payload).Err()
+	}); err != nil {
+		return fmt.Errorf("publish eval batch update event: %w", err)
+	}
+	return nil
+}
+
+// Subscribe attaches to the per-batch channel. Subscribers see only events
+// for the requested batch ID — there is no server-side filter to maintain
+// in callers, and unrelated batches in the same org cause no fanout.
+func (s *EvalBatchStreams) Subscribe(batchID uuid.UUID) (*EvalBatchSubscription, error) {
+	if s == nil || s.client == nil {
+		return nil, errors.New("redis unavailable")
+	}
+	if !s.client.Available() {
+		return nil, errors.New("redis unavailable")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pubsub := s.client.raw().Subscribe(ctx, evalBatchStreamChannel(batchID))
+	if _, err := pubsub.Receive(ctx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return nil, fmt.Errorf("subscribe eval batch stream: %w", err)
+	}
+
+	sub := &EvalBatchSubscription{
+		ch:     make(chan models.EvalBatchUpdatedEvent, 32),
+		cancel: cancel,
+		pubsub: pubsub,
+	}
+	sub.C = sub.ch
+
+	go func() {
+		defer close(sub.ch)
+		defer cancel()
+
+		for msg := range pubsub.Channel() {
+			var event models.EvalBatchUpdatedEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
+				s.logger.Warn().Err(err).Str("channel", msg.Channel).Msg("failed to decode eval batch update event")
+				continue
+			}
+
+			select {
+			case sub.ch <- event:
+			case <-ctx.Done():
+				sub.setCloseReason(ctx.Err().Error())
+				return
+			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			sub.setCloseReason(err.Error())
+			return
+		}
+		sub.setCloseReason("subscription closed")
+	}()
+
+	return sub, nil
+}
+
+func (s *EvalBatchSubscription) Close() {
+	if s == nil {
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.pubsub != nil {
+		_ = s.pubsub.Close()
+	}
+}
+
+func (s *EvalBatchSubscription) CloseReason() string {
+	if s == nil {
+		return "subscription closed"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closeReason == "" {
+		return "subscription closed"
+	}
+	return s.closeReason
+}
+
+// evalBatchStreamChannel scopes the pub/sub channel by batch ID so subscribers
+// only see events for the batch they're watching. Per-batch keys (instead of
+// per-org) cap fanout at one PUBLISH per batch transition rather than O(orgs ×
+// in-flight batches), which matters at scale even though Redis comfortably
+// handles 100k+ channels.
+func evalBatchStreamChannel(batchID uuid.UUID) string {
+	return fmt.Sprintf("143:stream:{batch:%s}:eval_batches", batchID.String())
+}
+
+// EvalBootstrapStreams mirrors EvalBatchStreams for bootstrap (PR-history scan)
+// runs and is similarly keyed per-bootstrap-run. Bootstrap is rarer than batch
+// activity but the same scoping rationale applies — subscribers only care
+// about the run they're watching.
+type EvalBootstrapStreams struct {
+	client *Client
+	logger zerolog.Logger
+}
+
+type EvalBootstrapSubscription struct {
+	C <-chan models.EvalBootstrapUpdatedEvent
+
+	ch     chan models.EvalBootstrapUpdatedEvent
+	cancel context.CancelFunc
+	pubsub *redis.PubSub
+
+	mu          sync.Mutex
+	closeReason string
+}
+
+func (s *EvalBootstrapSubscription) setCloseReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeReason = reason
+}
+
+func NewEvalBootstrapStreams(client *Client, logger zerolog.Logger) *EvalBootstrapStreams {
+	if client == nil {
+		return nil
+	}
+	return &EvalBootstrapStreams{client: client, logger: logger}
+}
+
+func (s *EvalBootstrapStreams) Available() bool {
+	return s != nil && s.client != nil && s.client.Available()
+}
+
+// PublishUpdated fans out an event keyed on event.BootstrapRunID.
+func (s *EvalBootstrapStreams) PublishUpdated(ctx context.Context, event models.EvalBootstrapUpdatedEvent) error {
+	if s == nil || s.client == nil {
+		return nil
+	}
+
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("marshal eval bootstrap update event: %w", err)
+	}
+
+	if err := s.client.doCommand(ctx, "publish", func() error {
+		return s.client.raw().Publish(ctx, evalBootstrapStreamChannel(event.BootstrapRunID), payload).Err()
+	}); err != nil {
+		return fmt.Errorf("publish eval bootstrap update event: %w", err)
+	}
+	return nil
+}
+
+func (s *EvalBootstrapStreams) Subscribe(runID uuid.UUID) (*EvalBootstrapSubscription, error) {
+	if s == nil || s.client == nil {
+		return nil, errors.New("redis unavailable")
+	}
+	if !s.client.Available() {
+		return nil, errors.New("redis unavailable")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pubsub := s.client.raw().Subscribe(ctx, evalBootstrapStreamChannel(runID))
+	if _, err := pubsub.Receive(ctx); err != nil {
+		cancel()
+		_ = pubsub.Close()
+		return nil, fmt.Errorf("subscribe eval bootstrap stream: %w", err)
+	}
+
+	sub := &EvalBootstrapSubscription{
+		ch:     make(chan models.EvalBootstrapUpdatedEvent, 32),
+		cancel: cancel,
+		pubsub: pubsub,
+	}
+	sub.C = sub.ch
+
+	go func() {
+		defer close(sub.ch)
+		defer cancel()
+
+		for msg := range pubsub.Channel() {
+			var event models.EvalBootstrapUpdatedEvent
+			if err := json.Unmarshal([]byte(msg.Payload), &event); err != nil {
+				s.logger.Warn().Err(err).Str("channel", msg.Channel).Msg("failed to decode eval bootstrap update event")
+				continue
+			}
+
+			select {
+			case sub.ch <- event:
+			case <-ctx.Done():
+				sub.setCloseReason(ctx.Err().Error())
+				return
+			}
+		}
+
+		if err := ctx.Err(); err != nil {
+			sub.setCloseReason(err.Error())
+			return
+		}
+		sub.setCloseReason("subscription closed")
+	}()
+
+	return sub, nil
+}
+
+func (s *EvalBootstrapSubscription) Close() {
+	if s == nil {
+		return
+	}
+	if s.cancel != nil {
+		s.cancel()
+	}
+	if s.pubsub != nil {
+		_ = s.pubsub.Close()
+	}
+}
+
+func (s *EvalBootstrapSubscription) CloseReason() string {
+	if s == nil {
+		return "subscription closed"
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closeReason == "" {
+		return "subscription closed"
+	}
+	return s.closeReason
+}
+
+func evalBootstrapStreamChannel(runID uuid.UUID) string {
+	return fmt.Sprintf("143:stream:{bootstrap:%s}:eval_bootstraps", runID.String())
+}

--- a/internal/cache/eval_streams_test.go
+++ b/internal/cache/eval_streams_test.go
@@ -1,0 +1,177 @@
+package cache
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalBatchStreams_AvailabilityAndHelpers(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, NewEvalBatchStreams(nil, zerolog.Nop()), "constructor should return nil when Redis client is missing")
+
+	client, _ := testRedisClient(t)
+	streams := NewEvalBatchStreams(client, zerolog.Nop())
+	require.True(t, streams.Available(), "streams should report available when Redis is healthy")
+
+	sub, err := streams.Subscribe(uuid.New())
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	require.Equal(t, "subscription closed", sub.CloseReason(), "fresh subscriptions should report the default close reason")
+	sub.Close()
+	require.NotEmpty(t, sub.CloseReason(), "closing a subscription should leave a non-empty close reason")
+
+	require.Equal(t, "subscription closed", (*EvalBatchSubscription)(nil).CloseReason(), "nil subscription receivers should report the default close reason")
+
+	require.Equal(t, "143:stream:{batch:00000000-0000-0000-0000-000000000000}:eval_batches", evalBatchStreamChannel(uuid.Nil), "channel helper should scope eval batch streams by batch ID so unrelated batches in the same org don't fan out")
+}
+
+func TestEvalBatchStreams_PublishAndSubscribe(t *testing.T) {
+	t.Parallel()
+
+	client, _ := testRedisClient(t)
+	streams := NewEvalBatchStreams(client, zerolog.Nop())
+	batchID := uuid.New()
+
+	sub, err := streams.Subscribe(batchID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	event := models.EvalBatchUpdatedEvent{
+		BatchID:   batchID,
+		OrgID:     uuid.New(),
+		Status:    models.EvalBatchStatusRunning,
+		UpdatedAt: time.Now().UTC(),
+	}
+
+	require.NoError(t, streams.PublishUpdated(context.Background(), event), "publish should succeed for valid events")
+	require.Eventually(t, func() bool {
+		select {
+		case got := <-sub.C:
+			return got.BatchID == event.BatchID && got.Status == event.Status
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "published eval batch events should be delivered to subscribers")
+}
+
+func TestEvalBatchStreams_PerBatchScoping(t *testing.T) {
+	t.Parallel()
+
+	// Per-batch channel keys (vs per-org) mean a subscriber to batch A must
+	// not receive events for batch B even though they're in the same org.
+	// Locks in the scoping change so a future regression to per-org keys
+	// would surface here instead of as a quiet performance bug.
+	client, _ := testRedisClient(t)
+	streams := NewEvalBatchStreams(client, zerolog.Nop())
+	orgID := uuid.New()
+	batchA := uuid.New()
+	batchB := uuid.New()
+
+	subA, err := streams.Subscribe(batchA)
+	require.NoError(t, err, "subscribe to batch A should succeed")
+	defer subA.Close()
+
+	require.NoError(t, streams.PublishUpdated(context.Background(), models.EvalBatchUpdatedEvent{
+		BatchID:   batchB,
+		OrgID:     orgID,
+		Status:    models.EvalBatchStatusRunning,
+		UpdatedAt: time.Now().UTC(),
+	}), "publish for batch B should succeed")
+
+	require.Never(t, func() bool {
+		select {
+		case <-subA.C:
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 20*time.Millisecond, "subscriber to batch A must not receive events scoped to batch B")
+}
+
+func TestEvalBatchStreams_HandlesInvalidPayloadAndUnavailableRedis(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, (*EvalBatchStreams)(nil).PublishUpdated(context.Background(), models.EvalBatchUpdatedEvent{}), "publishing with nil streams should be a no-op")
+
+	client, _ := testRedisClient(t)
+	streams := NewEvalBatchStreams(client, zerolog.Nop())
+	batchID := uuid.New()
+
+	sub, err := streams.Subscribe(batchID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	require.NoError(t, client.raw().Publish(context.Background(), evalBatchStreamChannel(batchID), "{not-json").Err(), "test should inject an invalid payload into the channel")
+	require.Never(t, func() bool {
+		select {
+		case <-sub.C:
+			return true
+		default:
+			return false
+		}
+	}, 150*time.Millisecond, 20*time.Millisecond, "invalid JSON payloads should be skipped rather than delivered")
+
+	unavailable := &Client{logger: zerolog.Nop()}
+	unavailable.breaker = NewCircuitBreaker(zerolog.Nop())
+	streams = NewEvalBatchStreams(unavailable, zerolog.Nop())
+	require.False(t, streams.Available(), "streams should report unavailable when the underlying Redis client is not ready")
+	_, err = streams.Subscribe(uuid.New())
+	require.Error(t, err, "subscribe should fail cleanly when Redis is unavailable")
+	require.Contains(t, err.Error(), "redis unavailable", "subscribe should explain that Redis is unavailable")
+
+	unavailable.rdb = client.raw()
+	unavailable.breaker.ForceOpen()
+	err = streams.PublishUpdated(context.Background(), models.EvalBatchUpdatedEvent{BatchID: uuid.New()})
+	require.Error(t, err, "publish should fail when the breaker is open")
+	require.Contains(t, err.Error(), "publish eval batch update event", "publish should wrap Redis publish failures with operation context")
+
+	_, err = streams.Subscribe(uuid.New())
+	require.Error(t, err, "subscribe should fail when availability probes fail")
+	require.True(t, strings.Contains(err.Error(), "redis unavailable") || strings.Contains(err.Error(), "subscribe eval batch stream"), "subscribe should surface Redis availability errors")
+}
+
+func TestEvalBootstrapStreams_PublishAndSubscribe(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, NewEvalBootstrapStreams(nil, zerolog.Nop()), "constructor should return nil when Redis client is missing")
+	require.NoError(t, (*EvalBootstrapStreams)(nil).PublishUpdated(context.Background(), models.EvalBootstrapUpdatedEvent{}), "publishing with nil streams should be a no-op")
+
+	client, _ := testRedisClient(t)
+	streams := NewEvalBootstrapStreams(client, zerolog.Nop())
+	runID := uuid.New()
+	require.True(t, streams.Available(), "streams should report available when Redis is healthy")
+	require.Equal(t, "143:stream:{bootstrap:00000000-0000-0000-0000-000000000000}:eval_bootstraps", evalBootstrapStreamChannel(uuid.Nil), "channel helper should scope eval bootstrap streams by run ID")
+
+	sub, err := streams.Subscribe(runID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	sessionID := uuid.New()
+	event := models.EvalBootstrapUpdatedEvent{
+		BootstrapRunID: runID,
+		OrgID:          uuid.New(),
+		Status:         models.EvalBootstrapStatusRunning,
+		SessionID:      &sessionID,
+		UpdatedAt:      time.Now().UTC(),
+	}
+
+	require.NoError(t, streams.PublishUpdated(context.Background(), event), "publish should succeed for valid events")
+	require.Eventually(t, func() bool {
+		select {
+		case got := <-sub.C:
+			return got.BootstrapRunID == event.BootstrapRunID && got.Status == event.Status && got.SessionID != nil && *got.SessionID == sessionID
+		default:
+			return false
+		}
+	}, 2*time.Second, 20*time.Millisecond, "published eval bootstrap events should be delivered to subscribers")
+
+	require.Equal(t, "subscription closed", (*EvalBootstrapSubscription)(nil).CloseReason(), "nil subscription receivers should report the default close reason")
+	require.Equal(t, "subscription closed", sub.CloseReason(), "fresh subscriptions should report the default close reason before close")
+}

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1403,17 +1403,37 @@ func (s *SessionStore) UpdatePRCreationState(ctx context.Context, orgID, session
 	} else {
 		errArg = nil
 	}
+	// RETURNING + publishStatus replaces a prior frontend 2s poll on
+	// /sessions/{id}/pr that existed solely to observe this column's
+	// transitions. Detail page now relies on the session status SSE.
 	query := `UPDATE sessions
 		SET pr_creation_state = @state, pr_creation_error = @err
 		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
-		  AND pr_creation_state <> 'succeeded'`
-	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		  AND pr_creation_state <> 'succeeded'
+		RETURNING ` + sessionSelectColumns
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,
 		"state":  string(state),
 		"err":    errArg,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	session, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		// Pre-existing semantics: matching zero rows (e.g. the row is
+		// already in the terminal `succeeded` state) is a no-op, not an
+		// error. ErrNoRows here means the WHERE clause filtered the row
+		// out — surface no error and skip publishing since nothing changed.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	hydrateSessionPolicy(&session)
+	s.publishStatus(ctx, &session)
+	return nil
 }
 
 // TryMarkPRPushQueued atomically transitions pr_push_state from any non-in-
@@ -1428,18 +1448,32 @@ func (s *SessionStore) UpdatePRCreationState(ctx context.Context, orgID, session
 // side the matching guarantee that exactly one of the racing requests
 // returns 202 and the other returns 409.
 func (s *SessionStore) TryMarkPRPushQueued(ctx context.Context, orgID, sessionID uuid.UUID) (bool, error) {
+	// RETURNING + publishStatus so the API call that flips this column
+	// surfaces immediately on the session status SSE — the detail-page
+	// Push button used to wait for the worker's first state transition
+	// (or a 1s polling fallback) to reflect the user's click.
 	query := `UPDATE sessions
 		SET pr_push_state = 'queued', pr_push_error = NULL
 		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
-		  AND pr_push_state NOT IN ('queued', 'pushing')`
-	res, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		  AND pr_push_state NOT IN ('queued', 'pushing')
+		RETURNING ` + sessionSelectColumns
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,
 	})
 	if err != nil {
 		return false, err
 	}
-	return res.RowsAffected() > 0, nil
+	session, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	hydrateSessionPolicy(&session)
+	s.publishStatus(ctx, &session)
+	return true, nil
 }
 
 // UpdatePRPushState transitions pr_push_state and sets/clears pr_push_error
@@ -1462,16 +1496,31 @@ func (s *SessionStore) UpdatePRPushState(ctx context.Context, orgID, sessionID u
 	} else {
 		errArg = nil
 	}
+	// RETURNING + publishStatus so the detail-page Push button reflects
+	// transitions on the existing session status SSE without a separate poll.
 	query := `UPDATE sessions
 		SET pr_push_state = @state, pr_push_error = @err
-		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL`
-	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		WHERE id = @id AND org_id = @org_id AND deleted_at IS NULL
+		RETURNING ` + sessionSelectColumns
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"id":     sessionID,
 		"org_id": orgID,
 		"state":  string(state),
 		"err":    errArg,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	session, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+	hydrateSessionPolicy(&session)
+	s.publishStatus(ctx, &session)
+	return nil
 }
 
 // ClearSnapshotKey NULLs the snapshot_key column and transitions sandbox_state

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -275,13 +275,16 @@ func TestSessionStore_UpdatePRCreationState(t *testing.T) {
 			defer mock.Close()
 
 			store := NewSessionStore(mock)
+			store.SetLogger(zerolog.Nop())
+			store.SetStreams(nil)
 			orgID := uuid.New()
 			sessionID := uuid.New()
+			now := time.Now()
 
 			if !tt.expectErr {
-				mock.ExpectExec("UPDATE sessions").
+				mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_creation_state[\\s\\S]*RETURNING").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+					WillReturnRows(pgxmock.NewRows(sessionTestColumns).AddRow(newAgentSessionRow(sessionID, uuid.New(), orgID, now)...))
 			}
 
 			err = store.UpdatePRCreationState(context.Background(), orgID, sessionID, tt.state, tt.errMsg)
@@ -297,23 +300,91 @@ func TestSessionStore_UpdatePRCreationState(t *testing.T) {
 	}
 }
 
+func TestSessionStore_UpdatePRCreationState_PublishesSessionStatus(t *testing.T) {
+	t.Parallel()
+
+	// The frontend session-detail page now relies on the session status SSE
+	// (Redis stream `143:stream:{ses:ID}:status`) to observe pr_creation_state
+	// transitions in lieu of a 2s poll on /sessions/{id}/pr. This test locks
+	// in the publishStatus call by reading the miniredis stream after the
+	// transition and asserting the entry exists.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	store.SetLogger(zerolog.Nop())
+
+	mr := miniredis.RunT(t)
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), nil)
+	require.NotNil(t, client, "Redis client should initialize")
+	defer client.Close()
+	streams := cache.NewSessionStreams(client, zerolog.Nop(), nil)
+	require.NotNil(t, streams, "session streams helper should initialize")
+	store.SetStreams(streams)
+
+	now := time.Now()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	orgID := uuid.New()
+
+	mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_creation_state[\\s\\S]*RETURNING").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestColumns).AddRow(newAgentSessionRow(sessionID, issueID, orgID, now)...))
+
+	require.NoError(t, store.UpdatePRCreationState(context.Background(), orgID, sessionID, models.PRCreationStateSucceeded, ""), "UpdatePRCreationState should succeed")
+
+	streamKey := "143:stream:{ses:" + sessionID.String() + "}:status"
+	entries, err := mr.Stream(streamKey)
+	require.NoError(t, err, "miniredis should know about the status stream key after publish")
+	require.Len(t, entries, 1, "status stream should contain exactly one entry from the published transition")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionStore_UpdatePRCreationState_NoMatchingRowIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// Pre-existing semantics: the "AND pr_creation_state <> 'succeeded'" guard
+	// makes the terminal state sticky. When the WHERE clause filters the row
+	// out (already-succeeded session), the call must succeed without error and
+	// without publishing a stale status — preserving the prior Exec-based
+	// no-op behavior even after switching to RETURNING.
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	store.SetLogger(zerolog.Nop())
+	store.SetStreams(nil)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_creation_state[\\s\\S]*RETURNING").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+
+	err = store.UpdatePRCreationState(context.Background(), orgID, sessionID, models.PRCreationStateQueued, "")
+	require.NoError(t, err, "no-rows-affected should not surface as an error so callers stay idempotent")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_TryMarkPRPushQueued(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name         string
-		rowsAffected int64
-		wantQueued   bool
+		name       string
+		returnRow  bool
+		wantQueued bool
 	}{
 		{
-			name:         "rows affected returns true",
-			rowsAffected: 1,
-			wantQueued:   true,
+			name:       "row returned signals successful CAS",
+			returnRow:  true,
+			wantQueued: true,
 		},
 		{
-			name:         "no rows affected returns false (concurrent winner)",
-			rowsAffected: 0,
-			wantQueued:   false,
+			name:       "no row returned signals concurrent winner",
+			returnRow:  false,
+			wantQueued: false,
 		},
 	}
 
@@ -326,14 +397,21 @@ func TestSessionStore_TryMarkPRPushQueued(t *testing.T) {
 			defer mock.Close()
 
 			store := NewSessionStore(mock)
+			store.SetLogger(zerolog.Nop())
+			store.SetStreams(nil)
 			orgID := uuid.New()
 			sessionID := uuid.New()
+			now := time.Now()
 
 			// CAS update should pass exactly two args (id, org_id) and
 			// guard with a NOT IN ('queued','pushing') predicate.
-			mock.ExpectExec("UPDATE sessions[\\s\\S]*pr_push_state = 'queued'[\\s\\S]*pr_push_state NOT IN").
-				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
-				WillReturnResult(pgxmock.NewResult("UPDATE", tt.rowsAffected))
+			expect := mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_push_state = 'queued'[\\s\\S]*pr_push_state NOT IN[\\s\\S]*RETURNING").
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg())
+			if tt.returnRow {
+				expect.WillReturnRows(pgxmock.NewRows(sessionTestColumns).AddRow(newAgentSessionRow(sessionID, uuid.New(), orgID, now)...))
+			} else {
+				expect.WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+			}
 
 			queued, err := store.TryMarkPRPushQueued(context.Background(), orgID, sessionID)
 			require.NoError(t, err, "TryMarkPRPushQueued should not error on a successful CAS attempt")

--- a/internal/models/eval.go
+++ b/internal/models/eval.go
@@ -273,3 +273,26 @@ type EvalBootstrapRun struct {
 	CompletedAt  *time.Time          `db:"completed_at" json:"completed_at,omitempty"`
 	ErrorMessage *string             `db:"error_message" json:"error_message,omitempty"`
 }
+
+// EvalBatchUpdatedEvent is the lightweight pub/sub signal published whenever
+// an eval batch's status or one of its runs' statuses changes. Consumers fetch
+// the full EvalBatchDetail via the existing GET handler when they receive an
+// event; the payload deliberately does not include the runs array to keep
+// fanout cost bounded for large batches.
+type EvalBatchUpdatedEvent struct {
+	BatchID   uuid.UUID       `json:"batch_id"`
+	OrgID     uuid.UUID       `json:"org_id"`
+	Status    EvalBatchStatus `json:"status"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// EvalBootstrapUpdatedEvent is the pub/sub signal for bootstrap (PR-history
+// scan) status transitions. Mirrors EvalBatchUpdatedEvent — clients fetch the
+// full EvalBootstrapRun on receipt.
+type EvalBootstrapUpdatedEvent struct {
+	BootstrapRunID uuid.UUID           `json:"bootstrap_run_id"`
+	OrgID          uuid.UUID           `json:"org_id"`
+	Status         EvalBootstrapStatus `json:"status"`
+	SessionID      *uuid.UUID          `json:"session_id,omitempty"`
+	UpdatedAt      time.Time           `json:"updated_at"`
+}

--- a/internal/worker/eval_publish_test.go
+++ b/internal/worker/eval_publish_test.go
@@ -1,0 +1,182 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/cache"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// newPublishTestStreams wires miniredis-backed eval stream helpers so tests
+// can assert on actually-published events rather than relying on a stub that
+// can drift from production publish semantics. The miniredis instance is
+// torn down by t.Cleanup via RunT.
+func newPublishTestStreams(t *testing.T) (*cache.EvalBatchStreams, *cache.EvalBootstrapStreams) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	metrics, err := cache.NewMetrics()
+	require.NoError(t, err, "Redis metrics should initialize for publish tests")
+	client := cache.New(cache.Config{Topology: "standalone", URL: "redis://" + mr.Addr()}, zerolog.Nop(), metrics)
+	require.NotNil(t, client, "Redis client should initialize for publish tests")
+	t.Cleanup(func() { _ = client.Close() })
+	return cache.NewEvalBatchStreams(client, zerolog.Nop()), cache.NewEvalBootstrapStreams(client, zerolog.Nop())
+}
+
+func TestPublishEvalBatchSignal_DeliversToBatchSubscriber(t *testing.T) {
+	t.Parallel()
+
+	// Locks in the contract that worker code paths (newRunEvalHandler at
+	// run-start and after CompleteBatchIfDone) call publishEvalBatchSignal
+	// with the right shape and the resulting event lands on the per-batch
+	// channel. Without this test, a future refactor could quietly drop the
+	// publish call and break the SSE detail page without any unit failure.
+	batchStreams, _ := newPublishTestStreams(t)
+	services := &Services{EvalBatchStreams: batchStreams}
+
+	orgID := uuid.New()
+	batchID := uuid.New()
+	sub, err := batchStreams.Subscribe(batchID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	publishEvalBatchSignal(context.Background(), services, orgID, batchID, models.EvalBatchStatusRunning, zerolog.Nop())
+
+	select {
+	case got := <-sub.C:
+		require.Equal(t, batchID, got.BatchID, "delivered event should carry the publishing batch ID")
+		require.Equal(t, orgID, got.OrgID, "delivered event should carry the publishing org ID for downstream telemetry")
+		require.Equal(t, models.EvalBatchStatusRunning, got.Status, "delivered event should carry the published status as a hint (canonical state lives in Postgres)")
+		require.False(t, got.UpdatedAt.IsZero(), "delivered event should stamp UpdatedAt so subscribers can drop stale duplicates if needed")
+	case <-time.After(2 * time.Second):
+		t.Fatal("publishEvalBatchSignal did not deliver an event within the timeout")
+	}
+}
+
+func TestPublishEvalBatchSignal_NoOpWhenStreamsMissing(t *testing.T) {
+	t.Parallel()
+
+	// publishEvalBatchSignal is best-effort and must tolerate (1) a nil
+	// services struct, (2) a Services struct with EvalBatchStreams unset
+	// (production fallback when Redis is not configured), and (3) a zero
+	// batchID (no-batch single-run path). Each must be a silent no-op —
+	// the real publishing code is exercised by cache.EvalBatchStreams' own
+	// tests.
+	publishEvalBatchSignal(context.Background(), nil, uuid.New(), uuid.New(), models.EvalBatchStatusRunning, zerolog.Nop())
+	publishEvalBatchSignal(context.Background(), &Services{}, uuid.New(), uuid.New(), models.EvalBatchStatusRunning, zerolog.Nop())
+
+	batchStreams, _ := newPublishTestStreams(t)
+	services := &Services{EvalBatchStreams: batchStreams}
+	sub, err := batchStreams.Subscribe(uuid.New())
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+	publishEvalBatchSignal(context.Background(), services, uuid.New(), uuid.Nil, models.EvalBatchStatusRunning, zerolog.Nop())
+	require.Never(t, func() bool {
+		select {
+		case <-sub.C:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 20*time.Millisecond, "publish with zero batchID should be a silent no-op")
+}
+
+func TestPublishEvalBootstrapSignal_DeliversToRunSubscriber(t *testing.T) {
+	t.Parallel()
+
+	_, bootstrapStreams := newPublishTestStreams(t)
+	services := &Services{EvalBootstrapStreams: bootstrapStreams}
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	sessionID := uuid.New()
+	sub, err := bootstrapStreams.Subscribe(runID)
+	require.NoError(t, err, "subscribe should succeed against a healthy Redis instance")
+	defer sub.Close()
+
+	publishEvalBootstrapSignal(context.Background(), services, orgID, runID, models.EvalBootstrapStatusCompleted, &sessionID, zerolog.Nop())
+
+	select {
+	case got := <-sub.C:
+		require.Equal(t, runID, got.BootstrapRunID, "delivered event should carry the publishing run ID")
+		require.Equal(t, orgID, got.OrgID, "delivered event should carry the org ID")
+		require.Equal(t, models.EvalBootstrapStatusCompleted, got.Status, "delivered event should carry the published status hint")
+		require.NotNil(t, got.SessionID, "delivered event should preserve the session_id pointer when set")
+		require.Equal(t, sessionID, *got.SessionID, "delivered event should round-trip the session_id value")
+	case <-time.After(2 * time.Second):
+		t.Fatal("publishEvalBootstrapSignal did not deliver an event within the timeout")
+	}
+}
+
+func TestPublishEvalBootstrapSignal_NoOpWhenStreamsMissing(t *testing.T) {
+	t.Parallel()
+
+	publishEvalBootstrapSignal(context.Background(), nil, uuid.New(), uuid.New(), models.EvalBootstrapStatusRunning, nil, zerolog.Nop())
+	publishEvalBootstrapSignal(context.Background(), &Services{}, uuid.New(), uuid.New(), models.EvalBootstrapStatusRunning, nil, zerolog.Nop())
+}
+
+func TestPublishEvalBatchSignal_DropsCrossBatchEvents(t *testing.T) {
+	t.Parallel()
+
+	// Per-batch channel scoping means a publish for batch B must not be
+	// observable on a subscription to batch A even when both share an org.
+	// This is the worker-side counterpart to TestEvalBatchStreams_PerBatchScoping
+	// in the cache package — together they cover the full publish-then-
+	// receive path through the worker helper.
+	batchStreams, _ := newPublishTestStreams(t)
+	services := &Services{EvalBatchStreams: batchStreams}
+	orgID := uuid.New()
+	batchA := uuid.New()
+	batchB := uuid.New()
+
+	subA, err := batchStreams.Subscribe(batchA)
+	require.NoError(t, err)
+	defer subA.Close()
+
+	publishEvalBatchSignal(context.Background(), services, orgID, batchB, models.EvalBatchStatusRunning, zerolog.Nop())
+
+	require.Never(t, func() bool {
+		select {
+		case <-subA.C:
+			return true
+		default:
+			return false
+		}
+	}, 200*time.Millisecond, 20*time.Millisecond, "subscriber to batch A must not see publishes scoped to batch B")
+}
+
+// TestEvalEventPayloadsHaveStableJSONKeys guards against a future refactor
+// accidentally renaming the on-the-wire JSON keys, which the frontend
+// depends on. The keys are part of the public SSE contract.
+func TestEvalEventPayloadsHaveStableJSONKeys(t *testing.T) {
+	t.Parallel()
+
+	batchPayload, err := json.Marshal(models.EvalBatchUpdatedEvent{
+		BatchID:   uuid.New(),
+		OrgID:     uuid.New(),
+		Status:    models.EvalBatchStatusRunning,
+		UpdatedAt: time.Unix(0, 0).UTC(),
+	})
+	require.NoError(t, err)
+	for _, key := range []string{`"batch_id"`, `"org_id"`, `"status"`, `"updated_at"`} {
+		require.Contains(t, string(batchPayload), key, "EvalBatchUpdatedEvent JSON must keep the documented frontend keys")
+	}
+
+	bootstrapPayload, err := json.Marshal(models.EvalBootstrapUpdatedEvent{
+		BootstrapRunID: uuid.New(),
+		OrgID:          uuid.New(),
+		Status:         models.EvalBootstrapStatusRunning,
+		UpdatedAt:      time.Unix(0, 0).UTC(),
+	})
+	require.NoError(t, err)
+	for _, key := range []string{`"bootstrap_run_id"`, `"org_id"`, `"status"`, `"updated_at"`} {
+		require.Contains(t, string(bootstrapPayload), key, "EvalBootstrapUpdatedEvent JSON must keep the documented frontend keys")
+	}
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
@@ -168,6 +169,15 @@ type Services struct {
 	GitHub          agent.GitHubTokenProvider     // nil-safe: needed for eval repo cloning
 	TitleService    *services.SessionTitleService // nil-safe: session title regeneration
 	Linear          *linear.Service               // nil-safe: Linear session-linking disabled if nil
+	// EvalBatchStreams publishes lightweight pub/sub signals on every batch
+	// or run state transition so the eval-batch detail page can replace its
+	// 5s poll with a Redis-backed SSE. nil-safe: best-effort publish, the
+	// row is the source of truth and the page falls back to polling if SSE
+	// cannot be established.
+	EvalBatchStreams *cache.EvalBatchStreams
+	// EvalBootstrapStreams is the bootstrap (PR-history scan) counterpart to
+	// EvalBatchStreams; same nil-safety semantics.
+	EvalBootstrapStreams *cache.EvalBootstrapStreams
 	// SandboxAuthShutdown drains the per-session GitHub credential socket
 	// listeners. nil when no SandboxAuthSocketDir is configured (local
 	// dev). Called from cmd/server graceful shutdown after the API drains
@@ -1747,6 +1757,46 @@ func parseOrgID(orgIDFromPayload string, ctx context.Context) (uuid.UUID, error)
 	return orgID, nil
 }
 
+// publishEvalBatchSignal best-effort publishes an EvalBatchUpdatedEvent over
+// Redis pub/sub so the eval-batch detail page's SSE wakes immediately. The
+// event is intentionally minimal — clients re-fetch the full EvalBatchDetail
+// via the existing GET handler on receipt — so this stays cheap to fan out
+// even when many runs in the same batch finish in quick succession. Errors
+// are logged at warn and swallowed: the database row is the source of truth
+// and the page falls back to polling if SSE is unavailable. batchID may be
+// the zero UUID when called from a code path with no batch context, in which
+// case this is a no-op. The published channel is keyed on batchID so
+// unrelated batch viewers don't fan out.
+func publishEvalBatchSignal(ctx context.Context, services *Services, orgID, batchID uuid.UUID, status models.EvalBatchStatus, logger zerolog.Logger) {
+	if services == nil || services.EvalBatchStreams == nil || batchID == uuid.Nil {
+		return
+	}
+	if err := services.EvalBatchStreams.PublishUpdated(ctx, models.EvalBatchUpdatedEvent{
+		BatchID:   batchID,
+		OrgID:     orgID,
+		Status:    status,
+		UpdatedAt: time.Now().UTC(),
+	}); err != nil {
+		logger.Warn().Err(err).Str("batch_id", batchID.String()).Msg("failed to publish eval batch update event")
+	}
+}
+
+// publishEvalBootstrapSignal mirrors publishEvalBatchSignal for bootstrap runs.
+func publishEvalBootstrapSignal(ctx context.Context, services *Services, orgID, bootstrapRunID uuid.UUID, status models.EvalBootstrapStatus, sessionID *uuid.UUID, logger zerolog.Logger) {
+	if services == nil || services.EvalBootstrapStreams == nil || bootstrapRunID == uuid.Nil {
+		return
+	}
+	if err := services.EvalBootstrapStreams.PublishUpdated(ctx, models.EvalBootstrapUpdatedEvent{
+		BootstrapRunID: bootstrapRunID,
+		OrgID:          orgID,
+		Status:         status,
+		SessionID:      sessionID,
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		logger.Warn().Err(err).Str("bootstrap_run_id", bootstrapRunID.String()).Msg("failed to publish eval bootstrap update event")
+	}
+}
+
 // run_eval handler executes a single eval run: clones repo, runs agent, scores output.
 func newRunEvalHandler(stores *Stores, services *Services, logger zerolog.Logger) JobHandler {
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
@@ -1789,6 +1839,13 @@ func newRunEvalHandler(stores *Stores, services *Services, logger zerolog.Logger
 		if err := stores.EvalRuns.UpdateStatus(ctx, orgID, runID, models.EvalRunStatusRunning); err != nil {
 			return fmt.Errorf("update eval run status to running: %w", err)
 		}
+		// Wake any batch detail SSE subscribers so the matrix flips this
+		// run's tile to "running" without a polling round-trip. Batch
+		// itself stays "running"; we surface the parent batch's status
+		// rather than the run's so subscribers can ignore stale runs.
+		if run.BatchID != nil {
+			publishEvalBatchSignal(ctx, services, orgID, *run.BatchID, models.EvalBatchStatusRunning, logger)
+		}
 
 		startTime := time.Now()
 
@@ -1818,6 +1875,30 @@ func newRunEvalHandler(stores *Stores, services *Services, logger zerolog.Logger
 			if err := stores.EvalBatches.CompleteBatchIfDone(ctx, orgID, *run.BatchID); err != nil {
 				logger.Warn().Err(err).Str("batch_id", run.BatchID.String()).Msg("failed to check/complete batch")
 			}
+			// Re-fetch so the published event carries the post-CompleteBatchIfDone
+			// status. CompleteBatchIfDone only flips the batch when all runs are
+			// terminal, so most signals here will still be `running` — that's
+			// fine: the event is a "something changed" wake, the client fetches
+			// the full detail to see which run completed.
+			//
+			// Concurrency note: Redis pub/sub is at-most-once and unordered.
+			// Two runs in the same batch finishing nearly simultaneously can
+			// publish their "running" / "completed" events out of order — A
+			// re-reads `running`, B then flips to `completed` and publishes,
+			// A's earlier `running` arrives last. Subscribers must NOT read
+			// the Status field from the event; the event is a wake signal
+			// and the canonical state lives in Postgres. The frontend
+			// invalidate-and-refetch pattern in batch/[id]/page.tsx is what
+			// makes this self-healing — every event triggers a fresh GET on
+			// /evals/batch/{id}, so the worst case is one extra round-trip
+			// before the UI converges.
+			batchStatus := models.EvalBatchStatusRunning
+			if batch, err := stores.EvalBatches.GetByID(ctx, orgID, *run.BatchID); err == nil {
+				batchStatus = batch.Status
+			} else {
+				logger.Warn().Err(err).Str("batch_id", run.BatchID.String()).Msg("failed to re-read batch after run completion; publishing with running status")
+			}
+			publishEvalBatchSignal(ctx, services, orgID, *run.BatchID, batchStatus, logger)
 		}
 
 		logger.Info().
@@ -2391,6 +2472,7 @@ func newRunEvalBootstrapHandler(stores *Stores, services *Services, logger zerol
 		if err := stores.EvalBootstraps.UpdateStatus(ctx, orgID, bootstrapRunID, models.EvalBootstrapStatusRunning, sessionIDPtr); err != nil {
 			return fmt.Errorf("update bootstrap status to running: %w", err)
 		}
+		publishEvalBootstrapSignal(ctx, services, orgID, bootstrapRunID, models.EvalBootstrapStatusRunning, sessionIDPtr, logger)
 
 		logWriter := &bootstrapLogWriter{
 			store:     stores.SessionLogs,
@@ -2410,6 +2492,7 @@ func newRunEvalBootstrapHandler(stores *Stores, services *Services, logger zerol
 				models.EvalBootstrapStatusFailed, nil, &errMsg); updateErr != nil {
 				logger.Warn().Err(updateErr).Msg("failed to update bootstrap run with error")
 			}
+			publishEvalBootstrapSignal(ctx, services, orgID, bootstrapRunID, models.EvalBootstrapStatusFailed, sessionIDPtr, logger)
 			return fmt.Errorf("bootstrap scan failed: %w", scanErr)
 		}
 
@@ -2418,6 +2501,7 @@ func newRunEvalBootstrapHandler(stores *Stores, services *Services, logger zerol
 			models.EvalBootstrapStatusCompleted, candidatesJSON, nil); err != nil {
 			return fmt.Errorf("update bootstrap result: %w", err)
 		}
+		publishEvalBootstrapSignal(ctx, services, orgID, bootstrapRunID, models.EvalBootstrapStatusCompleted, sessionIDPtr, logger)
 
 		logWriter.log(ctx, "info", fmt.Sprintf("Bootstrap scan completed successfully. Found %d candidates.", len(candidates)))
 		if session.ID != uuid.Nil {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1432,12 +1432,12 @@ func TestPushPRChangesHandler_SuccessMarksPushingAndSucceeded(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
 	// Two state-machine writes: pushing → succeeded.
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	called := false
 	services := &Services{
@@ -1522,12 +1522,12 @@ func TestPushPRChangesHandler_NoChangesIsTreatedAsSuccess(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
 	// pushing → succeeded (NOT failed, despite the error from the service).
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -1575,13 +1575,17 @@ func TestPushPRChangesHandler_TerminalErrorBecomesFatal(t *testing.T) {
 			mock.ExpectQuery("SELECT .* FROM sessions").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-			// pushing → failed.
-			mock.ExpectExec("UPDATE sessions").
+			// idle → pushing, then pushing → failed. Both UpdatePRPushState
+			// calls now use RETURNING + publishStatus instead of bare Exec
+			// so the SSE detail page sees the transition without a poll;
+			// stub returning rows so the publish path stays no-op (streams
+			// are nil).
+			mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_push_state[\\s\\S]*RETURNING").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-			mock.ExpectExec("UPDATE sessions").
+				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+			mock.ExpectQuery("UPDATE sessions[\\s\\S]*pr_push_state[\\s\\S]*RETURNING").
 				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-				WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
 
 			services := &Services{
 				PR: &stubPRService{
@@ -1617,12 +1621,12 @@ func TestOpenPRHandler_TerminalPRErrorsBecomeFatal(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -1822,12 +1826,12 @@ func TestOpenPRHandler_SuccessMarksPushingAndSucceeded(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -1875,12 +1879,12 @@ func TestOpenPRHandler_HydratesLinkedIssuesBeforeCreatePR(t *testing.T) {
 			linkID, orgID, sessionID, issueID, string(models.SessionIssueLinkRolePrimary), 0, nil, now,
 			&title, &source, &externalID, nil, nil, &status, nil, nil,
 		))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -1927,12 +1931,12 @@ func TestOpenPRHandler_ForwardsAuthorModeToPRService(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -1966,12 +1970,12 @@ func TestOpenPRHandler_NonTerminalPRErrorsMarkFailedAndRetry(t *testing.T) {
 	mock.ExpectQuery("SELECT .* FROM sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	retryErr := errors.New("github timed out")
 	services := &Services{
@@ -3505,12 +3509,12 @@ func TestOpenPRHandler_UsesSnapshotPrimaryIssueFromPayload(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "org_id", "session_id", "turn_number", "linked_issues", "created_at"}).
 				AddRow(snapshotID, orgID, sessionID, 1, []byte(`[{"issue_id":"`+primaryIssueID.String()+`","role":"primary","position":0,"title":"Fix checkout timeout","source":"linear"}]`), now),
 		)
-	mock.ExpectExec("UPDATE sessions").
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE sessions").
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 	services := &Services{
 		PR: &stubPRService{
@@ -3621,12 +3625,12 @@ func TestOpenPRHandler_IssueSnapshotErrors(t *testing.T) {
 				pgxmock.NewRows([]string{"id", "org_id", "session_id", "turn_number", "linked_issues", "created_at"}).
 					AddRow(uuid.New(), orgID, sessionID, 2, []byte(`[{"issue_id":"`+primaryIssueID.String()+`","role":"primary","position":0,"title":"Fix checkout timeout","source":"linear"}]`), now),
 			)
-		mock.ExpectExec("UPDATE sessions").
+		mock.ExpectQuery("UPDATE sessions").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-		mock.ExpectExec("UPDATE sessions").
+			WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+		mock.ExpectQuery("UPDATE sessions").
 			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			WillReturnRows(pgxmock.NewRows(workerSessionColumns))
 
 		handler := newOpenPRHandler(stores, &Services{
 			PR: &stubPRService{


### PR DESCRIPTION
## Summary
Three migrations to shed Postgres polling in favor of Redis-backed SSE: (1) PR creation/push state — store mutators now use RETURNING + publishStatus on the existing per-session Redis stream, and the frontend drops its 2s `/sessions/{id}/pr` poll; (2) eval batch + bootstrap — new per-resource pub/sub channels (`{batch:UUID}:eval_batches`, `{bootstrap:UUID}:eval_bootstraps`) with matching SSE handlers, worker publish hooks at every state transition, a shared `useEvalSSE` hook with capped exponential reconnect, and a slow polling backstop when SSE is unavailable; (3) SSE log polling fallback hardened with per-connection randomized intervals in [2.0s, 3.5s] (heartbeat in [12s, 18s]) so a Redis outage doesn't translate into a synchronized N-client dogpile against Postgres. Cross-org `?org_id=` query parity with `pull_requests.go` for EventSource clients that can't send `X-Active-Org-ID` headers, and an `atomic.Int64` test-override hook keeps existing tests fast and race-detector clean.

## Test plan
- [x] Full Go suite passes (`go test ./...`)
- [x] Race detector clean on the polling tests (`go test -race ./internal/api/handlers/ -run 'StreamLogsViaPolling|SSEFallback|StreamBatchUpdates|StreamBootstrapUpdates'`)
- [x] Frontend lint, typecheck, and full vitest suite pass (1619 tests)
- [ ] Manual: trigger a PR creation and confirm the detail page button transitions without polling network traffic
- [ ] Manual: start an eval batch and watch the matrix update via SSE; kill Redis and confirm the page falls back to polling
- [ ] Manual: kick off a bootstrap scan and confirm the candidates list wakes via SSE on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)