### PR TITLE
Fix Push changes visibility by using session dirty/unpushed state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1742,6 +1742,54 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('shows Push changes only when the session has unpushed changes', async () => {
+    const sessionWithUnpushedChanges: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      has_unpushed_changes: true,
+      pr_push_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithUnpushedChanges } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    expect(await screen.findByRole('button', { name: 'Push changes' })).toBeInTheDocument();
+  });
+
+  it('hides Push changes when the PR already matches the latest session head', async () => {
+    const sessionWithoutUnpushedChanges: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+      has_unpushed_changes: false,
+      pr_push_state: 'idle',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithoutUnpushedChanges } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Push changes' })).not.toBeInTheDocument();
+    });
+  });
+
   it('does not show a PR snapshot error when the PR already exists', async () => {
     const sessionWithStalePRError: Session = {
       ...mockSessions[0],
@@ -2363,6 +2411,7 @@ describe('SessionDetailPage', () => {
       diff_stats: { added: 1, removed: 1, files_changed: 1 },
       snapshot_key: 'snap-abc',
       pr_creation_state: 'succeeded',
+      has_unpushed_changes: true,
       pr_push_state: 'idle',
     };
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2507,7 +2507,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         ? "push_changes"
         : resumeActionParam === "create_pr"
           ? "create_pr"
-          : hasPR && prStatus === "open"
+          : hasPR && prStatus === "open" && !!session?.has_unpushed_changes
             ? "push_changes"
             : "create_pr";
     if (action === "push_changes") {
@@ -2517,7 +2517,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       // running would land an immediate 409 (or stale-snapshot error). The
       // effect re-runs when these dependencies flip, so the replay still
       // happens — just on the next tick when the session is actually ready.
-      const pushAvailable = hasPR && prStatus === "open";
+      const pushAvailable = hasPR && prStatus === "open" && !!session?.has_unpushed_changes;
       if (!pushAvailable || !hasSnapshot || isRunning) return;
       resumeAttemptRef.current = resumePRParam;
       pushChangesMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
@@ -2526,7 +2526,7 @@ export function SessionDetailContent({ id }: { id: string }) {
     if (!canCreatePR) return;
     resumeAttemptRef.current = resumePRParam;
     createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
-  }, [canCreatePR, createPRMutation, hasPR, hasSnapshot, isRunning, prStatus, pushChangesMutation, resumeActionParam, resumePRParam]);
+  }, [canCreatePR, createPRMutation, hasPR, hasSnapshot, isRunning, prStatus, pushChangesMutation, resumeActionParam, resumePRParam, session?.has_unpushed_changes]);
 
   const sessionDiff = session?.diff;
   const diffStats = useMemo(() => {
@@ -2936,12 +2936,12 @@ export function SessionDetailContent({ id }: { id: string }) {
   }
 
   // Push-changes button derived state. Mirrors the PR creation block above
-  // but operates on session.pr_push_state. Rendered inside the PR health
-  // banner alongside Resolve conflicts / Fix tests / Merge so all PR-level
-  // actions live in one place; the backend exits cleanly with "no changes"
-  // if there is nothing to push, so we don't gate on a frontend-side dirty
-  // check.
-  const pushAvailable = hasPR && prStatus === "open";
+  // but operates on session.pr_push_state and the backend-derived
+  // has_unpushed_changes signal. Rendered inside the PR health banner
+  // alongside Resolve conflicts / Fix tests / Merge so all PR-level
+  // actions live in one place, while still hiding Push changes when the
+  // latest session head already matches the remote PR branch.
+  const pushAvailable = hasPR && prStatus === "open" && !!session.has_unpushed_changes;
   const pushState = session.pr_push_state;
   const queueingPush = localPushState === "submitting";
   const pushingChanges =

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -154,6 +154,7 @@ export interface Session {
   pr_creation_error?: string;
   pr_push_state?: "idle" | "queued" | "pushing" | "succeeded" | "failed";
   pr_push_error?: string;
+  has_unpushed_changes?: boolean;
   target_branch?: string;
   repository_id?: string;
   linked_issues?: Array<{

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -917,7 +917,7 @@ var sessionRowColumns = []string{
 	"target_branch", "working_branch",
 	"base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
-	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id", "has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -960,6 +960,7 @@ func previewSessionRow(id, orgID uuid.UUID, containerID *string, snapshotKey *st
 		"pr_creation_error":              (*string)(nil),
 		"pr_push_state":                  "idle",
 		"pr_push_error":                  (*string)(nil),
+		"has_unpushed_changes":           false,
 		"linear_private":                 false,
 		"linear_state_sync_disabled":     false,
 		"linear_identifier_hint":         (*string)(nil),

--- a/internal/api/handlers/session_files_test.go
+++ b/internal/api/handlers/session_files_test.go
@@ -115,6 +115,7 @@ var sessionColumnsForFiles = []string{
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -127,6 +128,8 @@ func sessionFileTestRow(values ...interface{}) []interface{} {
 	//   - 2 nils right after snapshot_key (pending_snapshot_key, pending_snapshot_set_at)
 	//   - 4 linear_* defaults (migration 000103) just before deleted_at
 	//   - 2 git_identity nils between deleted_at and created_at
+	// Callers already supply has_unpushed_changes, so this helper only backfills
+	// policy, pending_snapshot_*, linear_*, and git_identity_*.
 	if len(values) == len(sessionColumnsForFiles)-3-2-4-2 {
 		row := make([]interface{}, 0, len(values)+11)
 		row = append(row, values[:3]...)
@@ -201,6 +204,7 @@ func setupSessionMockFull(mock pgxmock.PgxPoolIface, orgID, sessionID uuid.UUID,
 				(*string)(nil), // pr_push_error
 				nil,            // diff_collected_at
 				nil,            // latest_diff_snapshot_id
+				false,          // has_unpushed_changes
 				nil,            // deleted_at
 				now,            // created_at
 			)...),

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -157,6 +157,7 @@ var sessionColumns = []string{
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -235,20 +236,22 @@ const (
 func TestPreLinearSessionColumnsLenStaysInSync(t *testing.T) {
 	t.Parallel()
 	const pendingSnapshotFieldsAdded = 2
+	const unpushedChangesFieldAdded = 1
 	const linearFieldsAdded = 4
 	const identityFieldsAdded = 2
 	const prPushFieldsAdded = 2
-	require.Equal(t, preLinearSessionColumnsLen+pendingSnapshotFieldsAdded+linearFieldsAdded+identityFieldsAdded+prPushFieldsAdded, len(sessionColumns),
+	require.Equal(t, preLinearSessionColumnsLen+pendingSnapshotFieldsAdded+unpushedChangesFieldAdded+linearFieldsAdded+identityFieldsAdded+prPushFieldsAdded, len(sessionColumns),
 		"sessionColumns shifted; bump preLinearSessionColumnsLen, pendingSnapshotFieldsAdded, "+
-			"linearFieldsAdded, identityFieldsAdded, or prPushFieldsAdded if a new migration added more session columns")
+			"unpushedChangesFieldAdded, linearFieldsAdded, identityFieldsAdded, or prPushFieldsAdded if a new migration added more session columns")
 }
 
-// linearSessionDefaults returns the placeholder values for the four
-// linear_* columns inserted by migration 103. Test rows that don't pass
+// linearSessionDefaults returns the placeholder values for the derived
+// has_unpushed_changes field plus the four linear_* columns. Test rows that don't pass
 // values for these get them auto-padded by sessionTestRow (one of the
 // length-difference cases below).
 func linearSessionDefaults() []interface{} {
 	return []interface{}{
+		false,                                 // has_unpushed_changes
 		false,                                 // linear_private
 		false,                                 // linear_state_sync_disabled
 		(*string)(nil),                        // linear_identifier_hint
@@ -256,7 +259,7 @@ func linearSessionDefaults() []interface{} {
 	}
 }
 
-// padLinearFields injects the four linear_* defaults at the position right
+// padLinearFields injects has_unpushed_changes plus the linear_* defaults at the position right
 // before the trailing deleted_at/created_at columns when the row was built
 // without them. Called from sessionTestRow on each row regardless of the
 // branch that resolved its prior shape. Runs before padSessionIdentityColumns,
@@ -269,7 +272,7 @@ func padLinearFields(values []interface{}) []interface{} {
 		return values
 	}
 	insertAt := len(values) - 2 // before deleted_at, created_at
-	row := make([]interface{}, 0, len(values)+4)
+	row := make([]interface{}, 0, len(values)+5)
 	row = append(row, values[:insertAt]...)
 	row = append(row, linearSessionDefaults()...)
 	row = append(row, values[insertAt:]...)
@@ -7334,6 +7337,7 @@ func pushSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time, opts pus
 		"pr_push_error":                  (*string)(nil),
 		"diff_collected_at":              nil,
 		"latest_diff_snapshot_id":        nil,
+		"has_unpushed_changes":           false,
 		"linear_private":                 false,
 		"linear_state_sync_disabled":     false,
 		"linear_identifier_hint":         (*string)(nil),

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -33,6 +33,7 @@ var sessionColumns = []string{
 	"base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
 	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -95,6 +96,7 @@ func newSessionRow(id, issueID, orgID uuid.UUID, now time.Time) []interface{} {
 		(*string)(nil), // pr_push_error
 		nil,            // diff_collected_at
 		nil,            // latest_diff_snapshot_id
+		false,          // has_unpushed_changes
 		false,          // linear_private
 		false,          // linear_state_sync_disabled
 		(*string)(nil), // linear_identifier_hint
@@ -256,9 +258,38 @@ func TestSessionStore_GetByID(t *testing.T) {
 			require.NotNil(t, run.PrimaryIssueID, "should populate the primary issue ID")
 			require.Equal(t, issueID, *run.PrimaryIssueID, "should return the correct issue ID")
 			require.Equal(t, models.AgentType("claude_code"), run.AgentType, "should return the correct agent type")
+			require.False(t, run.HasUnpushedChanges, "GetByID should default has_unpushed_changes to false when the derived column is false")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+func TestSessionStore_GetByID_WithUnpushedChanges(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now()
+	row := newSessionRow(runID, issueID, orgID, now)
+	row[78] = true // has_unpushed_changes
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionColumns).
+				AddRow(row...),
+		)
+
+	run, err := store.GetByID(context.Background(), orgID, runID)
+	require.NoError(t, err, "GetByID should not return an error when the session exists")
+	require.True(t, run.HasUnpushedChanges, "GetByID should surface the derived has_unpushed_changes flag")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestSessionStore_ListRecentByOrg(t *testing.T) {

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -108,6 +108,25 @@ const sessionPrimaryIssueIDColumn = `(SELECT sil.issue_id
 		WHERE sil.org_id = sessions.org_id AND sil.session_id = sessions.id AND sil.role = 'primary'
 		LIMIT 1) AS primary_issue_id`
 
+// hasUnpushedChangesColumn derives whether the session's latest persisted diff
+// snapshot still contains content not represented on the open PR branch. A
+// snapshot is considered pushable when it either captured a dirty worktree or
+// its recorded HEAD differs from the PR head SHA.
+const hasUnpushedChangesColumn = `EXISTS (
+		SELECT 1
+		FROM pull_requests pr
+		JOIN session_diff_snapshots sds
+		  ON sds.id = sessions.latest_diff_snapshot_id
+		 AND sds.org_id = sessions.org_id
+		WHERE pr.session_id = sessions.id
+		  AND pr.org_id = sessions.org_id
+		  AND pr.status = 'open'
+		  AND (
+		    sds.workspace_dirty
+		    OR (sds.head_commit_sha IS NOT NULL AND sds.head_commit_sha IS DISTINCT FROM pr.head_sha)
+		  )
+	) AS has_unpushed_changes`
+
 // sessionSelectColumns is used for single-session queries where we want all fields.
 const sessionSelectColumns = `id,
 	` + sessionPrimaryIssueIDColumn + `,
@@ -124,6 +143,7 @@ const sessionSelectColumns = `id,
 	checkpointed_at, checkpoint_kind, checkpoint_capability, checkpoint_size_bytes, checkpoint_error,
 	recovery_state, recovery_queued_at, recovery_started_at, recovery_attempt_count,
 	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, pr_push_state, pr_push_error, diff_collected_at, latest_diff_snapshot_id,
+	` + hasUnpushedChangesColumn + `,
 	linear_private, linear_state_sync_disabled, linear_identifier_hint, linear_prepare_state,
 	deleted_at, git_identity_source, git_identity_user_id, created_at`
 
@@ -144,6 +164,7 @@ const sessionListColumns = `id,
 	checkpointed_at, checkpoint_kind, checkpoint_capability, checkpoint_size_bytes, checkpoint_error,
 	recovery_state, recovery_queued_at, recovery_started_at, recovery_attempt_count,
 	target_branch, working_branch, base_commit_sha, repository_id, diff_stats, NULL::jsonb AS diff_history, input_manifest, archived_at, archived_by_user_id, automation_run_id, pr_creation_state, pr_creation_error, pr_push_state, pr_push_error, diff_collected_at, latest_diff_snapshot_id,
+	` + hasUnpushedChangesColumn + `,
 	linear_private, linear_state_sync_disabled, linear_identifier_hint, linear_prepare_state,
 	deleted_at, git_identity_source, git_identity_user_id, created_at`
 
@@ -1267,12 +1288,12 @@ func (s *SessionStore) writeDiffSnapshot(ctx context.Context, db DBTX, orgID, se
 	insertQuery := `
 		INSERT INTO session_diff_snapshots (
 			session_id, org_id, turn_number, sequence_number, source,
-			base_commit_sha, head_commit_sha, working_branch, target_branch, diff,
+			base_commit_sha, head_commit_sha, workspace_dirty, working_branch, target_branch, diff,
 			files_changed, lines_added, lines_removed, captured_at
 		)
 		SELECT
 			@session_id, @org_id, @turn_number, 1, @source,
-			@base_commit_sha, @head_commit_sha, working_branch, target_branch, @diff,
+			@base_commit_sha, @head_commit_sha, @workspace_dirty, working_branch, target_branch, @diff,
 			@files_changed, @lines_added, @lines_removed, @captured_at
 		FROM sessions
 		WHERE id = @session_id AND org_id = @org_id
@@ -1285,6 +1306,7 @@ func (s *SessionStore) writeDiffSnapshot(ctx context.Context, db DBTX, orgID, se
 		"source":          source,
 		"base_commit_sha": *result.DiffBaseCommitSHA,
 		"head_commit_sha": result.DiffHeadCommitSHA,
+		"workspace_dirty": result.DiffWorkspaceDirty,
 		"diff":            *result.Diff,
 		"files_changed":   stats.FilesChanged,
 		"lines_added":     stats.Added,
@@ -1310,6 +1332,30 @@ func (s *SessionStore) writeDiffSnapshot(ctx context.Context, db DBTX, orgID, se
 		return fmt.Errorf("update session latest diff snapshot: %w", err)
 	}
 	return nil
+}
+
+// MarkLatestDiffSnapshotPushed normalizes the latest persisted diff snapshot
+// after a successful PR create/push so the read-model no longer treats that
+// snapshot as pending local work. This updates both the recorded head commit
+// and the dirty-worktree bit because the push flow stages/commits any
+// uncommitted changes before pushing.
+func (s *SessionStore) MarkLatestDiffSnapshotPushed(ctx context.Context, orgID, sessionID uuid.UUID, pushedHeadSHA string) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE session_diff_snapshots
+		SET head_commit_sha = @head_commit_sha,
+		    workspace_dirty = FALSE
+		WHERE id = (
+			SELECT latest_diff_snapshot_id
+			FROM sessions
+			WHERE id = @id AND org_id = @org_id
+		)
+		  AND org_id = @org_id
+	`, pgx.NamedArgs{
+		"id":              sessionID,
+		"org_id":          orgID,
+		"head_commit_sha": pushedHeadSHA,
+	})
+	return err
 }
 
 func (s *SessionStore) UpdateBaseCommitSHA(ctx context.Context, orgID, sessionID uuid.UUID, baseCommitSHA string) error {

--- a/internal/db/session_store_diff_test.go
+++ b/internal/db/session_store_diff_test.go
@@ -65,6 +65,7 @@ func TestSessionStore_UpdateResult_WithDiffSnapshot(t *testing.T) {
 		Diff:              &diff,
 		DiffBaseCommitSHA: &baseSHA,
 		DiffHeadCommitSHA: &headSHA,
+		DiffWorkspaceDirty: true,
 		DiffCollectedAt:   &collectedAt,
 		DiffSource:        "review",
 	}
@@ -82,7 +83,7 @@ func TestSessionStore_UpdateResult_WithDiffSnapshot(t *testing.T) {
 			),
 		)
 	mock.ExpectQuery("INSERT INTO session_diff_snapshots").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(snapshotID))
 	mock.ExpectExec("UPDATE sessions\\s+SET latest_diff_snapshot_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -103,6 +104,7 @@ func TestSessionStore_UpdateResult_WithDiffSnapshotBeginFailure(t *testing.T) {
 	result := &models.SessionResult{
 		Diff:              &diff,
 		DiffBaseCommitSHA: &baseSHA,
+		DiffWorkspaceDirty: true,
 	}
 
 	err := store.UpdateResult(context.Background(), uuid.New(), uuid.New(), "completed", result)
@@ -126,6 +128,7 @@ func TestSessionStore_UpdateTurnComplete_WithDiffSnapshot(t *testing.T) {
 	result := &models.SessionResult{
 		Diff:              &diff,
 		DiffBaseCommitSHA: &baseSHA,
+		DiffWorkspaceDirty: true,
 	}
 
 	mock.ExpectBegin()
@@ -135,7 +138,7 @@ func TestSessionStore_UpdateTurnComplete_WithDiffSnapshot(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectQuery("INSERT INTO session_diff_snapshots").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(snapshotID))
 	mock.ExpectExec("UPDATE sessions\\s+SET latest_diff_snapshot_id").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -169,13 +172,34 @@ func TestSessionStore_UpdateTurnComplete_WithDiffSnapshotInsertFailure(t *testin
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectQuery("INSERT INTO session_diff_snapshots").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("insert failed"))
 	mock.ExpectRollback()
 
 	err = store.UpdateTurnComplete(context.Background(), uuid.New(), uuid.New(), 2, result, "agent-123", "snap-key")
 	require.Error(t, err, "UpdateTurnComplete should return an error when snapshot insertion fails")
 	require.Contains(t, err.Error(), "insert session diff snapshot", "UpdateTurnComplete should surface the snapshot insertion failure")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionStore_MarkLatestDiffSnapshotPushed(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	headSHA := "abc1234567890abcdef1234567890abcdef12345"
+
+	mock.ExpectExec("UPDATE session_diff_snapshots").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.MarkLatestDiffSnapshotPushed(context.Background(), orgID, sessionID, headSHA)
+	require.NoError(t, err, "MarkLatestDiffSnapshotPushed should update the latest diff snapshot state")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -35,6 +35,7 @@ var sessionTestColumns = []string{
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -96,6 +97,7 @@ func newAgentSessionRow(sessionID, issueID, orgID uuid.UUID, now time.Time) []in
 		(*string)(nil), // pr_push_error
 		nil,            // diff_collected_at
 		nil,            // latest_diff_snapshot_id
+		false,          // has_unpushed_changes
 		false,          // linear_private
 		false,          // linear_state_sync_disabled
 		(*string)(nil), // linear_identifier_hint
@@ -170,6 +172,7 @@ func TestSessionStore_QueryColumnsStayInSyncWithSessionModel(t *testing.T) {
 		"base_commit_sha",
 		"diff_collected_at",
 		"latest_diff_snapshot_id",
+		"has_unpushed_changes",
 		"origin",
 		"interaction_mode",
 		"validation_policy",

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -276,6 +276,10 @@ type Session struct {
 	PRPushError          *string     `db:"pr_push_error" json:"pr_push_error,omitempty"`
 	DiffCollectedAt      *time.Time  `db:"diff_collected_at" json:"diff_collected_at,omitempty"`
 	LatestDiffSnapshotID *uuid.UUID  `db:"latest_diff_snapshot_id" json:"latest_diff_snapshot_id,omitempty"`
+	// HasUnpushedChanges is a derived read-model field: true when the most
+	// recent persisted session HEAD differs from the open PR's tracked head
+	// commit, which means "Push changes" is actionable.
+	HasUnpushedChanges bool `db:"has_unpushed_changes" json:"has_unpushed_changes"`
 	// LinearPrivate suppresses every Linear write for this session. The agent
 	// still receives Linear context locally; nothing leaves 143. Frozen at
 	// session create — see design 62 §"Composer controls must express distinct
@@ -469,6 +473,7 @@ type SessionResult struct {
 	FailureCategory     *string         `json:"failure_category,omitempty"`
 	DiffBaseCommitSHA   *string         `json:"-"`
 	DiffHeadCommitSHA   *string         `json:"-"`
+	DiffWorkspaceDirty  bool            `json:"-"`
 	DiffCollectedAt     *time.Time      `json:"-"`
 	DiffSource          string          `json:"-"`
 }
@@ -482,6 +487,7 @@ type SessionDiffSnapshot struct {
 	Source         string    `db:"source" json:"source"`
 	BaseCommitSHA  string    `db:"base_commit_sha" json:"base_commit_sha"`
 	HeadCommitSHA  *string   `db:"head_commit_sha" json:"head_commit_sha,omitempty"`
+	WorkspaceDirty bool      `db:"workspace_dirty" json:"workspace_dirty"`
 	WorkingBranch  *string   `db:"working_branch" json:"working_branch,omitempty"`
 	TargetBranch   *string   `db:"target_branch" json:"target_branch,omitempty"`
 	Diff           string    `db:"diff" json:"diff"`

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1560,7 +1560,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	}
 
 	// Store the successful result.
-	runResult := o.buildRunResult(run, result)
+	runResult := o.buildRunResult(ctx, run, sandbox, result)
 	status := "completed"
 	isInteractive := run.IsInteractive() && snapshotKey != ""
 
@@ -2417,7 +2417,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	if snapshotKey == "" && session.SnapshotKey != nil {
 		snapshotKey = *session.SnapshotKey
 	}
-	if err := o.sessions.UpdateTurnComplete(ctx, session.OrgID, session.ID, turnNumber, o.buildRunResult(session, result), agentSessionID, snapshotKey); err != nil {
+	if err := o.sessions.UpdateTurnComplete(ctx, session.OrgID, session.ID, turnNumber, o.buildRunResult(ctx, session, sandbox, result), agentSessionID, snapshotKey); err != nil {
 		return fmt.Errorf("update turn complete: %w", err)
 	}
 
@@ -2887,12 +2887,15 @@ func (o *Orchestrator) ensureCodexAuth(ctx context.Context, run *models.Session,
 }
 
 // buildRunResult converts an AgentResult into the DB update struct.
-func (o *Orchestrator) buildRunResult(run *models.Session, result *AgentResult) *models.SessionResult {
+func (o *Orchestrator) buildRunResult(ctx context.Context, run *models.Session, sandbox *Sandbox, result *AgentResult) *models.SessionResult {
 	tokenUsage, err := json.Marshal(result.TokenUsage)
 	if err != nil {
 		o.logger.Warn().Err(err).Msg("failed to marshal token usage")
 		tokenUsage = nil
 	}
+
+	headSHA := o.captureCurrentHeadSHA(ctx, sandbox)
+	workspaceDirty := o.captureWorkspaceDirty(ctx, sandbox)
 
 	return &models.SessionResult{
 		ConfidenceScore:     &result.ConfidenceScore,
@@ -2903,9 +2906,49 @@ func (o *Orchestrator) buildRunResult(run *models.Session, result *AgentResult) 
 		Diff:                strPtr(result.Diff),
 		Error:               strPtr(result.Error),
 		DiffBaseCommitSHA:   run.BaseCommitSHA,
+		DiffHeadCommitSHA:   headSHA,
+		DiffWorkspaceDirty:  workspaceDirty,
 		DiffCollectedAt:     timePtr(time.Now().UTC()),
 		DiffSource:          "turn_complete",
 	}
+}
+
+func (o *Orchestrator) captureCurrentHeadSHA(ctx context.Context, sandbox *Sandbox) *string {
+	if sandbox == nil {
+		return nil
+	}
+	var stdout, stderr bytes.Buffer
+	exitCode, err := o.provider.Exec(ctx, sandbox, "git rev-parse HEAD", &stdout, &stderr)
+	if err != nil {
+		o.logger.Warn().Err(err).Msg("failed to capture current head sha")
+		return nil
+	}
+	if exitCode != 0 {
+		o.logger.Warn().Int("exit_code", exitCode).Str("stderr", stderr.String()).Msg("failed to capture current head sha")
+		return nil
+	}
+	headSHA := strings.TrimSpace(stdout.String())
+	if headSHA == "" {
+		return nil
+	}
+	return &headSHA
+}
+
+func (o *Orchestrator) captureWorkspaceDirty(ctx context.Context, sandbox *Sandbox) bool {
+	if sandbox == nil {
+		return false
+	}
+	var stdout, stderr bytes.Buffer
+	exitCode, err := o.provider.Exec(ctx, sandbox, "git status --porcelain --untracked-files=all -- .", &stdout, &stderr)
+	if err != nil {
+		o.logger.Warn().Err(err).Msg("failed to capture workspace dirty state")
+		return false
+	}
+	if exitCode != 0 {
+		o.logger.Warn().Int("exit_code", exitCode).Str("stderr", stderr.String()).Msg("failed to capture workspace dirty state")
+		return false
+	}
+	return strings.TrimSpace(stdout.String()) != ""
 }
 
 func (o *Orchestrator) captureBaseCommitSHA(ctx context.Context, sandbox *Sandbox) (string, error) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -2178,6 +2178,70 @@ func TestRunAgent_CapturesAndPersistsBaseCommitSHA(t *testing.T) {
 	require.Equal(t, "abc123", *run.BaseCommitSHA, "RunAgent should store the captured base commit sha on the session")
 }
 
+func TestRunAgent_PersistsDiffHeadCommitSHAOnResult(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	headCalls := 0
+	d.provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if cmd == "git rev-parse HEAD" {
+			headCalls++
+			if headCalls == 1 {
+				_, _ = io.WriteString(stdout, "base123\n")
+			} else {
+				_, _ = io.WriteString(stdout, "result456\n")
+			}
+		}
+		return 0, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should succeed")
+
+	results := d.sessions.getResultUpdates()
+	require.NotEmpty(t, results, "RunAgent should persist a final result update")
+	last := results[len(results)-1]
+	require.NotNil(t, last.result.DiffHeadCommitSHA, "RunAgent should persist the session HEAD SHA alongside the diff result")
+	require.Equal(t, "result456", *last.result.DiffHeadCommitSHA, "RunAgent should store the latest session HEAD SHA, not the initial base commit SHA")
+}
+
+func TestRunAgent_PersistsDiffWorkspaceDirtyOnResult(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	headCalls := 0
+	d.provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		switch cmd {
+		case "git rev-parse HEAD":
+			headCalls++
+			if headCalls == 1 {
+				_, _ = io.WriteString(stdout, "base123\n")
+			} else {
+				_, _ = io.WriteString(stdout, "result456\n")
+			}
+		case "git status --porcelain --untracked-files=all -- .":
+			_, _ = io.WriteString(stdout, " M app.go\n")
+		}
+		return 0, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should succeed")
+
+	results := d.sessions.getResultUpdates()
+	require.NotEmpty(t, results, "RunAgent should persist a final result update")
+	last := results[len(results)-1]
+	require.True(t, last.result.DiffWorkspaceDirty, "RunAgent should persist whether the session workspace still had uncommitted changes")
+}
+
 func TestRunAgent_UsesDesignatedWorkingBranchForSandboxAndSession(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -602,6 +602,9 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 	if err := s.pullRequests.Create(ctx, pr); err != nil {
 		return nil, fmt.Errorf("store pull request: %w", err)
 	}
+	if err := s.sessions.MarkLatestDiffSnapshotPushed(ctx, run.OrgID, run.ID, headSHA); err != nil {
+		s.logger.Warn().Err(err).Str("session_id", run.ID.String()).Msg("failed to mark latest diff snapshot as pushed after PR creation")
+	}
 
 	// Record the pending snapshot, then dispatch the upload. If capture
 	// failed in pushSessionBranch the path is empty — log and skip the
@@ -787,6 +790,9 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 
 	if err := s.pullRequests.UpdateHeadSHA(ctx, run.OrgID, pr.ID, pushed.HeadSHA); err != nil {
 		return nil, fmt.Errorf("update pull request head sha: %w", err)
+	}
+	if err := s.sessions.MarkLatestDiffSnapshotPushed(ctx, run.OrgID, run.ID, pushed.HeadSHA); err != nil {
+		s.logger.Warn().Err(err).Str("session_id", run.ID.String()).Msg("failed to mark latest diff snapshot as pushed after PR push")
 	}
 	pr.HeadSHA = &pushed.HeadSHA
 	s.enqueuePullRequestStateSync(ctx, pr)

--- a/internal/services/github/pr_handlers_test.go
+++ b/internal/services/github/pr_handlers_test.go
@@ -49,7 +49,7 @@ var sessionColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id", "has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -215,6 +215,7 @@ func TestHandlePullRequestEvent_MergedFlow(t *testing.T) {
 					(*string)(nil),                // pr_push_error
 					nil,                           // diff_collected_at
 					nil,                           // latest_diff_snapshot_id
+					false,                         // has_unpushed_changes
 					false,                         // linear_private
 					false,                         // linear_state_sync_disabled
 					(*string)(nil),                // linear_identifier_hint

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -1578,7 +1578,7 @@ var prHealthSessionColumns = []string{
 	"runtime_extension_count", "runtime_extension_seconds", "runtime_stop_reason", "runtime_graceful_stop_at",
 	"checkpointed_at", "checkpoint_kind", "checkpoint_capability", "checkpoint_size_bytes", "checkpoint_error",
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
-	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest", "archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id", "has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -1602,7 +1602,7 @@ func newPRHealthSessionRow(sessionID, orgID uuid.UUID, now time.Time, status str
 		"", nil, nil, 0,
 		nil, nil, nil, nil, nil, nil, nil,
 		nil, nil, nil, "idle", (*string)(nil), "idle", (*string)(nil), nil, nil,
-		false, false, (*string)(nil), models.LinearPrepareStateNone,
+		false, false, false, (*string)(nil), models.LinearPrepareStateNone,
 		nil, nil, nil, now,
 	}
 }

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3394,6 +3394,9 @@ func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
 	mock.ExpectExec("UPDATE pull_requests SET head_sha").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE session_diff_snapshots").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectQuery("INSERT INTO jobs").
 		WithArgs(pgx.NamedArgs{
 			"org_id":     orgID,
@@ -4280,6 +4283,9 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
+	mock.ExpectExec("UPDATE session_diff_snapshots").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	mock.ExpectQuery("UPDATE sessions SET status").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
@@ -4426,6 +4432,9 @@ func TestCreatePR_SuccessDispatchesPostPRSnapshotUpload(t *testing.T) {
 	mock.ExpectQuery("INSERT INTO pull_requests").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(uuid.New(), now, now))
+	mock.ExpectExec("UPDATE session_diff_snapshots").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 	// SetPendingSnapshotKey: the synchronous write that records the
 	// post-PR upload in flight. pgx NamedArgs expand to positional args by
 	// @-placeholder order: SET pending_snapshot_key = @key first, then

--- a/internal/services/preview/manager_test.go
+++ b/internal/services/preview/manager_test.go
@@ -157,7 +157,7 @@ var sessionTestCols = []string{
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id",
-	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id", "has_unpushed_changes",
 	// Migration 102 — Linear session-linking columns. Migration 100 — git
 	// identity audit columns. Mocks must include both so SessionStore.GetByID's
 	// row decode finds every selected field.
@@ -216,6 +216,7 @@ func newSessionRow(sessionID, orgID uuid.UUID, containerID *string, now time.Tim
 		"pr_creation_error":              (*string)(nil),
 		"pr_push_state":                  "idle",
 		"pr_push_error":                  (*string)(nil),
+		"has_unpushed_changes":           false,
 		"linear_private":                 false,
 		"linear_state_sync_disabled":     false,
 		"linear_identifier_hint":         (*string)(nil),

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -62,6 +62,7 @@ var workerSessionColumns = []string{
 	"recovery_state", "recovery_queued_at", "recovery_started_at", "recovery_attempt_count",
 	"target_branch", "working_branch", "base_commit_sha", "repository_id", "diff_stats", "diff_history", "input_manifest",
 	"archived_at", "archived_by_user_id", "automation_run_id", "pr_creation_state", "pr_creation_error", "pr_push_state", "pr_push_error", "diff_collected_at", "latest_diff_snapshot_id",
+	"has_unpushed_changes",
 	"linear_private", "linear_state_sync_disabled", "linear_identifier_hint", "linear_prepare_state",
 	"deleted_at", "git_identity_source", "git_identity_user_id", "created_at",
 }
@@ -194,13 +195,15 @@ func expandLegacyWorkerSessionRow(values []any) []any {
 }
 
 // preLinearWorkerSessionColumnsLen is len(workerSessionColumns) before
-// migration 103 added the four linear_* fields. Test rows authored before
-// that migration produce dispatch output that's exactly 4 short of the
+// the has_unpushed_changes read-model field and migration 103 added the
+// linear_* fields. Test rows authored before that migration produce
+// dispatch output that's exactly 5 short of the
 // current sessionColumns; we pad after dispatch so the shape matches.
 const preLinearWorkerSessionColumnsLen = 76
 
 func workerLinearSessionDefaults() []any {
 	return []any{
+		false,          // has_unpushed_changes
 		false,          // linear_private
 		false,          // linear_state_sync_disabled
 		(*string)(nil), // linear_identifier_hint
@@ -208,7 +211,8 @@ func workerLinearSessionDefaults() []any {
 	}
 }
 
-// padWorkerLinearFields injects the four linear_* defaults at the position
+// padWorkerLinearFields injects has_unpushed_changes plus the linear_*
+// defaults at the position
 // right before the trailing deleted_at/created_at columns when a row was
 // built without them.
 func padWorkerLinearFields(values []any) []any {
@@ -219,7 +223,7 @@ func padWorkerLinearFields(values []any) []any {
 		return values
 	}
 	insertAt := len(values) - 2 // before deleted_at, created_at
-	row := make([]any, 0, len(values)+4)
+	row := make([]any, 0, len(values)+5)
 	row = append(row, values[:insertAt]...)
 	row = append(row, workerLinearSessionDefaults()...)
 	row = append(row, values[insertAt:]...)

--- a/migrations/000109_session_diff_snapshot_workspace_dirty.down.sql
+++ b/migrations/000109_session_diff_snapshot_workspace_dirty.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE session_diff_snapshots
+    DROP COLUMN IF EXISTS workspace_dirty;

--- a/migrations/000109_session_diff_snapshot_workspace_dirty.up.sql
+++ b/migrations/000109_session_diff_snapshot_workspace_dirty.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE session_diff_snapshots
+    ADD COLUMN workspace_dirty boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
`Push changes` is no longer shown based on `HEAD` alone. The backend now captures whether the workspace/worktree had uncommitted changes and normalizes session diff snapshots after a successful PR push so the frontend’s `has_unpushed_changes` signal stays correct.

## Changes
- **DB schema/migrations**
  - Added `workspace_dirty` to `session_diff_snapshots` (`migrations/000109_session_diff_snapshot_workspace_dirty.up.sql`, plus down migration).
- **Backend (orchestration + session read model)**
  - Updated the orchestrator to persist both:
    - the current `HEAD`
    - whether the worktree still had uncommitted changes (`workspace_dirty`)
  - Updated session diff snapshot handling to mark a snapshot as pushable when it is **either**:
    - dirty (`workspace_dirty`), **or**
    - ahead of the PR head
  - After **successful `Create PR`** or **`Push changes`**, normalized the latest diff snapshot to the pushed head and marked it **clean**, so the button hides correctly.
- **Frontend**
  - Updated `SessionDetailContent` to only enable/show the `"push_changes"` action when `hasPR && prStatus === "open" && session.has_unpushed_changes`:
    - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
- **Tests**
  - Added regression tests covering:
    - shows `"Push changes"` only when `has_unpushed_changes` is true
    - hides `"Push changes"` when the PR already matches the latest session head
    - snapshot normalization after push
  - Touched relevant backend and frontend test files across session store/orchestrator/pr handling to reflect the corrected behavior.

## Test plan
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

[143.dev](https://143.dev) | [session 620899c7](https://143.dev/sessions/620899c7-3ed0-4221-bb50-a326579fe3fc)