### PR TITLE
Dedupe sandbox-hold jobs and self-heal lost AcquireTurnHold races

### DIFF
--- a/internal/api/handlers/internal_issues.go
+++ b/internal/api/handlers/internal_issues.go
@@ -218,11 +218,12 @@ func (h *InternalIssueHandler) dispatchSession(r *http.Request, orgID uuid.UUID,
 		return nil, err
 	}
 
+	dedupeKey := db.RunAgentDedupeKey(session.ID)
 	payload := map[string]string{
 		"session_id": session.ID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -401,11 +401,12 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 			return
 		}
 
+		dedupeKey := db.ContinueSessionDedupeKey(sessionID)
 		payload := map[string]string{
 			"session_id": sessionID.String(),
 			"org_id":     orgID.String(),
 		}
-		if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "continue_session", payload, 5, nil); err != nil {
+		if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
 			// Delete the orphaned message and revert session status.
 			if msg.ID != 0 {
 				if delErr := h.messageStore.Delete(r.Context(), msg.ID); delErr != nil {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -835,12 +835,16 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Enqueue the run_agent job.
+	// Enqueue the run_agent job. Dedupe by session ID so a double-clicked
+	// submit (or any other transient retry path) cannot land two run_agent
+	// rows for the same session — the second insert would race the first at
+	// AcquireTurnHold and surface "sandbox race" to the user.
+	dedupeKey := db.RunAgentDedupeKey(run.ID)
 	payload := map[string]string{
 		"session_id": run.ID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue agent run job", err)
 		return
 	}
@@ -881,12 +885,17 @@ func (h *SessionHandler) RetrySession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Re-enqueue the run_agent job. If this fails, roll back the session status
-	// so it doesn't get stuck in pending with no job to pick it up.
+	// so it doesn't get stuck in pending with no job to pick it up. Dedupe by
+	// session ID so a Retry can never land alongside an in-flight run_agent
+	// for the same session — the partial unique index on (queue, dedupe_key)
+	// only covers pending|running, so legitimate retries after the prior job
+	// reaches a terminal state still go through.
+	dedupeKey := db.RunAgentDedupeKey(sessionID)
 	payload := map[string]string{
 		"session_id": sessionID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		if undoErr := h.runStore.UndoResetForRetry(r.Context(), orgID, sessionID, "Retry failed: could not enqueue job", ""); undoErr != nil {
 			h.logger.Error().Err(undoErr).Str("session_id", sessionID.String()).Msg("failed to undo retry reset after enqueue failure")
 		}
@@ -1998,12 +2007,16 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Enqueue continue_session job.
+	// Enqueue continue_session job. Dedupe at the session level — only one
+	// continue_session can hold the shared sandbox at a time, so a duplicate
+	// would race AcquireTurnHold and dead-letter via the orchestrator's
+	// self-heal path.
+	dedupeKey := db.ContinueSessionDedupeKey(sessionID)
 	payload := map[string]string{
 		"session_id": sessionID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.EnqueueInTx(r.Context(), tx, orgID, "agent", "continue_session", payload, 5, nil); err != nil {
+	if _, err := h.jobStore.EnqueueInTx(r.Context(), tx, orgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job", err)
 		return
 	}
@@ -2765,11 +2778,12 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	dedupeKey := db.RunAgentDedupeKey(session.ID)
 	payload := map[string]string{
 		"session_id": session.ID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue manual session", err)
 		return
 	}

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -16,6 +16,25 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// RunAgentDedupeKey returns the dedupe key used for run_agent enqueues. The
+// partial unique index on (queue, dedupe_key) WHERE status IN
+// ('pending','running') collapses concurrent run_agent enqueues for the same
+// session into one — preventing the COALESCE race at AcquireTurnHold that
+// surfaced as "sandbox race: another holder attached first" in production.
+// Terminal-status rows (succeeded/failed/dead_letter) don't conflict, so a
+// legitimate retry after the prior job finishes still goes through.
+func RunAgentDedupeKey(sessionID uuid.UUID) string {
+	return "run_agent:" + sessionID.String()
+}
+
+// ContinueSessionDedupeKey returns the dedupe key used for continue_session
+// enqueues. Session-level (not thread-level) because the underlying sandbox
+// container is shared across threads — only one continue_session can hold
+// the turn at a time. See RunAgentDedupeKey for the partial-index rationale.
+func ContinueSessionDedupeKey(sessionID uuid.UUID) string {
+	return "continue_session:" + sessionID.String()
+}
+
 type JobStore struct {
 	db       DBTX
 	notifier *cache.JobNotifier

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1822,6 +1822,34 @@ func (s *SessionStore) PublishHydratedContainerID(ctx context.Context, orgID, se
 	return actualContainerID, nil
 }
 
+// ContainerHoldState returns whether the expected container is currently held
+// by an agent turn, by a preview, or both. It is intentionally pinned to
+// container_id = @expected so callers diagnosing a race do not accidentally
+// read holder state for a newer container published after their liveness probe.
+func (s *SessionStore) ContainerHoldState(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (turnHolds bool, previewHolds bool, err error) {
+	query := `SELECT
+			COALESCE(s.turn_holding_container, FALSE) AS turn_holds,
+			EXISTS (
+				SELECT 1
+				FROM preview_instances p
+				WHERE p.session_id = s.id
+				  AND p.org_id = s.org_id
+				  AND p.preview_holding_container = TRUE
+			) AS preview_holds
+		FROM sessions s
+		WHERE s.id = @id
+		  AND s.org_id = @org_id
+		  AND s.container_id = @expected`
+	if err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
+		"id":       sessionID,
+		"org_id":   orgID,
+		"expected": expectedContainerID,
+	}).Scan(&turnHolds, &previewHolds); err != nil {
+		return false, false, fmt.Errorf("container hold state: %w", err)
+	}
+	return turnHolds, previewHolds, nil
+}
+
 // SetWorkerNodeIDForContainer records the worker node currently owning the
 // session's live container. The update is CAS-scoped to the expected
 // container_id so callers do not accidentally stamp ownership onto a newer

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1816,6 +1816,72 @@ func TestSessionStore_PublishHydratedContainerID_DBError(t *testing.T) {
 	require.Contains(t, err.Error(), "publish hydrated container id")
 }
 
+func TestSessionStore_ContainerHoldState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		turnHolds    bool
+		previewHolds bool
+		expectedTurn bool
+		expectedPrev bool
+	}{
+		{
+			name:         "turn holder owns container",
+			turnHolds:    true,
+			previewHolds: false,
+			expectedTurn: true,
+			expectedPrev: false,
+		},
+		{
+			name:         "preview holder owns container",
+			turnHolds:    false,
+			previewHolds: true,
+			expectedTurn: false,
+			expectedPrev: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "pgxmock pool should be created")
+			defer mock.Close()
+
+			store := NewSessionStore(mock)
+			mock.ExpectQuery(`SELECT\s+COALESCE\(s\.turn_holding_container, FALSE\) AS turn_holds`).
+				WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+				WillReturnRows(pgxmock.NewRows([]string{"turn_holds", "preview_holds"}).AddRow(tt.turnHolds, tt.previewHolds))
+
+			gotTurn, gotPreview, err := store.ContainerHoldState(context.Background(), uuid.New(), uuid.New(), "container-1")
+			require.NoError(t, err, "ContainerHoldState should read holder state")
+			require.Equal(t, tt.expectedTurn, gotTurn, "ContainerHoldState should return the exact turn holder flag")
+			require.Equal(t, tt.expectedPrev, gotPreview, "ContainerHoldState should return the exact preview holder flag")
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionStore_ContainerHoldState_DBError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should be created")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	mock.ExpectQuery(`SELECT\s+COALESCE\(s\.turn_holding_container, FALSE\) AS turn_holds`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("boom"))
+
+	_, _, err = store.ContainerHoldState(context.Background(), uuid.New(), uuid.New(), "container-1")
+	require.Error(t, err, "ContainerHoldState should return database errors")
+	require.Contains(t, err.Error(), "container hold state", "ContainerHoldState should wrap the database error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_FinalizeContainerDestroy(t *testing.T) {
 	t.Parallel()
 

--- a/internal/integration/session_retry_test.go
+++ b/internal/integration/session_retry_test.go
@@ -76,6 +76,20 @@ func TestIntegration_RetrySession_ResetsAndReenqueues(t *testing.T) {
 	require.Equal(t, "pending", job.Status)
 	require.Equal(t, session.ID.String(), payloadField(t, job.Payload, "session_id"))
 	require.Equal(t, orgID.String(), payloadField(t, job.Payload, "org_id"))
+
+	// 3. The dedupe_key must be set so that a duplicate retry (or any other
+	// run_agent enqueue path) is collapsed by the partial unique index on
+	// (queue, dedupe_key) WHERE status IN ('pending','running'). Verified via
+	// a direct query because listJobs hides this column. Regression guard:
+	// the prod incident at session f996f0e1 was caused by retry passing
+	// dedupe_key=NULL, letting a stale pending run_agent and the retry's new
+	// run_agent both fire and race AcquireTurnHold.
+	var dedupeKey *string
+	err = pool.QueryRow(context.Background(),
+		`SELECT dedupe_key FROM jobs WHERE id = $1`, job.ID).Scan(&dedupeKey)
+	require.NoError(t, err)
+	require.NotNil(t, dedupeKey, "retry's run_agent enqueue must set a dedupe_key to suppress duplicate jobs")
+	require.Equal(t, "run_agent:"+session.ID.String(), *dedupeKey, "dedupe key must follow the canonical run_agent:<sessionID> format from db.RunAgentDedupeKey")
 }
 
 // TestIntegration_RetrySession_RejectsNonFailedSession guards the inverse:

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -49,10 +49,85 @@ var ErrSessionTimedOut = errors.New("session timed out")
 // job is requeued without consuming an attempt.
 var ErrSnapshotPending = errors.New("snapshot upload pending")
 
+// ErrSandboxRaceLoser is returned from RunAgent / ContinueSession when
+// AcquireTurnHold's COALESCE reveals that another holder published a
+// container_id first AND that container is alive — i.e. a duplicate
+// run_agent / continue_session job is concurrently running the same turn.
+// The "winner" owns the session row and will update its result; the loser
+// must NOT call failRun (that would race the winner's terminal write and
+// corrupt the row) and must NOT have its job retried (every retry would
+// lose the same race). Worker handlers recognize this error and convert it
+// to a FatalError so the duplicate job dead-letters silently without
+// surfacing a user-visible failure.
+var ErrSandboxRaceLoser = errors.New("sandbox race: another holder attached first")
+
+// ErrStaleSandboxIDCleared is returned from RunAgent / ContinueSession when
+// AcquireTurnHold reports a different container_id but an IsAlive probe
+// reveals that the "winner" container is dead — a stale orphan from a
+// crashed worker that the startup reconciler hasn't reaped yet. The loser
+// CAS-clears container_id via ClearContainerID and signals retry: the next
+// attempt will see a clean row and create a fresh sandbox. Worker handlers
+// convert this to a RetryableError with a short backoff so the retry happens
+// without consuming an attempt counter.
+var ErrStaleSandboxIDCleared = errors.New("sandbox race: cleared stale orphan container_id, retry")
+
 // canonicalTimeoutLogMessage is the single log phrase emitted whenever a
 // session hits its configured deadline. Kept deliberately narrow so
 // Grafana alerts can key off one string across RunAgent and ContinueSession.
 const canonicalTimeoutLogMessage = "session exceeded configured timeout"
+
+// sandboxRaceProbeTimeout bounds the IsAlive probe at the AcquireTurnHold
+// race-loss diagnosis site. Short enough that a docker-daemon hiccup can't
+// stall the loser's cleanup, long enough that a healthy IsAlive (typically
+// sub-100ms) succeeds with margin.
+const sandboxRaceProbeTimeout = 3 * time.Second
+
+// diagnoseAcquireHoldRaceLoss decides whether a lost AcquireTurnHold is a
+// genuine duplicate run (winner is alive) or a stale orphan from a crashed
+// prior worker (winner is dead, never released). It probes IsAlive on
+// actualContainerID and, if dead, CAS-clears the row so the caller's retry
+// re-enters against a clean session row. Returns ErrSandboxRaceLoser for
+// genuine duplicates (worker dead-letters silently) or ErrStaleSandboxIDCleared
+// for stale orphans (worker requeues without consuming an attempt). Probe
+// or clear errors are intentionally conservative — they fall back to
+// ErrSandboxRaceLoser to avoid clobbering a real active turn on a transient
+// docker / DB hiccup; the startup reconciler remains the safety net.
+func (o *Orchestrator) diagnoseAcquireHoldRaceLoss(
+	ctx context.Context,
+	orgID, sessionID uuid.UUID,
+	actualContainerID string,
+	log zerolog.Logger,
+) error {
+	aliveCtx, cancel := context.WithTimeout(ctx, sandboxRaceProbeTimeout)
+	defer cancel()
+	alive, aliveErr := o.provider.IsAlive(aliveCtx, &Sandbox{ID: actualContainerID, Provider: "docker"})
+	if aliveErr != nil {
+		log.Warn().Err(aliveErr).
+			Str("winning_container_id", actualContainerID).
+			Msg("IsAlive probe failed during sandbox race-loss diagnosis; assuming alive winner and dead-lettering this duplicate")
+		return ErrSandboxRaceLoser
+	}
+	if alive {
+		return ErrSandboxRaceLoser
+	}
+	cleared, clearErr := o.sessions.ClearContainerID(ctx, orgID, sessionID, actualContainerID)
+	if clearErr != nil {
+		log.Warn().Err(clearErr).
+			Str("winning_container_id", actualContainerID).
+			Msg("ClearContainerID failed during sandbox race-loss diagnosis; falling back to silent dead-letter so a transient DB error doesn't trigger a tight retry loop")
+		return ErrSandboxRaceLoser
+	}
+	if !cleared {
+		log.Info().
+			Str("winning_container_id", actualContainerID).
+			Msg("ClearContainerID CAS lost during race-loss diagnosis (a new holder acquired between IsAlive and Clear); dead-lettering this duplicate")
+		return ErrSandboxRaceLoser
+	}
+	log.Warn().
+		Str("stale_container_id", actualContainerID).
+		Msg("cleared stale orphan container_id from a crashed prior turn; signaling retry to re-enter against the clean row")
+	return ErrStaleSandboxIDCleared
+}
 
 // GitHubTokenProvider abstracts retrieving a GitHub App installation token.
 type GitHubTokenProvider interface {
@@ -151,6 +226,14 @@ type SessionStore interface {
 	// caller owns the destroy, false when a new holder acquired in the gap
 	// (caller must leave the container alone).
 	FinalizeContainerDestroy(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (cleared bool, err error)
+	// ClearContainerID is the CAS-safe orphan reset: it nulls container_id
+	// and clears the stuck turn_holding_container flag, but only when the
+	// expected ID still matches AND no preview hold has appeared. Used by
+	// the AcquireTurnHold race-loss path to recover from a stale orphan
+	// container_id (worker crashed mid-turn, never released): the loser
+	// probes IsAlive on actualContainerID, and if dead, calls ClearContainerID
+	// so the retry can re-enter against a clean row.
+	ClearContainerID(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (cleared bool, err error)
 }
 
 // SessionLogStore defines the log persistence operations.
@@ -1305,9 +1388,15 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		log.Warn().
 			Str("winning_container_id", actualContainerID).
 			Str("losing_container_id", sandbox.ID).
-			Msg("another holder published container_id first; aborting turn so the user can retry against the winning container")
-		o.failRun(ctx, run, "sandbox race: another holder attached first, please retry")
-		return fmt.Errorf("sandbox race: actual container %s != created %s", actualContainerID, sandbox.ID)
+			Msg("another holder published container_id first; diagnosing whether the winner is alive or a stale orphan")
+		// Self-heal: ask the diagnosis helper whether the "winner" is alive
+		// (real duplicate → dead-letter via ErrSandboxRaceLoser) or a stale
+		// orphan (worker crashed mid-turn → CAS-clear and signal retry via
+		// ErrStaleSandboxIDCleared). Either way, do NOT failRun — the winner
+		// (if any) owns the session row, and the orphan path leaves the row
+		// pending for the retry to re-enter cleanly.
+		diagErr := o.diagnoseAcquireHoldRaceLoss(ctx, run.OrgID, run.ID, actualContainerID, log)
+		return fmt.Errorf("%w: actual container %s != created %s", diagErr, actualContainerID, sandbox.ID)
 	}
 	defer func() {
 		exitReason := containerExitReason(ctx, err)
@@ -2075,8 +2164,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		// true, sandbox.ID came from the row's existing container_id and
 		// belongs to whoever set it — tearing it down here would kill a
 		// container another holder is still using. On the losing-race path
-		// we instead leave it alone; the caller's retry will attach to
-		// actualContainerID via the reuse path.
+		// we instead leave it alone; the winner is using actualContainerID.
 		if !reusedExisting {
 			if destroyErr := o.provider.Destroy(destroyCtx, sandbox); destroyErr != nil {
 				log.Error().Err(destroyErr).Str("losing_container_id", sandbox.ID).Msg("failed to destroy sandbox after losing hydrate race")
@@ -2088,17 +2176,12 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		log.Warn().
 			Str("winning_container_id", actualContainerID).
 			Str("losing_container_id", sandbox.ID).
-			Msg("another holder published container_id first; aborting turn so the user can retry against the winning container")
-		if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusIdle)); revertErr != nil {
-			log.Error().Err(revertErr).Msg("failed to revert session to idle after losing hydrate race")
-		}
-		o.registerSandboxFailureMessage(
-			ctx,
-			session,
-			"Another session activity was starting at the same time. Please try again.",
-			"sandbox race",
-		)
-		return fmt.Errorf("sandbox race: actual container %s != local %s", actualContainerID, sandbox.ID)
+			Msg("another holder published container_id first; diagnosing whether the winner is alive or a stale orphan")
+		// Self-heal: see RunAgent's symmetrical site for rationale. The
+		// diagnosis helper either dead-letters this duplicate (real winner
+		// active) or CAS-clears a stale orphan and signals retry.
+		diagErr := o.diagnoseAcquireHoldRaceLoss(ctx, session.OrgID, session.ID, actualContainerID, log)
+		return fmt.Errorf("%w: actual container %s != local %s", diagErr, actualContainerID, sandbox.ID)
 	}
 	containerStartedAt := time.Now()
 	var usageEventID uuid.UUID

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -71,6 +71,14 @@ var ErrSandboxRaceLoser = errors.New("sandbox race: another holder attached firs
 // without consuming an attempt counter.
 var ErrStaleSandboxIDCleared = errors.New("sandbox race: cleared stale orphan container_id, retry")
 
+// ErrSandboxPreviewRace is returned from RunAgent / ContinueSession when
+// AcquireTurnHold reports a different live container_id, but holder-state
+// inspection shows the live container belongs to a preview hydrate rather
+// than another agent turn. There is no "winning" agent job to publish the
+// user's turn result, so the worker must retry instead of silently
+// dead-lettering as a duplicate.
+var ErrSandboxPreviewRace = errors.New("sandbox race: preview holder attached first, retry")
+
 // canonicalTimeoutLogMessage is the single log phrase emitted whenever a
 // session hits its configured deadline. Kept deliberately narrow so
 // Grafana alerts can key off one string across RunAgent and ContinueSession.
@@ -108,6 +116,22 @@ func (o *Orchestrator) diagnoseAcquireHoldRaceLoss(
 		return ErrSandboxRaceLoser
 	}
 	if alive {
+		turnHolds, previewHolds, stateErr := o.sessions.ContainerHoldState(ctx, orgID, sessionID, actualContainerID)
+		if stateErr != nil {
+			log.Warn().Err(stateErr).
+				Str("winning_container_id", actualContainerID).
+				Msg("holder-state probe failed during sandbox race-loss diagnosis; assuming alive turn winner and dead-lettering this duplicate")
+			return ErrSandboxRaceLoser
+		}
+		if turnHolds {
+			return ErrSandboxRaceLoser
+		}
+		if previewHolds {
+			return ErrSandboxPreviewRace
+		}
+		log.Warn().
+			Str("winning_container_id", actualContainerID).
+			Msg("live container has no recorded turn or preview holder during race-loss diagnosis; assuming alive winner and dead-lettering this duplicate")
 		return ErrSandboxRaceLoser
 	}
 	cleared, clearErr := o.sessions.ClearContainerID(ctx, orgID, sessionID, actualContainerID)
@@ -234,6 +258,11 @@ type SessionStore interface {
 	// probes IsAlive on actualContainerID, and if dead, calls ClearContainerID
 	// so the retry can re-enter against a clean row.
 	ClearContainerID(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (cleared bool, err error)
+	// ContainerHoldState returns whether the expected live container is held
+	// by an agent turn, by a preview, or both. Used after an AcquireTurnHold
+	// COALESCE loss so an alive preview hydrate is retried rather than
+	// misclassified as a duplicate agent job.
+	ContainerHoldState(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (turnHolds bool, previewHolds bool, err error)
 }
 
 // SessionLogStore defines the log persistence operations.
@@ -1385,17 +1414,23 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		if sandboxCfg.AuthSocketPath != "" {
 			o.closeSandboxAuth(run.ID, log)
 		}
+		// Self-heal: ask the diagnosis helper whether the "winner" is alive
+		// (real duplicate → dead-letter via ErrSandboxRaceLoser), an alive
+		// preview holder (retry), or a stale orphan (worker crashed mid-turn
+		// → CAS-clear and signal retry via ErrStaleSandboxIDCleared). Either
+		// way, do NOT failRun — the winner (if any) owns the session row, and
+		// the orphan path leaves the row pending for the retry to re-enter
+		// cleanly.
 		log.Warn().
 			Str("winning_container_id", actualContainerID).
 			Str("losing_container_id", sandbox.ID).
 			Msg("another holder published container_id first; diagnosing whether the winner is alive or a stale orphan")
-		// Self-heal: ask the diagnosis helper whether the "winner" is alive
-		// (real duplicate → dead-letter via ErrSandboxRaceLoser) or a stale
-		// orphan (worker crashed mid-turn → CAS-clear and signal retry via
-		// ErrStaleSandboxIDCleared). Either way, do NOT failRun — the winner
-		// (if any) owns the session row, and the orphan path leaves the row
-		// pending for the retry to re-enter cleanly.
 		diagErr := o.diagnoseAcquireHoldRaceLoss(ctx, run.OrgID, run.ID, actualContainerID, log)
+		if errors.Is(diagErr, ErrSandboxPreviewRace) {
+			if revertErr := o.sessions.UpdateStatus(ctx, run.OrgID, run.ID, string(models.SessionStatusPending)); revertErr != nil {
+				log.Error().Err(revertErr).Msg("failed to revert session to pending after preview won sandbox race")
+			}
+		}
 		return fmt.Errorf("%w: actual container %s != created %s", diagErr, actualContainerID, sandbox.ID)
 	}
 	defer func() {
@@ -2181,6 +2216,11 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		// diagnosis helper either dead-letters this duplicate (real winner
 		// active) or CAS-clears a stale orphan and signals retry.
 		diagErr := o.diagnoseAcquireHoldRaceLoss(ctx, session.OrgID, session.ID, actualContainerID, log)
+		if errors.Is(diagErr, ErrSandboxPreviewRace) {
+			if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusIdle)); revertErr != nil {
+				log.Error().Err(revertErr).Msg("failed to revert session to idle after preview won sandbox race")
+			}
+		}
 		return fmt.Errorf("%w: actual container %s != local %s", diagErr, actualContainerID, sandbox.ID)
 	}
 	containerStartedAt := time.Now()

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -174,9 +174,11 @@ type mockSessionStore struct {
 	setWorkerNodeErr       error
 	releaseHoldFn          func() (bool, string, error)
 	finalizeFn             func(expectedContainerID string) (bool, error)
+	clearContainerIDFn     func(expectedContainerID string) (bool, error)
 	acquireHoldCalls       int
 	releaseHoldCalls       int
 	finalizeCalls          int
+	clearContainerIDCalls  int
 
 	// Programmable response for the rehydrate-pass query. Each call returns
 	// the next page; the field is used only by orchestrator-wrapper tests in
@@ -443,6 +445,18 @@ func (m *mockSessionStore) FinalizeContainerDestroy(ctx context.Context, orgID, 
 	m.mu.Lock()
 	m.finalizeCalls++
 	fn := m.finalizeFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(expectedContainerID)
+	}
+	// Default: CAS succeeds.
+	return true, nil
+}
+
+func (m *mockSessionStore) ClearContainerID(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (bool, error) {
+	m.mu.Lock()
+	m.clearContainerIDCalls++
+	fn := m.clearContainerIDFn
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(expectedContainerID)
@@ -1367,11 +1381,14 @@ func TestRunAgent_AcquireHoldErrorFailsRun(t *testing.T) {
 	require.Equal(t, 0, d.sessions.finalizeCalls)
 }
 
-// TestRunAgent_AcquireHoldLosesRaceFailsRun covers the branch where
-// AcquireTurnHold succeeds but returns a different container_id (another
-// holder published first). We must destroy our local sandbox and fail the
-// run so the retry picks up the winning container via the reuse path.
-func TestRunAgent_AcquireHoldLosesRaceFailsRun(t *testing.T) {
+// TestRunAgent_AcquireHoldLosesRaceSelfHeals covers the branch where
+// AcquireTurnHold succeeds but returns a different container_id and the
+// winning container is alive (real concurrent duplicate). The loser must
+// destroy its local sandbox and return ErrSandboxRaceLoser WITHOUT touching
+// the session row — the winner owns the row and will publish the
+// authoritative result. The worker handler converts ErrSandboxRaceLoser into
+// a FatalError so the duplicate job dead-letters silently.
+func TestRunAgent_AcquireHoldLosesRaceSelfHeals(t *testing.T) {
 	t.Parallel()
 
 	orgID := testOrg()
@@ -1382,16 +1399,122 @@ func TestRunAgent_AcquireHoldLosesRaceFailsRun(t *testing.T) {
 	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
 		return "winner-container", nil
 	}
+	// Default IsAlive=true; explicit here for readability — the alive branch
+	// is what distinguishes "real winner" from "stale orphan".
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return true, nil
+	}
 
 	orch := buildOrchestrator(d)
 	err := orch.RunAgent(context.Background(), run)
 	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "loser must surface ErrSandboxRaceLoser so the worker can dead-letter")
 	require.Contains(t, err.Error(), "sandbox race")
 
 	require.Equal(t, 1, d.sessions.acquireHoldCalls)
 	require.Equal(t, 1, d.provider.GetDestroyCalls(), "must destroy the losing sandbox")
 	require.Equal(t, 0, d.sessions.releaseHoldCalls, "no release — we never held")
 	require.Equal(t, 0, d.sessions.finalizeCalls)
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "alive winner — must NOT clear container_id (would kill the active turn)")
+	for _, ru := range d.sessions.resultUpdates {
+		require.NotEqual(t, "failed", ru.status, "loser must not mark the session failed — winner owns the row")
+	}
+}
+
+// TestRunAgent_AcquireHoldLosesRaceClearsStaleOrphan covers the recovery
+// branch where the "winning" container_id is actually a stale orphan from a
+// crashed prior worker. The orchestrator must CAS-clear the row via
+// ClearContainerID and return ErrStaleSandboxIDCleared so the worker
+// requeues against a clean row.
+func TestRunAgent_AcquireHoldLosesRaceClearsStaleOrphan(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "stale-orphan-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return false, nil
+	}
+	var clearedID string
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		clearedID = expected
+		return true, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared, "stale orphan path must surface ErrStaleSandboxIDCleared so the worker requeues")
+	require.NotErrorIs(t, err, agent.ErrSandboxRaceLoser, "stale orphan must not be misdiagnosed as a real race loss")
+
+	require.Equal(t, 1, d.sessions.clearContainerIDCalls, "must CAS-clear the stale orphan")
+	require.Equal(t, "stale-orphan-container", clearedID, "must clear the exact ID returned by AcquireTurnHold")
+	require.Equal(t, 1, d.provider.GetDestroyCalls(), "must still destroy the losing sandbox")
+	for _, ru := range d.sessions.resultUpdates {
+		require.NotEqual(t, "failed", ru.status, "stale-orphan path must not mark the session failed")
+	}
+}
+
+// TestRunAgent_AcquireHoldLosesRaceFallsBackOnIsAliveError verifies the
+// conservative fallback: when the IsAlive probe errors (e.g. transient
+// docker hiccup), we must NOT clear the row (could kill an active turn).
+// Instead, fall through to ErrSandboxRaceLoser; the startup reconciler is
+// the safety net for true orphans.
+func TestRunAgent_AcquireHoldLosesRaceFallsBackOnIsAliveError(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "winner-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return false, errors.New("docker daemon hiccup")
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "transient IsAlive error must NOT trigger the orphan-clear path")
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "must not clear container_id when liveness is unknown")
+}
+
+// TestRunAgent_AcquireHoldLosesRaceSkipsClearWhenCASLost covers the
+// TOCTOU-safe behavior: ClearContainerID returning cleared=false (a new
+// holder acquired between the IsAlive probe and the CAS) must fall through
+// to ErrSandboxRaceLoser rather than ErrStaleSandboxIDCleared. Otherwise we
+// would request a retry against a row that's actually busy.
+func TestRunAgent_AcquireHoldLosesRaceSkipsClearWhenCASLost(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	d := defaultDeps()
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "winner-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return false, nil
+	}
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		return false, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "CAS-lost clear must dead-letter, not retry")
+	require.Equal(t, 1, d.sessions.clearContainerIDCalls, "must have attempted the clear")
 }
 
 func TestRunAgent_SetWorkerNodeIDFailureFailsRun(t *testing.T) {
@@ -1640,8 +1763,9 @@ func TestRunAgent_AuthSocketClosedOnHydrateRaceLoss(t *testing.T) {
 
 	orch := buildOrchestrator(d)
 	err := orch.RunAgent(context.Background(), run)
-	require.Error(t, err, "RunAgent should fail when AcquireTurnHold reports a different container_id")
-	require.Contains(t, err.Error(), "sandbox race", "RunAgent should surface the sandbox-race condition")
+	require.Error(t, err, "RunAgent should return an error when AcquireTurnHold reports a different container_id")
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "RunAgent should surface ErrSandboxRaceLoser on the lost hydrate race")
+	require.Contains(t, err.Error(), "sandbox race")
 
 	require.Equal(t, 1, authStub.listenCalls, "auth socket must be opened before the race is detected")
 	require.Equal(t, 1, authStub.closeCalls, "auth socket must be closed when the local sandbox is destroyed after losing the hydrate race")
@@ -3813,6 +3937,114 @@ func TestContinueSession_AuthSocketClosedOnAcquireHoldError(t *testing.T) {
 
 	require.Equal(t, 1, authStub.listenCalls, "auth socket must be opened before acquire-hold")
 	require.Equal(t, 1, authStub.closeCalls, "auth socket must be closed when acquire-hold fails after the listener was opened")
+}
+
+// TestContinueSession_AcquireHoldLosesRaceSelfHeals is the ContinueSession
+// parity for TestRunAgent_AcquireHoldLosesRaceSelfHeals: when AcquireTurnHold
+// reports a different (alive) container_id, ContinueSession must surface
+// ErrSandboxRaceLoser without touching the session row, leaving the winner's
+// terminal write authoritative.
+func TestContinueSession_AcquireHoldLosesRaceSelfHeals(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+
+	d := defaultDeps()
+	d.creds = &mockCredentialProvider{
+		byProvider: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderAnthropic: {
+				Provider: models.ProviderAnthropic,
+				Config:   models.AnthropicConfig{APIKey: "sk-ant-test"},
+			},
+		},
+	}
+	d.orgs = &mockOrgStore{org: models.Organization{ID: orgID}}
+	d.identityResolver = identity.NewResolver(d.github, zerolog.Nop())
+	d.users = fakeUserStore{}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "follow up"},
+	}
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "winner-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return true, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "ContinueSession loser must surface ErrSandboxRaceLoser")
+	require.Contains(t, err.Error(), "sandbox race")
+
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "alive winner — must not clear container_id")
+	for _, ru := range d.sessions.resultUpdates {
+		require.NotEqual(t, "failed", ru.status, "ContinueSession loser must not mark the session failed — winner owns the row")
+	}
+	for _, status := range d.sessions.statusUpdates {
+		require.NotEqual(t, string(models.SessionStatusIdle), status, "loser must not flip the session back to idle — winner is mid-turn")
+	}
+}
+
+// TestContinueSession_AcquireHoldLosesRaceClearsStaleOrphan covers the
+// ContinueSession recovery branch: stale orphan container_id from a crashed
+// prior worker must be CAS-cleared so the worker requeues.
+func TestContinueSession_AcquireHoldLosesRaceClearsStaleOrphan(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+
+	d := defaultDeps()
+	d.creds = &mockCredentialProvider{
+		byProvider: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderAnthropic: {
+				Provider: models.ProviderAnthropic,
+				Config:   models.AnthropicConfig{APIKey: "sk-ant-test"},
+			},
+		},
+	}
+	d.orgs = &mockOrgStore{org: models.Organization{ID: orgID}}
+	d.identityResolver = identity.NewResolver(d.github, zerolog.Nop())
+	d.users = fakeUserStore{}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "follow up"},
+	}
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "stale-orphan-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return false, nil
+	}
+	var clearedID string
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		clearedID = expected
+		return true, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared, "ContinueSession stale-orphan path must surface ErrStaleSandboxIDCleared")
+	require.Equal(t, 1, d.sessions.clearContainerIDCalls)
+	require.Equal(t, "stale-orphan-container", clearedID)
 }
 
 // TestContinueSession_AuthSocketClosedOnHydrateFailure verifies that the

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -175,10 +175,12 @@ type mockSessionStore struct {
 	releaseHoldFn          func() (bool, string, error)
 	finalizeFn             func(expectedContainerID string) (bool, error)
 	clearContainerIDFn     func(expectedContainerID string) (bool, error)
+	containerHoldStateFn   func(expectedContainerID string) (bool, bool, error)
 	acquireHoldCalls       int
 	releaseHoldCalls       int
 	finalizeCalls          int
 	clearContainerIDCalls  int
+	containerStateCalls    int
 
 	// Programmable response for the rehydrate-pass query. Each call returns
 	// the next page; the field is used only by orchestrator-wrapper tests in
@@ -463,6 +465,18 @@ func (m *mockSessionStore) ClearContainerID(ctx context.Context, orgID, sessionI
 	}
 	// Default: CAS succeeds.
 	return true, nil
+}
+
+func (m *mockSessionStore) ContainerHoldState(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (bool, bool, error) {
+	m.mu.Lock()
+	m.containerStateCalls++
+	fn := m.containerHoldStateFn
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(expectedContainerID)
+	}
+	// Default: the live winner is another turn holder.
+	return true, false, nil
 }
 
 // ListContainerHoldingSessions returns the next pre-canned page from
