### PR TITLE
Move preview build artifacts off /var/tmp tmpfs onto writable rootfs

### DIFF
--- a/.143/preview-start.sh
+++ b/.143/preview-start.sh
@@ -9,32 +9,63 @@
 #      a server restart inside the same sandbox keeps the reviewer signed in
 #   5. exec the server
 #
-# Everything lives under $TMPDIR (= /var/tmp in the sandbox), not /tmp:
-# the sandbox mounts /tmp as a 256 MiB noexec tmpfs but /var/tmp as a
-# 512 MiB exec-allowed tmpfs (see internal/services/agent/providers/docker.go).
-# Writing the GOCACHE + binaries to /tmp ran the small tmpfs out of space
-# while the Go build was copying its final a.out, and noexec would have
-# blocked exec'ing the resulting binary anyway. SESSION_SECRET still lives
-# on a tmpfs, so a sandbox recycle still resets it and the reviewer simply
-# re-signs-in with the public demo credentials.
+# Scratch lives under $HOME on the container's writable rootfs, NOT in
+# $TMPDIR. The sandbox mounts /tmp (256 MiB) and /var/tmp (512 MiB) as
+# tmpfs (see internal/services/agent/providers/docker.go), and the Go
+# build's GOCACHE + $WORK + the migrate/server output binaries together
+# blow past 512 MiB while compiling deps like aws-sdk-go-v2/service/s3.
+# Moving them off tmpfs also frees that footprint from the container's
+# memory cgroup (tmpfs pages count against the memory limit per the
+# Tmpfs comment in providers/docker.go), giving the running server more
+# heap headroom.
+#
+# The rootfs is wiped automatically when the container is removed — both
+# on the happy path (Destroy) and the crash path (orphan reconciler), so
+# no explicit cleanup is needed here. Size is bounded by
+# SANDBOX_DISK_LIMIT_GB (default 10 GB) on hosts whose Docker storage
+# driver supports project quotas (overlay2 + XFS with pquota); on hosts
+# without that, providers/docker.go silently disables the quota and the
+# only ceiling is host disk. Prod is provisioned with the supported
+# driver; dev hosts without it should treat the cap as advisory.
+#
+# Cleanup invariant: this path must stay on a non-bind-mounted directory.
+# Today $HOME and the repo workdir are both rootfs-only (the only host
+# binds are /etc/resolv.conf and the auth-socket dir; see Mounts in
+# providers/docker.go). If a future change bind-mounts $HOME from the
+# host, move SCRATCH_DIR to a path that's still on the rootfs — otherwise
+# build artifacts will outlive the sandbox.
+#
+# GOTMPDIR is set explicitly so `go build`'s intermediate $WORK files
+# don't fall back to the ambient GOTMPDIR=/var/tmp set by docker.go,
+# which would put the largest churn back on the small tmpfs.
 #
 # -u catches typos in required env vars (DATABASE_URL, PREVIEW_ORIGIN)
 # instead of silently substituting empty strings and failing downstream.
 set -eu
 
-SCRATCH_DIR="${TMPDIR:-/var/tmp}/143-preview"
+# Fall back to /home/sandbox if HOME is somehow unset; the sandbox image
+# bakes that as the user's home so it's the right default. The fallback
+# matches HomeDir in internal/services/agent/adapter.go.
+SCRATCH_DIR="${HOME:-/home/sandbox}/.cache/143-preview"
 SECRET_FILE="${SCRATCH_DIR}/session_secret"
 MIGRATE_BIN="${SCRATCH_DIR}/143-migrate"
 SERVER_BIN="${SCRATCH_DIR}/143-server"
 
 mkdir -p "$SCRATCH_DIR"
+# Lock down the scratch dir up-front so anything dropped here later
+# (notably SECRET_FILE) inherits a sandbox-only parent. SECRET_FILE
+# itself is also chmod 600 below; this is defense in depth, not the
+# primary control.
+chmod 700 "$SCRATCH_DIR"
 
-# Persist the Go build cache across in-sandbox server restarts so rebuilds
-# after a code edit reuse object files instead of recompiling the world.
-# A full sandbox recycle wipes the tmpfs and pays the cold-build cost once.
+# Persist the Go build cache and intermediate $WORK dir across in-sandbox
+# server restarts so rebuilds after a code edit reuse object files
+# instead of recompiling the world. A full sandbox recycle wipes the
+# rootfs and pays the cold-build cost once.
 GOCACHE="${SCRATCH_DIR}/gocache"
-export GOCACHE
-mkdir -p "$GOCACHE"
+GOTMPDIR="${SCRATCH_DIR}/gotmp"
+export GOCACHE GOTMPDIR
+mkdir -p "$GOCACHE" "$GOTMPDIR"
 
 echo '[143-preview] building binaries...'
 # Merge stderr into stdout so `go build` compile errors are captured by the
@@ -50,7 +81,6 @@ echo '[143-preview] running migrations...'
 echo '[143-preview] seeding database...'
 psql -v ON_ERROR_STOP=1 "$DATABASE_URL" -f .143/seed.sql
 
-chmod 700 "$SCRATCH_DIR"
 if [ ! -s "$SECRET_FILE" ]; then
     # tr strips the trailing newline base64 appends — SESSION_SECRET is
     # consumed as an opaque byte string and a stray \n causes subtle


### PR DESCRIPTION
## Summary

- `go build ./cmd/server` was failing the dogfood preview readiness probe with `no space left on device` — the build's intermediate `$WORK`, `GOCACHE`, and the migrate/server binaries all competed for the 512 MiB tmpfs at `/var/tmp` and blew past it while compiling deps like `aws-sdk-go-v2/service/s3`.
- Point `SCRATCH_DIR` at `$HOME/.cache/143-preview` and export `GOTMPDIR` explicitly so all build state lives on the container's writable rootfs (capped by `SANDBOX_DISK_LIMIT_GB`, wiped on container destroy) instead of the tmpfs; as a bonus, that footprint no longer counts against the memory cgroup.
- Also reorders `chmod 700` to run immediately after `mkdir` (lock down up-front rather than after seeding) and rewrites the comment block to document the new architecture, the bind-mount footgun ($HOME must remain non-bind-mounted), and the storage-driver caveat for `DiskLimitGB`.

## Test plan

- [ ] Re-spin the preview that originally failed (https://143.dev/sessions/1a84c44a-705f-4487-a795-b23a336002a6?preview=1) and confirm the readiness probe passes
- [ ] After a successful run, `du -sh ~/.cache/143-preview` inside the sandbox to record the rootfs footprint
- [ ] Verify hot-restart behavior: trigger a server restart inside the same sandbox and confirm the rebuild reuses GOCACHE rather than recompiling cold

🤖 Generated with [Claude Code](https://claude.com/claude-code)