### PR TITLE
Carry automation run goal_snapshot into the agent prompt seed

### DIFF
--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -498,6 +498,16 @@ func newAutomationRunHandler(stores *Stores, services *Services, logger zerolog.
 			targetBranch = &b
 		}
 
+		// Carry the run's GoalSnapshot into PMApproach so promptSeedForSession
+		// surfaces it as the synthesized issue's description. Without this the
+		// agent receives an empty "Session task" seed and silently ignores any
+		// conditions or invariants the user wrote in the automation goal.
+		var goalSeed *string
+		if strings.TrimSpace(run.GoalSnapshot) != "" {
+			g := run.GoalSnapshot
+			goalSeed = &g
+		}
+
 		session := &models.Session{
 			OrgID:             orgID,
 			AgentType:         agentType,
@@ -509,6 +519,7 @@ func newAutomationRunHandler(stores *Stores, services *Services, logger zerolog.
 			TargetBranch:      targetBranch,
 			RepositoryID:      automation.RepositoryID,
 			AutomationRunID:   &runID,
+			PMApproach:        goalSeed,
 		}
 		if err := stores.Sessions.Create(ctx, session); err != nil {
 			// Session creation failed after we claimed the row — flip

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2533,14 +2533,18 @@ func TestAutomationRunHandler_HappyPath(t *testing.T) {
 	// 4. Create the session. automation_run_id is the 19th arg — asserting
 	// that specific value here is what proves the handler actually linked the
 	// session back to the run it's servicing (without it, audit+stats joins
-	// on sessions.automation_run_id would silently miss every row). The
-	// trailing four AnyArgs are the linear_* policy columns added by
-	// migration 103.
+	// on sessions.automation_run_id would silently miss every row).
+	// pm_approach is the 11th arg and must carry the run's goal_snapshot —
+	// without that, promptSeedForSession synthesizes an empty "Session task"
+	// seed and the agent silently ignores everything the user wrote in the
+	// automation goal. The trailing four AnyArgs are the linear_* policy
+	// columns added by migration 103.
+	expectedGoal := "goal"
 	mock.ExpectBegin()
 	mock.ExpectQuery(`INSERT INTO sessions`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), &expectedGoal, pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), &runID,
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),


### PR DESCRIPTION
## Summary
- Automation sessions were created without populating any prompt-seed fields, so `promptSeedForSession` fell through to the synthetic "Session task" branch with `PMApproach`/`PMReasoning` both nil. The agent's prompt never saw the automation goal — conditions and invariants the user wrote were silently ignored in the resulting PRs.
- Fix: copy `run.GoalSnapshot` into `session.PMApproach` at session-creation time so the existing PM-driven prompt-seed path surfaces the goal as the synthesized issue's description.
- Pinned the new wiring in the existing happy-path test by asserting the 11th INSERT arg (`pm_approach`) equals the run's goal text, with a comment explaining why the assertion is load-bearing.

## Test plan
- [x] `go test ./internal/worker/ -run TestAutomationRunHandler -count=1` passes
- [x] `go test ./internal/services/agent/ -run TestPromptSeed -count=1` passes
- [x] `go build ./...` clean
- [ ] Trigger a real automation run with conditions in the goal and confirm the agent's prompt reflects them and the resulting PR honors them

🤖 Generated with [Claude Code](https://claude.com/claude-code)