@@ -4045,6 +4059,65 @@ func TestContinueSession_AcquireHoldLosesRaceClearsStaleOrphan(t *testing.T) {
 	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared, "ContinueSession stale-orphan path must surface ErrStaleSandboxIDCleared")
 	require.Equal(t, 1, d.sessions.clearContainerIDCalls)
 	require.Equal(t, "stale-orphan-container", clearedID)
+}
+
+// TestContinueSession_AcquireHoldLosesRaceToPreviewRetries covers the case
+// where a preview hydrate published container_id first. The container is
+// alive, but no agent turn owns it yet; the continuation must not dead-letter
+// silently as a duplicate job because there is no winning agent job to finish
+// the user's turn. Instead it reverts the session to idle and returns a
+// retryable preview-race sentinel so the next job attempt can attach to the
+// preview container through the normal reuse path.
+func TestContinueSession_AcquireHoldLosesRaceToPreviewRetries(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+
+	d := defaultDeps()
+	d.creds = &mockCredentialProvider{
+		byProvider: map[models.ProviderName]*models.DecryptedCredential{
+			models.ProviderAnthropic: {
+				Provider: models.ProviderAnthropic,
+				Config:   models.AnthropicConfig{APIKey: "sk-ant-test"},
+			},
+		},
+	}
+	d.orgs = &mockOrgStore{org: models.Organization{ID: orgID}}
+	d.identityResolver = identity.NewResolver(d.github, zerolog.Nop())
+	d.users = fakeUserStore{}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "follow up"},
+	}
+	d.sessions.acquireHoldFn = func(proposed string) (string, error) {
+		return "preview-container", nil
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return true, nil
+	}
+	d.sessions.containerHoldStateFn = func(expected string) (bool, bool, error) {
+		require.Equal(t, "preview-container", expected, "holder-state probe should inspect the winning container")
+		return false, true, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.Error(t, err, "ContinueSession should return the preview race for the worker to retry")
+	require.ErrorIs(t, err, agent.ErrSandboxPreviewRace, "preview-held containers should be retried, not dead-lettered as duplicate agent jobs")
+	require.NotErrorIs(t, err, agent.ErrSandboxRaceLoser, "preview-held containers should not be classified as duplicate agent jobs")
+	require.Contains(t, d.sessions.statusUpdates, string(models.SessionStatusIdle), "preview race should revert session status so retry re-enters cleanly")
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "alive preview container must not be cleared")
+	for _, ru := range d.sessions.resultUpdates {
+		require.NotEqual(t, "failed", ru.status, "preview race should not mark the session failed")
+	}
 }
 
 // TestContinueSession_AuthSocketClosedOnHydrateFailure verifies that the

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -145,6 +145,10 @@ func (s *runtimeTestSessionStore) ClearContainerID(context.Context, uuid.UUID, u
 	return true, nil
 }
 
