### PR TITLE
Show coding-agent labels on /settings/account and drop the resolution-line footer

### DIFF
--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -17,7 +17,7 @@ function emptyCodingCredentialsHandlers() {
 }
 
 describe("Account settings page", () => {
-  it("renders the personal stack and surfaces the effective resolution line", async () => {
+  it("renders the personal stack alongside the org fallback", async () => {
     server.use(
       http.get("/api/v1/coding-credentials", ({ request }) => {
         const scope = new URL(request.url).searchParams.get("scope");
@@ -97,14 +97,14 @@ describe("Account settings page", () => {
 
     expect(screen.getByText("My settings")).toBeInTheDocument();
     expect(await screen.findByText("My coding agents")).toBeInTheDocument();
+    // Both the user-set label and the auto-generated usage note render so
+    // multiple rows of the same agent/auth-type can still be told apart.
+    expect(await screen.findByText("Claude Code API key")).toBeInTheDocument();
     expect(await screen.findByText("sk-ant...5678")).toBeInTheDocument();
+    expect(await screen.findByText("Codex API key")).toBeInTheDocument();
     expect(await screen.findByText("sk-open...1234")).toBeInTheDocument();
     expect(await screen.findByText("Org fallback")).toBeInTheDocument();
     expect(await screen.findByText("Team seat A")).toBeInTheDocument();
-    // The resolution line is rendered as a single block with the label and the
-    // ordered list. We assert on a substring match because the runtime is free
-    // to format the separator however it likes.
-    expect(await screen.findByText(/Personal #1.*Personal #2.*Org #1/)).toBeInTheDocument();
   });
 
   it("renders the org fallback section even when the personal stack is empty", async () => {
@@ -150,13 +150,9 @@ describe("Account settings page", () => {
 
     // Personal stack should show the empty-state copy.
     expect(await screen.findByText(/No personal auth configured/)).toBeInTheDocument();
-    // Org fallback should still render. Notes column prefers usage_note over
-    // label, so we look for the masked-key style hint.
+    // Org fallback should still render with both the label and the masked key.
+    expect(await screen.findByText("Org Claude key")).toBeInTheDocument();
     expect(await screen.findByText("sk-ant...team")).toBeInTheDocument();
-    // Effective resolution should be Org #1 only — no Personal segments.
-    const resolutionLine = await screen.findByText(/Effective resolution for you/);
-    expect(resolutionLine.parentElement?.textContent).toMatch(/Org #1/);
-    expect(resolutionLine.parentElement?.textContent).not.toMatch(/Personal #/);
   });
 
   it("uses the shared provider-card modal with Gemini, Amp, and Pi support", async () => {

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2 } from "lucide-react";
 import { notify as toast } from "@/lib/notify";
@@ -73,30 +73,6 @@ function statusLabel(status: CodingAuthStatus | string | undefined) {
   }
 }
 
-// effectiveResolutionLine renders the ordered list as a one-line "Personal #1
-// → Personal #2 → Org #1" string. Mirrors the design doc's "Effective
-// resolution for you" hint and is the single most-asked support question, so
-// surfacing it ambient on the page eliminates the round-trip.
-//
-// `rows` comes from /api/v1/coding-credentials?scope=resolved, which is
-// backed by ListResolvable (status='active' rows only). Counting is
-// therefore safe: every row counted is one the resolver would actually walk.
-function effectiveResolutionLine(rows: CodingCredentialSummary[]): string {
-  const personalCount = rows.filter((r) => r.scope === "personal").length;
-  const orgCount = rows.filter((r) => r.scope === "org").length;
-  const segments: string[] = [];
-  for (let i = 0; i < personalCount; i++) {
-    segments.push(`Personal #${i + 1}`);
-  }
-  for (let i = 0; i < orgCount; i++) {
-    segments.push(`Org #${i + 1}`);
-  }
-  if (segments.length === 0) {
-    return "No credentials configured.";
-  }
-  return segments.join(" → ");
-}
-
 export default function AccountPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -118,20 +94,9 @@ export default function AccountPage() {
     queryKey: ["coding-credentials", "org"],
     queryFn: () => api.codingCredentials.list("org"),
   });
-  // Resolved — the merged ordered list (personal-then-org) the runtime uses.
-  // Drives the "Effective resolution" line at the bottom of the page.
-  const { data: resolvedResp } = useQuery<ListResponse<CodingCredentialSummary>>({
-    queryKey: ["coding-credentials", "resolved"],
-    queryFn: () => api.codingCredentials.list("resolved"),
-  });
 
   const personalRows = personalResp?.data ?? [];
   const orgRows = orgResp?.data ?? [];
-
-  const resolutionLine = useMemo(
-    () => effectiveResolutionLine(resolvedResp?.data ?? []),
-    [resolvedResp?.data],
-  );
 
   const storedReasoningDefaults = getCodingAgentReasoningDefaultsFromSettings(user?.settings);
   const effectiveReasoningDefaults = pendingReasoningDefaults ?? storedReasoningDefaults;
@@ -268,7 +233,12 @@ export default function AccountPage() {
                       ) : null}
                     </TableCell>
                     <TableCell>{authTypeLabel(row.auth_type)}</TableCell>
-                    <TableCell>{row.usage_note ?? row.label}</TableCell>
+                    <TableCell>
+                      <div>{row.label}</div>
+                      {row.usage_note && row.usage_note !== row.label ? (
+                        <div className="text-xs text-muted-foreground">{row.usage_note}</div>
+                      ) : null}
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline">{statusLabel(row.status)}</Badge>
                     </TableCell>
@@ -315,7 +285,12 @@ export default function AccountPage() {
                     <TableCell className="text-muted-foreground">{idx + 1}</TableCell>
                     <TableCell>{agentLabel(row.agent)}</TableCell>
                     <TableCell>{authTypeLabel(row.auth_type)}</TableCell>
-                    <TableCell>{row.usage_note ?? row.label}</TableCell>
+                    <TableCell>
+                      <div>{row.label}</div>
+                      {row.usage_note && row.usage_note !== row.label ? (
+                        <div className="text-xs text-muted-foreground">{row.usage_note}</div>
+                      ) : null}
+                    </TableCell>
                     <TableCell>
                       <Badge variant="outline">{statusLabel(row.status)}</Badge>
                     </TableCell>
@@ -329,10 +304,6 @@ export default function AccountPage() {
                 )}
               </TableBody>
             </Table>
-            <div className="mt-4 rounded-md border border-dashed border-muted bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-              <span className="font-medium text-foreground">Effective resolution for you:</span>{" "}
-              {resolutionLine}
-            </div>
           </CardContent>
         </Card>
 


### PR DESCRIPTION
## Summary
- Notes column on the personal stack and org-fallback tables now shows the user-set label as primary text with the auto-generated usage note (e.g. \"ChatGPT subscription\") as a muted subtitle, so multiple Codex subscription rows can be told apart.
- Removed the \"Effective resolution for you\" footer (and its resolved query / helper) since the ordering is already obvious from the table.

## Test plan
- [x] frontend typecheck
- [x] vitest run on src/app/(dashboard)/settings/account/page.test.tsx