### PR TITLE
Unify PM and session model lists onto the AGENTS registry

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.tsx
@@ -54,8 +54,8 @@ import { clearDraft, loadDraft, saveDraft } from "@/lib/session-draft";
 import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
 import {
-  AGENTS,
   agentTypeForModel,
+  availableAgentModelGroups,
   isAgentAvailable,
 } from "@/lib/agents";
 import { NoReposWarning } from "@/components/no-repos-warning";
@@ -375,19 +375,19 @@ export function ManualSessionCreatePageContent() {
 
   const codexAuthStatus = codexAuthResponse?.data;
   const codingAuths = useMemo(() => codingAuthsResponse?.data ?? [], [codingAuthsResponse]);
-  const modelGroups = useMemo(() => {
-    // Show agents available from either the user-resolved credential path or
-    // the org coding-auth stack so the picker reflects both scopes.
-    const availableAgents = AGENTS.filter((agent) =>
-      isAgentAvailable(agent.key, resolvedCredentials, codexAuthStatus, codingAuths),
-    );
-    // Sort so the default agent type appears first, preserve original order otherwise.
-    return [...availableAgents].sort((a, b) => {
-      if (a.key === defaultAgentType) return -1;
-      if (b.key === defaultAgentType) return 1;
-      return AGENTS.indexOf(a) - AGENTS.indexOf(b);
-    });
-  }, [codingAuths, defaultAgentType, resolvedCredentials, codexAuthStatus]);
+  // Sessions run under the user's own credentials, so we don't pass
+  // orgAgentConfig — agents the org has keys for but the user doesn't are
+  // intentionally hidden from the picker.
+  const modelGroups = useMemo(
+    () =>
+      availableAgentModelGroups(
+        resolvedCredentials,
+        codexAuthStatus,
+        codingAuths,
+        defaultAgentType,
+      ),
+    [codingAuths, defaultAgentType, resolvedCredentials, codexAuthStatus],
+  );
 
   // Drop a previously selected model (from React state or restored draft) when
   // its agent is no longer integrated — keeps the picker value consistent with

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -48,6 +48,49 @@ describe("AutopilotSettingsPage", () => {
     expect(screen.queryByText("Priority weights")).not.toBeInTheDocument();
   });
 
+  it("opens the PM model dropdown with groups for every agent the org has configured (incl. Amp modes and Pi)", async () => {
+    server.use(
+      http.get("/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Org",
+          settings: {
+            pm_model: "gpt-5.4",
+            default_agent_type: "codex",
+            agent_config: {
+              codex: { OPENAI_API_KEY: "sk-***" },
+              claude_code: { ANTHROPIC_API_KEY: "sk-ant-***" },
+              gemini_cli: { GEMINI_API_KEY: "AIza-***" },
+              amp: { AMP_API_KEY: "amp_***" },
+              pi: { PI_API_KEY: "pi_***" },
+            },
+          },
+          created_at: "2026-03-20T00:00:00Z",
+          updated_at: "2026-03-20T00:00:00Z",
+        },
+      })),
+      http.get("/api/v1/repositories", () => HttpResponse.json({ data: [], meta: {} })),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AutopilotSettingsPage />);
+
+    await user.click(await screen.findByLabelText("PM model"));
+
+    // Group labels — Amp's row is relabeled "Amp modes" so the mode names
+    // (smart/deep/...) read correctly next to model IDs from other agents.
+    expect(await screen.findByText("Codex")).toBeInTheDocument();
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Gemini CLI")).toBeInTheDocument();
+    expect(screen.getByText("Amp modes")).toBeInTheDocument();
+    expect(screen.getByText("Pi")).toBeInTheDocument();
+
+    // Spot-check a row from each kind: Codex model, Amp mode, Pi provider/model.
+    expect(screen.getByRole("option", { name: "claude-opus-4-7" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "smart" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "anthropic/claude-opus-4-7" })).toBeInTheDocument();
+  });
+
   it("autosaves the PM cadence when the value changes and the input blurs", async () => {
     let capturedBody: unknown;
     server.use(

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -23,7 +23,7 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
-import { availableAgentModelGroups } from "@/lib/agents";
+import { availableAgentModelGroups, pmUsableResolvedCredentials } from "@/lib/agents";
 import { DEFAULT_PM_MODEL } from "@/lib/model-constants";
 import { queryKeys } from "@/lib/query-keys";
 import {
@@ -38,7 +38,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingAuth, ListResponse, Organization, OrgSettings, RepoSettings, Repository, ResolvedCredential, SingleResponse } from "@/lib/types";
+import type { CodingAuth, ListResponse, Organization, OrgSettings, RepoSettings, Repository, ResolvedCredential, SingleResponse, UserCredentialSummary } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();
@@ -57,6 +57,11 @@ export default function AutopilotSettingsPage() {
   const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),
+    enabled: isAdmin,
+  });
+  const { data: teamDefaultsResponse } = useQuery<ListResponse<UserCredentialSummary>>({
+    queryKey: queryKeys.credentials.teamDefaults,
+    queryFn: () => api.userCredentials.listTeamDefaults(),
     enabled: isAdmin,
   });
   const { data: codexAuthResponse } = useQuery({
@@ -85,16 +90,20 @@ export default function AutopilotSettingsPage() {
     [codingAuthsResponse],
   );
   const codexAuthStatus = codexAuthResponse?.data;
+  const pmResolvedCredentials = useMemo(
+    () => pmUsableResolvedCredentials(resolvedCredentials, teamDefaultsResponse?.data ?? []),
+    [resolvedCredentials, teamDefaultsResponse],
+  );
 
   const pmModelGroups = useMemo(() => {
     return availableAgentModelGroups(
-      resolvedCredentials,
+      pmResolvedCredentials,
       codexAuthStatus,
       codingAuths,
       settings.default_agent_type || "codex",
       { orgAgentConfig: settings.agent_config },
     );
-  }, [resolvedCredentials, codexAuthStatus, codingAuths, settings.default_agent_type, settings.agent_config]);
+  }, [pmResolvedCredentials, codexAuthStatus, codingAuths, settings.default_agent_type, settings.agent_config]);
 
   const scheduleHoursServer = settings.pm_schedule_hours ?? 24;
   const pmModel = settings.pm_model ?? DEFAULT_PM_MODEL;

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -23,7 +23,8 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
-import { DEFAULT_PM_MODEL, PM_MODELS_BY_PROVIDER } from "@/lib/model-constants";
+import { availableAgentModelGroups } from "@/lib/agents";
+import { DEFAULT_PM_MODEL } from "@/lib/model-constants";
 import { queryKeys } from "@/lib/query-keys";
 import {
   applyOrgSettingsPatch,
@@ -37,7 +38,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { ListResponse, Organization, OrgSettings, RepoSettings, Repository, SingleResponse } from "@/lib/types";
+import type { CodingAuth, ListResponse, Organization, OrgSettings, RepoSettings, Repository, ResolvedCredential, SingleResponse } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();
@@ -53,6 +54,21 @@ export default function AutopilotSettingsPage() {
     queryFn: () => api.repositories.list(),
     enabled: isAdmin,
   });
+  const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
+    queryKey: queryKeys.credentials.resolved,
+    queryFn: () => api.userCredentials.listResolved(),
+    enabled: isAdmin,
+  });
+  const { data: codexAuthResponse } = useQuery({
+    queryKey: queryKeys.codexAuth.status,
+    queryFn: () => api.codexAuth.status(),
+    enabled: isAdmin,
+  });
+  const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
+    queryKey: ["coding-auths"],
+    queryFn: () => api.codingAuths.list(),
+    enabled: isAdmin,
+  });
 
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const repositories = repositoriesResponse?.data ?? [];
@@ -60,18 +76,25 @@ export default function AutopilotSettingsPage() {
     const repoSettings = (repository.settings ?? {}) as RepoSettings;
     return repoSettings.pm != null;
   });