+func (s *runtimeTestSessionStore) ContainerHoldState(context.Context, uuid.UUID, uuid.UUID, string) (bool, bool, error) {
+	return true, false, nil
+}
+
 type runtimeTestJobStore struct{}
 
 func (s *runtimeTestJobStore) Enqueue(context.Context, uuid.UUID, string, string, any, int, *string) (uuid.UUID, error) {

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -141,6 +141,10 @@ func (s *runtimeTestSessionStore) FinalizeContainerDestroy(context.Context, uuid
 	return true, nil
 }
 
+func (s *runtimeTestSessionStore) ClearContainerID(context.Context, uuid.UUID, uuid.UUID, string) (bool, error) {
+	return true, nil
+}
+
 type runtimeTestJobStore struct{}
 
 func (s *runtimeTestJobStore) Enqueue(context.Context, uuid.UUID, string, string, any, int, *string) (uuid.UUID, error) {

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -577,11 +577,12 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 	if err := txMessages.Create(ctx, msg); err != nil {
 		return nil, err
 	}
+	continueDedupeKey := db.ContinueSessionDedupeKey(claimed.ID)
 	payload := map[string]string{
 		"session_id": claimed.ID.String(),
 		"org_id":     pr.OrgID.String(),
 	}
-	if _, err := s.jobs.EnqueueInTx(ctx, tx, pr.OrgID, "agent", "continue_session", payload, 5, nil); err != nil {
+	if _, err := s.jobs.EnqueueInTx(ctx, tx, pr.OrgID, "agent", "continue_session", payload, 5, &continueDedupeKey); err != nil {
 		return nil, err
 	}
 	repairRun := &models.PullRequestRepairRun{
@@ -671,11 +672,12 @@ func (s *PRService) createRepairRevisionSession(ctx context.Context, pr models.P
 	if err := txMessages.Create(ctx, msg); err != nil {
 		return nil, err
 	}
+	dedupeKey := db.RunAgentDedupeKey(session.ID)
 	payload := map[string]string{
 		"session_id": session.ID.String(),
 		"org_id":     session.OrgID.String(),
 	}
-	if _, err := s.jobs.EnqueueInTx(ctx, tx, session.OrgID, "agent", "run_agent", payload, 5, nil); err != nil {
+	if _, err := s.jobs.EnqueueInTx(ctx, tx, session.OrgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return nil, err
 	}
 	repairRun := &models.PullRequestRepairRun{

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -959,7 +959,7 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 						"job_type":   "run_agent",
 						"payload":    pgxmock.AnyArg(),
 						"priority":   5,
-						"dedupe_key": (*string)(nil),
+						"dedupe_key": pgxmock.AnyArg(),
 					}).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 				mock.ExpectQuery("INSERT INTO pull_request_repair_runs").
@@ -1008,7 +1008,7 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 						"job_type":   "continue_session",
 						"payload":    pgxmock.AnyArg(),
 						"priority":   5,
-						"dedupe_key": (*string)(nil),
+						"dedupe_key": pgxmock.AnyArg(),
 					}).
 					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 				mock.ExpectQuery("INSERT INTO pull_request_repair_runs").

--- a/internal/services/pm/execute.go
+++ b/internal/services/pm/execute.go
@@ -3,6 +3,7 @@ package pm
 import (
 	"context"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 )
@@ -84,11 +85,12 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 			}
 		}
 
+		dedupeKey := db.RunAgentDedupeKey(run.ID)
 		payload := map[string]string{
 			"session_id": run.ID.String(),
 			"org_id":     orgID.String(),
 		}
-		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 			s.logger.Error().Err(err).Str("session_id", run.ID.String()).Msg("failed to enqueue agent run job")
 			task.Status = models.PMTaskStatusSkippedCapacity
 			continue

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -245,11 +245,12 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 		}
 
 		// Enqueue the agent run job.
