### PR TITLE
Replace sticky day separators in chat timeline with inline divider

### DIFF
--- a/frontend/src/components/chat-timeline.test.tsx
+++ b/frontend/src/components/chat-timeline.test.tsx
@@ -284,4 +284,32 @@ describe("ChatTimeline", () => {
     expect(screen.getByText("No attachments")).toBeInTheDocument();
     expect(screen.queryByAltText("Attached image")).not.toBeInTheDocument();
   });
+
+  it("renders day separators inline instead of sticky", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-02T12:00:00Z"));
+
+    const entries: TimelineEntry[] = [
+      {
+        kind: "message",
+        data: makeMessage({ id: 15, created_at: "2026-01-01T08:00:00Z", content: "Yesterday message" }),
+      },
+      {
+        kind: "message",
+        data: makeMessage({ id: 16, created_at: "2026-01-02T08:00:00Z", content: "Today message" }),
+      },
+    ];
+
+    render(<ChatTimeline entries={entries} isRunning={false} />);
+
+    const yesterdayLabel = screen.getByText("Yesterday");
+    const todayLabel = screen.getByText("Today");
+
+    expect(yesterdayLabel).toBeInTheDocument();
+    expect(todayLabel).toBeInTheDocument();
+    expect(yesterdayLabel.parentElement?.parentElement).not.toHaveClass("sticky");
+    expect(yesterdayLabel.parentElement?.parentElement).not.toHaveClass("top-0");
+
+    vi.useRealTimers();
+  });
 });

--- a/frontend/src/components/chat-timeline.tsx
+++ b/frontend/src/components/chat-timeline.tsx
@@ -5,6 +5,7 @@ import { ChevronRight, AlertTriangle, FileCode2, FileText, ClipboardList, Check,
 import Image from "next/image";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
 import {
   Tooltip,
   TooltipContent,
@@ -98,12 +99,12 @@ function DaySeparator({ dateStr }: { dateStr: string }) {
   const label = formatDaySeparatorLabel(dateStr);
   if (!label) return null;
   return (
-    <div className="sticky top-0 z-10 -mx-4 px-4 py-1.5 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <div className="h-px flex-1 bg-border" />
-        <span className="font-medium tabular-nums">{label}</span>
-        <div className="h-px flex-1 bg-border" />
+    <div className="my-4 flex items-center gap-3 px-1">
+      <Separator className="flex-1 bg-border/70" />
+      <div className="rounded-full border border-border/60 bg-muted/35 px-2.5 py-1 text-xs font-medium tabular-nums text-muted-foreground shadow-xs">
+        {label}
       </div>
+      <Separator className="flex-1 bg-border/70" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Updated the Sessions/Chat timeline day separators to no longer use `position: sticky`. The new inline “pill + subtle rules” divider better matches the existing scrolling UI while keeping the day label readable.

## Changes
- **frontend/src/components/chat-timeline.tsx**
  - Replaced the `DaySeparator` markup/classes:
    - Removed `sticky top-0` header behavior.
    - Added an inline layout using `Separator` with a centered, rounded pill label and lighter left/right rules.
- **frontend/src/components/chat-timeline.test.tsx**
  - Added a test asserting day labels render inline (not `sticky` and not `top-0`) for consecutive “Yesterday/Today” entries.

## Test plan
- `npx vitest run src/components/chat-timeline.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; existing Next.js lockfile/middleware warnings remain)

[143.dev](https://143.dev) | [session 864190b2](https://143.dev/sessions/864190b2-766c-40f0-a946-138dcee218e1)