### PR TITLE
Add Link Linear issue affordance to session composer

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3937,8 +3937,8 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findByPlaceholderText('Send a follow-up message...');
-    expect(screen.getByTitle('Attach files or images')).toBeInTheDocument();
-    expect(screen.getByTitle('Attach files or images')).not.toBeDisabled();
+    expect(screen.getByTitle('Add files, photos, or a Linear issue')).toBeInTheDocument();
+    expect(screen.getByTitle('Add files, photos, or a Linear issue')).not.toBeDisabled();
   });
 
   it('shows Codex agent type label', async () => {
@@ -3963,7 +3963,73 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findByPlaceholderText('Session is not active');
-    expect(screen.getByTitle('Attach files or images')).toBeDisabled();
+    expect(screen.getByTitle('Add files, photos, or a Linear issue')).toBeDisabled();
+  });
+
+  it('appends a Linear identifier to the follow-up message via the dropdown', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snapshot/test',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    const composer = await screen.findByPlaceholderText('Send a follow-up message...');
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTitle('Add files, photos, or a Linear issue'));
+    await user.click(await screen.findByRole('menuitem', { name: 'Link Linear issue' }));
+
+    const linearInput = await screen.findByLabelText('Linear issue id or URL');
+    await user.type(linearInput, 'ACS-1234');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(composer).toHaveValue('ACS-1234');
+    // Submitting the ref must close the input so the user can keep typing
+    // their message in the textarea — leaving it open would steal the next
+    // keystroke.
+    expect(screen.queryByLabelText('Linear issue id or URL')).not.toBeInTheDocument();
+  });
+
+  it('shows an inline error and keeps the input open when the Linear ref is malformed', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+      snapshot_key: 'snapshot/test',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    const composer = await screen.findByPlaceholderText('Send a follow-up message...');
+    const user = userEvent.setup();
+
+    await user.click(screen.getByTitle('Add files, photos, or a Linear issue'));
+    await user.click(await screen.findByRole('menuitem', { name: 'Link Linear issue' }));
+
+    const linearInput = await screen.findByLabelText('Linear issue id or URL');
+    await user.type(linearInput, 'fix the bug');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    // The ref-validation error must surface so the user knows why nothing
+    // happened; without this, an invalid input silently swallowed the click.
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Linear URL/);
+    expect(screen.getByLabelText('Linear issue id or URL')).toBeInTheDocument();
+    expect(composer).toHaveValue('');
   });
 
   it('enters review mode and shows review diff view with file tree', async () => {
@@ -4198,7 +4264,7 @@ describe('SessionDetailPage', () => {
 
     await screen.findByPlaceholderText('Session environment has expired and can no longer be continued');
 
-    const attachButton = container.querySelector('button[title="Attach files or images"]') as HTMLButtonElement | null;
+    const attachButton = container.querySelector('button[title="Add files, photos, or a Linear issue"]') as HTMLButtonElement | null;
     expect(attachButton).not.toBeNull();
     expect(attachButton).toBeDisabled();
     await user.hover(attachButton?.parentElement as HTMLElement);

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -30,6 +30,14 @@ import {
   Pencil,
   Plus,
 } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { LinearIcon } from "@/components/linear-icon";
+import { looksLikeLinearRef } from "@/lib/linear-refs";
 import { notify as toast } from "@/lib/notify";
 import { Badge } from "@/components/ui/badge";
 import { MarkdownContent } from "@/components/markdown";
@@ -843,12 +851,59 @@ function SessionComposer({
 
   const composerCardRef = useRef<HTMLDivElement>(null);
   const composerInputSurfaceRef = useRef<HTMLDivElement>(null);
+  const linearInputRef = useRef<HTMLInputElement>(null);
   const [caretPosition, setCaretPosition] = useState(message.length);
   const [selectedTriggerIndex, setSelectedTriggerIndex] = useState(0);
   const [triggerDismissed, setTriggerDismissed] = useState(false);
   const [pickerPosition, setPickerPosition] = useState<TriggerPickerPosition | null>(null);
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false);
   const isMobile = useMediaQuery("(max-width: 767px)");
+  const [showLinearInput, setShowLinearInput] = useState(false);
+  const [linearInput, setLinearInput] = useState("");
+  const [linearInputError, setLinearInputError] = useState<string | null>(null);
+
+  // Focus the Linear input the render after it mounts. Using a layout
+  // effect (rather than the previous requestAnimationFrame inside the menu
+  // item's onClick) guarantees the input is in the DOM before we focus —
+  // the rAF version raced React's commit and silently dropped focus on the
+  // first open in tight render budgets.
+  useEffect(() => {
+    if (showLinearInput) {
+      linearInputRef.current?.focus();
+    }
+  }, [showLinearInput]);
+
+  function addLinearLink() {
+    const trimmed = linearInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (!looksLikeLinearRef(trimmed)) {
+      // Block obvious garbage at submit time. The backend re-validates with
+      // the org's team-key allowlist; this is a UX hint, not a security
+      // boundary, so the regex matches detect.go's lax shape and we leave
+      // the input open so the user can correct it.
+      setLinearInputError("Enter a Linear URL (https://linear.app/...) or key like ACS-1234");
+      return;
+    }
+    // Append the trimmed ref to the message body. SendMessage hands the body
+    // to ResolveAndLinkMidSession which scans it for Linear refs and creates
+    // the session_issue_link row asynchronously, so plain-text append is
+    // exactly what the backend expects.
+    const next = message.length === 0
+      ? trimmed
+      : `${message}${message.endsWith(" ") || message.endsWith("\n") ? "" : " "}${trimmed}`;
+    onMessageChange(next);
+    setLinearInput("");
+    setLinearInputError(null);
+    setShowLinearInput(false);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(next.length, next.length);
+    });
+  }
 
   const activeTrigger = useMemo(
     () => findActiveTrigger(message, caretPosition, COMPOSER_TRIGGER_SPECS),
@@ -1299,22 +1354,78 @@ function SessionComposer({
             className="px-3 pb-2"
           />
 
+          {showLinearInput && (
+            <div className="flex flex-col gap-1 px-3 pb-2">
+              <div className="flex items-center gap-2">
+                <LinearIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <Input
+                  ref={linearInputRef}
+                  value={linearInput}
+                  onChange={(event) => {
+                    setLinearInput(event.target.value);
+                    if (linearInputError) {
+                      setLinearInputError(null);
+                    }
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      addLinearLink();
+                    } else if (event.key === "Escape") {
+                      event.preventDefault();
+                      setLinearInput("");
+                      setLinearInputError(null);
+                      setShowLinearInput(false);
+                    }
+                  }}
+                  placeholder="ACS-1234 or https://linear.app/acme/issue/ACS-1234"
+                  aria-label="Linear issue id or URL"
+                  aria-invalid={linearInputError ? true : undefined}
+                  className="h-8"
+                />
+                <Button type="button" variant="outline" size="sm" onClick={addLinearLink}>
+                  Add
+                </Button>
+              </div>
+              {linearInputError && (
+                <p role="alert" className="pl-6 text-xs text-destructive">{linearInputError}</p>
+              )}
+            </div>
+          )}
+
           <div className="px-2 pb-2">
             {isMobile ? (
               <>
                 <div className="flex items-center gap-2">
-                  <DisabledTooltip disabled={!canSendMessage || isUploading} content={attachDisabledReason}>
-                    <Button
-                      type="button"
-                      size="icon"
-                      variant="ghost"
-                      className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                      title="Attach files or images"
-                      disabled={!canSendMessage || isUploading}
-                      onClick={() => uploadInputRef.current?.click()}
-                    >
-                      {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
-                    </Button>
+                  <DisabledTooltip disabled={!canSendMessage} content={attachDisabledReason}>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                          title="Add files, photos, or a Linear issue"
+                          aria-label="Add files, photos, or a Linear issue"
+                          disabled={!canSendMessage}
+                        >
+                          {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="start">
+                        <DropdownMenuItem
+                          disabled={isUploading}
+                          onClick={() => uploadInputRef.current?.click()}
+                        >
+                          <Paperclip className="mr-2 h-4 w-4" />
+                          Upload files or photos
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => setShowLinearInput(true)}>
+                          <LinearIcon className="mr-2 h-4 w-4" />
+                          Link Linear issue
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   </DisabledTooltip>
                   <Button
                     type="button"
@@ -1380,18 +1491,35 @@ function SessionComposer({
               </>
             ) : (
               <div className="flex items-center gap-1">
-                <DisabledTooltip disabled={!canSendMessage || isUploading} content={attachDisabledReason}>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-                    title="Attach files or images"
-                    disabled={!canSendMessage || isUploading}
-                    onClick={() => uploadInputRef.current?.click()}
-                  >
-                    {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Paperclip className="h-4 w-4" />}
-                  </Button>
+                <DisabledTooltip disabled={!canSendMessage} content={attachDisabledReason}>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+                        title="Add files, photos, or a Linear issue"
+                        aria-label="Add files, photos, or a Linear issue"
+                        disabled={!canSendMessage}
+                      >
+                        {isUploading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start">
+                      <DropdownMenuItem
+                        disabled={isUploading}
+                        onClick={() => uploadInputRef.current?.click()}
+                      >
+                        <Paperclip className="mr-2 h-4 w-4" />
+                        Upload files or photos
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => setShowLinearInput(true)}>
+                        <LinearIcon className="mr-2 h-4 w-4" />
+                        Link Linear issue
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </DisabledTooltip>
 
                 {availableModels.length > 0 && (

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -33,6 +33,8 @@ import {
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
 import { BranchPicker } from "@/components/branch-picker";
+import { LinearIcon } from "@/components/linear-icon";
+import { looksLikeLinearRef } from "@/lib/linear-refs";
 import { PendingAttachmentStrip } from "@/components/pending-attachment-strip";
 import { SessionComposerTriggerPicker, flattenGroups, type TriggerPickerGroup, type TriggerPickerPosition } from "@/components/session-composer-trigger-picker";
 import { api } from "@/lib/api";
@@ -116,6 +118,20 @@ export function ManualSessionCreatePageContent() {
   const [isUploading, setIsUploading] = useState(false);
   const [showImageInput, setShowImageInput] = useState(false);
   const [imageURL, setImageURL] = useState("");
+  const [showLinearInput, setShowLinearInput] = useState(false);
+  const [linearInput, setLinearInput] = useState("");
+  const [linearInputError, setLinearInputError] = useState<string | null>(null);
+  const linearInputRef = useRef<HTMLInputElement>(null);
+
+  // Focus the Linear input the render after it mounts. Layout effect (vs.
+  // requestAnimationFrame inside the menu item's onClick) guarantees the
+  // input is committed to the DOM before we focus, so the first menu open
+  // doesn't race React's render and silently drop focus.
+  useEffect(() => {
+    if (showLinearInput) {
+      linearInputRef.current?.focus();
+    }
+  }, [showLinearInput]);
   const [selectedModel, setSelectedModel] = useState("");
   const [reasoningOverride, setReasoningOverride] = useState<CodingAgentReasoningEffort>("");
   const [userSelectedRepoId, setUserSelectedRepoId] = useState<string | null>(repoId ?? null);
@@ -796,6 +812,37 @@ export function ManualSessionCreatePageContent() {
     setShowImageInput(false);
   }
 
+  function addLinearLink() {
+    const trimmed = linearInput.trim();
+    if (!trimmed) {
+      return;
+    }
+    if (!looksLikeLinearRef(trimmed)) {
+      // UX-only validation. The backend ResolveAndLinkAtCreate re-validates
+      // with the org's team-key allowlist, so this catches obvious garbage
+      // (free text, typos) without claiming to be authoritative.
+      setLinearInputError("Enter a Linear URL (https://linear.app/...) or key like ACS-1234");
+      return;
+    }
+    // Append the URL or identifier to the message body. The Linear linker on
+    // the backend (ResolveAndLinkAtCreate) scans the message text for both
+    // linear.app URLs and bare identifiers like ACS-1234, so passing the
+    // user's input through verbatim is enough to wire the issue up.
+    setMessage((previous) => {
+      if (previous.length === 0) {
+        return trimmed;
+      }
+      const separator = previous.endsWith("\n") ? "" : previous.endsWith(" ") ? "" : " ";
+      return `${previous}${separator}${trimmed}`;
+    });
+    setLinearInput("");
+    setLinearInputError(null);
+    setShowLinearInput(false);
+    requestAnimationFrame(() => {
+      messageInputRef.current?.focus();
+    });
+  }
+
   function removeAttachment(value: string) {
     setAttachments((previous) => previous.filter((item) => item !== value));
   }
@@ -1145,6 +1192,44 @@ export function ManualSessionCreatePageContent() {
               </div>
             )}
 
+            {showLinearInput && (
+              <div className="flex flex-col gap-1 pb-3">
+                <div className="flex items-center gap-2">
+                  <LinearIcon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <Input
+                    ref={linearInputRef}
+                    value={linearInput}
+                    onChange={(event) => {
+                      setLinearInput(event.target.value);
+                      if (linearInputError) {
+                        setLinearInputError(null);
+                      }
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter") {
+                        event.preventDefault();
+                        addLinearLink();
+                      } else if (event.key === "Escape") {
+                        event.preventDefault();
+                        setLinearInput("");
+                        setLinearInputError(null);
+                        setShowLinearInput(false);
+                      }
+                    }}
+                    placeholder="ACS-1234 or https://linear.app/acme/issue/ACS-1234"
+                    aria-label="Linear issue id or URL"
+                    aria-invalid={linearInputError ? true : undefined}
+                  />
+                  <Button type="button" variant="outline" onClick={addLinearLink}>
+                    Add
+                  </Button>
+                </div>
+                {linearInputError && (
+                  <p role="alert" className="pl-6 text-xs text-destructive">{linearInputError}</p>
+                )}
+              </div>
+            )}
+
             <div className="pt-2">
               {isMobile ? (
                 <>
@@ -1163,6 +1248,10 @@ export function ManualSessionCreatePageContent() {
                         <DropdownMenuItem onClick={() => setShowImageInput(true)}>
                           <Link data-testid="add-image-url-link-icon" className="mr-2 h-4 w-4" />
                           Add image URL
+                        </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => setShowLinearInput(true)}>
+                          <LinearIcon className="mr-2 h-4 w-4" />
+                          Link Linear issue
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>
@@ -1214,6 +1303,10 @@ export function ManualSessionCreatePageContent() {
                       <DropdownMenuItem onClick={() => setShowImageInput(true)}>
                         <Link data-testid="add-image-url-link-icon" className="mr-2 h-4 w-4" />
                         Add image URL
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onClick={() => setShowLinearInput(true)}>
+                        <LinearIcon className="mr-2 h-4 w-4" />
+                        Link Linear issue
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>

--- a/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/page.test.tsx
@@ -589,6 +589,40 @@ describe('ManualSessionCreatePage', () => {
     expect(screen.getByPlaceholderText('https://example.com/screenshot.png')).toBeInTheDocument();
   });
 
+  it('appends a Linear URL to the prompt body via the Link Linear issue menu item', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    await user.click(screen.getByRole('button', { name: 'Add files or photos' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Link Linear issue' }));
+
+    await user.type(screen.getByLabelText('Linear issue id or URL'), 'https://linear.app/acme/issue/ACS-1234');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    // The linker on the backend (ResolveAndLinkAtCreate) scans the message
+    // body for Linear refs, so the URL must end up inside the textarea
+    // verbatim — anything else means the link won't fire on submit.
+    expect(screen.getByPlaceholderText('Tell the agent what to do...')).toHaveValue('https://linear.app/acme/issue/ACS-1234');
+    // The input pane should close after a successful add so the user can
+    // get back to typing their actual prompt.
+    expect(screen.queryByLabelText('Linear issue id or URL')).not.toBeInTheDocument();
+  });
+
+  it('rejects free-text input in the Linear add affordance with an inline error', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    await user.click(screen.getByRole('button', { name: 'Add files or photos' }));
+    await user.click(screen.getByRole('menuitem', { name: 'Link Linear issue' }));
+
+    await user.type(screen.getByLabelText('Linear issue id or URL'), 'just some text');
+    await user.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Linear URL/);
+    expect(screen.getByLabelText('Linear issue id or URL')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Tell the agent what to do...')).toHaveValue('');
+  });
+
   it('uploads a file via the upload endpoint and shows thumbnail', async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/components/linear-icon.tsx
+++ b/frontend/src/components/linear-icon.tsx
@@ -1,0 +1,18 @@
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+import { getIntegrationByKey } from "@/lib/integrations";
+
+export function LinearIcon({ className }: { className?: string }) {
+  const linear = getIntegrationByKey("linear");
+  return (
+    <Image
+      src={linear.logoSrc}
+      alt=""
+      aria-hidden="true"
+      width={16}
+      height={16}
+      unoptimized
+      className={cn("object-contain dark:invert", className)}
+    />
+  );
+}

--- a/frontend/src/lib/linear-refs.ts
+++ b/frontend/src/lib/linear-refs.ts
@@ -1,0 +1,28 @@
+// Mirror of the backend detection regexes in
+// internal/services/linear/detect.go. Keep in lockstep so the composer
+// affordance accepts exactly what ScanInputs would pick up — anything looser
+// shows the user a "linked" UI for input the backend will silently ignore;
+// anything stricter rejects valid keys that the linker would have caught.
+//
+// The trailing `(?:[/?#][^\s]*)?$` matches anything Linear's "Copy issue
+// link" might suffix (slug paths like `/comment/abc`, query strings like
+// `?focused=…`, anchors like `#section`). The backend's URL pattern is
+// unanchored and stops capture at the issue key — but the *whole pasted
+// string* still needs to be accepted by this UX gate, otherwise users who
+// paste a tracker-decorated URL see "Enter a Linear URL…" while the backend
+// would happily extract the key.
+const linearURLPattern = /^https?:\/\/linear\.app\/[^/\s]+\/issue\/[A-Z][A-Z0-9_]{0,9}-[0-9]+(?:[/?#][^\s]*)?$/;
+const linearBareIdentifierPattern = /^[A-Z][A-Z0-9_]{0,9}-[0-9]+$/;
+
+// looksLikeLinearRef returns true when input is a plausibly-linkable Linear
+// reference (URL or bare key). Used in the composer Linear-input affordance
+// to reject obvious garbage before submit. The backend re-validates with the
+// org's team-key allowlist, so this is a UX hint only — never a security
+// boundary.
+export function looksLikeLinearRef(input: string): boolean {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  return linearURLPattern.test(trimmed) || linearBareIdentifierPattern.test(trimmed);
+}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -107,6 +107,7 @@ type linearLinkerHolder struct{ fn linearSessionLinker }
 // validation and produce a session with an empty user turn.
 type linearSessionLinker interface {
 	ResolveAndLinkAtCreate(ctx context.Context, in linear.CreateInput) (linear.CreateResult, error)
+	ResolveAndLinkMidSession(ctx context.Context, in linear.MidSessionInput) error
 	Enabled(ctx context.Context, orgID uuid.UUID) bool
 	TeamKeyAllowlist(ctx context.Context, orgID uuid.UUID) (map[string]bool, error)
 }
@@ -1789,6 +1790,7 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 				writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 				return
 			}
+			h.maybeLinkLinearMidSession(r.Context(), orgID, sessionID, body.Message, userID)
 			writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
 			return
 		}
@@ -1827,6 +1829,7 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		committed = true
 
 		h.emitReviewCommentResolutionAudits(r, sessionID, msg.ID, resolvedComments)
+		h.maybeLinkLinearMidSession(r.Context(), orgID, sessionID, body.Message, userID)
 		writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
 		return
 	}
@@ -1940,8 +1943,46 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 			marshalAuditDetails(h.logger, questionDetails))
 	}
 	h.emitReviewCommentResolutionAudits(r, sessionID, msg.ID, resolvedComments)
+	h.maybeLinkLinearMidSession(r.Context(), orgID, sessionID, body.Message, userID)
 
 	writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
+}
+
+// midSessionLinkTimeout caps the detached-context window we give the
+// fire-and-forget mid-session linker. Detached from the request context so a
+// user closing their browser tab between SendMessage's writeJSON and the
+// allowlist+enqueue calls doesn't cancel the link work; bounded so a wedged
+// DB connection can't hold the goroutine forever.
+const midSessionLinkTimeout = 30 * time.Second
+
+// maybeLinkLinearMidSession kicks off detection + async enqueue for a
+// follow-up message body in a detached goroutine. It runs off the request
+// path so SendMessage's running-session fast path stays free of the extra
+// allowlist read and job-insert it would otherwise add to user-perceived
+// latency. Failures are logged but never surface to the caller — the message
+// has already been committed and the agent will see Linear refs as text
+// regardless of whether the side-band link row gets created. This mirrors the
+// design 62 fail-soft contract on the async post-create catch-up path.
+func (h *SessionHandler) maybeLinkLinearMidSession(ctx context.Context, orgID, sessionID uuid.UUID, messageBody string, userID *uuid.UUID) {
+	linker := h.getLinearLinker()
+	if linker == nil {
+		return
+	}
+	detached := context.WithoutCancel(ctx)
+	go func() {
+		bgCtx, cancel := context.WithTimeout(detached, midSessionLinkTimeout)
+		defer cancel()
+		if err := linker.ResolveAndLinkMidSession(bgCtx, linear.MidSessionInput{
+			OrgID:       orgID,
+			SessionID:   sessionID,
+			MessageBody: messageBody,
+			UserID:      userID,
+		}); err != nil {
+			h.logger.Warn().Err(err).
+				Str("session_id", sessionID.String()).
+				Msg("mid-session linear linking failed; follow-up message was sent but no link row was created")
+		}
+	}()
 }
 
 // currentResolutionPass returns the pass number to record on a comment that

--- a/internal/api/handlers/sessions_linear_test.go
+++ b/internal/api/handlers/sessions_linear_test.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/linear"
+	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
@@ -33,6 +35,14 @@ type fakeLinearLinker struct {
 	// MISSING_MESSAGE bypass requires the bare-identifier prefix to be in
 	// the allowlist) continue to pass without each test having to wire it.
 	teamKeys map[string]bool
+	// midSessionMu guards the mid-session observation fields. SendMessage
+	// dispatches the linker call to a detached goroutine, so the test
+	// goroutine and the handler goroutine touch these concurrently — without
+	// the mutex the race detector flags every assertion.
+	midSessionMu     sync.Mutex
+	midSessionCalled int
+	midSessionGotIn  linear.MidSessionInput
+	midSessionErr    error
 }
 
 func (f *fakeLinearLinker) Enabled(context.Context, uuid.UUID) bool {
@@ -46,6 +56,22 @@ func (f *fakeLinearLinker) ResolveAndLinkAtCreate(_ context.Context, in linear.C
 		return linear.CreateResult{}, f.err
 	}
 	return f.result, nil
+}
+
+func (f *fakeLinearLinker) ResolveAndLinkMidSession(_ context.Context, in linear.MidSessionInput) error {
+	f.midSessionMu.Lock()
+	defer f.midSessionMu.Unlock()
+	f.midSessionCalled++
+	f.midSessionGotIn = in
+	return f.midSessionErr
+}
+
+// midSessionObservation snapshots the mid-session call counters under the
+// mutex so callers can assert without racing the handler goroutine.
+func (f *fakeLinearLinker) midSessionObservation() (int, linear.MidSessionInput) {
+	f.midSessionMu.Lock()
+	defer f.midSessionMu.Unlock()
+	return f.midSessionCalled, f.midSessionGotIn
 }
 
 func (f *fakeLinearLinker) TeamKeyAllowlist(_ context.Context, _ uuid.UUID) (map[string]bool, error) {
@@ -638,5 +664,163 @@ func TestSessionHandler_CreateManual_AllowsLinearOverridesByDefault(t *testing.T
 	handler.CreateManual(w, req)
 
 	require.Equal(t, http.StatusCreated, w.Code, "default settings must keep the per-session override path open")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestSessionHandler_SendMessage_FiresMidSessionLinker pins the contract for
+// follow-up Linear linking. When a user posts a message into an existing
+// session and the body contains a Linear ref, the handler must hand it off to
+// the linker — otherwise the in-session "Link Linear issue" affordance is a
+// label without a backing action and the LinkedIssueChips list never updates.
+func TestSessionHandler_SendMessage_FiresMidSessionLinker(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+
+	// Running-session fast path: no tx, no enqueue. We pin this branch
+	// because it's the leanest mock; the linker call site is shared across
+	// the other two branches and is exercised by the unit test above.
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil, // triggered_by_user_id
+				nil, 2, now, "running", nil,
+				nil,      // target_branch
+				nil,      // working_branch
+				nil,      // repository_id
+				nil,      // diff_stats
+				nil,      // diff_history
+				nil,      // input_manifest
+				nil, nil, // archived_at, archived_by_user_id
+				nil,            // automation_run_id
+				"idle",         // pr_creation_state
+				(*string)(nil), // pr_creation_error
+				nil,            // deleted_at
+				now,
+			),
+		)
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+	handler := newSessionHandler(t, mock)
+	linker := &fakeLinearLinker{}
+	handler.SetLinearLinker(linker)
+
+	body := `{"message":"Could you also look at https://linear.app/acme/issue/ACS-9?"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/messages", strings.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: "member"})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.SendMessage(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "follow-up should still succeed")
+	// SendMessage dispatches the linker call to a detached goroutine so the
+	// running-session fast path doesn't pay the allowlist+enqueue latency.
+	// Wait for it before asserting — the assertion otherwise races the
+	// goroutine and flakes on slow CI.
+	require.Eventually(t, func() bool {
+		called, _ := linker.midSessionObservation()
+		return called == 1
+	}, time.Second, 5*time.Millisecond, "SendMessage must hand follow-up bodies to the mid-session linker so the in-session linking action backs onto a real link row")
+	called, gotIn := linker.midSessionObservation()
+	require.Equal(t, 1, called)
+	require.Equal(t, orgID, gotIn.OrgID, "mid-session call should preserve org scope")
+	require.Equal(t, sessionID, gotIn.SessionID, "mid-session call should target the receiving session")
+	require.Contains(t, gotIn.MessageBody, "ACS-9", "the linker should see the user-typed body so detection can find the Linear ref")
+	require.NotNil(t, gotIn.UserID, "linking attribution should carry the sender's user id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// TestSessionHandler_SendMessage_SwallowsMidSessionLinkerError is the fail-
+// soft contract: even if the linker returns an error (Linear API outage,
+// allowlist DB hiccup), the user's follow-up message must still succeed and
+// return 201. The linker's failure is logged but never bubbles into the
+// response — matching the design 62 "no Linear writes block the user".
+func TestSessionHandler_SendMessage_SwallowsMidSessionLinkerError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	now := time.Now()
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	userID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			addSessionRow(pgxmock.NewRows(sessionColumns),
+				sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
+				nil, nil, nil, nil,
+				nil, false, &now, nil, nil,
+				nil, nil, nil, false,
+				nil, nil, nil, nil, nil,
+				nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				nil, 2, now, "running", nil,
+				nil, nil, nil, nil, nil, nil,
+				nil, nil,
+				nil,
+				"idle",
+				(*string)(nil),
+				nil,
+				now,
+			),
+		)
+	mock.ExpectQuery("INSERT INTO session_messages").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
+
+	handler := newSessionHandler(t, mock)
+	linker := &fakeLinearLinker{midSessionErr: errors.New("linear unreachable")}
+	handler.SetLinearLinker(linker)
+
+	body := `{"message":"see ACS-9"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sessionID.String()+"/messages", strings.NewReader(body))
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("id", sessionID.String())
+	ctx := context.WithValue(req.Context(), chi.RouteCtxKey, rctx)
+	ctx = middleware.WithOrgID(ctx, orgID)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: "member"})
+	req = req.WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	handler.SendMessage(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "linker errors must not surface to the user; the message itself succeeded")
+	// Async dispatch — wait before asserting that the linker was reached at
+	// all. The error path is still fail-soft: the goroutine logs and exits.
+	require.Eventually(t, func() bool {
+		called, _ := linker.midSessionObservation()
+		return called == 1
+	}, time.Second, 5*time.Millisecond)
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/services/linear/mid_session.go
+++ b/internal/services/linear/mid_session.go
@@ -1,0 +1,163 @@
+package linear
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// MidSessionInput is the bounded set of inputs detection scans on a follow-up
+// message inside an existing session. Mid-session scope is strictly the
+// message body the user just posted; scanning historic context would re-
+// trigger linking on every send and surprise users by linking refs they
+// never typed in this turn.
+//
+// AddedByUserID is forwarded so the resulting session_issue_links row attributes
+// the link to the human who sent the follow-up — matching the create path's
+// audit shape.
+type MidSessionInput struct {
+	OrgID       uuid.UUID
+	SessionID   uuid.UUID
+	MessageBody string
+	UserID      *uuid.UUID
+}
+
+// ResolveAndLinkMidSession is the SendMessage entry point. It detects Linear
+// refs in the follow-up message body and enqueues the
+// link_linear_issue_mid_session worker for async resolution + linking.
+//
+// Returns silently with no error when:
+//   - Linear is not enabled for the org (Path C — design 62).
+//   - The message has no detectable refs.
+//
+// All linking is async because SendMessage already does its own DB work in a
+// transaction and we don't want to add a Linear API round-trip to user-facing
+// latency. The worker fires the SSE links-changed event so the composer's
+// LinkedIssueChips updates without a manual reload.
+func (s *Service) ResolveAndLinkMidSession(ctx context.Context, in MidSessionInput) error {
+	if s == nil || !s.Enabled(ctx, in.OrgID) {
+		return nil
+	}
+	if in.MessageBody == "" {
+		return nil
+	}
+	allow, err := s.TeamKeyAllowlist(ctx, in.OrgID)
+	if err != nil {
+		return fmt.Errorf("load team key allowlist: %w", err)
+	}
+	hits := ScanInputs([]string{in.MessageBody}, allow)
+	if len(hits) == 0 {
+		return nil
+	}
+	for i := range hits {
+		hits[i].Source = DetectionSourceMidSession
+	}
+	return s.enqueueMidSessionLinkWorker(ctx, in, hits)
+}
+
+func (s *Service) enqueueMidSessionLinkWorker(ctx context.Context, in MidSessionInput, hits []Detected) error {
+	enqueuer := s.loadJobEnqueuer()
+	if enqueuer == nil {
+		return errors.New("linear job enqueuer is not configured")
+	}
+	identifiers := make([]string, 0, len(hits))
+	for _, h := range hits {
+		identifiers = append(identifiers, h.Identifier)
+	}
+	// Order-invariant dedupe: a user who edits and re-sends the same set of
+	// refs (or whose retry surfaces them in a different order) should not
+	// produce a duplicate enqueue. Order is preserved in the payload so
+	// linkRelatedRefs still walks them in detection order.
+	hashInput := make([]string, 0, len(identifiers)+1)
+	hashInput = append(hashInput, identifiers...)
+	sort.Strings(hashInput)
+	hashInput = append(hashInput, in.SessionID.String())
+	hash := SourceInputsHash(hashInput)
+	dedupeKey := "link_linear_issue_mid_session:" + in.SessionID.String() + ":" + hash
+	payload := map[string]any{
+		"org_id":      in.OrgID.String(),
+		"session_id":  in.SessionID.String(),
+		"identifiers": identifiers,
+		"refs":        linkRefsFromDetected(hits),
+	}
+	if in.UserID != nil {
+		payload["user_id"] = in.UserID.String()
+	}
+	return enqueuer(ctx, in.OrgID, "link_linear_issue_mid_session", payload, &dedupeKey)
+}
+
+// LinkMidSessionRefs is the worker-side entry point. It resolves each ref and
+// links it as related — never primary, since the primary slot is reserved for
+// session-create per design 62 ("primary is the issue this session is about,
+// chosen at create time").
+//
+// Idempotent on the (session_id, issue_id) unique constraint inside
+// SessionIssueLinkStore.CreateAllowingNullRepo: a re-run for the same ref is a
+// no-op insert that returns the existing link id.
+//
+// linear_prepare_state is intentionally untouched. The create path owns that
+// gate (it controls whether turn 1 may start) and a follow-up message must not
+// reopen it after the agent run is already in flight.
+//
+// Allowlist staleness is acceptable here: the team-key gate runs in
+// ScanInputs at enqueue time, not in ResolvePrimary. So a bare-id ref whose
+// team prefix gets removed between enqueue and worker drain still resolves
+// (against the cached issue row) and gets linked. That's the desired
+// behavior — the user already saw their ref accepted; revoking the team key
+// shouldn't retroactively reject in-flight follow-ups.
+func (s *Service) LinkMidSessionRefs(ctx context.Context, orgID, sessionID uuid.UUID, refs []LinkRef, userID *uuid.UUID) error {
+	if s == nil || len(refs) == 0 {
+		return nil
+	}
+	startPosition := 1
+	if existing, err := s.links.ListBySession(ctx, orgID, sessionID); err == nil {
+		// Continue numbering after existing related links so sort order
+		// reflects the order issues were linked across sessions and follow-ups.
+		// Position collisions are harmless (the sort is stable on created_at as
+		// a tiebreaker) but giving each new link a fresh slot keeps the UI
+		// chronological.
+		for _, link := range existing {
+			if link.Position >= startPosition {
+				startPosition = link.Position + 1
+			}
+		}
+	}
+	linked := false
+	for i, ref := range refs {
+		resolved, err := s.ResolvePrimary(ctx, orgID, ref.detected())
+		if errors.Is(err, ErrCrossWorkspace) {
+			s.logger.Debug().
+				Str("identifier", ref.Identifier).
+				Str("session_id", sessionID.String()).
+				Msg("mid-session linear ref dropped: cross-workspace")
+			continue
+		}
+		if err != nil {
+			s.logger.Warn().Err(err).
+				Str("identifier", ref.Identifier).
+				Str("session_id", sessionID.String()).
+				Msg("failed to resolve mid-session linear issue")
+			continue
+		}
+		if _, err := s.LinkResolved(ctx, orgID, sessionID, resolved, models.SessionIssueLinkRoleRelated, startPosition+i, userID); err != nil {
+			s.logger.Warn().Err(err).
+				Str("identifier", ref.Identifier).
+				Str("session_id", sessionID.String()).
+				Msg("failed to link mid-session linear issue")
+			continue
+		}
+		linked = true
+	}
+	if linked {
+		// LinkResolved already emits an "inserted" notification per ref, but a
+		// terminal "refreshed" lets clients that buffer mid-stream events know
+		// the worker batch is complete and they can stop showing a spinner.
+		s.notifyLinksChanged(ctx, orgID, sessionID, "refreshed")
+	}
+	return nil
+}

--- a/internal/services/linear/mid_session_test.go
+++ b/internal/services/linear/mid_session_test.go
@@ -1,0 +1,160 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveAndLinkMidSession(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled integration is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &Service{}
+		err := svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       uuid.New(),
+			SessionID:   uuid.New(),
+			MessageBody: "https://linear.app/acme/issue/ACS-1",
+		})
+		require.NoError(t, err, "ResolveAndLinkMidSession should silently no-op when Linear is disabled")
+	})
+
+	t.Run("empty message is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &Service{integrations: fakeIntegrationReader{}}
+		err := svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:     uuid.New(),
+			SessionID: uuid.New(),
+		})
+		require.NoError(t, err, "empty body should not even reach detection")
+	})
+
+	t.Run("no refs is no-op", func(t *testing.T) {
+		t.Parallel()
+
+		svc := &Service{integrations: fakeIntegrationReader{}}
+		err := svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       uuid.New(),
+			SessionID:   uuid.New(),
+			MessageBody: "fix the build please",
+		})
+		require.NoError(t, err, "messages without refs should silently no-op")
+	})
+
+	t.Run("allowlist load failure returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		svc := newCreatePathService(mock, createPathClient{}, nil)
+		svc.teamKeys = db.NewLinearTeamKeyStore(mock)
+		mock.ExpectQuery(`SELECT k\.org_id, k\.integration_id, k\.workspace_id, k\.team_id, k\.team_key, k\.team_name, k\.refreshed_at`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnError(errors.New("db unavailable"))
+
+		err = svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       uuid.New(),
+			SessionID:   uuid.New(),
+			MessageBody: "ACS-123 should fix it",
+		})
+		require.Error(t, err, "ResolveAndLinkMidSession should surface allowlist errors so the caller can log them")
+		require.Contains(t, err.Error(), "load team key allowlist", "error should be wrapped with context")
+	})
+
+	t.Run("URL ref is enqueued as mid-session work", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		var enqueuedJobType string
+		var enqueuedDedupe string
+		var enqueuedPayload map[string]any
+		svc := newCreatePathService(mock, createPathClient{}, nil)
+		svc.SetJobEnqueuer(func(_ context.Context, gotOrgID uuid.UUID, jobType string, payload any, dedupeKey *string) error {
+			require.Equal(t, orgID, gotOrgID, "enqueue should preserve org scope")
+			require.NotNil(t, dedupeKey, "enqueue should use a dedupe key")
+			enqueuedJobType = jobType
+			enqueuedDedupe = *dedupeKey
+			body, marshalErr := json.Marshal(payload)
+			require.NoError(t, marshalErr)
+			require.NoError(t, json.Unmarshal(body, &enqueuedPayload))
+			return nil
+		})
+
+		err = svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       orgID,
+			SessionID:   sessionID,
+			MessageBody: "follow-up: also see https://linear.app/acme/issue/ACS-7",
+			UserID:      &userID,
+		})
+		require.NoError(t, err, "URL refs should enqueue async linking without error")
+		require.Equal(t, "link_linear_issue_mid_session", enqueuedJobType, "mid-session linking should use the dedicated job type")
+		require.Contains(t, enqueuedDedupe, sessionID.String(), "dedupe key should scope by session id")
+		require.Equal(t, []any{"ACS-7"}, enqueuedPayload["identifiers"], "payload should carry the detected identifier")
+		require.Equal(t, userID.String(), enqueuedPayload["user_id"], "payload should attribute the link to the sender")
+	})
+
+	t.Run("bare identifier requires team-key allowlist", func(t *testing.T) {
+		t.Parallel()
+
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		now := time.Now().UTC()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		svc := newCreatePathService(mock, createPathClient{}, nil)
+		svc.teamKeys = db.NewLinearTeamKeyStore(mock)
+		// Allowlist returns a single ACS prefix; the FOO-99 bare id below
+		// should be ignored because its prefix isn't allowlisted.
+		mock.ExpectQuery(`SELECT k\.org_id, k\.integration_id, k\.workspace_id, k\.team_id, k\.team_key, k\.team_name, k\.refreshed_at`).
+			WithArgs(pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"org_id", "integration_id", "workspace_id", "team_id", "team_key", "team_name", "refreshed_at"}).
+				AddRow(orgID, uuid.New(), "ws-1", "team-1", "ACS", "Core", now))
+
+		var enqueueCalls int
+		svc.SetJobEnqueuer(func(context.Context, uuid.UUID, string, any, *string) error {
+			enqueueCalls++
+			return nil
+		})
+
+		err = svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       orgID,
+			SessionID:   sessionID,
+			MessageBody: "found duplicate of FOO-99 — see ACS-42 for context",
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, enqueueCalls, "only the allowlisted bare-identifier should produce an enqueue")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("missing job enqueuer surfaces a clear error", func(t *testing.T) {
+		t.Parallel()
+
+		svc := newCreatePathService(nil, createPathClient{}, nil)
+		err := svc.ResolveAndLinkMidSession(context.Background(), MidSessionInput{
+			OrgID:       uuid.New(),
+			SessionID:   uuid.New(),
+			MessageBody: "see https://linear.app/acme/issue/ACS-1",
+		})
+		require.Error(t, err, "missing enqueuer should be surfaced so SendMessage can log it")
+	})
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -82,6 +82,7 @@ func RegisterHandlers(w *Worker, stores *Stores, services *Services, retentionCf
 	if services != nil && services.Linear != nil {
 		w.Register("prepare_linear_primary", newPrepareLinearPrimaryHandler(services.Linear, logger))
 		w.Register("link_linear_issue", newLinkLinearIssueHandler(services.Linear, logger))
+		w.Register("link_linear_issue_mid_session", newLinkLinearIssueMidSessionHandler(services.Linear, logger))
 		w.Register("refresh_linear_team_keys", newRefreshLinearTeamKeysHandler(services.Linear, logger))
 		w.Register("linear_milestone", newLinearMilestoneHandler(stores, services.Linear, logger))
 	}
@@ -2646,6 +2647,56 @@ func newLinkLinearIssueHandler(svc *linear.Service, logger zerolog.Logger) JobHa
 		}
 		if err := svc.LinkRelatedLinearRefs(ctx, orgID, sessionID, refs, userID); err != nil {
 			logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("link_linear_issue failed")
+			return &RetryableError{Err: err}
+		}
+		return nil
+	}
+}
+
+// link_linear_issue_mid_session handler links Linear refs detected in a
+// follow-up message body. Distinct from link_linear_issue because the
+// post-create catch-up path treats refs[0] as the already-linked primary; the
+// mid-session path has no such primary in the payload, so all refs are
+// candidate related links.
+func newLinkLinearIssueMidSessionHandler(svc *linear.Service, logger zerolog.Logger) JobHandler {
+	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
+		var input struct {
+			OrgID       string           `json:"org_id"`
+			SessionID   string           `json:"session_id"`
+			Identifiers []string         `json:"identifiers"`
+			Refs        []linear.LinkRef `json:"refs,omitempty"`
+			UserID      string           `json:"user_id,omitempty"`
+		}
+		if err := json.Unmarshal(payload, &input); err != nil {
+			return fmt.Errorf("unmarshal link_linear_issue_mid_session payload: %w", err)
+		}
+		orgID, err := parseOrgID(input.OrgID, ctx)
+		if err != nil {
+			return err
+		}
+		sessionID, err := uuid.Parse(input.SessionID)
+		if err != nil {
+			return fmt.Errorf("parse session ID: %w", err)
+		}
+		var userID *uuid.UUID
+		if input.UserID != "" {
+			if parsed, err := uuid.Parse(input.UserID); err == nil {
+				userID = &parsed
+			} else {
+				// See prepare_linear_primary handler for the rationale on
+				// logging instead of failing — same trade-off applies here.
+				logger.Warn().Err(err).
+					Str("session_id", sessionID.String()).
+					Str("user_id_raw", input.UserID).
+					Msg("link_linear_issue_mid_session: malformed user_id in payload; proceeding with nil attribution")
+			}
+		}
+		refs := input.Refs
+		if len(refs) == 0 {
+			refs = linearRefsFromIdentifiers(input.Identifiers)
+		}
+		if err := svc.LinkMidSessionRefs(ctx, orgID, sessionID, refs, userID); err != nil {
+			logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("link_linear_issue_mid_session failed")
 			return &RetryableError{Err: err}
 		}
 		return nil

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -730,6 +730,52 @@ func TestLinearJobHandlers(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	})
 