+		dedupeKey := db.RunAgentDedupeKey(run.ID)
 		payload := map[string]string{
 			"session_id": run.ID.String(),
 			"org_id":     orgID.String(),
 		}
-		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, nil); err != nil {
+		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 			s.logger.Error().Err(err).Str("session_id", run.ID.String()).Msg("failed to enqueue project agent run")
 			continue
 		}

--- a/internal/services/prioritization/service.go
+++ b/internal/services/prioritization/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/db"
 	llmpkg "github.com/assembledhq/143/internal/llm"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/prompts"
@@ -347,7 +348,7 @@ func (s *Service) CheckAutoTrigger(ctx context.Context, orgID uuid.UUID, score *
 		"session_id": run.ID.String(),
 		"org_id":     orgID.String(),
 	}
-	dedupeKey := fmt.Sprintf("run_agent:%s", run.ID.String())
+	dedupeKey := db.RunAgentDedupeKey(run.ID)
 	if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return fmt.Errorf("enqueue run_agent job: %w", err)
 	}

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -281,13 +281,16 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*mod
 	// Reuse the session continuation worker for phase 1. The latest user
 	// message carries thread_id, so the orchestrator attributes assistant
 	// messages and streamed logs back to this tab while still operating on the
-	// single shared sandbox.
+	// single shared sandbox. Dedupe at the session level — only one
+	// continue_session can hold the shared sandbox at a time, regardless of
+	// which thread fired it.
+	dedupeKey := db.ContinueSessionDedupeKey(thread.SessionID)
 	payload := map[string]string{
 		"session_id": thread.SessionID.String(),
 		"thread_id":  input.ThreadID.String(),
 		"org_id":     input.OrgID.String(),
 	}
