### PR TITLE
Capitalize CI check status pills (Failed/Passed/Pending)

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -226,9 +226,9 @@ describe("PRHealthBanner", () => {
     expect(screen.getByText("Unit tests")).toBeInTheDocument();
     expect(screen.getByText("E2E tests")).toBeInTheDocument();
     expect(screen.getByText("Lint")).toBeInTheDocument();
-    expect(screen.getAllByText("failed").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("pending").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("passed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Failed").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Pending").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Passed").length).toBeGreaterThan(0);
   });
 
   it("renders each hover-card check as an external link when details URLs are available", async () => {
@@ -291,7 +291,7 @@ describe("PRHealthBanner", () => {
 
     expect(await screen.findByText("CI jobs")).toBeInTheDocument();
     expect(screen.getByText("Legacy check")).toBeInTheDocument();
-    expect(screen.getAllByText("pending").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Pending").length).toBeGreaterThanOrEqual(2);
   });
 
   it("does not render a separate conflicts badge when the summary already covers merge conflicts", () => {

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -113,14 +113,14 @@ export function PRHealthBanner({
                                   <ExternalLink aria-hidden="true" className="h-3 w-3 shrink-0 text-muted-foreground" />
                                 </div>
                                 <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                  {check.status}
+                                  {checkStatusLabel(check.status)}
                                 </Badge>
                               </a>
                             ) : (
                               <div key={`${check.name}-${check.status}`} className="flex items-center justify-between gap-3 px-1 py-1">
                                 <div className="min-w-0 text-xs text-foreground truncate">{check.name}</div>
                                 <Badge variant="secondary" className={cn("shrink-0 text-xs", checkStatusBadgeClassName(check.status))}>
-                                  {check.status}
+                                  {checkStatusLabel(check.status)}
                                 </Badge>
                               </div>
                             )
@@ -264,6 +264,17 @@ function checksAllowMerge(
   return checks.length === 0
     ? checksConfirmed
     : checks.every((check) => check.status === "passed");
+}
+
+function checkStatusLabel(status: PullRequestCheckStatus) {
+  switch (status) {
+    case "failed":
+      return "Failed";
+    case "pending":
+      return "Pending";
+    case "passed":
+      return "Passed";
+  }
 }
 
 function checkStatusBadgeClassName(status: PullRequestCheckStatus) {


### PR DESCRIPTION
## Summary
- Capitalize the per-check status pills in the PR health banner CI jobs hover card so they read Failed, Passed, and Pending instead of the lowercase API values.

## Test plan
- [x] vitest run src/components/pr-health-banner.test.tsx