### PR TITLE
Stage sandbox-firewall.sh via .new + atomic rename to avoid ETXTBSY

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -160,8 +160,13 @@ if [ "$ROLE" = "worker" ]; then
   # hanging waiting for a password that CI can't provide.
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+  # Stage to a .new path and atomically rename. Writing in place reuses the
+  # existing inode, which can yield ETXTBSY ("Text file busy") on the later
+  # `sudo sandbox-firewall.sh` exec if anything still holds the old inode
+  # open for write (lingering sftp-server FD, ssh ControlMaster, or a
+  # concurrent run). rename(2) gives the new contents a fresh inode.
   if ! scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
-      deploy@"$HOST":/opt/143/deploy/scripts/; then
+      deploy@"$HOST":/opt/143/deploy/scripts/sandbox-firewall.sh.new; then
     echo "ERROR: scp of sandbox-firewall.sh failed."
     echo "  Hint: the worker likely has root-owned files under /opt/143/deploy/scripts AND"
     echo "  the 'deploy' user lacks NOPASSWD sudo. One-time fix on the worker host:"
@@ -172,7 +177,9 @@ if [ "$ROLE" = "worker" ]; then
     echo "    2) Re-run the deploy."
     exit 1
   fi
-  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh"
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh.new && \
+     mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh"
 fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -165,7 +165,7 @@ if [ "$ROLE" = "worker" ]; then
   # `sudo sandbox-firewall.sh` exec if anything still holds the old inode
   # open for write (lingering sftp-server FD, ssh ControlMaster, or a
   # concurrent run). rename(2) gives the new contents a fresh inode.
-  if ! scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
+  if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
       deploy@"$HOST":/opt/143/deploy/scripts/sandbox-firewall.sh.new; then
     echo "ERROR: scp of sandbox-firewall.sh failed."
     echo "  Hint: the worker likely has root-owned files under /opt/143/deploy/scripts AND"
@@ -178,8 +178,8 @@ if [ "$ROLE" = "worker" ]; then
     exit 1
   fi
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "chmod +x /opt/143/deploy/scripts/sandbox-firewall.sh.new && \
-     mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh"
+    "mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh \
+     || { rm -f /opt/143/deploy/scripts/sandbox-firewall.sh.new; exit 1; }"
 fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \


### PR DESCRIPTION
## Summary
Worker deploys were failing at `sudo /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox` with `Text file busy`. `scp` overwrites the existing inode in place, so any process still holding it open for write (sftp-server FD, ssh ControlMaster, concurrent run) makes the later `execve` fail with ETXTBSY. This stages the script to `sandbox-firewall.sh.new` and `mv`s it into place, allocating a fresh inode (same approach already used for `Caddyfile.new`).

## Test plan
- [ ] Run `make deploy-fleet` and confirm the worker rolls over without `Text file busy`
- [ ] Re-run a second deploy back-to-back and confirm idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)