### PR TITLE
Fix PM-spawned sessions writing wrong autonomy_level enum

### DIFF
--- a/internal/services/pm/execute.go
+++ b/internal/services/pm/execute.go
@@ -60,12 +60,16 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 			repoID = primaryIssue.RepositoryID
 		}
 
+		// Session.autonomy_level is a per-run knob (full|semi|supervised),
+		// not the org-level automation policy (manual|auto_simple|auto_all).
+		// Default PM-spawned runs to "semi", matching the API session-create
+		// default in internal/api/handlers/sessions.go.
 		run := &models.Session{
 			PrimaryIssueID: &primaryIssueID,
 			OrgID:          orgID,
 			AgentType:      agentType,
 			Status:         "pending",
-			AutonomyLevel:  string(settings.AutonomyLevel),
+			AutonomyLevel:  "semi",
 			TokenMode:      tokenModeFromComplexity(task.Complexity),
 			PMPlanID:       &plan.ID,
 			Title:          &task.Title,

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -214,12 +214,14 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 			reasoning = *task.Reasoning
 		}
 
+		// See note in executePlan: this column is the per-session knob
+		// (full|semi|supervised), not the org-level automation policy.
 		run := &models.Session{
 			OrgID:          orgID,
 			PrimaryIssueID: task.IssueID,
 			AgentType:      agentType,
 			Status:         string(models.SessionStatusPending),
-			AutonomyLevel:  string(settings.AutonomyLevel),
+			AutonomyLevel:  "semi",
 			TokenMode:      tokenModeFromTaskComplexity(task.Complexity),
 			PMPlanID:       &planID,
 			Title:          &task.Title,


### PR DESCRIPTION
## Summary
- PM auto-create paths in `executePlan` and `dispatchProjectTasks` were writing the org-level automation policy (`manual` / `auto_simple` / `auto_all`) into `sessions.autonomy_level`, which is a different enum (`full` / `semi` / `supervised`) enforced by `chk_sessions_autonomy_level`.
- Every PM-driven session insert in `auto_*` mode hit `SQLSTATE 23514` (seen in production logs as `failed to create agent run from PM plan`); `manual` orgs dodged it because they bail out before the insert.
- Default PM-spawned sessions to `"semi"` to match the API session-create default at `internal/api/handlers/sessions.go:793`.

## Test plan
- [x] `go build ./internal/services/pm/...`
- [x] `go test ./internal/services/pm/...`
- [x] `make lint`
- [ ] Confirm in prod logs that `chk_sessions_autonomy_level` violations stop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)