### PR TITLE
Wire per-push credential socket so PR creation can authenticate git push

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -991,6 +991,7 @@ func buildServices(
 		prService,
 		sandboxProvider,
 		snapshotStore,
+		sandboxAuthServer,
 		integrationStore,
 		userCredentialStore,
 		appUserAuthSvc,
@@ -1114,6 +1115,7 @@ func wireWorkerPRService(
 	prService *ghservice.PRService,
 	sandboxProvider agent.SandboxProvider,
 	snapshotStore storage.SnapshotStore,
+	sandboxAuthServer agent.SandboxAuthServer,
 	integrationStore *db.IntegrationStore,
 	userCredentialStore *db.UserCredentialStore,
 	appUserAuthSvc *ghservice.AppUserAuthService,
@@ -1126,6 +1128,7 @@ func wireWorkerPRService(
 		return
 	}
 	prService.SetSandboxPushDeps(sandboxProvider, snapshotStore)
+	prService.SetSandboxAuth(sandboxAuthServer)
 	prService.SetIntegrationStore(integrationStore)
 	prService.SetUserCredentialStore(userCredentialStore)
 	prService.SetAppUserAuth(appUserAuthSvc)

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/assembledhq/143/internal/prompts"
 	"github.com/assembledhq/143/internal/services/agent"
 	"github.com/assembledhq/143/internal/services/github/identity"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
 	"github.com/assembledhq/143/internal/services/storage"
 )
 
@@ -77,8 +78,9 @@ type PRService struct {
 	prHealthStreams  *cache.PullRequestStreams
 	llmClient        llm.Client
 	audit            *db.AuditEmitter
-	sandboxProvider  agent.SandboxProvider // used by the push-based PR flow
-	snapshots        storage.SnapshotStore // used by the push-based PR flow
+	sandboxProvider  agent.SandboxProvider   // used by the push-based PR flow
+	snapshots        storage.SnapshotStore   // used by the push-based PR flow
+	sandboxAuth      agent.SandboxAuthServer // per-push GitHub credential socket; required for the push-based PR flow
 	logger           zerolog.Logger
 	baseURL          string
 	appBaseURL       string
@@ -240,6 +242,18 @@ func (s *PRService) SetPreviewTeardown(previews *db.PreviewStore, stopper Previe
 func (s *PRService) SetSandboxPushDeps(provider agent.SandboxProvider, snapshots storage.SnapshotStore) {
 	s.sandboxProvider = provider
 	s.snapshots = snapshots
+}
+
+// SetSandboxAuth wires the per-session credential socket bridge used to
+// authenticate `git push` from the pr_push sandbox. The push sandbox is
+// hydrated from a snapshot whose .git/config carries
+// `credential.helper=!143-tools git-credential` (set by git-bootstrap during
+// the original agent run); the helper expects _143_AUTH_SOCK to point at a
+// listening socket. Without one wired here, the helper exits non-zero and the
+// push fails. Required for CreatePR / PushChangesToPR; if nil, both return a
+// configuration error.
+func (s *PRService) SetSandboxAuth(server agent.SandboxAuthServer) {
+	s.sandboxAuth = server
 }
 
 func (s *PRService) SetPullRequestStreams(streams *cache.PullRequestStreams) {
@@ -522,7 +536,7 @@ func (s *PRService) CreatePR(ctx context.Context, run *models.Session, params ..
 		}
 	}
 
-	pushed, err := s.pushSessionBranch(ctx, run, &repo, token, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
 	if err != nil {
 		return nil, err
 	}
@@ -755,11 +769,17 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 		}
 	}
 
+	// Resolve identity for the commit name/email and the co-author trailer.
+	// The push token itself is supplied to git inside the sandbox by the
+	// per-session credential socket (see pushSessionBranch); we only need
+	// resolution.Token here for the GitHub REST calls below — none in this
+	// flow, but PushChangesToPR resolves anyway so the resolver's user-token
+	// validation runs (and returns a clear error to the UI) before we open
+	// a sandbox.
 	resolution, err := s.resolveToken(ctx, run, &repo, orgSettings, opts.AuthorMode)
 	if err != nil {
 		return nil, fmt.Errorf("resolve token: %w", err)
 	}
-	token := resolution.Token
 
 	// Use the persisted head_ref captured at PR-creation time. Guarded by the
 	// ErrLegacyPRMissingHeadRef check above, so we know it's set here.
@@ -774,7 +794,7 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 		}
 	}
 
