### PR TITLE
Fix View PR to render as an external link and prevent interactive nesting guardrail bypass

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -298,10 +298,9 @@ describe('SessionDetailPage', () => {
     const sheet = await screen.findByRole('dialog');
     const closeBtn = within(sheet).getByRole('button', { name: 'Close details' });
     expect(closeBtn).toBeInTheDocument();
-    const viewPRButton = within(sheet).getByRole('button', { name: 'View PR' });
-    expect(viewPRButton).toBeInTheDocument();
-    expect(viewPRButton.className).not.toContain('w-full');
-    expect(viewPRButton.closest('a')?.className ?? '').not.toContain('w-full');
+    const viewPRLink = within(sheet).getByRole('link', { name: 'View PR' });
+    expect(viewPRLink).toBeInTheDocument();
+    expect(viewPRLink.className).not.toContain('w-full');
     expect(within(sheet).queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
 
     await user.click(closeBtn);
@@ -1253,6 +1252,17 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByText('View PR')).toBeInTheDocument();
   });
 
+  it('renders View PR as a real link instead of nesting a button inside a link', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const viewPRLink = await screen.findByRole('link', { name: 'View PR' });
+
+    expect(viewPRLink).toHaveAttribute('href', 'https://github.com/example/repo/pull/42');
+    expect(viewPRLink).toHaveAttribute('target', '_blank');
+    expect(viewPRLink).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    expect(within(viewPRLink).queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it('keeps the tab rail scrollable while separating top-right actions', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
@@ -1263,7 +1273,7 @@ describe('SessionDetailPage', () => {
 	expect(tabRail).toHaveClass('scrollbar-hide');
 	expect(tabRail).toHaveClass('min-w-0');
 	expect(actions).toHaveClass('shrink-0');
-    expect(within(actions).getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+    expect(within(actions).getByRole('link', { name: 'View PR' })).toBeInTheDocument();
   });
 
   it('shows the horizontal tab scrollbar only when tabs run into the action buttons', async () => {
@@ -1345,7 +1355,7 @@ describe('SessionDetailPage', () => {
 
     expect((await screen.findAllByText('PR closed')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was closed without merging.')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Resolve conflicts' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Fix tests' })).not.toBeInTheDocument();
@@ -1466,7 +1476,7 @@ describe('SessionDetailPage', () => {
     expect(screen.queryAllByText('PR merged')).toHaveLength(1);
     expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
-    expect(screen.getByRole('button', { name: 'View PR' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.getByLabelText('Merged PR status')).toHaveClass('text-violet-700', 'dark:text-violet-400');
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();
   });
@@ -1846,7 +1856,7 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
 
-    expect(screen.getByRole('button', { name: /View PR/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View PR/ })).toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
@@ -2636,7 +2646,7 @@ describe('SessionDetailPage', () => {
 
     await waitFor(
       async () => {
-        expect(await screen.findByRole('button', { name: /View PR/ })).toBeInTheDocument();
+        expect(await screen.findByRole('link', { name: /View PR/ })).toBeInTheDocument();
       },
       { timeout: 12000 },
     );

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3178,12 +3178,12 @@ export function SessionDetailContent({ id }: { id: string }) {
                     PR closed
                   </Badge>
                 )}
-                <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
-                  <Button variant="outline" size="sm" className="h-7 text-xs gap-1.5">
+                <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5">
+                  <a href={prData.data.github_pr_url} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3 w-3" />
                     View PR
-                  </Button>
-                </a>
+                  </a>
+                </Button>
               </>
             ) : showPRAction && !prErrorNotice ? (
               <DisabledTooltip disabled={prActionDisabled} content={prActionTitle}>

--- a/frontend/src/interactive-nesting.test.ts
+++ b/frontend/src/interactive-nesting.test.ts
@@ -1,0 +1,233 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+type Imports = {
+  nextLinkNames: Set<string>;
+  buttonNames: Set<string>;
+};
+
+type Finding = {
+  file: string;
+  line: number;
+  type: "link-contains-button" | "button-contains-interactive";
+  outer: string;
+  inner: string;
+};
+
+const SRC_ROOT = path.dirname(fileURLToPath(import.meta.url));
+const FRONTEND_ROOT = path.resolve(SRC_ROOT, "..");
+
+describe("interactive nesting", () => {
+  it("does not nest buttons inside links or links inside buttons", () => {
+    const files = collectSourceFiles(SRC_ROOT);
+    const findings = files.flatMap((filePath) => findInteractiveNesting(filePath));
+
+    expect(findings).toEqual([]);
+  });
+
+  it("treats dynamic asChild expressions as unsafe", () => {
+    const fixturePath = path.join(SRC_ROOT, "__interactive-nesting-dynamic-aschild__.test.tsx");
+    const source = `
+      import Link from "next/link";
+      import { Button } from "@/components/ui/button";
+
+      export function Example({ asChild }: { asChild: boolean }) {
+        return (
+          <Button asChild={asChild}>
+            <Link href="/settings">Settings</Link>
+          </Button>
+        );
+      }
+    `;
+
+    fs.writeFileSync(fixturePath, source);
+
+    try {
+      expect(findInteractiveNesting(fixturePath)).toMatchObject([
+        {
+          file: path.relative(FRONTEND_ROOT, fixturePath),
+          type: "button-contains-interactive",
+          outer: "Button",
+          inner: "Link",
+        },
+      ]);
+    } finally {
+      fs.rmSync(fixturePath, { force: true });
+    }
+  });
+});
+
+function collectSourceFiles(root: string): string[] {
+  const files: string[] = [];
+
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      if (!/\.(tsx|jsx)$/.test(entry.name)) continue;
+      if (/\.test\.(tsx|jsx)$/.test(entry.name)) continue;
+
+      files.push(fullPath);
+    }
+  }
+
+  walk(root);
+  return files;
+}
+
+function findInteractiveNesting(filePath: string): Finding[] {
+  const sourceText = fs.readFileSync(filePath, "utf8");
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const imports = collectImports(sourceFile);
+  const findings: Finding[] = [];
+
+  function visit(node: ts.Node) {
+    if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const outer = describeElement(node, imports);
+      const opening = ts.isJsxElement(node) ? node.openingElement : node;
+      const line = sourceFile.getLineAndCharacterOfPosition(opening.getStart()).line + 1;
+      const descendants = collectDescendantJSX(node);
+
+      if (outer.isAnchor || outer.isLink) {
+        const nestedButton = descendants.find((descendant) => {
+          const inner = describeElement(descendant, imports);
+          return inner.isRawButton || inner.isButton;
+        });
+
+        if (nestedButton) {
+          findings.push({
+            file: path.relative(FRONTEND_ROOT, filePath),
+            line,
+            type: "link-contains-button",
+            outer: outer.tag,
+            inner: describeElement(nestedButton, imports).tag,
+          });
+        }
+      }
+
+      if (outer.isRawButton || (outer.isButton && !outer.asChild)) {
+        const nestedInteractive = descendants.find((descendant) => {
+          const inner = describeElement(descendant, imports);
+          return inner.isAnchor || inner.isLink || inner.isRawButton || (inner.isButton && !inner.asChild);
+        });
+
+        if (nestedInteractive) {
+          findings.push({
+            file: path.relative(FRONTEND_ROOT, filePath),
+            line,
+            type: "button-contains-interactive",
+            outer: outer.tag,
+            inner: describeElement(nestedInteractive, imports).tag,
+          });
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+
+  return findings;
+}
+
+function collectImports(sourceFile: ts.SourceFile): Imports {
+  const nextLinkNames = new Set<string>();
+  const buttonNames = new Set<string>();
+
+  sourceFile.forEachChild((node) => {
+    if (!ts.isImportDeclaration(node) || !ts.isStringLiteral(node.moduleSpecifier)) return;
+
+    const modulePath = node.moduleSpecifier.text;
+    const clause = node.importClause;
+    if (!clause) return;
+
+    if (modulePath === "next/link") {
+      if (clause.name) nextLinkNames.add(clause.name.text);
+      if (clause.namedBindings && ts.isNamedImports(clause.namedBindings)) {
+        for (const element of clause.namedBindings.elements) {
+          nextLinkNames.add(element.name.text);
+        }
+      }
+    }
+
+    if ((modulePath === "@/components/ui/button" || modulePath.endsWith("/components/ui/button")) &&
+      clause.namedBindings &&
+      ts.isNamedImports(clause.namedBindings)) {
+      for (const element of clause.namedBindings.elements) {
+        const importedName = (element.propertyName || element.name).text;
+        if (importedName === "Button") {
+          buttonNames.add(element.name.text);
+        }
+      }
+    }
+  });
+
+  return { nextLinkNames, buttonNames };
+}
+
+function collectDescendantJSX(node: ts.JsxElement | ts.JsxSelfClosingElement): Array<ts.JsxElement | ts.JsxSelfClosingElement> {
+  const descendants: Array<ts.JsxElement | ts.JsxSelfClosingElement> = [];
+
+  function visit(child: ts.Node) {
+    if ((ts.isJsxElement(child) || ts.isJsxSelfClosingElement(child)) && child !== node) {
+      descendants.push(child);
+    }
+    ts.forEachChild(child, visit);
+  }
+
+  ts.forEachChild(node, visit);
+
+  return descendants;
+}
+
+function describeElement(node: ts.JsxElement | ts.JsxSelfClosingElement, imports: Imports) {
+  const opening = ts.isJsxElement(node) ? node.openingElement : node;
+  const tag = getTagName(opening.tagName);
+  const isAnchor = tag === "a";
+  const isLink = imports.nextLinkNames.has(tag);
+  const isRawButton = tag === "button";
+  const isButton = imports.buttonNames.has(tag);
+  const asChild = isButton && hasStaticallyEnabledAsChild(opening.attributes);
+
+  return { tag, isAnchor, isLink, isRawButton, isButton, asChild };
+}
+
+function hasStaticallyEnabledAsChild(attributes: ts.JsxAttributes): boolean {
+  for (const prop of attributes.properties) {
+    if (!ts.isJsxAttribute(prop) || getAttributeName(prop.name) !== "asChild") continue;
+
+    if (!prop.initializer) return true;
+    if (ts.isStringLiteral(prop.initializer)) return true;
+    if (ts.isJsxExpression(prop.initializer)) {
+      const expression = prop.initializer.expression;
+      if (!expression) return true;
+      return expression.kind === ts.SyntaxKind.TrueKeyword;
+    }
+
+    return false;
+  }
+
+  return false;
+}
+
+function getTagName(tagName: ts.JsxTagNameExpression): string {
+  if (ts.isIdentifier(tagName)) return tagName.text;
+  if (ts.isJsxNamespacedName(tagName)) return `${tagName.namespace.text}:${tagName.name.text}`;
+  if (ts.isPropertyAccessExpression(tagName)) return tagName.name.text;
+  return tagName.getText();
+}
+
+function getAttributeName(attributeName: ts.JsxAttributeName): string {
+  if (ts.isIdentifier(attributeName)) return attributeName.text;
+  return `${attributeName.namespace.text}:${attributeName.name.text}`;
+}


### PR DESCRIPTION
## Summary
Updated the “View PR” control to render as a real `<a>` link (not a button nested inside a link) to prevent navigation/screen-freezing issues. Tightened the interactive nesting guardrail so dynamically enabled `asChild` cases are flagged, and added a regression test to cover this scenario.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Adjusted tests to assert “View PR” is a **link** (`role="link"`) with correct `href`, `target="_blank"`, and `rel` (noopener/noreferrer).
  - Added regression test ensuring the link does **not** contain a nested `button`.
  - Updated related assertions that previously expected a `button`.
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Updated the “View PR” rendering to be an anchor element so it’s accessible and avoids invalid interactive nesting.
- **frontend/src/interactive-nesting.test.ts**
  - Fixed the guardrail logic so `asChild` is only considered safe when **statically enabled**; dynamic cases like `asChild={flag}` are now rejected.
  - Added/extended a regression test for the dynamic `asChild` scenario.

## Test plan
- `npx vitest run src/interactive-nesting.test.ts`
- `npx vitest run src/app/(dashboard)/sessions/[id]/page.test.tsx -t "renders View PR as a real link instead of nesting a button inside a link"`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (passed; only pre-existing Next.js warnings about multiple lockfiles and deprecated `middleware` convention)

[143.dev](https://143.dev) | [session 0df1f85a](https://143.dev/sessions/0df1f85a-1005-498b-a757-0d8cb6d93b5e)