### PR TITLE
[codex] fix preview service shutdown

### DIFF
--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -28,8 +28,12 @@ export GOCACHE
 mkdir -p "$GOCACHE"
 
 echo '[143-preview] building binaries...'
-go build -o /tmp/143-migrate ./cmd/migrate
-go build -o /tmp/143-server ./cmd/server
+# Merge stderr into stdout so `go build` compile errors are captured by the
+# preview executor's output tail and surfaced in the launch error. Without
+# this, the executor discards stderr (see docker_preview.go) and the user
+# only sees the "building binaries..." line followed by "exited with code 1".
+go build -o /tmp/143-migrate ./cmd/migrate 2>&1
+go build -o /tmp/143-server ./cmd/server 2>&1
 
 echo '[143-preview] running migrations...'
 /tmp/143-migrate up

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -896,6 +896,26 @@ func (d *DockerProvider) ExecStream(ctx context.Context, sb *agent.Sandbox, cmd 
 	}
 	defer attachResp.Close()
 
+	// StdCopy reads from a hijacked TCP connection that does NOT observe
+	// ctx cancellation — once the connection is upgraded, the docker client
+	// detaches it from the http transport's normal cancellation. Without
+	// this watcher a long-running command (a preview service like
+	// `npm run dev`, an interactive shell, anything that does not exit on
+	// its own) blocks here forever after the caller cancels, deadlocking
+	// preview StopPreview at state.wg.Wait() and stranding the sandbox.
+	// Closing the hijacked connection from under StdCopy unblocks it with
+	// a read error; the caller can disambiguate via ctx.Err().
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			// Close is idempotent with the deferred Close above.
+			attachResp.Close()
+		case <-done:
+		}
+	}()
+
 	// Use StdCopy with a line-splitting writer for stdout so onLine is
 	// called for each complete line as it arrives from Docker's stream.
 	lineWriter := &lineSplitter{onLine: onLine}

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1741,4 +1742,112 @@ func TestRedactToken(t *testing.T) {
 		redactToken("fatal: ghp_secret@github.com/org/repo.git not found", "ghp_secret"))
 	require.Equal(t, "fatal: repo not found",
 		redactToken("fatal: repo not found", ""))
