### PR TITLE
Surface Linear auth failures with reconnect CTA

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1020,16 +1020,17 @@ func buildServices(
 	// the shared Build helper so the API server (router.go) and the worker
 	// (here) wire the service identically.
 	linearService := linear.Build(linear.BuildDeps{
-		Pool:         pool,
-		Logger:       logger,
-		Integrations: integrationStore,
-		Credentials:  credentialStore,
-		Issues:       issueStore,
-		Sessions:     sessionStore,
-		IssueLinks:   db.NewSessionIssueLinkStore(pool),
-		Orgs:         orgStore,
-		Jobs:         jobStore,
-		AppBaseURL:   cfg.FrontendURL,
+		Pool:               pool,
+		Logger:             logger,
+		Integrations:       integrationStore,
+		IntegrationsWriter: integrationStore,
+		Credentials:        credentialStore,
+		Issues:             issueStore,
+		Sessions:           sessionStore,
+		IssueLinks:         db.NewSessionIssueLinkStore(pool),
+		Orgs:               orgStore,
+		Jobs:               jobStore,
+		AppBaseURL:         cfg.FrontendURL,
 	})
 	prService.SetLinearMilestoneEnqueuer(linear.MilestoneEnqueuerFor(jobStore, logger))
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.test.tsx
@@ -137,11 +137,12 @@ describe('LinkedIssueChips', () => {
     expect(screen.getByLabelText('NRE in foo (related)')).toBeInTheDocument();
   });
 
-  it('renders the prepare-failed warning chip with sr-only detail', () => {
+  it('renders the prepare-failed recovery chip as a link with sr-only detail', () => {
     const session = makeSession({ linear_prepare_state: 'failed' });
     render(<LinkedIssueChips session={session} />);
-    const chip = screen.getByRole('status');
+    const chip = screen.getByRole('link', { name: /Linear: prepare failed/i });
     expect(chip).toHaveTextContent(/Linear: prepare failed/);
+    expect(chip).toHaveAttribute('href', '/settings/integrations');
     // The detail element backs aria-describedby and must exist in the DOM
     // even though it's visually hidden.
     expect(chip).toHaveAttribute('aria-describedby', 'linear-prepare-failed-detail');

--- a/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
@@ -38,7 +38,7 @@ export function LinkedIssueChips({ session }: { session: Session }) {
           className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30 hover:bg-amber-500/20"
           aria-describedby="linear-prepare-failed-detail"
         >
-          Linear: prepare failed — fix
+          Linear: prepare failed
           {/* sr-only sibling instead of `title=…`: most screen readers ignore
               title attributes, so the detail goes through aria-describedby. */}
           <span id="linear-prepare-failed-detail" className="sr-only">

--- a/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
@@ -27,22 +27,29 @@ export function LinkedIssueChips({ session }: { session: Session }) {
   return (
     <div className="flex flex-wrap items-center gap-1 ml-2 shrink-0">
       {prepareFailed && (
-        <span
+        // Clickable link rather than a plain status chip: the most common
+        // root cause we've seen for prepare-failed is a revoked Linear OAuth
+        // token, and the integrations settings page now surfaces the
+        // specific reason + a Reconnect CTA. Sending the user there beats
+        // a dead-end "prepare failed" badge with no path forward.
+        <a
           key="linear-prepare-failed"
+          href="/settings/integrations"
           role="status"
-          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30"
+          className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30 hover:bg-amber-500/20"
           aria-describedby="linear-prepare-failed-detail"
         >
-          Linear: prepare failed
+          Linear: prepare failed — fix
           {/* sr-only sibling instead of `title=…`: most screen readers ignore
               title attributes, so the detail goes through aria-describedby. */}
           <span id="linear-prepare-failed-detail" className="sr-only">
             Linear context preparation failed; turn 1 ran without the primary
-            issue snapshot. Re-paste the Linear URL in a follow-up message
-            to re-trigger detection, or contact an operator to inspect the
-            session&apos;s debug surface.
+            issue snapshot. The most common cause is a revoked or expired
+            Linear access token — open Settings → Integrations to verify the
+            connection, or re-paste the Linear URL in a follow-up message
+            to re-trigger detection.
           </span>
-        </span>
+        </a>
       )}
       {links.map((link) => {
         const isLinear = link.issue_source === "linear";

--- a/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/linked-issue-chips.tsx
@@ -35,7 +35,6 @@ export function LinkedIssueChips({ session }: { session: Session }) {
         <a
           key="linear-prepare-failed"
           href="/settings/integrations"
-          role="status"
           className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium bg-amber-500/10 text-amber-700 dark:text-amber-300 border border-amber-500/30 hover:bg-amber-500/20"
           aria-describedby="linear-prepare-failed-detail"
         >

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -172,6 +172,14 @@ export default function IntegrationsPage() {
   const linearIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "linear" && integration.status === "active"
   );
+  // The auth-error banner needs to fire even when status !== "active" — the
+  // worker flips Linear to "error" on a 401, which would otherwise look
+  // identical to "never connected" through the linearConnected flag below
+  // and the user would never learn their token expired.
+  const linearAuthErrorRow = integrationsResp?.data?.find(
+    (integration) => integration.provider === "linear" && integration.auth_error
+  );
+  const linearAuthError = linearAuthErrorRow?.auth_error ?? null;
   const slackIntegration = integrationsResp?.data?.find(
     (integration) => integration.provider === "slack" && integration.status === "active"
   );
@@ -211,6 +219,7 @@ export default function IntegrationsPage() {
         sentryConnected={Boolean(sentryIntegration)}
         linearConnected={Boolean(linearIntegration)}
         linearLoading={false}
+        linearAuthError={linearAuthError}
         slackConnected={Boolean(slackIntegration)}
         notionConnected={Boolean(notionIntegration)}
         notionLoading={notionConnectMutation.isPending}

--- a/frontend/src/components/integration-connection-cards.test.tsx
+++ b/frontend/src/components/integration-connection-cards.test.tsx
@@ -291,6 +291,69 @@ describe("integration connection cards", () => {
     expect(screen.getByText("Failed to disconnect.")).toBeInTheDocument();
   });
 
+  it("renders the auth-error banner and folds Reconnect into the row's primary CTA", async () => {
+    const user = userEvent.setup();
+    const onConnectLinear = vi.fn();
+
+    renderWithProviders(
+      <AdditionalIntegrationCards
+        sentryConnected={false}
+        linearConnected={false}
+        linearLoading={false}
+        linearAuthError={{
+          reason: "Linear rejected the access token (HTTP 401). Reconnect to continue syncing.",
+          at: "2026-05-02T20:02:11Z",
+        }}
+        slackConnected={false}
+        notionConnected={false}
+        onConnectSentry={vi.fn()}
+        onConnectLinear={onConnectLinear}
+        onConnectSlack={vi.fn()}
+        onConnectNotion={vi.fn()}
+      />
+    );
+
+    // Reason banner present.
+    expect(screen.getByText("Reconnect required")).toBeInTheDocument();
+    expect(screen.getByText(/Linear rejected the access token/)).toBeInTheDocument();
+
+    // Single CTA on the row — not duplicated inside the banner.
+    const reconnectButtons = screen.getAllByRole("button", { name: "Reconnect Linear" });
+    expect(reconnectButtons).toHaveLength(1);
+
+    // Generic "Connect Linear" affordance is suppressed when authErrored.
+    expect(screen.queryByRole("button", { name: "Connect Linear" })).not.toBeInTheDocument();
+
+    await user.click(reconnectButtons[0]);
+    expect(onConnectLinear).toHaveBeenCalledTimes(1);
+  });
+
+  it("readOnly auth-errored row shows a 'Reconnect required' badge and no buttons", () => {
+    renderWithProviders(
+      <AdditionalIntegrationCards
+        sentryConnected={false}
+        linearConnected={false}
+        linearLoading={false}
+        linearAuthError={{
+          reason: "Linear rejected the access token (HTTP 401). Reconnect to continue syncing.",
+          at: "2026-05-02T20:02:11Z",
+        }}
+        slackConnected={false}
+        notionConnected={false}
+        onConnectSentry={vi.fn()}
+        onConnectLinear={vi.fn()}
+        onConnectSlack={vi.fn()}
+        onConnectNotion={vi.fn()}
+        readOnly
+      />
+    );
+
+    // Two "Reconnect required" elements expected: the alert title above the
+    // row and the read-only status badge in the action slot.
+    expect(screen.getAllByText("Reconnect required")).toHaveLength(2);
+    expect(screen.queryByRole("button", { name: "Reconnect Linear" })).not.toBeInTheDocument();
+  });
+
   it("readOnly hides connect/disconnect buttons and per-repo controls; shows status badges instead", () => {
     renderWithProviders(
       <AllIntegrationCards

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -214,14 +214,25 @@ function ConnectedReposList({
 // (IntegrationAction with authErrored=true) so there's a single CTA per
 // row instead of two.
 function IntegrationAuthErrorAlert({ info }: { info: IntegrationAuthErrorInfo }) {
-  // Render the absolute timestamp; "ago" math without a real date library
-  // would drift across renders and the absolute timestamp is precise enough
-  // for an operator-facing settings page.
+  // Render the absolute timestamp in an unambiguous, locale-stable format
+  // (YYYY-MM-DD HH:MM:SS in the viewer's local timezone) so operators
+  // helping each other across regions can compare notes without
+  // 5/2/2026-vs-02/05/2026 confusion. Local time still — the user is
+  // already implicitly in their tz when they read the page.
   let observedAt = info.at;
   try {
     const d = new Date(info.at);
     if (!Number.isNaN(d.getTime())) {
-      observedAt = d.toLocaleString();
+      const fmt = new Intl.DateTimeFormat("sv-SE", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+      });
+      observedAt = fmt.format(d);
     }
   } catch {
     // fall back to the raw string

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -43,10 +43,21 @@ type SourceControlIntegrationCardProps = IntegrationCallbacks & RepoCallbacks & 
   isSyncing?: boolean;
 };
 
+// IntegrationAuthErrorInfo mirrors the shape the backend returns on
+// Integration.auth_error: a controlled reason string plus the timestamp
+// the failure was last observed. Surfaced as an amber banner attached to
+// the relevant integration card so the user sees "you need to reconnect"
+// rather than a generic "session prepare failed" downstream.
+export type IntegrationAuthErrorInfo = {
+  reason: string;
+  at: string;
+};
+
 type AdditionalIntegrationCardsProps = IntegrationCallbacks & {
   sentryConnected: boolean;
   linearConnected: boolean;
   linearLoading: boolean;
+  linearAuthError?: IntegrationAuthErrorInfo | null;
   slackConnected: boolean;
   notionConnected: boolean;
   notionLoading?: boolean;
@@ -197,6 +208,38 @@ function ConnectedReposList({
   );
 }
 
+// IntegrationAuthErrorAlert renders the amber "your token was rejected"
+// banner the integrations card slots in via `extra`. Reason + timestamp
+// only — the actual Reconnect button lives in the row's main action slot
+// (IntegrationAction with authErrored=true) so there's a single CTA per
+// row instead of two.
+function IntegrationAuthErrorAlert({ info }: { info: IntegrationAuthErrorInfo }) {
+  // Render the absolute timestamp; "ago" math without a real date library
+  // would drift across renders and the absolute timestamp is precise enough
+  // for an operator-facing settings page.
+  let observedAt = info.at;
+  try {
+    const d = new Date(info.at);
+    if (!Number.isNaN(d.getTime())) {
+      observedAt = d.toLocaleString();
+    }
+  } catch {
+    // fall back to the raw string
+  }
+  return (
+    <div
+      role="alert"
+      className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
+    >
+      <div className="font-medium">Reconnect required</div>
+      <p className="mt-0.5 text-amber-700/90 dark:text-amber-200/90">{info.reason}</p>
+      <p className="mt-0.5 text-xs text-amber-700/70 dark:text-amber-200/70">
+        Last seen at {observedAt}
+      </p>
+    </div>
+  );
+}
+
 function IntegrationLogo({ name, src }: { name: string; src: string }) {
   return (
     <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-muted/50 dark:bg-white/5 ring-1 ring-border/50 transition-transform duration-200 group-hover:scale-105">
@@ -230,6 +273,7 @@ function IntegrationAction({
   disconnectError,
   loading,
   readOnly,
+  authErrored,
 }: {
   connected: boolean;
   integrationKey: IntegrationKey;
@@ -240,14 +284,40 @@ function IntegrationAction({
   disconnectError?: string | null;
   loading?: boolean;
   readOnly?: boolean;
+  /**
+   * When true, the row's primary action becomes a "Reconnect <Provider>"
+   * button instead of "Connect"/"Disconnect". Set whenever the backend
+   * surfaces Integration.auth_error so the user has a single clear CTA
+   * (the amber banner above the row carries the reason; this is the action).
+   */
+  authErrored?: boolean;
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   if (readOnly) {
     return (
-      <Badge variant={connected ? "secondary" : "outline"} className="text-xs">
-        {connected ? "Connected" : "Not connected"}
+      <Badge variant={authErrored ? "outline" : connected ? "secondary" : "outline"} className="text-xs">
+        {authErrored ? "Reconnect required" : connected ? "Connected" : "Not connected"}
       </Badge>
+    );
+  }
+
+  if (authErrored) {
+    // Single CTA in the auth-errored state: skip the disconnect / connected
+    // / connect branches below so the user sees one unambiguous "Reconnect"
+    // button. onConnect drives the OAuth flow which the API handler treats
+    // as a reconnect (ensureIntegration resets status and clears markers).
+    return (
+      <Button
+        size="sm"
+        variant="default"
+        loading={loading}
+        disabled={loading}
+        onClick={onConnect}
+        aria-label={`Reconnect ${integrationName}`}
+      >
+        {`Reconnect ${integrationName}`}
+      </Button>
     );
   }
 
@@ -377,6 +447,7 @@ export function AdditionalIntegrationCards({
   sentryConnected,
   linearConnected,
   linearLoading,
+  linearAuthError,
   slackConnected,
   notionConnected,
   notionLoading,
@@ -423,6 +494,7 @@ export function AdditionalIntegrationCards({
           description: linear.description,
           logo: <IntegrationLogo name={linear.name} src={linear.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
+          extra: linearAuthError ? <IntegrationAuthErrorAlert info={linearAuthError} /> : undefined,
           action: (
             <IntegrationAction
               connected={linearConnected}
@@ -434,6 +506,7 @@ export function AdditionalIntegrationCards({
               disconnectError={disconnectErrorProvider === "linear" ? disconnectError : null}
               loading={linearLoading}
               readOnly={readOnly}
+              authErrored={Boolean(linearAuthError)}
             />
           ),
         },
@@ -496,6 +569,7 @@ export function AllIntegrationCards({
   sentryConnected,
   linearConnected,
   linearLoading,
+  linearAuthError,
   slackConnected,
   notionConnected,
   notionLoading,
@@ -565,6 +639,7 @@ export function AllIntegrationCards({
           description: linear.description,
           logo: <IntegrationLogo name={linear.name} src={linear.logoSrc} />,
           badge: <Badge variant="secondary" className="text-xs">Optional</Badge>,
+          extra: linearAuthError ? <IntegrationAuthErrorAlert info={linearAuthError} /> : undefined,
           action: (
             <IntegrationAction
               connected={linearConnected}
@@ -576,6 +651,7 @@ export function AllIntegrationCards({
               disconnectError={disconnectErrorProvider === "linear" ? disconnectError : null}
               loading={linearLoading}
               readOnly={readOnly}
+              authErrored={Boolean(linearAuthError)}
             />
           ),
         },

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -84,6 +84,17 @@ export interface Integration {
   org_id: string;
   provider: string;
   github_app_installed?: boolean;
+  /**
+   * Surfaced by the backend when a provider rejects our access token (e.g.
+   * Linear returns 401). Populated by deriveIntegrationStatus on the server
+   * — when present, the integrations settings card renders an amber banner
+   * with a Reconnect CTA. The reason field is a controlled string from the
+   * backend; never render arbitrary provider responses through this surface.
+   */
+  auth_error?: {
+    reason: string;
+    at: string;
+  };
   status: string;
   last_synced_at?: string;
   created_at: string;

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -1208,13 +1208,17 @@ func (h *IntegrationHandler) maybeEnqueuePMContext(ctx context.Context, orgID uu
 }
 
 func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.UUID, provider models.IntegrationProvider) (models.Integration, bool, error) {
-	activeIntegrations, err := h.integrationStore.ListByOrgAndProvider(ctx, orgID, string(provider))
+	// One round trip: returns active rows first, then errored rows. Lets a
+	// reconnect after a 401-flip reuse the original row instead of leaving
+	// a stale errored row plus a fresh duplicate. Active-first ORDER BY in
+	// SQL keeps the existing "prefer active" precedence.
+	reusableIntegrations, err := h.integrationStore.ListReusableForReconnect(ctx, orgID, string(provider))
 	if err != nil {
 		return models.Integration{}, false, err
 	}
 
-	if len(activeIntegrations) > 0 {
-		integration := activeIntegrations[0]
+	if len(reusableIntegrations) > 0 {
+		integration := reusableIntegrations[0]
 		// A reconnect flow lands here: if the row is errored (most often
 		// from a prior 401 the worker stamped) restore it to active and
 		// strip the auth-error markers so the settings UI's Reconnect CTA

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -339,29 +339,28 @@ func (h *IntegrationHandler) deriveIntegrationStatus(ctx context.Context, integr
 	integration.GitHubAppInstalled = &installed
 }
 
-// readAuthErrorFromConfig extracts the {last_auth_error, last_auth_error_at}
-// pair the linear service stamps when it sees a 401. Returns nil when
-// either key is missing or the timestamp doesn't parse — partial markers
-// are treated as absent so a malformed jsonb doesn't render an empty banner.
+// readAuthErrorFromConfig extracts the auth-error pair the linear service
+// stamps when it sees a 401. Returns nil when either key is missing or the
+// timestamp doesn't parse — partial markers are treated as absent so a
+// malformed jsonb doesn't render an empty banner.
 func readAuthErrorFromConfig(raw json.RawMessage) *models.IntegrationAuthError {
 	if len(raw) == 0 {
 		return nil
 	}
-	var cfg struct {
-		LastAuthError   string `json:"last_auth_error"`
-		LastAuthErrorAt string `json:"last_auth_error_at"`
-	}
+	cfg := map[string]any{}
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return nil
 	}
-	if cfg.LastAuthError == "" || cfg.LastAuthErrorAt == "" {
+	reason, _ := cfg[models.IntegrationConfigAuthErrorKey].(string)
+	atStr, _ := cfg[models.IntegrationConfigAuthErrorAtKey].(string)
+	if reason == "" || atStr == "" {
 		return nil
 	}
-	at, err := time.Parse(time.RFC3339, cfg.LastAuthErrorAt)
+	at, err := time.Parse(time.RFC3339, atStr)
 	if err != nil {
 		return nil
 	}
-	return &models.IntegrationAuthError{Reason: cfg.LastAuthError, At: at}
+	return &models.IntegrationAuthError{Reason: reason, At: at}
 }
 
 // DisconnectIntegration sets the integration status to inactive for a given provider.
@@ -1226,13 +1225,22 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 		// the OAuth flow from completing because the credential write has
 		// already succeeded; the next successful Linear API call will
 		// invoke ClearIntegrationUnauthorized and converge state anyway.
+		// When both fields need to change we write atomically so the row
+		// can never be observed as "active with stale auth_error markers"
+		// (which would render no Reconnect CTA but also no Connect CTA).
 		clearedConfig, configChanged := stripAuthErrorMarkers(integration.Config)
-		if configChanged {
+		statusErrored := integration.Status == models.IntegrationStatusError
+		switch {
+		case configChanged && statusErrored:
+			if err := h.integrationStore.UpdateStatusAndConfig(ctx, orgID, integration.ID, string(models.IntegrationStatusActive), clearedConfig); err == nil {
+				integration.Config = clearedConfig
+				integration.Status = models.IntegrationStatusActive
+			}
+		case configChanged:
 			if err := h.integrationStore.UpdateConfig(ctx, orgID, integration.ID, clearedConfig); err == nil {
 				integration.Config = clearedConfig
 			}
-		}
-		if integration.Status == models.IntegrationStatusError {
+		case statusErrored:
 			if err := h.integrationStore.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err == nil {
 				integration.Status = models.IntegrationStatusActive
 			}
@@ -1261,12 +1269,10 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 // dropped — the caller skips the UPDATE when nothing changed to avoid
 // pointless updated_at churn on the integrations row.
 //
-// Defined here (in the integrations handler package) so the OAuth reconnect
-// path doesn't need to import internal/services/linear and so the key names
-// stay private to the linear service. We accept the small string-literal
-// duplication ("last_auth_error", "last_auth_error_at") in exchange for a
-// clean dependency direction; if more providers grow auth-error markers
-// later, lift this to a shared helper.
+// Lives in the integrations handler so the OAuth reconnect path doesn't
+// need to import internal/services/linear; the key names are shared via
+// constants in the models package so writer (linear service) and readers
+// (this handler) can't drift.
 func stripAuthErrorMarkers(raw json.RawMessage) (json.RawMessage, bool) {
 	if len(raw) == 0 {
 		return raw, false
@@ -1275,13 +1281,13 @@ func stripAuthErrorMarkers(raw json.RawMessage) (json.RawMessage, bool) {
 	if err := json.Unmarshal(raw, &cfg); err != nil {
 		return raw, false
 	}
-	_, hadErr := cfg["last_auth_error"]
-	_, hadAt := cfg["last_auth_error_at"]
+	_, hadErr := cfg[models.IntegrationConfigAuthErrorKey]
+	_, hadAt := cfg[models.IntegrationConfigAuthErrorAtKey]
 	if !hadErr && !hadAt {
 		return raw, false
 	}
-	delete(cfg, "last_auth_error")
-	delete(cfg, "last_auth_error_at")
+	delete(cfg, models.IntegrationConfigAuthErrorKey)
+	delete(cfg, models.IntegrationConfigAuthErrorAtKey)
 	out, err := json.Marshal(cfg)
 	if err != nil {
 		return raw, false

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -308,7 +308,19 @@ func (h *IntegrationHandler) ListIntegrations(w http.ResponseWriter, r *http.Req
 }
 
 func (h *IntegrationHandler) deriveIntegrationStatus(ctx context.Context, integration *models.Integration) {
-	if integration == nil || integration.Provider != models.IntegrationProviderGitHub {
+	if integration == nil {
+		return
+	}
+
+	// Auth-error surfacing is provider-agnostic: the linear service stamps
+	// the markers, but the UI can render the same banner for any provider
+	// that adopts the convention later. Read-only — never echo the rest of
+	// config (which holds tokens).
+	if authErr := readAuthErrorFromConfig(integration.Config); authErr != nil {
+		integration.AuthError = authErr
+	}
+
+	if integration.Provider != models.IntegrationProviderGitHub {
 		return
 	}
 
@@ -325,6 +337,31 @@ func (h *IntegrationHandler) deriveIntegrationStatus(ctx context.Context, integr
 		}
 	}
 	integration.GitHubAppInstalled = &installed
+}
+
+// readAuthErrorFromConfig extracts the {last_auth_error, last_auth_error_at}
+// pair the linear service stamps when it sees a 401. Returns nil when
+// either key is missing or the timestamp doesn't parse — partial markers
+// are treated as absent so a malformed jsonb doesn't render an empty banner.
+func readAuthErrorFromConfig(raw json.RawMessage) *models.IntegrationAuthError {
+	if len(raw) == 0 {
+		return nil
+	}
+	var cfg struct {
+		LastAuthError   string `json:"last_auth_error"`
+		LastAuthErrorAt string `json:"last_auth_error_at"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+	if cfg.LastAuthError == "" || cfg.LastAuthErrorAt == "" {
+		return nil
+	}
+	at, err := time.Parse(time.RFC3339, cfg.LastAuthErrorAt)
+	if err != nil {
+		return nil
+	}
+	return &models.IntegrationAuthError{Reason: cfg.LastAuthError, At: at}
 }
 
 // DisconnectIntegration sets the integration status to inactive for a given provider.
@@ -1177,7 +1214,26 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 	}
 
 	if len(activeIntegrations) > 0 {
-		return activeIntegrations[0], false, nil
+		integration := activeIntegrations[0]
+		// A reconnect flow lands here: if the row is errored (most often
+		// from a prior 401 the worker stamped) restore it to active and
+		// strip the auth-error markers so the settings UI's Reconnect CTA
+		// goes away immediately. Best-effort — failures here don't prevent
+		// the OAuth flow from completing because the credential write has
+		// already succeeded; the next successful Linear API call will
+		// invoke ClearIntegrationUnauthorized and converge state anyway.
+		clearedConfig, configChanged := stripAuthErrorMarkers(integration.Config)
+		if configChanged {
+			if err := h.integrationStore.UpdateConfig(ctx, orgID, integration.ID, clearedConfig); err == nil {
+				integration.Config = clearedConfig
+			}
+		}
+		if integration.Status == models.IntegrationStatusError {
+			if err := h.integrationStore.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err == nil {
+				integration.Status = models.IntegrationStatusActive
+			}
+		}
+		return integration, false, nil
 	}
 
 	integration := &models.Integration{
@@ -1193,6 +1249,40 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 	h.maybeEnqueuePMContext(ctx, orgID)
 
 	return *integration, true, nil
+}
+
+// stripAuthErrorMarkers removes the auth-error keys the linear service
+// stamps into integrations.config when it observes a 401. Returns the
+// (possibly unchanged) jsonb and a flag indicating whether any keys were
+// dropped — the caller skips the UPDATE when nothing changed to avoid
+// pointless updated_at churn on the integrations row.
+//
+// Defined here (in the integrations handler package) so the OAuth reconnect
+// path doesn't need to import internal/services/linear and so the key names
+// stay private to the linear service. We accept the small string-literal
+// duplication ("last_auth_error", "last_auth_error_at") in exchange for a
+// clean dependency direction; if more providers grow auth-error markers
+// later, lift this to a shared helper.
+func stripAuthErrorMarkers(raw json.RawMessage) (json.RawMessage, bool) {
+	if len(raw) == 0 {
+		return raw, false
+	}
+	cfg := map[string]any{}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return raw, false
+	}
+	_, hadErr := cfg["last_auth_error"]
+	_, hadAt := cfg["last_auth_error_at"]
+	if !hadErr && !hadAt {
+		return raw, false
+	}
+	delete(cfg, "last_auth_error")
+	delete(cfg, "last_auth_error_at")
+	out, err := json.Marshal(cfg)
+	if err != nil {
+		return raw, false
+	}
+	return out, true
 }
 
 // --- Redirect URLs ---

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -376,7 +376,7 @@ func TestIntegrationHandler_HandleLinearOAuthCallback_SavesCredentialAndIntegrat
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -455,9 +455,10 @@ func TestIntegrationHandler_HandleLinearOAuthCallback_AsyncRefreshAndEnqueue(t *
 	mock.ExpectQuery("INSERT INTO org_credentials").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+
 	mock.ExpectQuery("INSERT INTO integrations").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
@@ -537,7 +538,7 @@ func TestIntegrationHandler_ConnectLinear_CreatesIntegrationWhenMissing(t *testi
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -576,7 +577,7 @@ func TestIntegrationHandler_ConnectLinear_ReturnsExistingIntegration(t *testing.
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
@@ -598,6 +599,50 @@ func TestIntegrationHandler_ConnectLinear_ReturnsExistingIntegration(t *testing.
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestIntegrationHandler_ConnectLinear_ReactivatesErroredIntegration(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+				AddRow(integrationID, orgID, "linear", json.RawMessage(`{"workspace_id":"wks-1","last_auth_error":"prior","last_auth_error_at":"2026-05-02T20:02:11Z"}`), "error", nil, now),
+		)
+
+	mock.ExpectExec("UPDATE integrations SET config").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE integrations SET status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "ConnectLinear should reuse an errored integration")
+
+	var resp models.SingleResponse[models.Integration]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "ConnectLinear response should be valid JSON")
+	require.Equal(t, integrationID, resp.Data.ID, "ConnectLinear should return the existing errored integration ID")
+	require.Equal(t, models.IntegrationStatusActive, resp.Data.Status, "ConnectLinear should reactivate the errored integration")
+	require.NotContains(t, string(resp.Data.Config), "last_auth_error", "ConnectLinear should strip stale auth-error markers")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenLookupFails(t *testing.T) {
 	t.Parallel()
 
@@ -610,7 +655,7 @@ func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenLookupFails(t 
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("db unavailable"))
 
@@ -637,7 +682,7 @@ func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenCreateFails(t 
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -763,7 +808,7 @@ func TestIntegrationHandler_HandleSentryOAuthCallback_SavesCredentialAndIntegrat
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -927,7 +972,7 @@ func TestIntegrationHandler_ConnectSentry_CreatesIntegration(t *testing.T) {
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -963,7 +1008,7 @@ func TestIntegrationHandler_ConnectSentry_ReturnsExisting(t *testing.T) {
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
@@ -1114,7 +1159,7 @@ func TestIntegrationHandler_HandleGitHubOAuthCallback_SavesCredentialAndIntegrat
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -1236,7 +1281,7 @@ func TestIntegrationHandler_HandleGitHubOAuthCallback_DelegatesToAppInstalled(t 
 	// When installation_id and setup_action=install are present, the callback
 	// handler should delegate to HandleGitHubAppInstalled instead of trying
 	// to exchange a code. Expect the ensureIntegration + UpdateConfig queries.
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -1274,7 +1319,7 @@ func TestIntegrationHandler_ConnectGitHub_CreatesIntegration(t *testing.T) {
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -1310,7 +1355,7 @@ func TestIntegrationHandler_ConnectGitHub_ReturnsExisting(t *testing.T) {
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(
 			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
@@ -1342,7 +1387,7 @@ func TestIntegrationHandler_ConnectGitHub_DBError(t *testing.T) {
 	store := db.NewIntegrationStore(mock)
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("db unavailable"))
 
@@ -1374,7 +1419,7 @@ func TestIntegrationHandler_EnsureIntegration_CreateFails(t *testing.T) {
 	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
 
 	// No existing integrations
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 
@@ -1565,7 +1610,7 @@ func TestIntegrationHandler_ConnectNotion_Success(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
 	// Expect integration check (none exists).
-	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status = 'active'").
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
 

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -620,11 +620,10 @@ func TestIntegrationHandler_ConnectLinear_ReactivatesErroredIntegration(t *testi
 				AddRow(integrationID, orgID, "linear", json.RawMessage(`{"workspace_id":"wks-1","last_auth_error":"prior","last_auth_error_at":"2026-05-02T20:02:11Z"}`), "error", nil, now),
 		)
 
-	mock.ExpectExec("UPDATE integrations SET config").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	mock.ExpectExec("UPDATE integrations SET status").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+	// Single atomic UPDATE: status and config flip together so the row
+	// can't be observed mid-flip.
+	mock.ExpectExec("UPDATE integrations SET status = @status, config = @config").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -211,16 +211,17 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	// worker gets its own instance via buildServices in cmd/server/main.go.
 	// Both call linear.Build so wiring stays in lockstep.
 	linearService := linear.Build(linear.BuildDeps{
-		Pool:         pool,
-		Logger:       logger,
-		Integrations: integrationStore,
-		Credentials:  credentialStore,
-		Issues:       issueStore,
-		Sessions:     sessionStore,
-		IssueLinks:   sessionIssueLinkStore,
-		Orgs:         orgStore,
-		Jobs:         jobStore,
-		AppBaseURL:   cfg.FrontendURL,
+		Pool:               pool,
+		Logger:             logger,
+		Integrations:       integrationStore,
+		IntegrationsWriter: integrationStore,
+		Credentials:        credentialStore,
+		Issues:             issueStore,
+		Sessions:           sessionStore,
+		IssueLinks:         sessionIssueLinkStore,
+		Orgs:               orgStore,
+		Jobs:               jobStore,
+		AppBaseURL:         cfg.FrontendURL,
 	})
 	if sessionStreams != nil {
 		// Republish session status on every link change so the detail view

--- a/internal/db/integration_store_test.go
+++ b/internal/db/integration_store_test.go
@@ -213,6 +213,40 @@ func TestIntegrationStore_ListByOrg(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestIntegrationStore_ListReusableForReconnect(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewIntegrationStore(mock)
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now()
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(integrationColumns).
+				AddRow(integrationID, orgID, "linear", json.RawMessage(`{}`), "error", nil, now),
+		)
+
+	integrations, err := store.ListReusableForReconnect(context.Background(), orgID, "linear")
+	require.NoError(t, err, "ListReusableForReconnect should not return an error")
+	require.Equal(t, []models.Integration{
+		{
+			ID:        integrationID,
+			OrgID:     orgID,
+			Provider:  models.IntegrationProviderLinear,
+			Config:    json.RawMessage(`{}`),
+			Status:    models.IntegrationStatusError,
+			CreatedAt: now,
+		},
+	}, integrations, "ListReusableForReconnect should return reusable active or errored integrations")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestIntegrationStore_UpdateLastSyncedAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/integration_store_test.go
+++ b/internal/db/integration_store_test.go
@@ -288,6 +288,26 @@ func TestIntegrationStore_UpdateStatus(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestIntegrationStore_UpdateStatusAndConfig(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewIntegrationStore(mock)
+	orgID := uuid.New()
+	integrationID := uuid.New()
+
+	mock.ExpectExec("UPDATE integrations SET status = @status, config = @config").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	err = store.UpdateStatusAndConfig(context.Background(), orgID, integrationID, "active", json.RawMessage(`{"workspace_id":"wks-1"}`))
+	require.NoError(t, err, "UpdateStatusAndConfig should not return an error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestIntegrationStore_ListOrgsWithActiveIntegrations(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/integrations.go
+++ b/internal/db/integrations.go
@@ -161,6 +161,20 @@ func (s *IntegrationStore) UpdateConfig(ctx context.Context, orgID, integrationI
 	return err
 }
 
+// UpdateStatusAndConfig flips status and rewrites config in a single SQL
+// statement so the auth-error mark / clear paths can't observe a partial
+// state where one field updated and the other didn't.
+func (s *IntegrationStore) UpdateStatusAndConfig(ctx context.Context, orgID, integrationID uuid.UUID, status string, config json.RawMessage) error {
+	query := `UPDATE integrations SET status = @status, config = @config, updated_at = now() WHERE org_id = @org_id AND id = @id`
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":     integrationID,
+		"org_id": orgID,
+		"status": status,
+		"config": config,
+	})
+	return err
+}
+
 // GetByGitHubInstallationID returns the active GitHub integration for the
 // given installation id, used by webhook dispatch to map an event to an org.
 // lint:allow-no-orgid reason="GitHub webhook lookup by installation ID; no org context available pre-auth"

--- a/internal/db/integrations.go
+++ b/internal/db/integrations.go
@@ -92,6 +92,30 @@ func (s *IntegrationStore) ListByOrgAndProvider(ctx context.Context, orgID uuid.
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Integration])
 }
 
+// ListReusableForReconnect returns rows for (org, provider) that the
+// OAuth reconnect path can reuse: active rows first, then rows the worker
+// flipped to error after a 401, so a reconnect converges back onto the
+// same row instead of creating a duplicate. Single round trip with the
+// ORDER BY pinned in SQL — callers can take the first row.
+func (s *IntegrationStore) ListReusableForReconnect(ctx context.Context, orgID uuid.UUID, provider string) ([]models.Integration, error) {
+	query := `
+		SELECT id, org_id, provider, config, status, last_synced_at, created_at
+		FROM integrations
+		WHERE org_id = @org_id
+		  AND provider = @provider
+		  AND status IN ('active', 'error')
+		ORDER BY (status = 'active') DESC, created_at DESC`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":   orgID,
+		"provider": provider,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query reusable integrations by org and provider: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.Integration])
+}
+
 func (s *IntegrationStore) ListByOrg(ctx context.Context, orgID uuid.UUID) ([]models.Integration, error) {
 	query := `
 		SELECT id, org_id, provider, config, status, last_synced_at, created_at

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -71,9 +71,24 @@ type Integration struct {
 	Provider           IntegrationProvider `db:"provider" json:"provider"`
 	Config             json.RawMessage     `db:"config" json:"-"` // never expose config in JSON (contains secrets)
 	GitHubAppInstalled *bool               `db:"-" json:"github_app_installed,omitempty"`
-	Status             IntegrationStatus   `db:"status" json:"status"`
-	LastSyncedAt       *time.Time          `db:"last_synced_at" json:"last_synced_at,omitempty"`
-	CreatedAt          time.Time           `db:"created_at" json:"created_at"`
+	// AuthError is a derived view of the auth-failure markers stamped into
+	// config jsonb when a provider rejects our access token (currently only
+	// Linear). Populated by ListIntegrations / Get* paths via deriveIntegrationStatus
+	// so the integrations settings UI can render a "Reconnect" CTA without
+	// leaking the rest of config (which contains secrets — see json:"-" above).
+	AuthError    *IntegrationAuthError `db:"-" json:"auth_error,omitempty"`
+	Status       IntegrationStatus     `db:"status" json:"status"`
+	LastSyncedAt *time.Time            `db:"last_synced_at" json:"last_synced_at,omitempty"`
+	CreatedAt    time.Time             `db:"created_at" json:"created_at"`
+}
+
+// IntegrationAuthError is the user-facing shape of an auth failure: a
+// short reason string and the timestamp the failure was last observed.
+// SECURITY: must not include raw provider responses or tokens — the
+// reason field is set to a controlled string at the call site.
+type IntegrationAuthError struct {
+	Reason string    `json:"reason"`
+	At     time.Time `json:"at"`
 }
 
 type Repository struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -91,6 +91,16 @@ type IntegrationAuthError struct {
 	At     time.Time `json:"at"`
 }
 
+// IntegrationConfigAuthErrorKey / IntegrationConfigAuthErrorAtKey are the
+// jsonb keys used to stamp an auth-error reason and timestamp into
+// integrations.config. Defined here so the writer (linear service) and
+// readers (api/handlers) share a single source of truth without forcing
+// a dependency edge between those packages.
+const (
+	IntegrationConfigAuthErrorKey   = "last_auth_error"
+	IntegrationConfigAuthErrorAtKey = "last_auth_error_at"
+)
+
 type Repository struct {
 	ID             uuid.UUID       `db:"id" json:"id"`
 	OrgID          uuid.UUID       `db:"org_id" json:"org_id"`

--- a/internal/services/linear/auth_status.go
+++ b/internal/services/linear/auth_status.go
@@ -1,0 +1,173 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// authErrorReasonUnauthorized is the human-readable reason stamped into the
+// integrations.config jsonb when Linear rejects the access token. The
+// integrations settings UI renders this verbatim above the Reconnect CTA, so
+// keep it terse and operator-actionable rather than dropping the raw error.
+const authErrorReasonUnauthorized = "Linear rejected the access token (HTTP 401). Reconnect to continue syncing."
+
+// configAuthErrorKey / configAuthErrorAtKey are the jsonb keys we stamp on
+// integrations.config. We keep them inline (rather than introducing a new
+// column) per design call: zero migration, and the only consumer is the
+// integrations settings page which already deserializes config to display
+// workspace metadata.
+const (
+	configAuthErrorKey   = "last_auth_error"
+	configAuthErrorAtKey = "last_auth_error_at"
+)
+
+// MarkIntegrationUnauthorized flips the org's Linear integration row to
+// IntegrationStatusError and stamps an auth-error reason + timestamp into
+// the existing config jsonb. Best-effort: every step logs and swallows on
+// failure because this is a side-channel signal — the caller is in the
+// middle of handling the original ErrUnauthorized and shouldn't have its
+// retry/dead-letter contract perturbed by a status-write hiccup.
+//
+// The function is the missing "integration health check" from the comment
+// at client.go:664 turned inside-out: instead of a periodic probe, every
+// 401 anywhere becomes the probe. Combined with ClearIntegrationUnauthorized
+// from a successful call, the credential status reflects reality within
+// one Linear API round-trip.
+//
+// Nil-safe in three layers: nil receiver, nil writer (tests / api-only mode
+// without write surface), and "integration row not found" (org never
+// installed Linear) all fall through silently.
+func (s *Service) MarkIntegrationUnauthorized(ctx context.Context, orgID uuid.UUID) {
+	if s == nil || s.integrationsWriter == nil || s.integrations == nil {
+		return
+	}
+	integration, err := s.integrations.GetByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderLinear))
+	if err != nil {
+		s.logger.Debug().Err(err).
+			Str("org_id", orgID.String()).
+			Msg("MarkIntegrationUnauthorized: integration lookup failed; skipping status flip")
+		return
+	}
+	cfg := decodeIntegrationConfig(integration.Config)
+	// Skip the writes if we're already in error state with a fresh-enough
+	// reason: re-stamping every retry would create churn on the integrations
+	// row updated_at and noise in any future audit trail.
+	if integration.Status == models.IntegrationStatusError && hasRecentAuthError(cfg) {
+		return
+	}
+	cfg[configAuthErrorKey] = authErrorReasonUnauthorized
+	cfg[configAuthErrorAtKey] = time.Now().UTC().Format(time.RFC3339)
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		s.logger.Warn().Err(err).
+			Str("org_id", orgID.String()).
+			Msg("MarkIntegrationUnauthorized: marshal config failed; status flip skipped")
+		return
+	}
+	if err := s.integrationsWriter.UpdateConfig(ctx, orgID, integration.ID, raw); err != nil {
+		s.logger.Warn().Err(err).
+			Str("org_id", orgID.String()).
+			Str("integration_id", integration.ID.String()).
+			Msg("MarkIntegrationUnauthorized: persist config patch failed")
+	}
+	if err := s.integrationsWriter.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusError)); err != nil {
+		s.logger.Warn().Err(err).
+			Str("org_id", orgID.String()).
+			Str("integration_id", integration.ID.String()).
+			Msg("MarkIntegrationUnauthorized: persist status flip failed")
+		return
+	}
+	s.logger.Warn().
+		Str("org_id", orgID.String()).
+		Str("integration_id", integration.ID.String()).
+		Msg("Linear integration marked errored after 401 — user must reconnect")
+}
+
+// ClearIntegrationUnauthorized clears the auth-error markers and flips the
+// status back to active when the row was previously in error state. Called
+// from any successful Linear API path so a reconnect (or a transient blip
+// resolving on its own) un-sticks the banner without operator intervention.
+//
+// No-op when the row is already active and free of stale markers.
+func (s *Service) ClearIntegrationUnauthorized(ctx context.Context, orgID uuid.UUID) {
+	if s == nil || s.integrationsWriter == nil || s.integrations == nil {
+		return
+	}
+	integration, err := s.integrations.GetByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderLinear))
+	if err != nil {
+		return
+	}
+	cfg := decodeIntegrationConfig(integration.Config)
+	hadError := configHasAuthError(cfg)
+	statusErrored := integration.Status == models.IntegrationStatusError
+	if !hadError && !statusErrored {
+		return
+	}
+	if hadError {
+		delete(cfg, configAuthErrorKey)
+		delete(cfg, configAuthErrorAtKey)
+		raw, err := json.Marshal(cfg)
+		if err == nil {
+			if err := s.integrationsWriter.UpdateConfig(ctx, orgID, integration.ID, raw); err != nil {
+				s.logger.Warn().Err(err).
+					Str("org_id", orgID.String()).
+					Str("integration_id", integration.ID.String()).
+					Msg("ClearIntegrationUnauthorized: clear config failed; banner may persist")
+			}
+		}
+	}
+	if statusErrored {
+		if err := s.integrationsWriter.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err != nil {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Str("integration_id", integration.ID.String()).
+				Msg("ClearIntegrationUnauthorized: status flip back to active failed")
+			return
+		}
+		s.logger.Info().
+			Str("org_id", orgID.String()).
+			Str("integration_id", integration.ID.String()).
+			Msg("Linear integration recovered — flipped back to active after successful API call")
+	}
+}
+
+func decodeIntegrationConfig(raw json.RawMessage) map[string]any {
+	cfg := map[string]any{}
+	if len(raw) == 0 {
+		return cfg
+	}
+	_ = json.Unmarshal(raw, &cfg)
+	return cfg
+}
+
+func configHasAuthError(cfg map[string]any) bool {
+	_, ok := cfg[configAuthErrorKey]
+	return ok
+}
+
+// hasRecentAuthError treats a stamp younger than recentAuthErrorWindow as
+// "fresh enough that we don't need to overwrite it." Older stamps get
+// re-stamped so the timestamp surfaced in the UI tracks the most recent
+// failure rather than the first one in a long error streak.
+func hasRecentAuthError(cfg map[string]any) bool {
+	v, ok := cfg[configAuthErrorAtKey]
+	if !ok {
+		return false
+	}
+	str, ok := v.(string)
+	if !ok || str == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) < recentAuthErrorWindow
+}
+
+const recentAuthErrorWindow = 5 * time.Minute

--- a/internal/services/linear/auth_status.go
+++ b/internal/services/linear/auth_status.go
@@ -16,16 +16,6 @@ import (
 // keep it terse and operator-actionable rather than dropping the raw error.
 const authErrorReasonUnauthorized = "Linear rejected the access token (HTTP 401). Reconnect to continue syncing."
 
-// configAuthErrorKey / configAuthErrorAtKey are the jsonb keys we stamp on
-// integrations.config. We keep them inline (rather than introducing a new
-// column) per design call: zero migration, and the only consumer is the
-// integrations settings page which already deserializes config to display
-// workspace metadata.
-const (
-	configAuthErrorKey   = "last_auth_error"
-	configAuthErrorAtKey = "last_auth_error_at"
-)
-
 // MarkIntegrationUnauthorized flips the org's Linear integration row to
 // IntegrationStatusError and stamps an auth-error reason + timestamp into
 // the existing config jsonb. Best-effort: every step logs and swallows on
@@ -38,6 +28,10 @@ const (
 // 401 anywhere becomes the probe. Combined with ClearIntegrationUnauthorized
 // from a successful call, the credential status reflects reality within
 // one Linear API round-trip.
+//
+// Status + config are written in a single SQL statement so a failure can't
+// leave the row half-updated (config stamped but status still active, or
+// vice versa).
 //
 // Nil-safe in three layers: nil receiver, nil writer (tests / api-only mode
 // without write surface), and "integration row not found" (org never
@@ -60,8 +54,8 @@ func (s *Service) MarkIntegrationUnauthorized(ctx context.Context, orgID uuid.UU
 	if integration.Status == models.IntegrationStatusError && hasRecentAuthError(cfg) {
 		return
 	}
-	cfg[configAuthErrorKey] = authErrorReasonUnauthorized
-	cfg[configAuthErrorAtKey] = time.Now().UTC().Format(time.RFC3339)
+	cfg[models.IntegrationConfigAuthErrorKey] = authErrorReasonUnauthorized
+	cfg[models.IntegrationConfigAuthErrorAtKey] = time.Now().UTC().Format(time.RFC3339)
 	raw, err := json.Marshal(cfg)
 	if err != nil {
 		s.logger.Warn().Err(err).
@@ -69,17 +63,11 @@ func (s *Service) MarkIntegrationUnauthorized(ctx context.Context, orgID uuid.UU
 			Msg("MarkIntegrationUnauthorized: marshal config failed; status flip skipped")
 		return
 	}
-	if err := s.integrationsWriter.UpdateConfig(ctx, orgID, integration.ID, raw); err != nil {
+	if err := s.integrationsWriter.UpdateStatusAndConfig(ctx, orgID, integration.ID, string(models.IntegrationStatusError), raw); err != nil {
 		s.logger.Warn().Err(err).
 			Str("org_id", orgID.String()).
 			Str("integration_id", integration.ID.String()).
-			Msg("MarkIntegrationUnauthorized: persist config patch failed")
-	}
-	if err := s.integrationsWriter.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusError)); err != nil {
-		s.logger.Warn().Err(err).
-			Str("org_id", orgID.String()).
-			Str("integration_id", integration.ID.String()).
-			Msg("MarkIntegrationUnauthorized: persist status flip failed")
+			Msg("MarkIntegrationUnauthorized: persist status+config failed")
 		return
 	}
 	s.logger.Warn().
@@ -93,7 +81,10 @@ func (s *Service) MarkIntegrationUnauthorized(ctx context.Context, orgID uuid.UU
 // from any successful Linear API path so a reconnect (or a transient blip
 // resolving on its own) un-sticks the banner without operator intervention.
 //
-// No-op when the row is already active and free of stale markers.
+// No-op when the row is already active and free of stale markers. When
+// both pieces of state need to change they're written atomically; when
+// only one needs to change we use the narrower update so unaffected
+// columns don't churn updated_at.
 func (s *Service) ClearIntegrationUnauthorized(ctx context.Context, orgID uuid.UUID) {
 	if s == nil || s.integrationsWriter == nil || s.integrations == nil {
 		return
@@ -108,20 +99,41 @@ func (s *Service) ClearIntegrationUnauthorized(ctx context.Context, orgID uuid.U
 	if !hadError && !statusErrored {
 		return
 	}
+
+	var clearedRaw json.RawMessage
 	if hadError {
-		delete(cfg, configAuthErrorKey)
-		delete(cfg, configAuthErrorAtKey)
+		delete(cfg, models.IntegrationConfigAuthErrorKey)
+		delete(cfg, models.IntegrationConfigAuthErrorAtKey)
 		raw, err := json.Marshal(cfg)
-		if err == nil {
-			if err := s.integrationsWriter.UpdateConfig(ctx, orgID, integration.ID, raw); err != nil {
-				s.logger.Warn().Err(err).
-					Str("org_id", orgID.String()).
-					Str("integration_id", integration.ID.String()).
-					Msg("ClearIntegrationUnauthorized: clear config failed; banner may persist")
-			}
+		if err != nil {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Str("integration_id", integration.ID.String()).
+				Msg("ClearIntegrationUnauthorized: marshal cleared config failed; banner may persist")
+			// Fall through and at least flip status if needed.
+		} else {
+			clearedRaw = raw
 		}
 	}
-	if statusErrored {
+
+	switch {
+	case clearedRaw != nil && statusErrored:
+		if err := s.integrationsWriter.UpdateStatusAndConfig(ctx, orgID, integration.ID, string(models.IntegrationStatusActive), clearedRaw); err != nil {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Str("integration_id", integration.ID.String()).
+				Msg("ClearIntegrationUnauthorized: status+config flip failed")
+			return
+		}
+	case clearedRaw != nil:
+		if err := s.integrationsWriter.UpdateConfig(ctx, orgID, integration.ID, clearedRaw); err != nil {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Str("integration_id", integration.ID.String()).
+				Msg("ClearIntegrationUnauthorized: clear config failed; banner may persist")
+			return
+		}
+	case statusErrored:
 		if err := s.integrationsWriter.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err != nil {
 			s.logger.Warn().Err(err).
 				Str("org_id", orgID.String()).
@@ -129,6 +141,9 @@ func (s *Service) ClearIntegrationUnauthorized(ctx context.Context, orgID uuid.U
 				Msg("ClearIntegrationUnauthorized: status flip back to active failed")
 			return
 		}
+	}
+
+	if statusErrored {
 		s.logger.Info().
 			Str("org_id", orgID.String()).
 			Str("integration_id", integration.ID.String()).
@@ -146,7 +161,7 @@ func decodeIntegrationConfig(raw json.RawMessage) map[string]any {
 }
 
 func configHasAuthError(cfg map[string]any) bool {
-	_, ok := cfg[configAuthErrorKey]
+	_, ok := cfg[models.IntegrationConfigAuthErrorKey]
 	return ok
 }
 
@@ -155,7 +170,7 @@ func configHasAuthError(cfg map[string]any) bool {
 // re-stamped so the timestamp surfaced in the UI tracks the most recent
 // failure rather than the first one in a long error streak.
 func hasRecentAuthError(cfg map[string]any) bool {
-	v, ok := cfg[configAuthErrorAtKey]
+	v, ok := cfg[models.IntegrationConfigAuthErrorAtKey]
 	if !ok {
 		return false
 	}

--- a/internal/services/linear/auth_status_test.go
+++ b/internal/services/linear/auth_status_test.go
@@ -21,11 +21,17 @@ import (
 // MarkIntegrationUnauthorized / ClearIntegrationUnauthorized do the right
 // writes (and skip writes when nothing changed).
 type fakeIntegrationStore struct {
-	mu          sync.Mutex
-	row         models.Integration
-	notFoundErr error // when set, GetByOrgAndProvider returns this instead of a row
-	statusCalls []string
-	configCalls []json.RawMessage
+	mu             sync.Mutex
+	row            models.Integration
+	notFoundErr    error // when set, GetByOrgAndProvider returns this instead of a row
+	statusCalls    []string
+	configCalls    []json.RawMessage
+	statusCfgCalls []statusAndConfigCall
+}
+
+type statusAndConfigCall struct {
+	status string
+	config json.RawMessage
 }
 
 func (f *fakeIntegrationStore) GetByOrgAndProvider(_ context.Context, _ uuid.UUID, _ string) (models.Integration, error) {
@@ -53,6 +59,15 @@ func (f *fakeIntegrationStore) UpdateConfig(_ context.Context, _, _ uuid.UUID, c
 	return nil
 }
 
+func (f *fakeIntegrationStore) UpdateStatusAndConfig(_ context.Context, _, _ uuid.UUID, status string, cfg json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statusCfgCalls = append(f.statusCfgCalls, statusAndConfigCall{status: status, config: cfg})
+	f.row.Status = models.IntegrationStatus(status)
+	f.row.Config = cfg
+	return nil
+}
+
 func newAuthStatusService(store *fakeIntegrationStore) *Service {
 	return &Service{
 		logger:             zerolog.Nop(),
@@ -74,17 +89,20 @@ func TestMarkIntegrationUnauthorized_FlipsStatusAndStampsConfig(t *testing.T) {
 
 	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
 
-	require.Equal(t, []string{string(models.IntegrationStatusError)}, store.statusCalls)
-	require.Len(t, store.configCalls, 1, "config should be patched once")
+	// Single atomic write, never the legacy two-step pair.
+	require.Empty(t, store.statusCalls, "should not call UpdateStatus alone")
+	require.Empty(t, store.configCalls, "should not call UpdateConfig alone")
+	require.Len(t, store.statusCfgCalls, 1, "config+status should be patched in one atomic call")
+	require.Equal(t, string(models.IntegrationStatusError), store.statusCfgCalls[0].status)
 
 	var patched map[string]any
-	require.NoError(t, json.Unmarshal(store.configCalls[0], &patched))
+	require.NoError(t, json.Unmarshal(store.statusCfgCalls[0].config, &patched))
 	require.Equal(t, "wks-1", patched["workspace_id"], "existing keys must be preserved")
-	require.Contains(t, patched, configAuthErrorKey)
-	require.Contains(t, patched, configAuthErrorAtKey)
-	require.Equal(t, authErrorReasonUnauthorized, patched[configAuthErrorKey])
+	require.Contains(t, patched, models.IntegrationConfigAuthErrorKey)
+	require.Contains(t, patched, models.IntegrationConfigAuthErrorAtKey)
+	require.Equal(t, authErrorReasonUnauthorized, patched[models.IntegrationConfigAuthErrorKey])
 
-	at, err := time.Parse(time.RFC3339, patched[configAuthErrorAtKey].(string))
+	at, err := time.Parse(time.RFC3339, patched[models.IntegrationConfigAuthErrorAtKey].(string))
 	require.NoError(t, err, "stamped timestamp must be RFC3339")
 	require.WithinDuration(t, time.Now().UTC(), at, 5*time.Second)
 }
@@ -93,8 +111,8 @@ func TestMarkIntegrationUnauthorized_SkipsWhenAlreadyErroredRecently(t *testing.
 	t.Parallel()
 	now := time.Now().UTC().Format(time.RFC3339)
 	cfg, err := json.Marshal(map[string]any{
-		configAuthErrorKey:   "prior",
-		configAuthErrorAtKey: now,
+		models.IntegrationConfigAuthErrorKey:   "prior",
+		models.IntegrationConfigAuthErrorAtKey: now,
 	})
 	require.NoError(t, err)
 	store := &fakeIntegrationStore{
@@ -108,16 +126,17 @@ func TestMarkIntegrationUnauthorized_SkipsWhenAlreadyErroredRecently(t *testing.
 
 	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
 
-	require.Empty(t, store.statusCalls, "no status flip when already errored within window")
-	require.Empty(t, store.configCalls, "no config rewrite when stamp is fresh")
+	require.Empty(t, store.statusCalls, "no status write when already errored within window")
+	require.Empty(t, store.configCalls, "no config write when stamp is fresh")
+	require.Empty(t, store.statusCfgCalls, "no atomic write when nothing changed")
 }
 
 func TestMarkIntegrationUnauthorized_RestampWhenStaleStamp(t *testing.T) {
 	t.Parallel()
 	stale := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
 	cfg, err := json.Marshal(map[string]any{
-		configAuthErrorKey:   "older error",
-		configAuthErrorAtKey: stale,
+		models.IntegrationConfigAuthErrorKey:   "older error",
+		models.IntegrationConfigAuthErrorAtKey: stale,
 	})
 	require.NoError(t, err)
 	store := &fakeIntegrationStore{
@@ -131,14 +150,16 @@ func TestMarkIntegrationUnauthorized_RestampWhenStaleStamp(t *testing.T) {
 
 	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
 
-	// Stale stamp falls past the recency window: both writes proceed (the
-	// status write is idempotent — error→error — but the config write
-	// refreshes the timestamp surfaced in the UI).
-	require.Len(t, store.configCalls, 1, "stale timestamp should be refreshed")
-	require.Equal(t, []string{string(models.IntegrationStatusError)}, store.statusCalls)
+	// Stale stamp falls past the recency window: a single atomic write
+	// refreshes both fields (status idempotently stays at error; config
+	// gets a refreshed timestamp surfaced in the UI).
+	require.Empty(t, store.statusCalls)
+	require.Empty(t, store.configCalls)
+	require.Len(t, store.statusCfgCalls, 1, "stale timestamp should be refreshed via atomic write")
+	require.Equal(t, string(models.IntegrationStatusError), store.statusCfgCalls[0].status)
 	var refreshed map[string]any
-	require.NoError(t, json.Unmarshal(store.configCalls[0], &refreshed))
-	stampedAt, err := time.Parse(time.RFC3339, refreshed[configAuthErrorAtKey].(string))
+	require.NoError(t, json.Unmarshal(store.statusCfgCalls[0].config, &refreshed))
+	stampedAt, err := time.Parse(time.RFC3339, refreshed[models.IntegrationConfigAuthErrorAtKey].(string))
 	require.NoError(t, err)
 	require.WithinDuration(t, time.Now().UTC(), stampedAt, 5*time.Second, "stamp must be refreshed to ~now")
 }
@@ -153,6 +174,7 @@ func TestMarkIntegrationUnauthorized_NilSafe(t *testing.T) {
 	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
 	require.Empty(t, storeNotFound.statusCalls)
 	require.Empty(t, storeNotFound.configCalls)
+	require.Empty(t, storeNotFound.statusCfgCalls)
 
 	// Nil writer (only reader wired) — must not panic.
 	svcReadOnly := &Service{
@@ -165,9 +187,9 @@ func TestMarkIntegrationUnauthorized_NilSafe(t *testing.T) {
 func TestClearIntegrationUnauthorized_RestoresStatusAndStripsMarkers(t *testing.T) {
 	t.Parallel()
 	cfg, err := json.Marshal(map[string]any{
-		"workspace_id":       "wks-1",
-		configAuthErrorKey:   "prior",
-		configAuthErrorAtKey: time.Now().UTC().Format(time.RFC3339),
+		"workspace_id":                         "wks-1",
+		models.IntegrationConfigAuthErrorKey:   "prior",
+		models.IntegrationConfigAuthErrorAtKey: time.Now().UTC().Format(time.RFC3339),
 	})
 	require.NoError(t, err)
 	store := &fakeIntegrationStore{
@@ -181,14 +203,63 @@ func TestClearIntegrationUnauthorized_RestoresStatusAndStripsMarkers(t *testing.
 
 	svc.ClearIntegrationUnauthorized(context.Background(), uuid.New())
 
-	require.Equal(t, []string{string(models.IntegrationStatusActive)}, store.statusCalls)
-	require.Len(t, store.configCalls, 1)
+	// Both pieces of state changed → one atomic write.
+	require.Empty(t, store.statusCalls)
+	require.Empty(t, store.configCalls)
+	require.Len(t, store.statusCfgCalls, 1)
+	require.Equal(t, string(models.IntegrationStatusActive), store.statusCfgCalls[0].status)
 
 	var cleared map[string]any
-	require.NoError(t, json.Unmarshal(store.configCalls[0], &cleared))
-	require.NotContains(t, cleared, configAuthErrorKey, "auth error key should be stripped")
-	require.NotContains(t, cleared, configAuthErrorAtKey)
+	require.NoError(t, json.Unmarshal(store.statusCfgCalls[0].config, &cleared))
+	require.NotContains(t, cleared, models.IntegrationConfigAuthErrorKey, "auth error key should be stripped")
+	require.NotContains(t, cleared, models.IntegrationConfigAuthErrorAtKey)
 	require.Equal(t, "wks-1", cleared["workspace_id"], "non-auth keys preserved")
+}
+
+func TestClearIntegrationUnauthorized_OnlyConfigDirty(t *testing.T) {
+	t.Parallel()
+	// status=active but stale markers in config (e.g. crash mid-Mark).
+	// Should clear config alone, no status write.
+	cfg, err := json.Marshal(map[string]any{
+		"workspace_id":                         "wks-1",
+		models.IntegrationConfigAuthErrorKey:   "stale",
+		models.IntegrationConfigAuthErrorAtKey: time.Now().UTC().Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusActive,
+			Config: cfg,
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.ClearIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Empty(t, store.statusCalls)
+	require.Empty(t, store.statusCfgCalls)
+	require.Len(t, store.configCalls, 1, "narrower update used when only config needed clearing")
+}
+
+func TestClearIntegrationUnauthorized_OnlyStatusDirty(t *testing.T) {
+	t.Parallel()
+	// status=error but no markers (e.g. config was hand-edited). Should
+	// flip status alone via the narrower update.
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusError,
+			Config: json.RawMessage(`{"workspace_id":"wks-1"}`),
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.ClearIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Empty(t, store.configCalls)
+	require.Empty(t, store.statusCfgCalls)
+	require.Equal(t, []string{string(models.IntegrationStatusActive)}, store.statusCalls)
 }
 
 func TestClearIntegrationUnauthorized_NoOpWhenAlreadyHealthy(t *testing.T) {
@@ -206,4 +277,5 @@ func TestClearIntegrationUnauthorized_NoOpWhenAlreadyHealthy(t *testing.T) {
 
 	require.Empty(t, store.statusCalls)
 	require.Empty(t, store.configCalls)
+	require.Empty(t, store.statusCfgCalls)
 }

--- a/internal/services/linear/auth_status_test.go
+++ b/internal/services/linear/auth_status_test.go
@@ -1,0 +1,209 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// fakeIntegrationStore is a tiny in-memory pair (reader + writer) backing
+// the auth-status tests. Mirrors the *db.IntegrationStore surface the
+// production wiring passes — no Linear DB shape, just enough to verify
+// MarkIntegrationUnauthorized / ClearIntegrationUnauthorized do the right
+// writes (and skip writes when nothing changed).
+type fakeIntegrationStore struct {
+	mu          sync.Mutex
+	row         models.Integration
+	notFoundErr error // when set, GetByOrgAndProvider returns this instead of a row
+	statusCalls []string
+	configCalls []json.RawMessage
+}
+
+func (f *fakeIntegrationStore) GetByOrgAndProvider(_ context.Context, _ uuid.UUID, _ string) (models.Integration, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.notFoundErr != nil {
+		return models.Integration{}, f.notFoundErr
+	}
+	return f.row, nil
+}
+
+func (f *fakeIntegrationStore) UpdateStatus(_ context.Context, _, _ uuid.UUID, status string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.statusCalls = append(f.statusCalls, status)
+	f.row.Status = models.IntegrationStatus(status)
+	return nil
+}
+
+func (f *fakeIntegrationStore) UpdateConfig(_ context.Context, _, _ uuid.UUID, cfg json.RawMessage) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.configCalls = append(f.configCalls, cfg)
+	f.row.Config = cfg
+	return nil
+}
+
+func newAuthStatusService(store *fakeIntegrationStore) *Service {
+	return &Service{
+		logger:             zerolog.Nop(),
+		integrations:       store,
+		integrationsWriter: store,
+	}
+}
+
+func TestMarkIntegrationUnauthorized_FlipsStatusAndStampsConfig(t *testing.T) {
+	t.Parallel()
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusActive,
+			Config: json.RawMessage(`{"workspace_id":"wks-1"}`),
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Equal(t, []string{string(models.IntegrationStatusError)}, store.statusCalls)
+	require.Len(t, store.configCalls, 1, "config should be patched once")
+
+	var patched map[string]any
+	require.NoError(t, json.Unmarshal(store.configCalls[0], &patched))
+	require.Equal(t, "wks-1", patched["workspace_id"], "existing keys must be preserved")
+	require.Contains(t, patched, configAuthErrorKey)
+	require.Contains(t, patched, configAuthErrorAtKey)
+	require.Equal(t, authErrorReasonUnauthorized, patched[configAuthErrorKey])
+
+	at, err := time.Parse(time.RFC3339, patched[configAuthErrorAtKey].(string))
+	require.NoError(t, err, "stamped timestamp must be RFC3339")
+	require.WithinDuration(t, time.Now().UTC(), at, 5*time.Second)
+}
+
+func TestMarkIntegrationUnauthorized_SkipsWhenAlreadyErroredRecently(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC().Format(time.RFC3339)
+	cfg, err := json.Marshal(map[string]any{
+		configAuthErrorKey:   "prior",
+		configAuthErrorAtKey: now,
+	})
+	require.NoError(t, err)
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusError,
+			Config: cfg,
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Empty(t, store.statusCalls, "no status flip when already errored within window")
+	require.Empty(t, store.configCalls, "no config rewrite when stamp is fresh")
+}
+
+func TestMarkIntegrationUnauthorized_RestampWhenStaleStamp(t *testing.T) {
+	t.Parallel()
+	stale := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	cfg, err := json.Marshal(map[string]any{
+		configAuthErrorKey:   "older error",
+		configAuthErrorAtKey: stale,
+	})
+	require.NoError(t, err)
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusError,
+			Config: cfg,
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
+
+	// Stale stamp falls past the recency window: both writes proceed (the
+	// status write is idempotent — error→error — but the config write
+	// refreshes the timestamp surfaced in the UI).
+	require.Len(t, store.configCalls, 1, "stale timestamp should be refreshed")
+	require.Equal(t, []string{string(models.IntegrationStatusError)}, store.statusCalls)
+	var refreshed map[string]any
+	require.NoError(t, json.Unmarshal(store.configCalls[0], &refreshed))
+	stampedAt, err := time.Parse(time.RFC3339, refreshed[configAuthErrorAtKey].(string))
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().UTC(), stampedAt, 5*time.Second, "stamp must be refreshed to ~now")
+}
+
+func TestMarkIntegrationUnauthorized_NilSafe(t *testing.T) {
+	t.Parallel()
+	// Nil receiver / nil writer / lookup error all fall through silently.
+	(*Service)(nil).MarkIntegrationUnauthorized(context.Background(), uuid.New())
+
+	storeNotFound := &fakeIntegrationStore{notFoundErr: errors.New("no rows")}
+	svc := newAuthStatusService(storeNotFound)
+	svc.MarkIntegrationUnauthorized(context.Background(), uuid.New())
+	require.Empty(t, storeNotFound.statusCalls)
+	require.Empty(t, storeNotFound.configCalls)
+
+	// Nil writer (only reader wired) — must not panic.
+	svcReadOnly := &Service{
+		logger:       zerolog.Nop(),
+		integrations: &fakeIntegrationStore{row: models.Integration{Status: models.IntegrationStatusActive}},
+	}
+	svcReadOnly.MarkIntegrationUnauthorized(context.Background(), uuid.New())
+}
+
+func TestClearIntegrationUnauthorized_RestoresStatusAndStripsMarkers(t *testing.T) {
+	t.Parallel()
+	cfg, err := json.Marshal(map[string]any{
+		"workspace_id":       "wks-1",
+		configAuthErrorKey:   "prior",
+		configAuthErrorAtKey: time.Now().UTC().Format(time.RFC3339),
+	})
+	require.NoError(t, err)
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusError,
+			Config: cfg,
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.ClearIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Equal(t, []string{string(models.IntegrationStatusActive)}, store.statusCalls)
+	require.Len(t, store.configCalls, 1)
+
+	var cleared map[string]any
+	require.NoError(t, json.Unmarshal(store.configCalls[0], &cleared))
+	require.NotContains(t, cleared, configAuthErrorKey, "auth error key should be stripped")
+	require.NotContains(t, cleared, configAuthErrorAtKey)
+	require.Equal(t, "wks-1", cleared["workspace_id"], "non-auth keys preserved")
+}
+
+func TestClearIntegrationUnauthorized_NoOpWhenAlreadyHealthy(t *testing.T) {
+	t.Parallel()
+	store := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			Status: models.IntegrationStatusActive,
+			Config: json.RawMessage(`{"workspace_id":"wks-1"}`),
+		},
+	}
+	svc := newAuthStatusService(store)
+
+	svc.ClearIntegrationUnauthorized(context.Background(), uuid.New())
+
+	require.Empty(t, store.statusCalls)
+	require.Empty(t, store.configCalls)
+}

--- a/internal/services/linear/build.go
+++ b/internal/services/linear/build.go
@@ -16,18 +16,19 @@ import (
 // stores) the Linear service needs. Pulling this out of router.go and
 // cmd/server/main.go avoids two diverging copies of identical wiring.
 type BuildDeps struct {
-	Pool          *pgxpool.Pool
-	Logger        zerolog.Logger
-	Integrations  IntegrationReader
-	Credentials   CredentialReader
-	Issues        *db.IssueStore
-	Sessions      *db.SessionStore
-	IssueLinks    *db.SessionIssueLinkStore
-	Orgs          *db.OrganizationStore
-	Jobs          *db.JobStore
-	JobQueueName  string
-	JobPriority   int
-	ClientFactory ClientFactory
+	Pool               *pgxpool.Pool
+	Logger             zerolog.Logger
+	Integrations       IntegrationReader
+	IntegrationsWriter IntegrationWriter
+	Credentials        CredentialReader
+	Issues             *db.IssueStore
+	Sessions           *db.SessionStore
+	IssueLinks         *db.SessionIssueLinkStore
+	Orgs               *db.OrganizationStore
+	Jobs               *db.JobStore
+	JobQueueName       string
+	JobPriority        int
+	ClientFactory      ClientFactory
 	// AppBaseURL is the absolute origin (e.g. cfg.FrontendURL) we send to
 	// Linear inside attachment URLs and comment bodies. Empty falls back to
 	// a relative path which Linear renders as plain text — production
@@ -119,20 +120,21 @@ func Build(deps BuildDeps) *Service {
 	}
 
 	svc := NewService(Config{
-		Logger:            deps.Logger,
-		Integrations:      deps.Integrations,
-		Credentials:       deps.Credentials,
-		Issues:            deps.Issues,
-		Links:             deps.IssueLinks,
-		TeamKeys:          db.NewLinearTeamKeyStore(deps.Pool),
-		ProviderState:     db.NewLinearProviderStateStore(deps.Pool),
-		StateEvents:       db.NewLinearStateEventStore(deps.Pool),
-		Sessions:          deps.Sessions,
-		ClientFactory:     clientFactory,
-		OrgSettingsLoader: loader,
-		Pool:              deps.Pool,
-		AppBaseURL:        deps.AppBaseURL,
-		TeamKeyCache:      teamKeyCache,
+		Logger:             deps.Logger,
+		Integrations:       deps.Integrations,
+		IntegrationsWriter: deps.IntegrationsWriter,
+		Credentials:        deps.Credentials,
+		Issues:             deps.Issues,
+		Links:              deps.IssueLinks,
+		TeamKeys:           db.NewLinearTeamKeyStore(deps.Pool),
+		ProviderState:      db.NewLinearProviderStateStore(deps.Pool),
+		StateEvents:        db.NewLinearStateEventStore(deps.Pool),
+		Sessions:           deps.Sessions,
+		ClientFactory:      clientFactory,
+		OrgSettingsLoader:  loader,
+		Pool:               deps.Pool,
+		AppBaseURL:         deps.AppBaseURL,
+		TeamKeyCache:       teamKeyCache,
 	})
 
 	if deps.Jobs != nil {

--- a/internal/services/linear/create_path.go
+++ b/internal/services/linear/create_path.go
@@ -238,6 +238,17 @@ func (s *Service) resolveWithBudget(parent context.Context, orgID uuid.UUID, hit
 			Msg("linear inline resolution fell back to async")
 		return nil, nil
 	default:
+		if errors.Is(err, ErrUnauthorized) {
+			// 401 from the inline path means the org's Linear token is dead.
+			// Flip the integration row to error + stamp the reason so the
+			// integrations settings page surfaces a Reconnect CTA instead of
+			// the user only learning about it via the per-session "prepare
+			// failed" chip after the worker dead-letters. Detached context so
+			// the inline budget cancellation doesn't kill the status write.
+			markCtx, markCancel := context.WithTimeout(context.WithoutCancel(parent), markIntegrationStatusTimeout)
+			s.MarkIntegrationUnauthorized(markCtx, orgID)
+			markCancel()
+		}
 		s.logger.Debug().
 			Dur("elapsed", elapsed).
 			Err(err).
@@ -247,6 +258,11 @@ func (s *Service) resolveWithBudget(parent context.Context, orgID uuid.UUID, hit
 		return nil, err
 	}
 }
+
+// markIntegrationStatusTimeout caps the side-channel status flip on
+// ErrUnauthorized. The write is a single short UPDATE; we still bound it so
+// a wedged DB doesn't pile up goroutines on a Linear-outage retry storm.
+const markIntegrationStatusTimeout = 3 * time.Second
 
 var errLinearRefDropped = errors.New("linear ref dropped")
 

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -2,6 +2,7 @@ package linear
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -55,16 +56,17 @@ import (
 type Service struct {
 	logger zerolog.Logger
 
-	integrations      IntegrationReader
-	credentials       CredentialReader
-	issues            *db.IssueStore
-	links             *db.SessionIssueLinkStore
-	teamKeys          *db.LinearTeamKeyStore
-	providerState     providerStateStore
-	stateEvents       stateEventStore
-	sessions          *db.SessionStore
-	clientFactory     ClientFactory
-	orgSettingsLoader OrgSettingsLoader
+	integrations       IntegrationReader
+	integrationsWriter IntegrationWriter
+	credentials        CredentialReader
+	issues             *db.IssueStore
+	links              *db.SessionIssueLinkStore
+	teamKeys           *db.LinearTeamKeyStore
+	providerState      providerStateStore
+	stateEvents        stateEventStore
+	sessions           *db.SessionStore
+	clientFactory      ClientFactory
+	orgSettingsLoader  OrgSettingsLoader
 	// jobEnqueuer / linksChanged are populated by the boot-time wiring in
 	// router.go and cmd/server/main.go *after* NewService returns: the SSE
 	// streams aren't constructed until later, and the JobStore comes from a
@@ -167,6 +169,15 @@ type LinksChangedNotifier func(ctx context.Context, orgID, sessionID uuid.UUID, 
 // integration status for an org.
 type IntegrationReader interface {
 	GetByOrgAndProvider(ctx context.Context, orgID uuid.UUID, provider string) (models.Integration, error)
+}
+
+// IntegrationWriter is the optional surface used by Mark/ClearIntegration*
+// to flip status and patch config when the service observes auth failures
+// or a successful probe. Optional and nil-safe so test harnesses (and any
+// wiring path that doesn't need write access) can stay minimal.
+type IntegrationWriter interface {
+	UpdateStatus(ctx context.Context, orgID, id uuid.UUID, status string) error
+	UpdateConfig(ctx context.Context, orgID, integrationID uuid.UUID, config json.RawMessage) error
 }
 
 // CredentialReader is the narrow surface the service needs to resolve a
@@ -283,17 +294,18 @@ type WorkflowState struct {
 // Config packages constructor dependencies. Using a config struct keeps the
 // constructor signature stable as we add more stores over time.
 type Config struct {
-	Logger            zerolog.Logger
-	Integrations      IntegrationReader
-	Credentials       CredentialReader
-	Issues            *db.IssueStore
-	Links             *db.SessionIssueLinkStore
-	TeamKeys          *db.LinearTeamKeyStore
-	ProviderState     *db.LinearProviderStateStore
-	StateEvents       *db.LinearStateEventStore
-	Sessions          *db.SessionStore
-	ClientFactory     ClientFactory
-	OrgSettingsLoader OrgSettingsLoader
+	Logger             zerolog.Logger
+	Integrations       IntegrationReader
+	IntegrationsWriter IntegrationWriter
+	Credentials        CredentialReader
+	Issues             *db.IssueStore
+	Links              *db.SessionIssueLinkStore
+	TeamKeys           *db.LinearTeamKeyStore
+	ProviderState      *db.LinearProviderStateStore
+	StateEvents        *db.LinearStateEventStore
+	Sessions           *db.SessionStore
+	ClientFactory      ClientFactory
+	OrgSettingsLoader  OrgSettingsLoader
 	// Pool is used by HandleMilestone / HandleStateTransition to begin a tx
 	// for SELECT ... FOR UPDATE on the provider-state row, so two concurrent
 	// milestone events for the same link can't both create a rolling
@@ -320,20 +332,21 @@ func NewService(cfg Config) *Service {
 		cache = &teamKeyAllowlistCache{}
 	}
 	return &Service{
-		teamKeyCache:      cache,
-		logger:            cfg.Logger,
-		integrations:      cfg.Integrations,
-		credentials:       cfg.Credentials,
-		issues:            cfg.Issues,
-		links:             cfg.Links,
-		teamKeys:          cfg.TeamKeys,
-		providerState:     cfg.ProviderState,
-		stateEvents:       cfg.StateEvents,
-		sessions:          cfg.Sessions,
-		clientFactory:     cfg.ClientFactory,
-		orgSettingsLoader: cfg.OrgSettingsLoader,
-		pool:              cfg.Pool,
-		appBaseURL:        strings.TrimRight(cfg.AppBaseURL, "/"),
+		teamKeyCache:       cache,
+		logger:             cfg.Logger,
+		integrations:       cfg.Integrations,
+		integrationsWriter: cfg.IntegrationsWriter,
+		credentials:        cfg.Credentials,
+		issues:             cfg.Issues,
+		links:              cfg.Links,
+		teamKeys:           cfg.TeamKeys,
+		providerState:      cfg.ProviderState,
+		stateEvents:        cfg.StateEvents,
+		sessions:           cfg.Sessions,
+		clientFactory:      cfg.ClientFactory,
+		orgSettingsLoader:  cfg.OrgSettingsLoader,
+		pool:               cfg.Pool,
+		appBaseURL:         strings.TrimRight(cfg.AppBaseURL, "/"),
 	}
 }
 

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -178,6 +178,9 @@ type IntegrationReader interface {
 type IntegrationWriter interface {
 	UpdateStatus(ctx context.Context, orgID, id uuid.UUID, status string) error
 	UpdateConfig(ctx context.Context, orgID, integrationID uuid.UUID, config json.RawMessage) error
+	// UpdateStatusAndConfig is used by Mark/ClearIntegration* when both
+	// fields need to change so the row can't be observed mid-flip.
+	UpdateStatusAndConfig(ctx context.Context, orgID, integrationID uuid.UUID, status string, config json.RawMessage) error
 }
 
 // CredentialReader is the narrow surface the service needs to resolve a

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -2683,6 +2683,15 @@ func newPrepareLinearPrimaryHandler(svc *linear.Service, logger zerolog.Logger) 
 		})
 		if err := svc.PrepareLinearPrimaryRefs(ctx, orgID, sessionID, refs, userID); err != nil {
 			logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("prepare_linear_primary failed")
+			if errors.Is(err, linear.ErrUnauthorized) {
+				// Flip the integration to errored on the very first 401 so the
+				// settings UI shows a Reconnect CTA without waiting for retry
+				// exhaustion. Doing this inside the retry loop (vs only the
+				// dead-letter hook) is intentional: retries are 5s apart and
+				// exhaustion takes minutes, but the user is staring at the
+				// session-detail page waiting for context to load.
+				svc.MarkIntegrationUnauthorized(ctx, orgID)
+			}
 			return &RetryableError{Err: err}
 		}
 		return nil
@@ -2886,6 +2895,9 @@ func newLinearMilestoneHandler(stores *Stores, svc *linear.Service, logger zerol
 		}
 		if err := svc.HandleMilestone(ctx, in); err != nil {
 			logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("HandleMilestone failed")
+			if errors.Is(err, linear.ErrUnauthorized) {
+				svc.MarkIntegrationUnauthorized(ctx, orgID)
+			}
 			return mapLinearWriteErrorToRetry(err)
 		}
 		if err := svc.HandleStateTransition(ctx, in); err != nil {
@@ -2893,6 +2905,9 @@ func newLinearMilestoneHandler(stores *Stores, svc *linear.Service, logger zerol
 			// State transitions are recorded in the event log even when
 			// they skip; rate limits are the one case we *do* want to
 			// retry, otherwise the audit trail says "skipped" forever.
+			if errors.Is(err, linear.ErrUnauthorized) {
+				svc.MarkIntegrationUnauthorized(ctx, orgID)
+			}
 			if retry := mapLinearWriteErrorToRetry(err); retry != nil {
 				return retry
 			}
@@ -2904,6 +2919,10 @@ func newLinearMilestoneHandler(stores *Stores, svc *linear.Service, logger zerol
 // mapLinearWriteErrorToRetry returns a RetryableError with a Retry-After
 // hint when the underlying Linear API call hit a 429 rate limit. All other
 // errors return as-is (worker will use default exponential backoff).
+//
+// On ErrUnauthorized the caller is responsible for invoking
+// svc.MarkIntegrationUnauthorized — done at each call site rather than here
+// so this helper stays a pure error-classifier without the orgID dependency.
 func mapLinearWriteErrorToRetry(err error) error {
 	var rate *linear.RateLimitError
 	if errors.As(err, &rate) {
@@ -2914,8 +2933,9 @@ func mapLinearWriteErrorToRetry(err error) error {
 		return &RetryableError{Err: err, RetryAfter: &delay}
 	}
 	if errors.Is(err, linear.ErrUnauthorized) {
-		// Token expired — let the retry happen at default backoff so the
-		// integration health check has time to refresh.
+		// Token expired/revoked — let the retry happen at default backoff
+		// while the user reconnects. The status flip happens at the call
+		// site; here we only classify the retry shape.
 		return &RetryableError{Err: err}
 	}
 	return &RetryableError{Err: err}
@@ -2923,6 +2943,11 @@ func mapLinearWriteErrorToRetry(err error) error {
 
 // refresh_linear_team_keys handler refreshes the per-org team-key cache.
 // Scheduled every 24h and after OAuth install. Idempotent.
+//
+// Doubles as the periodic Linear health probe the codebase has been
+// missing: a successful refresh clears any stale "needs reauth" banner; a
+// 401 flips the integration to errored so the settings UI surfaces a
+// Reconnect CTA without waiting for the next session create to fail.
 func newRefreshLinearTeamKeysHandler(svc *linear.Service, logger zerolog.Logger) JobHandler {
 	return func(ctx context.Context, jobType string, payload json.RawMessage) error {
 		var input struct {
@@ -2937,8 +2962,14 @@ func newRefreshLinearTeamKeysHandler(svc *linear.Service, logger zerolog.Logger)
 		}
 		if err := svc.RefreshTeamKeys(ctx, orgID); err != nil {
 			logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("refresh_linear_team_keys failed")
+			if errors.Is(err, linear.ErrUnauthorized) {
+				svc.MarkIntegrationUnauthorized(ctx, orgID)
+			}
 			return &RetryableError{Err: err}
 		}
+		// Refresh succeeded — token works. Clear any stale auth-error
+		// banner. No-op when the row is already healthy.
+		svc.ClearIntegrationUnauthorized(ctx, orgID)
 		return nil
 	}
 }


### PR DESCRIPTION
## Summary
- A user hit "Linear: prepare failed" on a session and there was no in-app signal that the underlying cause was a revoked Linear OAuth token (every API call was returning HTTP 401 for ~3h before the session created). The "integration health check (every 6h)" referenced in `client.go:664` turned out not to exist; nothing flipped credential status on 401, and the integrations settings UI rendered an errored row identically to a never-connected one.
- Backend now flips `integrations.status` to `error` (and stamps `last_auth_error` + `last_auth_error_at` into the existing config jsonb) at every site that observes `linear.ErrUnauthorized`: inline create path, `prepare_linear_primary`, `linear_milestone` writes, and `refresh_linear_team_keys`. The 24h `refresh_linear_team_keys` cron now also clears the markers on success — so it doubles as the periodic health probe the codebase was missing. Reconnecting via OAuth resets a previously-errored row in `ensureIntegration`.
- Frontend integrations page renders an amber "Reconnect required" alert with the reason + timestamp, and the row's primary action becomes a single "Reconnect Linear" button (no duplicate CTA inside the alert). The session-detail "prepare failed" chip is now a clickable link to `/settings/integrations` so users have a path forward.

## Test plan
- [x] `go test ./internal/services/linear/... ./internal/api/handlers/... ./internal/worker/... ./internal/models/...` (new `auth_status_test.go` covers flip / skip-when-fresh / restamp-when-stale / nil-safety / restore / no-op-when-healthy)
- [x] `golangci-lint run` clean on touched packages
- [x] Frontend `tsc --noEmit`, `eslint`, vitest (18/18 cards tests including new banner + single-CTA assertion, 10/10 chip tests)
- [ ] Manual: trigger a 401 by revoking the OAuth app in Linear, confirm the amber alert + Reconnect button appear within seconds, reconnect via the same button, confirm banner clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)