+  const resolvedCredentials = useMemo(
+    () => resolvedCredsResponse?.data ?? [],
+    [resolvedCredsResponse],
+  );
+  const codingAuths = useMemo(
+    () => codingAuthsResponse?.data ?? [],
+    [codingAuthsResponse],
+  );
+  const codexAuthStatus = codexAuthResponse?.data;
 
-  const enabledPmModelGroups = useMemo(() => {
-    const agentConfig = settings.agent_config ?? {};
-    const defaultAgent = settings.default_agent_type || "codex";
-
-    return Object.entries(PM_MODELS_BY_PROVIDER)
-      .filter(([providerKey, { apiKeyVar }]) => {
-        const orgKey = agentConfig[providerKey]?.[apiKeyVar];
-        return Boolean(orgKey) || providerKey === defaultAgent;
-      })
-      .map(([, { label, models }]) => ({ label, models }));
-  }, [settings.agent_config, settings.default_agent_type]);
+  const pmModelGroups = useMemo(() => {
+    return availableAgentModelGroups(
+      resolvedCredentials,
+      codexAuthStatus,
+      codingAuths,
+      settings.default_agent_type || "codex",
+      { orgAgentConfig: settings.agent_config },
+    );
+  }, [resolvedCredentials, codexAuthStatus, codingAuths, settings.default_agent_type, settings.agent_config]);
 
   const scheduleHoursServer = settings.pm_schedule_hours ?? 24;
   const pmModel = settings.pm_model ?? DEFAULT_PM_MODEL;
