### PR TITLE
Refine SwipeActionRow release behavior and haptics with regression tests

### DIFF
--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -80,6 +80,84 @@ describe('SwipeActionRow', () => {
     expect(onAction).toHaveBeenCalledTimes(1);
   });
 
+  it('continues from the revealed position on a follow-up swipe and auto-fires', () => {
+    const onAction = vi.fn();
+
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={onAction}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+    Object.defineProperty(container!, 'offsetWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 320, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 240, clientY: 24 }],
+    });
+    fireEvent.touchEnd(surface!);
+
+    expect(container).toHaveAttribute('data-swipe-state', 'open');
+    expect(onAction).not.toHaveBeenCalled();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 240, clientY: 24 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 170, clientY: 28 }],
+    });
+    fireEvent.touchEnd(surface!);
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes an open row on a tap without needing a synthetic click', () => {
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={() => {}}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 220, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 120, clientY: 24 }],
+    });
+    fireEvent.touchEnd(surface!);
+
+    expect(container).toHaveAttribute('data-swipe-state', 'open');
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 120, clientY: 24 }],
+    });
+    fireEvent.touchEnd(surface!);
+
+    expect(container).toHaveAttribute('data-swipe-state', 'closed');
+  });
+
   it('auto-fires the action when released past the commit threshold', () => {
     const onAction = vi.fn();
 
@@ -299,6 +377,116 @@ describe('SwipeActionRow', () => {
       );
     } finally {
       console.error = originalConsoleError;
+      if (originalVibrate) {
+        Object.defineProperty(navigator, 'vibrate', {
+          configurable: true,
+          value: originalVibrate,
+        });
+      } else {
+        Reflect.deleteProperty(navigator, 'vibrate');
+      }
+    }
+  });
+
+  it('only emits the ready haptic once per gesture even if the swipe crosses the threshold multiple times', () => {
+    const onAction = vi.fn();
+    const originalVibrate = navigator.vibrate;
+    const vibrate = vi.fn();
+    Object.defineProperty(navigator, 'vibrate', {
+      configurable: true,
+      value: vibrate,
+    });
+
+    try {
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={onAction}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+      expect(surface).not.toBeNull();
+      const container = surface!.parentElement;
+      expect(container).not.toBeNull();
+      Object.defineProperty(container!, 'offsetWidth', {
+        configurable: true,
+        value: 390,
+      });
+
+      fireEvent.touchStart(surface!, {
+        touches: [{ clientX: 320, clientY: 20 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 170, clientY: 24 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 230, clientY: 24 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 150, clientY: 24 }],
+      });
+
+      expect(vibrate).toHaveBeenCalledTimes(1);
+      expect(vibrate).toHaveBeenNthCalledWith(1, 10);
+      expect(onAction).not.toHaveBeenCalled();
+    } finally {
+      if (originalVibrate) {
+        Object.defineProperty(navigator, 'vibrate', {
+          configurable: true,
+          value: originalVibrate,
+        });
+      } else {
+        Reflect.deleteProperty(navigator, 'vibrate');
+      }
+    }
+  });
+
+  it('uses a distinct confirmation haptic when the archive commits on release', () => {
+    const onAction = vi.fn();
+    const originalVibrate = navigator.vibrate;
+    const vibrate = vi.fn();
+    Object.defineProperty(navigator, 'vibrate', {
+      configurable: true,
+      value: vibrate,
+    });
+
+    try {
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={onAction}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+      expect(surface).not.toBeNull();
+      const container = surface!.parentElement;
+      expect(container).not.toBeNull();
+      Object.defineProperty(container!, 'offsetWidth', {
+        configurable: true,
+        value: 390,
+      });
+
+      fireEvent.touchStart(surface!, {
+        touches: [{ clientX: 320, clientY: 20 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 170, clientY: 24 }],
+      });
+      fireEvent.touchEnd(surface!);
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(vibrate).toHaveBeenCalledTimes(2);
+      expect(vibrate).toHaveBeenNthCalledWith(1, 10);
+      expect(vibrate).toHaveBeenNthCalledWith(2, [16, 24, 40]);
+    } finally {
       if (originalVibrate) {
         Object.defineProperty(navigator, 'vibrate', {
           configurable: true,

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -17,6 +17,8 @@ const TOUCH_QUERY = "(pointer: coarse)";
 const COMMIT_THRESHOLD_RATIO = 0.36;
 const MIN_COMMIT_THRESHOLD = 140;
 const COMMIT_ANIMATION_MS = 220;
+const READY_HAPTIC_MS = 10;
+const COMMIT_HAPTIC_PATTERN = [16, 24, 40];
 // Pre-measurement fallback when a gesture starts before the row has dimensions.
 // Real width is captured from offsetWidth at touchstart.
 const FALLBACK_ROW_WIDTH = ACTION_WIDTH * 4;
@@ -24,6 +26,7 @@ const FALLBACK_ROW_WIDTH = ACTION_WIDTH * 4;
 type DragState = {
   startX: number;
   startY: number;
+  startOffset: number;
   width: number;
   swiping: boolean;
   locked: boolean;
@@ -86,6 +89,7 @@ export function SwipeActionRow({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const dragRef = useRef<DragState | null>(null);
   const commitTimerRef = useRef<number | null>(null);
+  const readyHapticPlayedRef = useRef(false);
   // Mirrors isCommitted for use inside touchmove handlers, where the rendered
   // closure can lag behind rapid state transitions.
   const committedRef = useRef(false);
@@ -114,6 +118,7 @@ export function SwipeActionRow({
     setIsDragging(false);
     setIsCommitted(false);
     committedRef.current = false;
+    readyHapticPlayedRef.current = false;
     dragRef.current = null;
   };
 
@@ -123,6 +128,7 @@ export function SwipeActionRow({
     setIsDragging(false);
     setIsCommitted(false);
     committedRef.current = false;
+    readyHapticPlayedRef.current = false;
     dragRef.current = null;
   };
 
@@ -135,7 +141,8 @@ export function SwipeActionRow({
     setOffset(width);
     dragRef.current = null;
     committedRef.current = false;
-    vibrate([15, 30, 40]);
+    readyHapticPlayedRef.current = false;
+    vibrate(COMMIT_HAPTIC_PATTERN);
     onAction();
     if (commitTimerRef.current !== null) {
       window.clearTimeout(commitTimerRef.current);
@@ -162,10 +169,12 @@ export function SwipeActionRow({
     dragRef.current = {
       startX: touch.clientX,
       startY: touch.clientY,
+      startOffset: offsetRef.current,
       width,
       swiping: false,
       locked: false,
     };
+    readyHapticPlayedRef.current = false;
     setIsDragging(true);
   };
 
@@ -196,7 +205,7 @@ export function SwipeActionRow({
       event.preventDefault();
     }
 
-    const nextOffset = Math.max(0, Math.min(drag.width, -deltaX));
+    const nextOffset = Math.max(0, Math.min(drag.width, drag.startOffset - deltaX));
     offsetRef.current = nextOffset;
     setOffset(nextOffset);
 
@@ -204,19 +213,26 @@ export function SwipeActionRow({
     if (willCommit !== committedRef.current) {
       committedRef.current = willCommit;
       setIsCommitted(willCommit);
-      if (willCommit) {
-        // Light tick when the user crosses into the auto-commit zone.
-        vibrate(8);
+      if (willCommit && !readyHapticPlayedRef.current) {
+        // One light pulse signals that release will archive; avoid replaying it
+        // if the user scrubs back and forth near the threshold.
+        readyHapticPlayedRef.current = true;
+        vibrate(READY_HAPTIC_MS);
       }
     }
   };
 
   const handleTouchEnd = () => {
+    const drag = dragRef.current;
     const width =
-      dragRef.current?.width ??
+      drag?.width ??
       containerRef.current?.offsetWidth ??
       FALLBACK_ROW_WIDTH;
     const latestOffset = offsetRef.current;
+    if (drag && !drag.locked && drag.startOffset >= OPEN_THRESHOLD) {
+      close();
+      return;
+    }
     if (latestOffset >= commitThresholdFor(width)) {
       commitAction(width);
       return;


### PR DESCRIPTION
## Summary
This update refines `SwipeActionRow` swipe state transitions so follow-up swipes and taps behave predictably, and it improves haptic behavior to avoid repeated “ready” feedback within a single gesture. The accompanying tests lock in the key regressions to prevent future changes from reintroducing inconsistent behavior.

## Changes
- **`frontend/src/components/swipe-action-row.tsx`**
  - Ensure a swipe interaction can **continue from the already revealed/open position** on a follow-up swipe.
  - Adjust tap/interaction handling so an **open row closes on tap** without relying on a synthetic click.
  - Refine haptic emission so the **“ready” haptic is fired only once per gesture**, even if the swipe crosses thresholds multiple times.
- **`frontend/src/components/swipe-action-row.test.tsx`**
  - Added test coverage for:
    - **Continuing from the revealed position on a follow-up swipe** and auto-firing the action when released.
    - **Closing an open row on tap** (no synthetic click dependency).
    - **Emitting “ready” haptic only once per gesture** (asserts JS-side `navigator.vibrate` calls).

## Test plan
- Ran the frontend unit tests for `SwipeActionRow` to verify the new behavior and regressions:
  - Gesture continuation from open state
  - Tap-to-close behavior
  - Single “ready” haptic emission per gesture (via mocked `navigator.vibrate`)

[143.dev](https://143.dev) | [session 0f73cfd7](https://143.dev/sessions/0f73cfd7-6bf6-41db-b497-240e84a63d82)