-	if _, err := s.jobStore.Enqueue(ctx, input.OrgID, "agent", "continue_session", payload, 5, nil); err != nil {
+	if _, err := s.jobStore.Enqueue(ctx, input.OrgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
 		if revertErr := s.sessionStore.UpdateStatus(ctx, input.OrgID, input.SessionID, string(models.SessionStatusIdle)); revertErr != nil {
 			s.logger.Error().Err(revertErr).Str("session_id", input.SessionID.String()).Msg("failed to revert session to idle after thread enqueue failure")
 		}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -529,7 +529,7 @@ func newAutomationRunHandler(stores *Stores, services *Services, logger zerolog.
 		// transition above somehow returned true twice — defense in depth),
 		// the job store rejects the second insert and the second handler
 		// returns cleanly without a duplicate agent run.
-		dedupeKey := fmt.Sprintf("run_agent:%s", session.ID.String())
+		dedupeKey := db.RunAgentDedupeKey(session.ID)
 		agentPayload := map[string]string{
 			"session_id": session.ID.String(),
 			"org_id":     orgID.String(),
@@ -909,6 +909,31 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 			runErr = services.Orchestrator.RunAgent(jobCtx, &run)
 		}
 		if err := runErr; err != nil {
+			if errors.Is(err, agent.ErrStaleSandboxIDCleared) {
+				// The orchestrator detected a stale orphan container_id from
+				// a crashed prior worker, CAS-cleared it, and signaled retry.
+				// Requeue without consuming an attempt — the next attempt
+				// sees a clean row and creates a fresh sandbox. A short
+				// backoff lets any in-flight cleanup settle.
+				retryAfter := 2 * time.Second
+				logger.Info().
+					Str("session_id", runID.String()).
+					Err(err).
+					Msg("run_agent cleared stale orphan container_id; retrying against the clean row")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
+			if errors.Is(err, agent.ErrSandboxRaceLoser) {
+				// A duplicate run_agent job lost the AcquireTurnHold race to
+				// the winner that owns the session row. The winner will
+				// publish the authoritative result; this duplicate must
+				// dead-letter immediately (every retry would lose the same
+				// race) without surfacing a user-visible failure.
+				logger.Info().
+					Str("session_id", runID.String()).
+					Err(err).
+					Msg("duplicate run_agent job lost sandbox-hold race; dead-lettering silently — winner retains the session row")
+				return &FatalError{Err: err}
+			}
 			if errors.Is(err, agent.ErrConcurrencyLimit) {
 				// If the session has been pending for too long, fail it
 				// instead of retrying indefinitely.
@@ -1020,6 +1045,29 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 			// attempt. The session row is unchanged at this point.
 			if errors.Is(err, agent.ErrSnapshotPending) {
 				return &RetryableError{Err: err}
+			}
+			if errors.Is(err, agent.ErrStaleSandboxIDCleared) {
+				// Stale orphan container_id cleared; retry against the clean
+				// row. See newRunAgentHandler for full rationale.
+				retryAfter := 2 * time.Second
+				logger.Info().
+					Str("session_id", sessionID.String()).
+					Err(err).
+					Msg("continue_session cleared stale orphan container_id; retrying against the clean row")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
+			if errors.Is(err, agent.ErrSandboxRaceLoser) {
+				// A duplicate continue_session job lost the AcquireTurnHold
+				// race to the winner. Dead-letter immediately without
+				// retries (every retry would lose the same race) and
+				// without touching the session row — the winner owns it.
+				// The thread is left as the orchestrator left it; the
+				// winner's success/failure path will release it.
+				logger.Info().
+					Str("session_id", sessionID.String()).
+					Err(err).
+					Msg("duplicate continue_session job lost sandbox-hold race; dead-lettering silently — winner retains the session row")
+				return &FatalError{Err: err}
 			}
 			if hasThread {
 				if statusErr := stores.SessionThreads.UpdateStatus(ctx, orgID, threadID, models.ThreadStatusIdle); statusErr != nil {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -922,6 +922,17 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 					Msg("run_agent cleared stale orphan container_id; retrying against the clean row")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter}
 			}
+			if errors.Is(err, agent.ErrSandboxPreviewRace) {
+				// A preview hydrate published the live container first. There is
+				// no winning agent job to publish a terminal result, so retry
+				// after the orchestrator reverted the session back to pending.
+				retryAfter := 2 * time.Second
+				logger.Info().
+					Str("session_id", runID.String()).
+					Err(err).
+					Msg("run_agent lost sandbox publish race to preview; retrying against session state")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
 			if errors.Is(err, agent.ErrSandboxRaceLoser) {
 				// A duplicate run_agent job lost the AcquireTurnHold race to
 				// the winner that owns the session row. The winner will
@@ -1054,6 +1065,17 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Str("session_id", sessionID.String()).
 					Err(err).
 					Msg("continue_session cleared stale orphan container_id; retrying against the clean row")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
+			if errors.Is(err, agent.ErrSandboxPreviewRace) {
+				// A preview hydrate published the live container first. Retry
+				// so the next attempt fetches the updated session row and
+				// attaches to that preview-held container via the reuse path.
+				retryAfter := 2 * time.Second
+				logger.Info().
+					Str("session_id", sessionID.String()).
+					Err(err).
+					Msg("continue_session lost sandbox publish race to preview; retrying against the preview container")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter}
 			}
 			if errors.Is(err, agent.ErrSandboxRaceLoser) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -3850,6 +3851,93 @@ func TestRunAgentHandler_PropagatesRunErrors(t *testing.T) {
 	require.Error(t, err, "run_agent should propagate orchestrator failures")
 	require.Contains(t, err.Error(), "execute failed", "run_agent should preserve the orchestrator error")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+// TestRunAgentHandler_StaleSandboxIDClearedRetries locks the recovery
+// contract for the stale-orphan path: when the orchestrator returns
+// ErrStaleSandboxIDCleared (the "winning" container_id was a stale orphan
+// from a crashed prior worker, now CAS-cleared), the handler must requeue
+// via RetryableError so the next attempt re-enters against the clean row.
+// Crucially, this must NOT consume an attempt counter and must NOT mutate
+// the session row.
+func TestRunAgentHandler_StaleSandboxIDClearedRetries(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(runID, issueID, orgID, string(models.SessionStatusPending), 0, nil, nil)...,
+			),
+		)
+	// No UPDATE expectations: the orchestrator clears container_id internally
+	// via ClearContainerID, but the handler itself must not touch the row.
+
+	orch := &orchestratorServiceStub{
+		runAgentFn: func(ctx context.Context, run *models.Session) error {
+			return fmt.Errorf("stale orphan: %w", agent.ErrStaleSandboxIDCleared)
+		},
+	}
+	handler := newRunAgentHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(context.Background(), "run_agent", payload)
+	require.Error(t, err, "run_agent must return an error so the queue requeues the job")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "ErrStaleSandboxIDCleared must surface as a RetryableError so the attempt counter isn't consumed")
+	require.NotNil(t, retryable.RetryAfter, "RetryAfter must be set so the requeue uses a deliberate backoff, not the queue default")
+	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared, "handler must preserve the underlying sentinel for telemetry")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met (handler must not mutate the row)")
+}
+
+// TestRunAgentHandler_SandboxRaceLoserDeadLetters locks the self-heal contract
+// for duplicate run_agent jobs: when the orchestrator returns
+// ErrSandboxRaceLoser (this duplicate lost AcquireTurnHold to a winner that
+// owns the session row), the handler must dead-letter the job via FatalError
+// without retries and without touching the session row — the winner will
+// publish the authoritative result.
+func TestRunAgentHandler_SandboxRaceLoserDeadLetters(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(runID, issueID, orgID, string(models.SessionStatusPending), 0, nil, nil)...,
+			),
+		)
+	// Deliberately register no UPDATE expectations: the loser must not write
+	// to the session row. pgxmock's strict matching will fail the test if the
+	// handler issues any unexpected query.
+
+	orch := &orchestratorServiceStub{
+		runAgentFn: func(ctx context.Context, run *models.Session) error {
+			return fmt.Errorf("loser: %w", agent.ErrSandboxRaceLoser)
+		},
+	}
+	handler := newRunAgentHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(context.Background(), "run_agent", payload)
+	require.Error(t, err, "run_agent must surface a fatal error when it lost the AcquireTurnHold race")
+	var fatal *FatalError
+	require.ErrorAs(t, err, &fatal, "ErrSandboxRaceLoser must dead-letter the duplicate job")
+	require.ErrorIs(t, err, agent.ErrSandboxRaceLoser, "handler must preserve the underlying race-loser error for telemetry")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met (loser must not mutate the row)")
 }
 
 func TestContinueSessionHandler_UsesRuntimeCeilingDeadline(t *testing.T) {

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -4022,6 +4022,42 @@ func TestContinueSessionHandler_WrapsSnapshotPendingAsRetryable(t *testing.T) {
 	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should call the orchestrator once before bailing")
 }
 
+func TestContinueSessionHandler_WrapsPreviewRaceAsRetryable(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, string(models.SessionStatusIdle), 2, nil, nil)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			return fmt.Errorf("preview published first: %w", agent.ErrSandboxPreviewRace)
+		},
+	}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+
+	err := handler(context.Background(), "continue_session", payload)
+	require.Error(t, err, "continue_session should propagate the preview race signal")
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "ErrSandboxPreviewRace must be wrapped as RetryableError so the worker retries against the preview container")
+	require.NotNil(t, retryable.RetryAfter, "preview race retries should use a short deliberate backoff")
+	require.ErrorIs(t, retryable.Err, agent.ErrSandboxPreviewRace, "the wrapped error must preserve the ErrSandboxPreviewRace sentinel")
+	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should call the orchestrator once before returning the retry")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes the "sandbox race: another holder attached first, please retry" failure that surfaced in production at session `f996f0e1-…`. Root cause: `RetrySession` (and other run_agent enqueue paths) passed `dedupe_key=NULL`, so a user-clicked Retry could land a second `run_agent` job alongside an in-flight original. Both reached `AcquireTurnHold`, the loser called `failRun`, and the session was marked failed even though the winner ultimately succeeded.

## Changes

- **Dedupe keys on every `run_agent` and `continue_session` enqueue** via new `db.RunAgentDedupeKey` / `db.ContinueSessionDedupeKey` helpers. The partial unique index on `(queue, dedupe_key) WHERE status IN ('pending','running')` collapses concurrent enqueues; terminal-status rows still allow legitimate retries.
- **Self-heal in the orchestrator's race-loss path.** `RunAgent` and `ContinueSession` now diagnose the "winning" `container_id`: a live winner returns `ErrSandboxRaceLoser` (worker dead-letters silently via `FatalError`, no row mutation), while a dead winner is a stale orphan from a crashed prior worker — the orchestrator CAS-clears it via `ClearContainerID` and returns `ErrStaleSandboxIDCleared` so the worker requeues against the clean row with a 2s backoff. Conservative fallback to `ErrSandboxRaceLoser` on probe / clear errors so a transient docker hiccup can't kill an active turn.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] New unit tests cover live-winner, stale-orphan, IsAlive-error fallback, and CAS-lost branches for both `RunAgent` and `ContinueSession`
- [x] Worker handler tests verify `ErrSandboxRaceLoser → FatalError` and `ErrStaleSandboxIDCleared → RetryableError{RetryAfter: 2s}` translations, with pgxmock strict-matching proving the loser issues no row writes
- [x] Integration test `TestIntegration_RetrySession_ResetsAndReenqueues` strengthened to assert `dedupe_key = "run_agent:<sessionID>"` so the prod incident cannot recur silently
- [ ] Manual verification post-deploy: confirm no new "sandbox race" surfacing on retried sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)