+}
+
+// blockingHijackedConn is a net.Conn whose Read blocks until Close is called,
+// modeling a hijacked exec connection for a long-running process (e.g. a
+// preview service like `npm run dev`) that never produces output and never
+// EOFs on its own. Closing the connection unblocks the read with EOF — the
+// same shape the docker daemon presents when the underlying exec is killed.
+type blockingHijackedConn struct {
+	pr        *io.PipeReader
+	pw        *io.PipeWriter
+	closeOnce sync.Once
+}
+
+func newBlockingHijackedConn() *blockingHijackedConn {
+	pr, pw := io.Pipe()
+	return &blockingHijackedConn{pr: pr, pw: pw}
+}
+
+func (c *blockingHijackedConn) Read(p []byte) (int, error)  { return c.pr.Read(p) }
+func (c *blockingHijackedConn) Write(p []byte) (int, error) { return len(p), nil }
+func (c *blockingHijackedConn) Close() error {
+	c.closeOnce.Do(func() {
+		_ = c.pw.Close()
+		_ = c.pr.Close()
+	})
+	return nil
+}
+func (c *blockingHijackedConn) LocalAddr() net.Addr                { return nil }
+func (c *blockingHijackedConn) RemoteAddr() net.Addr               { return nil }
+func (c *blockingHijackedConn) SetDeadline(t time.Time) error      { return nil }
+func (c *blockingHijackedConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c *blockingHijackedConn) SetWriteDeadline(t time.Time) error { return nil }
+
+// TestDockerProvider_ExecStream_CancelUnblocksHijackedRead verifies that
+// canceling the context unblocks ExecStream when StdCopy is reading from a
+// hijacked connection that would otherwise never EOF.
+//
+// Regression: pre-fix, ExecStream blocked indefinitely on the hijacked read
+// because stdcopy.StdCopy reads from a raw net.Conn that doesn't observe
+// ctx cancellation. That deadlocked preview StopPreview's state.wg.Wait()
+// and stranded sandboxes for ~15 minutes — until the cleanup worker's idle
+// pass eventually destroyed the container, killing the exec process and
+// closing the hijacked connection from the daemon side.
+//
+// The fix spawns a watcher goroutine inside ExecStream that closes the
+// hijacked connection when ctx is canceled, unblocking StdCopy promptly.
+func TestDockerProvider_ExecStream_CancelUnblocksHijackedRead(t *testing.T) {
+	t.Parallel()
+
+	conn := newBlockingHijackedConn()
+	defer conn.Close()
+
+	mock := &mockDockerClient{}
+	mock.containerExecAttachFn = func(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+		return types.HijackedResponse{
+			Conn:   conn,
+			Reader: bufio.NewReader(conn),
+		}, nil
+	}
+	// Have ExecInspect honor ctx so the post-StdCopy inspect surfaces the
+	// cancellation if StdCopy returned a clean EOF (the io.Pipe shape).
+	mock.containerExecInspectFn = func(ctx context.Context, _ string) (container.ExecInspect, error) {
+		if err := ctx.Err(); err != nil {
+			return container.ExecInspect{}, err
+		}
+		return container.ExecInspect{ExitCode: 0}, nil
+	}
+
+	p := NewDockerProvider(mock, newTestLogger())
+	sb := &agent.Sandbox{ID: "test-container", Provider: "docker", WorkDir: "/workspace"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	type result struct {
+		exitCode int
+		err      error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		ec, err := p.ExecStream(ctx, sb, "long-running-service", func([]byte) {}, io.Discard)
+		resultCh <- result{ec, err}
+	}()
+
+	// Give the goroutine time to enter StdCopy on the hijacked read. If we
+	// race ahead of it, canceling ctx before the watcher is registered would
+	// still unblock the read on the next Close — but we want to exercise the
+	// realistic ordering where StdCopy is already blocked.
+	time.Sleep(50 * time.Millisecond)
+
+	// Sanity: ExecStream should still be running. Pre-fix this would also
+	// pass — the bug is in cancellation, not initial blocking.
+	select {
+	case r := <-resultCh:
+		t.Fatalf("ExecStream returned before ctx was canceled: exitCode=%d err=%v", r.exitCode, r.err)
+	default:
+	}
+
+	cancel()
+
+	select {
+	case r := <-resultCh:
+		// Either StdCopy errored ("read exec output: ...") or ExecInspect
+		// observed the canceled ctx ("inspect exec: context canceled"). Both
+		// shapes are acceptable; what matters is that ExecStream returned.
+		require.Error(t, r.err, "expected ExecStream to surface an error after ctx cancel")
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExecStream did not return within 2s after ctx cancel — the hijacked read was not unblocked")
+	}
 }

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -388,6 +388,7 @@ func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) 
 
 	// Cancel all service goroutines and wait for background work to finish.
 	state.cancelFn()
+	d.terminateServiceProcesses(state)
 	state.wg.Wait()
 
 	// Tear down infrastructure containers.
@@ -408,6 +409,75 @@ func (d *DockerPreviewProvider) StopPreview(ctx context.Context, handle string) 
 	d.mu.Unlock()
 
 	return nil