@@ -154,11 +177,11 @@ export default function AutopilotSettingsPage() {
                     <SelectItem value={DEFAULT_PM_MODEL}>
                       Auto ({DEFAULT_PM_MODEL})
                     </SelectItem>
-                    {enabledPmModelGroups.map((group) => {
+                    {pmModelGroups.map((group) => {
                       const models = group.models.filter((m) => m !== DEFAULT_PM_MODEL);
                       if (models.length === 0) return null;
                       return (
-                        <SelectGroup key={group.label}>
+                        <SelectGroup key={group.key}>
                           <SelectLabel>{group.label}</SelectLabel>
                           {models.map((model) => (
                             <SelectItem key={model} value={model}>

--- a/frontend/src/components/repo-pm-settings.tsx
+++ b/frontend/src/components/repo-pm-settings.tsx
@@ -22,7 +22,7 @@ import {
 import { X } from "lucide-react";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
-import { availableAgentModelGroups } from "@/lib/agents";
+import { availableAgentModelGroups, pmUsableResolvedCredentials } from "@/lib/agents";
 import { queryKeys } from "@/lib/query-keys";
 import type {
   CodingAuth,
@@ -34,6 +34,7 @@ import type {
   Repository,
   ResolvedCredential,
   SingleResponse,
+  UserCredentialSummary,
 } from "@/lib/types";
 import { DEFAULT_PM_MODEL } from "@/lib/model-constants";
 
@@ -88,6 +89,10 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),
   });
+  const { data: teamDefaultsResponse } = useQuery<ListResponse<UserCredentialSummary>>({
+    queryKey: queryKeys.credentials.teamDefaults,
+    queryFn: () => api.userCredentials.listTeamDefaults(),
+  });
   const { data: codexAuthResponse } = useQuery({
     queryKey: queryKeys.codexAuth.status,
     queryFn: () => api.codexAuth.status(),
@@ -137,19 +142,23 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
     [codingAuthsResponse],
   );
   const codexAuthStatus = codexAuthResponse?.data;
+  const pmResolvedCredentials = useMemo(
+    () => pmUsableResolvedCredentials(resolvedCredentials, teamDefaultsResponse?.data ?? []),
+    [resolvedCredentials, teamDefaultsResponse],
+  );
 
   const pmModelGroups = useMemo(() => {
     return availableAgentModelGroups(
-      resolvedCredentials,
+      pmResolvedCredentials,
       codexAuthStatus,
       codingAuths,
       orgSettings.default_agent_type || "codex",
       { orgAgentConfig: orgSettings.agent_config },
     );
-  }, [resolvedCredentials, codexAuthStatus, codingAuths, orgSettings.default_agent_type, orgSettings.agent_config]);
+  }, [pmResolvedCredentials, codexAuthStatus, codingAuths, orgSettings.default_agent_type, orgSettings.agent_config]);
 
   const credentialsLoaded = Boolean(
-    resolvedCredsResponse && codexAuthResponse && codingAuthsResponse,
+    resolvedCredsResponse && teamDefaultsResponse && codexAuthResponse && codingAuthsResponse,
   );
 
   const autosave = useAutosave<RepoPatch>({

--- a/frontend/src/components/repo-pm-settings.tsx
+++ b/frontend/src/components/repo-pm-settings.tsx
@@ -22,16 +22,20 @@ import {
 import { X } from "lucide-react";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
+import { availableAgentModelGroups } from "@/lib/agents";
 import { queryKeys } from "@/lib/query-keys";
 import type {
+  CodingAuth,
+  ListResponse,
   Organization,
   OrgSettings,
   RepoSettings,
   RepoPMSettings,
   Repository,
+  ResolvedCredential,
   SingleResponse,
 } from "@/lib/types";
-import { DEFAULT_PM_MODEL, PM_MODELS_BY_PROVIDER } from "@/lib/model-constants";
+import { DEFAULT_PM_MODEL } from "@/lib/model-constants";
 
 const PM_SCHEDULE_MIN = 1;
 const PM_SCHEDULE_MAX = 24;
@@ -80,6 +84,18 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
+  const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
+    queryKey: queryKeys.credentials.resolved,
+    queryFn: () => api.userCredentials.listResolved(),
+  });
+  const { data: codexAuthResponse } = useQuery({
+    queryKey: queryKeys.codexAuth.status,
+    queryFn: () => api.codexAuth.status(),
+  });
+  const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
+    queryKey: ["coding-auths"],
+    queryFn: () => api.codingAuths.list(),
+  });
 
   const orgSettings = (orgResponse?.data?.settings ?? {}) as OrgSettings;
   const repoSettings = (repository.settings ?? {}) as RepoSettings;
@@ -112,17 +128,29 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
   const [focusInput, setFocusInput] = useState("");
   const [avoidInput, setAvoidInput] = useState("");
 
-  const enabledPmModelGroups = useMemo(() => {
-    const agentConfig = orgSettings.agent_config ?? {};
-    const defaultAgent = orgSettings.default_agent_type || "codex";
+  const resolvedCredentials = useMemo(
+    () => resolvedCredsResponse?.data ?? [],
+    [resolvedCredsResponse],
+  );
+  const codingAuths = useMemo(
+    () => codingAuthsResponse?.data ?? [],
+    [codingAuthsResponse],
+  );
+  const codexAuthStatus = codexAuthResponse?.data;
 
-    return Object.entries(PM_MODELS_BY_PROVIDER)
-      .filter(([providerKey, { apiKeyVar }]) => {
-        const orgKey = agentConfig[providerKey]?.[apiKeyVar];
-        return Boolean(orgKey) || providerKey === defaultAgent;
-      })
-      .map(([, { label, models }]) => ({ label, models }));
-  }, [orgSettings.agent_config, orgSettings.default_agent_type]);
+  const pmModelGroups = useMemo(() => {
+    return availableAgentModelGroups(
+      resolvedCredentials,
+      codexAuthStatus,
+      codingAuths,
+      orgSettings.default_agent_type || "codex",
+      { orgAgentConfig: orgSettings.agent_config },
+    );
+  }, [resolvedCredentials, codexAuthStatus, codingAuths, orgSettings.default_agent_type, orgSettings.agent_config]);
+
+  const credentialsLoaded = Boolean(
+    resolvedCredsResponse && codexAuthResponse && codingAuthsResponse,
+  );
 
   const autosave = useAutosave<RepoPatch>({
     queryKey: ["repository", repository.id],
@@ -311,13 +339,17 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
                       <SelectValue placeholder="Select a model" />
                     </SelectTrigger>
                     <SelectContent>
-                      {enabledPmModelGroups.length === 0 ? (
+                      {!credentialsLoaded ? (
+                        <SelectItem value={DEFAULT_PM_MODEL} disabled>
+                          Loading providers…
+                        </SelectItem>
+                      ) : pmModelGroups.length === 0 ? (
                         <SelectItem value={DEFAULT_PM_MODEL} disabled>
                           No providers configured
                         </SelectItem>
                       ) : (
-                        enabledPmModelGroups.map((group) => (
-                          <SelectGroup key={group.label}>
+                        pmModelGroups.map((group) => (
+                          <SelectGroup key={group.key}>
                             <SelectLabel>{group.label}</SelectLabel>
                             {group.models.map((model) => (
                               <SelectItem key={model} value={model}>

--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { availableAgentModelGroups } from "./agents";
+import type { CodingAuth, ResolvedCredential } from "./types";
+
+const codexCred: ResolvedCredential = {
+  provider: "openai",
+  source: "user",
+  masked_key: "sk-***",
+};
+
+const claudeCred: ResolvedCredential = {
+  provider: "anthropic",
+  source: "user",
+  masked_key: "sk-ant-***",
+};
+
+const ampCodingAuth: CodingAuth = {
+  id: "ca-amp",
+  org_id: "org-1",
+  priority: 0,
+  agent: "amp",
+  auth_type: "api_key",
+  label: "Amp",
+  scope: "org",
+  provider: "amp",
+  status: "healthy",
+  is_default: true,
+  created_at: "2026-03-20T00:00:00Z",
+  updated_at: "2026-03-20T00:00:00Z",
+};
+
+describe("availableAgentModelGroups", () => {
+  it("includes only the default agent when no creds resolve", () => {
+    const groups = availableAgentModelGroups([], null, [], "codex");
+    expect(groups.map((g) => g.key)).toEqual(["codex"]);
+  });
+
+  it("returns user-available agents and keeps the default first", () => {
+    const groups = availableAgentModelGroups([codexCred, claudeCred], null, [], "claude_code");
+    expect(groups.map((g) => g.key)).toEqual(["claude_code", "codex"]);
+  });
+
+  it("relabels the Amp group as 'Amp modes' so mode rows aren't mistaken for model IDs", () => {
+    const groups = availableAgentModelGroups([], null, [ampCodingAuth], "codex");
+    const amp = groups.find((g) => g.key === "amp");
+    expect(amp?.label).toBe("Amp modes");
+  });
+
+  it("orgAgentConfig surfaces agents whose API key is set even without user creds (PM scope)", () => {
+    const groups = availableAgentModelGroups(
+      [],
+      null,
+      [],
+      "codex",
+      {
+        orgAgentConfig: {
+          claude_code: { ANTHROPIC_API_KEY: "sk-ant-***" },
+        },
+      },
+    );
+    expect(groups.map((g) => g.key)).toEqual(["codex", "claude_code"]);
+  });
+
+  it("session scope (no orgAgentConfig) hides agents the user can't run", () => {
+    const groups = availableAgentModelGroups([], null, [], "codex");
+    expect(groups.map((g) => g.key)).not.toContain("claude_code");
+  });
+
+  it("ignores org agent_config entries that point at the wrong env var", () => {
+    const groups = availableAgentModelGroups(
+      [],
+      null,
+      [],
+      "codex",
+      {
+        orgAgentConfig: {
+          claude_code: { ANTHROPIC_BASE_URL: "https://example.com" },
+        },
+      },
+    );
+    expect(groups.map((g) => g.key)).toEqual(["codex"]);
+  });
+});

--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { availableAgentModelGroups } from "./agents";
-import type { CodingAuth, ResolvedCredential } from "./types";
+import { availableAgentModelGroups, pmUsableResolvedCredentials } from "./agents";
+import type { CodingAuth, ResolvedCredential, UserCredentialSummary } from "./types";
 
 const codexCred: ResolvedCredential = {
   provider: "openai",
@@ -80,5 +80,45 @@ describe("availableAgentModelGroups", () => {
       },
     );
     expect(groups.map((g) => g.key)).toEqual(["codex"]);
+  });
+});
+
+describe("pmUsableResolvedCredentials", () => {
+  it("excludes personal-only credentials because PM runs without a user id", () => {
+    const credentials = pmUsableResolvedCredentials([claudeCred], []);
+    const groups = availableAgentModelGroups(credentials, null, [], "codex");
+
+    expect(credentials).toEqual([]);
+    expect(groups.map((g) => g.key)).toEqual(["codex"]);
+  });
+
+  it("retains org and team-default resolved credentials for PM runs", () => {
+    const credentials = pmUsableResolvedCredentials(
+      [
+        { provider: "anthropic", source: "org", masked_key: "sk-ant-org-***" },
+        { provider: "gemini", source: "team_default", masked_key: "gemini-team-***" },
+      ],
+      [],
+    );
+    const groups = availableAgentModelGroups(credentials, null, [], "codex");
+
+    expect(groups.map((g) => g.key)).toEqual(["codex", "claude_code", "gemini_cli"]);
+  });
+
+  it("adds team defaults even when a personal credential shadows them in resolved credentials", () => {
+    const teamDefault: UserCredentialSummary = {
+      provider: "anthropic",
+      configured: true,
+      is_team_default: true,
+      masked_key: "sk-ant-team-***",
+    };
+
+    const credentials = pmUsableResolvedCredentials([claudeCred], [teamDefault]);
+    const groups = availableAgentModelGroups(credentials, null, [], "codex");
+
+    expect(credentials).toEqual([
+      { provider: "anthropic", source: "team_default", masked_key: "sk-ant-team-***" },
+    ]);
+    expect(groups.map((g) => g.key)).toEqual(["codex", "claude_code"]);
   });
 });

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -174,3 +174,59 @@ export function isAgentAvailable(
     (row) => row.agent === agentType && codingAuthStatusAllowsSelection(row.status),
   );
 }
+
+export interface AgentModelGroup {
+  key: string;
+  label: string;
+  models: readonly string[];
+}
+
+export interface AvailableAgentModelGroupsOptions {
+  // orgAgentConfig: when provided, agents whose sensitive env var (the API key)
+  // is set in the org-level agent_config also pass the availability filter.
+  // PM dropdowns pass this because the PM runs server-side using org keys —
+  // an admin without personal credentials should still see provider groups
+  // the org has configured. The session picker omits this since sessions run
+  // under the user's own credentials.
+  orgAgentConfig?: Record<string, Record<string, string>>;
+}
+
+// availableAgentModelGroups returns model groups suitable for the session and
+// PM model dropdowns. An agent passes the availability filter when any of:
+//   1. isAgentAvailable returns true (user has resolved creds / Codex OAuth /
+//      coding auth for this agent),
+//   2. orgAgentConfig has the agent's API key set (PM-only, see options),
+//   3. it is the default agent (always retained so the dropdown is never empty).
+// Groups are sorted with the default agent first; Amp's label is rewritten to
+// "Amp modes" so users can see those rows are agent modes, not model IDs.
+export function availableAgentModelGroups(
+  resolvedCredentials: readonly ResolvedCredential[],
+  codexAuthStatus: CodexAuthStatus | null | undefined,
+  codingAuths: readonly CodingAuth[],
+  defaultAgentType: string,
+  options: AvailableAgentModelGroupsOptions = {},
+): AgentModelGroup[] {
+  const orgAgentConfig = options.orgAgentConfig;
+  const orgConfiguredAgent = (agent: AgentMeta): boolean => {
+    if (!orgAgentConfig) return false;
+    const apiKeyVar = agent.envVars.find((v) => v.sensitive)?.name;
+    if (!apiKeyVar) return false;
+    return Boolean(orgAgentConfig[agent.key]?.[apiKeyVar]);
+  };
+  const filtered = AGENTS.filter(
+    (agent) =>
+      isAgentAvailable(agent.key, resolvedCredentials, codexAuthStatus, codingAuths) ||
+      orgConfiguredAgent(agent) ||
+      agent.key === defaultAgentType,
+  );
+  filtered.sort((a, b) => {
+    if (a.key === defaultAgentType) return -1;
+    if (b.key === defaultAgentType) return 1;
+    return AGENTS.indexOf(a) - AGENTS.indexOf(b);
+  });
+  return filtered.map((agent) => ({
+    key: agent.key,
+    label: agent.key === "amp" ? `${agent.label} modes` : agent.label,
+    models: agent.models,
+  }));
+}

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -10,7 +10,7 @@ import {
   AVAILABLE_GEMINI_CLI_MODELS,
   AVAILABLE_PI_MODELS,
 } from "@/lib/model-constants";
-import type { CodexAuthStatus, CodingAuth, ResolvedCredential } from "@/lib/types";
+import type { CodexAuthStatus, CodingAuth, ResolvedCredential, UserCredentialSummary } from "@/lib/types";
 
 export interface AgentEnvVar {
   name: string;
@@ -229,4 +229,36 @@ export function availableAgentModelGroups(
     label: agent.key === "amp" ? `${agent.label} modes` : agent.label,
     models: agent.models,
   }));
+}
+
+// PM jobs run server-side without a user id, so they cannot use the current
+// admin's personal credentials. Keep org/team-default resolved credentials,
+// then add explicit team defaults because the resolved endpoint reports only
+// the first source for a provider and a personal credential can shadow a
+// PM-usable team default.
+export function pmUsableResolvedCredentials(
+  resolvedCredentials: readonly ResolvedCredential[],
+  teamDefaults: readonly UserCredentialSummary[],
+): ResolvedCredential[] {
+  const byProvider = new Map<string, ResolvedCredential>();
+
+  for (const credential of resolvedCredentials) {
+    if (credential.source !== "org" && credential.source !== "team_default") {
+      continue;
+    }
+    byProvider.set(credential.provider, credential);
+  }
+
+  for (const credential of teamDefaults) {
+    if (!credential.configured || !credential.is_team_default) {
+      continue;
+    }
+    byProvider.set(credential.provider, {
+      provider: credential.provider,
+      source: "team_default",
+      masked_key: credential.masked_key,
+    });
+  }
+
+  return Array.from(byProvider.values());
 }

--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -4,12 +4,10 @@ import {
   AVAILABLE_CODEX_MODELS,
   AVAILABLE_CLAUDE_CODE_MODELS,
   AVAILABLE_GEMINI_CLI_MODELS,
-  AVAILABLE_PM_MODELS,
   DEFAULT_PM_MODEL,
   DEFAULT_LLM_MODEL,
   CODEX_MODEL_GPT_5_4,
   LLM_PROVIDER_INFO,
-  PM_MODELS_BY_PROVIDER,
   LLM_MODELS_BY_PROVIDER,
   ownerProviderForModel,
 } from "./model-constants";
@@ -17,21 +15,6 @@ import {
 describe("model constants", () => {
   it("uses gpt-5.4 as the PM default", () => {
     expect(DEFAULT_PM_MODEL).toBe(CODEX_MODEL_GPT_5_4);
-  });
-
-  it("includes all provider models in AVAILABLE_PM_MODELS", () => {
-    expect(AVAILABLE_PM_MODELS).toEqual([
-      ...AVAILABLE_CLAUDE_CODE_MODELS,
-      ...AVAILABLE_GEMINI_CLI_MODELS,
-      ...AVAILABLE_CODEX_MODELS,
-    ]);
-  });
-
-  it("PM_MODELS_BY_PROVIDER maps each provider to its models and api key", () => {
-    expect(Object.keys(PM_MODELS_BY_PROVIDER)).toEqual(["claude_code", "gemini_cli", "codex"]);
-    expect(PM_MODELS_BY_PROVIDER.claude_code.models).toEqual(AVAILABLE_CLAUDE_CODE_MODELS);
-    expect(PM_MODELS_BY_PROVIDER.gemini_cli.models).toEqual(AVAILABLE_GEMINI_CLI_MODELS);
-    expect(PM_MODELS_BY_PROVIDER.codex.models).toEqual(AVAILABLE_CODEX_MODELS);
   });
 
   it("includes latest Claude Code models", () => {

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -73,25 +73,11 @@ export const AVAILABLE_PI_MODELS = [
   PI_MODEL_GEMINI_2_5_PRO,
 ] as const;
 
-// PM model configuration: maps each provider to its available models and API key env var.
-export const PM_MODELS_BY_PROVIDER: Record<string, { label: string; models: readonly string[]; apiKeyVar: string }> = {
-  claude_code: { label: "Claude Code", models: AVAILABLE_CLAUDE_CODE_MODELS, apiKeyVar: "ANTHROPIC_API_KEY" },
-  gemini_cli: { label: "Gemini CLI", models: AVAILABLE_GEMINI_CLI_MODELS, apiKeyVar: "GEMINI_API_KEY" },
-  codex: { label: "Codex", models: AVAILABLE_CODEX_MODELS, apiKeyVar: "OPENAI_API_KEY" },
-};
-
 export const DEFAULT_PM_MODEL = CODEX_MODEL_GPT_5_4;
 
-// Agent type options for session/project creation forms live on the AGENTS
-// registry in @/lib/agents. Import AGENTS (and agentTypeForModel) from there —
-// keeping a second list here would drift.
-
-// All PM models across every provider (for validation).
-export const AVAILABLE_PM_MODELS = [
-  ...AVAILABLE_CLAUDE_CODE_MODELS,
-  ...AVAILABLE_GEMINI_CLI_MODELS,
-  ...AVAILABLE_CODEX_MODELS,
-] as const;
+// PM and session model dropdowns are both built from the AGENTS registry in
+// @/lib/agents (see availableAgentModelGroups). Keeping a second PM-only list
+// here would drift away from the session picker.
 
 // General-purpose LLM models (used by validation, prioritization, PM services).
 // NOTE: This is a static fallback. The frontend should prefer fetching models

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -43,6 +43,7 @@ export const queryKeys = {
   credentials: {
     all: ["credentials"] as const,
     resolved: ["credentials", "resolved"] as const,
+    teamDefaults: ["credentials", "team-defaults"] as const,
   },
   codexAuth: {
     status: ["codex-auth-status"] as const,

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -722,6 +722,13 @@ export const handlers = [
     });
   }),
 
+  http.get('/api/v1/settings/coding-auths', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    });
+  }),
+
   http.get('/api/v1/sessions/:id/files/context', () => {
     return HttpResponse.json({
       data: {

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -722,6 +722,13 @@ export const handlers = [
     });
   }),
 
+  http.get('/api/v1/settings/credentials/team', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    });
+  }),
+
   http.get('/api/v1/settings/coding-auths', () => {
     return HttpResponse.json({
       data: [],

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -6,14 +6,19 @@ import (
 	"strings"
 )
 
-// AvailablePMModels includes all models from every provider.
-// The PM agent can use any model from any configured provider.
+// AvailablePMModels is the union of every coding-agent's model list. It mirrors
+// the model set the session picker offers (frontend lib/agents.ts AGENTS) so
+// admins can pick any model the org could otherwise spin up a session with —
+// including Amp modes ("smart"/"deep"/...) and Pi's curated provider/model
+// strings.
 var AvailablePMModels []string
 
 func init() {
 	AvailablePMModels = append(AvailablePMModels, AvailableClaudeCodeModels...)
 	AvailablePMModels = append(AvailablePMModels, AvailableGeminiCLIModels...)
 	AvailablePMModels = append(AvailablePMModels, AvailableCodexModels...)
+	AvailablePMModels = append(AvailablePMModels, AvailableAmpModes...)
+	AvailablePMModels = append(AvailablePMModels, AvailablePiModels...)
 }
 
 // Amp uses agent "modes" (not models) to select model + system prompt + tools.
@@ -91,13 +96,65 @@ var AvailableCodexModels = []string{
 	CodexModelGPT53CodexSpark,
 }
 
-func IsSupportedPMModel(model string) bool {
-	for _, supportedModel := range AvailablePMModels {
-		if model == supportedModel {
-			return true
+// AgentTypeForModel returns the AgentType whose curated model list contains
+// the given model. The curated lookup runs first so an entry like
+// "openai/gpt-5.4" resolves to AgentTypePi (its native registry) rather than
+// being misread by the slash heuristic — only after every list misses do we
+// fall back to AgentTypePi for unknown "provider/model"-shaped strings, since
+// Pi accepts arbitrary provider/model overrides at run time. Returns an empty
+// AgentType when no agent owns the model.
+//
+// Mirrors the frontend agentTypeForModel helper in lib/agents.ts so PM and
+// session pickers route through the same agent-resolution rules.
+func AgentTypeForModel(model string) AgentType {
+	if model == "" {
+		return ""
+	}
+	for _, m := range AvailableCodexModels {
+		if m == model {
+			return AgentTypeCodex
 		}
 	}
-	return false
+	for _, m := range AvailableClaudeCodeModels {
+		if m == model {
+			return AgentTypeClaudeCode
+		}
+	}
+	for _, m := range AvailableGeminiCLIModels {
+		if m == model {
+			return AgentTypeGeminiCLI
+		}
+	}
+	for _, m := range AvailableAmpModes {
+		if m == model {
+			return AgentTypeAmp
+		}
+	}
+	for _, m := range AvailablePiModels {
+		if m == model {
+			return AgentTypePi
+		}
+	}
+	if strings.Contains(model, "/") {
+		return AgentTypePi
+	}
+	return ""
+}
+
+// ValidatePMModel validates a pm_model setting using the same rules as
+// session model validation. It resolves the model's agent type via
+// AgentTypeForModel and delegates to ValidateModelForAgentType, so PM
+// accepts every model the session picker accepts — including Pi's
+// arbitrary "provider/model" overrides.
+func ValidatePMModel(model string) error {
+	if model == "" {
+		return nil
+	}
+	agentType := AgentTypeForModel(model)
+	if agentType == "" {
+		return fmt.Errorf("pm_model %q is not recognized — pick a model from any configured coding agent", model)
+	}
+	return ValidateModelForAgentType(agentType, model)
 }
 
 func IsSupportedClaudeCodeModel(model string) bool {
@@ -377,8 +434,8 @@ func ValidateSettingsModels(settings OrgSettings) error {
 	if err := settings.LLMReasoningEffort.Validate(); err != nil {
 		return err
 	}
-	if settings.PMModel != "" && !IsSupportedPMModel(settings.PMModel) {
-		return fmt.Errorf("pm_model must be one of: %v", AvailablePMModels)
+	if err := ValidatePMModel(settings.PMModel); err != nil {
+		return err
 	}
 
 	for agentTypeStr, envVars := range settings.AgentConfig {

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -11,12 +11,15 @@ func TestPMModelConstants(t *testing.T) {
 
 	require.Equal(t, CodexModelGPT54, DefaultPMModel, "DefaultPMModel should use CodexModelGPT54")
 
-	// AvailablePMModels should include all provider models.
+	// AvailablePMModels mirrors the union of every coding agent's model list,
+	// matching the session picker (frontend availableAgentModelGroups).
 	var expected []string
 	expected = append(expected, AvailableClaudeCodeModels...)
 	expected = append(expected, AvailableGeminiCLIModels...)
 	expected = append(expected, AvailableCodexModels...)
-	require.Equal(t, expected, AvailablePMModels, "AvailablePMModels should include all provider models")
+	expected = append(expected, AvailableAmpModes...)
+	expected = append(expected, AvailablePiModels...)
+	require.Equal(t, expected, AvailablePMModels, "AvailablePMModels should include every agent's models")
 }
 
 func TestClaudeCodeModelConstants(t *testing.T) {
@@ -173,6 +176,47 @@ func TestIsSupportedPiModel(t *testing.T) {
 	require.False(t, IsSupportedPiModel(""), "empty Pi model should be rejected")
 }
 
+func TestAgentTypeForModel(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		model string
+		want  AgentType
+	}{
+		{"", ""},
+		{CodexModelGPT54, AgentTypeCodex},
+		{ClaudeCodeModelOpus47, AgentTypeClaudeCode},
+		{GeminiCLIModelGemini25Pro, AgentTypeGeminiCLI},
+		{AmpModeSmart, AgentTypeAmp},
+		// Curated Pi entry contains "/" — must resolve to Pi via the curated
+		// lookup (not the slash heuristic) so we keep precedence stable if a
+		// non-Pi agent later registers a slash-shaped model.
+		{PiModelClaudeOpus47, AgentTypePi},
+		// Slash heuristic only fires after every curated list misses.
+		{"moonshot/kimi-k2", AgentTypePi},
+		{"unknown-model", ""},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, AgentTypeForModel(tc.model), "AgentTypeForModel(%q)", tc.model)
+	}
+}
+
+func TestValidatePMModel(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, ValidatePMModel(""), "empty pm_model is allowed (caller falls back to default)")
+	require.NoError(t, ValidatePMModel(CodexModelGPT54))
+	require.NoError(t, ValidatePMModel(ClaudeCodeModelOpus47))
+	require.NoError(t, ValidatePMModel(AmpModeSmart))
+	require.NoError(t, ValidatePMModel(PiModelClaudeOpus47))
+	// Custom Pi provider/model — accepted with parity to ValidateModelForAgentType.
+	require.NoError(t, ValidatePMModel("moonshot/kimi-k2"))
+
+	err := ValidatePMModel("not-a-model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"not-a-model"`)
+}
+
 func TestValidateSettingsModels(t *testing.T) {
 	t.Parallel()
 
@@ -208,6 +252,24 @@ func TestValidateSettingsModels(t *testing.T) {
 			name: "accepts codex model as pm model",
 			settings: OrgSettings{
 				PMModel: CodexModelGPT53Codex,
+			},
+		},
+		{
+			name: "accepts amp mode as pm model",
+			settings: OrgSettings{
+				PMModel: AmpModeSmart,
+			},
+		},
+		{
+			name: "accepts pi model as pm model",
+			settings: OrgSettings{
+				PMModel: PiModelClaudeOpus47,
+			},
+		},
+		{
+			name: "accepts custom pi provider/model as pm model (parity with sessions)",
+			settings: OrgSettings{
+				PMModel: "moonshot/kimi-k2",
 			},
 		},
 		{

--- a/internal/models/repo_settings.go
+++ b/internal/models/repo_settings.go
@@ -60,8 +60,10 @@ func MergeRepoPMSettings(org OrgSettings, repo RepoSettings) OrgSettings {
 
 // ValidateRepoPMSettings validates the model references in repo PM settings.
 func ValidateRepoPMSettings(pm RepoPMSettings) error {
-	if pm.PMModel != nil && *pm.PMModel != "" && !IsSupportedPMModel(*pm.PMModel) {
-		return fmt.Errorf("pm.pm_model must be one of: %v", AvailablePMModels)
+	if pm.PMModel != nil {
+		if err := ValidatePMModel(*pm.PMModel); err != nil {
+			return fmt.Errorf("pm.pm_model: %w", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Frontend: replaces `PM_MODELS_BY_PROVIDER` / `AVAILABLE_PM_MODELS` with one `availableAgentModelGroups` helper driven off `lib/agents.ts AGENTS`, used by both PM dropdowns (settings/autopilot, repo-pm-settings) and sessions/new — Amp is relabeled "Amp modes" everywhere so mode rows aren't mistaken for model IDs. PM dropdowns also surface agents the org has set in `agent_config` on top of the viewing user's resolved credentials, since the PM runs server-side under those keys.
- Backend: `AvailablePMModels` is now the union of every coding agent's models (incl. Amp modes and Pi); `pm_model` validation routes through a new `ValidatePMModel` that resolves the agent type via `AgentTypeForModel` and delegates to `ValidateModelForAgentType`, the same path sessions use. Net behavior change: PM accepts arbitrary Pi `provider/model` overrides, matching session behavior.
- Tests: new Go tests for `AgentTypeForModel` and `ValidatePMModel`, new vitest covering `availableAgentModelGroups` filter scopes, and an autopilot-page test asserting all five agent groups (codex/claude_code/gemini_cli/Amp modes/Pi) render with representative rows.

## Test plan
- [ ] Open Settings → Autopilot, verify the PM model dropdown groups Codex / Claude Code / Gemini CLI / Amp modes / Pi as expected for the org's configured agents
- [ ] Open a repository's PM settings and confirm the dropdown matches and shows "Loading providers…" before queries resolve, not "No providers configured"
- [ ] Save `pm_model` as a Codex, Claude, Gemini, Amp mode, curated Pi model, and a custom Pi `provider/model` string — all should succeed
- [ ] Open the new session picker and confirm Amp's group reads "Amp modes" and the model list matches the PM dropdown
- [ ] Run `make test` (Go) and `npm run test:ci` (frontend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)