### PR TITLE
[codex] Add personal subscription auth

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -195,8 +195,13 @@ func main() {
 	}); err != nil {
 		logger.Fatal().Err(err).Msg("failed to initialize coding-credentials mirror metrics")
 	}
-	codexAuthSvc := codexauth.NewService(credentialStore, logger)
-	claudeCodeAuthSvc := claudecodeauth.NewService(credentialStore, logger)
+	// Both OAuth services depend on a scope-aware credential surface. The
+	// adapter routes org-scope traffic to the legacy OrgCredentialStore
+	// (mirrored to coding_credentials) and personal-scope traffic to the
+	// unified CodingCredentialStore directly — see internal/db/scoped_credential_store.go.
+	scopedCredentialStore := db.NewScopedCredentialStore(credentialStore, codingCredentialStore)
+	codexAuthSvc := codexauth.NewService(scopedCredentialStore, logger)
+	claudeCodeAuthSvc := claudecodeauth.NewService(scopedCredentialStore, logger)
 
 	// Platform LLM client for internal features (titles, PR descriptions, project
 	// generation, validation, prioritization). Uses the cheap PLATFORM_LLM_MODEL.

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3281,20 +3281,40 @@ describe('SessionDetailPage', () => {
       failure_explanation: 'Codex token expired',
       agent_type: 'codex',
     };
+    let statusScope: string | null = null;
+    let initiateBody: Record<string, unknown> | null = null;
 
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: codexAuthSession } satisfies SingleResponse<Session>);
       }),
-      http.get('/api/v1/settings/codex-auth/status', () => {
+      http.get('/api/v1/settings/codex-auth/status', ({ request }) => {
+        statusScope = new URL(request.url).searchParams.get('scope');
         return HttpResponse.json({ data: { status: 'none' } });
+      }),
+      http.post('/api/v1/settings/codex-auth/initiate', async ({ request }) => {
+        initiateBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({
+          data: {
+            user_code: 'TEST-CODE',
+            verification_uri: 'https://auth.openai.com/codex/device',
+            expires_in: 900,
+          },
+        });
       }),
     );
 
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
     await screen.findByText('Failure details');
     expect(screen.getByText('codex_auth_expired')).toBeInTheDocument();
-    expect(screen.getByText('Re-authenticate with ChatGPT')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(statusScope).toBe('personal');
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByText('Re-authenticate with ChatGPT'));
+    await waitFor(() => {
+      expect(initiateBody).toMatchObject({ scope: 'personal' });
+    });
     // Should NOT show failure_next_steps for codex auth failures
     expect(screen.queryByText('Next steps')).not.toBeInTheDocument();
   });
@@ -3311,7 +3331,8 @@ describe('SessionDetailPage', () => {
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({ data: codexAuthSession } satisfies SingleResponse<Session>);
       }),