+}
+
+const serviceTerminateTimeout = 5 * time.Second
+
+type serviceProcessTarget struct {
+	name string
+	pid  int
+	port int
+}
+
+func (d *DockerPreviewProvider) terminateServiceProcesses(state *previewState) {
+	if d.executor == nil || state.sandbox == nil {
+		return
+	}
+
+	d.mu.RLock()
+	targets := make([]serviceProcessTarget, 0, len(state.services))
+	for name, ss := range state.services {
+		targets = append(targets, serviceProcessTarget{
+			name: name,
+			pid:  ss.pid,
+			port: ss.port,
+		})
+	}
+	d.mu.RUnlock()
+	sort.Slice(targets, func(i, j int) bool {
+		return targets[i].name < targets[j].name
+	})
+
+	for _, target := range targets {
+		if target.pid <= 0 && target.port <= 0 {
+			continue
+		}
+
+		termCtx, cancel := context.WithTimeout(context.Background(), serviceTerminateTimeout)
+		var stderr bytes.Buffer
+		exitCode, err := d.executor.Exec(termCtx, state.sandbox, buildTerminateServiceProcessCmd(target.pid, target.port), io.Discard, &stderr)
+		cancel()
+		if err != nil {
+			d.logger.Warn().Err(err).Str("service", target.name).Msg("failed to terminate preview service process")
+			continue
+		}
+		if exitCode != 0 {
+			d.logger.Warn().
+				Str("service", target.name).
+				Int("exit_code", exitCode).
+				Str("stderr", strings.TrimSpace(stderr.String())).
+				Msg("preview service process termination command exited non-zero")
+		}
+	}
+}
+
+func buildTerminateServiceProcessCmd(pid, port int) string {
+	var explicitPID string
+	if pid > 0 {
+		explicitPID = fmt.Sprintf("printf '%%s\\n' %d", pid)
+	} else {
+		explicitPID = ":"
+	}
+
+	var portPIDs string
+	if port > 0 {
+		portPIDs = fmt.Sprintf("if command -v lsof >/dev/null 2>&1; then lsof -ti :%d 2>/dev/null || true; fi", port)
+	} else {
+		portPIDs = ":"
+	}
+
+	collectPIDs := fmt.Sprintf("{ %s; %s; } | awk 'NF && !seen[$1]++'", explicitPID, portPIDs)
+	return fmt.Sprintf(`pids="$(%s)"; if [ -n "$pids" ]; then kill $pids 2>/dev/null || true; sleep 1; kill -9 $pids 2>/dev/null || true; fi`, collectPIDs)
 }
 
 // =============================================================================
@@ -1012,23 +1082,40 @@ func (d *DockerPreviewProvider) startService(
 			}
 		}()
 
-		exitCode, err := d.executor.ExecStream(svcCtx, state.sandbox, cmd, func(line []byte) {
-			// Append to the per-service ring buffer so we can replay the tail
-			// to the observer when the service fails. We copy the bytes
-			// because ExecStream reuses the slice across calls.
-			s := string(line)
+		// appendTail records one line into the per-service ring buffer so we
+		// can replay it to the observer when the service fails. The closure
+		// is shared by stdout and stderr so a process that only logs errors
+		// to stderr (every Go binary using log.Print, every `go build` error)
+		// still surfaces a useful tail instead of an empty buffer.
+		appendTail := func(line string) {
 			d.mu.Lock()
 			if len(ss.outputTail) >= serviceTailLines {
 				ss.outputTail = ss.outputTail[1:]
 			}
-			ss.outputTail = append(ss.outputTail, s)
+			ss.outputTail = append(ss.outputTail, line)
 			d.mu.Unlock()
-			d.logger.Debug().Str("service", name).Str("output", s).Msg("service output")
-		}, io.Discard)
+			d.logger.Debug().Str("service", name).Str("output", line).Msg("service output")
+		}
+		stderrSplitter := &previewLineSplitter{onLine: func(line []byte) {
+			appendTail(string(line))
+		}}
+		exitCode, err := d.executor.ExecStream(svcCtx, state.sandbox, cmd, func(line []byte) {
+			// Copy the bytes because ExecStream reuses the slice across calls.
+			appendTail(string(line))
+		}, stderrSplitter)
+		stderrSplitter.flush()
 
 		d.mu.Lock()
 		var tail []string
