### PR TITLE
Default PM to gpt-5.4, add gpt-5.5 + claude-opus-4-7, drop legacy aliases

### DIFF
--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -7,8 +7,7 @@ import {
   AVAILABLE_PM_MODELS,
   DEFAULT_PM_MODEL,
   DEFAULT_LLM_MODEL,
-  CLAUDE_CODE_MODEL_SONNET,
-  LEGACY_PM_ALIASES,
+  CODEX_MODEL_GPT_5_4,
   LLM_PROVIDER_INFO,
   PM_MODELS_BY_PROVIDER,
   LLM_MODELS_BY_PROVIDER,
@@ -16,13 +15,12 @@ import {
 } from "./model-constants";
 
 describe("model constants", () => {
-  it("uses claude-sonnet-4-5 as the PM default", () => {
-    expect(DEFAULT_PM_MODEL).toBe(CLAUDE_CODE_MODEL_SONNET);
+  it("uses gpt-5.4 as the PM default", () => {
+    expect(DEFAULT_PM_MODEL).toBe(CODEX_MODEL_GPT_5_4);
   });
 
-  it("includes legacy aliases and all provider models in AVAILABLE_PM_MODELS", () => {
+  it("includes all provider models in AVAILABLE_PM_MODELS", () => {
     expect(AVAILABLE_PM_MODELS).toEqual([
-      ...LEGACY_PM_ALIASES,
       ...AVAILABLE_CLAUDE_CODE_MODELS,
       ...AVAILABLE_GEMINI_CLI_MODELS,
       ...AVAILABLE_CODEX_MODELS,
@@ -38,6 +36,7 @@ describe("model constants", () => {
 
   it("includes latest Claude Code model aliases", () => {
     expect(AVAILABLE_CLAUDE_CODE_MODELS).toEqual([
+      "claude-opus-4-7",
       "claude-opus-4-6",
       "claude-sonnet-4-6",
       "claude-sonnet-4-5",
@@ -56,6 +55,7 @@ describe("model constants", () => {
 
   it("includes latest Codex models", () => {
     expect(AVAILABLE_CODEX_MODELS).toEqual([
+      "gpt-5.5",
       "gpt-5.4",
       "gpt-5.4-mini",
       "gpt-5.3-codex",

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -34,7 +34,7 @@ describe("model constants", () => {
     expect(PM_MODELS_BY_PROVIDER.codex.models).toEqual(AVAILABLE_CODEX_MODELS);
   });
 
-  it("includes latest Claude Code model aliases", () => {
+  it("includes latest Claude Code models", () => {
     expect(AVAILABLE_CLAUDE_CODE_MODELS).toEqual([
       "claude-opus-4-7",
       "claude-opus-4-6",

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -1,15 +1,15 @@
 export const CLAUDE_CODE_MODEL_OPUS_47 = "claude-opus-4-7";
-export const CLAUDE_CODE_MODEL_OPUS = "claude-opus-4-6";
+export const CLAUDE_CODE_MODEL_OPUS_46 = "claude-opus-4-6";
 export const CLAUDE_CODE_MODEL_SONNET_46 = "claude-sonnet-4-6";
-export const CLAUDE_CODE_MODEL_SONNET = "claude-sonnet-4-5";
-export const CLAUDE_CODE_MODEL_HAIKU = "claude-haiku-4-5";
+export const CLAUDE_CODE_MODEL_SONNET_45 = "claude-sonnet-4-5";
+export const CLAUDE_CODE_MODEL_HAIKU_45 = "claude-haiku-4-5";
 
 export const AVAILABLE_CLAUDE_CODE_MODELS = [
   CLAUDE_CODE_MODEL_OPUS_47,
-  CLAUDE_CODE_MODEL_OPUS,
+  CLAUDE_CODE_MODEL_OPUS_46,
   CLAUDE_CODE_MODEL_SONNET_46,
-  CLAUDE_CODE_MODEL_SONNET,
-  CLAUDE_CODE_MODEL_HAIKU,
+  CLAUDE_CODE_MODEL_SONNET_45,
+  CLAUDE_CODE_MODEL_HAIKU_45,
 ] as const;
 
 export const GEMINI_CLI_MODEL_GEMINI_3_1_PRO_PREVIEW = "gemini-3.1-pro-preview";

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -1,16 +1,11 @@
-// Legacy PM model aliases (kept for backward compatibility).
-export const PM_MODEL_OPUS = "opus";
-export const PM_MODEL_SONNET = "sonnet";
-export const PM_MODEL_HAIKU = "haiku";
-
-export const LEGACY_PM_ALIASES = [PM_MODEL_OPUS, PM_MODEL_SONNET, PM_MODEL_HAIKU] as const;
-
+export const CLAUDE_CODE_MODEL_OPUS_47 = "claude-opus-4-7";
 export const CLAUDE_CODE_MODEL_OPUS = "claude-opus-4-6";
 export const CLAUDE_CODE_MODEL_SONNET_46 = "claude-sonnet-4-6";
 export const CLAUDE_CODE_MODEL_SONNET = "claude-sonnet-4-5";
 export const CLAUDE_CODE_MODEL_HAIKU = "claude-haiku-4-5";
 
 export const AVAILABLE_CLAUDE_CODE_MODELS = [
+  CLAUDE_CODE_MODEL_OPUS_47,
   CLAUDE_CODE_MODEL_OPUS,
   CLAUDE_CODE_MODEL_SONNET_46,
   CLAUDE_CODE_MODEL_SONNET,
@@ -29,6 +24,7 @@ export const AVAILABLE_GEMINI_CLI_MODELS = [
   GEMINI_CLI_MODEL_GEMINI_2_5_FLASH,
 ] as const;
 
+export const CODEX_MODEL_GPT_5_5 = "gpt-5.5";
 export const CODEX_MODEL_GPT_5_4 = "gpt-5.4";
 export const CODEX_MODEL_GPT_5_4_MINI = "gpt-5.4-mini";
 export const CODEX_MODEL_GPT_5_3_CODEX = "gpt-5.3-codex";
@@ -37,6 +33,7 @@ export const CODEX_MODEL_GPT_5_CODEX = "gpt-5-codex";
 export const CODEX_MODEL_GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
 
 export const AVAILABLE_CODEX_MODELS = [
+  CODEX_MODEL_GPT_5_5,
   CODEX_MODEL_GPT_5_4,
   CODEX_MODEL_GPT_5_4_MINI,
   CODEX_MODEL_GPT_5_3_CODEX,
@@ -83,15 +80,14 @@ export const PM_MODELS_BY_PROVIDER: Record<string, { label: string; models: read
   codex: { label: "Codex", models: AVAILABLE_CODEX_MODELS, apiKeyVar: "OPENAI_API_KEY" },
 };
 
-export const DEFAULT_PM_MODEL = CLAUDE_CODE_MODEL_SONNET;
+export const DEFAULT_PM_MODEL = CODEX_MODEL_GPT_5_4;
 
 // Agent type options for session/project creation forms live on the AGENTS
 // registry in @/lib/agents. Import AGENTS (and agentTypeForModel) from there —
 // keeping a second list here would drift.
 
-// All PM models across every provider (for validation / backward compat).
+// All PM models across every provider (for validation).
 export const AVAILABLE_PM_MODELS = [
-  ...LEGACY_PM_ALIASES,
   ...AVAILABLE_CLAUDE_CODE_MODELS,
   ...AVAILABLE_GEMINI_CLI_MODELS,
   ...AVAILABLE_CODEX_MODELS,

--- a/internal/api/handlers/settings_audit_test.go
+++ b/internal/api/handlers/settings_audit_test.go
@@ -10,7 +10,7 @@ import (
 func TestSettingsAuditDiff_NoChange(t *testing.T) {
 	t.Parallel()
 
-	raw := json.RawMessage(`{"pm_model":"sonnet","max_concurrent_runs":10}`)
+	raw := json.RawMessage(`{"pm_model":"claude-sonnet-4-5","max_concurrent_runs":10}`)
 	changes := settingsAuditDiff(raw, raw)
 	require.Empty(t, changes, "identical blobs must not produce changes")
 }
@@ -18,11 +18,11 @@ func TestSettingsAuditDiff_NoChange(t *testing.T) {
 func TestSettingsAuditDiff_ScalarChange(t *testing.T) {
 	t.Parallel()
 
-	old := json.RawMessage(`{"pm_model":"sonnet"}`)
-	new_ := json.RawMessage(`{"pm_model":"opus"}`)
+	old := json.RawMessage(`{"pm_model":"claude-sonnet-4-5"}`)
+	new_ := json.RawMessage(`{"pm_model":"claude-opus-4-7"}`)
 	changes := settingsAuditDiff(old, new_)
 	require.Len(t, changes, 1)
-	require.Equal(t, map[string]any{"before": "sonnet", "after": "opus"}, changes["pm_model"])
+	require.Equal(t, map[string]any{"before": "claude-sonnet-4-5", "after": "claude-opus-4-7"}, changes["pm_model"])
 }
 
 func TestSettingsAuditDiff_NestedChangeFlattened(t *testing.T) {
@@ -41,8 +41,8 @@ func TestSettingsAuditDiff_NestedChangeFlattened(t *testing.T) {
 func TestSettingsAuditDiff_KeyAdded(t *testing.T) {
 	t.Parallel()
 
-	old := json.RawMessage(`{"pm_model":"sonnet"}`)
-	new_ := json.RawMessage(`{"pm_model":"sonnet","llm_model":"gpt-5.4-mini"}`)
+	old := json.RawMessage(`{"pm_model":"claude-sonnet-4-5"}`)
+	new_ := json.RawMessage(`{"pm_model":"claude-sonnet-4-5","llm_model":"gpt-5.4-mini"}`)
 	changes := settingsAuditDiff(old, new_)
 	require.Len(t, changes, 1)
 	entry, ok := changes["llm_model"].(map[string]any)
@@ -54,8 +54,8 @@ func TestSettingsAuditDiff_KeyAdded(t *testing.T) {
 func TestSettingsAuditDiff_KeyRemoved(t *testing.T) {
 	t.Parallel()
 
-	old := json.RawMessage(`{"pm_model":"sonnet","llm_model":"gpt-5.4-mini"}`)
-	new_ := json.RawMessage(`{"pm_model":"sonnet"}`)
+	old := json.RawMessage(`{"pm_model":"claude-sonnet-4-5","llm_model":"gpt-5.4-mini"}`)
+	new_ := json.RawMessage(`{"pm_model":"claude-sonnet-4-5"}`)
 	changes := settingsAuditDiff(old, new_)
 	require.Len(t, changes, 1)
 	entry, ok := changes["llm_model"].(map[string]any)
@@ -69,12 +69,12 @@ func TestSettingsAuditDiff_EmptyOldBlob(t *testing.T) {
 
 	// First-ever settings write: every incoming key is a change.
 	old := json.RawMessage(nil)
-	new_ := json.RawMessage(`{"pm_model":"sonnet"}`)
+	new_ := json.RawMessage(`{"pm_model":"claude-sonnet-4-5"}`)
 	changes := settingsAuditDiff(old, new_)
 	require.Len(t, changes, 1)
 	entry := changes["pm_model"].(map[string]any)
 	require.Nil(t, entry["before"])
-	require.Equal(t, "sonnet", entry["after"])
+	require.Equal(t, "claude-sonnet-4-5", entry["after"])
 }
 
 func TestSettingsAuditDiff_DeeplyNestedAgentConfig(t *testing.T) {

--- a/internal/api/handlers/settings_test.go
+++ b/internal/api/handlers/settings_test.go
@@ -306,7 +306,7 @@ func TestSettingsHandler_Update(t *testing.T) {
 		},
 		{
 			name: "updates successfully with supported models",
-			body: `{"settings":{"pm_model":"sonnet","agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"},"claude_code":{"ANTHROPIC_MODEL":"claude-sonnet-4-5"},"gemini_cli":{"GEMINI_MODEL":"gemini-3.1-pro-preview"}}}}`,
+			body: `{"settings":{"pm_model":"claude-sonnet-4-5","agent_config":{"codex":{"OPENAI_MODEL":"gpt-5.3-codex"},"claude_code":{"ANTHROPIC_MODEL":"claude-sonnet-4-5"},"gemini_cli":{"GEMINI_MODEL":"gemini-3.1-pro-preview"}}}}`,
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID uuid.UUID) {
 				now := time.Now()
 				mock.ExpectQuery("SELECT .+ FROM organizations WHERE id").

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -6,21 +6,11 @@ import (
 	"strings"
 )
 
-// Legacy PM model aliases (kept for backward compatibility).
-const (
-	PMModelOpus   = "opus"
-	PMModelSonnet = "sonnet"
-	PMModelHaiku  = "haiku"
-)
-
-var legacyPMAliases = []string{PMModelOpus, PMModelSonnet, PMModelHaiku}
-
-// AvailablePMModels includes all models from every provider plus legacy aliases.
+// AvailablePMModels includes all models from every provider.
 // The PM agent can use any model from any configured provider.
 var AvailablePMModels []string
 
 func init() {
-	AvailablePMModels = append(AvailablePMModels, legacyPMAliases...)
 	AvailablePMModels = append(AvailablePMModels, AvailableClaudeCodeModels...)
 	AvailablePMModels = append(AvailablePMModels, AvailableGeminiCLIModels...)
 	AvailablePMModels = append(AvailablePMModels, AvailableCodexModels...)
@@ -58,13 +48,14 @@ var AvailablePiModels = []string{
 }
 
 const (
-	ClaudeCodeModelOpus     = "claude-opus-4-6"
+	ClaudeCodeModelOpus47   = "claude-opus-4-7"
+	ClaudeCodeModelOpus46   = "claude-opus-4-6"
 	ClaudeCodeModelSonnet46 = "claude-sonnet-4-6"
-	ClaudeCodeModelSonnet   = "claude-sonnet-4-5"
-	ClaudeCodeModelHaiku    = "claude-haiku-4-5"
+	ClaudeCodeModelSonnet45 = "claude-sonnet-4-5"
+	ClaudeCodeModelHaiku45  = "claude-haiku-4-5"
 )
 
-var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku}
+var AvailableClaudeCodeModels = []string{ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45}
 
 const (
 	GeminiCLIModelGemini31ProPreview  = "gemini-3.1-pro-preview"
@@ -81,6 +72,7 @@ var AvailableGeminiCLIModels = []string{
 }
 
 const (
+	CodexModelGPT55           = "gpt-5.5"
 	CodexModelGPT54           = "gpt-5.4"
 	CodexModelGPT54Mini       = "gpt-5.4-mini"
 	CodexModelGPT53Codex      = "gpt-5.3-codex"
@@ -90,6 +82,7 @@ const (
 )
 
 var AvailableCodexModels = []string{
+	CodexModelGPT55,
 	CodexModelGPT54,
 	CodexModelGPT54Mini,
 	CodexModelGPT53Codex,
@@ -108,12 +101,6 @@ func IsSupportedPMModel(model string) bool {
 }
 
 func IsSupportedClaudeCodeModel(model string) bool {
-	// Accept legacy PM aliases (opus, sonnet, haiku) for Claude Code.
-	for _, alias := range legacyPMAliases {
-		if model == alias {
-			return true
-		}
-	}
 	for _, supportedModel := range AvailableClaudeCodeModels {
 		if model == supportedModel {
 			return true
@@ -412,7 +399,7 @@ func ValidateSettingsModels(settings OrgSettings) error {
 		case AgentTypeClaudeCode:
 			model := envVars["ANTHROPIC_MODEL"]
 			if model != "" && !IsSupportedClaudeCodeModel(model) {
-				return fmt.Errorf("agent_config.claude_code.ANTHROPIC_MODEL must be one of: %v or %v", legacyPMAliases, AvailableClaudeCodeModels)
+				return fmt.Errorf("agent_config.claude_code.ANTHROPIC_MODEL must be one of: %v", AvailableClaudeCodeModels)
 			}
 		case AgentTypeGeminiCLI:
 			model := envVars["GEMINI_MODEL"]

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -9,21 +9,21 @@ import (
 func TestPMModelConstants(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, PMModelSonnet, DefaultPMModel, "DefaultPMModel should use PMModelSonnet")
+	require.Equal(t, CodexModelGPT54, DefaultPMModel, "DefaultPMModel should use CodexModelGPT54")
 
-	// AvailablePMModels should include legacy aliases plus all provider models.
-	expected := []string{PMModelOpus, PMModelSonnet, PMModelHaiku}
+	// AvailablePMModels should include all provider models.
+	var expected []string
 	expected = append(expected, AvailableClaudeCodeModels...)
 	expected = append(expected, AvailableGeminiCLIModels...)
 	expected = append(expected, AvailableCodexModels...)
-	require.Equal(t, expected, AvailablePMModels, "AvailablePMModels should include legacy aliases and all provider models")
+	require.Equal(t, expected, AvailablePMModels, "AvailablePMModels should include all provider models")
 }
 
 func TestClaudeCodeModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{ClaudeCodeModelOpus, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet, ClaudeCodeModelHaiku},
+		[]string{ClaudeCodeModelOpus47, ClaudeCodeModelOpus46, ClaudeCodeModelSonnet46, ClaudeCodeModelSonnet45, ClaudeCodeModelHaiku45},
 		AvailableClaudeCodeModels,
 		"AvailableClaudeCodeModels should be ordered by capability",
 	)
@@ -43,7 +43,7 @@ func TestCodexModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{CodexModelGPT54, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
+		[]string{CodexModelGPT55, CodexModelGPT54, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
 		AvailableCodexModels,
 		"AvailableCodexModels should include the latest Codex model family",
 	)
@@ -115,7 +115,7 @@ func TestValidateModelForAgentType(t *testing.T) {
 		wantErr   bool
 	}{
 		{name: "valid codex model", agentType: AgentTypeCodex, model: CodexModelGPT53Codex},
-		{name: "valid claude model", agentType: AgentTypeClaudeCode, model: ClaudeCodeModelSonnet},
+		{name: "valid claude model", agentType: AgentTypeClaudeCode, model: ClaudeCodeModelSonnet45},
 		{name: "valid gemini model", agentType: AgentTypeGeminiCLI, model: GeminiCLIModelGemini31ProPreview},
 		{name: "valid amp mode", agentType: AgentTypeAmp, model: AmpModeSmart},
 		{name: "valid pi model", agentType: AgentTypePi, model: PiModelClaudeSonnet46},
@@ -184,26 +184,18 @@ func TestValidateSettingsModels(t *testing.T) {
 		{
 			name: "accepts valid pm and agent models",
 			settings: OrgSettings{
-				PMModel: PMModelSonnet,
+				PMModel: ClaudeCodeModelSonnet45,
 				AgentConfig: AgentEnvConfig{
 					"codex":       {"OPENAI_MODEL": CodexModelGPT53Codex},
-					"claude_code": {"ANTHROPIC_MODEL": ClaudeCodeModelSonnet},
+					"claude_code": {"ANTHROPIC_MODEL": ClaudeCodeModelSonnet45},
 					"gemini_cli":  {"GEMINI_MODEL": GeminiCLIModelGemini31ProPreview},
-				},
-			},
-		},
-		{
-			name: "accepts claude alias values",
-			settings: OrgSettings{
-				AgentConfig: AgentEnvConfig{
-					"claude_code": {"ANTHROPIC_MODEL": PMModelOpus},
 				},
 			},
 		},
 		{
 			name: "accepts claude code model as pm model",
 			settings: OrgSettings{
-				PMModel: ClaudeCodeModelSonnet,
+				PMModel: ClaudeCodeModelSonnet45,
 			},
 		},
 		{

--- a/internal/models/org_settings.go
+++ b/internal/models/org_settings.go
@@ -408,7 +408,7 @@ const (
 	DefaultMinPriorityThreshold                     = 30.0
 	DefaultDefaultAgentType           AgentType     = AgentTypeCodex
 	DefaultPMScheduleHours                          = 24
-	DefaultPMModel                                  = PMModelSonnet
+	DefaultPMModel                                  = CodexModelGPT54
 	DefaultAuditRetentionDays                       = 90
 	DefaultContextRefreshIntervalDays               = 14
 	DefaultOrgSize                    OrgSize       = OrgSizeMedium

--- a/internal/models/org_settings_test.go
+++ b/internal/models/org_settings_test.go
@@ -52,7 +52,7 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 		"agent_autonomy": "conservative",
 		"product_direction": "focus on billing",
 		"pm_schedule_hours": 6,
-		"pm_model": "sonnet",
+		"pm_model": "claude-sonnet-4-5",
 		"product_context": {
 			"philosophy": "Prefer minimal diffs",
 			"direction": "Harden billing",
@@ -77,7 +77,7 @@ func TestParseOrgSettings_OverrideValues(t *testing.T) {
 	require.Equal(t, 50.0, s.MinPriorityThreshold, "should override min_priority_threshold")
 	require.Equal(t, "focus on billing", s.ProductDirection, "should override product_direction")
 	require.Equal(t, 6, s.PMScheduleHours, "should override pm_schedule_hours")
-	require.Equal(t, "sonnet", s.PMModel, "should override pm_model")
+	require.Equal(t, "claude-sonnet-4-5", s.PMModel, "should override pm_model")
 	require.NotNil(t, s.ProductContext, "should parse product_context")
 	require.Equal(t, "Prefer minimal diffs", s.ProductContext.Philosophy, "should parse product_context.philosophy")
 	require.Equal(t, "Harden billing", s.ProductContext.Direction, "should parse product_context.direction")
@@ -124,7 +124,7 @@ func TestParseOrgSettings_AgentConfig(t *testing.T) {
 
 	raw := json.RawMessage(`{
 		"agent_config": {
-			"claude_code": {"ANTHROPIC_MODEL": "opus", "ANTHROPIC_API_KEY": "sk-ant-org"},
+			"claude_code": {"ANTHROPIC_MODEL": "claude-opus-4-7", "ANTHROPIC_API_KEY": "sk-ant-org"},
 			"gemini_cli": {"GEMINI_MODEL": "gemini-2.5-pro"}
 		}
 	}`)
@@ -133,7 +133,7 @@ func TestParseOrgSettings_AgentConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, s.AgentConfig, "should parse agent_config")
-	require.Equal(t, "opus", s.AgentConfig["claude_code"]["ANTHROPIC_MODEL"])
+	require.Equal(t, "claude-opus-4-7", s.AgentConfig["claude_code"]["ANTHROPIC_MODEL"])
 	require.Equal(t, "sk-ant-org", s.AgentConfig["claude_code"]["ANTHROPIC_API_KEY"])
 	require.Equal(t, "gemini-2.5-pro", s.AgentConfig["gemini_cli"]["GEMINI_MODEL"])
 	require.NotContains(t, s.AgentConfig, "codex", "codex should not be present when not configured")

--- a/internal/models/repo_settings_test.go
+++ b/internal/models/repo_settings_test.go
@@ -18,7 +18,7 @@ func TestParseRepoSettings_Empty(t *testing.T) {
 
 func TestParseRepoSettings_WithPM(t *testing.T) {
 	t.Parallel()
-	raw := json.RawMessage(`{"pm":{"pm_schedule_hours":2,"pm_model":"opus"}}`)
+	raw := json.RawMessage(`{"pm":{"pm_schedule_hours":2,"pm_model":"claude-opus-4-7"}}`)
 	s, err := ParseRepoSettings(raw)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -29,8 +29,8 @@ func TestParseRepoSettings_WithPM(t *testing.T) {
 	if *s.PM.PMScheduleHours != 2 {
 		t.Fatalf("expected pm_schedule_hours=2, got %d", *s.PM.PMScheduleHours)
 	}
-	if *s.PM.PMModel != "opus" {
-		t.Fatalf("expected pm_model=opus, got %s", *s.PM.PMModel)
+	if *s.PM.PMModel != "claude-opus-4-7" {
+		t.Fatalf("expected pm_model=claude-opus-4-7, got %s", *s.PM.PMModel)
 	}
 }
 
@@ -62,7 +62,7 @@ func TestMergeRepoPMSettings_Overrides(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	hours := 2
-	model := "opus"
+	model := "claude-opus-4-7"
 	threshold := 50.0
 	repo := RepoSettings{
 		PM: &RepoPMSettings{
@@ -81,8 +81,8 @@ func TestMergeRepoPMSettings_Overrides(t *testing.T) {
 	if merged.PMScheduleHours != 2 {
 		t.Fatalf("expected schedule hours=2, got %d", merged.PMScheduleHours)
 	}
-	if merged.PMModel != "opus" {
-		t.Fatalf("expected pm_model=opus, got %s", merged.PMModel)
+	if merged.PMModel != "claude-opus-4-7" {
+		t.Fatalf("expected pm_model=claude-opus-4-7, got %s", merged.PMModel)
 	}
 	if merged.MinPriorityThreshold != 50.0 {
 		t.Fatalf("expected threshold=50, got %f", merged.MinPriorityThreshold)
@@ -121,7 +121,7 @@ func TestMergeRepoPMSettings_PartialOverride(t *testing.T) {
 
 func TestValidateRepoPMSettings_ValidModel(t *testing.T) {
 	t.Parallel()
-	model := "opus"
+	model := "claude-opus-4-7"
 	pm := RepoPMSettings{PMModel: &model}
 	if err := ValidateRepoPMSettings(pm); err != nil {
 		t.Fatalf("expected valid, got: %v", err)


### PR DESCRIPTION
## Summary
- Switch the autopilot **PM model "Auto"** default from `claude-sonnet-4-5` to `gpt-5.4` (frontend label and backend `DefaultPMModel`).
- Add `gpt-5.5` to the Codex model catalog and `claude-opus-4-7` to the Claude Code catalog (both listed first as most capable).
- Rename Claude Code constants to carry version suffixes — `ClaudeCodeModelOpus46`, `ClaudeCodeModelSonnet45`, `ClaudeCodeModelHaiku45`.
- Remove the legacy `"opus"`/`"sonnet"`/`"haiku"` PM aliases (constants, `legacyPMAliases`, frontend `LEGACY_PM_ALIASES`, the backward-compat branch in `IsSupportedClaudeCodeModel`); verified via prod readonly query that no rows in `organizations.settings`, `organizations.settings.agent_config.claude_code.ANTHROPIC_MODEL`, or `repositories.settings.pm.pm_model` still use those values, so no migration is needed.

## Test plan
- [x] `vitest run src/lib/model-constants.test.ts src/app/(dashboard)/settings/autopilot/page.test.tsx` (25 passed)
- [ ] CI runs the Go test suite (local Go is 1.23, repo requires 1.26)
- [ ] Manually verify the autopilot page renders "Auto (gpt-5.4)" and that gpt-5.5 / claude-opus-4-7 appear in their provider sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)