### PR TITLE
Clean up LLM keys UI copy and update affected tests

### DIFF
--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx
@@ -77,7 +77,7 @@ describe("DefaultModelCard", () => {
     expect(screen.getByRole("combobox", { name: /LLM Model/i })).toBeDisabled();
   });
 
-  it("labels the key as 143's default and shows the cost-cap callout when on platform default", () => {
+  it("labels the key as 143's default and folds the cost-cap note into the helper copy when on platform default", () => {
     renderWithProviders(
       <DefaultModelCard
         value="gpt-5.4-mini"
@@ -94,7 +94,11 @@ describe("DefaultModelCard", () => {
     );
     expect(screen.getByText(/Using 143's default OpenAI key/i)).toBeInTheDocument();
     expect(screen.queryByText(/Uses your OpenAI key/)).not.toBeInTheDocument();
-    expect(screen.getByText(/capped at lower-cost models/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Used for organization-level LLM features, separate from the coding agents configured on the Agent settings page\. 143's default key is capped at lower-cost models\./i,
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Add your own OpenAI key/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertTriangle, Check, Info } from "lucide-react";
+import { AlertTriangle, Check } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import {
@@ -74,19 +74,12 @@ export function DefaultModelCard({
               ownerName={ownerProvider && ownerConfigured ? ownerName : null}
               usesPlatformDefault={ownerUsesPlatformDefault}
             />
-            {ownerUsesPlatformDefault && ownerHasModelRestriction && (
-              <div className="flex items-start gap-1.5 rounded-md border border-amber-300/60 bg-amber-50 px-2.5 py-1.5 text-xs text-amber-800 dark:border-amber-700/40 dark:bg-amber-950/20 dark:text-amber-200">
-                <Info className="mt-0.5 h-3 w-3 shrink-0" />
-                <div className="space-y-1">
-                  <p>
-                    143&apos;s default key is capped at lower-cost models.
-                  </p>
-                </div>
-              </div>
-            )}
             <p className="text-xs text-muted-foreground">
               Used for organization-level LLM features, separate from the coding agents configured
               on the Agent settings page.
+              {ownerUsesPlatformDefault && ownerHasModelRestriction
+                ? " 143's default key is capped at lower-cost models."
+                : ""}
             </p>
           </div>
 

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx
@@ -49,7 +49,7 @@ describe("ProviderKeyRow", () => {
         onEdit={() => {}}
       />,
     );
-    expect(screen.getByText("current")).toBeInTheDocument();
+    expect(screen.getByText("Current")).toBeInTheDocument();
 
     rerender(
       <ProviderKeyRow
@@ -60,7 +60,7 @@ describe("ProviderKeyRow", () => {
         onEdit={() => {}}
       />,
     );
-    expect(screen.queryByText("current")).not.toBeInTheDocument();
+    expect(screen.queryByText("Current")).not.toBeInTheDocument();
   });
 
   it("shows 'Using 143's default key' when only the platform default is available", () => {

--- a/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
+++ b/frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx
@@ -64,7 +64,7 @@ export function ProviderKeyRow({
             className="text-xs px-1.5 py-0"
             title="Provider for the current default model"
           >
-            current
+            Current
           </Badge>
         )}
       </div>


### PR DESCRIPTION
## Summary
This updates the LLM settings UI copy to be cleaner and more consistent (per VIR-67). Specifically, it folds the “cost-cap” helper callout into the existing helper text and fixes the badge capitalization in the provider key row.

## Changes
- **`frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.tsx`**
  - Removed the separate Amber info callout (`Info` icon + bordered box).
  - Moved the “capped at lower-cost models” message into the existing helper `<p>` text when `ownerUsesPlatformDefault && ownerHasModelRestriction`.
- **`frontend/src/app/(dashboard)/settings/llm/_components/DefaultModelCard.test.tsx`**
  - Updated assertions to match the new combined helper copy text (cost-cap note now included in the helper).
- **`frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.tsx`**
  - Updated badge text from `CURRENT` to `Current`.
- **`frontend/src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx`**
  - Updated expectation to look for `Current` instead of `current`.

## Test plan
- Ran: `npx vitest run 'src/app/(dashboard)/settings/llm/_components/ProviderKeyRow.test.tsx'`
- Confirmed the test passed.

[143.dev](https://143.dev) | [session e0e42f9d](https://143.dev/sessions/e0e42f9d-026b-48dd-9621-923951015b28)