-	pushed, err := s.pushSessionBranch(ctx, run, &repo, token, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
+	pushed, err := s.pushSessionBranch(ctx, run, &repo, orgSettings, *run.SnapshotKey, branchName, commitMsg, authorName, authorEmail)
 	if err != nil {
 		return nil, err
 	}
@@ -938,9 +958,15 @@ func (s *PRService) SyncSessionTitle(ctx context.Context, session *models.Sessio
 // container, stages + commits any uncommitted changes, and pushes HEAD to a
 // new remote branch. The sandbox is always destroyed on return.
 //
-// The GitHub token is never passed via argv or URL. It's written to a file
-// inside the sandbox and read by a GIT_ASKPASS helper, so `ps` inside the
-// container shows only a plain https URL with no credentials.
+// Authentication comes from the per-session credential socket, not from argv
+// or URL. The sandbox snapshot already has
+// `credential.helper=!143-tools git-credential` baked into .git/config (set by
+// git-bootstrap during the original agent run); we open a fresh listener
+// keyed by a per-push UUID and bind-mount it into the container so the helper
+// resolves to a live token. Using a per-push UUID (rather than the session
+// ID) avoids kicking the agent run's listener — important when a preview
+// hold is keeping the agent's container alive across turns.
+//
 // pushResult captures what pushSessionBranch produced on a successful push:
 // the new HEAD SHA from the remote (parsed from the script's stdout sentinel),
 // and an optional snapshot of the post-push sandbox spooled to a local temp
@@ -959,17 +985,39 @@ func (s *PRService) pushSessionBranch(
 	ctx context.Context,
 	run *models.Session,
 	repo *models.Repository,
-	token, snapshotKey, branchName, commitMsg, authorName, authorEmail string,
+	orgSettings models.OrgSettings,
+	snapshotKey, branchName, commitMsg, authorName, authorEmail string,
 ) (*pushResult, error) {
+	if s.sandboxAuth == nil {
+		return nil, fmt.Errorf("PRService: sandbox auth socket not configured")
+	}
+
 	cfg := agent.DefaultSandboxConfig()
 	cfg.SessionID = run.ID.String()
 	cfg.OrgID = run.OrgID.String()
 	cfg.Purpose = "pr_push"
+	if cfg.Env == nil {
+		cfg.Env = map[string]string{}
+	}
 	// Mirror the workspace layout used at session start so restore overlays
 	// the snapshot onto the path git already has recorded in .git/config.
 	if slug := agent.SlugForRepo(repo.FullName); slug != "" {
 		cfg.WorkDir = fmt.Sprintf("%s/%s", cfg.HomeDir, slug)
 	}
+
+	// Open a per-push credential listener. Keyed by a fresh UUID so it can't
+	// collide with the agent run's listener (still active when a preview is
+	// holding the original container alive across turns).
+	pushID := uuid.New()
+	socketPath, err := s.sandboxAuth.Listen(ctx, pushID, run, repo, orgSettings)
+	if err != nil {
+		return nil, fmt.Errorf("open sandbox auth socket: %w", err)
+	}
+	defer s.sandboxAuth.Close(pushID)
+	cfg.AuthSocketPath = socketPath
+	cfg.Env[sandboxauth.SocketEnvVar] = sandboxauth.SandboxSocketPath
+	cfg.Env[sandboxauth.GitNameEnvVar] = authorName
+	cfg.Env[sandboxauth.GitEmailEnvVar] = authorEmail
 
 	sandbox, err := agent.HydrateSandboxFromSnapshot(ctx, s.sandboxProvider, s.snapshots, snapshotKey, cfg)
 	if err != nil {
@@ -988,20 +1036,14 @@ func (s *PRService) pushSessionBranch(
 		}
 	}()
 
-	// Write the commit message, credential, and askpass helper to files.
-	// Passing the credential via file keeps it out of argv and shell history.
+	// Commit message goes to a file so multi-line / hostile content can't
+	// leak through argv. Token goes via the helper socket — no token files,
+	// no askpass shell stub.
 	if err := s.sandboxProvider.WriteFile(ctx, sandbox, pushCommitMsgPath, []byte(commitMsg)); err != nil {
 		return nil, fmt.Errorf("write commit message to sandbox: %w", err)
 	}
-	if err := s.sandboxProvider.WriteFile(ctx, sandbox, pushInputPath, []byte(token)); err != nil {
-		return nil, fmt.Errorf("write credential to sandbox: %w", err)
-	}
-	helperScript := "#!/bin/sh\nexec cat " + shellQuote(pushInputPath) + "\n"
-	if err := s.sandboxProvider.WriteFile(ctx, sandbox, pushHelperPath, []byte(helperScript)); err != nil {
-		return nil, fmt.Errorf("write push helper to sandbox: %w", err)
-	}
 
-	pushURL := fmt.Sprintf("https://x-access-token@github.com/%s.git", repo.FullName)
+	pushURL := fmt.Sprintf("https://github.com/%s.git", repo.FullName)
 	script := buildPushScript(sandbox.WorkDir, authorName, authorEmail, branchName, pushURL)
 
 	var stdout, stderr bytes.Buffer
@@ -1016,9 +1058,6 @@ func (s *PRService) pushSessionBranch(
 		return nil, ErrNoChanges
 	default:
 		msg := strings.TrimSpace(stderr.String())
-		// Defense in depth: if the token ever leaks into stderr (e.g. via a
-		// future code path that reintroduces it), scrub before returning.
-		msg = strings.ReplaceAll(msg, token, "***")
 		if msg == "" {
 			msg = "(no stderr)"
 		}
@@ -1109,16 +1148,10 @@ func (s *PRService) captureSandboxSnapshot(ctx context.Context, sandbox *agent.S
 	return path, size, nil
 }
 
-// Sandbox-internal paths used by the push flow. Under /tmp so they're
-// auto-cleaned on sandbox destroy; the trap inside the script also removes
-// them explicitly on exit for defense in depth.
-const (
-	pushCommitMsgPath = "/tmp/143-pr-commit-msg"
-	pushInputPath     = "/tmp/143-pr-input"
-	// /tmp is mounted noexec in sandbox containers; the askpass helper must
-	// live on the exec-allowed scratch tmpfs so git can invoke it.
-	pushHelperPath = "/var/tmp/143-pr-helper.sh"
-)
+// pushCommitMsgPath is the in-sandbox file the script reads `git commit -F`
+// from. Under /tmp so it's auto-cleaned on sandbox destroy; the trap inside
+// the script also removes it explicitly on exit for defense in depth.
+const pushCommitMsgPath = "/tmp/143-pr-commit-msg"
 
 // pushExitNoChanges is the sentinel exit code the push script uses when the
 // restored working tree has no uncommitted changes AND no commits ahead of
@@ -1133,36 +1166,32 @@ const pushHeadSHASentinel = "__143_HEAD_SHA="
 
 // pushScriptTemplate is the shell script executed inside the restored
 // sandbox. All variable interpolations are pre-quoted by the caller (see
-// buildPushScript) so they're safe to embed directly. The credential is read
-// by the `GIT_ASKPASS` helper from pushInputPath — it never appears in argv.
-//
-// The cleanup function is hoisted into a shell function rather than inlined
-// in the trap because `trap 'rm -f %[1]s ...'` would interleave single-
-// quoted strings in a way that works but is fragile to reason about.
+// buildPushScript) so they're safe to embed directly. Authentication comes
+// from credential.helper=!143-tools git-credential (already in the snapshot's
+// .git/config) talking to the per-push host socket bridge — no token files,
+// no GIT_ASKPASS, no userinfo in the URL.
 //
 // On the success branch (push lands), the script prints
 // `__143_HEAD_SHA=<sha>` so the caller can persist the just-pushed commit
 // onto the PullRequest row without a second GitHub round-trip. The line is
-// only emitted on the success branch — the `exit %[7]d` no-changes contract
-// is unchanged.
+// only emitted on the success branch — the no-changes contract is unchanged.
 const pushScriptTemplate = `set -eu
-cleanup() { rm -f %[1]s %[2]s %[3]s; }
+cleanup() { rm -f %[1]s; }
 trap cleanup EXIT
-cd %[4]s
-git config user.name %[5]s
-git config user.email %[6]s
+cd %[2]s
+git config user.name %[3]s
+git config user.email %[4]s
 git add -A
 if ! git diff --cached --quiet; then
     git commit -F %[1]s
 fi
 if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
     if git merge-base --is-ancestor HEAD @{u}; then
-        exit %[7]d
+        exit %[5]d
     fi
 fi
-chmod +x %[3]s
-GIT_ASKPASS=%[3]s GIT_TERMINAL_PROMPT=0 git push %[8]s HEAD:refs/heads/%[9]s
-echo "%[10]s$(git rev-parse HEAD)"
+git push %[6]s HEAD:refs/heads/%[7]s
+echo "%[8]s$(git rev-parse HEAD)"
 `
 
 // buildPushScript renders pushScriptTemplate with caller-supplied values.
@@ -1173,8 +1202,6 @@ func buildPushScript(workDir, authorName, authorEmail, branchName, pushURL strin
 	return fmt.Sprintf(
 		pushScriptTemplate,
 		shellQuote(pushCommitMsgPath),
-		shellQuote(pushInputPath),
-		shellQuote(pushHelperPath),
 		shellQuote(workDir),
 		shellQuote(authorName),
 		shellQuote(authorEmail),

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -770,12 +770,11 @@ func (s *PRService) PushChangesToPR(ctx context.Context, run *models.Session, pa
 	}
 
 	// Resolve identity for the commit name/email and the co-author trailer.
-	// The push token itself is supplied to git inside the sandbox by the
-	// per-session credential socket (see pushSessionBranch); we only need
-	// resolution.Token here for the GitHub REST calls below — none in this
-	// flow, but PushChangesToPR resolves anyway so the resolver's user-token
-	// validation runs (and returns a clear error to the UI) before we open
-	// a sandbox.
+	// The push token itself flows via the per-session credential socket (see
+	// pushSessionBranch), so resolution.Token isn't read here — we resolve
+	// purely to run the resolver's user-token validation before opening a
+	// sandbox, so a revoked grant surfaces as a clear UI error rather than a
+	// helper-side ECONNREFUSED.
 	resolution, err := s.resolveToken(ctx, run, &repo, orgSettings, opts.AuthorMode)
 	if err != nil {
 		return nil, fmt.Errorf("resolve token: %w", err)
@@ -1016,8 +1015,10 @@ func (s *PRService) pushSessionBranch(
 	defer s.sandboxAuth.Close(pushID)
 	cfg.AuthSocketPath = socketPath
 	cfg.Env[sandboxauth.SocketEnvVar] = sandboxauth.SandboxSocketPath
-	cfg.Env[sandboxauth.GitNameEnvVar] = authorName
-	cfg.Env[sandboxauth.GitEmailEnvVar] = authorEmail
+	// GitNameEnvVar / GitEmailEnvVar are intentionally NOT set: those are
+	// consumed by `143-tools git-bootstrap`, which the pr_push sandbox never
+	// runs (the snapshot already has user.name/email configured, and the
+	// push script re-sets them via `git config` from the resolved identity).
 
 	sandbox, err := agent.HydrateSandboxFromSnapshot(ctx, s.sandboxProvider, s.snapshots, snapshotKey, cfg)
 	if err != nil {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3911,16 +3911,16 @@ func TestPushSessionBranch(t *testing.T) {
 // assert the per-push listener is opened and closed exactly once across every
 // success and failure path.
 type fakeSandboxAuth struct {
-	socketPath  string
-	listenErr   error
-	listenCount int
-	closeCount  int
-	lastSession uuid.UUID
+	socketPath    string
+	listenErr     error
+	listenCount   int
+	closeCount    int
+	lastListenKey uuid.UUID
 }
 
 func (f *fakeSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *models.Session, _ *models.Repository, _ models.OrgSettings) (string, error) {
 	f.listenCount++
-	f.lastSession = sessionID
+	f.lastListenKey = sessionID
 	if f.listenErr != nil {
 		return "", f.listenErr
 	}
@@ -3971,14 +3971,17 @@ func TestPushSessionBranch_AuthSocketWired(t *testing.T) {
 	// what keeps a still-active agent listener (e.g. preview holding the
 	// agent container alive) from being yanked.
 	require.Equal(t, 1, auth.listenCount)
-	require.NotEqual(t, run.ID, auth.lastSession, "auth listener must be keyed by a per-push UUID, not the session ID")
+	require.NotEqual(t, run.ID, auth.lastListenKey, "auth listener must be keyed by a per-push UUID, not the session ID")
 
 	// The sandbox config the provider saw must carry the host socket path
 	// + the in-container env var that 143-tools git-credential reads.
 	require.Equal(t, "/host/socket-dir/sock", provider.lastConfig.AuthSocketPath)
 	require.Equal(t, sandboxauth.SandboxSocketPath, provider.lastConfig.Env[sandboxauth.SocketEnvVar])
-	require.Equal(t, "Bot", provider.lastConfig.Env[sandboxauth.GitNameEnvVar])
-	require.Equal(t, "bot@example.com", provider.lastConfig.Env[sandboxauth.GitEmailEnvVar])
+	// GitNameEnvVar / GitEmailEnvVar are deliberately absent: they're
+	// consumed only by `143-tools git-bootstrap`, which the pr_push sandbox
+	// never runs. The push script sets identity directly via `git config`.
+	require.NotContains(t, provider.lastConfig.Env, sandboxauth.GitNameEnvVar)
+	require.NotContains(t, provider.lastConfig.Env, sandboxauth.GitEmailEnvVar)
 }
 
 func TestPushSessionBranch_RequiresSandboxAuth(t *testing.T) {

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/assembledhq/143/internal/services/sandboxauth"
 	"github.com/assembledhq/143/internal/services/storage"
 )
 
@@ -3425,6 +3426,7 @@ func TestPushChangesToPR_EnqueuesHealthSyncAfterSuccessfulPush(t *testing.T) {
 		jobs:            db.NewJobStore(mock),
 		sandboxProvider: provider,
 		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
 		logger:          zerolog.Nop(),
 	}
 
@@ -3590,13 +3592,12 @@ func TestBuildPushScript_Structure(t *testing.T) {
 		"Test User",
 		"test@example.com",
 		"143/abc123/fix-typo",
-		"https://x-access-token@github.com/owner/repo.git",
+		"https://github.com/owner/repo.git",
 	)
 
-	// Input path, helper path, and commit-msg path must appear in the
-	// cleanup function so files are removed on exit. The helper must live
-	// outside /tmp because sandbox containers mount /tmp as noexec.
-	require.Contains(t, script, "cleanup() { rm -f '/tmp/143-pr-commit-msg' '/tmp/143-pr-input' '/var/tmp/143-pr-helper.sh'; }")
+	// Only the commit-msg file is created by the script; auth comes from
+	// the per-push credential socket, so there's nothing else to clean up.
+	require.Contains(t, script, "cleanup() { rm -f '/tmp/143-pr-commit-msg'; }")
 	require.Contains(t, script, "trap cleanup EXIT")
 
 	// Author identity is set via git config with quoted values.
@@ -3609,17 +3610,19 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// Commit message is read from file (not argv).
 	require.Contains(t, script, "git commit -F '/tmp/143-pr-commit-msg'")
 
-	// Push uses askpass + disables terminal prompt; branch and URL are quoted.
-	require.Contains(t, script, "GIT_ASKPASS='/var/tmp/143-pr-helper.sh' GIT_TERMINAL_PROMPT=0")
-	require.Contains(t, script, "'https://x-access-token@github.com/owner/repo.git'")
-	require.Contains(t, script, "HEAD:refs/heads/'143/abc123/fix-typo'")
+	// Push goes to a credential-free URL — auth flows through
+	// credential.helper=!143-tools git-credential talking to the
+	// per-push host socket.
+	require.Contains(t, script, "git push 'https://github.com/owner/repo.git' HEAD:refs/heads/'143/abc123/fix-typo'")
 
 	// No-changes sentinel exit code is present in the upstream-ancestor branch.
 	require.Contains(t, script, "exit 77")
 
-	// Critically: script must NOT contain a secret-looking userinfo pattern,
-	// because tokens are passed via GIT_ASKPASS, not in the URL.
-	require.NotContains(t, script, "x-access-token:")
+	// Defense in depth: the script must not embed userinfo in the URL or
+	// reference any GIT_ASKPASS-style helper. Both auth mechanisms are gone.
+	require.NotContains(t, script, "x-access-token")
+	require.NotContains(t, script, "GIT_ASKPASS")
+	require.NotContains(t, script, "GIT_TERMINAL_PROMPT")
 }
 
 func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
@@ -3632,7 +3635,7 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 		"Bot",
 		"bot@example.com",
 		"143/abc/it's-fine",
-		"https://x-access-token@github.com/o/r.git",
+		"https://github.com/o/r.git",
 	)
 	require.Contains(t, script, `HEAD:refs/heads/'143/abc/it'\''s-fine'`)
 }
@@ -3797,13 +3800,6 @@ func TestPushSessionBranch(t *testing.T) {
 			wantDestroyCnt: 1,
 		},
 		{
-			name:           "write helper failure returns error",
-			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
-			provider:       &prTestSandboxProvider{writeErrs: map[string]error{pushHelperPath: errors.New("chmod failed")}},
-			wantErrSubstr:  "write push helper to sandbox",
-			wantDestroyCnt: 1,
-		},
-		{
 			name:           "exec failure returns error",
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
 			provider:       &prTestSandboxProvider{execErr: errors.New("sandbox exec failed")},
@@ -3818,10 +3814,10 @@ func TestPushSessionBranch(t *testing.T) {
 			wantDestroyCnt: 1,
 		},
 		{
-			name:           "nonzero exit scrubs token from stderr",
+			name:           "nonzero exit surfaces stderr",
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
-			provider:       &prTestSandboxProvider{execExit: 12, execStderr: "token leaked: secret-token"},
-			wantErrSubstr:  "git push failed (exit 12): token leaked: ***",
+			provider:       &prTestSandboxProvider{execExit: 12, execStderr: "remote: rejected"},
+			wantErrSubstr:  "git push failed (exit 12): remote: rejected",
 			wantDestroyCnt: 1,
 		},
 		{
@@ -3853,9 +3849,11 @@ func TestPushSessionBranch(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			auth := &fakeSandboxAuth{socketPath: "/tmp/fake.sock"}
 			svc := &PRService{
 				sandboxProvider: tt.provider,
 				snapshots:       tt.snapshots,
+				sandboxAuth:     auth,
 				logger:          zerolog.Nop(),
 			}
 			run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
@@ -3865,7 +3863,7 @@ func TestPushSessionBranch(t *testing.T) {
 				context.Background(),
 				run,
 				repo,
-				"secret-token",
+				models.OrgSettings{},
 				"snapshots/key.tar",
 				"143/abc123/fix",
 				"commit message",
@@ -3887,9 +3885,8 @@ func TestPushSessionBranch(t *testing.T) {
 				require.NoError(t, err, "pushSessionBranch should succeed")
 				require.NotNil(t, result, "pushSessionBranch should return a non-nil result on success")
 				require.Equal(t, []byte("commit message"), tt.provider.writes[pushCommitMsgPath], "pushSessionBranch should write the commit message file")
-				require.Equal(t, []byte("secret-token"), tt.provider.writes[pushInputPath], "pushSessionBranch should write the credential input file")
-				require.Contains(t, string(tt.provider.writes[pushHelperPath]), pushInputPath, "pushSessionBranch should write a helper script that reads the credential input file")
-				require.Contains(t, tt.provider.lastExecCmd, "GIT_ASKPASS", "pushSessionBranch should run git push through the helper script")
+				require.NotContains(t, tt.provider.lastExecCmd, "GIT_ASKPASS", "pushSessionBranch should auth via the credential socket, not askpass")
+				require.NotContains(t, tt.provider.lastExecCmd, "x-access-token", "pushSessionBranch should not embed credentials in the push URL")
 				require.Equal(t, tt.wantHeadSHA, result.HeadSHA, "pushSessionBranch should return the parsed HEAD SHA")
 				if tt.wantSnapshotCaptured {
 					require.NotEmpty(t, result.CapturedSnapshotPath, "pushSessionBranch should spool the post-push snapshot to a temp file")
@@ -3902,8 +3899,105 @@ func TestPushSessionBranch(t *testing.T) {
 			}
 
 			require.Equal(t, tt.wantDestroyCnt, tt.provider.destroyed, "pushSessionBranch should always destroy the hydrated sandbox")
+			// Whatever the outcome, the per-push auth listener must be closed
+			// — leaking it would strand the listener until orchestrator shutdown.
+			require.Equal(t, 1, auth.listenCount, "pushSessionBranch should open exactly one auth listener")
+			require.Equal(t, 1, auth.closeCount, "pushSessionBranch should close the auth listener on every exit path")
 		})
 	}
+}
+
+// fakeSandboxAuth records Listen/Close calls so pushSessionBranch tests can
+// assert the per-push listener is opened and closed exactly once across every
+// success and failure path.
+type fakeSandboxAuth struct {
+	socketPath  string
+	listenErr   error
+	listenCount int
+	closeCount  int
+	lastSession uuid.UUID
+}
+
+func (f *fakeSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *models.Session, _ *models.Repository, _ models.OrgSettings) (string, error) {
+	f.listenCount++
+	f.lastSession = sessionID
+	if f.listenErr != nil {
+		return "", f.listenErr
+	}
+	return f.socketPath, nil
+}
+
+func (f *fakeSandboxAuth) Close(_ uuid.UUID) {
+	f.closeCount++
+}
+
+// TestPushSessionBranch_AuthSocketWired locks in the regression fix: the
+// pr_push sandbox MUST get a credential socket wired before HydrateSandboxFromSnapshot
+// runs, otherwise the snapshot's baked-in `credential.helper=!143-tools git-credential`
+// will exit non-zero with `_143_AUTH_SOCK is not set` and the push fails.
+func TestPushSessionBranch_AuthSocketWired(t *testing.T) {
+	t.Parallel()
+
+	provider := &prTestSandboxProvider{execStdout: pushHeadSHASentinel + "abc1234567890abcdef1234567890abcdef12345\n"}
+	auth := &fakeSandboxAuth{socketPath: "/host/socket-dir/sock"}
+	svc := &PRService{
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     auth,
+		logger:          zerolog.Nop(),
+	}
+	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	repo := &models.Repository{FullName: "owner/repo"}
+
+	result, err := svc.pushSessionBranch(
+		context.Background(),
+		run,
+		repo,
+		models.OrgSettings{},
+		"snapshots/key.tar",
+		"143/abc/fix",
+		"commit message",
+		"Bot",
+		"bot@example.com",
+	)
+	t.Cleanup(func() {
+		if result != nil && result.CapturedSnapshotPath != "" {
+			_ = os.Remove(result.CapturedSnapshotPath)
+		}
+	})
+	require.NoError(t, err)
+
+	// Listener keyed by a fresh per-push UUID, NOT the session ID — that's
+	// what keeps a still-active agent listener (e.g. preview holding the
+	// agent container alive) from being yanked.
+	require.Equal(t, 1, auth.listenCount)
+	require.NotEqual(t, run.ID, auth.lastSession, "auth listener must be keyed by a per-push UUID, not the session ID")
+
+	// The sandbox config the provider saw must carry the host socket path
+	// + the in-container env var that 143-tools git-credential reads.
+	require.Equal(t, "/host/socket-dir/sock", provider.lastConfig.AuthSocketPath)
+	require.Equal(t, sandboxauth.SandboxSocketPath, provider.lastConfig.Env[sandboxauth.SocketEnvVar])
+	require.Equal(t, "Bot", provider.lastConfig.Env[sandboxauth.GitNameEnvVar])
+	require.Equal(t, "bot@example.com", provider.lastConfig.Env[sandboxauth.GitEmailEnvVar])
+}
+
+func TestPushSessionBranch_RequiresSandboxAuth(t *testing.T) {
+	t.Parallel()
+
+	svc := &PRService{
+		sandboxProvider: &prTestSandboxProvider{},
+		snapshots:       &prTestSnapshotStore{},
+		logger:          zerolog.Nop(),
+	}
+	_, err := svc.pushSessionBranch(
+		context.Background(),
+		&models.Session{ID: uuid.New(), OrgID: uuid.New()},
+		&models.Repository{FullName: "o/r"},
+		models.OrgSettings{},
+		"k", "b", "m", "n", "e@x",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sandbox auth socket not configured")
 }
 
 func TestParsePushHeadSHA(t *testing.T) {
@@ -4339,6 +4433,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 		orgs:            db.NewOrganizationStore(mock),
 		sandboxProvider: provider,
 		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
 		baseURL:         server.URL,
 		httpClient:      server.Client(),
 		logger:          zerolog.Nop(),
@@ -4494,6 +4589,7 @@ func TestCreatePR_SuccessDispatchesPostPRSnapshotUpload(t *testing.T) {
 		orgs:            db.NewOrganizationStore(mock),
 		sandboxProvider: provider,
 		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
 		baseURL:         server.URL,
 		httpClient:      server.Client(),
 		logger:          zerolog.Nop(),
@@ -4564,10 +4660,11 @@ func TestCreatePR_NoCommitsBetweenMapsToErrNoChanges(t *testing.T) {
 		sandboxProvider: &prTestSandboxProvider{
 			execStdout: pushHeadSHASentinel + "abc1234567890abcdef1234567890abcdef12345\n",
 		},
-		snapshots:  &prTestSnapshotStore{payload: []byte("snapshot")},
-		baseURL:    server.URL,
-		httpClient: server.Client(),
-		logger:     zerolog.Nop(),
+		snapshots:   &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth: &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
+		baseURL:     server.URL,
+		httpClient:  server.Client(),
+		logger:      zerolog.Nop(),
 	}
 
 	run := &models.Session{


### PR DESCRIPTION
## Summary
- The pr_push sandbox is hydrated from a snapshot whose `.git/config` carries `credential.helper=!143-tools git-credential` (set by git-bootstrap during the original agent run), but `pushSessionBranch` never wired the host socket the helper dials. Every PR push failed with `_143_AUTH_SOCK is not set; was the container started by the orchestrator?` and exit 1.
- Open a sandboxauth listener keyed by a fresh per-push UUID (so it can't kick the agent run's listener while a preview hold keeps the original container alive), bind-mount it into the pr_push container, and set `_143_AUTH_SOCK` on the sandbox config before `HydrateSandboxFromSnapshot`.
- With auth flowing through the socket, drop the parallel askpass plumbing: no `GIT_ASKPASS`, no `pushInputPath` / `pushHelperPath` token+helper files, no `x-access-token@` userinfo in the push URL. One auth model now covers both agent runs and PR pushes.

## Compatibility note
This requires the snapshot's `.git/config` to have the `!143-tools git-credential` helper, which `git-bootstrap` started writing in #583 (Apr 27). Snapshots captured before #583 don't have the helper *and* don't have an embedded token — pushes from those will fail to authenticate. Low practical risk (snapshots TTL out and #583 has been live for ~1 week), but worth flagging if anyone is sitting on an unusually old session.

## Test plan
- [x] `go test ./...` (full suite passes)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New `TestPushSessionBranch_AuthSocketWired` regression test asserts the listener is keyed by a per-push UUID (not the session ID) and that `AuthSocketPath` + `_143_AUTH_SOCK` land on the sandbox config
- [x] New `TestPushSessionBranch_RequiresSandboxAuth` covers the config-error path
- [x] `TestBuildPushScript_*` updated to lock in absence of `GIT_ASKPASS` / `x-access-token`
- [ ] Smoke-test on staging: open a PR from a session whose snapshot was captured after #583 (the change that started writing the helper into `.git/config`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