+	t.Run("link_linear_issue_mid_session validates payloads", func(t *testing.T) {
+		t.Parallel()
+
+		handler := newLinkLinearIssueMidSessionHandler(linearservice.NewService(linearservice.Config{}), zerolog.Nop())
+		require.Error(t, handler(context.Background(), "link_linear_issue_mid_session", json.RawMessage(`{bad json`)), "link_linear_issue_mid_session should reject invalid JSON")
+		require.Error(t, handler(context.Background(), "link_linear_issue_mid_session", json.RawMessage(`{"org_id":"not-a-uuid","session_id":"`+uuid.NewString()+`"}`)), "link_linear_issue_mid_session should reject invalid org ids")
+		require.Error(t, handler(context.Background(), "link_linear_issue_mid_session", json.RawMessage(`{"org_id":"`+uuid.NewString()+`","session_id":"not-a-uuid"}`)), "link_linear_issue_mid_session should reject invalid session ids")
+	})
+
+	t.Run("link_linear_issue_mid_session no-ops when payload has no refs", func(t *testing.T) {
+		t.Parallel()
+
+		stores, mock := newTestStores(t)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+
+		svc := linearservice.NewService(linearservice.Config{Sessions: stores.Sessions, Logger: zerolog.Nop()})
+		handler := newLinkLinearIssueMidSessionHandler(svc, zerolog.Nop())
+		payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","identifiers":[],"user_id":"` + userID.String() + `"}`)
+
+		err := handler(context.Background(), "link_linear_issue_mid_session", payload)
+		require.NoError(t, err, "link_linear_issue_mid_session should silently no-op when no refs are present (e.g. payload was enqueued before allowlist filtered everything out)")
+		require.NoError(t, mock.ExpectationsWereMet(), "no database writes should fire on the empty-payload path")
+	})
+
+	t.Run("link_linear_issue_mid_session tolerates malformed user_id", func(t *testing.T) {
+		t.Parallel()
+
+		stores, mock := newTestStores(t)
+		defer mock.Close()
+
+		orgID := uuid.New()
+		sessionID := uuid.New()
+
+		svc := linearservice.NewService(linearservice.Config{Sessions: stores.Sessions, Logger: zerolog.Nop()})
+		handler := newLinkLinearIssueMidSessionHandler(svc, zerolog.Nop())
+		payload := json.RawMessage(`{"org_id":"` + orgID.String() + `","session_id":"` + sessionID.String() + `","identifiers":[],"user_id":"not-a-uuid"}`)
+
+		err := handler(context.Background(), "link_linear_issue_mid_session", payload)
+		require.NoError(t, err, "the mid-session handler must not fail the job for a malformed user_id; it should warn and proceed")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
 	t.Run("refresh_linear_team_keys validates payloads", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## Summary
- New "Link Linear issue" entry in the +/attach dropdown on both the new-session create form and the in-session follow-up composer; pasting a URL or bare key (e.g. `ACS-1234`) appends it to the message body so the existing detection pipeline picks it up at create time and on follow-ups.
- Backend wires a new \`ResolveAndLinkMidSession\` path on \`linear.Service\` plus a \`link_linear_issue_mid_session\` worker; mid-session refs always link as \`role='related'\` (primary stays reserved for create-time per design 62) and the call is dispatched off the request goroutine with a detached context so the running-session SendMessage fast path keeps its zero-extra-DB-write character.
- Frontend regex mirrors \`detect.go\` lax-shape, accepts URLs with query strings or anchors, and shows an inline error for free-text input; everything is fail-soft (linker errors are logged, the message still 201s).

## Test plan
- [ ] \`go test -race ./internal/api/handlers/... ./internal/services/linear/... ./internal/worker/...\`
- [ ] \`npx vitest run src/app/(dashboard)/sessions/[id]/page.test.tsx src/app/(dashboard)/sessions/new/page.test.tsx\`
- [ ] Manually paste a URL, bare key, and a tracker-decorated URL into both composers and verify the chip appears after submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)