### PR TITLE
Recover PR push from stale remote tip and surface a clear error

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -280,6 +280,14 @@ const (
 	// SnapshotUnavailablePRMessage is shown when the DB points at a checkpoint
 	// that is no longer present in storage.
 	SnapshotUnavailablePRMessage = "This session had a saved checkpoint, but it is no longer available in storage. Send a new message to rebuild the sandbox, then create the PR again."
+	// PushRejectedPRMessage is shown when `git push` was rejected because the
+	// remote branch advanced (or appeared) outside this session — typically a
+	// stale tip from a prior partial-success attempt or a manual push. The
+	// session's working branch embeds the session UUID so 143 owns the
+	// namespace; the script uses --force-with-lease to recover automatically,
+	// and this error fires when even the lease check fails (a true concurrent
+	// write between ls-remote and push).
+	PushRejectedPRMessage = "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session."
 )
 
 // WaitForPostPRSnapshotUploads blocks until every in-flight post-PR snapshot
@@ -325,6 +333,13 @@ var (
 // uncommitted changes relative to the base branch — there's nothing to push.
 // This typically means the diff was reverted or the session produced no edits.
 var ErrNoChanges = errors.New("no changes to push")
+
+// ErrPushRejected is returned by pushSessionBranch when `git push` exits
+// non-zero with a rejection (non-fast-forward, stale info from
+// --force-with-lease, "failed to push some refs"). Distinct from generic exec
+// failures so the worker can surface a targeted user-facing message instead
+// of the catch-all "Check GitHub access or repo permissions" fallback.
+var ErrPushRejected = errors.New("git push rejected by remote")
 
 // identityResolver returns a resolver wired with the PRService's current
 // dependencies. Lazily built on first use and cached; any Set* mutator
@@ -1062,6 +1077,9 @@ func (s *PRService) pushSessionBranch(
 		if msg == "" {
 			msg = "(no stderr)"
 		}
+		if isPushRejection(msg) {
+			return nil, fmt.Errorf("%w (exit %d): %s", ErrPushRejected, exitCode, msg)
+		}
 		return nil, fmt.Errorf("git push failed (exit %d): %s", exitCode, msg)
 	}
 
@@ -1176,6 +1194,22 @@ const pushHeadSHASentinel = "__143_HEAD_SHA="
 // `__143_HEAD_SHA=<sha>` so the caller can persist the just-pushed commit
 // onto the PullRequest row without a second GitHub round-trip. The line is
 // only emitted on the success branch — the no-changes contract is unchanged.
+//
+// Push uses --force-with-lease keyed on the SHA we just observed via
+// ls-remote. Rationale:
+//   - The session's working branch embeds the session UUID, so 143 owns the
+//     namespace and is the only legitimate writer.
+//   - Snapshot restores rebuild the local commit with fresh metadata, so a
+//     second attempt produces a different SHA than a prior partial-success
+//     push left on the remote — a plain push would fail non-fast-forward
+//     forever. The lease lets us recover from that state automatically.
+//   - The lease still aborts if a third party raced us between ls-remote and
+//     push, which is the only case this scheme can't (and shouldn't) recover
+//     from silently — surface ErrPushRejected so the UI says so.
+//
+// When the remote branch does not exist, ls-remote prints nothing,
+// remote_sha is empty, and `--force-with-lease=<ref>:` resolves to "expect
+// the ref to not exist" — a safe creation push.
 const pushScriptTemplate = `set -eu
 cleanup() { rm -f %[1]s; }
 trap cleanup EXIT
@@ -1191,7 +1225,8 @@ if git rev-parse --abbrev-ref --symbolic-full-name @{u} >/dev/null 2>&1; then
         exit %[5]d
     fi
 fi
-git push %[6]s HEAD:refs/heads/%[7]s
+remote_sha=$(git ls-remote %[6]s refs/heads/%[7]s | awk 'NR==1 {print $1}')
+git push --force-with-lease=refs/heads/%[7]s:"${remote_sha}" %[6]s HEAD:refs/heads/%[7]s
 echo "%[8]s$(git rev-parse HEAD)"
 `
 
@@ -1215,6 +1250,30 @@ func buildPushScript(workDir, authorName, authorEmail, branchName, pushURL strin
 		// sentinel to include shell metacharacters MUST add quoting here.
 		pushHeadSHASentinel,
 	)
+}
+
+// isPushRejection inspects git's stderr from a failed `git push` and reports
+// whether the failure was a server-side rejection (non-fast-forward, stale
+// info from --force-with-lease, generic "failed to push some refs"). Used to
+// promote those cases to ErrPushRejected so the worker can render a
+// targeted user-facing message instead of the catch-all permissions fallback.
+//
+// Match is substring-based and case-insensitive: git's wording is stable
+// enough across versions that anchoring on these phrases is safer than
+// trying to parse exit codes (always 1) or structured output (none).
+func isPushRejection(stderr string) bool {
+	lc := strings.ToLower(stderr)
+	for _, marker := range []string{
+		"non-fast-forward",
+		"stale info",
+		"failed to push some refs",
+		"rejected",
+	} {
+		if strings.Contains(lc, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // shellQuote single-quotes s for safe interpolation into a POSIX shell.

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1067,6 +1067,29 @@ func (s *PRService) pushSessionBranch(
 	if execErr != nil {
 		return nil, fmt.Errorf("exec push script: %w", execErr)
 	}
+
+	// One internal retry on a server-side rejection. The script is
+	// idempotent: the second run finds the index clean (already committed),
+	// skips the commit branch, re-reads the remote SHA via ls-remote, and
+	// retries the push with a fresh --force-with-lease. This collapses the
+	// race window between our first ls-remote and our first push (the only
+	// case --force-with-lease can fail when 143 owns the branch namespace)
+	// into self-healing instead of surfacing ErrPushRejected. A persistent
+	// rejection on the second attempt still bubbles up.
+	if exitCode != 0 && exitCode != pushExitNoChanges && isPushRejection(stderr.String()) {
+		s.logger.Info().
+			Str("session_id", run.ID.String()).
+			Str("branch", branchName).
+			Str("stderr", strings.TrimSpace(stderr.String())).
+			Msg("push rejected on first attempt; retrying once with fresh lease")
+		stdout.Reset()
+		stderr.Reset()
+		exitCode, execErr = s.sandboxProvider.Exec(ctx, sandbox, script, &stdout, &stderr)
+		if execErr != nil {
+			return nil, fmt.Errorf("exec push script (retry): %w", execErr)
+		}
+	}
+
 	switch exitCode {
 	case 0:
 		// Continue to HeadSHA parse + snapshot capture below.

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3610,10 +3610,12 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// Commit message is read from file (not argv).
 	require.Contains(t, script, "git commit -F '/tmp/143-pr-commit-msg'")
 
-	// Push goes to a credential-free URL — auth flows through
-	// credential.helper=!143-tools git-credential talking to the
-	// per-push host socket.
-	require.Contains(t, script, "git push 'https://github.com/owner/repo.git' HEAD:refs/heads/'143/abc123/fix-typo'")
+	// Push uses --force-with-lease keyed on the remote SHA we just observed
+	// via ls-remote. Auth flows through credential.helper=!143-tools
+	// git-credential talking to the per-push host socket — no userinfo in
+	// the URL.
+	require.Contains(t, script, "git ls-remote 'https://github.com/owner/repo.git' refs/heads/'143/abc123/fix-typo'")
+	require.Contains(t, script, `git push --force-with-lease=refs/heads/'143/abc123/fix-typo':"${remote_sha}" 'https://github.com/owner/repo.git' HEAD:refs/heads/'143/abc123/fix-typo'`)
 
 	// No-changes sentinel exit code is present in the upstream-ancestor branch.
 	require.Contains(t, script, "exit 77")
@@ -3638,6 +3640,53 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 		"https://github.com/o/r.git",
 	)
 	require.Contains(t, script, `HEAD:refs/heads/'143/abc/it'\''s-fine'`)
+	// The branch is interpolated three times now (ls-remote, lease ref, push
+	// ref); each must round-trip through shellQuote so the embedded quote
+	// can't break out and corrupt the script.
+	require.Contains(t, script, `git ls-remote 'https://github.com/o/r.git' refs/heads/'143/abc/it'\''s-fine'`)
+	require.Contains(t, script, `--force-with-lease=refs/heads/'143/abc/it'\''s-fine':"${remote_sha}"`)
+}
+
+func TestIsPushRejection(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{
+			name: "non-fast-forward",
+			in:   "To https://github.com/o/r.git\n ! [rejected]   HEAD -> b (non-fast-forward)\nerror: failed to push some refs",
+			want: true,
+		},
+		{
+			name: "stale info from force-with-lease",
+			in:   " ! [rejected]   HEAD -> b (stale info)\nerror: failed to push some refs to 'https://github.com/o/r.git'",
+			want: true,
+		},
+		{
+			name: "uppercase still matches",
+			in:   "REJECTED",
+			want: true,
+		},
+		{
+			name: "unrelated network error",
+			in:   "fatal: unable to access 'https://github.com/o/r.git/': Could not resolve host",
+			want: false,
+		},
+		{
+			name: "empty stderr",
+			in:   "",
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, c.want, isPushRejection(c.in))
+		})
+	}
 }
 
 func TestFormatBranchName_PrefersSessionWorkingBranch(t *testing.T) {
@@ -3814,10 +3863,24 @@ func TestPushSessionBranch(t *testing.T) {
 			wantDestroyCnt: 1,
 		},
 		{
-			name:           "nonzero exit surfaces stderr",
+			name:           "nonzero exit with non-rejection stderr surfaces raw error",
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
-			provider:       &prTestSandboxProvider{execExit: 12, execStderr: "remote: rejected"},
-			wantErrSubstr:  "git push failed (exit 12): remote: rejected",
+			provider:       &prTestSandboxProvider{execExit: 12, execStderr: "fatal: unable to access remote"},
+			wantErrSubstr:  "git push failed (exit 12): fatal: unable to access remote",
+			wantDestroyCnt: 1,
+		},
+		{
+			name:           "non-fast-forward rejection maps to ErrPushRejected",
+			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
+			provider:       &prTestSandboxProvider{execExit: 1, execStderr: "! [rejected]   HEAD -> b (non-fast-forward)\nerror: failed to push some refs"},
+			wantErrIs:      ErrPushRejected,
+			wantDestroyCnt: 1,
+		},
+		{
+			name:           "stale info from force-with-lease maps to ErrPushRejected",
+			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
+			provider:       &prTestSandboxProvider{execExit: 1, execStderr: "! [rejected]   HEAD -> b (stale info)"},
+			wantErrIs:      ErrPushRejected,
 			wantDestroyCnt: 1,
 		},
 		{

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -123,19 +123,33 @@ func (s *prTestSnapshotStore) Delete(_ context.Context, key string) error {
 }
 
 type prTestSandboxProvider struct {
-	lastConfig  agent.SandboxConfig
-	lastExecCmd string
-	writes      map[string][]byte
-	execExit    int
-	execErr     error
-	execStderr  string
-	execStdout  string
-	createErr   error
-	restoreErr  error
-	writeErrs   map[string]error
-	destroyErr  error
-	destroyed   int
-	snapshotErr error
+	lastConfig    agent.SandboxConfig
+	lastExecCmd   string
+	writes        map[string][]byte
+	execExit      int
+	execErr       error
+	execStderr    string
+	execStdout    string
+	execSequence  []prTestExecResponse
+	execCallCount int
+	createErr     error
+	restoreErr    error
+	writeErrs     map[string]error
+	destroyErr    error
+	destroyed     int
+	snapshotErr   error
+}
+
+// prTestExecResponse drives a multi-call Exec sequence: each provider Exec()
+// pops the next response (capped at the slice length, after which the static
+// execExit/execStdout/execStderr/execErr fields take over). Lets tests assert
+// behavior that depends on the order of two or more sandbox executions —
+// e.g. "first push attempt is rejected, second succeeds".
+type prTestExecResponse struct {
+	exit   int
+	stdout string
+	stderr string
+	err    error
 }
 
 func (p *prTestSandboxProvider) Name() string { return "test" }
@@ -154,6 +168,18 @@ func (p *prTestSandboxProvider) CloneRepo(context.Context, *agent.Sandbox, strin
 
 func (p *prTestSandboxProvider) Exec(_ context.Context, _ *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
 	p.lastExecCmd = cmd
+	idx := p.execCallCount
+	p.execCallCount++
+	if idx < len(p.execSequence) {
+		r := p.execSequence[idx]
+		if r.stdout != "" {
+			_, _ = io.WriteString(stdout, r.stdout)
+		}
+		if r.stderr != "" {
+			_, _ = io.WriteString(stderr, r.stderr)
+		}
+		return r.exit, r.err
+	}
 	if p.execStdout != "" {
 		_, _ = io.WriteString(stdout, p.execStdout)
 	}
@@ -3992,6 +4018,118 @@ func (f *fakeSandboxAuth) Listen(_ context.Context, sessionID uuid.UUID, _ *mode
 
 func (f *fakeSandboxAuth) Close(_ uuid.UUID) {
 	f.closeCount++
+}
+
+// TestPushSessionBranch_RetryOnRejection_Succeeds locks in the self-healing
+// behavior: if the first push attempt is rejected (race between our
+// ls-remote and our push, only failure mode --force-with-lease can
+// surface when 143 owns the branch namespace), the service runs the
+// idempotent push script a second time, picks up the new remote SHA,
+// and succeeds — without surfacing ErrPushRejected.
+func TestPushSessionBranch_RetryOnRejection_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	const headSHA = "abc1234567890abcdef1234567890abcdef12345"
+	provider := &prTestSandboxProvider{
+		execSequence: []prTestExecResponse{
+			{exit: 1, stderr: "! [rejected]   HEAD -> b (stale info)\nerror: failed to push some refs"},
+			{exit: 0, stdout: pushHeadSHASentinel + headSHA + "\n"},
+		},
+	}
+	svc := &PRService{
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
+		logger:          zerolog.Nop(),
+	}
+	run := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	repo := &models.Repository{FullName: "owner/repo"}
+
+	result, err := svc.pushSessionBranch(
+		context.Background(),
+		run,
+		repo,
+		models.OrgSettings{},
+		"snapshots/key.tar",
+		"143/abc/fix",
+		"commit message",
+		"Bot",
+		"bot@example.com",
+	)
+	t.Cleanup(func() {
+		if result != nil && result.CapturedSnapshotPath != "" {
+			_ = os.Remove(result.CapturedSnapshotPath)
+		}
+	})
+
+	require.NoError(t, err, "self-heal: a single rejection followed by success must NOT surface ErrPushRejected")
+	require.Equal(t, headSHA, result.HeadSHA)
+	require.Equal(t, 2, provider.execCallCount, "pushSessionBranch must execute the script exactly twice — once rejected, once retried")
+}
+
+// TestPushSessionBranch_RetryOnRejection_PersistentRejection asserts the
+// retry is one-shot: a second rejection bubbles up as ErrPushRejected so
+// the worker can surface it (instead of looping silently).
+func TestPushSessionBranch_RetryOnRejection_PersistentRejection(t *testing.T) {
+	t.Parallel()
+
+	rejectStderr := "! [rejected]   HEAD -> b (non-fast-forward)\nerror: failed to push some refs"
+	provider := &prTestSandboxProvider{
+		execSequence: []prTestExecResponse{
+			{exit: 1, stderr: rejectStderr},
+			{exit: 1, stderr: rejectStderr},
+		},
+	}
+	svc := &PRService{
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
+		logger:          zerolog.Nop(),
+	}
+
+	_, err := svc.pushSessionBranch(
+		context.Background(),
+		&models.Session{ID: uuid.New(), OrgID: uuid.New()},
+		&models.Repository{FullName: "owner/repo"},
+		models.OrgSettings{},
+		"snapshots/key.tar",
+		"143/abc/fix",
+		"commit message",
+		"Bot",
+		"bot@example.com",
+	)
+	require.ErrorIs(t, err, ErrPushRejected, "persistent rejection must still surface ErrPushRejected")
+	require.Equal(t, 2, provider.execCallCount, "retry budget is one — at most two total attempts")
+}
+
+// TestPushSessionBranch_NoRetryOnNonRejection asserts the retry is gated
+// on isPushRejection: non-rejection failures (e.g. exec errors, network)
+// are NOT retried, since they aren't the race --force-with-lease detects.
+func TestPushSessionBranch_NoRetryOnNonRejection(t *testing.T) {
+	t.Parallel()
+
+	provider := &prTestSandboxProvider{execExit: 1, execStderr: "fatal: unable to access remote"}
+	svc := &PRService{
+		sandboxProvider: provider,
+		snapshots:       &prTestSnapshotStore{payload: []byte("snapshot")},
+		sandboxAuth:     &fakeSandboxAuth{socketPath: "/tmp/fake.sock"},
+		logger:          zerolog.Nop(),
+	}
+
+	_, err := svc.pushSessionBranch(
+		context.Background(),
+		&models.Session{ID: uuid.New(), OrgID: uuid.New()},
+		&models.Repository{FullName: "owner/repo"},
+		models.OrgSettings{},
+		"snapshots/key.tar",
+		"143/abc/fix",
+		"commit message",
+		"Bot",
+		"bot@example.com",
+	)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrPushRejected)
+	require.Equal(t, 1, provider.execCallCount, "non-rejection failure must NOT be retried")
 }
 
 // TestPushSessionBranch_AuthSocketWired locks in the regression fix: the

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1430,6 +1430,8 @@ func userFacingPRError(err error) string {
 		return "This pull request is no longer open."
 	case errors.Is(err, ghservice.ErrLegacyPRMissingHeadRef):
 		return "This PR predates branch tracking; create a new PR to push follow-up changes."
+	case errors.Is(err, ghservice.ErrPushRejected):
+		return ghservice.PushRejectedPRMessage
 	default:
 		return "Check GitHub access or repo permissions and try again."
 	}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2238,6 +2238,16 @@ func TestUserFacingPRError(t *testing.T) {
 			want: "No changes to push.",
 		},
 		{
+			name: "push rejected",
+			err:  ghservice.ErrPushRejected,
+			want: "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session.",
+		},
+		{
+			name: "wrapped push rejected",
+			err:  fmt.Errorf("git push failed: %w (stale info)", ghservice.ErrPushRejected),
+			want: "GitHub rejected the push because the remote branch changed during the attempt. Try again, or delete the branch on GitHub if it was created outside this session.",
+		},
+		{
 			name: "generic fallback",
 			err:  errors.New("boom"),
 			want: "Check GitHub access or repo permissions and try again.",


### PR DESCRIPTION
## Summary
- PR creation could land on the remote but fail before recording PR state, leaving every retry stuck in a non-fast-forward loop with a generic "Check GitHub access or repo permissions" message in the UI.
- The push script now `ls-remote`s the session branch and pushes with `--force-with-lease=refs/heads/<branch>:<remote_sha>`, auto-recovering from stale tips while still aborting on a true concurrent write between `ls-remote` and `push`.
- Push rejections (non-fast-forward, stale info, "failed to push some refs") now wrap a new `ErrPushRejected` sentinel that maps to a targeted user-facing message via \`userFacingPRError()\`.
- Left as a non-terminal error so the worker retries — a retry re-reads the remote SHA via ls-remote and typically succeeds.

## Test plan
- [x] \`make lint\`
- [x] \`go test ./internal/services/github/... ./internal/worker/...\`
- [x] New \`TestIsPushRejection\`; \`TestPushSessionBranch\` covers non-fast-forward + stale-info → \`ErrPushRejected\`; \`TestUserFacingPRError\` covers the sentinel and a wrapped variant; \`TestBuildPushScript_*\` updated for the new ls-remote + force-with-lease + thrice-quoted branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)