### PR TITLE
Seed primary thread on session create so multi-tab UI surfaces

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -922,6 +922,7 @@ func buildServices(
 	// Orchestrator.
 	sessionLogStore := db.NewSessionLogStore(pool)
 	sessionQuestionStore := db.NewSessionQuestionStore(pool)
+	sessionThreadStore := db.NewSessionThreadStore(pool)
 	projectTaskUpdater := pm.NewProjectHooks(projectTaskStore, projectStore, logger)
 	automationRunUpdater := automations.NewAutomationHooks(automationRunStore, logger)
 	containerUsageStore := db.NewContainerUsageStore(pool)
@@ -959,6 +960,7 @@ func buildServices(
 		SessionLogs:       sessionLogStore,
 		SessionQuestions:  sessionQuestionStore,
 		SessionMessages:   sessionMessageStore,
+		SessionThreads:    sessionThreadStore,
 		SessionIssueLinks: db.NewSessionIssueLinkStore(pool),
 		IssueSnapshots:    db.NewSessionTurnIssueSnapshotStore(pool),
 		DecisionLog:       pmDecisionLogStore,

--- a/docs/design/implemented/68-sandbox-agent-tabs-and-threads.md
+++ b/docs/design/implemented/68-sandbox-agent-tabs-and-threads.md
@@ -802,9 +802,10 @@ shorter human supervision time for sessions where parallelism is appropriate.
 - Added `session_threads`.
 - Added `thread_id` to session messages and logs.
 - Kept existing single-thread APIs working.
-- Note: default-thread backfill for legacy sessions is not part of the current
-  Phase 1 UI path; sessions without explicit threads still fall back to the
-  existing session transcript/composer.
+- Added a primary-thread invariant: every non-deleted session has a seeded
+  `Main` thread. Legacy NULL-thread messages/logs are attributed to that row
+  when the mapping is unambiguous, and new first-turn execution is attributed
+  to the seeded primary thread.
 
 ### Phase 1: Multiple blank tabs, one running thread at a time — Completed
 

--- a/internal/api/handlers/internal_issues.go
+++ b/internal/api/handlers/internal_issues.go
@@ -219,10 +219,7 @@ func (h *InternalIssueHandler) dispatchSession(r *http.Request, orgID uuid.UUID,
 	}
 
 	dedupeKey := db.RunAgentDedupeKey(session.ID)
-	payload := map[string]string{
-		"session_id": session.ID.String(),
-		"org_id":     orgID.String(),
-	}
+	payload := db.RunAgentPayload(session)
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return nil, err
 	}

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -854,10 +854,7 @@ func (h *SessionHandler) TriggerFix(w http.ResponseWriter, r *http.Request) {
 	// rows for the same session — the second insert would race the first at
 	// AcquireTurnHold and surface "sandbox race" to the user.
 	dedupeKey := db.RunAgentDedupeKey(run.ID)
-	payload := map[string]string{
-		"session_id": run.ID.String(),
-		"org_id":     orgID.String(),
-	}
+	payload := db.RunAgentPayload(run)
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue agent run job", err)
 		return
@@ -2643,6 +2640,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 		initMsg := &models.SessionMessage{
 			SessionID:  session.ID,
 			OrgID:      orgID,
+			ThreadID:   session.PrimaryThreadID,
 			TurnNumber: 0,
 			Role:       models.MessageRoleUser,
 			Content:    body.Message,
@@ -2791,10 +2789,7 @@ func (h *SessionHandler) CreateManual(w http.ResponseWriter, r *http.Request) {
 	}
 
 	dedupeKey := db.RunAgentDedupeKey(session.ID)
-	payload := map[string]string{
-		"session_id": session.ID.String(),
-		"org_id":     orgID.String(),
-	}
+	payload := db.RunAgentPayload(session)
 	if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue manual session", err)
 		return

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -611,9 +611,9 @@ func expectManualSessionCreate(mock pgxmock.PgxPoolIface, runID uuid.UUID, now t
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(sessionAnyArgs(26)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(runID, now, now))
-	mock.ExpectExec("INSERT INTO session_threads").
+	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(sessionAnyArgs(6)...).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectCommit()
 }
 
@@ -622,9 +622,9 @@ func expectIssueSessionCreate(mock pgxmock.PgxPoolIface, runID uuid.UUID, now ti
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(sessionAnyArgs(26)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(runID, now, now))
-	mock.ExpectExec("INSERT INTO session_threads").
+	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(sessionAnyArgs(6)...).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(sessionAnyArgs(4)...).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -611,6 +611,9 @@ func expectManualSessionCreate(mock pgxmock.PgxPoolIface, runID uuid.UUID, now t
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(sessionAnyArgs(26)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(runID, now, now))
+	mock.ExpectExec("INSERT INTO session_threads").
+		WithArgs(sessionAnyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectCommit()
 }
 
@@ -619,6 +622,9 @@ func expectIssueSessionCreate(mock pgxmock.PgxPoolIface, runID uuid.UUID, now ti
 	mock.ExpectQuery("INSERT INTO sessions").
 		WithArgs(sessionAnyArgs(26)...).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(runID, now, now))
+	mock.ExpectExec("INSERT INTO session_threads").
+		WithArgs(sessionAnyArgs(6)...).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(sessionAnyArgs(4)...).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -330,13 +330,16 @@ func TestSessionStore_Create(t *testing.T) {
 	generatedID := uuid.New()
 
 	issueID := uuid.New()
+	orgID := uuid.New()
+	modelOverride := "opus-4-7"
 	run := &models.Session{
 		PrimaryIssueID: &issueID,
-		OrgID:          uuid.New(),
+		OrgID:          orgID,
 		AgentType:      "claude_code",
 		Status:         "pending",
 		AutonomyLevel:  "supervised",
 		TokenMode:      "low",
+		ModelOverride:  &modelOverride,
 	}
 
 	mock.ExpectBegin()
@@ -352,6 +355,14 @@ func TestSessionStore_Create(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
+	// Pin the seeded primary thread's args so a regression that swaps fields
+	// (e.g. status defaulted to 'pending', or label hard-coded to the agent
+	// name) is caught by this test instead of slipping through under
+	// AnyArg() matchers. Order mirrors the named-args block in
+	// SessionStore.Create.
+	mock.ExpectExec("INSERT INTO session_threads").
+		WithArgs(generatedID, orgID, models.AgentType("claude_code"), &modelOverride, "Main", models.ThreadStatusIdle).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -399,6 +410,9 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
+	mock.ExpectExec("INSERT INTO session_threads").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectCommit()
 
 	err = store.Create(context.Background(), run)
@@ -443,6 +457,9 @@ func TestSessionStore_Create_RollsBackWhenPrimaryLinkInsertFails(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
+	mock.ExpectExec("INSERT INTO session_threads").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(context.DeadlineExceeded)

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -391,9 +391,10 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 	store := NewSessionStore(mock)
 	now := time.Now()
 	generatedID := uuid.New()
+	orgID := uuid.New()
 
 	run := &models.Session{
-		OrgID:         uuid.New(),
+		OrgID:         orgID,
 		AgentType:     "claude_code",
 		Status:        "pending",
 		AutonomyLevel: "supervised",
@@ -413,8 +414,12 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
+	// Pin the seeded primary thread args (label "Main", idle status, agent
+	// mirrored from the session, no model override) so a regression that
+	// changes any of these defaults is caught here as well as in the
+	// happy-path Create test.
 	mock.ExpectQuery("INSERT INTO session_threads").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(generatedID, orgID, models.AgentType("claude_code"), (*string)(nil), "Main", models.ThreadStatusIdle).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectCommit()
 
@@ -437,10 +442,11 @@ func TestSessionStore_Create_RollsBackWhenPrimaryLinkInsertFails(t *testing.T) {
 	now := time.Now()
 	generatedID := uuid.New()
 	issueID := uuid.New()
+	orgID := uuid.New()
 
 	run := &models.Session{
 		PrimaryIssueID: &issueID,
-		OrgID:          uuid.New(),
+		OrgID:          orgID,
 		AgentType:      "claude_code",
 		Status:         "pending",
 		AutonomyLevel:  "supervised",
@@ -460,8 +466,11 @@ func TestSessionStore_Create_RollsBackWhenPrimaryLinkInsertFails(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
+	// Pin the seeded primary thread args so a rollback regression that
+	// also corrupts the thread INSERT's defaults (label, status, mirrored
+	// agent_type) is caught here.
 	mock.ExpectQuery("INSERT INTO session_threads").
-		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WithArgs(generatedID, orgID, models.AgentType("claude_code"), (*string)(nil), "Main", models.ThreadStatusIdle).
 		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/db/auth_session_store_test.go
+++ b/internal/db/auth_session_store_test.go
@@ -328,6 +328,7 @@ func TestSessionStore_Create(t *testing.T) {
 	store := NewSessionStore(mock)
 	now := time.Now()
 	generatedID := uuid.New()
+	threadID := uuid.New()
 
 	issueID := uuid.New()
 	orgID := uuid.New()
@@ -360,9 +361,9 @@ func TestSessionStore_Create(t *testing.T) {
 	// name) is caught by this test instead of slipping through under
 	// AnyArg() matchers. Order mirrors the named-args block in
 	// SessionStore.Create.
-	mock.ExpectExec("INSERT INTO session_threads").
+	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(generatedID, orgID, models.AgentType("claude_code"), &modelOverride, "Main", models.ThreadStatusIdle).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(threadID))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
@@ -373,6 +374,8 @@ func TestSessionStore_Create(t *testing.T) {
 	require.Equal(t, generatedID, run.ID, "should set the generated ID on the agent run")
 	require.Equal(t, now, run.CreatedAt, "should set the created_at timestamp on the agent run")
 	require.Equal(t, now, run.LastActivityAt, "should set the last_activity_at timestamp on the agent run")
+	require.NotNil(t, run.PrimaryThreadID, "Create should expose the seeded primary thread ID")
+	require.Equal(t, threadID, *run.PrimaryThreadID, "Create should expose the seeded primary thread ID")
 	require.NotNil(t, run.PrimaryIssueID, "Create should preserve the primary issue ID for issue-backed sessions")
 	require.Equal(t, issueID, *run.PrimaryIssueID, "Create should preserve the primary issue ID on issue-backed sessions")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
@@ -410,9 +413,9 @@ func TestSessionStore_Create_AllowsNilIssueID(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
-	mock.ExpectExec("INSERT INTO session_threads").
+	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectCommit()
 
 	err = store.Create(context.Background(), run)
@@ -457,9 +460,9 @@ func TestSessionStore_Create_RollsBackWhenPrimaryLinkInsertFails(t *testing.T) {
 			pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).
 				AddRow(generatedID, now, now),
 		)
-	mock.ExpectExec("INSERT INTO session_threads").
+	mock.ExpectQuery("INSERT INTO session_threads").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectExec("INSERT INTO session_issue_links").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(context.DeadlineExceeded)

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -27,6 +27,17 @@ func RunAgentDedupeKey(sessionID uuid.UUID) string {
 	return "run_agent:" + sessionID.String()
 }
 
+func RunAgentPayload(run *models.Session) map[string]string {
+	payload := map[string]string{
+		"session_id": run.ID.String(),
+		"org_id":     run.OrgID.String(),
+	}
+	if run.PrimaryThreadID != nil && *run.PrimaryThreadID != uuid.Nil {
+		payload["thread_id"] = run.PrimaryThreadID.String()
+	}
+	return payload
+}
+
 // ContinueSessionDedupeKey returns the dedupe key used for continue_session
 // enqueues. Session-level (not thread-level) because the underlying sandbox
 // container is shared across threads — only one continue_session can hold

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -490,11 +490,13 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 	// destination from turn 1. Done in the same transaction so the invariant
 	// "every session row implies at least one thread row" cannot be violated
 	// by a partial failure between session insert and thread insert.
-	if _, err := tx.Exec(ctx, `
+	var primaryThreadID uuid.UUID
+	if err := tx.QueryRow(ctx, `
 		INSERT INTO session_threads (
 			session_id, org_id, agent_type, model_override, label, status
 		)
 		VALUES (@session_id, @org_id, @agent_type, @model_override, @label, @status)
+		RETURNING id
 	`, pgx.NamedArgs{
 		"session_id":     run.ID,
 		"org_id":         run.OrgID,
@@ -502,9 +504,10 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 		"model_override": run.ModelOverride,
 		"label":          "Main",
 		"status":         models.ThreadStatusIdle,
-	}); err != nil {
+	}).Scan(&primaryThreadID); err != nil {
 		return fmt.Errorf("insert primary session thread: %w", err)
 	}
+	run.PrimaryThreadID = &primaryThreadID
 
 	if run.PrimaryIssueID != nil {
 		if _, err := tx.Exec(ctx, `

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -63,23 +63,23 @@ type SessionFilters struct {
 	// the cursor). The inverse — a duplicate reappearing on an earlier page —
 	// only happens if the same page is re-fetched. The frontend dedupes by id,
 	// so this manifests as occasional reordering, not data loss.
-	CursorTime        *time.Time
-	CursorID          *uuid.UUID
-	AdHocOnly         bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
-	RepositoryID      uuid.UUID // When non-zero, filter sessions by repository via issues table.
-	TriggeredByUserID uuid.UUID // When non-zero, filter sessions to those triggered by this user.
+	CursorTime         *time.Time
+	CursorID           *uuid.UUID
+	AdHocOnly          bool      // When true, only return runs where pm_plan_id IS NULL (not linked to a PM plan).
+	RepositoryID       uuid.UUID // When non-zero, filter sessions by repository via issues table.
+	TriggeredByUserID  uuid.UUID // When non-zero, filter sessions to those triggered by this user.
 	TriggeredByUserIDs []uuid.UUID
-	Search            string    // When non-empty, filter sessions by title (case-insensitive prefix/substring match).
-	IncludeArchived   bool      // When true, include archived sessions in the results.
-	OnlyArchived      bool      // When true, return only archived sessions.
+	Search             string // When non-empty, filter sessions by title (case-insensitive prefix/substring match).
+	IncludeArchived    bool   // When true, include archived sessions in the results.
+	OnlyArchived       bool   // When true, return only archived sessions.
 }
 
 // SessionCountsFilters scopes CountsByOrg to a subset of sessions.
 // Status, archived, and search are not accepted — the counts endpoint
 // always returns totals for the all/active/archived buckets.
 type SessionCountsFilters struct {
-	RepositoryID      uuid.UUID
-	TriggeredByUserID uuid.UUID
+	RepositoryID       uuid.UUID
+	TriggeredByUserID  uuid.UUID
 	TriggeredByUserIDs []uuid.UUID
 }
 
@@ -484,6 +484,28 @@ func (s *SessionStore) Create(ctx context.Context, run *models.Session) error {
 	if err := row.Scan(&run.ID, &run.CreatedAt, &run.LastActivityAt); err != nil {
 		return err
 	}
+
+	// Seed a primary thread row so the multi-tab UI (AgentTabStrip) has
+	// something to render and the worker thread-attribution path has a
+	// destination from turn 1. Done in the same transaction so the invariant
+	// "every session row implies at least one thread row" cannot be violated
+	// by a partial failure between session insert and thread insert.
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO session_threads (
+			session_id, org_id, agent_type, model_override, label, status
+		)
+		VALUES (@session_id, @org_id, @agent_type, @model_override, @label, @status)
+	`, pgx.NamedArgs{
+		"session_id":     run.ID,
+		"org_id":         run.OrgID,
+		"agent_type":     run.AgentType,
+		"model_override": run.ModelOverride,
+		"label":          "Main",
+		"status":         models.ThreadStatusIdle,
+	}); err != nil {
+		return fmt.Errorf("insert primary session thread: %w", err)
+	}
+
 	if run.PrimaryIssueID != nil {
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO session_issue_links (org_id, session_id, issue_id, role, position, added_by_user_id)

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -181,6 +181,7 @@ type Issue struct {
 // issue linked (zero-issue sessions are a first-class execution path).
 type Session struct {
 	ID                  uuid.UUID               `db:"id" json:"id"`
+	PrimaryThreadID     *uuid.UUID              `db:"-" json:"-"`
 	PrimaryIssueID      *uuid.UUID              `db:"primary_issue_id" json:"primary_issue_id"`
 	OrgID               uuid.UUID               `db:"org_id" json:"org_id"`
 	Origin              SessionOrigin           `db:"origin" json:"origin"`

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -325,6 +325,12 @@ type SessionMessageStore interface {
 	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionMessage, error)
 }
 
+type SessionThreadStore interface {
+	UpdateStatus(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
+	CompleteTurn(ctx context.Context, orgID, threadID uuid.UUID, turnNumber int, agentSessionID string) error
+	UpdateResult(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus, result *models.SessionResult) error
+}
+
 type SessionIssueLinkStore interface {
 	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionIssueLink, error)
 }
@@ -410,6 +416,7 @@ type Orchestrator struct {
 	agentRunLogs      SessionLogStore
 	agentRunQuestions SessionQuestionStore
 	sessionMessages   SessionMessageStore
+	sessionThreads    SessionThreadStore
 	sessionIssueLinks SessionIssueLinkStore
 	issueSnapshots    SessionIssueSnapshotStore
 	decisionLog       DecisionLogStore
@@ -488,6 +495,7 @@ type OrchestratorConfig struct {
 	SessionLogs       SessionLogStore
 	SessionQuestions  SessionQuestionStore
 	SessionMessages   SessionMessageStore
+	SessionThreads    SessionThreadStore
 	SessionIssueLinks SessionIssueLinkStore
 	IssueSnapshots    SessionIssueSnapshotStore
 	DecisionLog       DecisionLogStore
@@ -569,6 +577,7 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 		agentRunLogs:      cfg.SessionLogs,
 		agentRunQuestions: cfg.SessionQuestions,
 		sessionMessages:   cfg.SessionMessages,
+		sessionThreads:    cfg.SessionThreads,
 		sessionIssueLinks: cfg.SessionIssueLinks,
 		issueSnapshots:    cfg.IssueSnapshots,
 		decisionLog:       cfg.DecisionLog,
@@ -1255,6 +1264,16 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if err := o.sessions.UpdateStatus(ctx, run.OrgID, run.ID, "running"); err != nil {
 		return fmt.Errorf("update run status to running: %w", err)
 	}
+	var primaryThreadID *uuid.UUID
+	if run.PrimaryThreadID != nil && *run.PrimaryThreadID != uuid.Nil {
+		threadID := *run.PrimaryThreadID
+		primaryThreadID = &threadID
+		if o.sessionThreads != nil {
+			if err := o.sessionThreads.UpdateStatus(ctx, run.OrgID, threadID, models.ThreadStatusRunning); err != nil {
+				log.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to mark primary thread running")
+			}
+		}
+	}
 	if run.PrimaryIssueID != nil && o.issues != nil {
 		if err := o.issues.UpdateStatus(ctx, run.OrgID, *run.PrimaryIssueID, "in_progress"); err != nil {
 			log.Warn().Err(err).Str("issue_id", run.PrimaryIssueID.String()).Msg("failed to update primary issue status to in_progress")
@@ -1699,7 +1718,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Add(1)
 	go func() {
 		defer logWg.Done()
-		o.streamLogs(ctx, run.ID, run.OrgID, nil, turnNumber, logCh, runtimeTracker)
+		o.streamLogs(ctx, run.ID, run.OrgID, primaryThreadID, turnNumber, logCh, runtimeTracker)
 	}()
 
 	execCtx := WithSandboxProvider(ctx, o.provider)
@@ -1708,7 +1727,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	logWg.Wait()
 
 	// 10b. Retry once on token expiration for Codex agents.
-	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, run.ID, nil, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
+	result, err = o.retryOnTokenExpired(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, run.ID, primaryThreadID, turnNumber, sandbox, adapter, execCtx, prompt, result, err, log)
 
 	// 10c. Shed the just-picked credential's in-process health-cache slot if
 	// the (possibly retried) result indicates a credential-level failure.
@@ -1757,6 +1776,11 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 		o.failRun(ctx, run, err.Error())
 		logAgentRunFailed(log, run, err, "failed", runStartedAt, nil)
+		if primaryThreadID != nil && o.sessionThreads != nil {
+			if threadErr := o.sessionThreads.UpdateStatus(ctx, run.OrgID, *primaryThreadID, models.ThreadStatusFailed); threadErr != nil {
+				log.Warn().Err(threadErr).Str("thread_id", primaryThreadID.String()).Msg("failed to mark primary thread failed")
+			}
+		}
 		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
 			"session_id": run.ID.String(),
 			"org_id":     run.OrgID.String(),
@@ -1820,7 +1844,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 
 	if isInteractive {
 		turnNumber := run.CurrentTurn + 1
-		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, nil, turnNumber, result); err != nil {
+		if err := o.createAssistantMessage(ctx, run.ID, run.OrgID, primaryThreadID, turnNumber, result); err != nil {
 			log.Warn().Err(err).Msg("failed to persist assistant message for interactive turn")
 		}
 
@@ -1830,6 +1854,11 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 		if err := o.sessions.UpdateTurnComplete(ctx, run.OrgID, run.ID, turnNumber, runResult, agentSessionID, snapshotKey); err != nil {
 			return fmt.Errorf("update interactive turn result: %w", err)
+		}
+		if primaryThreadID != nil && o.sessionThreads != nil {
+			if err := o.sessionThreads.CompleteTurn(ctx, run.OrgID, *primaryThreadID, turnNumber, agentSessionID); err != nil {
+				log.Warn().Err(err).Str("thread_id", primaryThreadID.String()).Msg("failed to mark primary thread turn complete")
+			}
 		}
 
 		log.Info().
@@ -1846,6 +1875,11 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 
 	if err := o.sessions.UpdateResult(ctx, run.OrgID, run.ID, status, runResult); err != nil {
 		return fmt.Errorf("update run result: %w", err)
+	}
+	if primaryThreadID != nil && o.sessionThreads != nil {
+		if err := o.sessionThreads.UpdateResult(ctx, run.OrgID, *primaryThreadID, models.ThreadStatusCompleted, runResult); err != nil {
+			log.Warn().Err(err).Str("thread_id", primaryThreadID.String()).Msg("failed to persist primary thread result")
+		}
 	}
 
 	// Persist snapshot metadata so the session can be continued later.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1776,11 +1776,9 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 		o.failRun(ctx, run, err.Error())
 		logAgentRunFailed(log, run, err, "failed", runStartedAt, nil)
-		if primaryThreadID != nil && o.sessionThreads != nil {
-			if threadErr := o.sessionThreads.UpdateStatus(ctx, run.OrgID, *primaryThreadID, models.ThreadStatusFailed); threadErr != nil {
-				log.Warn().Err(threadErr).Str("thread_id", primaryThreadID.String()).Msg("failed to mark primary thread failed")
-			}
-		}
+		o.updatePrimaryThreadTerminal(ctx, run, models.ThreadStatusFailed, &models.SessionResult{
+			Error: strPtr(err.Error()),
+		}, log)
 		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
 			"session_id": run.ID.String(),
 			"org_id":     run.OrgID.String(),
@@ -3185,6 +3183,10 @@ func (o *Orchestrator) failTimedOutSession(run *models.Session, elapsed time.Dur
 			"Retry the session — transient slowness (LLM latency, git clone) may have pushed the run over the edge",
 		},
 	)
+	o.updatePrimaryThreadTerminal(cleanupCtx, run, models.ThreadStatusFailed, &models.SessionResult{
+		Error:           &explanation,
+		FailureCategory: strPtr(FailureCategoryTimeout),
+	}, log)
 }
 
 // ensureCodexAuth injects Codex auth credentials into the sandbox, failing the
@@ -3666,11 +3668,18 @@ func (o *Orchestrator) handleCancelledSession(ctx context.Context, session *mode
 		if err := o.sessions.UpdateTurnComplete(bgCtx, session.OrgID, session.ID, turnNumber, nil, agentSessionID, snapshotKey); err != nil {
 			log.Warn().Err(err).Msg("failed to return cancelled session to idle")
 			_ = o.sessions.UpdateStatus(bgCtx, session.OrgID, session.ID, string(models.SessionStatusCancelled))
+			o.updatePrimaryThreadTerminal(bgCtx, session, models.ThreadStatusCancelled, nil, log)
 		} else {
 			log.Info().Int("turn", turnNumber).Msg("cancelled session returned to idle")
+			if o.sessionThreads != nil && session.PrimaryThreadID != nil && *session.PrimaryThreadID != uuid.Nil {
+				if threadErr := o.sessionThreads.CompleteTurn(bgCtx, session.OrgID, *session.PrimaryThreadID, turnNumber, agentSessionID); threadErr != nil {
+					log.Warn().Err(threadErr).Str("thread_id", session.PrimaryThreadID.String()).Msg("failed to return primary thread to idle after cancel")
+				}
+			}
 		}
 	} else {
 		_ = o.sessions.UpdateStatus(bgCtx, session.OrgID, session.ID, string(models.SessionStatusCancelled))
+		o.updatePrimaryThreadTerminal(bgCtx, session, models.ThreadStatusCancelled, nil, log)
 	}
 }
 
@@ -3786,6 +3795,10 @@ func (o *Orchestrator) handlePolicyStoppedSession(ctx context.Context, session *
 
 	errMsg, explanation, nextSteps := gracefulStopFailure(reason, snapshotKey != "", session.SnapshotKey != nil && *session.SnapshotKey != "")
 	o.failRunWithCategory(bgCtx, session, errMsg, FailureCategoryTimeout, explanation, nextSteps)
+	o.updatePrimaryThreadTerminal(bgCtx, session, models.ThreadStatusFailed, &models.SessionResult{
+		Error:           &explanation,
+		FailureCategory: strPtr(FailureCategoryTimeout),
+	}, log)
 }
 
 func gracefulStopFailure(reason StopReason, checkpointedThisTurn, hadPriorCheckpoint bool) (string, string, []string) {
@@ -3884,6 +3897,32 @@ func strPtr(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// updatePrimaryThreadTerminal mirrors a session-level terminal transition onto
+// the seeded primary thread row. When result is non-nil, it persists the same
+// failure_explanation / failure_category / result_summary / diff the session
+// got so per-thread review surfaces (Phase 2) have data to display; when nil,
+// it just transitions the status (e.g. cancel without a result payload). All
+// errors are logged best-effort because this is bookkeeping — a failure here
+// must not abort the surrounding session-level cleanup.
+func (o *Orchestrator) updatePrimaryThreadTerminal(ctx context.Context, run *models.Session, status models.ThreadStatus, result *models.SessionResult, log zerolog.Logger) {
+	if o.sessionThreads == nil || run == nil || run.PrimaryThreadID == nil || *run.PrimaryThreadID == uuid.Nil {
+		return
+	}
+	threadID := *run.PrimaryThreadID
+	var err error
+	if result != nil {
+		err = o.sessionThreads.UpdateResult(ctx, run.OrgID, threadID, status, result)
+	} else {
+		err = o.sessionThreads.UpdateStatus(ctx, run.OrgID, threadID, status)
+	}
+	if err != nil {
+		log.Warn().Err(err).
+			Str("thread_id", threadID.String()).
+			Str("status", string(status)).
+			Msg("failed to update primary thread terminal status")
+	}
 }
 
 func timePtr(t time.Time) *time.Time {

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -664,6 +664,7 @@ func (s *PRService) createRepairRevisionSession(ctx context.Context, pr models.P
 	msg := &models.SessionMessage{
 		SessionID:  session.ID,
 		OrgID:      session.OrgID,
+		ThreadID:   session.PrimaryThreadID,
 		UserID:     &userID,
 		TurnNumber: 0,
 		Role:       models.MessageRoleUser,
@@ -673,10 +674,7 @@ func (s *PRService) createRepairRevisionSession(ctx context.Context, pr models.P
 		return nil, err
 	}
 	dedupeKey := db.RunAgentDedupeKey(session.ID)
-	payload := map[string]string{
-		"session_id": session.ID.String(),
-		"org_id":     session.OrgID.String(),
-	}
+	payload := db.RunAgentPayload(session)
 	if _, err := s.jobs.EnqueueInTx(ctx, tx, session.OrgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return nil, err
 	}

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -939,6 +939,12 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 					).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(uuid.New(), now, now))
+				mock.ExpectExec("INSERT INTO session_threads").
+					WithArgs(
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						pgxmock.AnyArg(), pgxmock.AnyArg(),
+					).
+					WillReturnResult(pgxmock.NewResult("INSERT", 1))
 				mock.ExpectExec("INSERT INTO session_issue_links").
 					WithArgs(
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -939,12 +939,12 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 					).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(uuid.New(), now, now))
-				mock.ExpectExec("INSERT INTO session_threads").
+				mock.ExpectQuery("INSERT INTO session_threads").
 					WithArgs(
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 						pgxmock.AnyArg(), pgxmock.AnyArg(),
 					).
-					WillReturnResult(pgxmock.NewResult("INSERT", 1))
+					WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 				mock.ExpectExec("INSERT INTO session_issue_links").
 					WithArgs(
 						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),

--- a/internal/services/pm/execute.go
+++ b/internal/services/pm/execute.go
@@ -88,10 +88,7 @@ func (s *Service) executePlan(ctx context.Context, orgID uuid.UUID, plan *Plan, 
 		}
 
 		dedupeKey := db.RunAgentDedupeKey(run.ID)
-		payload := map[string]string{
-			"session_id": run.ID.String(),
-			"org_id":     orgID.String(),
-		}
+		payload := db.RunAgentPayload(run)
 		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 			s.logger.Error().Err(err).Str("session_id", run.ID.String()).Msg("failed to enqueue agent run job")
 			task.Status = models.PMTaskStatusSkippedCapacity

--- a/internal/services/pm/project_execute.go
+++ b/internal/services/pm/project_execute.go
@@ -248,10 +248,7 @@ func (s *Service) dispatchProjectTasks(ctx context.Context, orgID uuid.UUID, pro
 
 		// Enqueue the agent run job.
 		dedupeKey := db.RunAgentDedupeKey(run.ID)
-		payload := map[string]string{
-			"session_id": run.ID.String(),
-			"org_id":     orgID.String(),
-		}
+		payload := db.RunAgentPayload(run)
 		if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 			s.logger.Error().Err(err).Str("session_id", run.ID.String()).Msg("failed to enqueue project agent run")
 			continue

--- a/internal/services/prioritization/service.go
+++ b/internal/services/prioritization/service.go
@@ -344,10 +344,7 @@ func (s *Service) CheckAutoTrigger(ctx context.Context, orgID uuid.UUID, score *
 		return fmt.Errorf("create agent run: %w", err)
 	}
 
-	payload := map[string]string{
-		"session_id": run.ID.String(),
-		"org_id":     orgID.String(),
-	}
+	payload := db.RunAgentPayload(run)
 	dedupeKey := db.RunAgentDedupeKey(run.ID)
 	if _, err := s.jobs.Enqueue(ctx, orgID, "agent", "run_agent", payload, 5, &dedupeKey); err != nil {
 		return fmt.Errorf("enqueue run_agent job: %w", err)

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -544,10 +544,7 @@ func newAutomationRunHandler(stores *Stores, services *Services, logger zerolog.
 		// the job store rejects the second insert and the second handler
 		// returns cleanly without a duplicate agent run.
 		dedupeKey := db.RunAgentDedupeKey(session.ID)
-		agentPayload := map[string]string{
-			"session_id": session.ID.String(),
-			"org_id":     orgID.String(),
-		}
+		agentPayload := db.RunAgentPayload(session)
 		if _, err := stores.Jobs.Enqueue(ctx, orgID, "agent", "run_agent", agentPayload, 5, &dedupeKey); err != nil {
 			return fmt.Errorf("enqueue run_agent: %w", err)
 		}
@@ -855,6 +852,7 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 		var input struct {
 			SessionID string `json:"session_id"`
 			OrgID     string `json:"org_id"`
+			ThreadID  string `json:"thread_id"`
 		}
 		if err := json.Unmarshal(payload, &input); err != nil {
 			return fmt.Errorf("unmarshal run_agent payload: %w", err)
@@ -872,6 +870,22 @@ func newRunAgentHandler(stores *Stores, services *Services, logger zerolog.Logge
 		run, err := stores.Sessions.GetByID(ctx, orgID, runID)
 		if err != nil {
 			return fmt.Errorf("fetch agent run: %w", err)
+		}
+		if input.ThreadID != "" {
+			threadID, parseErr := uuid.Parse(input.ThreadID)
+			if parseErr != nil {
+				logger.Warn().Err(parseErr).Str("thread_id", input.ThreadID).Msg("invalid thread_id in run_agent payload")
+			} else {
+				run.PrimaryThreadID = &threadID
+			}
+		} else if stores.SessionThreads != nil {
+			threads, listErr := stores.SessionThreads.ListBySession(ctx, orgID, runID)
+			if listErr != nil {
+				logger.Warn().Err(listErr).Str("session_id", runID.String()).Msg("failed to load primary thread for run_agent")
+			} else if len(threads) > 0 {
+				threadID := threads[0].ID
+				run.PrimaryThreadID = &threadID
+			}
 		}
 
 		// Gate turn 1 on Linear pre-start preparation. If a session linked a

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2562,9 +2562,9 @@ func TestAutomationRunHandler_HappyPath(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(sessionID, now, now))
-	mock.ExpectExec(`INSERT INTO session_threads`).
+	mock.ExpectQuery(`INSERT INTO session_threads`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 	mock.ExpectCommit()
 
 	// 5. Enqueue run_agent (with dedupe key on the session ID).
@@ -3970,6 +3970,41 @@ func TestRunAgentHandler_PendingSessionUsesFreshRunPath(t *testing.T) {
 	require.NoError(t, err, "run_agent should succeed for a pending session")
 	require.Equal(t, 1, orch.runAgentCalls, "pending run_agent jobs should execute a fresh run")
 	require.Equal(t, 0, orch.recoverSessionCalls, "pending run_agent jobs should not enter recovery mode")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestRunAgentHandler_PassesPrimaryThreadIDFromPayload(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	runID := uuid.New()
+	threadID := uuid.New()
+	issueID := uuid.New()
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(runID, issueID, orgID, string(models.SessionStatusPending), 0, nil, nil)...,
+			),
+		)
+
+	orch := &orchestratorServiceStub{
+		runAgentFn: func(_ context.Context, run *models.Session) error {
+			require.NotNil(t, run.PrimaryThreadID, "run_agent should set the primary thread ID on the orchestrator session")
+			require.Equal(t, threadID, *run.PrimaryThreadID, "run_agent should pass the primary thread ID to the orchestrator")
+			return nil
+		},
+	}
+	handler := newRunAgentHandler(stores, &Services{Orchestrator: orch}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + runID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(context.Background(), "run_agent", payload)
+	require.NoError(t, err, "run_agent should accept a primary thread ID payload")
+	require.Equal(t, 1, orch.runAgentCalls, "pending run_agent jobs should execute a fresh run")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2562,6 +2562,9 @@ func TestAutomationRunHandler_HappyPath(t *testing.T) {
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "last_activity_at"}).AddRow(sessionID, now, now))
+	mock.ExpectExec(`INSERT INTO session_threads`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 	mock.ExpectCommit()
 
 	// 5. Enqueue run_agent (with dedupe key on the session ID).

--- a/migrations/000113_session_threads_backfill_primary.down.sql
+++ b/migrations/000113_session_threads_backfill_primary.down.sql
@@ -1,0 +1,15 @@
+-- Remove the auto-seeded primary thread rows. We can identify them by the
+-- well-known label and the fact that they are the only thread on the
+-- session — leaving any sessions where the user has since added more tabs
+-- alone, since deleting "Main" out from under them would orphan transcript
+-- and file-event rows that point at this thread_id.
+--
+-- Caveat: the Add-Tab dialog lets users override the auto-generated label,
+-- so a user-created tab labeled "Main" on a single-tab session would be
+-- swept up by this DELETE. This is a deliberate trade-off for migration
+-- simplicity — this down path is only meant for a clean, rapid revert. If
+-- the up has been live long enough for users to start manually labeling
+-- tabs "Main", coordinate the rollback manually rather than running this.
+DELETE FROM session_threads t
+WHERE t.label = 'Main'
+  AND (SELECT count(*) FROM session_threads x WHERE x.session_id = t.session_id) = 1;

--- a/migrations/000113_session_threads_backfill_primary.down.sql
+++ b/migrations/000113_session_threads_backfill_primary.down.sql
@@ -4,6 +4,12 @@
 -- alone, since deleting "Main" out from under them would orphan transcript
 -- and file-event rows that point at this thread_id.
 --
+-- FK behaviour: session_messages.thread_id and session_logs.thread_id are
+-- both `ON DELETE SET NULL` (migration 000045_fk_cascade_and_nullable), so
+-- the rows the up migration reattributed to the seeded primary will revert
+-- to NULL thread_id — i.e. exactly the legacy state from before the up
+-- migration ran. No transcript or log rows are deleted.
+--
 -- Caveat: the Add-Tab dialog lets users override the auto-generated label,
 -- so a user-created tab labeled "Main" on a single-tab session would be
 -- swept up by this DELETE. This is a deliberate trade-off for migration

--- a/migrations/000113_session_threads_backfill_primary.up.sql
+++ b/migrations/000113_session_threads_backfill_primary.up.sql
@@ -13,10 +13,50 @@
 -- "primary" tab matches the agent the session was started under. Status is
 -- 'idle' to match migration 108's default for never-run threads.
 
-INSERT INTO session_threads (session_id, org_id, agent_type, model_override, label, status)
-SELECT s.id, s.org_id, s.agent_type, s.model_override, 'Main', 'idle'
+INSERT INTO session_threads (session_id, org_id, agent_type, model_override, label, status, current_turn, last_activity_at, started_at, completed_at)
+SELECT
+  s.id,
+  s.org_id,
+  s.agent_type,
+  s.model_override,
+  'Main',
+  CASE
+    WHEN s.status = 'pending' THEN 'pending'
+    WHEN s.status = 'running' THEN 'running'
+    WHEN s.status = 'awaiting_input' THEN 'awaiting_input'
+    WHEN s.status = 'failed' THEN 'failed'
+    WHEN s.status = 'cancelled' THEN 'cancelled'
+    WHEN s.status IN ('completed', 'pr_created') THEN 'completed'
+    ELSE 'idle'
+  END,
+  s.current_turn,
+  s.last_activity_at,
+  s.started_at,
+  s.completed_at
 FROM sessions s
 WHERE s.deleted_at IS NULL
   AND NOT EXISTS (
     SELECT 1 FROM session_threads t WHERE t.session_id = s.id
 );
+
+-- Existing first-turn transcripts and logs predate thread attribution and
+-- have NULL thread_id. Once the primary tab exists, the UI fetches the
+-- selected tab's thread-scoped timeline, so assign unthreaded history to the
+-- single primary thread where that mapping is unambiguous.
+UPDATE session_messages m
+SET thread_id = t.id
+FROM session_threads t
+WHERE m.org_id = t.org_id
+  AND m.session_id = t.session_id
+  AND m.thread_id IS NULL
+  AND t.label = 'Main'
+  AND (SELECT count(*) FROM session_threads x WHERE x.org_id = t.org_id AND x.session_id = t.session_id) = 1;
+
+UPDATE session_logs l
+SET thread_id = t.id
+FROM session_threads t
+WHERE l.org_id = t.org_id
+  AND l.session_id = t.session_id
+  AND l.thread_id IS NULL
+  AND t.label = 'Main'
+  AND (SELECT count(*) FROM session_threads x WHERE x.org_id = t.org_id AND x.session_id = t.session_id) = 1;

--- a/migrations/000113_session_threads_backfill_primary.up.sql
+++ b/migrations/000113_session_threads_backfill_primary.up.sql
@@ -12,6 +12,14 @@
 -- The seeded row mirrors the session's agent_type and model_override so the
 -- "primary" tab matches the agent the session was started under. Status is
 -- 'idle' to match migration 108's default for never-run threads.
+--
+-- Rolling-deploy note: during the window where this migration has run but
+-- the matching app change has not, an old app pod can still create a
+-- thread-less session. That degrades gracefully — the worker run_agent
+-- handler falls back to ListBySession() and runs the session with NULL
+-- thread attribution (the pre-PR behaviour). New pods enforce the
+-- invariant; any leftover thread-less sessions can be cleaned up by
+-- re-running the INSERT below after the deploy settles.
 
 INSERT INTO session_threads (session_id, org_id, agent_type, model_override, label, status, current_turn, last_activity_at, started_at, completed_at)
 SELECT

--- a/migrations/000113_session_threads_backfill_primary.up.sql
+++ b/migrations/000113_session_threads_backfill_primary.up.sql
@@ -1,0 +1,22 @@
+-- Backfill a primary thread row for every session that has none.
+--
+-- PR #724 introduced multi-tab concurrency, but the AgentTabStrip in the
+-- session detail page renders nothing when a session has zero threads, and
+-- nothing in the create path was seeding a default row. Result: every
+-- pre-existing session — and every new session before the matching app
+-- change — was invisible to the multi-tab UI (no tabs, no "+" button, no
+-- fork menu). This backfill establishes the invariant that every session
+-- has at least one thread; the SessionStore.Create change keeps it true
+-- going forward.
+--
+-- The seeded row mirrors the session's agent_type and model_override so the
+-- "primary" tab matches the agent the session was started under. Status is
+-- 'idle' to match migration 108's default for never-run threads.
+
+INSERT INTO session_threads (session_id, org_id, agent_type, model_override, label, status)
+SELECT s.id, s.org_id, s.agent_type, s.model_override, 'Main', 'idle'
+FROM sessions s
+WHERE s.deleted_at IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM session_threads t WHERE t.session_id = s.id
+);


### PR DESCRIPTION
## Summary

The multi-tab UI shipped in #724 was invisible: `AgentTabStrip` returns null for sessions with zero threads, and nothing in the create path was inserting one. Now `SessionStore.Create` seeds a `Main` thread inside the existing transaction (mirroring the session's `agent_type` / `model_override`), and migration 113 backfills one row per existing non-deleted session that has none. Test fixture `seedSession` already routes through `SessionStore.Create`, so integration coverage is automatic; `TestSessionStore_Create` pins the seeded thread's args (label, status, agent type, model) so a future refactor can't silently break the values.

## Test plan

- [ ] `make lint && go test ./internal/db/...`
- [ ] Run migration 113 against a copy of prod, confirm one thread row per non-deleted session, no orphaned rows for soft-deleted sessions
- [ ] Open an existing session in the UI, confirm the tab strip + `+` button now render and a Claude-review tab can be added
