### PR TITLE
Fix mobile wrapping for automations timezone dropdown in Settings

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -22,6 +22,64 @@ vi.mock("next/navigation", () => ({
 }));
 
 describe("AutomationDetailPage", () => {
+  it("allows the timezone selector to wrap cleanly on mobile layouts", async () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await userEvent.setup().click(screen.getByRole("tab", { name: "Settings" }));
+
+    const timezoneButton = screen.getByTitle("UTC");
+    const scheduleRow = timezoneButton.parentElement;
+
+    expect(scheduleRow).toHaveClass("flex-wrap");
+    expect(timezoneButton).toHaveClass("w-full", "sm:w-auto");
+  });
+
   it("renders a back button to the automations list preserving query params", async () => {
     server.use(
       http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -134,7 +134,7 @@ function SettingsTab({ automation }: { automation: Automation }) {
               </SelectContent>
             </Select>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-start gap-2 sm:items-center">
             <span className="text-sm text-muted-foreground">At</span>
             <Select value={intervalRunHour} onValueChange={setIntervalRunHour}>
               <SelectTrigger className="w-20" aria-label="Run at hour">
@@ -165,6 +165,7 @@ function SettingsTab({ automation }: { automation: Automation }) {
               value={timezone}
               onChange={setTimezone}
               detected={detectedTimezone}
+              className="w-full sm:w-auto"
             />
           </div>
         </div>

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -20,6 +20,43 @@ describe("NewAutomationPage", () => {
     pushMock.mockReset();
   });
 
+  it("allows the timezone selector to wrap cleanly on mobile layouts", async () => {
+    const expectedTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    const timezoneButton = await screen.findByTitle(expectedTimezone);
+    const scheduleRow = timezoneButton.parentElement;
+
+    expect(scheduleRow).toHaveClass("flex-wrap");
+    expect(timezoneButton).toHaveClass("w-full", "sm:w-auto");
+  });
+
   it("prefills the form from the selected template and links to the full library", async () => {
     server.use(
       http.get("/api/v1/repositories", () =>

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -295,7 +295,7 @@ export default function NewAutomationPage() {
                   </SelectContent>
                 </Select>
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-start gap-2 sm:items-center">
                 <span className="text-sm text-muted-foreground">At</span>
                 <Select value={intervalRunHour} onValueChange={setIntervalRunHour}>
                   <SelectTrigger className="w-20" aria-label="Run at hour">
@@ -326,6 +326,7 @@ export default function NewAutomationPage() {
                   value={timezone}
                   onChange={setTimezone}
                   detected={detectedTimezone}
+                  className="w-full sm:w-auto"
                 />
               </div>
             </div>

--- a/frontend/src/app/(dashboard)/automations/timezone-picker.tsx
+++ b/frontend/src/app/(dashboard)/automations/timezone-picker.tsx
@@ -93,10 +93,10 @@ export function TimezonePicker({
           aria-expanded={open}
           // Match the sibling SelectTrigger (h-9 / text-sm) so the trio in
           // the schedule row lines up visually.
-          className={cn("h-9 justify-between font-normal", className)}
+          className={cn("h-9 min-w-0 justify-between font-normal", className)}
           title={value}
         >
-          <span className="max-w-[180px] truncate">{value}</span>
+          <span className="min-w-0 max-w-[180px] truncate">{value}</span>
           <ChevronDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-60" />
         </Button>
       </PopoverTrigger>


### PR DESCRIPTION
## Summary
Updated the automations Settings layout so the timezone dropdown doesn’t overflow or misalign on mobile. Added/extended regression tests to verify the timezone selector wraps correctly for small screens.

## Changes
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Adjusted the timezone row container to support wrapping: `flex-wrap` + `items-start` on mobile.
  - Updated the timezone picker styling to use `w-full` on mobile and `sm:w-auto` on larger screens.
- **frontend/src/app/(dashboard)/automations/timezone-picker.tsx**
  - Ensured the timezone trigger element receives responsive width classes so it can wrap cleanly on mobile.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Added a test asserting the timezone row/container uses `flex-wrap` and the timezone trigger uses `w-full sm:w-auto`.
- **frontend/src/app/(dashboard)/automations/new/page.tsx** / **new/page.test.tsx**
  - Mirrored the same wrapping behavior and added a corresponding regression test for the “New automation” flow.

## Test plan
- Ran the updated frontend test suite for automations pages (detail + new) and verified the new mobile wrapping assertions pass.

[143.dev](https://143.dev) | [session d1884715](https://143.dev/sessions/d1884715-8946-48ee-8d37-ccb92fb6113b)