-		failed := err != nil || exitCode != 0
+		// If svcCtx was canceled, the service was torn down intentionally
+		// (StopPreview, or readiness-failure cleanup tearing down siblings).
+		// ExecStream's hijacked-connection watcher closes the read mid-stream
+		// in that case and returns a "read exec output" error, but that's the
+		// expected shape of an intentional stop — not a real service failure.
+		// Without this check, a healthy service torn down during cleanup would
+		// be reported to observers as Failed instead of Stopped.
+		stoppedByCancel := svcCtx.Err() != nil && err != nil
+		failed := !stoppedByCancel && (err != nil || exitCode != 0)
 		if failed {
 			ss.status = models.PreviewServiceStatusFailed
 			if err != nil {
@@ -1272,6 +1359,38 @@ func generateHandle() (string, error) {
 
 func shellEscape(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
+// previewLineSplitter is an io.Writer that calls onLine for each newline-
+// delimited line written to it. Used as the stderr sink for ExecStream so
+// stderr is fed into the same per-service ring buffer as stdout. The trailing
+// flush() drains a partial final line that wasn't terminated by '\n' (a
+// common shape for `go build` errors and panic stacks that exit without a
+// newline) so it isn't silently lost.
+type previewLineSplitter struct {
+	onLine func(line []byte)
+	buf    bytes.Buffer
+}
+
+func (l *previewLineSplitter) Write(p []byte) (int, error) {
+	n := len(p)
+	l.buf.Write(p)
+	for {
+		line, err := l.buf.ReadBytes('\n')
+		if err != nil {
+			l.buf.Write(line)
+			break
+		}
+		l.onLine(bytes.TrimRight(line, "\n"))
+	}
+	return n, nil
+}
+
+func (l *previewLineSplitter) flush() {
+	if l.buf.Len() > 0 {
+		l.onLine(l.buf.Bytes())
+		l.buf.Reset()
+	}
 }
 
 // tcpPreviewStream wraps a net.Conn as a PreviewStream.

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -686,6 +686,33 @@ func (f *fakeServiceExecutor) ReadFile(_ context.Context, _ *agent.Sandbox, _ st
 	return nil, nil
 }
 
+type recordingStopExecutor struct {
+	mu        sync.Mutex
+	execCalls []string
+}
+
+func (r *recordingStopExecutor) ExecStream(ctx context.Context, _ *agent.Sandbox, _ string, _ func(line []byte), _ io.Writer) (int, error) {
+	<-ctx.Done()
+	return -1, ctx.Err()
+}
+
+func (r *recordingStopExecutor) Exec(_ context.Context, _ *agent.Sandbox, cmd string, _, _ io.Writer) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.execCalls = append(r.execCalls, cmd)
+	return 0, nil
+}
+
+func (r *recordingStopExecutor) ReadFile(_ context.Context, _ *agent.Sandbox, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+func (r *recordingStopExecutor) calls() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.execCalls...)
+}
+
 // TestNotifyService_NilSafe verifies the helper functions tolerate a nil
 // observer — providers must work both when StartPreview is called from the
 // manager (with an observer) and when it's called from a context that
@@ -1110,6 +1137,47 @@ func TestStartPreview_NilObserver_DoesNotPanic(t *testing.T) {
 
 	close(release)
 	require.NoError(t, d.StopPreview(context.Background(), handle.Handle))
+}
+
+func TestStopPreview_TerminatesServiceProcessesBeforeCleanup(t *testing.T) {
+	t.Parallel()
+
+	exec := &recordingStopExecutor{}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	handle := "preview-stop-test"
+	cancelled := make(chan struct{})
+	d.previews[handle] = &previewState{
+		handle:   handle,
+		sandbox:  &agent.Sandbox{ID: "sb"},
+		infra:    map[string]*preview.InfraHandle{},
+		services: map[string]*serviceState{},
+		cancelFn: func() { close(cancelled) },
+	}
+	d.previews[handle].services["web"] = &serviceState{
+		name:   "web",
+		pid:    4242,
+		port:   3000,
+		status: models.PreviewServiceStatusReady,
+	}
+	d.previews[handle].services["worker"] = &serviceState{
+		name:   "worker",
+		port:   9000,
+		status: models.PreviewServiceStatusReady,
+	}
+
+	err := d.StopPreview(context.Background(), handle)
+
+	require.NoError(t, err, "StopPreview should complete service cleanup")
+	select {
+	case <-cancelled:
+	default:
+		require.Fail(t, "StopPreview should cancel service goroutines before cleanup")
+	}
+	calls := exec.calls()
+	require.Len(t, calls, 2, "StopPreview should issue one termination command per service")
+	require.Contains(t, strings.Join(calls, "\n"), "4242", "termination command should target the recorded service PID")
+	require.Contains(t, strings.Join(calls, "\n"), ":3000", "termination command should target the ready service port")
+	require.Contains(t, strings.Join(calls, "\n"), ":9000", "termination command should still use the port when PID detection has not populated")
 }
 
 // TestWaitForReadiness_FailsFastWhenServiceExited verifies that the readiness


### PR DESCRIPTION
Fixes preview shutdown by making Docker exec streams unblock on context cancellation and by explicitly terminating service PIDs/listening ports during StopPreview.

It also captures stderr in preview service tails, so build/runtime failures surface actionable diagnostics instead of only an exit code.

The root cause was Docker hijacked exec reads ignoring ctx cancellation, leaving StopPreview waiting and sometimes leaving long-running preview processes alive.

Validated with `go vet ./...`, `go build ./...`, and `go test ./...`.
