### PR TITLE
Fix clipped active underline on SessionDetail “Changes” tab when badge is shown

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2691,6 +2691,24 @@ describe('SessionDetailPage', () => {
     expect(changesTab).toHaveTextContent('Changes2');
   });
 
+  it('reserves bottom space for the active Changes underline when the file count badge is shown', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);\ndiff --git a/src/new.ts b/src/new.ts\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+export const x = 1;',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    expect(screen.getByLabelText('Session detail tabs')).toHaveClass('pb-1');
+  });
+
   it('does not show file count badge on Changes tab when session has no diff', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3027,7 +3027,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             ref={detailTabsRef}
             aria-label="Session detail tabs"
             className={cn(
-              "min-w-0 flex-1 overflow-x-auto overflow-y-hidden",
+              "min-w-0 flex-1 overflow-x-auto overflow-y-hidden pb-1",
               detailTabsOverflow ? "mask-fade-r" : "scrollbar-hide",
             )}
           >


### PR DESCRIPTION
## Summary
Adjusted the session detail tab rail styling to ensure the active underline for the **Changes** tab isn’t clipped when the file count badge increases the tab height. Added a regression test to cover this specific badge+underline layout issue.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Added `pb-1` (bottom padding) to the tab container (`aria-label="Session detail tabs"`) so the active underline has space even when the **Changes** badge is present.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added a test that renders a session with a diff (badge shown) and asserts the tab rail includes the expected bottom padding class (`pb-1`).
  
## Test plan
- Ran: `npx vitest run "src/app/(dashboard)/sessions/[id]/page.test.tsx"`
- Also ran: `npm run typecheck`, `npm run lint`, and `npm run build` (build succeeded; existing Next.js warnings remain unchanged).

[143.dev](https://143.dev) | [session a8d041a4](https://143.dev/sessions/a8d041a4-d3e6-435c-8cb4-e9fef3effce6)