### PR TITLE
Fix mobile diff pagination blank screen by resetting scroll container on file switch

### DIFF
--- a/frontend/src/components/code-review/diff-pane.test.tsx
+++ b/frontend/src/components/code-review/diff-pane.test.tsx
@@ -229,4 +229,30 @@ describe("DiffPane", () => {
 
     expect(onActiveFileChange).toHaveBeenCalledWith(1);
   });
+
+  it("replaces the scroll container when resetScrollKey changes so mobile file switches do not keep a stale offset", () => {
+    const { container, rerender } = render(
+      <DiffPane
+        files={[makeDiffFile("a.ts")]}
+        viewMode="unified"
+        resetScrollKey="a.ts"
+      />
+    );
+
+    const firstScrollContainer = container.firstElementChild as HTMLDivElement;
+    firstScrollContainer.scrollTop = 480;
+
+    rerender(
+      <DiffPane
+        files={[makeDiffFile("b.ts")]}
+        viewMode="unified"
+        resetScrollKey="b.ts"
+      />
+    );
+
+    const secondScrollContainer = container.firstElementChild as HTMLDivElement;
+
+    expect(secondScrollContainer).not.toBe(firstScrollContainer);
+    expect(secondScrollContainer.scrollTop).toBe(0);
+  });
 });

--- a/frontend/src/components/code-review/diff-pane.tsx
+++ b/frontend/src/components/code-review/diff-pane.tsx
@@ -184,6 +184,7 @@ export const DiffPane = forwardRef<DiffPaneHandle, DiffPaneProps>(
 
     return (
       <div
+        key={resetScrollKey ?? "all-files"}
         ref={containerRef}
         onScroll={reportVisibleActiveFile}
         className="flex-1 overflow-y-auto p-4 space-y-4"


### PR DESCRIPTION
## Summary
This fixes a mobile browser scroll quirk in the Session Details code diff viewer where switching files could leave a stale scroll offset, contributing to a blank/incorrect diff area. We now force React to recreate the diff scroll container whenever `resetScrollKey` changes.

## Changes
- **`frontend/src/components/code-review/diff-pane.tsx`**
  - Added a `key={resetScrollKey ?? "all-files"}` to the scroll container wrapper so it is replaced when the active file changes and `resetScrollKey` updates.
  - This ensures the new file starts at `scrollTop = 0` instead of inheriting a prior offset.
- **`frontend/src/components/code-review/diff-pane.test.tsx`**
  - Added a regression test verifying that when `resetScrollKey` changes (e.g., `a.ts` → `b.ts`), the scroll container DOM node is replaced and the new container’s `scrollTop` resets to `0`.

## Test plan
- Ran the component unit tests for `DiffPane`, including the new regression test.
- Verified existing session detail/integration tests continue to pass to ensure file-switching behavior remains correct.

[143.dev](https://143.dev) | [session b32feb81](https://143.dev/sessions/b32feb81-8631-47fe-877e-766a93cc966a)