### PR TITLE
Move preview build artifacts off the 256 MiB noexec /tmp tmpfs

### DIFF
--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -5,25 +5,34 @@
 #   1. build binaries once (go run would rebuild twice for migrate+server)
 #   2. run migrations
 #   3. seed the database
-#   4. generate + cache SESSION_SECRET at /tmp/143-preview/session_secret so
+#   4. generate + cache SESSION_SECRET at $SCRATCH_DIR/session_secret so
 #      a server restart inside the same sandbox keeps the reviewer signed in
 #   5. exec the server
 #
-# SESSION_SECRET intentionally lives in /tmp/ (not committed): a full
-# sandbox recycle generates a fresh secret, at which point the reviewer
-# simply re-signs-in with the public demo credentials.
+# Everything lives under $TMPDIR (= /var/tmp in the sandbox), not /tmp:
+# the sandbox mounts /tmp as a 256 MiB noexec tmpfs but /var/tmp as a
+# 512 MiB exec-allowed tmpfs (see internal/services/agent/providers/docker.go).
+# Writing the GOCACHE + binaries to /tmp ran the small tmpfs out of space
+# while the Go build was copying its final a.out, and noexec would have
+# blocked exec'ing the resulting binary anyway. SESSION_SECRET still lives
+# on a tmpfs, so a sandbox recycle still resets it and the reviewer simply
+# re-signs-in with the public demo credentials.
 #
 # -u catches typos in required env vars (DATABASE_URL, PREVIEW_ORIGIN)
 # instead of silently substituting empty strings and failing downstream.
 set -eu
 
-SECRET_DIR=/tmp/143-preview
-SECRET_FILE="${SECRET_DIR}/session_secret"
+SCRATCH_DIR="${TMPDIR:-/var/tmp}/143-preview"
+SECRET_FILE="${SCRATCH_DIR}/session_secret"
+MIGRATE_BIN="${SCRATCH_DIR}/143-migrate"
+SERVER_BIN="${SCRATCH_DIR}/143-server"
+
+mkdir -p "$SCRATCH_DIR"
 
 # Persist the Go build cache across in-sandbox server restarts so rebuilds
 # after a code edit reuse object files instead of recompiling the world.
-# A full sandbox recycle wipes /tmp and pays the cold-build cost once.
-GOCACHE="${SECRET_DIR}/gocache"
+# A full sandbox recycle wipes the tmpfs and pays the cold-build cost once.
+GOCACHE="${SCRATCH_DIR}/gocache"
 export GOCACHE
 mkdir -p "$GOCACHE"
 
@@ -32,17 +41,16 @@ echo '[143-preview] building binaries...'
 # preview executor's output tail and surfaced in the launch error. Without
 # this, the executor discards stderr (see docker_preview.go) and the user
 # only sees the "building binaries..." line followed by "exited with code 1".
-go build -o /tmp/143-migrate ./cmd/migrate 2>&1
-go build -o /tmp/143-server ./cmd/server 2>&1
+go build -o "$MIGRATE_BIN" ./cmd/migrate 2>&1
+go build -o "$SERVER_BIN" ./cmd/server 2>&1
 
 echo '[143-preview] running migrations...'
-/tmp/143-migrate up
+"$MIGRATE_BIN" up
 
 echo '[143-preview] seeding database...'
 psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f .143/seed.sql
 
-mkdir -p "$SECRET_DIR"
-chmod 700 "$SECRET_DIR"
+chmod 700 "$SCRATCH_DIR"
 if [ ! -s "$SECRET_FILE" ]; then
     # tr strips the trailing newline base64 appends — SESSION_SECRET is
     # consumed as an opaque byte string and a stray \n causes subtle
@@ -56,4 +64,4 @@ export SESSION_SECRET
 echo '[143-preview] starting server...'
 BASE_URL="${PREVIEW_ORIGIN:-http://localhost:8080}" \
 FRONTEND_URL="${PREVIEW_ORIGIN:-http://localhost:8080}" \
-exec /tmp/143-server
+exec "$SERVER_BIN"


### PR DESCRIPTION
## Summary
- Preview sandbox mounts `/tmp` as a 256 MiB noexec tmpfs and `/var/tmp` as a 512 MiB exec-allowed tmpfs (`internal/services/agent/providers/docker.go:338`), but `.143/preview-start.sh` wrote the Go build cache and compiled binaries into `/tmp` — the cache filled the tmpfs and the final `go build` step failed with `no space left on device` while copying `a.out` to `/tmp/143-server` (noexec would also have blocked exec).
- Anchor `GOCACHE`, `143-migrate`, `143-server`, and `session_secret` under `${TMPDIR:-/var/tmp}/143-preview` so the larger exec-allowed tmpfs is used.

## Test plan
- [ ] Launch a preview for this branch and confirm the `server` service passes its readiness probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)