### PR TITLE
Drop broad NOPASSWD sudo from cloud-init (defer to bootstrap.sh)

### DIFF
--- a/deploy/cloud-init/app.yml
+++ b/deploy/cloud-init/app.yml
@@ -20,7 +20,9 @@ users:
   - name: deploy
     groups: docker
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    # No sudo here — narrow NOPASSWD grant is installed by deploy/scripts/bootstrap.sh
+    # on the first `make provision-<role>` run. Cloud-init's runcmd doesn't need
+    # sudo (it runs as root and uses `su - deploy -c ...` for deploy-owned steps).
     ssh_authorized_keys:
       - ${SSH_PUBLIC_KEY}
 

--- a/deploy/cloud-init/db.yml
+++ b/deploy/cloud-init/db.yml
@@ -7,7 +7,9 @@ users:
   - name: deploy
     groups: docker
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    # No sudo here — narrow NOPASSWD grant is installed by deploy/scripts/bootstrap.sh
+    # on the first `make provision-<role>` run. Cloud-init's runcmd doesn't need
+    # sudo (it runs as root and uses `su - deploy -c ...` for deploy-owned steps).
     ssh_authorized_keys:
       - ${SSH_PUBLIC_KEY}
 

--- a/deploy/cloud-init/logging.yml
+++ b/deploy/cloud-init/logging.yml
@@ -15,7 +15,9 @@ users:
   - name: deploy
     groups: docker
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    # No sudo here — narrow NOPASSWD grant is installed by deploy/scripts/bootstrap.sh
+    # on the first `make provision-<role>` run. Cloud-init's runcmd doesn't need
+    # sudo (it runs as root and uses `su - deploy -c ...` for deploy-owned steps).
     ssh_authorized_keys:
       - ${SSH_PUBLIC_KEY}
 

--- a/deploy/cloud-init/redis.yml
+++ b/deploy/cloud-init/redis.yml
@@ -4,7 +4,9 @@ users:
   - name: deploy
     groups: docker
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    # No sudo here — narrow NOPASSWD grant is installed by deploy/scripts/bootstrap.sh
+    # on the first `make provision-<role>` run. Cloud-init's runcmd doesn't need
+    # sudo (it runs as root and uses `su - deploy -c ...` for deploy-owned steps).
     ssh_authorized_keys:
       - ${SSH_PUBLIC_KEY}
 

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -29,7 +29,9 @@ users:
   - name: deploy
     groups: docker
     shell: /bin/bash
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    # No sudo here — narrow NOPASSWD grant is installed by deploy/scripts/bootstrap.sh
+    # on the first `make provision-<role>` run. Cloud-init's runcmd doesn't need
+    # sudo (it runs as root and uses `su - deploy -c ...` for deploy-owned steps).
     ssh_authorized_keys:
       - ${SSH_PUBLIC_KEY}
 


### PR DESCRIPTION
## Summary
Removes the broad `sudo: ALL=(ALL) NOPASSWD:ALL` grant from the `deploy` user in all five cloud-init configs (`app`, `worker`, `db`, `logging`, `redis`), closing the follow-up gap noted in #728. The narrow `Cmnd_Alias`-based sudoers rule that #728 added to `bootstrap.sh` is now the single source of truth — no inline duplication across the cloud-init files.

## Why this works
- Cloud-init's `runcmd` blocks already run as root and use `su - deploy -c '...'` for any deploy-owned steps, so they never invoke `sudo` themselves.
- Every fresh box gets `make provision-<role>` immediately after cloud-init, which pipes `bootstrap.sh` over SSH as step 1/5. That script writes `/etc/sudoers.d/99-deploy` with the narrow alias before `deploy.sh` ever invokes `sudo`.
- Net result: between cloud-init finishing and the first provision run, the `deploy` user has no sudo at all (strictly safer than `NOPASSWD:ALL`); after provision, it has the same narrow grant established in #728.

## Test plan
- [ ] `make provision-worker HOST=<new-ip> WORKER_PRIVATE_IP=<priv-ip>` on a freshly cloud-init-bootstrapped box and confirm `make deploy-worker HOST=<new-ip>` succeeds end-to-end with no manual sudoers fixup.
- [ ] On the same fresh box (post-provision), `sudo -l -U deploy` lists only `DEPLOY_CMDS`, and `sudo bash` / `sudo cat /etc/shadow` are denied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