-      http.get('/api/v1/settings/codex-auth/status', () => {
+      http.get('/api/v1/settings/codex-auth/status', ({ request }) => {
+        expect(new URL(request.url).searchParams.get('scope')).toBe('personal');
         return HttpResponse.json({ data: { status: 'completed' } });
       }),
     );

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -399,8 +399,8 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
   const isCodexAuthFailure = session.failure_category === FAILURE_CATEGORY_CODEX_AUTH;
 
   const { data: codexAuthResponse } = useQuery<SingleResponse<CodexAuthStatus>>({
-    queryKey: ["codex-auth-status"],
-    queryFn: () => api.codexAuth.status(),
+    queryKey: ["codex-auth-status", "personal"],
+    queryFn: () => api.codexAuth.status(undefined, "personal"),
     enabled: isCodexAuthFailure,
   });
   const isCodexAuthenticated = codexAuthResponse?.data?.status === "completed";
@@ -504,6 +504,7 @@ function OverviewTab({ session, members }: { session: Session; members: User[] }
       )}
       {showDeviceCodeModal && (
         <CodexDeviceCodeModal
+          scope="personal"
           onClose={() => setShowDeviceCodeModal(false)}
           onConnected={() => {
             setShowDeviceCodeModal(false);

--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -72,6 +72,9 @@ const mocks = vi.hoisted(() => ({
   codingAuthsListMock: vi.fn().mockResolvedValue({
     data: [],
   }),
+  codingCredentialsListMock: vi.fn().mockResolvedValue({
+    data: [],
+  }),
   codexAuthStatusMock: vi.fn().mockResolvedValue({ data: { status: "completed" } }),
   authMeMock: vi.fn().mockResolvedValue({
     data: {
@@ -109,6 +112,9 @@ vi.mock("@/lib/api", () => ({
     },
     codingAuths: {
       list: mocks.codingAuthsListMock,
+    },
+    codingCredentials: {
+      list: mocks.codingCredentialsListMock,
     },
     codexAuth: {
       status: mocks.codexAuthStatusMock,

--- a/frontend/src/app/(dashboard)/settings/account/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.test.tsx
@@ -208,6 +208,7 @@ describe("Account settings page", () => {
 
     await user.click(screen.getByRole("button", { name: "Add auth" }));
     await user.click(await screen.findByLabelText("Claude Code"));
+    await user.click(screen.getByRole("radio", { name: /API key/i }));
     await user.type(screen.getByLabelText("Label"), "Personal Claude backup");
     // Use the input id directly — the visible label text is shared with the
     // help-tooltip button so getByLabelText("API key") would be ambiguous.

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -8,6 +8,8 @@ import { api } from "@/lib/api";
 import { apiKeyHelp, PERSONAL_PROVIDER_OPTIONS, personalProviderToAgent, type PersonalProvider } from "@/lib/coding-auth-metadata";
 import { captureError } from "@/lib/errors";
 import { APIKeyHelpTooltip } from "@/components/api-key-help-tooltip";
+import { ClaudeCodeAuthModal } from "@/components/claude-code-auth-modal";
+import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { CodingAuthDialog } from "@/components/coding-auth-dialog";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
@@ -16,6 +18,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { ThemeSelect } from "@/components/theme-select";
@@ -182,13 +185,50 @@ function CredentialList({
   );
 }
 
+// effectiveResolutionLine renders the ordered list as a one-line "Personal #1
+// → Personal #2 → Org #1" string. Mirrors the design doc's "Effective
+// resolution for you" hint and is the single most-asked support question, so
+// surfacing it ambient on the page eliminates the round-trip.
+//
+// `rows` comes from /api/v1/coding-credentials?scope=resolved, which is
+// backed by ListResolvable (status='active' rows only). Counting is
+// therefore safe: every row counted is one the resolver would actually walk.
+function effectiveResolutionLine(rows: CodingCredentialSummary[]): string {
+  const personalCount = rows.filter((r) => r.scope === "personal").length;
+  const orgCount = rows.filter((r) => r.scope === "org").length;
+  const segments: string[] = [];
+  for (let i = 0; i < personalCount; i++) {
+    segments.push(`Personal #${i + 1}`);
+  }
+  for (let i = 0; i < orgCount; i++) {
+    segments.push(`Org #${i + 1}`);
+  }
+  if (segments.length === 0) {
+    return "No credentials configured.";
+  }
+  return segments.join(" → ");
+}
+
+// Auth type for the personal Add-auth modal. Mirrors the org-side flow in
+// /settings/agent: subscription auth runs the OAuth handshake against the
+// upstream provider; api_key takes a static key. The modal exposes the
+// selector only when the chosen provider's supportsSubscription is true
+// (Codex + Claude Code today).
+type PersonalAuthType = "subscription" | "api_key";
+
 export default function AccountPage() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
   const [provider, setProvider] = useState<PersonalProvider>("openai");
+  const [authType, setAuthType] = useState<PersonalAuthType>("subscription");
   const [apiKey, setApiKey] = useState("");
   const [authLabel, setAuthLabel] = useState("");
+  // Subscription OAuth modal dispatch — only one is open at a time.
+  // The dialog itself closes when these open so the OAuth modal owns the
+  // user's attention during the device-code or paste-back flow.
+  const [showCodexModal, setShowCodexModal] = useState(false);
+  const [showClaudeModal, setShowClaudeModal] = useState(false);
   const [pendingReasoningDefaults, setPendingReasoningDefaults] = useState<UserSettingsUpdateRequest["coding_agent_reasoning_defaults"] | null>(null);
   const reasoningSaveInFlightRef = useRef(false);
   const queuedReasoningDefaultsRef = useRef<UserSettingsUpdateRequest["coding_agent_reasoning_defaults"] | null>(null);
@@ -296,6 +336,62 @@ export default function AccountPage() {
       return;
     }
     updateReasoningDefaultsMutation.mutate(defaults);
+  }
+
+  // The selected provider's metadata drives whether the auth-type selector
+  // is visible. For providers that don't ship a subscription OAuth flow
+  // (Gemini CLI / Amp / Pi), we coerce auth_type to "api_key" so the modal
+  // doesn't render a dead radio group.
+  const selectedProviderOption = PERSONAL_PROVIDER_OPTIONS.find((o) => o.key === provider) ?? PERSONAL_PROVIDER_OPTIONS[0];
+  const showAuthTypeSelector = selectedProviderOption.supportsSubscription;
+  const effectiveAuthType: PersonalAuthType = showAuthTypeSelector ? authType : "api_key";
+
+  // Default label shown as the modal placeholder. Mirrors the admin
+  // /settings/agent generated-label format ("Codex subscription" /
+  // "Claude Code API key" / etc) so the two flows feel consistent.
+  function defaultLabelFor(p: PersonalProvider, type: PersonalAuthType): string {
+    const agent = personalProviderToAgent(p);
+    const base = agent === "codex" ? "Codex"
+      : agent === "claude_code" ? "Claude Code"
+      : agent === "gemini_cli" ? "Gemini CLI"
+      : agent === "amp" ? "Amp"
+      : agent === "pi" ? "Pi"
+      : agent;
+    return type === "subscription" ? `${base} subscription` : `${base} API key`;
+  }
+  const generatedLabel = authLabel.trim() || defaultLabelFor(provider, effectiveAuthType);
+
+  function resetModalState() {
+    setApiKey("");
+    setAuthLabel("");
+    setProvider("openai");
+    setAuthType("subscription");
+  }
+
+  function closeAddModal() {
+    setAddOpen(false);
+    resetModalState();
+  }
+
+  // handlePrimary routes the modal's primary action to either the API-key
+  // POST or the subscription OAuth modal, depending on the selected
+  // auth_type. The OAuth modals invalidate query caches on success so the
+  // personal stack table refreshes once the subscription is active.
+  function handlePrimary() {
+    if (effectiveAuthType === "subscription") {
+      const agent = personalProviderToAgent(provider);
+      if (agent === "codex") {
+        setShowCodexModal(true);
+        setAddOpen(false);
+        return;
+      }
+      if (agent === "claude_code") {
+        setShowClaudeModal(true);
+        setAddOpen(false);
+        return;
+      }
+    }
+    createMutation.mutate();
   }
 
   return (
@@ -408,64 +504,142 @@ export default function AccountPage() {
       <CodingAuthDialog
         open={addOpen}
         onOpenChange={(open) => {
-          setAddOpen(open);
-          if (!open) {
-            setApiKey("");
-            setAuthLabel("");
-          }
+          if (!open) closeAddModal();
+          else setAddOpen(true);
         }}
         title="Add auth"
-        description="Add a personal API key that will be tried before the organization fallback stack."
+        description="Add a personal subscription or API key — your personal stack runs ahead of the organization fallback."
         providerOptions={PERSONAL_PROVIDER_OPTIONS}
         provider={provider}
-        onProviderChange={setProvider}
-        primaryLabel="Save auth"
-        onPrimary={() => createMutation.mutate()}
-        primaryDisabled={!apiKey.trim()}
-        onCancel={() => {
-          setApiKey("");
-          setAuthLabel("");
-          setAddOpen(false);
+        onProviderChange={(value) => {
+          const next = value as PersonalProvider;
+          setProvider(next);
+          // When switching to a provider that doesn't support subscription
+          // auth, reset the radio so the modal doesn't carry a dead value.
+          const opt = PERSONAL_PROVIDER_OPTIONS.find((o) => o.key === next);
+          if (!opt?.supportsSubscription) {
+            setAuthType("api_key");
+          } else {
+            setAuthType("subscription");
+          }
         }}
+        primaryLabel={effectiveAuthType === "subscription" ? "Continue" : "Save auth"}
+        onPrimary={handlePrimary}
+        primaryDisabled={effectiveAuthType === "api_key" && !apiKey.trim()}
+        onCancel={closeAddModal}
       >
+        {showAuthTypeSelector ? (
+          <div className="space-y-2">
+            <Label>Auth type</Label>
+            <RadioGroup
+              value={effectiveAuthType}
+              onValueChange={(value) => setAuthType(value as PersonalAuthType)}
+              className="grid gap-3 md:grid-cols-2"
+            >
+              <Label htmlFor="personal-auth-subscription" className="flex cursor-pointer items-start gap-3 rounded-xl border border-border p-4">
+                <RadioGroupItem value="subscription" id="personal-auth-subscription" />
+                <div className="space-y-1">
+                  <div className="font-medium text-sm">Subscription</div>
+                  <p className="text-xs text-muted-foreground">
+                    Sign in to your existing Codex or Claude subscription.
+                  </p>
+                </div>
+              </Label>
+              <Label htmlFor="personal-auth-api-key" className="flex cursor-pointer items-start gap-3 rounded-xl border border-border p-4">
+                <RadioGroupItem value="api_key" id="personal-auth-api-key" />
+                <div className="space-y-1">
+                  <div className="font-medium text-sm">API key</div>
+                  <p className="text-xs text-muted-foreground">
+                    Paste a key for pay-as-you-go billing or service accounts.
+                  </p>
+                </div>
+              </Label>
+            </RadioGroup>
+          </div>
+        ) : null}
+
         <div className="space-y-2">
           <Label htmlFor="personal-auth-label">Label</Label>
           <Input
             id="personal-auth-label"
             value={authLabel}
             onChange={(event) => setAuthLabel(event.target.value)}
-            placeholder={`${agentLabel(personalProviderToAgent(provider))} backup`}
+            placeholder={`Optional — defaults to "${defaultLabelFor(provider, effectiveAuthType)}"`}
           />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="personal-api-key" className="flex items-center gap-2">
-            API key
-            <APIKeyHelpTooltip
-              ariaLabel={`Where to get a ${apiKeyHelp(provider).label} API key`}
-              description={apiKeyHelp(provider).description}
-              href={apiKeyHelp(provider).href}
-              linkLabel={apiKeyHelp(provider).linkLabel}
+
+        {effectiveAuthType === "api_key" ? (
+          <div className="space-y-2">
+            <Label htmlFor="personal-api-key" className="flex items-center gap-2">
+              API key
+              <APIKeyHelpTooltip
+                ariaLabel={`Where to get a ${apiKeyHelp(provider).label} API key`}
+                description={apiKeyHelp(provider).description}
+                href={apiKeyHelp(provider).href}
+                linkLabel={apiKeyHelp(provider).linkLabel}
+              />
+            </Label>
+            <Input
+              id="personal-api-key"
+              type="password"
+              value={apiKey}
+              onChange={(event) => setApiKey(event.target.value)}
+              placeholder={
+                provider === "anthropic"
+                  ? "sk-ant-..."
+                  : provider === "gemini"
+                    ? "AIza..."
+                    : provider === "amp"
+                      ? "amp_..."
+                      : provider === "pi"
+                        ? "pi_..."
+                        : "sk-..."
+              }
             />
-          </Label>
-          <Input
-            id="personal-api-key"
-            type="password"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-            placeholder={
-              provider === "anthropic"
-                ? "sk-ant-..."
-                : provider === "gemini"
-                  ? "AIza..."
-                  : provider === "amp"
-                    ? "amp_..."
-                    : provider === "pi"
-                      ? "pi_..."
-                      : "sk-..."
-            }
-          />
-        </div>
+          </div>
+        ) : null}
       </CodingAuthDialog>
+
+      {showCodexModal ? (
+        <CodexDeviceCodeModal
+          label={generatedLabel}
+          scope="personal"
+          onClose={() => {
+            setShowCodexModal(false);
+            resetModalState();
+          }}
+          onConnected={() => {
+            setShowCodexModal(false);
+            resetModalState();
+            // Invalidate the personal stack so the new subscription appears.
+            void queryClient.invalidateQueries({ queryKey: ["coding-credentials"] });
+            // Legacy keys that still feed parts of the UI during the
+            // unified-credentials migration window.
+            void queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
+            void queryClient.invalidateQueries({ queryKey: ["credentials", "resolved"] });
+            toast.success("Personal subscription connected");
+          }}
+        />
+      ) : null}
+
+      {showClaudeModal ? (
+        <ClaudeCodeAuthModal
+          label={generatedLabel}
+          scope="personal"
+          onClose={() => {
+            setShowClaudeModal(false);
+            resetModalState();
+          }}
+          onConnected={() => {
+            setShowClaudeModal(false);
+            resetModalState();
+            void queryClient.invalidateQueries({ queryKey: ["coding-credentials"] });
+            void queryClient.invalidateQueries({ queryKey: ["user-credentials"] });
+            void queryClient.invalidateQueries({ queryKey: ["credentials", "resolved"] });
+            toast.success("Personal subscription connected");
+          }}
+        />
+      ) : null}
     </PageContainer>
   );
 }

--- a/frontend/src/app/(dashboard)/settings/account/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/account/page.tsx
@@ -185,30 +185,6 @@ function CredentialList({
   );
 }
 
-// effectiveResolutionLine renders the ordered list as a one-line "Personal #1
-// → Personal #2 → Org #1" string. Mirrors the design doc's "Effective
-// resolution for you" hint and is the single most-asked support question, so
-// surfacing it ambient on the page eliminates the round-trip.
-//
-// `rows` comes from /api/v1/coding-credentials?scope=resolved, which is
-// backed by ListResolvable (status='active' rows only). Counting is
-// therefore safe: every row counted is one the resolver would actually walk.
-function effectiveResolutionLine(rows: CodingCredentialSummary[]): string {
-  const personalCount = rows.filter((r) => r.scope === "personal").length;
-  const orgCount = rows.filter((r) => r.scope === "org").length;
-  const segments: string[] = [];
-  for (let i = 0; i < personalCount; i++) {
-    segments.push(`Personal #${i + 1}`);
-  }
-  for (let i = 0; i < orgCount; i++) {
-    segments.push(`Org #${i + 1}`);
-  }
-  if (segments.length === 0) {
-    return "No credentials configured.";
-  }
-  return segments.join(" → ");
-}
-
 // Auth type for the personal Add-auth modal. Mirrors the org-side flow in
 // /settings/agent: subscription auth runs the OAuth handshake against the
 // upstream provider; api_key takes a static key. The modal exposes the

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.test.tsx
@@ -91,6 +91,57 @@ describe("AutopilotSettingsPage", () => {
     expect(screen.getByRole("option", { name: "anthropic/claude-opus-4-7" })).toBeInTheDocument();
   });
 
+  it("includes unified org subscription credentials in PM model availability", async () => {
+    server.use(
+      http.get("/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Org",
+          settings: {
+            pm_model: "claude-sonnet-4-5",
+            default_agent_type: "codex",
+            agent_config: {},
+          },
+          created_at: "2026-03-20T00:00:00Z",
+          updated_at: "2026-03-20T00:00:00Z",
+        },
+      })),
+      http.get("/api/v1/repositories", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("/api/v1/settings/coding-auths", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("/api/v1/coding-credentials", ({ request }) => {
+        const url = new URL(request.url);
+        if (url.searchParams.get("scope") !== "org") {
+          return HttpResponse.json({ data: [], meta: {} });
+        }
+        return HttpResponse.json({
+          data: [{
+            id: "cred-1",
+            org_id: "org-1",
+            scope: "org",
+            priority: 1,
+            agent: "claude_code",
+            auth_type: "subscription",
+            provider: "anthropic_subscription",
+            label: "Claude subscription",
+            status: "healthy",
+            is_default: true,
+            created_at: "2026-03-20T00:00:00Z",
+            updated_at: "2026-03-20T00:00:00Z",
+          }],
+          meta: {},
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<AutopilotSettingsPage />);
+
+    await user.click(await screen.findByLabelText("PM model"));
+
+    expect(await screen.findByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "claude-sonnet-4-5" })).toBeInTheDocument();
+  });
+
   it("autosaves the PM cadence when the value changes and the input blurs", async () => {
     let capturedBody: unknown;
     server.use(

--- a/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/autopilot/page.tsx
@@ -38,7 +38,7 @@ import {
   PM_SCHEDULE_MAX_HOURS,
   clampNumber,
 } from "@/lib/settings-constants";
-import type { CodingAuth, ListResponse, Organization, OrgSettings, RepoSettings, Repository, ResolvedCredential, SingleResponse, UserCredentialSummary } from "@/lib/types";
+import type { CodingAuth, CodingCredentialSummary, ListResponse, Organization, OrgSettings, RepoSettings, Repository, ResolvedCredential, SingleResponse, UserCredentialSummary } from "@/lib/types";
 
 export default function AutopilotSettingsPage() {
   const { user } = useAuth();
@@ -74,6 +74,11 @@ export default function AutopilotSettingsPage() {
     queryFn: () => api.codingAuths.list(),
     enabled: isAdmin,
   });
+  const { data: orgCodingCredentialsResponse } = useQuery<ListResponse<CodingCredentialSummary>>({
+    queryKey: ["coding-credentials", "org"],
+    queryFn: () => api.codingCredentials.list("org"),
+    enabled: isAdmin,
+  });
 
   const settings = (settingsResponse?.data?.settings ?? {}) as OrgSettings;
   const repositories = repositoriesResponse?.data ?? [];
@@ -89,6 +94,14 @@ export default function AutopilotSettingsPage() {
     () => codingAuthsResponse?.data ?? [],
     [codingAuthsResponse],
   );
+  const orgCodingCredentials = useMemo(
+    () => orgCodingCredentialsResponse?.data ?? [],
+    [orgCodingCredentialsResponse],
+  );
+  const pmCodingAuthAvailability = useMemo(
+    () => [...codingAuths, ...orgCodingCredentials],
+    [codingAuths, orgCodingCredentials],
+  );
   const codexAuthStatus = codexAuthResponse?.data;
   const pmResolvedCredentials = useMemo(
     () => pmUsableResolvedCredentials(resolvedCredentials, teamDefaultsResponse?.data ?? []),
@@ -99,11 +112,11 @@ export default function AutopilotSettingsPage() {
     return availableAgentModelGroups(
       pmResolvedCredentials,
       codexAuthStatus,
-      codingAuths,
+      pmCodingAuthAvailability,
       settings.default_agent_type || "codex",
       { orgAgentConfig: settings.agent_config },
     );
-  }, [pmResolvedCredentials, codexAuthStatus, codingAuths, settings.default_agent_type, settings.agent_config]);
+  }, [pmResolvedCredentials, codexAuthStatus, pmCodingAuthAvailability, settings.default_agent_type, settings.agent_config]);
 
   const scheduleHoursServer = settings.pm_schedule_hours ?? 24;
   const pmModel = settings.pm_model ?? DEFAULT_PM_MODEL;

--- a/frontend/src/components/claude-code-auth-modal.test.tsx
+++ b/frontend/src/components/claude-code-auth-modal.test.tsx
@@ -52,7 +52,7 @@ describe("ClaudeCodeAuthModal", () => {
     render(<ClaudeCodeAuthModal label="team-a" onClose={onClose} />);
 
     await waitFor(() => {
-      expect(initiateMock).toHaveBeenCalledWith("team-a");
+      expect(initiateMock).toHaveBeenCalledWith("team-a", undefined);
     });
 
     await user.keyboard("{Escape}");
@@ -79,7 +79,7 @@ describe("ClaudeCodeAuthModal", () => {
       await Promise.resolve();
       await Promise.resolve();
     });
-    expect(completeMock).toHaveBeenCalledWith("team-a", "abc123#state456");
+    expect(completeMock).toHaveBeenCalledWith("team-a", "abc123#state456", undefined);
     expect(screen.getByText("Connected successfully!")).toBeInTheDocument();
 
     unmount();

--- a/frontend/src/components/claude-code-auth-modal.tsx
+++ b/frontend/src/components/claude-code-auth-modal.tsx
@@ -19,13 +19,20 @@ export function ClaudeCodeAuthModal({
   onClose,
   onConnected,
   label,
+  scope,
 }: {
   onClose: () => void;
   onConnected?: () => void;
   label: string;
+  // scope routes the pending-auth row into either the org or the caller's
+  // personal credential stack. Defaults to org for backwards compatibility
+  // with the admin /settings/agent flow.
+  scope?: 'org' | 'personal';
 }) {
-  // Capture the label at mount time so it stays stable throughout the auth flow.
+  // Capture the label + scope at mount time so they stay stable throughout
+  // the auth flow.
   const [stableLabel] = useState(() => label);
+  const [stableScope] = useState(() => scope);
   const connectedTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
   const [initiated, setInitiated] = useState<ClaudeCodeInitiateResponse | null>(null);
   const [status, setStatus] = useState<
@@ -39,7 +46,7 @@ export function ClaudeCodeAuthModal({
       setStatus("initiating");
       setError("");
       setCode("");
-      const resp = await api.claudeCodeAuth.initiate(stableLabel);
+      const resp = await api.claudeCodeAuth.initiate(stableLabel, stableScope);
       setInitiated(resp.data);
       setStatus("awaiting_paste");
     } catch (err) {
@@ -49,7 +56,7 @@ export function ClaudeCodeAuthModal({
       setError(message);
       setStatus("error");
     }
-  }, [stableLabel]);
+  }, [stableLabel, stableScope]);
 
   useEffect(() => {
     const id = setTimeout(() => {
@@ -84,7 +91,7 @@ export function ClaudeCodeAuthModal({
     try {
       setStatus("exchanging");
       setError("");
-      await api.claudeCodeAuth.complete(stableLabel, trimmed);
+      await api.claudeCodeAuth.complete(stableLabel, trimmed, stableScope);
       setStatus("completed");
       connectedTimerRef.current = setTimeout(() => {
         onConnected?.();
@@ -98,7 +105,7 @@ export function ClaudeCodeAuthModal({
       setError(message);
       setStatus("awaiting_paste");
     }
-  }, [code, stableLabel, onConnected]);
+  }, [code, stableLabel, stableScope, onConnected]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">

--- a/frontend/src/components/codex-device-code-modal.tsx
+++ b/frontend/src/components/codex-device-code-modal.tsx
@@ -11,13 +11,20 @@ export function CodexDeviceCodeModal({
   onClose,
   onConnected,
   label,
+  scope,
 }: {
   onClose: () => void;
   onConnected?: () => void;
   label?: string;
+  // scope routes the pending-auth row into either the org or the caller's
+  // personal credential stack. Defaults to org for backwards compatibility
+  // with the admin /settings/agent flow.
+  scope?: 'org' | 'personal';
 }) {
-  // Capture the label at mount time so it stays stable throughout the auth flow.
+  // Capture the label + scope at mount time so they stay stable throughout
+  // the auth flow.
   const [stableLabel] = useState(() => label);
+  const [stableScope] = useState(() => scope);
   const [deviceAuth, setDeviceAuth] = useState<CodexDeviceAuth | null>(null);
   const [status, setStatus] = useState<string>("initiating");
   const [error, setError] = useState("");
@@ -36,7 +43,7 @@ export function CodexDeviceCodeModal({
     try {
       setStatus("initiating");
       setError("");
-      const resp = await api.codexAuth.initiate(stableLabel);
+      const resp = await api.codexAuth.initiate(stableLabel, stableScope);
       setDeviceAuth(resp.data);
       setTimeLeft(resp.data.expires_in);
       setStatus("pending");
@@ -47,7 +54,7 @@ export function CodexDeviceCodeModal({
       setError(message);
       setStatus("error");
     }
-  }, [stableLabel]);
+  }, [stableLabel, stableScope]);
 
   useEffect(() => {
     const id = setTimeout(() => {
@@ -61,7 +68,7 @@ export function CodexDeviceCodeModal({
 
     pollRef.current = setInterval(async () => {
       try {
-        const resp = await api.codexAuth.status(stableLabel);
+        const resp = await api.codexAuth.status(stableLabel, stableScope);
         if (resp.data.status === "completed") {
           setStatus("completed");
           if (pollRef.current) clearInterval(pollRef.current);
@@ -94,7 +101,7 @@ export function CodexDeviceCodeModal({
       if (timerRef.current) clearInterval(timerRef.current);
       if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
     };
-  }, [status, stableLabel]);
+  }, [status, stableLabel, stableScope]);
 
   const minutes = Math.floor(timeLeft / 60);
   const seconds = timeLeft % 60;

--- a/frontend/src/components/repo-pm-settings.test.tsx
+++ b/frontend/src/components/repo-pm-settings.test.tsx
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import userEvent from "@testing-library/user-event";
+import { renderWithProviders, screen, waitFor, within } from "@/test/test-utils";
+import { server } from "@/test/mocks/server";
+import { RepoPMSettingsEditor } from "./repo-pm-settings";
+import type { Repository } from "@/lib/types";
+
+function repo(overrides: Partial<Repository> = {}): Repository {
+  return {
+    id: "repo-1",
+    org_id: "org-1",
+    integration_id: "integration-1",
+    github_id: 123,
+    full_name: "acme/app",
+    default_branch: "main",
+    private: true,
+    clone_url: "https://github.com/acme/app.git",
+    installation_id: 456,
+    status: "active",
+    settings: {},
+    created_at: "2026-03-20T00:00:00Z",
+    updated_at: "2026-03-20T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("RepoPMSettingsEditor", () => {
+  it("checks org-scoped coding credentials for PM availability", async () => {
+    let statusRequested = false;
+    let credentialsURL = "";
+
+    server.use(
+      http.get("/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Org",
+          settings: {
+            default_agent_type: "codex",
+            agent_config: {},
+          },
+          created_at: "2026-03-20T00:00:00Z",
+          updated_at: "2026-03-20T00:00:00Z",
+        },
+      })),
+      http.get("/api/v1/settings/codex-auth/status", () => {
+        statusRequested = true;
+        return HttpResponse.json({ data: { status: "none" } });
+      }),
+      http.get("/api/v1/coding-credentials", ({ request }) => {
+        credentialsURL = request.url;
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    renderWithProviders(<RepoPMSettingsEditor repository={repo()} />);
+
+    await waitFor(() => {
+      expect(credentialsURL).toContain("/api/v1/coding-credentials");
+    });
+    expect(credentialsURL).toContain("scope=org");
+    expect(statusRequested).toBe(false);
+  });
+
+  it("does not block PM model providers when org Codex status polling is forbidden", async () => {
+    const user = userEvent.setup();
+
+    server.use(
+      http.get("/api/v1/settings", () => HttpResponse.json({
+        data: {
+          id: "org-1",
+          name: "Org",
+          settings: {
+            default_agent_type: "codex",
+            agent_config: {},
+          },
+          created_at: "2026-03-20T00:00:00Z",
+          updated_at: "2026-03-20T00:00:00Z",
+        },
+      })),
+      http.get("/api/v1/settings/codex-auth/status", () =>
+        HttpResponse.json({ error: { code: "FORBIDDEN", message: "admin role required for scope=org operations" } }, { status: 403 }),
+      ),
+      http.patch("/api/v1/repositories/:id", async ({ request }) => {
+        const body = await request.json() as Partial<Repository>;
+        return HttpResponse.json({ data: repo(body) });
+      }),
+      http.get("/api/v1/coding-credentials", ({ request }) => {
+        const scope = new URL(request.url).searchParams.get("scope");
+        if (scope !== "org") {
+          return HttpResponse.json({ data: [], meta: {} });
+        }
+        return HttpResponse.json({
+          data: [{
+            id: "cred-1",
+            org_id: "org-1",
+            scope: "org",
+            priority: 1,
+            agent: "codex",
+            auth_type: "subscription",
+            provider: "openai_subscription",
+            label: "Team Codex",
+            status: "healthy",
+            is_default: true,
+            created_at: "2026-03-20T00:00:00Z",
+            updated_at: "2026-03-20T00:00:00Z",
+          }],
+          meta: {},
+        });
+      }),
+    );
+
+    renderWithProviders(<RepoPMSettingsEditor repository={repo({
+      settings: {
+        pm: {
+          pm_schedule_hours: 24,
+          pm_model: "gpt-5.4",
+          product_context: {
+            philosophy: "",
+            direction: "",
+            focus_areas: [],
+            avoid_areas: [],
+          },
+        },
+      },
+    })} />);
+
+    const trigger = await screen.findByRole("combobox", { name: "PM Model" });
+    await user.click(trigger);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(within(listbox).queryByText("Loading providers…")).not.toBeInTheDocument();
+    expect(within(listbox).getByText("Codex")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/repo-pm-settings.tsx
+++ b/frontend/src/components/repo-pm-settings.tsx
@@ -26,6 +26,7 @@ import { availableAgentModelGroups, pmUsableResolvedCredentials } from "@/lib/ag
 import { queryKeys } from "@/lib/query-keys";
 import type {
   CodingAuth,
+  CodingCredentialSummary,
   ListResponse,
   Organization,
   OrgSettings,
@@ -93,13 +94,13 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
     queryKey: queryKeys.credentials.teamDefaults,
     queryFn: () => api.userCredentials.listTeamDefaults(),
   });
-  const { data: codexAuthResponse } = useQuery({
-    queryKey: queryKeys.codexAuth.status,
-    queryFn: () => api.codexAuth.status(),
-  });
   const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
     queryKey: ["coding-auths"],
     queryFn: () => api.codingAuths.list(),
+  });
+  const { data: orgCodingCredentialsResponse } = useQuery<ListResponse<CodingCredentialSummary>>({
+    queryKey: ["coding-credentials", "org"],
+    queryFn: () => api.codingCredentials.list("org"),
   });
 
   const orgSettings = (orgResponse?.data?.settings ?? {}) as OrgSettings;
@@ -141,7 +142,14 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
     () => codingAuthsResponse?.data ?? [],
     [codingAuthsResponse],
   );
-  const codexAuthStatus = codexAuthResponse?.data;
+  const orgCodingCredentials = useMemo(
+    () => orgCodingCredentialsResponse?.data ?? [],
+    [orgCodingCredentialsResponse],
+  );
+  const pmCodingAuthAvailability = useMemo(
+    () => [...codingAuths, ...orgCodingCredentials],
+    [codingAuths, orgCodingCredentials],
+  );
   const pmResolvedCredentials = useMemo(
     () => pmUsableResolvedCredentials(resolvedCredentials, teamDefaultsResponse?.data ?? []),
     [resolvedCredentials, teamDefaultsResponse],
@@ -150,15 +158,15 @@ export function RepoPMSettingsEditor({ repository }: RepoPMSettingsProps) {
   const pmModelGroups = useMemo(() => {
     return availableAgentModelGroups(
       pmResolvedCredentials,
-      codexAuthStatus,
-      codingAuths,
+      null,
+      pmCodingAuthAvailability,
       orgSettings.default_agent_type || "codex",
       { orgAgentConfig: orgSettings.agent_config },
     );
-  }, [pmResolvedCredentials, codexAuthStatus, codingAuths, orgSettings.default_agent_type, orgSettings.agent_config]);
+  }, [pmResolvedCredentials, pmCodingAuthAvailability, orgSettings.default_agent_type, orgSettings.agent_config]);
 
   const credentialsLoaded = Boolean(
-    resolvedCredsResponse && teamDefaultsResponse && codexAuthResponse && codingAuthsResponse,
+    resolvedCredsResponse && teamDefaultsResponse && codingAuthsResponse && orgCodingCredentialsResponse,
   );
 
   const autosave = useAutosave<RepoPatch>({

--- a/frontend/src/components/setup-checklist.test.tsx
+++ b/frontend/src/components/setup-checklist.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
+import { renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { SetupChecklist } from "./setup-checklist";
 
 const mocks = vi.hoisted(() => ({
@@ -15,6 +15,12 @@ const mocks = vi.hoisted(() => ({
   codexAuthMock: vi.fn().mockResolvedValue({ data: { status: "pending" } }),
   integrationsListMock: vi.fn().mockResolvedValue({ data: [] }),
   repositoriesListMock: vi.fn().mockResolvedValue({ data: [] }),
+  userCredentialsListResolvedMock: vi.fn().mockResolvedValue({ data: [] }),
+  codingCredentialsListMock: vi.fn().mockResolvedValue({ data: [] }),
+  codexModalMock: vi.fn((props: unknown) => {
+    void props;
+    return <div data-testid="codex-device-code-modal" />;
+  }),
   sourceControlCardMock: vi.fn((props: unknown) => {
     void props;
     return <div data-testid="source-control-card" />;
@@ -30,6 +36,12 @@ vi.mock("@/lib/api", () => ({
     codexAuth: {
       status: mocks.codexAuthMock,
       start: vi.fn().mockResolvedValue({ data: {} }),
+    },
+    userCredentials: {
+      listResolved: mocks.userCredentialsListResolvedMock,
+    },
+    codingCredentials: {
+      list: mocks.codingCredentialsListMock,
     },
     integrations: {
       list: mocks.integrationsListMock,
@@ -55,7 +67,7 @@ vi.mock("@/hooks/use-github-repo-sync", () => ({
 }));
 
 vi.mock("@/components/codex-device-code-modal", () => ({
-  CodexDeviceCodeModal: () => null,
+  CodexDeviceCodeModal: (props: unknown) => mocks.codexModalMock(props),
 }));
 
 vi.mock("@/components/no-repos-warning", () => ({
@@ -97,6 +109,22 @@ describe("SetupChecklist", () => {
     await waitFor(() => {
       expect(screen.getByText("Codex")).toBeInTheDocument();
     });
+  });
+
+  it("checks and opens Codex auth in personal scope", async () => {
+    const user = userEvent.setup();
+
+    renderWithProviders(<SetupChecklist />);
+
+    await waitFor(() => {
+      expect(mocks.codexAuthMock).toHaveBeenCalledWith(undefined, "personal");
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Sign in with ChatGPT" }));
+
+    expect(mocks.codexModalMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ scope: "personal" }),
+    );
   });
 
   it("treats oauth-only github integrations as connected", async () => {

--- a/frontend/src/components/setup-checklist.tsx
+++ b/frontend/src/components/setup-checklist.tsx
@@ -17,7 +17,7 @@ import { CodexDeviceCodeModal } from "@/components/codex-device-code-modal";
 import { useDisconnectIntegration } from "@/hooks/use-disconnect-integration";
 import { useGitHubRepoSync } from "@/hooks/use-github-repo-sync";
 import { queryKeys } from "@/lib/query-keys";
-import { AGENTS_BY_KEY, isAgentConnected } from "@/lib/agents";
+import { AGENTS_BY_KEY, isAgentAvailable } from "@/lib/agents";
 import {
   Select,
   SelectContent,
@@ -25,7 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { OrgSettings } from "@/lib/types";
+import type { CodingCredentialSummary, ListResponse, OrgSettings } from "@/lib/types";
 
 function StepSection({
   step,
@@ -109,8 +109,8 @@ function AgentSelectionSection({ onConnectedChange }: { onConnectedChange?: (con
   const [selectedAgentTypeOverride, setSelectedAgentType] = useState<AgentType | null>(null);
 
   const { data: codexAuthResponse } = useQuery({
-    queryKey: queryKeys.codexAuth.status,
-    queryFn: () => api.codexAuth.status(),
+    queryKey: [...queryKeys.codexAuth.status, "personal"],
+    queryFn: () => api.codexAuth.status(undefined, "personal"),
   });
   const { data: settingsResponse } = useQuery({
     queryKey: queryKeys.settings.all,
@@ -120,12 +120,22 @@ function AgentSelectionSection({ onConnectedChange }: { onConnectedChange?: (con
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),
   });
+  const { data: resolvedCodingCredentialsResponse } = useQuery<ListResponse<CodingCredentialSummary>>({
+    queryKey: ["coding-credentials", "resolved"],
+    queryFn: () => api.codingCredentials.list("resolved"),
+  });
   const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const resolvedCredentials = resolvedCredsResponse?.data ?? [];
+  const resolvedCodingCredentials = resolvedCodingCredentialsResponse?.data ?? [];
 
   const selectedAgentType: AgentType = selectedAgentTypeOverride ?? settings?.default_agent_type ?? "codex";
 
-  const isSelectedAgentConnected = isAgentConnected(selectedAgentType, resolvedCredentials, codexAuthResponse?.data);
+  const isSelectedAgentConnected = isAgentAvailable(
+    selectedAgentType,
+    resolvedCredentials,
+    codexAuthResponse?.data,
+    resolvedCodingCredentials,
+  );
 
   const selectedAgent = agentOptions.find((agent) => agent.value === selectedAgentType) ?? agentOptions[0];
 
@@ -175,6 +185,7 @@ function AgentSelectionSection({ onConnectedChange }: { onConnectedChange?: (con
 
       {showDeviceCodeModal && (
         <CodexDeviceCodeModal
+          scope="personal"
           onClose={() => setShowDeviceCodeModal(false)}
           onConnected={() => {
             setShowDeviceCodeModal(false);

--- a/frontend/src/hooks/use-setup-status.test.tsx
+++ b/frontend/src/hooks/use-setup-status.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, waitFor } from "@/test/test-utils";
+import { useSetupStatus } from "./use-setup-status";
+
+const mocks = vi.hoisted(() => ({
+  settingsGet: vi.fn().mockResolvedValue({
+    data: { settings: { default_agent_type: "codex" } },
+  }),
+  codexStatus: vi.fn().mockResolvedValue({
+    data: { status: "completed", account_type: "plus" },
+  }),
+  listResolved: vi.fn().mockResolvedValue({ data: [] }),
+  codingCredentialsList: vi.fn().mockResolvedValue({ data: [] }),
+  integrationsList: vi.fn().mockResolvedValue({
+    data: [{ id: "int-1", provider: "github", status: "active" }],
+  }),
+  repositoriesList: vi.fn().mockResolvedValue({
+    data: [{ id: "repo-1", name: "repo" }],
+  }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    settings: { get: mocks.settingsGet },
+    codexAuth: { status: mocks.codexStatus },
+    userCredentials: { listResolved: mocks.listResolved },
+    codingCredentials: { list: mocks.codingCredentialsList },
+    integrations: { list: mocks.integrationsList },
+    repositories: { list: mocks.repositoriesList },
+  },
+}));
+
+function SetupStatusProbe() {
+  const status = useSetupStatus();
+  return (
+    <div>
+      <div>{status.isLoading ? "loading" : "loaded"}</div>
+      <div>{status.isSetupComplete ? "complete" : "incomplete"}</div>
+    </div>
+  );
+}
+
+describe("useSetupStatus", () => {
+  it("checks Codex auth status in personal scope", async () => {
+    renderWithProviders(<SetupStatusProbe />);
+
+    await waitFor(() => {
+      expect(mocks.codexStatus).toHaveBeenCalledWith(undefined, "personal");
+    });
+    expect(await screen.findByText("complete")).toBeInTheDocument();
+  });
+
+  it("counts personal Claude subscriptions from unified credentials as setup-complete agent auth", async () => {
+    mocks.settingsGet.mockResolvedValueOnce({
+      data: { settings: { default_agent_type: "claude_code" } },
+    });
+    mocks.codexStatus.mockResolvedValueOnce({ data: { status: "none" } });
+    mocks.codingCredentialsList.mockResolvedValueOnce({
+      data: [{
+        id: "cc-claude",
+        org_id: "org-1",
+        user_id: "user-1",
+        scope: "personal",
+        priority: 1,
+        agent: "claude_code",
+        auth_type: "subscription",
+        provider: "anthropic_subscription",
+        label: "Personal Claude",
+        status: "never_verified",
+        is_default: true,
+        created_at: "2026-03-20T00:00:00Z",
+        updated_at: "2026-03-20T00:00:00Z",
+      }],
+    });
+
+    renderWithProviders(<SetupStatusProbe />);
+
+    expect(await screen.findByText("complete")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/hooks/use-setup-status.test.tsx
+++ b/frontend/src/hooks/use-setup-status.test.tsx
@@ -66,7 +66,7 @@ describe("useSetupStatus", () => {
         auth_type: "subscription",
         provider: "anthropic_subscription",
         label: "Personal Claude",
-        status: "never_verified",
+        status: "healthy",
         is_default: true,
         created_at: "2026-03-20T00:00:00Z",
         updated_at: "2026-03-20T00:00:00Z",

--- a/frontend/src/hooks/use-setup-status.ts
+++ b/frontend/src/hooks/use-setup-status.ts
@@ -3,8 +3,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
-import { isAgentConnected } from "@/lib/agents";
-import type { OrgSettings, Integration, Repository, ListResponse, Organization, SingleResponse } from "@/lib/types";
+import { isAgentAvailable } from "@/lib/agents";
+import type { CodingCredentialSummary, OrgSettings, Integration, Repository, ListResponse, Organization, SingleResponse } from "@/lib/types";
 
 export function useSetupStatus() {
   const { data: settingsResponse, isLoading: settingsLoading } = useQuery<SingleResponse<Organization>>({
@@ -13,12 +13,16 @@ export function useSetupStatus() {
   });
 
   const { data: codexAuthStatusResponse, isLoading: codexAuthLoading } = useQuery({
-    queryKey: queryKeys.codexAuth.status,
-    queryFn: () => api.codexAuth.status(),
+    queryKey: [...queryKeys.codexAuth.status, "personal"],
+    queryFn: () => api.codexAuth.status(undefined, "personal"),
   });
   const { data: resolvedCredsResponse, isLoading: resolvedCredsLoading } = useQuery({
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),
+  });
+  const { data: resolvedCodingCredentialsResponse, isLoading: resolvedCodingCredentialsLoading } = useQuery<ListResponse<CodingCredentialSummary>>({
+    queryKey: ["coding-credentials", "resolved"],
+    queryFn: () => api.codingCredentials.list("resolved"),
   });
 
   const { data: integrationsResponse, isLoading: integrationsLoading } = useQuery<ListResponse<Integration>>({
@@ -34,15 +38,21 @@ export function useSetupStatus() {
   const rawSettings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const defaultAgent = rawSettings?.default_agent_type ?? "codex";
   const resolvedCredentials = resolvedCredsResponse?.data ?? [];
+  const resolvedCodingCredentials = resolvedCodingCredentialsResponse?.data ?? [];
 
-  const agentConnected = isAgentConnected(defaultAgent, resolvedCredentials, codexAuthStatusResponse?.data);
+  const agentConnected = isAgentAvailable(
+    defaultAgent,
+    resolvedCredentials,
+    codexAuthStatusResponse?.data,
+    resolvedCodingCredentials,
+  );
 
   const integrations = integrationsResponse?.data ?? [];
   const repositories = repositoriesResponse?.data ?? [];
   const githubReady = integrations.some((i) => i.provider === "github" && i.status === "active")
     && repositories.length > 0;
 
-  const isLoading = settingsLoading || codexAuthLoading || resolvedCredsLoading || integrationsLoading || repositoriesLoading;
+  const isLoading = settingsLoading || codexAuthLoading || resolvedCredsLoading || resolvedCodingCredentialsLoading || integrationsLoading || repositoriesLoading;
   const isSetupComplete = agentConnected && githubReady;
 
   return {

--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -40,7 +40,7 @@ const personalClaudeSubscription: CodingCredentialSummary = {
   auth_type: "subscription",
   provider: "anthropic_subscription",
   label: "Personal Claude",
-  status: "never_verified",
+  status: "healthy",
   is_default: true,
   created_at: "2026-03-20T00:00:00Z",
   updated_at: "2026-03-20T00:00:00Z",

--- a/frontend/src/lib/agents.test.ts
+++ b/frontend/src/lib/agents.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { availableAgentModelGroups, pmUsableResolvedCredentials } from "./agents";
-import type { CodingAuth, ResolvedCredential, UserCredentialSummary } from "./types";
+import type { CodingAuth, CodingCredentialSummary, ResolvedCredential, UserCredentialSummary } from "./types";
 
 const codexCred: ResolvedCredential = {
   provider: "openai",
@@ -30,6 +30,22 @@ const ampCodingAuth: CodingAuth = {
   updated_at: "2026-03-20T00:00:00Z",
 };
 
+const personalClaudeSubscription: CodingCredentialSummary = {
+  id: "cc-claude",
+  org_id: "org-1",
+  user_id: "user-1",
+  scope: "personal",
+  priority: 1,
+  agent: "claude_code",
+  auth_type: "subscription",
+  provider: "anthropic_subscription",
+  label: "Personal Claude",
+  status: "never_verified",
+  is_default: true,
+  created_at: "2026-03-20T00:00:00Z",
+  updated_at: "2026-03-20T00:00:00Z",
+};
+
 describe("availableAgentModelGroups", () => {
   it("includes only the default agent when no creds resolve", () => {
     const groups = availableAgentModelGroups([], null, [], "codex");
@@ -45,6 +61,11 @@ describe("availableAgentModelGroups", () => {
     const groups = availableAgentModelGroups([], null, [ampCodingAuth], "codex");
     const amp = groups.find((g) => g.key === "amp");
     expect(amp?.label).toBe("Amp modes");
+  });
+
+  it("treats unified personal subscription rows as available for session agents", () => {
+    const groups = availableAgentModelGroups([], null, [personalClaudeSubscription], "codex");
+    expect(groups.map((g) => g.key)).toEqual(["codex", "claude_code"]);
   });
 
   it("orgAgentConfig surfaces agents whose API key is set even without user creds (PM scope)", () => {

--- a/frontend/src/lib/agents.ts
+++ b/frontend/src/lib/agents.ts
@@ -12,6 +12,8 @@ import {
 } from "@/lib/model-constants";
 import type { CodexAuthStatus, CodingAuth, ResolvedCredential, UserCredentialSummary } from "@/lib/types";
 
+type CodingAuthAvailability = Pick<CodingAuth, "agent" | "status">;
+
 export interface AgentEnvVar {
   name: string;
   label: string;
@@ -167,7 +169,7 @@ export function isAgentAvailable(
   agentType: string,
   resolvedCredentials: readonly ResolvedCredential[],
   codexAuthStatus?: CodexAuthStatus | null,
-  codingAuths: readonly CodingAuth[] = [],
+  codingAuths: readonly CodingAuthAvailability[] = [],
 ): boolean {
   if (isAgentConnected(agentType, resolvedCredentials, codexAuthStatus)) return true;
   return codingAuths.some(
@@ -202,7 +204,7 @@ export interface AvailableAgentModelGroupsOptions {
 export function availableAgentModelGroups(
   resolvedCredentials: readonly ResolvedCredential[],
   codexAuthStatus: CodexAuthStatus | null | undefined,
-  codingAuths: readonly CodingAuth[],
+  codingAuths: readonly CodingAuthAvailability[],
   defaultAgentType: string,
   options: AvailableAgentModelGroupsOptions = {},
 ): AgentModelGroup[] {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -568,8 +568,23 @@ export const api = {
     syncGitHub: () => post<{ data: { repos_synced: number; errors: number } }>('/api/v1/integrations/github/sync'),
   },
   codexAuth: {
-    initiate: (label?: string) => post<import('./types').SingleResponse<import('./types').CodexDeviceAuth>>('/api/v1/settings/codex-auth/initiate', { label: label ?? '' }),
-    status: (label?: string) => get<import('./types').SingleResponse<import('./types').CodexAuthStatus>>(`/api/v1/settings/codex-auth/status${label ? `?label=${encodeURIComponent(label)}` : ''}`),
+    // `scope` defaults to "org" on the server; pass "personal" to write the
+    // pending-auth row against the caller's user_id in coding_credentials so
+    // the resulting subscription appears in the user's personal stack.
+    initiate: (label?: string, scope?: 'org' | 'personal') =>
+      post<import('./types').SingleResponse<import('./types').CodexDeviceAuth>>(
+        '/api/v1/settings/codex-auth/initiate',
+        { label: label ?? '', ...(scope ? { scope } : {}) },
+      ),
+    status: (label?: string, scope?: 'org' | 'personal') => {
+      const params = new URLSearchParams();
+      if (label) params.set('label', label);
+      if (scope) params.set('scope', scope);
+      const qs = params.toString();
+      return get<import('./types').SingleResponse<import('./types').CodexAuthStatus>>(
+        `/api/v1/settings/codex-auth/status${qs ? `?${qs}` : ''}`,
+      );
+    },
     listSubscriptions: () => get<import('./types').ListResponse<import('./types').CodexSubscription>>('/api/v1/settings/codex-auth/subscriptions'),
     removeSubscription: (id: string) => del(`/api/v1/settings/codex-auth/subscriptions/${id}`),
     // Disconnects every ChatGPT subscription for the org. Used by the
@@ -580,9 +595,19 @@ export const api = {
   claudeCodeAuth: {
     // Starts a PKCE auth flow. The response's authorize_url is opened in the
     // user's browser; after logging in the user pastes `<code>#<state>` back
-    // and the caller invokes complete() with it.
-    initiate: (label: string) => post<import('./types').SingleResponse<import('./types').ClaudeCodeInitiateResponse>>('/api/v1/settings/claude-code-auth/initiate', { label }),
-    complete: (label: string, code: string) => post<import('./types').SingleResponse<import('./types').ClaudeCodeCompleteResponse>>('/api/v1/settings/claude-code-auth/complete', { label, code }),
+    // and the caller invokes complete() with it. `scope` defaults to "org"
+    // on the server; "personal" routes the pending row into the caller's
+    // own user-scoped credential stack.
+    initiate: (label: string, scope?: 'org' | 'personal') =>
+      post<import('./types').SingleResponse<import('./types').ClaudeCodeInitiateResponse>>(
+        '/api/v1/settings/claude-code-auth/initiate',
+        { label, ...(scope ? { scope } : {}) },
+      ),
+    complete: (label: string, code: string, scope?: 'org' | 'personal') =>
+      post<import('./types').SingleResponse<import('./types').ClaudeCodeCompleteResponse>>(
+        '/api/v1/settings/claude-code-auth/complete',
+        { label, code, ...(scope ? { scope } : {}) },
+      ),
     listSubscriptions: () => get<import('./types').ListResponse<import('./types').ClaudeCodeSubscription>>('/api/v1/settings/claude-code-auth/subscriptions'),
     removeSubscription: (id: string) => del(`/api/v1/settings/claude-code-auth/subscriptions/${id}`),
     // Disconnects every Claude subscription for the org while leaving any

--- a/frontend/src/lib/coding-auth-metadata.ts
+++ b/frontend/src/lib/coding-auth-metadata.ts
@@ -70,12 +70,18 @@ export const PERSONAL_PROVIDER_OPTIONS: Array<{
   key: PersonalProvider;
   label: string;
   iconSrc?: string;
+  // Mirrors ORG_PROVIDER_OPTIONS.supportsSubscription. When true the
+  // personal Add-auth modal exposes the subscription radio so users can
+  // connect their own Codex / Claude Code OAuth flow as a personal-stack
+  // credential. The OAuth modal handles the device-code or PKCE handshake;
+  // the resulting row lands in coding_credentials with user_id set.
+  supportsSubscription: boolean;
 }> = [
-  { key: "openai", label: "Codex", iconSrc: "/agents/codex.svg" },
-  { key: "anthropic", label: "Claude Code", iconSrc: "/agents/claude_code.svg" },
-  { key: "gemini", label: "Gemini CLI", iconSrc: "/agents/gemini_cli.svg" },
-  { key: "amp", label: "Amp", iconSrc: "/agents/amp.svg" },
-  { key: "pi", label: "Pi" },
+  { key: "openai", label: "Codex", iconSrc: "/agents/codex.svg", supportsSubscription: true },
+  { key: "anthropic", label: "Claude Code", iconSrc: "/agents/claude_code.svg", supportsSubscription: true },
+  { key: "gemini", label: "Gemini CLI", iconSrc: "/agents/gemini_cli.svg", supportsSubscription: false },
+  { key: "amp", label: "Amp", iconSrc: "/agents/amp.svg", supportsSubscription: false },
+  { key: "pi", label: "Pi", supportsSubscription: false },
 ];
 
 export function apiKeyHelp(provider: ApiKeyProvider | PersonalProvider) {

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -736,6 +736,13 @@ export const handlers = [
     });
   }),
 
+  http.get('/api/v1/coding-credentials', () => {
+    return HttpResponse.json({
+      data: [],
+      meta: {},
+    });
+  }),
+
   http.get('/api/v1/sessions/:id/files/context', () => {
     return HttpResponse.json({
       data: {

--- a/internal/api/handlers/auth_scope.go
+++ b/internal/api/handlers/auth_scope.go
@@ -1,0 +1,62 @@
+// Package handlers — auth_scope.go
+//
+// Shared scope-resolution helpers for the OAuth subscription endpoints
+// (codex-auth, claude-code-auth). Both flows expose the same scope semantics:
+// org scope is admin-gated, personal scope coerces UserID from the request
+// context. Centralising the gating here keeps the two handlers in lockstep.
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// errAdminRequired marks an org-scope mutation that lacks admin role.
+var errAdminRequired = errors.New("admin role required for scope=org operations")
+
+// errInvalidScope marks a malformed scope query/body value.
+var errInvalidScope = errors.New("invalid scope: must be \"org\" or \"personal\"")
+
+// errUnauthenticated marks a request that didn't carry a user context.
+var errUnauthenticated = errors.New("unauthenticated")
+
+// resolveOAuthScope builds a models.Scope from already-extracted request
+// context, defaulting to org scope when scopeParam is empty. Personal scope
+// is allowed for any authenticated user; org scope requires admin role.
+//
+// Callers must extract orgID + userID + activeRole at the handler entry
+// point (so the org-id lint rule sees middleware.OrgIDFromContext directly
+// in each handler body) and pass them in here.
+func resolveOAuthScope(orgID uuid.UUID, userID uuid.UUID, activeRole, scopeParam string) (models.Scope, error) {
+	switch scopeParam {
+	case models.CodingCredentialScopePersonal:
+		uid := userID
+		return models.Scope{OrgID: orgID, UserID: &uid}, nil
+	case "", models.CodingCredentialScopeOrg:
+		if activeRole != "admin" {
+			return models.Scope{}, errAdminRequired
+		}
+		return models.Scope{OrgID: orgID}, nil
+	default:
+		return models.Scope{}, errInvalidScope
+	}
+}
+
+// writeAuthScopeError translates the scope-resolution sentinels above to
+// HTTP responses. Keeps the per-handler error-mapping noise down.
+func writeAuthScopeError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, errAdminRequired):
+		writeError(w, r, http.StatusForbidden, "FORBIDDEN", err.Error(), err)
+	case errors.Is(err, errInvalidScope):
+		writeError(w, r, http.StatusBadRequest, "INVALID_SCOPE", err.Error(), err)
+	case errors.Is(err, errUnauthenticated):
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", err.Error(), err)
+	default:
+		writeError(w, r, http.StatusInternalServerError, "SCOPE_RESOLVE_FAILED", "failed to resolve scope", err)
+	}
+}

--- a/internal/api/handlers/claude_code_auth.go
+++ b/internal/api/handlers/claude_code_auth.go
@@ -33,6 +33,11 @@ const claudeCodePasteMax = 2048
 // authorization-code + PKCE flow rather than device-code, so the endpoint
 // shape differs: /initiate returns an authorize URL, and the user pastes the
 // final code back via /complete (no polling).
+//
+// Every endpoint accepts an optional `scope` query param (or body field for
+// POSTs). Org scope (the default) requires admin role; personal scope is
+// available to any authenticated user and operates on the caller's own
+// credential rows.
 type ClaudeCodeAuthHandler struct {
 	svc    *claudecodeauth.Service
 	logger zerolog.Logger
@@ -43,19 +48,19 @@ func NewClaudeCodeAuthHandler(svc *claudecodeauth.Service, logger zerolog.Logger
 	return &ClaudeCodeAuthHandler{svc: svc, logger: logger}
 }
 
-// Initiate starts a new PKCE auth flow for a Claude subscription and returns
+// Initiate starts a new PKCE auth flow at the requested scope and returns
 // the authorize URL the user should open in a browser.
 func (h *ClaudeCodeAuthHandler) Initiate(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
-
-	var createdBy *uuid.UUID
-	if user := middleware.UserFromContext(r.Context()); user != nil {
-		id := user.ID
-		createdBy = &id
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
 	}
 
 	var body struct {
 		Label string `json:"label"`
+		Scope string `json:"scope"`
 	}
 	if r.Body != nil && r.ContentLength != 0 {
 		dec := json.NewDecoder(r.Body)
@@ -76,11 +81,29 @@ func (h *ClaudeCodeAuthHandler) Initiate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	resp, err := h.svc.InitiateOAuth(r.Context(), orgID, createdBy, body.Label)
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(body.Scope)),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	createdBy := user.ID
+
+	resp, err := h.svc.InitiateOAuth(r.Context(), scope, &createdBy, body.Label)
 	if err != nil {
 		var labelErr *db.ErrCredentialLabelTaken
 		if errors.As(err, &labelErr) {
 			writeError(w, r, http.StatusConflict, "LABEL_TAKEN", labelErr.Error(), err)
+			return
+		}
+		var labelErr2 *db.ErrCodingCredentialLabelTaken
+		if errors.As(err, &labelErr2) {
+			writeError(w, r, http.StatusConflict, "LABEL_TAKEN", labelErr2.Error(), err)
 			return
 		}
 		writeError(w, r, http.StatusInternalServerError, "AUTH_INITIATE_FAILED", "failed to initiate Claude OAuth", err)
@@ -94,10 +117,16 @@ func (h *ClaudeCodeAuthHandler) Initiate(w http.ResponseWriter, r *http.Request)
 // subscription tokens and promotes the pending row to active.
 func (h *ClaudeCodeAuthHandler) Complete(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
 
 	var body struct {
 		Label string `json:"label"`
 		Code  string `json:"code"`
+		Scope string `json:"scope"`
 	}
 	if r.Body == nil || r.ContentLength == 0 {
 		writeError(w, r, http.StatusBadRequest, "INVALID_REQUEST", "request body is required", nil)
@@ -130,7 +159,18 @@ func (h *ClaudeCodeAuthHandler) Complete(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	resp, err := h.svc.CompleteOAuth(r.Context(), orgID, body.Label, body.Code)
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(body.Scope)),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	resp, err := h.svc.CompleteOAuth(r.Context(), scope, body.Label, body.Code)
 	if err != nil {
 		switch {
 		case errors.Is(err, claudecodeauth.ErrPendingAuthNotFound):
@@ -148,11 +188,24 @@ func (h *ClaudeCodeAuthHandler) Complete(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, models.SingleResponse[claudecodeauth.CompleteResponse]{Data: *resp})
 }
 
-// List returns all connected Claude subscriptions for the org.
+// List returns all connected Claude subscriptions at the requested scope.
+//
+// Available to any authenticated user — see CodexAuthHandler.List for the
+// rationale. Mutations keep the admin gate on org scope.
 func (h *ClaudeCodeAuthHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
+	scope := models.Scope{OrgID: orgID}
+	if strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))) == models.CodingCredentialScopePersonal {
+		uid := user.ID
+		scope = models.Scope{OrgID: orgID, UserID: &uid}
+	}
 
-	subs, err := h.svc.ListSubscriptions(r.Context(), orgID)
+	subs, err := h.svc.ListSubscriptions(r.Context(), scope)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "AUTH_LIST_FAILED", "failed to list subscriptions", err)
 		return
@@ -168,6 +221,11 @@ func (h *ClaudeCodeAuthHandler) List(w http.ResponseWriter, r *http.Request) {
 // DisconnectByPath removes a specific Claude subscription by path param ID.
 func (h *ClaudeCodeAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
 	idStr := chi.URLParam(r, "id")
 	credID, err := uuid.Parse(idStr)
 	if err != nil {
@@ -175,7 +233,18 @@ func (h *ClaudeCodeAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if err := h.svc.DisconnectForOrg(r.Context(), orgID, credID); err != nil {
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	if err := h.svc.DisconnectForOrg(r.Context(), scope, credID); err != nil {
 		if errors.Is(err, claudecodeauth.ErrCredentialNotFound) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "credential not found", nil)
 			return
@@ -189,12 +258,28 @@ func (h *ClaudeCodeAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.
 	})
 }
 
-// DisconnectAll removes every Claude subscription for the org. Preserves any
-// Anthropic API-key credential (label="") so fallback auth keeps working.
+// DisconnectAll removes every Claude subscription at the requested scope.
+// Preserves any Anthropic API-key credential (label="") so fallback auth
+// keeps working.
 func (h *ClaudeCodeAuthHandler) DisconnectAll(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
 
-	if err := h.svc.DisconnectAll(r.Context(), orgID); err != nil {
+	if err := h.svc.DisconnectAll(r.Context(), scope); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "AUTH_DISCONNECT_FAILED", "failed to disconnect Claude subscriptions", err)
 		return
 	}

--- a/internal/api/handlers/claude_code_auth_test.go
+++ b/internal/api/handlers/claude_code_auth_test.go
@@ -28,6 +28,12 @@ func claudeTestLogger() zerolog.Logger {
 func claudeAddOrgContext(r *http.Request) *http.Request {
 	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	ctx := middleware.WithOrgID(r.Context(), orgID)
+	// Handlers now require a user + active role on the context: scope
+	// resolution defaults to org scope, which is admin-gated. Inject a stub
+	// admin user so the existing tests behave the same way they did before
+	// scope resolution was added.
+	ctx = middleware.WithUser(ctx, &models.User{ID: uuid.MustParse("00000000-0000-0000-0000-0000000000a1")})
+	ctx = middleware.WithActiveRole(ctx, "admin")
 	return r.WithContext(ctx)
 }
 
@@ -42,20 +48,17 @@ type claudeStoreStub struct {
 	getByIDCredential           *models.DecryptedCredential
 }
 
-func (s *claudeStoreStub) Get(context.Context, uuid.UUID, models.ProviderName) (*models.DecryptedCredential, error) {
-	return nil, errors.New("not found")
-}
-func (s *claudeStoreStub) UpsertWithLabel(context.Context, uuid.UUID, *uuid.UUID, string, models.ProviderConfig) (*uuid.UUID, error) {
+func (s *claudeStoreStub) UpsertWithLabel(context.Context, models.Scope, *uuid.UUID, string, models.ProviderConfig) (*uuid.UUID, error) {
 	return nil, errors.New("not implemented")
 }
-func (s *claudeStoreStub) InsertPendingAuth(context.Context, uuid.UUID, *uuid.UUID, string, models.ProviderConfig) (*uuid.UUID, error) {
+func (s *claudeStoreStub) InsertPendingAuth(context.Context, models.Scope, *uuid.UUID, string, models.ProviderConfig) (*uuid.UUID, error) {
 	if s.insertPendingAuthErr != nil {
 		return nil, s.insertPendingAuthErr
 	}
 	id := uuid.New()
 	return &id, nil
 }
-func (s *claudeStoreStub) GetByID(context.Context, uuid.UUID, uuid.UUID) (*models.DecryptedCredential, error) {
+func (s *claudeStoreStub) GetByID(context.Context, models.Scope, uuid.UUID) (*models.DecryptedCredential, error) {
 	if s.getByIDCredential != nil {
 		return s.getByIDCredential, nil
 	}
@@ -76,39 +79,39 @@ func (s *claudeStoreStub) GetByID(context.Context, uuid.UUID, uuid.UUID) (*model
 	}
 	return nil, claudecodeauth.ErrCredentialNotFound
 }
-func (s *claudeStoreStub) GetByProviderAndLabel(context.Context, uuid.UUID, models.ProviderName, string) (*models.DecryptedCredential, error) {
+func (s *claudeStoreStub) GetByProviderAndLabel(context.Context, models.Scope, models.ProviderName, string) (*models.DecryptedCredential, error) {
 	// Use the sentinel the service understands so CompleteOAuth maps it to
 	// ErrPendingAuthNotFound (404); a plain errors.New would now be treated
 	// as a real DB failure and surface as a 500.
 	return nil, claudecodeauth.ErrCredentialNotFound
 }
-func (s *claudeStoreStub) ListByProvider(context.Context, uuid.UUID, models.ProviderName) ([]models.DecryptedCredential, error) {
+func (s *claudeStoreStub) ListByProvider(context.Context, models.Scope, models.ProviderName) ([]models.DecryptedCredential, error) {
 	return nil, nil
 }
-func (s *claudeStoreStub) ClaimNextLabeledRoundRobin(context.Context, uuid.UUID, models.ProviderName) (*models.DecryptedCredential, error) {
+func (s *claudeStoreStub) ClaimNextLabeledRoundRobin(context.Context, models.Scope, models.ProviderName) (*models.DecryptedCredential, error) {
 	return nil, claudecodeauth.ErrCredentialNotFound
 }
-func (s *claudeStoreStub) DisableByID(context.Context, uuid.UUID, uuid.UUID) error {
+func (s *claudeStoreStub) DisableByID(context.Context, models.Scope, uuid.UUID) error {
 	if s.disableErr != nil {
 		return s.disableErr
 	}
 	s.disabled = true
 	return nil
 }
-func (s *claudeStoreStub) UpdateStatusByID(context.Context, uuid.UUID, uuid.UUID, string) error {
+func (s *claudeStoreStub) UpdateStatusByID(context.Context, models.Scope, uuid.UUID, string) error {
 	return nil
 }
-func (s *claudeStoreStub) UpsertByID(context.Context, uuid.UUID, uuid.UUID, models.ProviderConfig) error {
+func (s *claudeStoreStub) UpsertByID(context.Context, models.Scope, uuid.UUID, models.ProviderConfig) error {
 	return nil
 }
-func (s *claudeStoreStub) ExistsForProviderByID(context.Context, uuid.UUID, uuid.UUID, models.ProviderName) (bool, error) {
+func (s *claudeStoreStub) ExistsForProviderByID(context.Context, models.Scope, uuid.UUID, models.ProviderName) (bool, error) {
 	return s.existsForProviderByIDResult, nil
 }
-func (s *claudeStoreStub) DisableLabeled(context.Context, uuid.UUID, models.ProviderName) error {
+func (s *claudeStoreStub) DisableLabeled(context.Context, models.Scope, models.ProviderName) error {
 	s.disabled = true
 	return nil
 }
-func (s *claudeStoreStub) HasActiveLabeled(context.Context, uuid.UUID, models.ProviderName) (bool, error) {
+func (s *claudeStoreStub) HasActiveLabeled(context.Context, models.Scope, models.ProviderName) (bool, error) {
 	return false, nil
 }
 

--- a/internal/api/handlers/codex_auth.go
+++ b/internal/api/handlers/codex_auth.go
@@ -18,6 +18,13 @@ import (
 )
 
 // CodexAuthHandler serves the /api/v1/settings/codex-auth endpoints.
+//
+// Every endpoint accepts an optional `scope` query param (or body field for
+// POSTs). Org scope (the default) requires admin role; personal scope is
+// available to any authenticated user and operates on the caller's own
+// credential rows. Personal-scope writes flow through the unified
+// coding_credentials table; org-scope writes flow through the legacy
+// org_credentials table with a mirror to coding_credentials.
 type CodexAuthHandler struct {
 	svc    *codexauth.Service
 	logger zerolog.Logger
@@ -28,24 +35,20 @@ func NewCodexAuthHandler(svc *codexauth.Service, logger zerolog.Logger) *CodexAu
 	return &CodexAuthHandler{svc: svc, logger: logger}
 }
 
-// Initiate starts a new device code auth flow.
+// Initiate starts a new device code auth flow at the requested scope.
 func (h *CodexAuthHandler) Initiate(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
-
-	// Track which user is adding this subscription. Auth middleware normally
-	// populates this, but fall through as nil so tests without a user context
-	// continue to work — the DB column is nullable.
-	var createdBy *uuid.UUID
-	if user := middleware.UserFromContext(r.Context()); user != nil {
-		id := user.ID
-		createdBy = &id
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
 	}
 
-	// Parse optional label from request body. An empty body is allowed (legacy
-	// single-subscription flow), but malformed JSON is rejected so the client
-	// learns about the problem instead of silently dropping its label.
+	// Parse optional label + scope from request body. An empty body keeps
+	// legacy-compat single-subscription org callers working.
 	var body struct {
 		Label string `json:"label"`
+		Scope string `json:"scope"`
 	}
 	if r.Body != nil && r.ContentLength != 0 {
 		dec := json.NewDecoder(r.Body)
@@ -56,18 +59,38 @@ func (h *CodexAuthHandler) Initiate(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Validate and normalize label.
 	body.Label = strings.TrimSpace(body.Label)
 	if len(body.Label) > 100 {
 		writeError(w, r, http.StatusBadRequest, "INVALID_LABEL", "label must be 100 characters or fewer", nil)
 		return
 	}
 
-	resp, err := h.svc.InitiateDeviceAuth(r.Context(), orgID, createdBy, body.Label)
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(body.Scope)),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	// createdBy records who added the subscription. Set unconditionally —
+	// even on personal scope it's the same user, but storing it keeps the
+	// audit trail uniform.
+	createdBy := user.ID
+
+	resp, err := h.svc.InitiateDeviceAuth(r.Context(), scope, &createdBy, body.Label)
 	if err != nil {
 		var labelErr *db.ErrCredentialLabelTaken
 		if errors.As(err, &labelErr) {
 			writeError(w, r, http.StatusConflict, "LABEL_TAKEN", labelErr.Error(), err)
+			return
+		}
+		var labelErr2 *db.ErrCodingCredentialLabelTaken
+		if errors.As(err, &labelErr2) {
+			writeError(w, r, http.StatusConflict, "LABEL_TAKEN", labelErr2.Error(), err)
 			return
 		}
 		writeError(w, r, http.StatusInternalServerError, "AUTH_INITIATE_FAILED", "failed to initiate device auth", err)
@@ -80,15 +103,30 @@ func (h *CodexAuthHandler) Initiate(w http.ResponseWriter, r *http.Request) {
 // Status checks whether the device code auth flow has completed.
 func (h *CodexAuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
-	label := r.URL.Query().Get("label")
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
 
-	// Match Initiate's validation so callers can't probe arbitrary keys.
+	label := r.URL.Query().Get("label")
 	if len(label) > 100 {
 		writeError(w, r, http.StatusBadRequest, "INVALID_LABEL", "label must be 100 characters or fewer", nil)
 		return
 	}
 
-	status, err := h.svc.PollForToken(r.Context(), orgID, label)
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	status, err := h.svc.PollForToken(r.Context(), scope, label)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "AUTH_STATUS_FAILED", "failed to check auth status", err)
 		return
@@ -97,11 +135,26 @@ func (h *CodexAuthHandler) Status(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, models.SingleResponse[codexauth.AuthStatus]{Data: *status})
 }
 
-// List returns all connected Codex subscriptions.
+// List returns all connected Codex subscriptions at the requested scope.
+//
+// Available to any authenticated user — org scope is intentionally not
+// admin-gated here so coding-agent settings pages can render the org
+// fallback list to non-admin members. The mutation endpoints (Initiate,
+// Disconnect*) keep the admin gate on org scope.
 func (h *CodexAuthHandler) List(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
+	scope := models.Scope{OrgID: orgID}
+	if strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))) == models.CodingCredentialScopePersonal {
+		uid := user.ID
+		scope = models.Scope{OrgID: orgID, UserID: &uid}
+	}
 
-	subs, err := h.svc.ListSubscriptions(r.Context(), orgID)
+	subs, err := h.svc.ListSubscriptions(r.Context(), scope)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, "AUTH_LIST_FAILED", "failed to list subscriptions", err)
 		return
@@ -117,6 +170,11 @@ func (h *CodexAuthHandler) List(w http.ResponseWriter, r *http.Request) {
 // DisconnectByPath removes a specific ChatGPT OAuth credential by path param ID.
 func (h *CodexAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
 	idStr := chi.URLParam(r, "id")
 	credID, err := uuid.Parse(idStr)
 	if err != nil {
@@ -124,7 +182,18 @@ func (h *CodexAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	if err := h.svc.DisconnectForOrg(r.Context(), orgID, credID); err != nil {
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
+
+	if err := h.svc.DisconnectForOrg(r.Context(), scope, credID); err != nil {
 		if errors.Is(err, codexauth.ErrCredentialNotFound) {
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "credential not found", nil)
 			return
@@ -138,12 +207,27 @@ func (h *CodexAuthHandler) DisconnectByPath(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-// DisconnectAll removes all ChatGPT OAuth credentials for the given org.
+// DisconnectAll removes all ChatGPT OAuth credentials at the given scope.
 // Kept for backward compatibility with the old POST /disconnect endpoint.
 func (h *CodexAuthHandler) DisconnectAll(w http.ResponseWriter, r *http.Request) {
 	orgID := middleware.OrgIDFromContext(r.Context())
+	user := middleware.UserFromContext(r.Context())
+	if user == nil {
+		writeError(w, r, http.StatusUnauthorized, "UNAUTHENTICATED", "unauthenticated", nil)
+		return
+	}
+	scope, err := resolveOAuthScope(
+		orgID,
+		user.ID,
+		middleware.ActiveRoleFromContext(r.Context()),
+		strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAuthScopeError(w, r, err)
+		return
+	}
 
-	if err := h.svc.DisconnectAll(r.Context(), orgID); err != nil {
+	if err := h.svc.DisconnectAll(r.Context(), scope); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "AUTH_DISCONNECT_FAILED", "failed to disconnect ChatGPT", err)
 		return
 	}

--- a/internal/api/handlers/codex_auth_test.go
+++ b/internal/api/handlers/codex_auth_test.go
@@ -31,6 +31,12 @@ func codexBufferedLogger(buf *bytes.Buffer) zerolog.Logger {
 func codexAddOrgContext(r *http.Request) *http.Request {
 	orgID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
 	ctx := middleware.WithOrgID(r.Context(), orgID)
+	// Handlers now require a user + active role on the context: scope
+	// resolution defaults to org scope, which is admin-gated. Inject a stub
+	// admin user so the existing tests behave the same way they did before
+	// scope resolution was added.
+	ctx = middleware.WithUser(ctx, &models.User{ID: uuid.MustParse("00000000-0000-0000-0000-0000000000a1")})
+	ctx = middleware.WithActiveRole(ctx, "admin")
 	return r.WithContext(ctx)
 }
 
@@ -47,19 +53,7 @@ type codexCredentialStoreStub struct {
 	insertPendingAuthErr error
 }
 
-func (s *codexCredentialStoreStub) Upsert(_ context.Context, _ uuid.UUID, _ models.ProviderConfig) error {
-	return nil
-}
-
-func (s *codexCredentialStoreStub) Get(_ context.Context, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
-	return nil, errors.New("not found")
-}
-
-func (s *codexCredentialStoreStub) UpdateStatus(_ context.Context, _ uuid.UUID, _ models.ProviderName, _ string) error {
-	return nil
-}
-
-func (s *codexCredentialStoreStub) Disable(_ context.Context, _ uuid.UUID, _ models.ProviderName) error {
+func (s *codexCredentialStoreStub) Disable(_ context.Context, _ models.Scope, _ models.ProviderName) error {
 	if s.disableErr != nil {
 		return s.disableErr
 	}
@@ -67,37 +61,37 @@ func (s *codexCredentialStoreStub) Disable(_ context.Context, _ uuid.UUID, _ mod
 	return nil
 }
 
-func (s *codexCredentialStoreStub) UpsertWithLabel(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
+func (s *codexCredentialStoreStub) UpsertWithLabel(_ context.Context, _ models.Scope, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
 	return nil, errors.New("not implemented")
 }
 
-func (s *codexCredentialStoreStub) InsertPendingAuth(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
+func (s *codexCredentialStoreStub) InsertPendingAuth(_ context.Context, _ models.Scope, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
 	if s.insertPendingAuthErr != nil {
 		return nil, s.insertPendingAuthErr
 	}
 	return nil, errors.New("not implemented")
 }
 
-func (s *codexCredentialStoreStub) GetByID(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models.DecryptedCredential, error) {
+func (s *codexCredentialStoreStub) GetByID(_ context.Context, _ models.Scope, _ uuid.UUID) (*models.DecryptedCredential, error) {
 	if s.getByIDResult != nil {
 		return s.getByIDResult, nil
 	}
 	return nil, errors.New("not found")
 }
 
-func (s *codexCredentialStoreStub) ListByProvider(_ context.Context, _ uuid.UUID, _ models.ProviderName) ([]models.DecryptedCredential, error) {
+func (s *codexCredentialStoreStub) ListByProvider(_ context.Context, _ models.Scope, _ models.ProviderName) ([]models.DecryptedCredential, error) {
 	return nil, nil
 }
 
-func (s *codexCredentialStoreStub) GetByProviderAndLabel(_ context.Context, _ uuid.UUID, _ models.ProviderName, _ string) (*models.DecryptedCredential, error) {
+func (s *codexCredentialStoreStub) GetByProviderAndLabel(_ context.Context, _ models.Scope, _ models.ProviderName, _ string) (*models.DecryptedCredential, error) {
 	return nil, errors.New("not found")
 }
 
-func (s *codexCredentialStoreStub) ClaimNextRoundRobin(_ context.Context, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
+func (s *codexCredentialStoreStub) ClaimNextRoundRobin(_ context.Context, _ models.Scope, _ models.ProviderName) (*models.DecryptedCredential, error) {
 	return nil, errors.New("not found")
 }
 
-func (s *codexCredentialStoreStub) DisableByID(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *codexCredentialStoreStub) DisableByID(_ context.Context, _ models.Scope, _ uuid.UUID) error {
 	if s.disableErr != nil {
 		return s.disableErr
 	}
@@ -105,15 +99,15 @@ func (s *codexCredentialStoreStub) DisableByID(_ context.Context, _ uuid.UUID, _
 	return nil
 }
 
-func (s *codexCredentialStoreStub) UpdateStatusByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string) error {
+func (s *codexCredentialStoreStub) UpdateStatusByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ string) error {
 	return nil
 }
 
-func (s *codexCredentialStoreStub) UpsertByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.ProviderConfig) error {
+func (s *codexCredentialStoreStub) UpsertByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ models.ProviderConfig) error {
 	return nil
 }
 
-func (s *codexCredentialStoreStub) ExistsForProviderByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.ProviderName) (bool, error) {
+func (s *codexCredentialStoreStub) ExistsForProviderByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ models.ProviderName) (bool, error) {
 	return s.existsForProviderByIDResult, nil
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -778,6 +778,22 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Get("/api/v1/settings/codex-auth/subscriptions", codexAuthHandler.List)
 				r.Get("/api/v1/settings/claude-code-auth/subscriptions", claudeCodeAuthHandler.List)
 
+				// Codex / Claude OAuth subscription flows. Org-scope writes are
+				// admin-gated inside each handler (see resolveOAuthScope);
+				// personal-scope writes are available to any member because they
+				// target the caller's own credential rows. Routing both into the
+				// admin+member group lets a single endpoint serve both cases —
+				// the handler decides based on the request's scope param.
+				r.Post("/api/v1/settings/codex-auth/initiate", codexAuthHandler.Initiate)
+				r.Get("/api/v1/settings/codex-auth/status", codexAuthHandler.Status)
+				r.Post("/api/v1/settings/codex-auth/disconnect", codexAuthHandler.DisconnectAll) // legacy compat
+				r.Delete("/api/v1/settings/codex-auth/subscriptions/{id}", codexAuthHandler.DisconnectByPath)
+
+				r.Post("/api/v1/settings/claude-code-auth/initiate", claudeCodeAuthHandler.Initiate)
+				r.Post("/api/v1/settings/claude-code-auth/complete", claudeCodeAuthHandler.Complete)
+				r.Post("/api/v1/settings/claude-code-auth/disconnect", claudeCodeAuthHandler.DisconnectAll) // legacy compat
+				r.Delete("/api/v1/settings/claude-code-auth/subscriptions/{id}", claudeCodeAuthHandler.DisconnectByPath)
+
 				// Unified coding-credentials writes. Personal-scope mutations live in
 				// this group because they target the requester's own credentials and
 				// do not require admin privileges for members. The handler enforces
@@ -921,23 +937,11 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Put("/api/v1/settings/credentials/team/{provider}", userCredentialHandler.SetTeamDefault)
 				r.Delete("/api/v1/settings/credentials/team/{provider}", userCredentialHandler.DeleteTeamDefault)
 
-				// Codex (ChatGPT) OAuth device code auth. Subscription List is
-				// registered in the admin+member group so members can see which
-				// subscriptions are configured; everything else is admin-only.
-				r.Post("/api/v1/settings/codex-auth/initiate", codexAuthHandler.Initiate)
-				r.Get("/api/v1/settings/codex-auth/status", codexAuthHandler.Status)
-				r.Post("/api/v1/settings/codex-auth/disconnect", codexAuthHandler.DisconnectAll) // legacy compat
-				r.Delete("/api/v1/settings/codex-auth/subscriptions/{id}", codexAuthHandler.DisconnectByPath)
-
-				// Claude Code (Anthropic subscription) OAuth — PKCE authorization-code
-				// flow: initiate returns an authorize URL, user pastes back
-				// `<code>#<state>` which /complete exchanges for tokens. Subscription
-				// List sits in the admin+member group; everything else stays
-				// admin-only.
-				r.Post("/api/v1/settings/claude-code-auth/initiate", claudeCodeAuthHandler.Initiate)
-				r.Post("/api/v1/settings/claude-code-auth/complete", claudeCodeAuthHandler.Complete)
-				r.Post("/api/v1/settings/claude-code-auth/disconnect", claudeCodeAuthHandler.DisconnectAll) // legacy compat
-				r.Delete("/api/v1/settings/claude-code-auth/subscriptions/{id}", claudeCodeAuthHandler.DisconnectByPath)
+				// Codex / Claude OAuth subscription endpoints moved to the
+				// admin+member group above. The handlers' resolveOAuthScope
+				// keeps the admin gate on org-scope traffic, so members
+				// disconnecting their own personal subscription doesn't
+				// require elevating them to admin.
 
 				// Usage timeseries, breakdown, and export (admin-only)
 				r.Get("/api/v1/usage/timeseries", usageHandler.GetTimeseries)

--- a/internal/db/scoped_credential_store.go
+++ b/internal/db/scoped_credential_store.go
@@ -1,0 +1,456 @@
+// Package db — scoped_credential_store.go
+//
+// ScopedCredentialStore is a scope-aware façade for the OAuth subscription
+// flows (codexauth, claudecodeauth). It bridges two concrete stores during
+// the unified-credentials migration:
+//
+//   - Org-scoped operations (Scope.UserID == nil) flow through
+//     OrgCredentialStore, which persists to the legacy org_credentials table
+//     and mirrors to coding_credentials.
+//   - Personal-scoped operations (Scope.UserID != nil) target
+//     CodingCredentialStore directly. The legacy user_credentials table does
+//     not model multi-label rows that subscription credentials require, so
+//     personal subscriptions live exclusively in the unified store.
+//
+// The adapter preserves the legacy provider/config types that the OAuth
+// services emit (OpenAIChatGPTConfig, AnthropicConfig{Subscription:...}).
+// On the personal path it transparently translates writes to the unified
+// provider names + config types (openai_subscription / OpenAISubscriptionConfig,
+// anthropic_subscription / AnthropicSubscriptionConfig). Reads are translated
+// back so the OAuth services never see unified types.
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// ScopedCredentialStore implements the credential surface that the OAuth
+// services depend on, routing per-method by Scope.
+type ScopedCredentialStore struct {
+	org    *OrgCredentialStore
+	coding *CodingCredentialStore
+}
+
+// NewScopedCredentialStore wires the two backing stores. Both are required
+// in production — passing nil panics so a misconfigured boot fails fast at
+// startup rather than surfacing as confusing "personal scope requires
+// CodingCredentialStore" errors at the first incoming request.
+//
+// Tests that need a partial store (e.g. an in-memory fake) should
+// implement the auth services' CredentialStore interface directly instead
+// of constructing a ScopedCredentialStore with one nil backend.
+func NewScopedCredentialStore(org *OrgCredentialStore, coding *CodingCredentialStore) *ScopedCredentialStore {
+	if org == nil {
+		panic("db: NewScopedCredentialStore requires a non-nil OrgCredentialStore")
+	}
+	if coding == nil {
+		panic("db: NewScopedCredentialStore requires a non-nil CodingCredentialStore")
+	}
+	return &ScopedCredentialStore{org: org, coding: coding}
+}
+
+// Auth services define their own ErrCredentialNotFound sentinels and check
+// pgx.ErrNoRows + their local sentinel via isNotFoundError. To avoid a cycle
+// (the adapter can't import the auth packages), we surface unified-store
+// not-found errors with ErrCodingCredentialNotFound in the chain — auth
+// services have been updated to errors.Is against this in addition to their
+// local sentinel.
+
+// InsertPendingAuth inserts a pending-auth credential row at the given scope.
+func (s *ScopedCredentialStore) InsertPendingAuth(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+	if scope.IsPersonal() {
+		unified, err := translateConfigForUnifiedWrite(cfg)
+		if err != nil {
+			return nil, err
+		}
+		return s.coding.InsertPendingAuth(ctx, scope, label, unified, createdBy)
+	}
+	return s.org.InsertPendingAuth(ctx, scope.OrgID, createdBy, label, cfg)
+}
+
+// UpsertWithLabel writes an active credential at (scope, provider, label).
+// On the personal path: pending rows for the same label are promoted to
+// active; otherwise a fresh row is inserted.
+//
+// Concurrency note: the personal path is NOT atomic — it does a separate
+// GetByProviderAndLabel + (PromotePending | UpdateConfig | Create). The
+// legacy OrgCredentialStore.UpsertWithLabel is single-statement so it
+// avoids this race. In practice we get away with it because the auth
+// services serialise concurrent Initiate/Complete calls per (scope, label)
+// via a sync.Map mutex (see codexauth.Service.initMu /
+// claudecodeauth.Service.initMu), so two racing CompleteOAuth calls for
+// the same label cannot both reach this method at once. If a future caller
+// drops that mutex, two racing Creates would both lose to the unique
+// index and surface as ErrCodingCredentialLabelTaken to the user — the
+// fix would be a transactional helper on CodingCredentialStore.
+func (s *ScopedCredentialStore) UpsertWithLabel(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+	if scope.IsPersonal() {
+		unified, err := translateConfigForUnifiedWrite(cfg)
+		if err != nil {
+			return nil, err
+		}
+		// Look up an existing row at this (scope, provider, label) so we
+		// promote-or-rotate instead of erroring on conflict.
+		existing, lookupErr := s.coding.GetByProviderAndLabel(ctx, scope, unified.Provider(), label)
+		if lookupErr != nil && !errors.Is(lookupErr, ErrCodingCredentialNotFound) {
+			return nil, lookupErr
+		}
+		if existing != nil {
+			switch existing.Status {
+			case models.CodingCredentialStatusPendingAuth:
+				if err := s.coding.PromotePending(ctx, scope, existing.ID, unified); err != nil {
+					return nil, err
+				}
+				return &existing.ID, nil
+			case models.CodingCredentialStatusActive,
+				models.CodingCredentialStatusInvalid,
+				models.CodingCredentialStatusDisabled:
+				if err := s.coding.UpdateConfig(ctx, scope, existing.ID, unified); err != nil {
+					return nil, err
+				}
+				return &existing.ID, nil
+			}
+		}
+		return s.coding.Create(ctx, scope, label, unified, CreateOpts{CreatedBy: createdBy})
+	}
+	return s.org.UpsertWithLabel(ctx, scope.OrgID, createdBy, label, cfg)
+}
+
+// UpsertByID overwrites the config of a credential by ID. For pending_auth
+// rows this promotes them to active (CompleteOAuth); for active rows it
+// rotates the stored tokens (RefreshTokenByID).
+func (s *ScopedCredentialStore) UpsertByID(ctx context.Context, scope models.Scope, id uuid.UUID, cfg models.ProviderConfig) error {
+	if scope.IsPersonal() {
+		unified, err := translateConfigForUnifiedWrite(cfg)
+		if err != nil {
+			return err
+		}
+		// Look up the row's current status so we route promote-vs-rotate
+		// the same way the legacy UpsertByID does (which sets status='active'
+		// in either case but keeps disabled rows untouched).
+		row, err := s.coding.Get(ctx, scope, id)
+		if err != nil {
+			return err
+		}
+		if row.Status == models.CodingCredentialStatusPendingAuth {
+			return s.coding.PromotePending(ctx, scope, id, unified)
+		}
+		// UpdateConfig refuses to resurrect disabled rows — matches the
+		// legacy UpsertByID's `WHERE status != 'disabled'` guard.
+		return s.coding.UpdateConfig(ctx, scope, id, unified)
+	}
+	return s.org.UpsertByID(ctx, scope.OrgID, id, cfg)
+}
+
+// GetByID returns the credential at (scope, id). The returned row carries
+// legacy types regardless of which store backed it.
+func (s *ScopedCredentialStore) GetByID(ctx context.Context, scope models.Scope, id uuid.UUID) (*models.DecryptedCredential, error) {
+	if scope.IsPersonal() {
+		row, err := s.coding.Get(ctx, scope, id)
+		if err != nil {
+			return nil, err
+		}
+		legacy, err := decryptedCredentialFromCoding(row)
+		if err != nil {
+			return nil, err
+		}
+		return legacy, nil
+	}
+	return s.org.GetByID(ctx, scope.OrgID, id)
+}
+
+// GetByProviderAndLabel finds a row at (scope, provider, label). The provider
+// argument uses the legacy name (anthropic / openai_chatgpt); the adapter
+// translates to the unified provider for personal-scope lookups.
+func (s *ScopedCredentialStore) GetByProviderAndLabel(ctx context.Context, scope models.Scope, provider models.ProviderName, label string) (*models.DecryptedCredential, error) {
+	if scope.IsPersonal() {
+		unifiedProvider := translateProviderForUnified(provider)
+		row, err := s.coding.GetByProviderAndLabel(ctx, scope, unifiedProvider, label)
+		if err != nil {
+			return nil, err
+		}
+		legacy, err := decryptedCredentialFromCoding(row)
+		if err != nil {
+			return nil, err
+		}
+		return legacy, nil
+	}
+	return s.org.GetByProviderAndLabel(ctx, scope.OrgID, provider, label)
+}
+
+// ListByProvider lists every (scope, provider) row, translating personal
+// rows back to legacy types.
+func (s *ScopedCredentialStore) ListByProvider(ctx context.Context, scope models.Scope, provider models.ProviderName) ([]models.DecryptedCredential, error) {
+	if scope.IsPersonal() {
+		// On the personal path, "list anthropic" should surface subscription
+		// rows the OAuth flow created — those live under
+		// anthropic_subscription in the unified table. The legacy List, by
+		// contrast, returns rows stored as `anthropic` with an embedded
+		// Subscription. List both unified providers so the legacy callers
+		// (which key off provider=anthropic) see exactly the rows they own.
+		unifiedProvider := translateProviderForUnified(provider)
+		rows, err := s.coding.ListByProvider(ctx, scope, unifiedProvider)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]models.DecryptedCredential, 0, len(rows))
+		for i := range rows {
+			legacy, err := decryptedCredentialFromCoding(&rows[i])
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, *legacy)
+		}
+		return out, nil
+	}
+	return s.org.ListByProvider(ctx, scope.OrgID, provider)
+}
+
+// DisableByID soft-deletes a credential. Idempotent across scopes.
+func (s *ScopedCredentialStore) DisableByID(ctx context.Context, scope models.Scope, id uuid.UUID) error {
+	if scope.IsPersonal() {
+		err := s.coding.Disable(ctx, scope, id)
+		if errors.Is(err, ErrCodingCredentialNotFound) {
+			// Match legacy semantics: disabling a missing row is a no-op.
+			return nil
+		}
+		return err
+	}
+	return s.org.DisableByID(ctx, scope.OrgID, id)
+}
+
+// UpdateStatusByID flips the row's status. Used to mark a credential invalid
+// after a refresh fails authentication.
+func (s *ScopedCredentialStore) UpdateStatusByID(ctx context.Context, scope models.Scope, id uuid.UUID, status string) error {
+	if scope.IsPersonal() {
+		return s.coding.UpdateStatus(ctx, scope, id, status)
+	}
+	return s.org.UpdateStatusByID(ctx, scope.OrgID, id, status)
+}
+
+// ExistsForProviderByID is used by Disconnect to verify an id belongs to the
+// caller's scope before disabling. Includes disabled rows to distinguish
+// "not yours" from "already disconnected".
+func (s *ScopedCredentialStore) ExistsForProviderByID(ctx context.Context, scope models.Scope, id uuid.UUID, provider models.ProviderName) (bool, error) {
+	if scope.IsPersonal() {
+		row, err := s.coding.Get(ctx, scope, id)
+		if err != nil {
+			if errors.Is(err, ErrCodingCredentialNotFound) {
+				return false, nil
+			}
+			return false, err
+		}
+		// Any unified row whose provider maps back to the requested legacy
+		// provider counts. For Anthropic this matches both the API-key row
+		// (provider=anthropic) and subscription rows (anthropic_subscription).
+		return translateProviderFromUnified(row.Provider) == provider, nil
+	}
+	return s.org.ExistsForProviderByID(ctx, scope.OrgID, id, provider)
+}
+
+// HasActiveLabeled reports whether at least one active labeled credential
+// exists at (scope, provider). Backs HasActiveSubscription.
+func (s *ScopedCredentialStore) HasActiveLabeled(ctx context.Context, scope models.Scope, provider models.ProviderName) (bool, error) {
+	if scope.IsPersonal() {
+		unifiedProvider := translateProviderForUnified(provider)
+		rows, err := s.coding.ListByProvider(ctx, scope, unifiedProvider)
+		if err != nil {
+			return false, err
+		}
+		for _, row := range rows {
+			if row.Label != "" && row.Status == models.CodingCredentialStatusActive {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+	return s.org.HasActiveLabeled(ctx, scope.OrgID, provider)
+}
+
+// DisableLabeled disables every labeled subscription row at (scope, provider)
+// while leaving the API-key row (label="") intact. Used by DisconnectAll so
+// the caller doesn't lose their fallback API key.
+func (s *ScopedCredentialStore) DisableLabeled(ctx context.Context, scope models.Scope, provider models.ProviderName) error {
+	if scope.IsPersonal() {
+		// On the personal path the API-key row lives under provider=anthropic
+		// while subscription rows live under anthropic_subscription. Listing
+		// only the subscription provider is therefore safe — the API-key row
+		// is in a separate provider partition and untouched.
+		unifiedProvider := translateProviderForUnified(provider)
+		rows, err := s.coding.ListByProvider(ctx, scope, unifiedProvider)
+		if err != nil {
+			return err
+		}
+		for _, row := range rows {
+			if row.Label == "" || row.Status == models.CodingCredentialStatusDisabled {
+				continue
+			}
+			if err := s.coding.Disable(ctx, scope, row.ID); err != nil && !errors.Is(err, ErrCodingCredentialNotFound) {
+				return err
+			}
+		}
+		return nil
+	}
+	return s.org.DisableLabeled(ctx, scope.OrgID, provider)
+}
+
+// Disable removes the unlabeled credential at (scope, provider). Legacy
+// single-credential path (codexauth.DisconnectAll) — personal scope is a
+// no-op since personal subscriptions always carry a label.
+func (s *ScopedCredentialStore) Disable(ctx context.Context, scope models.Scope, provider models.ProviderName) error {
+	if scope.IsPersonal() {
+		// "Disable everything for this provider" on the personal path:
+		// disable every active row at this provider regardless of label.
+		unifiedProvider := translateProviderForUnified(provider)
+		rows, err := s.coding.ListByProvider(ctx, scope, unifiedProvider)
+		if err != nil {
+			return err
+		}
+		for _, row := range rows {
+			if row.Status == models.CodingCredentialStatusDisabled {
+				continue
+			}
+			if err := s.coding.Disable(ctx, scope, row.ID); err != nil && !errors.Is(err, ErrCodingCredentialNotFound) {
+				return err
+			}
+		}
+		return nil
+	}
+	return s.org.Disable(ctx, scope.OrgID, provider)
+}
+
+// ClaimNextRoundRobin / ClaimNextLabeledRoundRobin back the legacy
+// GetValidToken runtime path that walks an org's subscription stack in
+// least-recently-used order. Personal scope routes through the unified
+// resolver (env.go's pickFromCodingProviderSet), so these methods return
+// ErrCodingCredentialNotFound on personal scope to surface the
+// misconfiguration loudly rather than silently never picking a credential.
+func (s *ScopedCredentialStore) ClaimNextRoundRobin(ctx context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
+	if scope.IsPersonal() {
+		return nil, ErrCodingCredentialNotFound
+	}
+	return s.org.ClaimNextRoundRobin(ctx, scope.OrgID, provider)
+}
+
+// ClaimNextLabeledRoundRobin is the labeled-row variant for providers like
+// Anthropic that mix API-key (label="") and subscription (label!="") rows.
+func (s *ScopedCredentialStore) ClaimNextLabeledRoundRobin(ctx context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
+	if scope.IsPersonal() {
+		return nil, ErrCodingCredentialNotFound
+	}
+	return s.org.ClaimNextLabeledRoundRobin(ctx, scope.OrgID, provider)
+}
+
+// translateProviderForUnified maps a legacy provider name (the value the
+// OAuth services pass in) to the unified provider where personal-scope
+// subscription rows actually live.
+func translateProviderForUnified(p models.ProviderName) models.ProviderName {
+	switch p {
+	case models.ProviderOpenAIChatGPT:
+		return models.ProviderOpenAISubscription
+	case models.ProviderAnthropic:
+		// Subscriptions live under anthropic_subscription. The bare
+		// anthropic provider in the unified table is API-key-only, which
+		// the OAuth services never read.
+		return models.ProviderAnthropicSubscription
+	}
+	return p
+}
+
+// translateProviderFromUnified is the inverse of translateProviderForUnified.
+func translateProviderFromUnified(p models.ProviderName) models.ProviderName {
+	switch p {
+	case models.ProviderOpenAISubscription:
+		return models.ProviderOpenAIChatGPT
+	case models.ProviderAnthropicSubscription:
+		return models.ProviderAnthropic
+	}
+	return p
+}
+
+// translateConfigForUnifiedWrite converts the legacy OAuth config types the
+// services emit into their unified counterparts before writing.
+func translateConfigForUnifiedWrite(cfg models.ProviderConfig) (models.ProviderConfig, error) {
+	switch v := cfg.(type) {
+	case models.OpenAIChatGPTConfig:
+		// OpenAIChatGPTConfig and OpenAISubscriptionConfig have identical
+		// field layouts; the conversion is a zero-cost rename that shifts
+		// the row to provider=openai_subscription on the unified table.
+		return models.OpenAISubscriptionConfig(v), nil
+	case models.AnthropicConfig:
+		// API-key-only AnthropicConfig is left as-is — personal anthropic
+		// API keys live under provider=anthropic in the unified table. Only
+		// subscription configs need the rewrite.
+		if v.Subscription == nil {
+			return v, nil
+		}
+		sub := v.Subscription
+		return models.AnthropicSubscriptionConfig{
+			AccessToken:   sub.AccessToken,
+			RefreshToken:  sub.RefreshToken,
+			ExpiresAt:     sub.ExpiresAt,
+			AccountType:   sub.AccountType,
+			RateLimitTier: sub.RateLimitTier,
+			Scopes:        sub.Scopes,
+			State:         sub.State,
+			CodeVerifier:  sub.CodeVerifier,
+			AuthorizeURL:  sub.AuthorizeURL,
+		}, nil
+	}
+	return cfg, nil
+}
+
+// translateConfigFromUnifiedRead is the inverse — invoked when surfacing a
+// unified row to a legacy-typed caller. The OAuth services pattern-match on
+// AnthropicConfig / OpenAIChatGPTConfig, so we hand them exactly that.
+func translateConfigFromUnifiedRead(cfg models.ProviderConfig) models.ProviderConfig {
+	switch v := cfg.(type) {
+	case models.OpenAISubscriptionConfig:
+		// Reverse of the write-side conversion — same identical-field
+		// rename, just back to the legacy type the OAuth services expect.
+		return models.OpenAIChatGPTConfig(v)
+	case models.AnthropicSubscriptionConfig:
+		return models.AnthropicConfig{
+			Subscription: &models.AnthropicSubscription{
+				AccessToken:   v.AccessToken,
+				RefreshToken:  v.RefreshToken,
+				ExpiresAt:     v.ExpiresAt,
+				AccountType:   v.AccountType,
+				RateLimitTier: v.RateLimitTier,
+				Scopes:        v.Scopes,
+				State:         v.State,
+				CodeVerifier:  v.CodeVerifier,
+				AuthorizeURL:  v.AuthorizeURL,
+			},
+		}
+	}
+	return cfg
+}
+
+// decryptedCredentialFromCoding maps a unified row to the legacy decrypted
+// shape. Provider and config are translated; UserID is dropped because the
+// legacy struct has no slot for it (callers already hold scope context).
+func decryptedCredentialFromCoding(row *models.DecryptedCodingCredential) (*models.DecryptedCredential, error) {
+	if row == nil {
+		return nil, fmt.Errorf("nil coding credential")
+	}
+	return &models.DecryptedCredential{
+		ID:             row.ID,
+		OrgID:          row.OrgID,
+		Provider:       translateProviderFromUnified(row.Provider),
+		Label:          row.Label,
+		Config:         translateConfigFromUnifiedRead(row.Config),
+		Status:         row.Status,
+		Priority:       row.Priority,
+		LastVerifiedAt: row.LastVerifiedAt,
+		CreatedBy:      row.CreatedBy,
+		CreatedAt:      row.CreatedAt,
+		UpdatedAt:      row.UpdatedAt,
+	}, nil
+}

--- a/internal/db/scoped_credential_store_test.go
+++ b/internal/db/scoped_credential_store_test.go
@@ -1,0 +1,238 @@
+// Package db — scoped_credential_store_test.go
+//
+// Unit coverage for the type/provider translation helpers and the
+// constructor's nil-guard. The adapter's routing behavior at the SQL layer
+// is exercised end-to-end through the auth-service tests in
+// internal/services/{codexauth,claudecodeauth}, which run against a
+// scope-aware in-memory mock that mirrors the real partitioning.
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+func TestScopedCredentialStore_TranslateProviderForUnified(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		legacy  models.ProviderName
+		unified models.ProviderName
+	}{
+		{models.ProviderOpenAIChatGPT, models.ProviderOpenAISubscription},
+		{models.ProviderAnthropic, models.ProviderAnthropicSubscription},
+		{models.ProviderGemini, models.ProviderGemini}, // pass-through
+		{models.ProviderAmp, models.ProviderAmp},
+		{models.ProviderPi, models.ProviderPi},
+	}
+	for _, c := range cases {
+		require.Equal(t, c.unified, translateProviderForUnified(c.legacy), "%s should map to %s", c.legacy, c.unified)
+	}
+}
+
+func TestScopedCredentialStore_TranslateProviderRoundtrip(t *testing.T) {
+	// translateProviderForUnified and its inverse must form a roundtrip for
+	// the OAuth provider names; otherwise a personal-scope read would
+	// surface a unified-typed cred to the auth service, which only knows
+	// about the legacy types.
+	t.Parallel()
+
+	for _, legacy := range []models.ProviderName{
+		models.ProviderOpenAIChatGPT,
+		models.ProviderAnthropic,
+	} {
+		round := translateProviderFromUnified(translateProviderForUnified(legacy))
+		require.Equal(t, legacy, round, "roundtrip should restore the legacy provider name for %s", legacy)
+	}
+}
+
+func TestScopedCredentialStore_TranslateConfigForUnifiedWrite_OpenAI(t *testing.T) {
+	// OpenAIChatGPTConfig and OpenAISubscriptionConfig have identical layouts
+	// — the conversion must preserve every field so a refresh round-trip
+	// after writing doesn't drop tokens or expiry.
+	t.Parallel()
+
+	expiry := time.Now().Add(time.Hour).UTC()
+	src := models.OpenAIChatGPTConfig{
+		AccessToken:     "access-123",
+		RefreshToken:    "refresh-456",
+		IDToken:         "id-789",
+		ExpiresAt:       expiry,
+		AccountType:     "plus",
+		DeviceAuthID:    "dev-abc",
+		UserCode:        "USER-CODE",
+		VerificationURI: "https://auth.openai.com/verify",
+		PollInterval:    7,
+	}
+	out, err := translateConfigForUnifiedWrite(src)
+	require.NoError(t, err)
+	got, ok := out.(models.OpenAISubscriptionConfig)
+	require.True(t, ok, "OpenAIChatGPTConfig must translate to OpenAISubscriptionConfig, got %T", out)
+	require.Equal(t, src.AccessToken, got.AccessToken)
+	require.Equal(t, src.RefreshToken, got.RefreshToken)
+	require.Equal(t, src.IDToken, got.IDToken)
+	require.True(t, src.ExpiresAt.Equal(got.ExpiresAt))
+	require.Equal(t, src.AccountType, got.AccountType)
+	require.Equal(t, src.DeviceAuthID, got.DeviceAuthID)
+	require.Equal(t, src.UserCode, got.UserCode)
+	require.Equal(t, src.VerificationURI, got.VerificationURI)
+	require.Equal(t, src.PollInterval, got.PollInterval)
+}
+
+func TestScopedCredentialStore_TranslateConfigForUnifiedWrite_AnthropicSubscription(t *testing.T) {
+	// AnthropicConfig with a non-nil Subscription must collapse to
+	// AnthropicSubscriptionConfig (the unified table's flattened shape).
+	t.Parallel()
+
+	expiry := time.Now().Add(time.Hour).UTC()
+	src := models.AnthropicConfig{
+		Subscription: &models.AnthropicSubscription{
+			AccessToken:   "access-claude",
+			RefreshToken:  "refresh-claude",
+			ExpiresAt:     expiry,
+			AccountType:   "claude_max",
+			RateLimitTier: "default_claude_max_20x",
+			Scopes:        []string{"user:profile", "user:inference"},
+			State:         "csrf-state",
+			CodeVerifier:  "pkce-verifier",
+			AuthorizeURL:  "https://claude.ai/authorize?...",
+		},
+	}
+	out, err := translateConfigForUnifiedWrite(src)
+	require.NoError(t, err)
+	got, ok := out.(models.AnthropicSubscriptionConfig)
+	require.True(t, ok, "AnthropicConfig{Subscription} must translate to AnthropicSubscriptionConfig, got %T", out)
+	require.Equal(t, src.Subscription.AccessToken, got.AccessToken)
+	require.Equal(t, src.Subscription.RefreshToken, got.RefreshToken)
+	require.True(t, src.Subscription.ExpiresAt.Equal(got.ExpiresAt))
+	require.Equal(t, src.Subscription.AccountType, got.AccountType)
+	require.Equal(t, src.Subscription.RateLimitTier, got.RateLimitTier)
+	require.Equal(t, src.Subscription.Scopes, got.Scopes)
+	require.Equal(t, src.Subscription.State, got.State)
+	require.Equal(t, src.Subscription.CodeVerifier, got.CodeVerifier)
+	require.Equal(t, src.Subscription.AuthorizeURL, got.AuthorizeURL)
+}
+
+func TestScopedCredentialStore_TranslateConfigForUnifiedWrite_AnthropicAPIKey(t *testing.T) {
+	// API-key-only AnthropicConfig (no Subscription) is left untouched —
+	// the unified table stores personal anthropic API keys under
+	// provider=anthropic, not anthropic_subscription.
+	t.Parallel()
+
+	src := models.AnthropicConfig{APIKey: "sk-ant-test"}
+	out, err := translateConfigForUnifiedWrite(src)
+	require.NoError(t, err)
+	got, ok := out.(models.AnthropicConfig)
+	require.True(t, ok, "API-key AnthropicConfig must pass through unchanged, got %T", out)
+	require.Equal(t, src.APIKey, got.APIKey)
+	require.Nil(t, got.Subscription)
+}
+
+func TestScopedCredentialStore_TranslateConfigFromUnifiedRead_Roundtrip(t *testing.T) {
+	// A write-then-read roundtrip must restore the legacy types exactly.
+	// The auth services pattern-match on AnthropicConfig / OpenAIChatGPTConfig
+	// so any drift would surface as "credential is not OpenAIChatGPTConfig"
+	// at the next refresh.
+	t.Parallel()
+
+	chatGPT := models.OpenAIChatGPTConfig{
+		AccessToken:  "access",
+		RefreshToken: "refresh",
+		IDToken:      "id",
+		ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+		AccountType:  "plus",
+	}
+	written, err := translateConfigForUnifiedWrite(chatGPT)
+	require.NoError(t, err)
+	read := translateConfigFromUnifiedRead(written)
+	got, ok := read.(models.OpenAIChatGPTConfig)
+	require.True(t, ok, "roundtrip should restore OpenAIChatGPTConfig, got %T", read)
+	require.Equal(t, chatGPT, got)
+
+	anthropic := models.AnthropicConfig{
+		Subscription: &models.AnthropicSubscription{
+			AccessToken:  "claude-access",
+			RefreshToken: "claude-refresh",
+			ExpiresAt:    time.Now().Add(time.Hour).UTC(),
+			Scopes:       []string{"user:profile"},
+		},
+	}
+	writtenA, err := translateConfigForUnifiedWrite(anthropic)
+	require.NoError(t, err)
+	readA := translateConfigFromUnifiedRead(writtenA)
+	gotA, ok := readA.(models.AnthropicConfig)
+	require.True(t, ok, "roundtrip should restore AnthropicConfig, got %T", readA)
+	require.NotNil(t, gotA.Subscription)
+	require.Equal(t, anthropic.Subscription.AccessToken, gotA.Subscription.AccessToken)
+	require.Equal(t, anthropic.Subscription.RefreshToken, gotA.Subscription.RefreshToken)
+	require.True(t, anthropic.Subscription.ExpiresAt.Equal(gotA.Subscription.ExpiresAt))
+	require.Equal(t, anthropic.Subscription.Scopes, gotA.Subscription.Scopes)
+}
+
+func TestScopedCredentialStore_DecryptedCredentialFromCoding_TranslatesProvider(t *testing.T) {
+	// The unified row's provider name (anthropic_subscription) must surface
+	// to the auth service as the legacy name (anthropic), since that's what
+	// the service's Provider checks compare against.
+	t.Parallel()
+
+	expiry := time.Now().Add(time.Hour).UTC()
+	created := time.Now().UTC()
+	row := &models.DecryptedCodingCredential{
+		ID:        uuid.New(),
+		OrgID:     uuid.New(),
+		UserID:    uuidPtr(uuid.New()),
+		Provider:  models.ProviderAnthropicSubscription,
+		Label:     "personal-claude",
+		Status:    models.CodingCredentialStatusActive,
+		Priority:  1,
+		CreatedAt: created,
+		UpdatedAt: created,
+		Config: models.AnthropicSubscriptionConfig{
+			AccessToken:  "access",
+			RefreshToken: "refresh",
+			ExpiresAt:    expiry,
+		},
+	}
+	legacy, err := decryptedCredentialFromCoding(row)
+	require.NoError(t, err)
+	require.Equal(t, models.ProviderAnthropic, legacy.Provider, "provider must translate back to anthropic for legacy callers")
+	require.Equal(t, row.ID, legacy.ID)
+	require.Equal(t, row.OrgID, legacy.OrgID)
+	require.Equal(t, row.Label, legacy.Label)
+
+	// The config must come back as AnthropicConfig with a populated
+	// Subscription — that's the shape the auth services pattern-match on.
+	cfg, ok := legacy.Config.(models.AnthropicConfig)
+	require.True(t, ok, "config must translate back to AnthropicConfig, got %T", legacy.Config)
+	require.NotNil(t, cfg.Subscription)
+	require.Equal(t, "access", cfg.Subscription.AccessToken)
+	require.Equal(t, "refresh", cfg.Subscription.RefreshToken)
+	require.True(t, expiry.Equal(cfg.Subscription.ExpiresAt))
+}
+
+func TestScopedCredentialStore_NewPanicsOnNilOrgStore(t *testing.T) {
+	// Construction-time guard: missing wiring fails fast at boot rather
+	// than surfacing as cryptic per-request errors.
+	t.Parallel()
+
+	require.PanicsWithValue(t,
+		"db: NewScopedCredentialStore requires a non-nil OrgCredentialStore",
+		func() { NewScopedCredentialStore(nil, &CodingCredentialStore{}) },
+	)
+}
+
+func TestScopedCredentialStore_NewPanicsOnNilCodingStore(t *testing.T) {
+	t.Parallel()
+
+	require.PanicsWithValue(t,
+		"db: NewScopedCredentialStore requires a non-nil CodingCredentialStore",
+		func() { NewScopedCredentialStore(&OrgCredentialStore{}, nil) },
+	)
+}
+
+func uuidPtr(id uuid.UUID) *uuid.UUID { return &id }

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -146,8 +146,15 @@ type CodingCredentialShedder interface {
 // service. Unified subscription resolution chooses a concrete credential id;
 // this interface lets auth.json injection refresh that exact row before
 // writing an access token into the sandbox.
+//
+// The scope must match the credential's owner: personal subscriptions live
+// in coding_credentials with user_id set, and the underlying lookup filters
+// on (org_id, user_id). Passing org scope for a personal credential would
+// mis-route the lookup and surface as "credential not found", silently
+// dropping personal subscriptions back to the org fallback after their
+// first 8h of token life.
 type CodexAuthRefresher interface {
-	RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error)
+	RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error)
 }
 
 // CodingCredentialMultiPicker is implemented by the real unified store for
@@ -901,7 +908,9 @@ func (e *AgentEnv) InjectCodexAuthForUser(ctx context.Context, orgID uuid.UUID, 
 		if picked, ok := e.lookupRecentCredential(orgID, userID, models.ProviderOpenAI); ok {
 			if chatGPT, ok := codexChatGPTConfigFromPicked(picked); ok {
 				if picked.Provider == models.ProviderOpenAISubscription {
-					refreshed, err := e.refreshCodexSubscriptionIfNeeded(ctx, orgID, picked.ID, chatGPT)
+					// Refresh against the picked row's actual scope —
+					// personal credentials carry UserID, org rows do not.
+					refreshed, err := e.refreshCodexSubscriptionIfNeeded(ctx, models.Scope{OrgID: orgID, UserID: picked.UserID}, picked.ID, chatGPT)
 					if err != nil {
 						return false, err
 					}
@@ -918,7 +927,7 @@ func (e *AgentEnv) InjectCodexAuthForUser(ctx context.Context, orgID uuid.UUID, 
 		if handled {
 			if chatGPT, ok := cfg.(models.OpenAIChatGPTConfig); ok {
 				if picked != nil && picked.Provider == models.ProviderOpenAISubscription {
-					refreshed, err := e.refreshCodexSubscriptionIfNeeded(ctx, orgID, picked.ID, chatGPT)
+					refreshed, err := e.refreshCodexSubscriptionIfNeeded(ctx, models.Scope{OrgID: orgID, UserID: picked.UserID}, picked.ID, chatGPT)
 					if err != nil {
 						return false, err
 					}
@@ -959,7 +968,7 @@ func codexChatGPTConfigFromPicked(picked models.DecryptedCodingCredential) (mode
 	return chatGPT, ok
 }
 
-func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, orgID uuid.UUID, credID uuid.UUID, cfg models.OpenAIChatGPTConfig) (*models.OpenAIChatGPTConfig, error) {
+func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, scope models.Scope, credID uuid.UUID, cfg models.OpenAIChatGPTConfig) (*models.OpenAIChatGPTConfig, error) {
 	if !cfg.NeedsRefresh(codexSubscriptionRefreshWindow) {
 		return &cfg, nil
 	}
@@ -975,7 +984,7 @@ func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, orgID u
 		return nil, fmt.Errorf("codex subscription %s is expired and no refresh provider is configured", credID)
 	}
 
-	refreshed, err := refresher.RefreshTokenByID(ctx, orgID, credID)
+	refreshed, err := refresher.RefreshTokenByID(ctx, scope, credID)
 	if err != nil {
 		if !cfg.IsExpired() {
 			e.logger.Warn().

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -202,11 +202,12 @@ func (m *envOrgStore) GetByID(_ context.Context, _ uuid.UUID) (models.Organizati
 }
 
 type envCodexAuthProvider struct {
-	token        *models.OpenAIChatGPTConfig
-	err          error
-	refreshToken *models.OpenAIChatGPTConfig
-	refreshErr   error
-	refreshIDs   []uuid.UUID
+	token         *models.OpenAIChatGPTConfig
+	err           error
+	refreshToken  *models.OpenAIChatGPTConfig
+	refreshErr    error
+	refreshIDs    []uuid.UUID
+	refreshScopes []models.Scope
 }
 
 func (m envCodexAuthProvider) GetValidToken(_ context.Context, _ uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
@@ -216,8 +217,9 @@ func (m envCodexAuthProvider) GetValidToken(_ context.Context, _ uuid.UUID) (*mo
 	return m.token, nil
 }
 
-func (m *envCodexAuthProvider) RefreshTokenByID(_ context.Context, _ uuid.UUID, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
+func (m *envCodexAuthProvider) RefreshTokenByID(_ context.Context, scope models.Scope, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
 	m.refreshIDs = append(m.refreshIDs, credID)
+	m.refreshScopes = append(m.refreshScopes, scope)
 	if m.refreshErr != nil {
 		return nil, m.refreshErr
 	}
@@ -1421,6 +1423,16 @@ func TestAgentEnvInjectCodexAuthForUser_RefreshesUnifiedSubscriptionByID(t *test
 	require.NoError(t, err, "InjectCodexAuthForUser should refresh an expired unified subscription before writing auth.json")
 	require.True(t, injected, "InjectCodexAuthForUser should inject the refreshed subscription")
 	require.Equal(t, []uuid.UUID{credID}, codexAuth.refreshIDs, "InjectCodexAuthForUser should refresh the selected credential id")
+
+	// The refresher must receive the picked credential's actual scope so
+	// the underlying coding_credentials lookup matches on (org_id, user_id).
+	// Passing org scope for a personal credential would silently miss the
+	// row and surface as "credential not found" once the access token
+	// expires (~8h after issuance).
+	require.Len(t, codexAuth.refreshScopes, 1, "refresh should be called exactly once")
+	require.Equal(t, orgID, codexAuth.refreshScopes[0].OrgID, "scope should carry the request org id")
+	require.NotNil(t, codexAuth.refreshScopes[0].UserID, "personal subscription must refresh under personal scope")
+	require.Equal(t, userID, *codexAuth.refreshScopes[0].UserID, "scope must carry the picked credential's user id")
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(provider.writes["/home/test/.codex/auth.json"], &payload), "auth.json should be valid JSON")

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -172,8 +172,15 @@ type ClaudeCodeAuthProvider interface {
 	GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.AnthropicSubscription, *uuid.UUID, error)
 }
 
+// ClaudeCodeAuthRefresher rotates an expired Claude subscription token by
+// credential id. The scope must match the credential's owner: personal
+// subscriptions live in coding_credentials with user_id set, and the
+// underlying lookup filters on (org_id, user_id) — passing org scope for a
+// personal credential would mis-route the lookup and surface as
+// "credential not found", silently dropping personal subscriptions back
+// to the org fallback after their first 8h of token life.
 type ClaudeCodeAuthRefresher interface {
-	RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) (*models.AnthropicSubscription, error)
+	RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.AnthropicSubscription, error)
 }
 
 // CredentialProvider abstracts retrieving org-scoped provider credentials.
@@ -3252,7 +3259,12 @@ func (o *Orchestrator) injectPickedUnifiedClaudeCodeAuth(ctx context.Context, or
 	if sub.NeedsRefresh(codexSubscriptionRefreshWindow) {
 		refresher, ok := o.claudeCodeAuth.(ClaudeCodeAuthRefresher)
 		if ok {
-			refreshed, err := refresher.RefreshTokenByID(ctx, orgID, picked.ID)
+			// Build scope from the picked row's UserID. Personal credentials
+			// (UserID != nil) require their scope on the lookup; passing
+			// org scope would miss them in coding_credentials and surface
+			// as "credential not found".
+			scope := models.Scope{OrgID: orgID, UserID: picked.UserID}
+			refreshed, err := refresher.RefreshTokenByID(ctx, scope, picked.ID)
 			if err == nil && refreshed != nil {
 				sub = *refreshed
 			} else if sub.IsExpired() {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -108,7 +108,7 @@ func (m *mockCodexAuthProvider) GetValidToken(ctx context.Context, orgID uuid.UU
 	return m.cfg, nil
 }
 
-func (m *mockCodexAuthProvider) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
+func (m *mockCodexAuthProvider) RefreshTokenByID(_ context.Context, _ models.Scope, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
 	m.refreshIDs = append(m.refreshIDs, credID)
 	if m.refreshErr != nil {
 		return nil, m.refreshErr

--- a/internal/services/claudecodeauth/service.go
+++ b/internal/services/claudecodeauth/service.go
@@ -46,6 +46,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -118,31 +119,35 @@ var defaultScopes = []string{
 	"user:file_upload",
 }
 
-// CredentialStore defines the credential operations needed by the auth service.
-// Mirrors codexauth.CredentialStore but uses the labeled round-robin variant
-// because ProviderAnthropic mixes an API-key row (label="") with subscription
-// rows (label!="").
+// CredentialStore defines the credential operations needed by the auth
+// service. Every method takes models.Scope so a single Service instance can
+// drive both org-scoped (admin) and personal-scoped (per-user) subscription
+// flows. Production wires *db.ScopedCredentialStore.
+//
+// Subscription credentials live under ProviderAnthropic with a non-empty
+// label. An Anthropic API-key credential uses label="" and shares the same
+// provider; the two are mutually exclusive per row, so one scope can hold
+// an API key alongside N labeled subscriptions.
 type CredentialStore interface {
-	Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
-	UpsertWithLabel(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
-	InsertPendingAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
-	GetByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID) (*models.DecryptedCredential, error)
-	GetByProviderAndLabel(ctx context.Context, orgID uuid.UUID, provider models.ProviderName, label string) (*models.DecryptedCredential, error)
-	ListByProvider(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) ([]models.DecryptedCredential, error)
-	ClaimNextLabeledRoundRobin(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
-	DisableByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID) error
-	UpdateStatusByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, status string) error
-	UpsertByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, cfg models.ProviderConfig) error
-	ExistsForProviderByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, provider models.ProviderName) (bool, error)
+	UpsertWithLabel(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
+	InsertPendingAuth(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
+	GetByID(ctx context.Context, scope models.Scope, id uuid.UUID) (*models.DecryptedCredential, error)
+	GetByProviderAndLabel(ctx context.Context, scope models.Scope, provider models.ProviderName, label string) (*models.DecryptedCredential, error)
+	ListByProvider(ctx context.Context, scope models.Scope, provider models.ProviderName) ([]models.DecryptedCredential, error)
+	ClaimNextLabeledRoundRobin(ctx context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error)
+	DisableByID(ctx context.Context, scope models.Scope, id uuid.UUID) error
+	UpdateStatusByID(ctx context.Context, scope models.Scope, id uuid.UUID, status string) error
+	UpsertByID(ctx context.Context, scope models.Scope, id uuid.UUID, cfg models.ProviderConfig) error
+	ExistsForProviderByID(ctx context.Context, scope models.Scope, id uuid.UUID, provider models.ProviderName) (bool, error)
 	// HasActiveLabeled reports whether at least one active labeled credential
-	// exists for (org, provider). Backs HasActiveSubscription with a cheap
+	// exists for (scope, provider). Backs HasActiveSubscription with a cheap
 	// EXISTS probe instead of listing every row.
-	HasActiveLabeled(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (bool, error)
-	// DisableLabeled disables all subscription rows (label != '') for an org's
-	// Anthropic credentials while leaving the API-key row (label='') intact.
-	// Used by DisconnectAll so the user doesn't lose their Anthropic API key
-	// when disconnecting every Claude subscription.
-	DisableLabeled(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) error
+	HasActiveLabeled(ctx context.Context, scope models.Scope, provider models.ProviderName) (bool, error)
+	// DisableLabeled disables all subscription rows (label != '') at (scope,
+	// provider) while leaving the API-key row (label='') intact. Used by
+	// DisconnectAll so the caller doesn't lose their Anthropic API key when
+	// disconnecting every Claude subscription.
+	DisableLabeled(ctx context.Context, scope models.Scope, provider models.ProviderName) error
 }
 
 // ErrCredentialNotFound is returned when no credential exists for the given org/provider.
@@ -249,9 +254,21 @@ func (s *Service) SetTokenURL(u string) { s.tokenURL = u }
 // SetProfileURL overrides the profile endpoint (useful for testing).
 func (s *Service) SetProfileURL(u string) { s.profileURL = u }
 
-// pendingKey returns the sync.Map key for init-side mutexes scoped to org+label.
-func pendingKey(orgID uuid.UUID, label string) string {
-	return orgID.String() + ":" + label
+// pendingKey returns the sync.Map key for init-side mutexes, namespaced by
+// scope so personal and org flows for the same label never collide. The
+// leading scope tag is part of the key so an org label like
+// `u:<userID>:label` cannot impersonate a personal-scope key.
+func pendingKey(scope models.Scope, label string) string {
+	if scope.IsPersonal() {
+		return "personal:" + scope.OrgID.String() + ":u:" + scope.UserID.String() + ":" + label
+	}
+	return "org:" + scope.OrgID.String() + ":" + label
+}
+
+// orgScope is a small constructor for org-only callers that haven't been
+// updated to think in scopes yet (e.g. legacy GetValidToken path).
+func orgScope(orgID uuid.UUID) models.Scope {
+	return models.Scope{OrgID: orgID}
 }
 
 // randomURLSafe returns a cryptographically random base64url-encoded string
@@ -292,14 +309,14 @@ func (s *Service) buildAuthorizeURL(challenge, state string) string {
 	return s.authorizeURL + "?" + q.Encode()
 }
 
-// InitiateOAuth starts a new PKCE auth flow for the given org+label. Generates
-// a verifier + state, persists them on a pending_auth row, and returns the
-// authorize URL for the caller to hand to the user's browser.
-func (s *Service) InitiateOAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string) (*InitiateResponse, error) {
-	// Serialize concurrent init calls for the same (org, label) — otherwise
+// InitiateOAuth starts a new PKCE auth flow at the given (scope, label).
+// Generates a verifier + state, persists them on a pending_auth row, and
+// returns the authorize URL for the caller to hand to the user's browser.
+func (s *Service) InitiateOAuth(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string) (*InitiateResponse, error) {
+	// Serialize concurrent init calls for the same (scope, label) — otherwise
 	// two racing initiations could both reach InsertPendingAuth, with the
 	// slower request silently overwriting the faster one's verifier.
-	pKey := pendingKey(orgID, label)
+	pKey := pendingKey(scope, label)
 	muVal, _ := s.initMu.LoadOrStore(pKey, &sync.Mutex{})
 	mu := muVal.(*sync.Mutex)
 	mu.Lock()
@@ -325,13 +342,14 @@ func (s *Service) InitiateOAuth(ctx context.Context, orgID uuid.UUID, createdBy 
 	}
 
 	if s.credentials != nil {
-		if _, err := s.credentials.InsertPendingAuth(ctx, orgID, createdBy, label, pendingCfg); err != nil {
+		if _, err := s.credentials.InsertPendingAuth(ctx, scope, createdBy, label, pendingCfg); err != nil {
 			return nil, fmt.Errorf("persist pending subscription: %w", err)
 		}
 	}
 
 	s.logger.Info().
-		Str("org_id", orgID.String()).
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
 		Str("label", label).
 		Msg("Claude Code OAuth initiated")
 
@@ -344,8 +362,8 @@ func (s *Service) InitiateOAuth(ctx context.Context, orgID uuid.UUID, createdBy 
 // CompleteOAuth exchanges the user's pasted "<code>#<state>" for tokens,
 // verifies the returned state matches the one we stored, and upgrades the
 // pending row to an active subscription.
-func (s *Service) CompleteOAuth(ctx context.Context, orgID uuid.UUID, label, codeAndState string) (*CompleteResponse, error) {
-	pKey := pendingKey(orgID, label)
+func (s *Service) CompleteOAuth(ctx context.Context, scope models.Scope, label, codeAndState string) (*CompleteResponse, error) {
+	pKey := pendingKey(scope, label)
 	muVal, _ := s.initMu.LoadOrStore(pKey, &sync.Mutex{})
 	mu := muVal.(*sync.Mutex)
 	mu.Lock()
@@ -368,7 +386,7 @@ func (s *Service) CompleteOAuth(ctx context.Context, orgID uuid.UUID, label, cod
 	if s.credentials == nil {
 		return nil, fmt.Errorf("credential store not configured")
 	}
-	cred, err := s.credentials.GetByProviderAndLabel(ctx, orgID, models.ProviderAnthropic, label)
+	cred, err := s.credentials.GetByProviderAndLabel(ctx, scope, models.ProviderAnthropic, label)
 	if err != nil {
 		// Only "no row" should surface as ErrPendingAuthNotFound (→ 404).
 		// Transient DB errors must bubble up as 500s so operators can see them.
@@ -421,18 +439,19 @@ func (s *Service) CompleteOAuth(ctx context.Context, orgID uuid.UUID, label, cod
 	// human-readable tier (AccountType) and the backend's rate_limit_tier.
 	// These fields are display-only; a failure here must not block auth.
 	if profile, perr := s.fetchProfile(ctx, sub.AccessToken); perr != nil {
-		s.logger.Warn().Err(perr).Str("org_id", orgID.String()).Str("label", label).Msg("claude profile fetch failed; continuing without tier info")
+		s.logger.Warn().Err(perr).Str("org_id", scope.OrgID.String()).Str("label", label).Msg("claude profile fetch failed; continuing without tier info")
 	} else if profile != nil {
 		sub.AccountType = profile.Organization.OrganizationType
 		sub.RateLimitTier = profile.Organization.RateLimitTier
 	}
 
-	if err := s.credentials.UpsertByID(ctx, orgID, cred.ID, models.AnthropicConfig{Subscription: sub}); err != nil {
+	if err := s.credentials.UpsertByID(ctx, scope, cred.ID, models.AnthropicConfig{Subscription: sub}); err != nil {
 		return nil, fmt.Errorf("store credential: %w", err)
 	}
 
 	s.logger.Info().
-		Str("org_id", orgID.String()).
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
 		Str("label", label).
 		Bool("has_refresh_token", sub.RefreshToken != "").
 		Int("expires_in", tokens.ExpiresIn).
@@ -595,12 +614,17 @@ func (s *Service) credRefreshMu(credID uuid.UUID) *sync.Mutex {
 }
 
 // RefreshTokenByID refreshes an expired access token for a specific credential.
-func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) (*models.AnthropicSubscription, error) {
+//
+// Scope must match the credential's owner — personal credentials require a
+// scope with the matching UserID. The unified runtime path constructs scope
+// from the picked credential's UserID (orchestrator.go); the legacy
+// org-fallback GetValidToken path constructs an org scope.
+func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.AnthropicSubscription, error) {
 	mu := s.credRefreshMu(credID)
 	mu.Lock()
 	defer mu.Unlock()
 
-	cred, err := s.credentials.GetByID(ctx, orgID, credID)
+	cred, err := s.credentials.GetByID(ctx, scope, credID)
 	if err != nil {
 		return nil, fmt.Errorf("get credential: %w", err)
 	}
@@ -653,7 +677,7 @@ func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID 
 			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
 			return nil, fmt.Errorf("refresh token already used by another client")
 		}
-		if err := s.credentials.UpdateStatusByID(ctx, orgID, credID, "invalid"); err != nil {
+		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, "invalid"); err != nil {
 			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
 		}
 		// Drop the per-credential refresh mutex so sync.Map doesn't grow
@@ -694,7 +718,7 @@ func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID 
 		newSub.RefreshToken = sub.RefreshToken
 	}
 
-	if err := s.credentials.UpsertByID(ctx, orgID, credID, models.AnthropicConfig{Subscription: newSub}); err != nil {
+	if err := s.credentials.UpsertByID(ctx, scope, credID, models.AnthropicConfig{Subscription: newSub}); err != nil {
 		return nil, fmt.Errorf("store refreshed credential: %w", err)
 	}
 
@@ -721,11 +745,12 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.A
 		return nil, nil, nil
 	}
 
+	scope := orgScope(orgID)
 	tried := make(map[uuid.UUID]struct{}, maxRoundRobinAttempts)
 	var lastErr error
 
 	for attempt := 0; attempt < maxRoundRobinAttempts; attempt++ {
-		cred, err := s.credentials.ClaimNextLabeledRoundRobin(ctx, orgID, models.ProviderAnthropic)
+		cred, err := s.credentials.ClaimNextLabeledRoundRobin(ctx, scope, models.ProviderAnthropic)
 		if err != nil {
 			if isNotFoundError(err) {
 				if lastErr != nil {
@@ -767,7 +792,7 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.A
 			return &sub, &credID, nil
 		}
 
-		refreshed, refreshErr := s.RefreshTokenByID(ctx, orgID, cred.ID)
+		refreshed, refreshErr := s.RefreshTokenByID(ctx, scope, cred.ID)
 		if refreshErr == nil {
 			credID := cred.ID
 			return refreshed, &credID, nil
@@ -781,7 +806,7 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.A
 		}
 
 		s.logger.Warn().Err(refreshErr).Str("cred_id", cred.ID.String()).Msg("token refresh failed and cached token expired; marking invalid")
-		if statusErr := s.credentials.UpdateStatusByID(ctx, orgID, cred.ID, "invalid"); statusErr != nil {
+		if statusErr := s.credentials.UpdateStatusByID(ctx, scope, cred.ID, "invalid"); statusErr != nil {
 			s.logger.Warn().Err(statusErr).Str("cred_id", cred.ID.String()).Msg("failed to mark credential invalid")
 		}
 		// Drop the per-credential refresh mutex — the credential is out of
@@ -806,19 +831,19 @@ func (s *Service) HasActiveSubscription(ctx context.Context, orgID uuid.UUID) (b
 	if s.credentials == nil {
 		return false, nil
 	}
-	exists, err := s.credentials.HasActiveLabeled(ctx, orgID, models.ProviderAnthropic)
+	exists, err := s.credentials.HasActiveLabeled(ctx, orgScope(orgID), models.ProviderAnthropic)
 	if err != nil {
 		return false, fmt.Errorf("check anthropic subscription: %w", err)
 	}
 	return exists, nil
 }
 
-// Disconnect removes a specific Claude subscription by ID for an org.
+// Disconnect removes a specific Claude subscription by ID at the given scope.
 // Ordering matches codexauth: DB first, then in-memory state, so a concurrent
 // refresh cannot resurrect the row after we "forget" its mutex.
-func (s *Service) Disconnect(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) error {
+func (s *Service) Disconnect(ctx context.Context, scope models.Scope, credID uuid.UUID) error {
 	if s.credentials != nil {
-		if err := s.credentials.DisableByID(ctx, orgID, credID); err != nil {
+		if err := s.credentials.DisableByID(ctx, scope, credID); err != nil {
 			return err
 		}
 	}
@@ -827,13 +852,16 @@ func (s *Service) Disconnect(ctx context.Context, orgID uuid.UUID, credID uuid.U
 }
 
 // DisconnectForOrg removes a credential by ID after verifying it belongs to
-// the given org. Returns ErrCredentialNotFound if the credential doesn't
-// exist, belongs to a different org, or belongs to a different provider.
-func (s *Service) DisconnectForOrg(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) error {
+// the given scope. Returns ErrCredentialNotFound if the credential doesn't
+// exist, belongs to a different scope, or belongs to a different provider.
+//
+// The name is preserved for backward compatibility with existing call sites;
+// despite "ForOrg", scope can be either org or personal.
+func (s *Service) DisconnectForOrg(ctx context.Context, scope models.Scope, credID uuid.UUID) error {
 	if s.credentials == nil {
 		return nil
 	}
-	cred, err := s.credentials.GetByID(ctx, orgID, credID)
+	cred, err := s.credentials.GetByID(ctx, scope, credID)
 	if err != nil {
 		if isNotFoundError(err) {
 			return ErrCredentialNotFound
@@ -844,19 +872,19 @@ func (s *Service) DisconnectForOrg(ctx context.Context, orgID uuid.UUID, credID 
 	if cred.Provider != models.ProviderAnthropic || cred.Label == "" || !ok || cfg.Subscription == nil {
 		return ErrCredentialNotFound
 	}
-	return s.Disconnect(ctx, orgID, credID)
+	return s.Disconnect(ctx, scope, credID)
 }
 
-// DisconnectAll removes every Claude subscription for the org, leaving any
-// Anthropic API-key row (label="") in place. Ordering matches Disconnect:
-// the DB rows are disabled first so a concurrent refresh cannot resurrect
-// a credential after we've dropped its mutex; only then do we clean up
-// the in-memory maps.
-func (s *Service) DisconnectAll(ctx context.Context, orgID uuid.UUID) error {
+// DisconnectAll removes every Claude subscription at the given scope,
+// leaving any Anthropic API-key row (label="") in place. Ordering matches
+// Disconnect: the DB rows are disabled first so a concurrent refresh cannot
+// resurrect a credential after we've dropped its mutex; only then do we
+// clean up the in-memory maps.
+func (s *Service) DisconnectAll(ctx context.Context, scope models.Scope) error {
 	if s.credentials == nil {
 		// Still clean the init mutexes so test doubles without a store
 		// don't leak entries.
-		s.clearInitMutexesForOrg(orgID)
+		s.clearInitMutexesForScope(scope)
 		return nil
 	}
 
@@ -864,12 +892,12 @@ func (s *Service) DisconnectAll(ctx context.Context, orgID uuid.UUID) error {
 	// refresh mutexes afterwards. ListByProvider errors are non-fatal here:
 	// the DisableLabeled call below is the source of truth, but log the miss
 	// so operators can correlate any leaked refresh mutexes.
-	creds, err := s.credentials.ListByProvider(ctx, orgID, models.ProviderAnthropic)
+	creds, err := s.credentials.ListByProvider(ctx, scope, models.ProviderAnthropic)
 	if err != nil {
-		s.logger.Warn().Err(err).Str("org_id", orgID.String()).Msg("failed to list claude subscriptions before disconnect cleanup")
+		s.logger.Warn().Err(err).Str("org_id", scope.OrgID.String()).Msg("failed to list claude subscriptions before disconnect cleanup")
 	}
 
-	if err := s.credentials.DisableLabeled(ctx, orgID, models.ProviderAnthropic); err != nil {
+	if err := s.credentials.DisableLabeled(ctx, scope, models.ProviderAnthropic); err != nil {
 		return err
 	}
 
@@ -879,33 +907,41 @@ func (s *Service) DisconnectAll(ctx context.Context, orgID uuid.UUID) error {
 		}
 		s.refreshMu.Delete(cred.ID.String())
 	}
-	s.clearInitMutexesForOrg(orgID)
+	s.clearInitMutexesForScope(scope)
 
 	return nil
 }
 
-// clearInitMutexesForOrg drops every init-side mutex scoped to orgID. Used
-// by DisconnectAll so a subsequent InitiateOAuth gets a fresh mutex instead
-// of reusing a stale one that might still be held by an in-flight call.
-func (s *Service) clearInitMutexesForOrg(orgID uuid.UUID) {
-	orgPrefix := orgID.String() + ":"
+// clearInitMutexesForScope drops every init-side mutex scoped to the given
+// scope. Used by DisconnectAll so a subsequent InitiateOAuth gets a fresh
+// mutex instead of reusing a stale one that might still be held by an
+// in-flight call. Keys carry a leading scope tag, so org and personal keys
+// cannot collide even when a label contains scope-looking delimiters.
+func (s *Service) clearInitMutexesForScope(scope models.Scope) {
+	matches := func(k string) bool {
+		if scope.IsPersonal() {
+			return strings.HasPrefix(k, "personal:"+scope.OrgID.String()+":u:"+scope.UserID.String()+":")
+		}
+		return strings.HasPrefix(k, "org:"+scope.OrgID.String()+":")
+	}
 	s.initMu.Range(func(key, _ any) bool {
-		if k, ok := key.(string); ok && strings.HasPrefix(k, orgPrefix) {
+		if k, ok := key.(string); ok && matches(k) {
 			s.initMu.Delete(key)
 		}
 		return true
 	})
 }
 
-// ListSubscriptions returns all connected Claude subscriptions for an org.
-// Skips the label="" row (which is the Anthropic API-key credential, not
-// a subscription) so the subscriptions list doesn't leak an API key summary.
-func (s *Service) ListSubscriptions(ctx context.Context, orgID uuid.UUID) ([]SubscriptionInfo, error) {
+// ListSubscriptions returns all connected Claude subscriptions at the given
+// scope. Skips the label="" row (which is the Anthropic API-key credential,
+// not a subscription) so the subscriptions list doesn't leak an API key
+// summary.
+func (s *Service) ListSubscriptions(ctx context.Context, scope models.Scope) ([]SubscriptionInfo, error) {
 	if s.credentials == nil {
 		return nil, nil
 	}
 
-	creds, err := s.credentials.ListByProvider(ctx, orgID, models.ProviderAnthropic)
+	creds, err := s.credentials.ListByProvider(ctx, scope, models.ProviderAnthropic)
 	if err != nil {
 		return nil, fmt.Errorf("list subscriptions: %w", err)
 	}
@@ -933,6 +969,16 @@ func (s *Service) ListSubscriptions(ctx context.Context, orgID uuid.UUID) ([]Sub
 }
 
 // isNotFoundError reports whether err signals "no matching credential row".
+// Three sentinels are checked because the credential store now spans both
+// legacy and unified backends:
+//   - pgx.ErrNoRows surfaces from the legacy OrgCredentialStore via
+//     pgx.CollectOneRow on a missing-row read.
+//   - ErrCredentialNotFound is the local sentinel returned by service-layer
+//     ownership checks (DisconnectForOrg).
+//   - db.ErrCodingCredentialNotFound surfaces from the unified
+//     CodingCredentialStore on personal-scope reads.
 func isNotFoundError(err error) bool {
-	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, ErrCredentialNotFound)
+	return errors.Is(err, pgx.ErrNoRows) ||
+		errors.Is(err, ErrCredentialNotFound) ||
+		errors.Is(err, db.ErrCodingCredentialNotFound)
 }

--- a/internal/services/claudecodeauth/service_test.go
+++ b/internal/services/claudecodeauth/service_test.go
@@ -23,8 +23,14 @@ import (
 // mockCredentialStore is a minimal in-memory store used to drive the
 // service's interactions. Only methods exercised by the tests below are
 // fully implemented; unused ones return sensible defaults.
+//
+// Each cred carries the scope it was inserted at via credScope so personal
+// and org rows for the same (org, label) pair don't collide in the
+// in-memory map — mirroring the real CodingCredentialStore's per-scope
+// partitioning.
 type mockCredentialStore struct {
-	creds map[uuid.UUID]*models.DecryptedCredential
+	creds     map[uuid.UUID]*models.DecryptedCredential
+	credScope map[uuid.UUID]models.Scope
 
 	getByIDErr            error
 	upsertByIDErr         error
@@ -38,21 +44,42 @@ type mockCredentialStore struct {
 }
 
 func newMockCredentialStore() *mockCredentialStore {
-	return &mockCredentialStore{creds: make(map[uuid.UUID]*models.DecryptedCredential)}
+	return &mockCredentialStore{
+		creds:     make(map[uuid.UUID]*models.DecryptedCredential),
+		credScope: make(map[uuid.UUID]models.Scope),
+	}
 }
 
-func (m *mockCredentialStore) Get(_ context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
+// scopesMatch is true when the cred at id was inserted under a scope that
+// matches the lookup scope. Tests that mutate creds directly (without going
+// through Upsert/InsertPendingAuth) inherit org-scope semantics — keeps
+// existing tests working without forcing them to pre-register scope.
+func (m *mockCredentialStore) scopesMatch(id uuid.UUID, scope models.Scope) bool {
+	stored, ok := m.credScope[id]
+	if !ok {
+		return scope.IsOrg()
+	}
+	if stored.IsPersonal() != scope.IsPersonal() {
+		return false
+	}
+	if stored.IsPersonal() {
+		return *stored.UserID == *scope.UserID && stored.OrgID == scope.OrgID
+	}
+	return stored.OrgID == scope.OrgID
+}
+
+func (m *mockCredentialStore) Get(_ context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider && cred.Label == "" {
+		if cred.OrgID == scope.OrgID && cred.Provider == provider && cred.Label == "" {
 			return cred, nil
 		}
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == cfg.Provider() && cred.Label == label {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == cfg.Provider() && cred.Label == label {
 			cred.Config = cfg
 			cred.Status = "active"
 			return &cred.ID, nil
@@ -61,20 +88,21 @@ func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, orgID uuid.UUID
 	id := uuid.New()
 	m.creds[id] = &models.DecryptedCredential{
 		ID:        id,
-		OrgID:     orgID,
+		OrgID:     scope.OrgID,
 		Provider:  cfg.Provider(),
 		Label:     label,
 		Config:    cfg,
 		Status:    "active",
 		CreatedBy: createdBy,
 	}
+	m.credScope[id] = scope
 	return &id, nil
 }
 
-func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
 	now := time.Now()
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == cfg.Provider() && cred.Label == label {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == cfg.Provider() && cred.Label == label {
 			if cred.Status != "pending_auth" && cred.Status != "disabled" {
 				return nil, &db.ErrCredentialLabelTaken{Label: label, ExistingStatus: cred.Status}
 			}
@@ -87,7 +115,7 @@ func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, orgID uuid.UU
 	id := uuid.New()
 	m.creds[id] = &models.DecryptedCredential{
 		ID:        id,
-		OrgID:     orgID,
+		OrgID:     scope.OrgID,
 		Provider:  cfg.Provider(),
 		Label:     label,
 		Config:    cfg,
@@ -96,51 +124,52 @@ func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, orgID uuid.UU
 		CreatedAt: now,
 		UpdatedAt: now,
 	}
+	m.credScope[id] = scope
 	return &id, nil
 }
 
-func (m *mockCredentialStore) GetByID(_ context.Context, orgID uuid.UUID, id uuid.UUID) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) GetByID(_ context.Context, scope models.Scope, id uuid.UUID) (*models.DecryptedCredential, error) {
 	if m.getByIDErr != nil {
 		return nil, m.getByIDErr
 	}
-	if cred, ok := m.creds[id]; ok && cred.OrgID == orgID {
+	if cred, ok := m.creds[id]; ok && m.scopesMatch(cred.ID, scope) {
 		return cred, nil
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) GetByProviderAndLabel(_ context.Context, orgID uuid.UUID, provider models.ProviderName, label string) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) GetByProviderAndLabel(_ context.Context, scope models.Scope, provider models.ProviderName, label string) (*models.DecryptedCredential, error) {
 	if m.getByProviderLabelErr != nil {
 		return nil, m.getByProviderLabelErr
 	}
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider && cred.Label == label {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == provider && cred.Label == label {
 			return cred, nil
 		}
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) ListByProvider(_ context.Context, orgID uuid.UUID, provider models.ProviderName) ([]models.DecryptedCredential, error) {
+func (m *mockCredentialStore) ListByProvider(_ context.Context, scope models.Scope, provider models.ProviderName) ([]models.DecryptedCredential, error) {
 	if m.listByProviderErr != nil {
 		return nil, m.listByProviderErr
 	}
 	var out []models.DecryptedCredential
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == provider {
 			out = append(out, *cred)
 		}
 	}
 	return out, nil
 }
 
-func (m *mockCredentialStore) ClaimNextLabeledRoundRobin(_ context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) ClaimNextLabeledRoundRobin(_ context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
 	if m.claimErr != nil {
 		return nil, m.claimErr
 	}
 	var oldest *models.DecryptedCredential
 	for _, cred := range m.creds {
-		if cred.OrgID != orgID || cred.Provider != provider || cred.Status != "active" || cred.Label == "" {
+		if !m.scopesMatch(cred.ID, scope) || cred.Provider != provider || cred.Status != "active" || cred.Label == "" {
 			continue
 		}
 		if oldest == nil {
@@ -161,28 +190,28 @@ func (m *mockCredentialStore) ClaimNextLabeledRoundRobin(_ context.Context, orgI
 	return oldest, nil
 }
 
-func (m *mockCredentialStore) DisableByID(_ context.Context, orgID uuid.UUID, id uuid.UUID) error {
+func (m *mockCredentialStore) DisableByID(_ context.Context, scope models.Scope, id uuid.UUID) error {
 	if m.disableErr != nil {
 		return m.disableErr
 	}
-	if cred, ok := m.creds[id]; ok && cred.OrgID == orgID {
+	if cred, ok := m.creds[id]; ok && m.scopesMatch(cred.ID, scope) {
 		cred.Status = "disabled"
 	}
 	return nil
 }
 
-func (m *mockCredentialStore) UpdateStatusByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, status string) error {
-	if cred, ok := m.creds[id]; ok && cred.OrgID == orgID {
+func (m *mockCredentialStore) UpdateStatusByID(_ context.Context, scope models.Scope, id uuid.UUID, status string) error {
+	if cred, ok := m.creds[id]; ok && m.scopesMatch(cred.ID, scope) {
 		cred.Status = status
 	}
 	return nil
 }
 
-func (m *mockCredentialStore) UpsertByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, cfg models.ProviderConfig) error {
+func (m *mockCredentialStore) UpsertByID(_ context.Context, scope models.Scope, id uuid.UUID, cfg models.ProviderConfig) error {
 	if m.upsertByIDErr != nil {
 		return m.upsertByIDErr
 	}
-	if cred, ok := m.creds[id]; ok && cred.OrgID == orgID {
+	if cred, ok := m.creds[id]; ok && m.scopesMatch(cred.ID, scope) {
 		if cred.Status == "disabled" {
 			return nil
 		}
@@ -192,34 +221,34 @@ func (m *mockCredentialStore) UpsertByID(_ context.Context, orgID uuid.UUID, id 
 	return nil
 }
 
-func (m *mockCredentialStore) ExistsForProviderByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, provider models.ProviderName) (bool, error) {
+func (m *mockCredentialStore) ExistsForProviderByID(_ context.Context, scope models.Scope, id uuid.UUID, provider models.ProviderName) (bool, error) {
 	if m.existsErr != nil {
 		return false, m.existsErr
 	}
-	if cred, ok := m.creds[id]; ok && cred.OrgID == orgID && cred.Provider == provider {
+	if cred, ok := m.creds[id]; ok && m.scopesMatch(cred.ID, scope) && cred.Provider == provider {
 		return true, nil
 	}
 	return false, nil
 }
 
-func (m *mockCredentialStore) DisableLabeled(_ context.Context, orgID uuid.UUID, provider models.ProviderName) error {
+func (m *mockCredentialStore) DisableLabeled(_ context.Context, scope models.Scope, provider models.ProviderName) error {
 	if m.disableLabeledErr != nil {
 		return m.disableLabeledErr
 	}
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider && cred.Label != "" {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == provider && cred.Label != "" {
 			cred.Status = "disabled"
 		}
 	}
 	return nil
 }
 
-func (m *mockCredentialStore) HasActiveLabeled(_ context.Context, orgID uuid.UUID, provider models.ProviderName) (bool, error) {
+func (m *mockCredentialStore) HasActiveLabeled(_ context.Context, scope models.Scope, provider models.ProviderName) (bool, error) {
 	if m.hasActiveLabeledErr != nil {
 		return false, m.hasActiveLabeledErr
 	}
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider && cred.Label != "" && cred.Status == "active" {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == provider && cred.Label != "" && cred.Status == "active" {
 			return true, nil
 		}
 	}
@@ -233,7 +262,7 @@ func TestInitiateOAuth_PersistsPendingSubscriptionRow(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -250,7 +279,7 @@ func TestInitiateOAuth_PersistsPendingSubscriptionRow(t *testing.T) {
 		t.Errorf("authorize URL state mismatch: %s", resp.AuthorizeURL)
 	}
 
-	cred, err := store.GetByProviderAndLabel(context.Background(), orgID, models.ProviderAnthropic, "team-a")
+	cred, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderAnthropic, "team-a")
 	if err != nil {
 		t.Fatalf("expected persisted pending row: %v", err)
 	}
@@ -279,14 +308,14 @@ func TestInitiateOAuth_LabelTakenByActiveRow(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	_, err := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	_, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
-	_, err = svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	_, err = svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err == nil {
 		t.Fatal("expected ErrCredentialLabelTaken, got nil")
 	}
@@ -304,7 +333,7 @@ func TestGetValidToken_SkipsAPIKeyRow(t *testing.T) {
 	orgID := uuid.New()
 
 	// Seed the API-key row (label=""), which must never be claimed for subs.
-	_, err := store.UpsertWithLabel(context.Background(), orgID, nil, "", models.AnthropicConfig{APIKey: "sk-ant-fake"})
+	_, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "", models.AnthropicConfig{APIKey: "sk-ant-fake"})
 	if err != nil {
 		t.Fatalf("seed api key: %v", err)
 	}
@@ -319,7 +348,7 @@ func TestGetValidToken_SkipsAPIKeyRow(t *testing.T) {
 			AccountType:  "pro",
 		},
 	}
-	subID, err := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", subCfg)
+	subID, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", subCfg)
 	if err != nil {
 		t.Fatalf("seed subscription: %v", err)
 	}
@@ -345,7 +374,7 @@ func TestGetValidToken_ReturnsNilWhenOnlyAPIKeyPresent(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	_, err := store.UpsertWithLabel(context.Background(), orgID, nil, "", models.AnthropicConfig{APIKey: "sk-ant-fake"})
+	_, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "", models.AnthropicConfig{APIKey: "sk-ant-fake"})
 	if err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -373,7 +402,7 @@ func TestGetValidToken_RotatesLRU(t *testing.T) {
 			ExpiresAt:    time.Now().Add(time.Hour),
 			AccountType:  "max",
 		}}
-		id, err := store.UpsertWithLabel(context.Background(), orgID, nil, label, cfg)
+		id, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, label, cfg)
 		if err != nil {
 			t.Fatalf("seed: %v", err)
 		}
@@ -401,12 +430,12 @@ func TestDisconnectAll_PreservesAPIKeyRow(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	apiKeyID, _ := store.UpsertWithLabel(context.Background(), orgID, nil, "", models.AnthropicConfig{APIKey: "sk-ant"})
-	subID, _ := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	apiKeyID, _ := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "", models.AnthropicConfig{APIKey: "sk-ant"})
+	subID, _ := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 
-	if err := svc.DisconnectAll(context.Background(), orgID); err != nil {
+	if err := svc.DisconnectAll(context.Background(), models.Scope{OrgID: orgID}); err != nil {
 		t.Fatalf("DisconnectAll: %v", err)
 	}
 
@@ -434,7 +463,7 @@ func TestDisconnectForOrg_RejectsUnlabeledAnthropicAPIKey(t *testing.T) {
 		Status:   "active",
 	}
 
-	err := svc.DisconnectForOrg(context.Background(), orgID, apiKeyID)
+	err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: orgID}, apiKeyID)
 	require.ErrorIs(t, err, ErrCredentialNotFound, "Claude subscription disconnect should reject an Anthropic API-key row")
 	require.Equal(t, "active", store.creds[apiKeyID].Status, "Anthropic API-key row should remain active")
 }
@@ -445,12 +474,12 @@ func TestListSubscriptions_SkipsAPIKeyRow(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	_, _ = store.UpsertWithLabel(context.Background(), orgID, nil, "", models.AnthropicConfig{APIKey: "sk-ant"})
-	_, _ = store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	_, _ = store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "", models.AnthropicConfig{APIKey: "sk-ant"})
+	_, _ = store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour), AccountType: "max"},
 	})
 
-	subs, err := svc.ListSubscriptions(context.Background(), orgID)
+	subs, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: orgID})
 	if err != nil {
 		t.Fatalf("ListSubscriptions: %v", err)
 	}
@@ -469,7 +498,7 @@ func TestListSubscriptions_SkipsAPIKeyRow(t *testing.T) {
 // row and returns its ID so tests can exercise the refresh path.
 func seedActiveSub(t *testing.T, store *mockCredentialStore, orgID uuid.UUID, label, access, refresh string, expiresAt time.Time) uuid.UUID {
 	t.Helper()
-	id, err := store.UpsertWithLabel(context.Background(), orgID, nil, label, models.AnthropicConfig{
+	id, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, label, models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{
 			AccessToken:  access,
 			RefreshToken: refresh,
@@ -510,7 +539,7 @@ func TestRefreshTokenByID_HappyPath(t *testing.T) {
 	// Expired so the refresh actually runs.
 	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
 
-	newSub, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err != nil {
 		t.Fatalf("RefreshTokenByID: %v", err)
 	}
@@ -547,7 +576,7 @@ func TestRefreshTokenByID_PreservesRefreshTokenWhenEmpty(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "keep-this-refresh", time.Now().Add(-time.Minute))
 
-	newSub, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err != nil {
 		t.Fatalf("RefreshTokenByID: %v", err)
 	}
@@ -573,12 +602,12 @@ func TestRefreshTokenByID_RejectsEmptyAccessToken(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
 
-	newSub, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	newSub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	require.Nil(t, newSub, "RefreshTokenByID should not return a subscription when the refresh response omits access_token")
 	require.Error(t, err, "RefreshTokenByID should fail closed when the refresh response omits access_token")
 	require.Contains(t, err.Error(), "empty access_token", "RefreshTokenByID should surface the empty access_token error")
 
-	storedCred, getErr := store.GetByID(context.Background(), orgID, credID)
+	storedCred, getErr := store.GetByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	require.NoError(t, getErr, "GetByID should return the seeded credential after a failed refresh")
 
 	storedCfg, ok := storedCred.Config.(models.AnthropicConfig)
@@ -606,7 +635,7 @@ func TestRefreshTokenByID_RefreshTokenReused(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want error on refresh_token_reused")
 	}
@@ -639,7 +668,7 @@ func TestRefreshTokenByID_UnauthorizedMarksInvalid(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old-access", "old-refresh", time.Now().Add(-time.Minute))
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want error on 401")
 	}
@@ -655,7 +684,7 @@ func TestRefreshTokenByID_NoRefreshToken(t *testing.T) {
 
 	orgID := uuid.New()
 	// Store a sub with empty refresh token + expired access.
-	id, err := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	id, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{
 			AccessToken: "old-access",
 			ExpiresAt:   time.Now().Add(-time.Minute),
@@ -665,7 +694,7 @@ func TestRefreshTokenByID_NoRefreshToken(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	_, err = svc.RefreshTokenByID(context.Background(), orgID, *id)
+	_, err = svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, *id)
 	if err == nil {
 		t.Fatal("want error when refresh_token is empty")
 	}
@@ -698,16 +727,16 @@ func TestCompleteOAuth_ParsesScopesAndFetchesProfile(t *testing.T) {
 	svc.SetProfileURL(profileTS.URL)
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "mycode#"+resp.State); err != nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "mycode#"+resp.State); err != nil {
 		t.Fatalf("CompleteOAuth: %v", err)
 	}
 
-	cred, err := store.GetByProviderAndLabel(context.Background(), orgID, models.ProviderAnthropic, "team-a")
+	cred, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderAnthropic, "team-a")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
@@ -747,12 +776,12 @@ func TestCompleteOAuth_ProfileFailureDoesNotBlock(t *testing.T) {
 	svc.SetProfileURL(profileTS.URL)
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "mycode#"+resp.State); err != nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "mycode#"+resp.State); err != nil {
 		t.Fatalf("want success despite profile failure, got %v", err)
 	}
 }
@@ -764,11 +793,11 @@ func TestDisconnectForOrg_WrongOrgNotFound(t *testing.T) {
 
 	org1 := uuid.New()
 	org2 := uuid.New()
-	id, _ := store.UpsertWithLabel(context.Background(), org1, nil, "team-a", models.AnthropicConfig{
+	id, _ := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: org1}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 
-	if err := svc.DisconnectForOrg(context.Background(), org2, *id); err != ErrCredentialNotFound {
+	if err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: org2}, *id); err != ErrCredentialNotFound {
 		t.Errorf("want ErrCredentialNotFound, got %v", err)
 	}
 }
@@ -856,7 +885,7 @@ func TestHasActiveSubscription(t *testing.T) {
 		t.Errorf("empty store: got (%v, %v), want (false, nil)", has, err)
 	}
 
-	_, _ = store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	_, _ = store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 	has, err = svc.HasActiveSubscription(context.Background(), orgID)
@@ -880,10 +909,10 @@ func TestCompleteOAuth_InvalidPasteFormat(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	if _, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a"); err != nil {
+	if _, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a"); err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "no-hash-at-all"); !errors.Is(err, ErrInvalidPaste) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "no-hash-at-all"); !errors.Is(err, ErrInvalidPaste) {
 		t.Errorf("want ErrInvalidPaste, got %v", err)
 	}
 }
@@ -894,10 +923,10 @@ func TestCompleteOAuth_StateMismatch(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	if _, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a"); err != nil {
+	if _, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a"); err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#wrong-state"); !errors.Is(err, ErrInvalidPaste) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#wrong-state"); !errors.Is(err, ErrInvalidPaste) {
 		t.Errorf("want ErrInvalidPaste for state mismatch, got %v", err)
 	}
 }
@@ -908,7 +937,7 @@ func TestCompleteOAuth_NoPendingRow(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#state"); !errors.Is(err, ErrPendingAuthNotFound) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#state"); !errors.Is(err, ErrPendingAuthNotFound) {
 		t.Errorf("want ErrPendingAuthNotFound, got %v", err)
 	}
 }
@@ -919,19 +948,19 @@ func TestCompleteOAuth_Expired(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
 
 	// Backdate the pending row past the TTL window.
-	cred, err := store.GetByProviderAndLabel(context.Background(), orgID, models.ProviderAnthropic, "team-a")
+	cred, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderAnthropic, "team-a")
 	if err != nil {
 		t.Fatalf("lookup: %v", err)
 	}
 	cred.UpdatedAt = time.Now().Add(-2 * pendingAuthTTL)
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); !errors.Is(err, ErrPendingAuthExpired) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); !errors.Is(err, ErrPendingAuthExpired) {
 		t.Errorf("want ErrPendingAuthExpired, got %v", err)
 	}
 }
@@ -943,14 +972,14 @@ func TestCompleteOAuth_AlreadyActive(t *testing.T) {
 
 	orgID := uuid.New()
 	// Seed an active (not pending) row — replay attempts must not overwrite it.
-	_, _ = store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	_, _ = store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{
 			AccessToken: "live", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour),
 			State: "s", CodeVerifier: "v",
 		},
 	})
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#s"); !errors.Is(err, ErrPendingAuthNotFound) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#s"); !errors.Is(err, ErrPendingAuthNotFound) {
 		t.Errorf("active row should surface as ErrPendingAuthNotFound, got %v", err)
 	}
 }
@@ -970,12 +999,12 @@ func TestCompleteOAuth_TokenExchangeFailure(t *testing.T) {
 	svc.SetProfileURL("")
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); err == nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); err == nil {
 		t.Fatal("want error from token exchange failure")
 	}
 }
@@ -1043,14 +1072,14 @@ func TestDisconnect_ClearsRefreshMutex(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	id, _ := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	id, _ := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 
 	// Prime the refresh mutex so Disconnect has something to drop.
 	_ = svc.credRefreshMu(*id)
 
-	if err := svc.Disconnect(context.Background(), orgID, *id); err != nil {
+	if err := svc.Disconnect(context.Background(), models.Scope{OrgID: orgID}, *id); err != nil {
 		t.Fatalf("Disconnect: %v", err)
 	}
 	if store.creds[*id].Status != "disabled" {
@@ -1064,11 +1093,11 @@ func TestDisconnectForOrg_Success(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	id, _ := store.UpsertWithLabel(context.Background(), orgID, nil, "team-a", models.AnthropicConfig{
+	id, _ := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a", models.AnthropicConfig{
 		Subscription: &models.AnthropicSubscription{AccessToken: "a", RefreshToken: "r", ExpiresAt: time.Now().Add(time.Hour)},
 	})
 
-	if err := svc.DisconnectForOrg(context.Background(), orgID, *id); err != nil {
+	if err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: orgID}, *id); err != nil {
 		t.Fatalf("DisconnectForOrg: %v", err)
 	}
 	if store.creds[*id].Status != "disabled" {
@@ -1081,10 +1110,10 @@ func TestDisconnectAll_NilStore(t *testing.T) {
 	svc := NewService(nil, zerolog.Nop())
 	// Populates an init mutex via InitiateOAuth before DisconnectAll sweeps it.
 	orgID := uuid.New()
-	if _, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a"); err != nil {
+	if _, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a"); err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if err := svc.DisconnectAll(context.Background(), orgID); err != nil {
+	if err := svc.DisconnectAll(context.Background(), models.Scope{OrgID: orgID}); err != nil {
 		t.Errorf("DisconnectAll with nil store: %v", err)
 	}
 }
@@ -1092,7 +1121,7 @@ func TestDisconnectAll_NilStore(t *testing.T) {
 func TestListSubscriptions_NilStore(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
-	subs, err := svc.ListSubscriptions(context.Background(), uuid.New())
+	subs, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: uuid.New()})
 	if err != nil || subs != nil {
 		t.Errorf("want (nil, nil); got (%v, %v)", subs, err)
 	}
@@ -1115,7 +1144,7 @@ func TestSetters(t *testing.T) {
 func TestCompleteOAuth_NilStore(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
-	_, err := svc.CompleteOAuth(context.Background(), uuid.New(), "team-a", "code#state")
+	_, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: uuid.New()}, "team-a", "code#state")
 	if err == nil || !strings.Contains(err.Error(), "credential store") {
 		t.Errorf("want credential-store error, got %v", err)
 	}
@@ -1126,7 +1155,7 @@ func TestCompleteOAuth_DBError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.getByProviderLabelErr = errors.New("db is down")
 	svc := NewService(store, zerolog.Nop())
-	_, err := svc.CompleteOAuth(context.Background(), uuid.New(), "team-a", "code#state")
+	_, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: uuid.New()}, "team-a", "code#state")
 	if err == nil || errors.Is(err, ErrPendingAuthNotFound) {
 		t.Errorf("want wrapped DB error, got %v", err)
 	}
@@ -1147,13 +1176,13 @@ func TestCompleteOAuth_UpsertError(t *testing.T) {
 	svc.SetProfileURL("")
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
 	store.upsertByIDErr = errors.New("db write failed")
 
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); err == nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); err == nil {
 		t.Fatal("want error when UpsertByID fails")
 	}
 }
@@ -1178,7 +1207,7 @@ func TestCompleteOAuth_PendingRowMissingState(t *testing.T) {
 		Status:    "pending_auth",
 		UpdatedAt: time.Now(),
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#state"); !errors.Is(err, ErrPendingAuthNotFound) {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#state"); !errors.Is(err, ErrPendingAuthNotFound) {
 		t.Errorf("want ErrPendingAuthNotFound, got %v", err)
 	}
 }
@@ -1199,7 +1228,7 @@ func TestCompleteOAuth_UnexpectedConfig(t *testing.T) {
 		Status:    "pending_auth",
 		UpdatedAt: time.Now(),
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#state"); err == nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#state"); err == nil {
 		t.Fatal("want error for unexpected config")
 	}
 }
@@ -1209,7 +1238,7 @@ func TestRefreshTokenByID_GetByIDError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.getByIDErr = errors.New("boom")
 	svc := NewService(store, zerolog.Nop())
-	_, err := svc.RefreshTokenByID(context.Background(), uuid.New(), uuid.New())
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err == nil {
 		t.Fatal("want error when GetByID fails")
 	}
@@ -1229,7 +1258,7 @@ func TestRefreshTokenByID_NotAnthropicConfig(t *testing.T) {
 		Status:   "active",
 	}
 	svc := NewService(store, zerolog.Nop())
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, id)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, id)
 	if err == nil {
 		t.Fatal("want error when config is not subscription")
 	}
@@ -1244,7 +1273,7 @@ func TestRefreshTokenByID_StillFreshAfterLock(t *testing.T) {
 	// Token is not near expiry — Refresh should short-circuit and return it.
 	credID := seedActiveSub(t, store, orgID, "team-a", "fresh", "refresh", time.Now().Add(time.Hour))
 
-	sub, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	sub, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err != nil || sub == nil {
 		t.Fatalf("want cached fresh token, got (%v, %v)", sub, err)
 	}
@@ -1269,7 +1298,7 @@ func TestRefreshTokenByID_Non200Status(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old", "refresh", time.Now().Add(-time.Minute))
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want error on 500")
 	}
@@ -1294,7 +1323,7 @@ func TestRefreshTokenByID_MalformedResponse(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old", "refresh", time.Now().Add(-time.Minute))
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want parse error on malformed JSON")
 	}
@@ -1315,7 +1344,7 @@ func TestRefreshTokenByID_NetworkError(t *testing.T) {
 	orgID := uuid.New()
 	credID := seedActiveSub(t, store, orgID, "team-a", "old", "refresh", time.Now().Add(-time.Minute))
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want network error")
 	}
@@ -1338,7 +1367,7 @@ func TestRefreshTokenByID_UpsertError(t *testing.T) {
 	credID := seedActiveSub(t, store, orgID, "team-a", "old", "refresh", time.Now().Add(-time.Minute))
 	store.upsertByIDErr = errors.New("db down")
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("want error from Upsert failure")
 	}
@@ -1423,7 +1452,7 @@ func TestDisconnect_StoreError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.disableErr = errors.New("db down")
 	svc := NewService(store, zerolog.Nop())
-	err := svc.Disconnect(context.Background(), uuid.New(), uuid.New())
+	err := svc.Disconnect(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err == nil {
 		t.Fatal("want error from DisableByID")
 	}
@@ -1432,7 +1461,7 @@ func TestDisconnect_StoreError(t *testing.T) {
 func TestDisconnect_NilStore(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
-	if err := svc.Disconnect(context.Background(), uuid.New(), uuid.New()); err != nil {
+	if err := svc.Disconnect(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New()); err != nil {
 		t.Errorf("want nil with nil store, got %v", err)
 	}
 }
@@ -1440,7 +1469,7 @@ func TestDisconnect_NilStore(t *testing.T) {
 func TestDisconnectForOrg_NilStore(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
-	if err := svc.DisconnectForOrg(context.Background(), uuid.New(), uuid.New()); err != nil {
+	if err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New()); err != nil {
 		t.Errorf("want nil with nil store, got %v", err)
 	}
 }
@@ -1450,7 +1479,7 @@ func TestDisconnectForOrg_ExistsError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.existsErr = errors.New("db down")
 	svc := NewService(store, zerolog.Nop())
-	err := svc.DisconnectForOrg(context.Background(), uuid.New(), uuid.New())
+	err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err == nil {
 		t.Fatal("want wrapped exists error")
 	}
@@ -1461,7 +1490,7 @@ func TestDisconnectAll_DisableLabeledError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.disableLabeledErr = errors.New("db down")
 	svc := NewService(store, zerolog.Nop())
-	if err := svc.DisconnectAll(context.Background(), uuid.New()); err == nil {
+	if err := svc.DisconnectAll(context.Background(), models.Scope{OrgID: uuid.New()}); err == nil {
 		t.Fatal("want wrapped DisableLabeled error")
 	}
 }
@@ -1474,7 +1503,7 @@ func TestDisconnectAll_LogsListByProviderError(t *testing.T) {
 	var logBuf bytes.Buffer
 	svc := NewService(store, zerolog.New(&logBuf))
 
-	err := svc.DisconnectAll(context.Background(), uuid.New())
+	err := svc.DisconnectAll(context.Background(), models.Scope{OrgID: uuid.New()})
 
 	require.NoError(t, err, "DisconnectAll should continue when listing subscription IDs fails during best-effort mutex cleanup")
 	require.Contains(t, logBuf.String(), "failed to list claude subscriptions before disconnect cleanup", "DisconnectAll should log the list failure so leaked refresh mutexes are visible to operators")
@@ -1496,7 +1525,7 @@ func TestListSubscriptions_StoreError(t *testing.T) {
 	store := newMockCredentialStore()
 	store.listByProviderErr = errors.New("db down")
 	svc := NewService(store, zerolog.Nop())
-	_, err := svc.ListSubscriptions(context.Background(), uuid.New())
+	_, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: uuid.New()})
 	if err == nil {
 		t.Fatal("want wrapped list error")
 	}
@@ -1520,7 +1549,7 @@ func TestListSubscriptions_SkipsNonSubscriptionConfig(t *testing.T) {
 		Status:   "active",
 	}
 
-	subs, err := svc.ListSubscriptions(context.Background(), orgID)
+	subs, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: orgID})
 	if err != nil {
 		t.Fatalf("ListSubscriptions: %v", err)
 	}
@@ -1610,11 +1639,11 @@ func TestExchangeAuthCode_EmptyAccessToken(t *testing.T) {
 	svc.SetProfileURL("")
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); err == nil || !strings.Contains(err.Error(), "empty access_token") {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); err == nil || !strings.Contains(err.Error(), "empty access_token") {
 		t.Errorf("want empty access_token error, got %v", err)
 	}
 }
@@ -1631,11 +1660,11 @@ func TestExchangeAuthCode_NetworkError(t *testing.T) {
 	svc.SetProfileURL("")
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); err == nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); err == nil {
 		t.Fatal("want network error")
 	}
 }
@@ -1655,11 +1684,83 @@ func TestExchangeAuthCode_MalformedResponse(t *testing.T) {
 	svc.SetProfileURL("")
 
 	orgID := uuid.New()
-	resp, err := svc.InitiateOAuth(context.Background(), orgID, nil, "team-a")
+	resp, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "team-a")
 	if err != nil {
 		t.Fatalf("InitiateOAuth: %v", err)
 	}
-	if _, err := svc.CompleteOAuth(context.Background(), orgID, "team-a", "code#"+resp.State); err == nil {
+	if _, err := svc.CompleteOAuth(context.Background(), models.Scope{OrgID: orgID}, "team-a", "code#"+resp.State); err == nil {
 		t.Fatal("want parse error")
 	}
+}
+
+// --- Personal-scope coverage ---
+//
+// The OAuth flow used to be exclusively org-scoped; this PR added personal
+// scope so individual users can connect their own Claude subscription as a
+// personal-stack credential. The tests below lock the new contract: scope
+// flows through Initiate, GetByProviderAndLabel sees the personal row, and
+// the personal pendingKey shape is distinct from the org one so the same
+// label can coexist across scopes.
+
+func TestPendingKey_ScopesAreDistinct(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	userID := uuid.New()
+	orgKey := pendingKey(models.Scope{OrgID: orgID}, "team-a")
+	personalKey := pendingKey(models.Scope{OrgID: orgID, UserID: &userID}, "team-a")
+	require.NotEqual(t, orgKey, personalKey, "personal scope must produce a distinct pending key")
+	require.Contains(t, personalKey, ":u:", "personal pendingKey expected to contain :u: segment")
+
+	collidingOrgLabel := "u:" + userID.String() + ":team-a"
+	collidingOrgKey := pendingKey(models.Scope{OrgID: orgID}, collidingOrgLabel)
+	require.NotEqual(t, collidingOrgKey, personalKey, "org labels must not be able to collide with personal pending keys")
+}
+
+func TestInitiateOAuth_PersonalScope(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	personalScope := models.Scope{OrgID: orgID, UserID: &userID}
+
+	resp, err := svc.InitiateOAuth(context.Background(), personalScope, &userID, "personal-claude")
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.State, "personal OAuth must produce a CSRF state")
+	require.Contains(t, resp.AuthorizeURL, "code_challenge=", "authorize URL missing PKCE challenge")
+
+	cred, err := store.GetByProviderAndLabel(context.Background(), personalScope, models.ProviderAnthropic, "personal-claude")
+	require.NoError(t, err, "personal pending row must be persisted")
+	require.Equal(t, "pending_auth", cred.Status, "personal row must start in pending_auth")
+	require.NotNil(t, cred.CreatedBy)
+	require.Equal(t, userID, *cred.CreatedBy)
+
+	_, err = store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderAnthropic, "personal-claude")
+	require.Error(t, err, "personal-scope row must not be visible to an org-scope read")
+}
+
+func TestInitiateOAuth_SameLabelAcrossScopes(t *testing.T) {
+	// A user adding a personal "claude-pro" subscription must not collide
+	// with an org-scope "claude-pro" subscription that already exists.
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	label := "claude-pro"
+
+	_, err := svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID}, nil, label)
+	require.NoError(t, err, "org initiate should succeed")
+	_, err = svc.InitiateOAuth(context.Background(), models.Scope{OrgID: orgID, UserID: &userID}, &userID, label)
+	require.NoError(t, err, "personal initiate with the same label must succeed")
+
+	orgRow, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderAnthropic, label)
+	require.NoError(t, err)
+	personalRow, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID, UserID: &userID}, models.ProviderAnthropic, label)
+	require.NoError(t, err)
+	require.NotEqual(t, orgRow.ID, personalRow.ID, "org and personal rows must be distinct credentials despite sharing the label")
 }

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/rs/zerolog"
 
+	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 )
 
@@ -44,24 +45,25 @@ const (
 	refreshWindow = 5 * time.Minute
 )
 
-// CredentialStore defines the credential operations needed by the auth service.
+// CredentialStore defines the credential operations needed by the auth
+// service. Every method takes models.Scope so a single Service instance can
+// drive both org-scoped (admin) and personal-scoped (per-user) subscription
+// flows. Production wires *db.ScopedCredentialStore, which routes org scope
+// to OrgCredentialStore and personal scope to CodingCredentialStore.
 type CredentialStore interface {
-	Upsert(ctx context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error
-	Get(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
-	UpdateStatus(ctx context.Context, orgID uuid.UUID, provider models.ProviderName, status string) error
-	Disable(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) error
+	Disable(ctx context.Context, scope models.Scope, provider models.ProviderName) error
 
 	// Multi-credential methods for round-robin subscription support.
-	UpsertWithLabel(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
-	InsertPendingAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
-	GetByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID) (*models.DecryptedCredential, error)
-	GetByProviderAndLabel(ctx context.Context, orgID uuid.UUID, provider models.ProviderName, label string) (*models.DecryptedCredential, error)
-	ListByProvider(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) ([]models.DecryptedCredential, error)
-	ClaimNextRoundRobin(ctx context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error)
-	DisableByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID) error
-	UpdateStatusByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, status string) error
-	UpsertByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, cfg models.ProviderConfig) error
-	ExistsForProviderByID(ctx context.Context, orgID uuid.UUID, id uuid.UUID, provider models.ProviderName) (bool, error)
+	UpsertWithLabel(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
+	InsertPendingAuth(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error)
+	GetByID(ctx context.Context, scope models.Scope, id uuid.UUID) (*models.DecryptedCredential, error)
+	GetByProviderAndLabel(ctx context.Context, scope models.Scope, provider models.ProviderName, label string) (*models.DecryptedCredential, error)
+	ListByProvider(ctx context.Context, scope models.Scope, provider models.ProviderName) ([]models.DecryptedCredential, error)
+	ClaimNextRoundRobin(ctx context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error)
+	DisableByID(ctx context.Context, scope models.Scope, id uuid.UUID) error
+	UpdateStatusByID(ctx context.Context, scope models.Scope, id uuid.UUID, status string) error
+	UpsertByID(ctx context.Context, scope models.Scope, id uuid.UUID, cfg models.ProviderConfig) error
+	ExistsForProviderByID(ctx context.Context, scope models.Scope, id uuid.UUID, provider models.ProviderName) (bool, error)
 }
 
 // ErrCredentialNotFound is returned when no credential exists for the given org/provider.
@@ -158,9 +160,28 @@ func (s *Service) SetIssuer(issuer string) {
 	s.issuer = issuer
 }
 
-// pendingKey returns the sync.Map key for pending auth state scoped to org+label.
-func pendingKey(orgID uuid.UUID, label string) string {
-	return orgID.String() + ":" + label
+// pendingKey returns the sync.Map key for pending auth state, namespaced by
+// scope so personal and org flows for the same label never collide. The
+// leading scope tag is part of the key so an org label like
+// `u:<userID>:label` cannot impersonate a personal-scope key.
+func pendingKey(scope models.Scope, label string) string {
+	if scope.IsPersonal() {
+		return "personal:" + scope.OrgID.String() + ":u:" + scope.UserID.String() + ":" + label
+	}
+	return "org:" + scope.OrgID.String() + ":" + label
+}
+
+// orgPendingPrefix returns the prefix used to find every pending entry that
+// belongs to org scope (i.e. excludes personal entries). Used by the org
+// DisconnectAll path.
+func orgPendingPrefix(orgID uuid.UUID) string {
+	return "org:" + orgID.String() + ":"
+}
+
+// orgScope is a small constructor for org-only callers that haven't been
+// updated to think in scopes yet (e.g. legacy GetValidToken).
+func orgScope(orgID uuid.UUID) models.Scope {
+	return models.Scope{OrgID: orgID}
 }
 
 // restorePendingFromDB recovers pending-auth state after a server restart.
@@ -168,11 +189,11 @@ func pendingKey(orgID uuid.UUID, label string) string {
 // complete (active) or unusable (bad config), (nil, restoredPending) when a
 // still-valid pending_auth row can resume polling, or (nil, nil) when there
 // is nothing to recover and the caller should report "no pending auth flow".
-func (s *Service) restorePendingFromDB(ctx context.Context, orgID uuid.UUID, label string) (*AuthStatus, *PendingAuth) {
+func (s *Service) restorePendingFromDB(ctx context.Context, scope models.Scope, label string) (*AuthStatus, *PendingAuth) {
 	if s.credentials == nil {
 		return nil, nil
 	}
-	cred, err := s.credentials.GetByProviderAndLabel(ctx, orgID, models.ProviderOpenAIChatGPT, label)
+	cred, err := s.credentials.GetByProviderAndLabel(ctx, scope, models.ProviderOpenAIChatGPT, label)
 	if err != nil {
 		return nil, nil
 	}
@@ -204,15 +225,40 @@ func (s *Service) restorePendingFromDB(ctx context.Context, orgID uuid.UUID, lab
 	return nil, nil
 }
 
-// InitiateDeviceAuth starts a new device code auth flow for the given org.
+func (s *Service) activeSubscriptionStatus(ctx context.Context, scope models.Scope) (*AuthStatus, error) {
+	if s.credentials == nil {
+		return nil, nil
+	}
+	creds, err := s.credentials.ListByProvider(ctx, scope, models.ProviderOpenAIChatGPT)
+	if err != nil {
+		return nil, fmt.Errorf("list subscriptions: %w", err)
+	}
+	for _, cred := range creds {
+		if cred.Status != "active" {
+			continue
+		}
+		cfg, ok := cred.Config.(models.OpenAIChatGPTConfig)
+		if !ok {
+			continue
+		}
+		return &AuthStatus{Status: "completed", AccountType: cfg.AccountType}, nil
+	}
+	return nil, nil
+}
+
+// InitiateDeviceAuth starts a new device code auth flow at the given scope.
 // The label distinguishes multiple subscriptions (e.g. "Team A", "Team B").
 // createdBy records which user added the subscription; pass nil if unknown.
-func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string) (*DeviceAuthResponse, error) {
-	// Serialize concurrent init calls for the same (org, label). Otherwise two
-	// racing initiations could both reach InsertPendingAuth, with the slower
-	// request overwriting the faster one's pending state (or worse, racing
-	// against a still-in-flight OpenAI call).
-	pKey := pendingKey(orgID, label)
+//
+// Scope determines where the pending row is persisted: org scope writes to
+// org_credentials (mirrored to coding_credentials), personal scope writes
+// directly to coding_credentials with user_id set.
+func (s *Service) InitiateDeviceAuth(ctx context.Context, scope models.Scope, createdBy *uuid.UUID, label string) (*DeviceAuthResponse, error) {
+	// Serialize concurrent init calls for the same (scope, label). Otherwise
+	// two racing initiations could both reach InsertPendingAuth, with the
+	// slower request overwriting the faster one's pending state (or worse,
+	// racing against a still-in-flight OpenAI call).
+	pKey := pendingKey(scope, label)
 	muVal, _ := s.initMu.LoadOrStore(pKey, &sync.Mutex{})
 	mu := muVal.(*sync.Mutex)
 	mu.Lock()
@@ -299,7 +345,7 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID, creat
 			ExpiresAt:       expiresAt,
 			PollInterval:    interval,
 		}
-		credID, err := s.credentials.InsertPendingAuth(ctx, orgID, createdBy, label, pendingCfg)
+		credID, err := s.credentials.InsertPendingAuth(ctx, scope, createdBy, label, pendingCfg)
 		if err != nil {
 			s.pending.Delete(pKey)
 			return nil, fmt.Errorf("persist pending device auth: %w", err)
@@ -308,7 +354,8 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID, creat
 	}
 
 	s.logger.Info().
-		Str("org_id", orgID.String()).
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
 		Str("user_code", result.UserCode).
 		Msg("device code auth initiated")
 
@@ -322,11 +369,11 @@ func (s *Service) InitiateDeviceAuth(ctx context.Context, orgID uuid.UUID, creat
 // PollForToken checks whether the user has completed authentication.
 // It performs a single poll attempt and returns the status.
 // The label identifies which subscription's auth flow to poll.
-func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID, label string) (*AuthStatus, error) {
-	pKey := pendingKey(orgID, label)
+func (s *Service) PollForToken(ctx context.Context, scope models.Scope, label string) (*AuthStatus, error) {
+	pKey := pendingKey(scope, label)
 	val, ok := s.pending.Load(pKey)
 	if !ok {
-		status, restored := s.restorePendingFromDB(ctx, orgID, label)
+		status, restored := s.restorePendingFromDB(ctx, scope, label)
 		if status != nil {
 			return status, nil
 		}
@@ -336,6 +383,15 @@ func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID, label strin
 			ok = true
 		}
 		if !ok {
+			if label == "" {
+				status, err := s.activeSubscriptionStatus(ctx, scope)
+				if err != nil {
+					return nil, err
+				}
+				if status != nil {
+					return status, nil
+				}
+			}
 			return &AuthStatus{Status: "none", Message: "no pending auth flow"}, nil
 		}
 	}
@@ -451,11 +507,11 @@ func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID, label strin
 	// Store credential. If we have a credential ID from the pending state, update
 	// by ID to preserve the label. Otherwise fall back to label-based upsert.
 	if pending.CredentialID != nil {
-		if err := s.credentials.UpsertByID(ctx, orgID, *pending.CredentialID, storedCfg); err != nil {
+		if err := s.credentials.UpsertByID(ctx, scope, *pending.CredentialID, storedCfg); err != nil {
 			return nil, fmt.Errorf("store credential: %w", err)
 		}
 	} else {
-		if _, err := s.credentials.UpsertWithLabel(ctx, orgID, nil, pending.Label, storedCfg); err != nil {
+		if _, err := s.credentials.UpsertWithLabel(ctx, scope, nil, pending.Label, storedCfg); err != nil {
 			return nil, fmt.Errorf("store credential: %w", err)
 		}
 	}
@@ -464,7 +520,8 @@ func (s *Service) PollForToken(ctx context.Context, orgID uuid.UUID, label strin
 	s.pending.Delete(pKey)
 
 	s.logger.Info().
-		Str("org_id", orgID.String()).
+		Str("org_id", scope.OrgID.String()).
+		Bool("personal", scope.IsPersonal()).
 		Bool("has_refresh_token", tokenResp.RefreshToken != "").
 		Int("expires_in", tokenResp.ExpiresIn).
 		Msg("ChatGPT OAuth completed successfully")
@@ -562,12 +619,17 @@ func (s *Service) credRefreshMu(credID uuid.UUID) *sync.Mutex {
 // RefreshTokenByID refreshes an expired access token for a specific credential.
 // It serializes refreshes per-credential to prevent concurrent calls from consuming
 // the same refresh token at OpenAI (which causes refresh_token_reused errors).
-func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
+//
+// Scope must match the credential's owner — personal credentials require a
+// scope with the matching UserID. The unified runtime path constructs scope
+// from the picked credential's UserID (orchestrator.go); the legacy
+// org-fallback GetValidToken path constructs an org scope.
+func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
 	mu := s.credRefreshMu(credID)
 	mu.Lock()
 	defer mu.Unlock()
 
-	cred, err := s.credentials.GetByID(ctx, orgID, credID)
+	cred, err := s.credentials.GetByID(ctx, scope, credID)
 	if err != nil {
 		return nil, fmt.Errorf("get credential: %w", err)
 	}
@@ -618,7 +680,7 @@ func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID 
 			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
 			return nil, fmt.Errorf("refresh token already used by another client")
 		}
-		if err := s.credentials.UpdateStatusByID(ctx, orgID, credID, "invalid"); err != nil {
+		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, "invalid"); err != nil {
 			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
 		}
 		return nil, fmt.Errorf("refresh token revoked (status %d)", resp.StatusCode)
@@ -646,7 +708,7 @@ func (s *Service) RefreshTokenByID(ctx context.Context, orgID uuid.UUID, credID 
 		AccountType:  cfg.AccountType,
 	}
 
-	if err := s.credentials.UpsertByID(ctx, orgID, credID, newCfg); err != nil {
+	if err := s.credentials.UpsertByID(ctx, scope, credID, newCfg); err != nil {
 		return nil, fmt.Errorf("store refreshed credential: %w", err)
 	}
 
@@ -674,11 +736,12 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 		return nil, nil
 	}
 
+	scope := orgScope(orgID)
 	tried := make(map[uuid.UUID]struct{}, maxRoundRobinAttempts)
 	var lastErr error
 
 	for attempt := 0; attempt < maxRoundRobinAttempts; attempt++ {
-		cred, err := s.credentials.ClaimNextRoundRobin(ctx, orgID, models.ProviderOpenAIChatGPT)
+		cred, err := s.credentials.ClaimNextRoundRobin(ctx, scope, models.ProviderOpenAIChatGPT)
 		if err != nil {
 			if isNotFoundError(err) {
 				if lastErr != nil {
@@ -712,7 +775,7 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 			return &cfg, nil
 		}
 
-		refreshed, refreshErr := s.RefreshTokenByID(ctx, orgID, cred.ID)
+		refreshed, refreshErr := s.RefreshTokenByID(ctx, scope, cred.ID)
 		if refreshErr == nil {
 			return refreshed, nil
 		}
@@ -729,7 +792,7 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 		// then try the next one. RefreshTokenByID may have already done
 		// this for some HTTP error paths; the second update is a no-op.
 		s.logger.Warn().Err(refreshErr).Str("cred_id", cred.ID.String()).Msg("token refresh failed and cached token expired; marking invalid")
-		if statusErr := s.credentials.UpdateStatusByID(ctx, orgID, cred.ID, "invalid"); statusErr != nil {
+		if statusErr := s.credentials.UpdateStatusByID(ctx, scope, cred.ID, "invalid"); statusErr != nil {
 			s.logger.Warn().Err(statusErr).Str("cred_id", cred.ID.String()).Msg("failed to mark credential invalid")
 		}
 	}
@@ -740,17 +803,18 @@ func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (*models.O
 	return nil, nil
 }
 
-// Disconnect removes a specific ChatGPT OAuth credential by ID for an org.
-// It also cleans up any in-memory pending auth state for this credential.
+// Disconnect removes a specific ChatGPT OAuth credential by ID at the given
+// scope. It also cleans up any in-memory pending auth state for this
+// credential.
 //
 // Ordering matters: the credential is disabled in the DB first, then in-memory
 // mutex/pending state is cleaned up. If we deleted the mutex first, a concurrent
 // refresh arriving between the Delete and DisableByID calls could acquire a
 // fresh mutex, successfully refresh, and UpsertByID the now-disabled row back
 // to active — silently resurrecting a credential the user just disconnected.
-func (s *Service) Disconnect(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) error {
+func (s *Service) Disconnect(ctx context.Context, scope models.Scope, credID uuid.UUID) error {
 	if s.credentials != nil {
-		if err := s.credentials.DisableByID(ctx, orgID, credID); err != nil {
+		if err := s.credentials.DisableByID(ctx, scope, credID); err != nil {
 			return err
 		}
 	}
@@ -768,47 +832,59 @@ func (s *Service) Disconnect(ctx context.Context, orgID uuid.UUID, credID uuid.U
 	return nil
 }
 
-// DisconnectForOrg removes a credential by ID after verifying it belongs to the given org.
-// Returns ErrCredentialNotFound if the credential doesn't exist or belongs to a different
-// org. Disconnecting an already-disabled credential is idempotent (returns nil) — this
-// matches the user's mental model where clicking "Remove" twice shouldn't error.
-func (s *Service) DisconnectForOrg(ctx context.Context, orgID uuid.UUID, credID uuid.UUID) error {
+// DisconnectForOrg removes a credential by ID after verifying it belongs to
+// the requested scope. Returns ErrCredentialNotFound if the credential
+// doesn't exist or belongs to a different scope. Idempotent — disconnecting
+// an already-disabled credential returns nil.
+//
+// The name is preserved for backward compatibility with existing call sites;
+// despite "ForOrg", scope can be either org or personal.
+func (s *Service) DisconnectForOrg(ctx context.Context, scope models.Scope, credID uuid.UUID) error {
 	if s.credentials == nil {
 		return nil
 	}
 	// ExistsForProviderByID includes disabled rows, so this distinguishes
-	// "not ours" (cross-org, bogus id, or another provider like an Anthropic
-	// API key) from "already disconnected". The provider filter prevents the
-	// codex-auth DELETE endpoint from disabling unrelated credentials.
-	exists, err := s.credentials.ExistsForProviderByID(ctx, orgID, credID, models.ProviderOpenAIChatGPT)
+	// "not ours" (cross-scope, bogus id, or another provider like an
+	// Anthropic API key) from "already disconnected". The provider filter
+	// prevents the codex-auth DELETE endpoint from disabling unrelated
+	// credentials.
+	exists, err := s.credentials.ExistsForProviderByID(ctx, scope, credID, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		return fmt.Errorf("check credential ownership: %w", err)
 	}
 	if !exists {
 		return ErrCredentialNotFound
 	}
-	return s.Disconnect(ctx, orgID, credID)
+	return s.Disconnect(ctx, scope, credID)
 }
 
-// DisconnectAll removes all ChatGPT OAuth credentials for the given org.
-func (s *Service) DisconnectAll(ctx context.Context, orgID uuid.UUID) error {
-	// Clean up in-memory pending auth and init mutexes for this org.
-	orgPrefix := orgID.String() + ":"
+// DisconnectAll removes all ChatGPT OAuth credentials at the given scope.
+//
+// Pending-state cleanup uses scope-aware filtering — pendingKey starts with a
+// scope tag, so an org-scope DisconnectAll cannot sweep personal entries that
+// happen to share the org id.
+func (s *Service) DisconnectAll(ctx context.Context, scope models.Scope) error {
+	matches := func(k string) bool {
+		if scope.IsPersonal() {
+			return strings.HasPrefix(k, "personal:"+scope.OrgID.String()+":u:"+scope.UserID.String()+":")
+		}
+		return strings.HasPrefix(k, orgPendingPrefix(scope.OrgID))
+	}
 	s.pending.Range(func(key, val any) bool {
-		if k, ok := key.(string); ok && strings.HasPrefix(k, orgPrefix) {
+		if k, ok := key.(string); ok && matches(k) {
 			s.pending.Delete(key)
 		}
 		return true
 	})
 	s.initMu.Range(func(key, val any) bool {
-		if k, ok := key.(string); ok && strings.HasPrefix(k, orgPrefix) {
+		if k, ok := key.(string); ok && matches(k) {
 			s.initMu.Delete(key)
 		}
 		return true
 	})
-	// Clean up refresh mutexes for all credentials belonging to this org.
+	// Clean up refresh mutexes for all credentials in this scope.
 	if s.credentials != nil {
-		creds, _ := s.credentials.ListByProvider(ctx, orgID, models.ProviderOpenAIChatGPT)
+		creds, _ := s.credentials.ListByProvider(ctx, scope, models.ProviderOpenAIChatGPT)
 		for _, cred := range creds {
 			s.refreshMu.Delete(cred.ID.String())
 		}
@@ -817,16 +893,16 @@ func (s *Service) DisconnectAll(ctx context.Context, orgID uuid.UUID) error {
 	if s.credentials == nil {
 		return nil
 	}
-	return s.credentials.Disable(ctx, orgID, models.ProviderOpenAIChatGPT)
+	return s.credentials.Disable(ctx, scope, models.ProviderOpenAIChatGPT)
 }
 
-// ListSubscriptions returns all connected Codex subscriptions for an org.
-func (s *Service) ListSubscriptions(ctx context.Context, orgID uuid.UUID) ([]SubscriptionInfo, error) {
+// ListSubscriptions returns all connected Codex subscriptions at the given scope.
+func (s *Service) ListSubscriptions(ctx context.Context, scope models.Scope) ([]SubscriptionInfo, error) {
 	if s.credentials == nil {
 		return nil, nil
 	}
 
-	creds, err := s.credentials.ListByProvider(ctx, orgID, models.ProviderOpenAIChatGPT)
+	creds, err := s.credentials.ListByProvider(ctx, scope, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		return nil, fmt.Errorf("list subscriptions: %w", err)
 	}
@@ -851,8 +927,17 @@ func (s *Service) ListSubscriptions(ctx context.Context, orgID uuid.UUID) ([]Sub
 }
 
 // isNotFoundError reports whether err signals "no matching credential row".
-// We rely on pgx's typed sentinel rather than string matching so the check
-// keeps working if the wrapper text changes.
+// We rely on typed sentinels rather than string matching so the check keeps
+// working if the wrapper text changes. Three sentinels are checked because
+// the credential store now spans both legacy and unified backends:
+//   - pgx.ErrNoRows surfaces from the legacy OrgCredentialStore via
+//     pgx.CollectOneRow on a missing-row read.
+//   - ErrCredentialNotFound is the local sentinel returned by service-layer
+//     ownership checks (DisconnectForOrg).
+//   - db.ErrCodingCredentialNotFound surfaces from the unified
+//     CodingCredentialStore on personal-scope reads.
 func isNotFoundError(err error) bool {
-	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, ErrCredentialNotFound)
+	return errors.Is(err, pgx.ErrNoRows) ||
+		errors.Is(err, ErrCredentialNotFound) ||
+		errors.Is(err, db.ErrCodingCredentialNotFound)
 }

--- a/internal/services/codexauth/service_initiate_test.go
+++ b/internal/services/codexauth/service_initiate_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
 )
 
 func TestInitiateDeviceAuth_IntervalParsing(t *testing.T) {
@@ -60,14 +62,14 @@ func TestInitiateDeviceAuth_IntervalParsing(t *testing.T) {
 			svc.SetIssuer(server.URL)
 
 			orgID := uuid.New()
-			_, err := svc.InitiateDeviceAuth(context.Background(), orgID, nil, "")
+			_, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID}, nil, "")
 			if tc.expectErr {
 				require.Error(t, err, "initiate should fail for invalid interval values")
 				return
 			}
 
 			require.NoError(t, err, "initiate should succeed for supported interval formats")
-			val, ok := svc.pending.Load(orgID.String() + ":")
+			val, ok := svc.pending.Load(pendingKey(models.Scope{OrgID: orgID}, ""))
 			require.True(t, ok, "pending auth should be stored after successful initiation")
 
 			pending, ok := val.(*PendingAuth)

--- a/internal/services/codexauth/service_test.go
+++ b/internal/services/codexauth/service_test.go
@@ -22,15 +22,23 @@ import (
 )
 
 // mockCredentialStore is a simple in-memory credential store for testing.
+//
+// Rows track the scope they were inserted under via the credScope map; that
+// lets personal-scope (UserID != nil) and org-scope (UserID == nil) rows
+// coexist for the same (org, provider, label) without colliding the way the
+// real CodingCredentialStore avoids it via its (org_id, user_id, provider,
+// label) NULLS-NOT-DISTINCT unique index.
 type mockCredentialStore struct {
-	creds  map[string]*models.DecryptedCredential
-	status map[string]string
+	creds     map[string]*models.DecryptedCredential
+	credScope map[uuid.UUID]models.Scope
+	status    map[string]string
 }
 
 func newMockCredentialStore() *mockCredentialStore {
 	return &mockCredentialStore{
-		creds:  make(map[string]*models.DecryptedCredential),
-		status: make(map[string]string),
+		creds:     make(map[string]*models.DecryptedCredential),
+		credScope: make(map[uuid.UUID]models.Scope),
+		status:    make(map[string]string),
 	}
 }
 
@@ -38,54 +46,96 @@ func (m *mockCredentialStore) key(orgID uuid.UUID, provider models.ProviderName)
 	return orgID.String() + ":" + string(provider)
 }
 
-func (m *mockCredentialStore) Upsert(_ context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error {
-	k := m.labelKey(orgID, cfg.Provider(), "")
+// scopeKey collapses a Scope to a string suitable for keying internal maps
+// alongside (provider, label). Mirrors how the real coding_credentials table
+// keys rows on (org_id, user_id, provider, label).
+func (m *mockCredentialStore) scopeKey(scope models.Scope) string {
+	if scope.IsPersonal() {
+		return scope.OrgID.String() + "|u|" + scope.UserID.String()
+	}
+	return scope.OrgID.String() + "|org"
+}
+
+// scopesMatch is true when a stored cred's scope matches the lookup scope.
+// Used by every read path so a personal-scope query never returns an
+// org-scope row (and vice versa).
+func (m *mockCredentialStore) scopesMatch(credID uuid.UUID, scope models.Scope) bool {
+	stored, ok := m.credScope[credID]
+	if !ok {
+		// Legacy seed paths that mutate m.creds directly without going
+		// through Upsert/InsertPendingAuth treat the row as org-scope by
+		// default. Keep that behaviour so existing tests don't need to
+		// register scope explicitly.
+		return scope.IsOrg()
+	}
+	if stored.IsPersonal() != scope.IsPersonal() {
+		return false
+	}
+	if stored.IsPersonal() {
+		return *stored.UserID == *scope.UserID && stored.OrgID == scope.OrgID
+	}
+	return stored.OrgID == scope.OrgID
+}
+
+func (m *mockCredentialStore) Upsert(_ context.Context, scope models.Scope, cfg models.ProviderConfig) error {
+	k := m.scopedLabelKey(scope, cfg.Provider(), "")
 	id := uuid.New()
 	m.creds[k] = &models.DecryptedCredential{
 		ID:       id,
-		OrgID:    orgID,
+		OrgID:    scope.OrgID,
 		Provider: cfg.Provider(),
 		Config:   cfg,
 		Status:   "active",
 	}
+	m.credScope[id] = scope
 	return nil
 }
 
-func (m *mockCredentialStore) Get(_ context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) Get(_ context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
 	// Return the first matching credential (prefers label="" for backward compat).
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider {
+		if cred.OrgID == scope.OrgID && cred.Provider == provider {
 			return cred, nil
 		}
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) UpdateStatus(_ context.Context, orgID uuid.UUID, provider models.ProviderName, status string) error {
+func (m *mockCredentialStore) UpdateStatus(_ context.Context, scope models.Scope, provider models.ProviderName, status string) error {
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider {
+		if cred.OrgID == scope.OrgID && cred.Provider == provider {
 			cred.Status = status
 		}
 	}
-	m.status[m.key(orgID, provider)] = status
+	m.status[m.key(scope.OrgID, provider)] = status
 	return nil
 }
 
-func (m *mockCredentialStore) Disable(_ context.Context, orgID uuid.UUID, provider models.ProviderName) error {
+func (m *mockCredentialStore) Disable(_ context.Context, scope models.Scope, provider models.ProviderName) error {
 	for k, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider {
+		if cred.OrgID == scope.OrgID && cred.Provider == provider {
 			delete(m.creds, k)
 		}
 	}
 	return nil
 }
 
+// labelKey is the per-row map key. We include the scope segment so personal
+// and org rows at the same (org, provider, label) don't overwrite each
+// other in the in-memory store. The legacy two-arg signature is preserved
+// for tests that compose it from raw orgID values.
 func (m *mockCredentialStore) labelKey(orgID uuid.UUID, provider models.ProviderName, label string) string {
-	return orgID.String() + ":" + string(provider) + ":" + label
+	return orgID.String() + "|org:" + string(provider) + ":" + label
 }
 
-func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
-	k := m.labelKey(orgID, cfg.Provider(), label)
+// scopedLabelKey is the scope-aware variant — preferred by the mock methods
+// themselves so personal-scope writes land in their own slot.
+func (m *mockCredentialStore) scopedLabelKey(scope models.Scope, provider models.ProviderName, label string) string {
+	return m.scopeKey(scope) + ":" + string(provider) + ":" + label
+}
+
+func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+	k := m.scopedLabelKey(scope, cfg.Provider(), label)
 	if existing, ok := m.creds[k]; ok {
 		existing.Config = cfg
 		existing.Status = "active"
@@ -94,18 +144,19 @@ func (m *mockCredentialStore) UpsertWithLabel(_ context.Context, orgID uuid.UUID
 	id := uuid.New()
 	m.creds[k] = &models.DecryptedCredential{
 		ID:        id,
-		OrgID:     orgID,
+		OrgID:     scope.OrgID,
 		Provider:  cfg.Provider(),
 		Label:     label,
 		Config:    cfg,
 		Status:    "active",
 		CreatedBy: createdBy,
 	}
+	m.credScope[id] = scope
 	return &id, nil
 }
 
-func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, orgID uuid.UUID, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
-	k := m.labelKey(orgID, cfg.Provider(), label)
+func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, scope models.Scope, createdBy *uuid.UUID, label string, cfg models.ProviderConfig) (*uuid.UUID, error) {
+	k := m.scopedLabelKey(scope, cfg.Provider(), label)
 	if existing, ok := m.creds[k]; ok {
 		// Mirror the real store: pending_auth and disabled rows are reusable;
 		// active and invalid rows reject with a typed error so callers can render
@@ -120,49 +171,50 @@ func (m *mockCredentialStore) InsertPendingAuth(_ context.Context, orgID uuid.UU
 	id := uuid.New()
 	m.creds[k] = &models.DecryptedCredential{
 		ID:        id,
-		OrgID:     orgID,
+		OrgID:     scope.OrgID,
 		Provider:  cfg.Provider(),
 		Label:     label,
 		Config:    cfg,
 		Status:    "pending_auth",
 		CreatedBy: createdBy,
 	}
+	m.credScope[id] = scope
 	return &id, nil
 }
 
-func (m *mockCredentialStore) GetByID(_ context.Context, orgID uuid.UUID, id uuid.UUID) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) GetByID(_ context.Context, scope models.Scope, id uuid.UUID) (*models.DecryptedCredential, error) {
 	for _, cred := range m.creds {
-		if cred.ID == id && cred.OrgID == orgID {
+		if cred.ID == id && m.scopesMatch(cred.ID, scope) {
 			return cred, nil
 		}
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) ListByProvider(_ context.Context, orgID uuid.UUID, provider models.ProviderName) ([]models.DecryptedCredential, error) {
+func (m *mockCredentialStore) ListByProvider(_ context.Context, scope models.Scope, provider models.ProviderName) ([]models.DecryptedCredential, error) {
 	var result []models.DecryptedCredential
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider {
+		if cred.OrgID == scope.OrgID && cred.Provider == provider {
 			result = append(result, *cred)
 		}
 	}
 	return result, nil
 }
 
-func (m *mockCredentialStore) GetByProviderAndLabel(_ context.Context, orgID uuid.UUID, provider models.ProviderName, label string) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) GetByProviderAndLabel(_ context.Context, scope models.Scope, provider models.ProviderName, label string) (*models.DecryptedCredential, error) {
 	for _, cred := range m.creds {
-		if cred.OrgID == orgID && cred.Provider == provider && cred.Label == label {
+		if m.scopesMatch(cred.ID, scope) && cred.Provider == provider && cred.Label == label {
 			return cred, nil
 		}
 	}
 	return nil, ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) ClaimNextRoundRobin(_ context.Context, orgID uuid.UUID, provider models.ProviderName) (*models.DecryptedCredential, error) {
+func (m *mockCredentialStore) ClaimNextRoundRobin(_ context.Context, scope models.Scope, provider models.ProviderName) (*models.DecryptedCredential, error) {
 	// Find the active credential with the oldest LastUsedAt (nil = never used, comes first).
 	var oldest *models.DecryptedCredential
 	for _, cred := range m.creds {
-		if cred.OrgID != orgID || cred.Provider != provider || cred.Status != "active" {
+		if cred.OrgID != scope.OrgID || cred.Provider != provider || cred.Status != "active" {
 			continue
 		}
 		if oldest == nil {
@@ -184,9 +236,9 @@ func (m *mockCredentialStore) ClaimNextRoundRobin(_ context.Context, orgID uuid.
 	return oldest, nil
 }
 
-func (m *mockCredentialStore) DisableByID(_ context.Context, orgID uuid.UUID, id uuid.UUID) error {
+func (m *mockCredentialStore) DisableByID(_ context.Context, scope models.Scope, id uuid.UUID) error {
 	for k, cred := range m.creds {
-		if cred.ID == id && cred.OrgID == orgID {
+		if cred.ID == id && cred.OrgID == scope.OrgID {
 			delete(m.creds, k)
 			return nil
 		}
@@ -194,9 +246,9 @@ func (m *mockCredentialStore) DisableByID(_ context.Context, orgID uuid.UUID, id
 	return nil
 }
 
-func (m *mockCredentialStore) UpdateStatusByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, status string) error {
+func (m *mockCredentialStore) UpdateStatusByID(_ context.Context, scope models.Scope, id uuid.UUID, status string) error {
 	for _, cred := range m.creds {
-		if cred.ID == id && cred.OrgID == orgID {
+		if cred.ID == id && cred.OrgID == scope.OrgID {
 			cred.Status = status
 			k := m.key(cred.OrgID, cred.Provider)
 			m.status[k] = status
@@ -206,9 +258,9 @@ func (m *mockCredentialStore) UpdateStatusByID(_ context.Context, orgID uuid.UUI
 	return nil
 }
 
-func (m *mockCredentialStore) UpsertByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, cfg models.ProviderConfig) error {
+func (m *mockCredentialStore) UpsertByID(_ context.Context, scope models.Scope, id uuid.UUID, cfg models.ProviderConfig) error {
 	for k, cred := range m.creds {
-		if cred.ID == id && cred.OrgID == orgID {
+		if cred.ID == id && cred.OrgID == scope.OrgID {
 			// Mirror the real store: disabled rows aren't resurrected by a refresh.
 			if cred.Status == "disabled" {
 				return nil
@@ -227,9 +279,9 @@ func (m *mockCredentialStore) UpsertByID(_ context.Context, orgID uuid.UUID, id 
 	return ErrCredentialNotFound
 }
 
-func (m *mockCredentialStore) ExistsForProviderByID(_ context.Context, orgID uuid.UUID, id uuid.UUID, provider models.ProviderName) (bool, error) {
+func (m *mockCredentialStore) ExistsForProviderByID(_ context.Context, scope models.Scope, id uuid.UUID, provider models.ProviderName) (bool, error) {
 	for _, cred := range m.creds {
-		if cred.ID == id && cred.OrgID == orgID && cred.Provider == provider {
+		if cred.ID == id && cred.OrgID == scope.OrgID && cred.Provider == provider {
 			return true, nil
 		}
 	}
@@ -266,7 +318,7 @@ func TestInitiateDeviceAuth(t *testing.T) {
 
 	orgID := uuid.New()
 	userID := uuid.New()
-	resp, err := svc.InitiateDeviceAuth(context.Background(), orgID, &userID, "")
+	resp, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID}, &userID, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -279,7 +331,7 @@ func TestInitiateDeviceAuth(t *testing.T) {
 	}
 
 	// The pending credential row should remember who started the flow.
-	cred, err := store.GetByProviderAndLabel(context.Background(), orgID, models.ProviderOpenAIChatGPT, "")
+	cred, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT, "")
 	if err != nil {
 		t.Fatalf("expected pending credential to be persisted: %v", err)
 	}
@@ -305,14 +357,14 @@ func TestPollForToken_AuthorizationPending(t *testing.T) {
 
 	orgID := uuid.New()
 	// Store a pending auth.
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		UserCode:     "ABCD-1234",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -335,14 +387,14 @@ func TestPollForToken_HTTP403Pending(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		UserCode:     "ABCD-1234",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -365,14 +417,14 @@ func TestPollForToken_HTTP404Pending(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		UserCode:     "ABCD-1234",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -410,14 +462,14 @@ func TestPollForToken_Success(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		UserCode:     "ABCD-1234",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -426,7 +478,7 @@ func TestPollForToken_Success(t *testing.T) {
 	}
 
 	// Verify credential was stored.
-	cred, err := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, err := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Fatalf("credential not stored: %v", err)
 	}
@@ -445,13 +497,13 @@ func TestPollForToken_Expired(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(-1 * time.Minute), // Already expired.
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -476,13 +528,13 @@ func TestPollForToken_SlowDown(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -491,7 +543,7 @@ func TestPollForToken_SlowDown(t *testing.T) {
 	}
 
 	// Verify interval was doubled.
-	val, _ := svc.pending.Load(orgID.String() + ":")
+	val, _ := svc.pending.Load(pendingKey(models.Scope{OrgID: orgID}, ""))
 	pending := val.(*PendingAuth)
 	if pending.Interval != 10 {
 		t.Errorf("expected interval 10 after slow_down, got %d", pending.Interval)
@@ -519,7 +571,7 @@ func TestGetValidToken_ValidToken(t *testing.T) {
 
 	orgID := uuid.New()
 	// Pre-store a valid credential.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_valid_token",
 		RefreshToken: "chr_valid_refresh",
 		ExpiresAt:    time.Now().Add(1 * time.Hour), // Not expiring soon.
@@ -557,7 +609,7 @@ func TestGetValidToken_AutoRefresh(t *testing.T) {
 
 	orgID := uuid.New()
 	// Pre-store a credential expiring within the refresh window.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_old_token",
 		RefreshToken: "chr_old_refresh",
 		ExpiresAt:    time.Now().Add(2 * time.Minute), // Within 5-min refresh window.
@@ -606,7 +658,7 @@ func TestGetValidToken_RoundRobinFailover(t *testing.T) {
 
 	// First credential: expired access token + broken refresh token. Seeded
 	// with an older LastUsedAt so round-robin claims it first.
-	firstID, err := store.UpsertWithLabel(context.Background(), orgID, nil, "Team A", models.OpenAIChatGPTConfig{
+	firstID, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Team A", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_broken_expired",
 		RefreshToken: "chr_broken",
 		ExpiresAt:    time.Now().Add(-1 * time.Hour),
@@ -620,7 +672,7 @@ func TestGetValidToken_RoundRobinFailover(t *testing.T) {
 
 	// Second credential: also expired but with a working refresh token.
 	// Seeded with a newer LastUsedAt so round-robin picks it second.
-	if _, err := store.UpsertWithLabel(context.Background(), orgID, nil, "Team B", models.OpenAIChatGPTConfig{
+	if _, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Team B", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_good_expired",
 		RefreshToken: "chr_good",
 		ExpiresAt:    time.Now().Add(-30 * time.Minute),
@@ -643,7 +695,7 @@ func TestGetValidToken_RoundRobinFailover(t *testing.T) {
 	}
 
 	// The first credential should have been marked invalid.
-	first, getErr := store.GetByID(context.Background(), orgID, *firstID)
+	first, getErr := store.GetByID(context.Background(), models.Scope{OrgID: orgID}, *firstID)
 	if getErr != nil {
 		t.Fatalf("get first credential: %v", getErr)
 	}
@@ -666,17 +718,17 @@ func TestRefreshTokenByID_Revoked(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_expired",
 		RefreshToken: "chr_revoked",
 		ExpiresAt:    time.Now().Add(-1 * time.Hour),
 	})
-	cred, err := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, err := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Fatalf("failed to get credential: %v", err)
 	}
 
-	_, err = svc.RefreshTokenByID(context.Background(), orgID, cred.ID)
+	_, err = svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, cred.ID)
 	if err == nil {
 		t.Fatal("expected error for revoked refresh token")
 	}
@@ -694,24 +746,24 @@ func TestDisconnect(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_token",
 		RefreshToken: "chr_refresh",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
 	})
 
 	// Get the credential ID assigned by Upsert.
-	cred, err := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, err := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Fatalf("failed to get credential: %v", err)
 	}
 
-	if err := svc.Disconnect(context.Background(), orgID, cred.ID); err != nil {
+	if err := svc.Disconnect(context.Background(), models.Scope{OrgID: orgID}, cred.ID); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
 	// Verify credential was deleted.
-	_, err = store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	_, err = store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err == nil {
 		t.Error("expected credential to be deleted")
 	}
@@ -724,20 +776,20 @@ func TestDisconnectForOrg_WrongOrg(t *testing.T) {
 
 	orgID := uuid.New()
 	otherOrgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken: "cha_token",
 	})
 
-	cred, _ := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, _ := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 
 	// Attempt to disconnect using a different org should fail.
-	err := svc.DisconnectForOrg(context.Background(), otherOrgID, cred.ID)
+	err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: otherOrgID}, cred.ID)
 	if err != ErrCredentialNotFound {
 		t.Fatalf("expected ErrCredentialNotFound, got: %v", err)
 	}
 
 	// Credential should still exist.
-	_, err = store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	_, err = store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Error("credential should not have been deleted")
 	}
@@ -748,7 +800,7 @@ func TestDisconnectForOrg_NotFound(t *testing.T) {
 	store := newMockCredentialStore()
 	svc := NewService(store, zerolog.Nop())
 
-	err := svc.DisconnectForOrg(context.Background(), uuid.New(), uuid.New())
+	err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err != ErrCredentialNotFound {
 		t.Fatalf("expected ErrCredentialNotFound, got: %v", err)
 	}
@@ -762,7 +814,7 @@ func TestListSubscriptions(t *testing.T) {
 	orgID := uuid.New()
 
 	// Empty org should return empty list.
-	subs, err := svc.ListSubscriptions(context.Background(), orgID)
+	subs, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: orgID})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -771,12 +823,12 @@ func TestListSubscriptions(t *testing.T) {
 	}
 
 	// Add a credential.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken: "cha_token",
 		AccountType: "plus",
 	})
 
-	subs, err = svc.ListSubscriptions(context.Background(), orgID)
+	subs, err = svc.ListSubscriptions(context.Background(), models.Scope{OrgID: orgID})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -795,7 +847,7 @@ func TestListSubscriptions_NilCredentials(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
 
-	subs, err := svc.ListSubscriptions(context.Background(), uuid.New())
+	subs, err := svc.ListSubscriptions(context.Background(), models.Scope{OrgID: uuid.New()})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -808,7 +860,7 @@ func TestDisconnect_NilCredentials(t *testing.T) {
 	t.Parallel()
 	svc := NewService(nil, zerolog.Nop())
 	// Should not panic when credentials store is nil.
-	err := svc.Disconnect(context.Background(), uuid.New(), uuid.New())
+	err := svc.Disconnect(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
@@ -817,46 +869,37 @@ func TestDisconnect_NilCredentials(t *testing.T) {
 // failingCredentialStore returns errors for all operations (simulates DB failure).
 type failingCredentialStore struct{}
 
-func (s *failingCredentialStore) Upsert(_ context.Context, _ uuid.UUID, _ models.ProviderConfig) error {
+func (s *failingCredentialStore) Disable(_ context.Context, _ models.Scope, _ models.ProviderName) error {
 	return fmt.Errorf("db connection refused")
 }
-func (s *failingCredentialStore) Get(_ context.Context, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
+func (s *failingCredentialStore) UpsertWithLabel(_ context.Context, _ models.Scope, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
 	return nil, fmt.Errorf("db connection refused")
 }
-func (s *failingCredentialStore) UpdateStatus(_ context.Context, _ uuid.UUID, _ models.ProviderName, _ string) error {
+func (s *failingCredentialStore) InsertPendingAuth(_ context.Context, _ models.Scope, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
+	return nil, fmt.Errorf("db connection refused")
+}
+func (s *failingCredentialStore) GetByID(_ context.Context, _ models.Scope, _ uuid.UUID) (*models.DecryptedCredential, error) {
+	return nil, fmt.Errorf("db connection refused")
+}
+func (s *failingCredentialStore) ListByProvider(_ context.Context, _ models.Scope, _ models.ProviderName) ([]models.DecryptedCredential, error) {
+	return nil, fmt.Errorf("db connection refused")
+}
+func (s *failingCredentialStore) GetByProviderAndLabel(_ context.Context, _ models.Scope, _ models.ProviderName, _ string) (*models.DecryptedCredential, error) {
+	return nil, fmt.Errorf("db connection refused")
+}
+func (s *failingCredentialStore) ClaimNextRoundRobin(_ context.Context, _ models.Scope, _ models.ProviderName) (*models.DecryptedCredential, error) {
+	return nil, fmt.Errorf("db connection refused")
+}
+func (s *failingCredentialStore) DisableByID(_ context.Context, _ models.Scope, _ uuid.UUID) error {
 	return fmt.Errorf("db connection refused")
 }
-func (s *failingCredentialStore) Disable(_ context.Context, _ uuid.UUID, _ models.ProviderName) error {
+func (s *failingCredentialStore) UpdateStatusByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ string) error {
 	return fmt.Errorf("db connection refused")
 }
-func (s *failingCredentialStore) UpsertWithLabel(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) InsertPendingAuth(_ context.Context, _ uuid.UUID, _ *uuid.UUID, _ string, _ models.ProviderConfig) (*uuid.UUID, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) GetByID(_ context.Context, _ uuid.UUID, _ uuid.UUID) (*models.DecryptedCredential, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) ListByProvider(_ context.Context, _ uuid.UUID, _ models.ProviderName) ([]models.DecryptedCredential, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) GetByProviderAndLabel(_ context.Context, _ uuid.UUID, _ models.ProviderName, _ string) (*models.DecryptedCredential, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) ClaimNextRoundRobin(_ context.Context, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
-	return nil, fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) DisableByID(_ context.Context, _ uuid.UUID, _ uuid.UUID) error {
+func (s *failingCredentialStore) UpsertByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ models.ProviderConfig) error {
 	return fmt.Errorf("db connection refused")
 }
-func (s *failingCredentialStore) UpdateStatusByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string) error {
-	return fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) UpsertByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.ProviderConfig) error {
-	return fmt.Errorf("db connection refused")
-}
-func (s *failingCredentialStore) ExistsForProviderByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ models.ProviderName) (bool, error) {
+func (s *failingCredentialStore) ExistsForProviderByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ models.ProviderName) (bool, error) {
 	return false, fmt.Errorf("db connection refused")
 }
 
@@ -888,7 +931,7 @@ func TestPollForToken_RateLimited(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
@@ -896,7 +939,7 @@ func TestPollForToken_RateLimited(t *testing.T) {
 	})
 
 	// Second poll should be rate-limited (no HTTP call).
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -924,13 +967,13 @@ func TestPollForToken_AccessDenied(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -942,7 +985,7 @@ func TestPollForToken_AccessDenied(t *testing.T) {
 	}
 
 	// Verify pending state was cleaned up.
-	if _, ok := svc.pending.Load(orgID.String() + ":"); ok {
+	if _, ok := svc.pending.Load(pendingKey(models.Scope{OrgID: orgID}, "")); ok {
 		t.Error("expected pending auth to be deleted after access_denied")
 	}
 }
@@ -963,13 +1006,13 @@ func TestPollForToken_ExpiredToken(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -994,13 +1037,13 @@ func TestPollForToken_UnknownError(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1027,13 +1070,13 @@ func TestPollForToken_EmptyErrorField(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	svc.pending.Store(orgID.String()+":", &PendingAuth{
+	svc.pending.Store(pendingKey(models.Scope{OrgID: orgID}, ""), &PendingAuth{
 		DeviceAuthID: "dev_123",
 		ExpiresAt:    time.Now().Add(15 * time.Minute),
 		Interval:     5,
 	})
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1053,7 +1096,7 @@ func TestPollForToken_RestoreFromDB_Active(t *testing.T) {
 
 	orgID := uuid.New()
 	// Pre-store an active credential in the DB.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_active_token",
 		RefreshToken: "chr_refresh",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
@@ -1061,7 +1104,7 @@ func TestPollForToken_RestoreFromDB_Active(t *testing.T) {
 	})
 
 	// Poll with no in-memory state — should find it in DB.
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1070,6 +1113,37 @@ func TestPollForToken_RestoreFromDB_Active(t *testing.T) {
 	}
 	if status.AccountType != "plus" {
 		t.Errorf("expected account type 'plus', got %s", status.AccountType)
+	}
+}
+
+func TestPollForToken_EmptyLabelDetectsActiveLabeledPersonalSubscription(t *testing.T) {
+	t.Parallel()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	scope := models.Scope{OrgID: orgID, UserID: &userID}
+	_, err := store.UpsertWithLabel(context.Background(), scope, &userID, "Codex subscription", models.OpenAIChatGPTConfig{
+		AccessToken:  "cha_personal",
+		RefreshToken: "chr_personal",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		AccountType:  "plus",
+	})
+	if err != nil {
+		t.Fatalf("seed personal subscription: %v", err)
+	}
+
+	status, err := svc.PollForToken(context.Background(), scope, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status.Status != "completed" {
+		t.Fatalf("expected completed status for active labeled personal subscription, got %q", status.Status)
+	}
+	if status.AccountType != "plus" {
+		t.Fatalf("expected account type 'plus', got %q", status.AccountType)
 	}
 }
 
@@ -1104,7 +1178,7 @@ func TestPollForToken_RestoreFromDB_PendingAuth(t *testing.T) {
 		Status: "pending_auth",
 	}
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1128,7 +1202,7 @@ func TestPollForToken_InvalidConfigType(t *testing.T) {
 		Status:   "active",
 	}
 
-	status, err := svc.PollForToken(context.Background(), orgID, "")
+	status, err := svc.PollForToken(context.Background(), models.Scope{OrgID: orgID}, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1156,13 +1230,13 @@ func TestGetValidToken_InactiveStatus(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_tok",
 		RefreshToken: "chr_tok",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
 	})
 	// Mark as inactive.
-	store.UpdateStatus(context.Background(), orgID, models.ProviderOpenAIChatGPT, "invalid")
+	store.UpdateStatus(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT, "invalid")
 
 	cfg, err := svc.GetValidToken(context.Background(), orgID)
 	if err != nil {
@@ -1209,7 +1283,7 @@ func TestGetValidToken_RefreshFailsButTokenValid(t *testing.T) {
 
 	orgID := uuid.New()
 	// Token expiring within refresh window but not yet expired.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_still_valid",
 		RefreshToken: "chr_refresh",
 		ExpiresAt:    time.Now().Add(3 * time.Minute), // Within 5-min window but still valid.
@@ -1243,7 +1317,7 @@ func TestGetValidToken_RefreshFailsTokenExpired(t *testing.T) {
 
 	orgID := uuid.New()
 	// Token already expired and refresh fails.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_expired",
 		RefreshToken: "chr_refresh",
 		ExpiresAt:    time.Now().Add(-1 * time.Minute), // Already expired.
@@ -1269,17 +1343,17 @@ func TestRefreshTokenByID_NonAuthError(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_tok",
 		RefreshToken: "chr_tok",
 		ExpiresAt:    time.Now().Add(-1 * time.Hour),
 	})
-	cred, err := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, err := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Fatalf("failed to get credential: %v", err)
 	}
 
-	_, err = svc.RefreshTokenByID(context.Background(), orgID, cred.ID)
+	_, err = svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, cred.ID)
 	if err == nil {
 		t.Fatal("expected error for 500 response")
 	}
@@ -1301,7 +1375,7 @@ func TestRefreshTokenByID_InvalidConfigType(t *testing.T) {
 		Status:   "active",
 	}
 
-	_, err := svc.RefreshTokenByID(context.Background(), orgID, credID)
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, credID)
 	if err == nil {
 		t.Fatal("expected error for invalid config type")
 	}
@@ -1312,7 +1386,7 @@ func TestRefreshTokenByID_NotFound(t *testing.T) {
 	store := newMockCredentialStore()
 	svc := NewService(store, zerolog.Nop())
 
-	_, err := svc.RefreshTokenByID(context.Background(), uuid.New(), uuid.New())
+	_, err := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: uuid.New()}, uuid.New())
 	if err == nil {
 		t.Fatal("expected error when credential not found")
 	}
@@ -1330,7 +1404,7 @@ func TestInitiateDeviceAuth_ServerError(t *testing.T) {
 	svc.SetHTTPClient(server.Client())
 	svc.SetIssuer(server.URL)
 
-	_, err := svc.InitiateDeviceAuth(context.Background(), uuid.New(), nil, "")
+	_, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: uuid.New()}, nil, "")
 	if err == nil {
 		t.Fatal("expected error for server error response")
 	}
@@ -1348,7 +1422,7 @@ func TestInitiateDeviceAuth_InvalidJSON(t *testing.T) {
 	svc.SetHTTPClient(server.Client())
 	svc.SetIssuer(server.URL)
 
-	_, err := svc.InitiateDeviceAuth(context.Background(), uuid.New(), nil, "")
+	_, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: uuid.New()}, nil, "")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON response")
 	}
@@ -1374,7 +1448,7 @@ func TestInitiateDeviceAuth_LabelConflict(t *testing.T) {
 	const label = "Team A"
 
 	// Seed an active credential under this label so the next initiate must conflict.
-	if _, err := store.UpsertWithLabel(context.Background(), orgID, nil, label, models.OpenAIChatGPTConfig{
+	if _, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, label, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_existing",
 		RefreshToken: "chr_existing",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
@@ -1382,7 +1456,7 @@ func TestInitiateDeviceAuth_LabelConflict(t *testing.T) {
 		t.Fatalf("seed active credential: %v", err)
 	}
 
-	_, err := svc.InitiateDeviceAuth(context.Background(), orgID, nil, label)
+	_, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID}, nil, label)
 	if err == nil {
 		t.Fatal("expected error when initiating against an existing active label")
 	}
@@ -1400,7 +1474,7 @@ func TestInitiateDeviceAuth_LabelConflict(t *testing.T) {
 
 	// In-memory pending state must be cleaned up so the next attempt is not
 	// shadowed by a stale entry.
-	if _, ok := svc.pending.Load(pendingKey(orgID, label)); ok {
+	if _, ok := svc.pending.Load(pendingKey(models.Scope{OrgID: orgID}, label)); ok {
 		t.Error("expected pending state for label to be cleared after conflict")
 	}
 }
@@ -1435,11 +1509,11 @@ func TestInitiateDeviceAuth_DisabledLabelResurrects(t *testing.T) {
 		Config:   models.OpenAIChatGPTConfig{},
 	}
 
-	if _, err := svc.InitiateDeviceAuth(context.Background(), orgID, nil, label); err != nil {
+	if _, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID}, nil, label); err != nil {
 		t.Fatalf("expected re-initiate against disabled label to succeed, got: %v", err)
 	}
 
-	cred, err := store.GetByProviderAndLabel(context.Background(), orgID, models.ProviderOpenAIChatGPT, label)
+	cred, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT, label)
 	if err != nil {
 		t.Fatalf("expected to find resurrected credential: %v", err)
 	}
@@ -1495,12 +1569,12 @@ func TestRefreshTokenByID_ConcurrentRefreshesAreSerialized(t *testing.T) {
 	svc.SetIssuer(server.URL)
 
 	orgID := uuid.New()
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_old",
 		RefreshToken: "chr_old",
 		ExpiresAt:    time.Now().Add(-1 * time.Minute), // Expired.
 	})
-	cred, err := store.Get(context.Background(), orgID, models.ProviderOpenAIChatGPT)
+	cred, err := store.Get(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT)
 	if err != nil {
 		t.Fatalf("failed to get credential: %v", err)
 	}
@@ -1509,7 +1583,7 @@ func TestRefreshTokenByID_ConcurrentRefreshesAreSerialized(t *testing.T) {
 	done := make(chan *models.OpenAIChatGPTConfig, 2)
 	for i := 0; i < 2; i++ {
 		go func() {
-			cfg, _ := svc.RefreshTokenByID(context.Background(), orgID, cred.ID)
+			cfg, _ := svc.RefreshTokenByID(context.Background(), models.Scope{OrgID: orgID}, cred.ID)
 			done <- cfg
 		}()
 	}
@@ -1547,7 +1621,7 @@ func TestGetValidToken_RefreshTokenReused_ExpiredToken(t *testing.T) {
 
 	orgID := uuid.New()
 	// Store a credential that is ALREADY EXPIRED and needs refresh.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_expired",
 		RefreshToken: "chr_reused",
 		ExpiresAt:    time.Now().Add(-10 * time.Minute), // Already expired.
@@ -1583,7 +1657,7 @@ func TestGetValidToken_RefreshTokenReused_ValidToken(t *testing.T) {
 
 	orgID := uuid.New()
 	// Store a credential within the refresh window but NOT yet expired.
-	store.Upsert(context.Background(), orgID, models.OpenAIChatGPTConfig{
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_still_valid",
 		RefreshToken: "chr_reused",
 		ExpiresAt:    time.Now().Add(3 * time.Minute), // Within 5-min window but still valid.
@@ -1614,7 +1688,7 @@ func TestDisconnectForOrg_AlreadyDisabled(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	credID, err := store.UpsertWithLabel(context.Background(), orgID, nil, "Team A", models.OpenAIChatGPTConfig{
+	credID, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Team A", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_token",
 		RefreshToken: "chr_refresh",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
@@ -1629,7 +1703,7 @@ func TestDisconnectForOrg_AlreadyDisabled(t *testing.T) {
 	store.creds[k].Status = "disabled"
 
 	// Disconnecting an already-disabled row should return nil, not ErrCredentialNotFound.
-	if err := svc.DisconnectForOrg(context.Background(), orgID, *credID); err != nil {
+	if err := svc.DisconnectForOrg(context.Background(), models.Scope{OrgID: orgID}, *credID); err != nil {
 		t.Fatalf("expected idempotent disconnect to succeed, got: %v", err)
 	}
 }
@@ -1644,11 +1718,11 @@ type alwaysSameCredStore struct {
 	fixed *models.DecryptedCredential
 }
 
-func (s *alwaysSameCredStore) ClaimNextRoundRobin(_ context.Context, _ uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
+func (s *alwaysSameCredStore) ClaimNextRoundRobin(_ context.Context, _ models.Scope, _ models.ProviderName) (*models.DecryptedCredential, error) {
 	return s.fixed, nil
 }
 
-func (s *alwaysSameCredStore) UpdateStatusByID(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string) error {
+func (s *alwaysSameCredStore) UpdateStatusByID(_ context.Context, _ models.Scope, _ uuid.UUID, _ string) error {
 	return nil // Simulate a silent status-update failure (no row actually marked invalid).
 }
 
@@ -1670,7 +1744,7 @@ func TestGetValidToken_TriedDedupeBreaksLoop(t *testing.T) {
 
 	base := newMockCredentialStore()
 	orgID := uuid.New()
-	if _, err := base.UpsertWithLabel(context.Background(), orgID, nil, "Solo", models.OpenAIChatGPTConfig{
+	if _, err := base.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Solo", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_expired",
 		RefreshToken: "chr_broken",
 		ExpiresAt:    time.Now().Add(-1 * time.Hour), // Already expired.
@@ -1711,7 +1785,7 @@ func TestDisconnectAll_CleansRefreshMutexes(t *testing.T) {
 	svc := NewService(store, zerolog.Nop())
 
 	orgID := uuid.New()
-	firstID, err := store.UpsertWithLabel(context.Background(), orgID, nil, "Team A", models.OpenAIChatGPTConfig{
+	firstID, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Team A", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_a",
 		RefreshToken: "chr_a",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
@@ -1719,7 +1793,7 @@ func TestDisconnectAll_CleansRefreshMutexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("seed first credential: %v", err)
 	}
-	secondID, err := store.UpsertWithLabel(context.Background(), orgID, nil, "Team B", models.OpenAIChatGPTConfig{
+	secondID, err := store.UpsertWithLabel(context.Background(), models.Scope{OrgID: orgID}, nil, "Team B", models.OpenAIChatGPTConfig{
 		AccessToken:  "cha_b",
 		RefreshToken: "chr_b",
 		ExpiresAt:    time.Now().Add(1 * time.Hour),
@@ -1738,7 +1812,7 @@ func TestDisconnectAll_CleansRefreshMutexes(t *testing.T) {
 		t.Fatal("expected refresh mutex to be populated for second credential")
 	}
 
-	if err := svc.DisconnectAll(context.Background(), orgID); err != nil {
+	if err := svc.DisconnectAll(context.Background(), models.Scope{OrgID: orgID}); err != nil {
 		t.Fatalf("DisconnectAll: %v", err)
 	}
 
@@ -1747,5 +1821,130 @@ func TestDisconnectAll_CleansRefreshMutexes(t *testing.T) {
 	}
 	if _, ok := svc.refreshMu.Load(secondID.String()); ok {
 		t.Error("expected refresh mutex for second credential to be cleared after DisconnectAll")
+	}
+}
+
+// --- Personal-scope coverage ---
+//
+// The OAuth flow used to be exclusively org-scoped; PR #729-equivalent
+// added personal scope so individual users can connect their own ChatGPT
+// subscription as a personal-stack credential. The tests below lock the
+// new contract: scope flows through Initiate, GetByProviderAndLabel sees
+// the personal row, and the personal pendingKey shape is distinct from
+// the org one so the same label can coexist across scopes.
+
+func TestPendingKey_ScopesAreDistinct(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	userID := uuid.New()
+	orgKey := pendingKey(models.Scope{OrgID: orgID}, "Team A")
+	personalKey := pendingKey(models.Scope{OrgID: orgID, UserID: &userID}, "Team A")
+	if orgKey == personalKey {
+		t.Fatal("pendingKey must namespace personal scope distinctly from org scope")
+	}
+	if !strings.Contains(personalKey, ":u:") {
+		t.Errorf("personal pendingKey expected to contain :u: segment, got %q", personalKey)
+	}
+
+	collidingOrgLabel := "u:" + userID.String() + ":Team A"
+	collidingOrgKey := pendingKey(models.Scope{OrgID: orgID}, collidingOrgLabel)
+	if collidingOrgKey == personalKey {
+		t.Fatalf("org label %q must not collide with personal pending key %q", collidingOrgLabel, personalKey)
+	}
+}
+
+func TestInitiateDeviceAuth_PersonalScope(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_auth_id":   "dev_personal_1",
+			"user_code":        "PERS-1234",
+			"verification_uri": "https://auth.openai.com/codex/device",
+			"expires_in":       900,
+			"interval":         5,
+		})
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	personalScope := models.Scope{OrgID: orgID, UserID: &userID}
+
+	resp, err := svc.InitiateDeviceAuth(context.Background(), personalScope, &userID, "Personal A")
+	if err != nil {
+		t.Fatalf("personal initiate: %v", err)
+	}
+	if resp.UserCode != "PERS-1234" {
+		t.Errorf("expected user code PERS-1234, got %q", resp.UserCode)
+	}
+
+	// The personal pending row must be reachable from personal scope and
+	// invisible to org scope — that is the whole point of the refactor.
+	cred, err := store.GetByProviderAndLabel(context.Background(), personalScope, models.ProviderOpenAIChatGPT, "Personal A")
+	if err != nil {
+		t.Fatalf("expected personal pending row to be persisted: %v", err)
+	}
+	if cred.Status != "pending_auth" {
+		t.Errorf("expected pending_auth status, got %q", cred.Status)
+	}
+	if cred.CreatedBy == nil || *cred.CreatedBy != userID {
+		t.Errorf("expected created_by=%s, got %v", userID, cred.CreatedBy)
+	}
+
+	if _, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT, "Personal A"); err == nil {
+		t.Error("personal-scope row must not be visible to an org-scope read")
+	}
+}
+
+func TestInitiateDeviceAuth_SameLabelAcrossScopes(t *testing.T) {
+	// A user adding a personal "Codex backup" subscription must not collide
+	// with an org-scope "Codex backup" subscription that already exists. The
+	// pending_auth keys live in distinct partitions; this test guards
+	// against a regression where they share a row.
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"device_auth_id":   "dev_shared_label",
+			"user_code":        "SHRD-1234",
+			"verification_uri": "https://auth.openai.com/codex/device",
+			"expires_in":       900,
+			"interval":         5,
+		})
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	label := "Codex backup"
+
+	if _, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID}, nil, label); err != nil {
+		t.Fatalf("org initiate: %v", err)
+	}
+	if _, err := svc.InitiateDeviceAuth(context.Background(), models.Scope{OrgID: orgID, UserID: &userID}, &userID, label); err != nil {
+		t.Fatalf("personal initiate with same label must succeed: %v", err)
+	}
+
+	orgRow, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID}, models.ProviderOpenAIChatGPT, label)
+	if err != nil {
+		t.Fatalf("expected org pending row: %v", err)
+	}
+	personalRow, err := store.GetByProviderAndLabel(context.Background(), models.Scope{OrgID: orgID, UserID: &userID}, models.ProviderOpenAIChatGPT, label)
+	if err != nil {
+		t.Fatalf("expected personal pending row: %v", err)
+	}
+	if orgRow.ID == personalRow.ID {
+		t.Error("org and personal rows must be distinct credentials despite sharing the label")
 	}
 }


### PR DESCRIPTION
## Summary

Adds **personal-scoped** Codex (ChatGPT) and Claude Code (Anthropic) OAuth so any authenticated user can connect their own subscription as a personal-stack credential — not only org admins. The existing org-scoped flow keeps its admin gate. Also fixes PR-push auth to flow through the sandbox credential socket (with an askpass fallback) so per-push GitHub credentials work end-to-end.

## Product changes

### New: per-user Codex / Claude subscription auth
- **Settings → Account** (`/settings/account`) gains a subscription option for personal coding auth. The "Add auth" modal now shows an **Auth type** selector (Subscription / API key) when the chosen provider supports it (Codex, Claude Code today). Picking Subscription launches the Codex device-code or Claude Code PKCE modal in personal mode; the resulting credential lands in the user's personal stack with `user_id` set, ahead of the org fallback.
- Gemini CLI / Amp / Pi keep the API-key-only experience (their `supportsSubscription` is `false`), so the radio doesn't render a dead control.
- Default-label placeholder is now provider-aware (`Codex subscription`, `Claude Code API key`, etc.) to mirror the admin `/settings/agent` flow.

### Setup, session-create, and PM/autopilot flows now see personal subscriptions
Several flows used to compute agent availability only from the org fallback stack. Each now also pulls personal-scope coding-credentials (or org-scope unified credentials, where appropriate) so a user with only a personal subscription doesn't get a misleading "agent not connected" state:
- `useSetupStatus` and the setup-checklist agent step query `coding-credentials?scope=resolved` and codex-auth status with `scope=personal`. The new `isAgentAvailable` helper replaces `isAgentConnected` so personal-stack credentials count toward "ready".
- `/sessions/new` (manual session composer) merges personal `resolved` coding-credentials into the availability set used by `availableAgentModelGroups` and the credentials-warning banner.
- `/sessions/[id]` Codex auth-failure reconnect prompt uses personal scope; the modal now reconnects the user's own subscription.
- **Repo PM settings** and **Autopilot settings** merge org-scope unified `coding-credentials` into PM model availability so PM runs can use admin-managed unified subscriptions, not just the legacy `coding_auths` table.

### OAuth modal scope prop
`CodexDeviceCodeModal` and `ClaudeCodeAuthModal` accept an optional `scope: 'org' | 'personal'` prop and capture it at mount time. The admin `/settings/agent` flow keeps the default org behavior; personal flows pass `scope="personal"`.

## API changes

- All `/api/v1/settings/codex-auth/*` and `/api/v1/settings/claude-code-auth/*` endpoints now accept an optional `scope` query param (or `scope` body field on POSTs):
  - `scope=org` (default) — admin-gated, writes through the legacy `org_credentials` table mirrored to `coding_credentials`.
  - `scope=personal` — available to any authenticated member, writes directly to `coding_credentials` with `user_id` set.
- Routes for these endpoints moved out of the admin-only chi group into the admin+member group; the new handler-level `resolveOAuthScope` enforces the admin gate on org scope. This means a member can disconnect *their own* personal subscription without being elevated to admin.
- `LABEL_TAKEN` mapping handles both legacy (`db.ErrCredentialLabelTaken`) and unified (`db.ErrCodingCredentialLabelTaken`) conflict errors.
- Frontend API client (`api.codexAuth.initiate/status`, `api.claudeCodeAuth.initiate/complete`) accepts an optional `scope` argument and forwards it.

## Backend architecture

- **`internal/db/scoped_credential_store.go`** (new). `ScopedCredentialStore` is a scope-aware façade implementing the existing `CredentialStore` surface used by `codexauth` and `claudecodeauth`. Org scope routes to `OrgCredentialStore` (legacy schema, mirrored to coding_credentials); personal scope routes to `CodingCredentialStore` directly. It transparently translates between legacy provider/config types (`OpenAIChatGPTConfig`, `AnthropicConfig{Subscription:…}`) and the unified types (`openai_subscription` / `anthropic_subscription`) so neither auth service needs to learn the unified schema.
  - Includes a documented concurrency note: the personal `UpsertWithLabel` path is not single-statement atomic, but the auth services serialize concurrent Initiate/Complete calls per `(scope, label)` via their `initMu` `sync.Map`, so two racing `CompleteOAuth`s for the same label can't reach this method at once.
- **`internal/api/handlers/auth_scope.go`** (new). `resolveOAuthScope` and `writeAuthScopeError` centralize scope parsing + the admin gate so both OAuth handlers stay in lockstep.
- **`codexauth.Service` / `claudecodeauth.Service`** (modified). Public methods (`InitiateDeviceAuth/InitiateOAuth`, `CompleteOAuth`, `Status`, `ListSubscriptions`, `Disconnect*`, `RefreshTokenByID`) now take `models.Scope` instead of `orgID uuid.UUID`. The `pendingKey` namespaces personal vs org keys (`personal:<orgID>:u:<userID>:<label>` vs `org:<orgID>:<label>`) so an org label can't impersonate a personal-scope key.
- **`agent.AgentEnv` Codex/Claude refresh paths.** `CodexAuthRefresher.RefreshTokenByID` and `ClaudeCodeAuthRefresher.RefreshTokenByID` now take `models.Scope`. The orchestrator and env injection code build the scope from the picked credential's `UserID` so personal credentials look up against `(org_id, user_id)` and don't mis-route to the org fallback after the first refresh window.
- **`cmd/server/main.go`** wires `db.NewScopedCredentialStore(orgStore, codingStore)` as the credential dependency for both OAuth services.

## PR push fix (rolled in from #743 / #744 follow-up)

`PRService.pushSessionBranch` now opens a per-push credential socket via `agent.SandboxAuthServer` and bind-mounts it into the `pr_push` sandbox; the snapshot's `credential.helper=!143-tools git-credential` (set during the original agent run) resolves against this fresh listener. Per-push UUIDs avoid colliding with the agent run's listener when a preview hold is keeping the original container alive across turns. When the auth server isn't configured (local/dev workers without a socket directory), `pushSessionBranch` falls back to the legacy token-file + `GIT_ASKPASS` path. `cmd/server/main.go` plumbs the auth server through `wireWorkerPRService → prService.SetSandboxAuth`.

## Test plan

- [x] `frontend` typecheck / lint / build pass
- [x] `git diff --check` clean
- [x] pre-commit lint-stores / gofmt pass
- [ ] Go vet/build/test were blocked locally by Go 1.23.7 vs repo's required Go 1.26 — needs to run in CI
- [ ] Manual: connect a personal Codex subscription via `/settings/account`, run a session, confirm the personal token is used and refreshed
- [ ] Manual: connect a personal Claude Code subscription via `/settings/account`, run a session, confirm the personal token is used and refreshed
- [ ] Manual: org admin can still connect org-scope subscriptions via `/settings/agent` (unchanged path)
- [ ] Manual: PR push from an active session succeeds via the sandbox auth socket; verify in dev that disabling the socket falls back to the askpass token path

🤖 Generated with [Claude Code](https://claude.com/claude-code)