### PR TITLE
Add platform-health observability: dashboards, alerts, structured logs

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -492,6 +492,7 @@ func main() {
 
 		recoveryLoop := cluster.NewRecoveryLoop(nodeManager, jobStore, logger, 90*time.Second, 100)
 		go recoveryLoop.Start(ctx, 30*time.Second)
+		go worker.RunQueueHealthSampler(ctx, jobStore, logger, time.Minute)
 
 		usageRollupStore := db.NewUsageRollupStore(pool)
 		reaperOpts := []agent.SessionReaperOption{

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -1,7 +1,9 @@
 package deploy_test
 
 import (
+	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -88,4 +90,114 @@ func TestWorkerProvisioningHandlesAddressingEdgeCases(t *testing.T) {
 	require.Contains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP//./-}`, "provision.sh's NODE_ID default should use the full dotted-to-dash IP so workers across multiple /24s don't collide on \"worker-<last-octet>\"")
 	require.NotContains(t, string(provisionScript), `worker-${WORKER_PRIVATE_IP##*.}`, "provision.sh should not fall back to the last-octet-only default — it collides across /24s")
 	require.Contains(t, string(provisionScript), "private IPv4 addresses on real interfaces", "provision.sh should detect multi-homed hosts and require the operator to set WORKER_PRIVATE_IP explicitly rather than silently picking a NIC")
+}
+
+func TestGrafanaProvisionedDashboardsUseValidDatasourcesAndRangeQueries(t *testing.T) {
+	t.Parallel()
+
+	dashboardFiles, err := os.ReadDir("../deploy/grafana/provisioning/dashboards")
+	require.NoError(t, err, "test should read provisioned dashboard directory")
+	dashboardNames := make(map[string]bool, len(dashboardFiles))
+	for _, dashboardFile := range dashboardFiles {
+		dashboardNames[dashboardFile.Name()] = true
+	}
+	require.True(t, dashboardNames["platform-health.json"], "platform health dashboard should be provisioned from the repo")
+
+	for _, dashboardFile := range dashboardFiles {
+		if dashboardFile.IsDir() || !strings.HasSuffix(dashboardFile.Name(), ".json") {
+			continue
+		}
+		rawDashboard, err := os.ReadFile("../deploy/grafana/provisioning/dashboards/" + dashboardFile.Name())
+		require.NoError(t, err, "test should read each provisioned dashboard")
+
+		var dashboard struct {
+			UID    string `json:"uid"`
+			Title  string `json:"title"`
+			Panels []struct {
+				Type       string `json:"type"`
+				Title      string `json:"title"`
+				Datasource *struct {
+					UID string `json:"uid"`
+				} `json:"datasource"`
+				Targets []struct {
+					QueryType  string `json:"queryType"`
+					Expr       string `json:"expr"`
+					Datasource *struct {
+						UID string `json:"uid"`
+					} `json:"datasource"`
+				} `json:"targets"`
+			} `json:"panels"`
+		}
+		require.NoError(t, json.Unmarshal(rawDashboard, &dashboard), "provisioned dashboard %s should be valid JSON", dashboardFile.Name())
+		require.NotEmpty(t, dashboard.UID, "provisioned dashboard %s should declare a stable UID", dashboardFile.Name())
+		require.NotEmpty(t, dashboard.Title, "provisioned dashboard %s should declare a title", dashboardFile.Name())
+
+		for _, panel := range dashboard.Panels {
+			if panel.Datasource != nil && panel.Datasource.UID != "" && panel.Datasource.UID != "-- Grafana --" {
+				require.Equal(t, "victorialogs", panel.Datasource.UID, "dashboard %s panel %q should use the provisioned VictoriaLogs datasource UID", dashboardFile.Name(), panel.Title)
+			}
+			for _, target := range panel.Targets {
+				if target.Datasource != nil && target.Datasource.UID != "" {
+					require.Equal(t, "victorialogs", target.Datasource.UID, "dashboard %s panel %q target should use the provisioned VictoriaLogs datasource UID", dashboardFile.Name(), panel.Title)
+				}
+				if panel.Type != "timeseries" || !strings.Contains(target.Expr, "| stats") {
+					if dashboardFile.Name() == "platform-health.json" && panel.Type == "stat" && strings.Contains(target.Expr, "pending_runnable") {
+						require.Equal(t, "statsRange", target.QueryType, "platform health stat panel %q should use a range query so Grafana can reduce the latest bucket", panel.Title)
+					}
+					continue
+				}
+				require.Equal(t, "statsRange", target.QueryType, "time-series stats panel %q in dashboard %s should use the VictoriaLogs range query type", panel.Title, dashboardFile.Name())
+			}
+		}
+	}
+}
+
+func TestProductionAlertsUseValidLogsQLRangeFilters(t *testing.T) {
+	t.Parallel()
+
+	alerts, err := os.ReadFile("../deploy/vmalert/rules/production-alerts.yml")
+	require.NoError(t, err, "test should read production vmalert rules")
+
+	alertConfig := string(alerts)
+	require.NotContains(t, alertConfig, "status:[", "VictoriaLogs numeric ranges should use field:range[...] syntax so vmalert can parse the rules")
+	require.GreaterOrEqual(t, strings.Count(alertConfig, "status:range[500,599]"), 3, "API 5xx alert rules should filter inclusive 500-599 statuses with valid LogsQL range syntax")
+}
+
+func TestLoggingDesignDocsTrackProvisionedDashboardsAndAlerts(t *testing.T) {
+	t.Parallel()
+
+	design, err := os.ReadFile("../docs/design/47-logging-victorialogs.md")
+	require.NoError(t, err, "test should read the VictoriaLogs design doc")
+
+	designText := string(design)
+	require.NotContains(t, designText, "Dashboard and alert curation remain follow-up operational work.", "logging design doc should not describe provisioned dashboards and alerts as future work")
+	require.Contains(t, designText, "deploy/grafana/provisioning/dashboards/errors.json", "logging design doc should track the provisioned error dashboard")
+	require.Contains(t, designText, "deploy/vmalert/rules/production-alerts.yml", "logging design doc should track repo-owned alert rules")
+}
+
+func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+
+	require.Contains(t, deployText, `"$ROLE" = "logging"`, "deploy script should have logging-role handling")
+	require.Contains(t, deployText, "docker-compose.vector.yml", "logging deploy should sync the shared Vector compose include")
+	require.Contains(t, deployText, "deploy/vector.yaml", "logging deploy should sync Vector config for the logging node")
+	require.Contains(t, deployText, "deploy/grafana/provisioning", "logging deploy should sync Grafana provisioning files")
+	require.Contains(t, deployText, "deploy/vmalert/rules", "logging deploy should sync vmalert rules")
+	require.Contains(t, deployText, "rm -rf /opt/143/deploy/grafana/provisioning /opt/143/deploy/vmalert/rules", "logging deploy should remove stale provisioned dashboards and rules before syncing repo-owned config")
+
+	compose, err := os.ReadFile("../docker-compose.logging.yml")
+	require.NoError(t, err, "test should read logging compose file")
+	composeText := string(compose)
+	require.Contains(t, composeText, "docker-compose.vector.yml", "logging compose should include the shared Vector collector")
+	require.Contains(t, deployText, "SERVER_ROLE=%s", "logging deploy should write SERVER_ROLE=logging for Vector")
+	vectorCheck := deployText[strings.Index(deployText, "# Verify Vector is running"):]
+	require.Contains(t, vectorCheck, `"$ROLE" = "logging"`, "logging deploy should verify the logging-node Vector collector after stack recreation")
+
+	dashboardProvider, err := os.ReadFile("../deploy/grafana/provisioning/dashboards/dashboards.yml")
+	require.NoError(t, err, "test should read Grafana dashboard provider config")
+	require.Contains(t, string(dashboardProvider), "disableDeletion: false", "Grafana dashboard provisioning should remove dashboards deleted from the repo")
 }

--- a/deploy/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: '143-provisioned'
+    orgId: 1
+    folder: '143'
+    type: file
+    disableDeletion: false
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/grafana/provisioning/dashboards/errors.json
+++ b/deploy/grafana/provisioning/dashboards/errors.json
@@ -1,0 +1,520 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Operational error dashboard: PR creation/push failures, session problems, worker job failures, and supporting API/reaper signals. All panels query VictoriaLogs.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Headline counters",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 1,
+      "title": "PR creation errors",
+      "description": "Count of `open_pr failed` log lines from the worker over the dashboard time range.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "service:worker AND level:error AND _msg:\"open_pr failed\" | stats count() as errors"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "PR push errors",
+      "description": "Count of `push_pr_changes failed` log lines from the worker.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "service:worker AND level:error AND _msg:\"push_pr_changes failed\" | stats count() as errors"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 3,
+      "title": "Session timeouts",
+      "description": "Sessions that hit the configured wall-clock timeout (canonical log line in orchestrator.failTimedOutSession).",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "level:error AND _msg:\"session exceeded configured timeout\" | stats count() as timeouts"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 4,
+      "title": "Fatal worker jobs",
+      "description": "Background jobs that exhausted retries and were dead-lettered.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 12, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 10 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "service:worker AND level:error AND _msg:\"job failed (fatal, skipping retries)\" | stats count() as failures"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 5,
+      "title": "API 5xx errors",
+      "description": "Count of `request failed` log lines with HTTP status 500-599 from the API.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 16, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 25 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "service:api AND level:error AND _msg:\"request failed\" AND status:range[500,599] | stats count() as errors"
+        }
+      ]
+    },
+    {
+      "type": "stat",
+      "id": 6,
+      "title": "Reaper errors",
+      "description": "Stale-session reaper failures: usually indicate DB issues or an inconsistent session state.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 4, "x": 20, "y": 1 },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 1 },
+            { "color": "red", "value": 5 }
+          ]},
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "level:error AND _msg:~\"^reaper:\" | stats count() as errors"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 101,
+      "title": "PR pipeline errors over time",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 6 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 10,
+      "title": "PR creation errors / minute",
+      "description": "Time series of `open_pr failed` worker logs.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 7 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "service:worker AND level:error AND _msg:\"open_pr failed\" | stats count() as errors",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 11,
+      "title": "PR push errors / minute",
+      "description": "Time series of `push_pr_changes failed` worker logs.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 7 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "service:worker AND level:error AND _msg:\"push_pr_changes failed\" | stats count() as errors",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 102,
+      "title": "Session problems over time",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 15 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 20,
+      "title": "Session timeouts / minute",
+      "description": "Sessions that exceeded the configured wall-clock timeout.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "level:error AND _msg:\"session exceeded configured timeout\" | stats count() as timeouts",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 21,
+      "title": "Run state-write failures / minute",
+      "description": "Errors persisting run-state from the orchestrator: `failed to update run to failed`, `failed to persist log entry`, `failed to create agent run question`. Indicates DB pressure or an unhealthy session pipeline.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "level:error AND (_msg:\"failed to update run to failed\" OR _msg:\"failed to persist log entry\" OR _msg:\"failed to create agent run question\" OR _msg:\"failed to update run failure details\") | stats count() as errors",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 103,
+      "title": "Errors by service / endpoint",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 24 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 30,
+      "title": "Error log volume by service",
+      "description": "Total `level:error` lines bucketed by service. Useful for spotting which subsystem is unhappy.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 25 },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "statsRange",
+          "expr": "level:error | stats by (service) count() as errors",
+          "step": "$__interval"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "id": 31,
+      "title": "Top error messages (range)",
+      "description": "Top distinct error messages in the dashboard time range. Click a row to scope further investigation.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 25 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "displayMode": "auto" },
+          "color": { "mode": "thresholds" },
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "red", "value": 50 }
+          ]}
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "stats",
+          "expr": "level:error | stats by (service, _msg) count() as count | sort by (count desc) | limit 25"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "id": 104,
+      "title": "Recent error log lines",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 33 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "logs",
+      "id": 40,
+      "title": "Recent PR / push / session errors (raw logs)",
+      "description": "Live tail of the error lines that drive the panels above.",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 34 },
+      "options": {
+        "showTime": true,
+        "showLabels": false,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "prettifyLogMessage": false,
+        "enableLogDetails": true,
+        "dedupStrategy": "none",
+        "sortOrder": "Descending"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "instant",
+          "expr": "level:error AND (_msg:\"open_pr failed\" OR _msg:\"push_pr_changes failed\" OR _msg:\"session exceeded configured timeout\" OR _msg:\"job failed (fatal, skipping retries)\" OR _msg:~\"^reaper:\")",
+          "maxLines": 200
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["143", "errors", "operations"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "143 — Error overview",
+  "uid": "errors-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/dashboards/platform-health.json
+++ b/deploy/grafana/provisioning/dashboards/platform-health.json
@@ -1,0 +1,246 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Platform health dashboard: queue pressure, agent/session outcomes, API traffic and latency, and sandbox/runtime health. All panels query VictoriaLogs.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "type": "row",
+      "id": 100,
+      "title": "Job queue health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "id": 1,
+      "title": "Runnable jobs",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 0, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "area", "justifyMode": "auto" },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 5 }, { "color": "red", "value": 20 }] } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: job queue sample\" | stats sum(pending_runnable) as runnable", "step": "$__interval" }]
+    },
+    {
+      "type": "stat",
+      "id": 2,
+      "title": "Oldest runnable job",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 5, "w": 6, "x": 6, "y": 1 },
+      "options": { "reduceOptions": { "calcs": ["max"], "fields": "", "values": false }, "orientation": "auto", "textMode": "auto", "colorMode": "background", "graphMode": "area", "justifyMode": "auto" },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "thresholds" }, "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 60 }, { "color": "red", "value": 300 }] } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: job queue sample\" | stats max(oldest_runnable_age_seconds) as oldest_seconds", "step": "$__interval" }]
+    },
+    {
+      "type": "timeseries",
+      "id": 3,
+      "title": "Runnable jobs by type",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: job queue sample\" | stats by (job_type) max(pending_runnable) as runnable", "step": "$__interval" }]
+    },
+    {
+      "type": "timeseries",
+      "id": 4,
+      "title": "Oldest runnable age by type",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 6 },
+      "fieldConfig": { "defaults": { "unit": "s", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["max"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: job queue sample\" | stats by (job_type) max(oldest_runnable_age_seconds) as oldest_seconds", "step": "$__interval" }]
+    },
+    {
+      "type": "table",
+      "id": 5,
+      "title": "Queue snapshot by job type",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "displayMode": "auto" } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "stats", "expr": "_msg:\"platform health: job queue sample\" | stats by (queue, job_type) max(pending_runnable) as pending_runnable, max(pending_deferred) as pending_deferred, max(running) as running, max(dead_letter) as dead_letter, max(oldest_runnable_age_seconds) as oldest_runnable_age_seconds | sort by (pending_runnable desc)" }]
+    },
+    {
+      "type": "row",
+      "id": 200,
+      "title": "Session and agent outcomes",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 20,
+      "title": "Agent starts and finishes",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 45, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "refId": "A", "queryType": "statsRange", "expr": "_msg:\"starting run_agent job\" | stats count() as starts", "step": "$__interval" },
+        { "refId": "B", "queryType": "statsRange", "expr": "_msg:\"agent run finished\" | stats count() as finishes", "step": "$__interval" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 21,
+      "title": "Agent outcomes by type",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 45, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "(_msg:\"agent run finished\" OR _msg:\"agent run failed\") | stats by (agent_type, outcome) count() as sessions", "step": "$__interval" }]
+    },
+    {
+      "type": "timeseries",
+      "id": 22,
+      "title": "Agent p95 duration by type",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"agent run finished\" | stats by (agent_type) quantile(0.95, duration_ms) as p95_ms", "step": "$__interval" }]
+    },
+    {
+      "type": "table",
+      "id": 23,
+      "title": "Failure and timeout reasons",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "displayMode": "auto" } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "stats", "expr": "(_msg:\"agent run failed\" OR _msg:\"session exceeded configured timeout\") | stats by (agent_type, outcome, stop_reason, error) count() as count | sort by (count desc) | limit 25" }]
+    },
+    {
+      "type": "row",
+      "id": 300,
+      "title": "API latency and traffic",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 30,
+      "title": "Request rate by status",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 35, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "service:api AND (_msg:\"request\" OR _msg:\"request failed\") | stats by (status_class) count() as requests", "step": "$__interval" }]
+    },
+    {
+      "type": "timeseries",
+      "id": 31,
+      "title": "API p95 / p99 duration",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "fieldConfig": { "defaults": { "unit": "ms", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "refId": "A", "queryType": "statsRange", "expr": "service:api AND (_msg:\"request\" OR _msg:\"request failed\") | stats quantile(0.95, duration_ms) as p95_ms", "step": "$__interval" },
+        { "refId": "B", "queryType": "statsRange", "expr": "service:api AND (_msg:\"request\" OR _msg:\"request failed\") | stats quantile(0.99, duration_ms) as p99_ms", "step": "$__interval" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 32,
+      "title": "API 5xx rate",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 45, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "service:api AND level:error AND _msg:\"request failed\" AND status:range[500,599] | stats count() as errors", "step": "$__interval" }]
+    },
+    {
+      "type": "table",
+      "id": 33,
+      "title": "Slowest endpoints",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "displayMode": "auto" } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "stats", "expr": "service:api AND (_msg:\"request\" OR _msg:\"request failed\") | stats by (method, path) quantile(0.95, duration_ms) as p95_ms, count() as requests | sort by (p95_ms desc) | limit 25" }]
+    },
+    {
+      "type": "row",
+      "id": 400,
+      "title": "Sandbox and runtime health",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "collapsed": false,
+      "panels": []
+    },
+    {
+      "type": "timeseries",
+      "id": 40,
+      "title": "Sandbox failure signals",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 57 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 45, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "normal" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "level:error AND (_msg:\"sandbox creation failed during continue_session\" OR _msg:\"sandbox hydrate failed during continue_session\" OR _msg:\"failed to destroy sandbox\" OR _msg:\"failed to snapshot session, session will not support follow-up turns\") | stats by (_msg) count() as failures", "step": "$__interval" }]
+    },
+    {
+      "type": "timeseries",
+      "id": 41,
+      "title": "Runtime utilization maxima",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 57 },
+      "fieldConfig": { "defaults": { "unit": "percentunit", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "line", "fillOpacity": 10, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["max"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
+      "targets": [
+        { "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: runtime sample\" | stats max(max_memory_util) as max_memory_util", "step": "$__interval" },
+        { "refId": "B", "queryType": "statsRange", "expr": "_msg:\"platform health: runtime sample\" | stats max(max_cpu_util) as max_cpu_util", "step": "$__interval" }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "id": 42,
+      "title": "Runtime sampler failures",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 65 },
+      "fieldConfig": { "defaults": { "unit": "short", "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 45, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "showPoints": "never", "stacking": { "group": "A", "mode": "none" } } }, "overrides": [] },
+      "options": { "legend": { "calcs": ["sum"], "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "single", "sort": "none" } },
+      "targets": [{ "refId": "A", "queryType": "statsRange", "expr": "_msg:\"platform health: runtime sample\" | stats sum(sample_failures) as sample_failures", "step": "$__interval" }]
+    },
+    {
+      "type": "table",
+      "id": 43,
+      "title": "Sandbox auth and credential wiring failures",
+      "datasource": { "type": "victoriametrics-logs-datasource", "uid": "victorialogs" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 65 },
+      "options": { "showHeader": true },
+      "fieldConfig": { "defaults": { "custom": { "align": "auto", "displayMode": "auto" } }, "overrides": [] },
+      "targets": [{ "refId": "A", "queryType": "stats", "expr": "(level:error OR level:warn) AND (_msg:~\"sandbox auth\" OR _msg:~\"auth wiring\" OR _msg:~\"credential\" OR _msg:~\"installation token\") | stats by (_msg) count() as count | sort by (count desc) | limit 25" }]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": ["143", "health", "operations"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "143 - Platform Health",
+  "uid": "platform-health",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/grafana/provisioning/datasources/victorialogs.yml
+++ b/deploy/grafana/provisioning/datasources/victorialogs.yml
@@ -1,6 +1,7 @@
 apiVersion: 1
 datasources:
   - name: VictoriaLogs
+    uid: victorialogs
     type: victoriametrics-logs-datasource
     access: proxy
     url: http://victorialogs:9428

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -81,8 +81,8 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for logging role (set it or add to .env.production.enc)}"
     GRAFANA_ALERTS_WARNING_WEBHOOK_URL="${GRAFANA_ALERTS_WARNING_WEBHOOK_URL:-$DISABLED_WARNING_WEBHOOK_URL}"
     GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL="${GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL:-$DISABLED_CRITICAL_WEBHOOK_URL}"
-    printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
-      "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
+    printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
+      "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "logging" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" 'cat > /opt/143/.env && chmod 600 /opt/143/.env'
   elif [ "$ROLE" = "db" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for db role (set it or add to .env.production.enc)}"
@@ -139,10 +139,15 @@ fi
 
 # Sync compose file so the remote always runs the latest version
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" deploy@"$HOST":/opt/143/
-if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; then
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" deploy@"$HOST":/opt/143/
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "mkdir -p /opt/143/deploy /opt/143/deploy/scripts"
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
+fi
+if [ "$ROLE" = "logging" ]; then
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" "rm -rf /opt/143/deploy/grafana/provisioning /opt/143/deploy/vmalert/rules && mkdir -p /opt/143/deploy/grafana /opt/143/deploy/vmalert"
+  scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/grafana/provisioning" deploy@"$HOST":/opt/143/deploy/grafana/
+  scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vmalert/rules" deploy@"$HOST":/opt/143/deploy/vmalert/
 fi
 if [ "$ROLE" = "app" ]; then
   # Sync Caddyfile so the remote always has the latest reverse-proxy config.
@@ -527,8 +532,8 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
   fi
 
-  # Verify Vector is running on app/worker nodes
-  if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+  # Verify Vector is running on app/worker/logging nodes
+  if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; then
     echo "Checking Vector log collector..."
     VECTOR_ID="$(docker compose -f "$COMPOSE_FILE" ps -q vector)"
     if [ -z "$VECTOR_ID" ]; then

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -239,7 +239,7 @@ fi
 # Step 2: Copy compose file and deploy configs
 echo "--- Step 2/5: Copying config files ---"
 scp "${SCP_OPTS[@]}" "$PROJECT_DIR/$COMPOSE_FILE" root@"$HOST":/opt/143/
-if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ]; then
+if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; then
   # Vector collector is included from the main compose file
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" root@"$HOST":/opt/143/
 fi
@@ -259,8 +259,8 @@ fi
 echo "--- Step 3/5: Writing secrets ---"
 if [ "$ROLE" = "logging" ]; then
   # Logging nodes need the Grafana admin password and the private IP for binding VictoriaLogs
-  printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
-    "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
+  printf 'GRAFANA_ADMIN_PASSWORD=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nGRAFANA_ALERTS_WARNING_WEBHOOK_URL=%s\nGRAFANA_ALERTS_CRITICAL_WEBHOOK_URL=%s\n' \
+    "$GRAFANA_ADMIN_PASSWORD" "$VICTORIALOGS_HOST" "logging" "$GRAFANA_ALERTS_WARNING_WEBHOOK_URL" "$GRAFANA_ALERTS_CRITICAL_WEBHOOK_URL" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 elif [ "$ROLE" = "db" ]; then
   printf 'DB_PASSWORD=%s\n' "$DB_PASSWORD" \

--- a/deploy/vmalert/rules/production-alerts.yml
+++ b/deploy/vmalert/rules/production-alerts.yml
@@ -4,7 +4,7 @@ groups:
     interval: 1m
     rules:
       - alert: API5xxBurstWarning
-        expr: '_time:5m service:api AND level:error AND _msg:"request failed" AND status:[500,599] | stats count() as errors | filter errors:>9'
+        expr: '_time:5m service:api AND level:error AND _msg:"request failed" AND status:range[500,599] | stats count() as errors | filter errors:>9'
         for: 1m
         labels:
           service: api
@@ -14,9 +14,9 @@ groups:
         annotations:
           summary: 'API 5xx burst warning'
           description: 'The API emitted {{ $value }} server-error responses in the last 5 minutes.'
-          runbook: 'Check VictoriaLogs for service=api level=error _msg="request failed" status:[500,599].'
+          runbook: 'Check VictoriaLogs for service=api level=error _msg="request failed" status:range[500,599].'
       - alert: API5xxBurstCritical
-        expr: '_time:5m service:api AND level:error AND _msg:"request failed" AND status:[500,599] | stats count() as errors | filter errors:>24'
+        expr: '_time:5m service:api AND level:error AND _msg:"request failed" AND status:range[500,599] | stats count() as errors | filter errors:>24'
         for: 1m
         labels:
           service: api
@@ -26,9 +26,9 @@ groups:
         annotations:
           summary: 'API 5xx burst critical'
           description: 'The API emitted {{ $value }} server-error responses in the last 5 minutes.'
-          runbook: 'Check VictoriaLogs for service=api level=error _msg="request failed" status:[500,599].'
+          runbook: 'Check VictoriaLogs for service=api level=error _msg="request failed" status:range[500,599].'
       - alert: EndpointFailureBurst
-        expr: '_time:10m service:api AND level:error AND _msg:"request failed" AND status:[500,599] | stats by (path) count() as errors | filter errors:>4 | fields path, errors'
+        expr: '_time:10m service:api AND level:error AND _msg:"request failed" AND status:range[500,599] | stats by (path) count() as errors | filter errors:>4 | fields path, errors'
         for: 1m
         labels:
           service: api
@@ -92,6 +92,64 @@ groups:
           summary: 'Worker fatal failures critical'
           description: 'Workers logged {{ $value }} fatal job failures in the last 10 minutes.'
           runbook: 'Treat this as an async pipeline incident and inspect worker logs, job backlog, and DB health.'
+
+  - name: pr-pipeline-errors
+    type: vlogs
+    interval: 1m
+    rules:
+      - alert: PRCreationErrorBurst
+        expr: '_time:15m service:worker AND level:error AND _msg:"open_pr failed" | stats count() as failures | filter failures:>4'
+        for: 1m
+        labels:
+          service: worker
+          severity: warning
+          team: platform
+          signal: logs
+        annotations:
+          summary: 'PR creation failures elevated'
+          description: 'Workers logged {{ $value }} `open_pr failed` errors in the last 15 minutes.'
+          runbook: 'Filter VictoriaLogs for service=worker _msg="open_pr failed". Check the wrapped error for git/GitHub auth, sandbox push, or createPullRequest API issues.'
+      - alert: PRPushErrorBurst
+        expr: '_time:15m service:worker AND level:error AND _msg:"push_pr_changes failed" | stats count() as failures | filter failures:>4'
+        for: 1m
+        labels:
+          service: worker
+          severity: warning
+          team: platform
+          signal: logs
+        annotations:
+          summary: 'PR push (push_pr_changes) failures elevated'
+          description: 'Workers logged {{ $value }} `push_pr_changes failed` errors in the last 15 minutes.'
+          runbook: 'Filter VictoriaLogs for service=worker _msg="push_pr_changes failed". Common causes: snapshot hydration, git push (token / branch protection), or sandbox creation.'
+
+  - name: session-problems
+    type: vlogs
+    interval: 1m
+    rules:
+      - alert: SessionTimeoutBurst
+        expr: '_time:30m level:error AND _msg:"session exceeded configured timeout" | stats count() as timeouts | filter timeouts:>9'
+        for: 1m
+        labels:
+          service: worker
+          severity: warning
+          team: platform
+          signal: logs
+        annotations:
+          summary: 'Session timeouts elevated'
+          description: '{{ $value }} sessions hit the configured wall-clock timeout in the last 30 minutes.'
+          runbook: 'Inspect orchestrator logs for stuck adapters, sandbox exec hangs, or misconfigured per-session deadlines.'
+      - alert: ReaperErrorBurst
+        expr: '_time:15m level:error AND _msg:~"^reaper:" | stats count() as errors | filter errors:>4'
+        for: 1m
+        labels:
+          service: worker
+          severity: warning
+          team: platform
+          signal: logs
+        annotations:
+          summary: 'Session reaper errors elevated'
+          description: 'The session reaper logged {{ $value }} errors in the last 15 minutes.'
+          runbook: 'Reaper errors usually indicate DB pressure or stale rows it cannot reconcile. Check DB health and recent reaper code paths.'
 
 # Scheduler heartbeat and queue backlog alerts are intentionally not yet
 # encoded here. The current system does not emit a dedicated scheduler

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -3,6 +3,9 @@
 # Access Grafana via SSH tunnel: make logs SSH_KEY=~/.ssh/143-deploy
 # See docs/design/47-logging-victorialogs.md
 
+include:
+  - docker-compose.vector.yml
+
 services:
   victorialogs:
     image: victoriametrics/victoria-logs:v1.50.0

--- a/docs/design/47-logging-victorialogs.md
+++ b/docs/design/47-logging-victorialogs.md
@@ -1,10 +1,10 @@
 # Design: Centralized Logging with VictoriaLogs
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-04-21
+> **Status:** Partially Implemented | **Last reviewed:** 2026-05-04
 >
-> **Implementation notes:** VictoriaLogs/Grafana Docker Compose, Vector collector config, logging-node cloud-init, deploy/provision script support, and `make logs` / `make logs-query` are implemented. Dashboard and alert curation remain follow-up operational work.
+> **Implementation notes:** VictoriaLogs/Grafana Docker Compose, Vector collector config, logging-node cloud-init, deploy/provision script support, `make logs` / `make logs-query`, provisioned Grafana error and platform health dashboards, and repo-owned `vmalert` alert rules are implemented. Scheduler heartbeat alerts remain follow-up operational work.
 
-Self-hosted VictoriaLogs + Grafana stack on a dedicated Hetzner logging server, with Vector collectors on the app and worker servers.
+Self-hosted VictoriaLogs + Grafana stack on a dedicated Hetzner logging server, with Vector collectors on the app, worker, and logging servers.
 
 ## Motivation
 
@@ -338,16 +338,19 @@ Provisioning workflow:
 
 ### Step 2: Deploy Vector Collectors
 
-1. Add `VICTORIALOGS_HOST` (logging server's private IP) and `SERVER_ROLE` to the `.env` on both app and worker servers. Update provisioning/deploy scripts to include these vars (see A.2 and A.3 changes below).
-2. Add `docker-compose.vector.yml` to the repo and `include` it from `docker-compose.app.yml` and `docker-compose.worker.yml`
-3. Deploy both — Vector starts collecting Docker logs immediately
+1. Add `VICTORIALOGS_HOST` (logging server's private IP) and `SERVER_ROLE` to the `.env` on app, worker, and logging servers. Update provisioning/deploy scripts to include these vars (see A.2 and A.3 changes below).
+2. Add `docker-compose.vector.yml` to the repo and `include` it from `docker-compose.app.yml`, `docker-compose.worker.yml`, and `docker-compose.logging.yml`
+3. Deploy the nodes — Vector starts collecting Docker logs immediately, including logging-node services such as `disk-monitor`
 4. Verify logs appear in Grafana
 
 ### Step 3: Set Up Dashboards and Alerts
 
-1. Create Grafana dashboards for key views (errors by service, agent run logs, request logs)
-2. Configure Grafana alerts (error rate spikes, agent run failures, sandbox OOM)
-3. Update `09-observability.md` and `10-infrastructure.md` to reference VictoriaLogs
+1. The provisioned error drilldown dashboard lives at `deploy/grafana/provisioning/dashboards/errors.json` and covers PR creation/push failures, session problems, worker fatal jobs, API 5xxs, reaper errors, top error messages, and raw recent error logs.
+2. The provisioned platform health dashboard lives at `deploy/grafana/provisioning/dashboards/platform-health.json` and covers job queue health, session/agent outcomes, API latency and traffic, and sandbox/runtime health from structured log signals.
+3. The Grafana dashboard provider uses `disableDeletion: false`, so removed dashboard JSON files are deleted from Grafana after provisioning resync.
+4. The repo-owned alert rules live at `deploy/vmalert/rules/production-alerts.yml` and are evaluated by `vmalert` against VictoriaLogs, then routed through Alertmanager.
+5. `deploy-logging` syncs `deploy/grafana/provisioning/`, `deploy/vmalert/rules/`, `docker-compose.vector.yml`, and `deploy/vector.yaml` before recreating the logging stack. This makes dashboard, datasource, Vector, and alert rule edits apply through normal deploys.
+6. Scheduler heartbeat alerts should wait for dedicated heartbeat signals so the rules are not guesswork.
 
 ## LogsQL Query Examples
 
@@ -373,7 +376,10 @@ org_id:"org-456" AND _time:[now-1h,now]
 trace_id:"tr-789" OR request_id:"req-012"
 
 # Numeric range filter (e.g. response times over 1 second)
-service:api AND response_time_ms:range(1000, Inf)
+service:api AND duration_ms:range(1000, Inf)
+
+# API request traffic by status class
+service:api AND (_msg:"request" OR _msg:"request failed") | stats by (status_class) count() as requests
 ```
 
 ## Alerting
@@ -408,6 +414,7 @@ The repo-owned production rule set now lives in `deploy/vmalert/rules/production
 - `vmalert` for rule evaluation
 - `Alertmanager` for grouping and delivery
 - `Grafana` for dashboards and alert visibility via the provisioned Alertmanager datasource
+- `Vector` for collecting logging-node container logs, including `disk-monitor`
 
 ## Resource Budget
 

--- a/docs/design/54-production-alerting.md
+++ b/docs/design/54-production-alerting.md
@@ -144,7 +144,7 @@ These are the first Grafana-managed alert rules 143.dev should create.
 **Signal**
 
 - Log-derived count from VictoriaLogs
-- Query shape: `service:api AND level:error AND _msg:"request failed" AND status:[500,599] AND _time:[now-5m,now]`
+- Query shape: `service:api AND level:error AND _msg:"request failed" AND status:range[500,599] AND _time:[now-5m,now]`
 
 **Initial threshold**
 
@@ -239,7 +239,7 @@ This is user-visible but usually not page-worthy unless it becomes sustained and
 
 ## How to Create the Grafana Alerts
 
-1. Confirm the VictoriaLogs datasource in Grafana sees the extracted fields `service`, `level`, `path`, `status`, `error_code`, and `error_message`.
+1. Confirm the VictoriaLogs datasource in Grafana sees the extracted fields `service`, `level`, `path`, `status`, `status_class`, `duration_ms`, `error_code`, and `error_message`.
 2. Build a small dashboard first in Explore to validate each query against recent data.
 3. For log-derived alerts, keep the rule definitions in version-controlled `vmalert` YAML instead of Grafana-managed rules. The current VictoriaLogs Grafana datasource is excellent for querying and dashboards, but it is not a dependable source of truth for provisioning Grafana-managed log alerts end to end.
 4. Use Alertmanager as the runtime notification router for `vmalert` rules. Grafana remains the operator UI via a provisioned Alertmanager datasource.
@@ -257,8 +257,12 @@ This is user-visible but usually not page-worthy unless it becomes sustained and
 The initial repo-owned files for this live in:
 
 - `deploy/grafana/provisioning/datasources/alertmanager.yml`
+- `deploy/grafana/provisioning/dashboards/errors.json`
+- `deploy/grafana/provisioning/dashboards/platform-health.json`
 - `deploy/vmalert/rules/production-alerts.yml`
-- `docker-compose.logging.yml` for the `vmalert` + Alertmanager runtime wiring
+- `docker-compose.logging.yml` for the `vmalert`, Alertmanager, Grafana, VictoriaLogs, and logging-node Vector runtime wiring
+
+`deploy-logging` is the source-of-truth path for these files: it syncs Grafana provisioning, vmalert rules, the shared Vector compose include, and Vector config to `/opt/143` on the logging node, then recreates the logging stack so rules reload reliably. Grafana also watches the provisioned dashboard directory and removes dashboards whose JSON files have been deleted from the repo.
 
 ## Automation Policy for Backend Sentry
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -325,7 +325,7 @@ Single system of record. Bundled in Docker Compose for local dev, swappable to m
 
 ## Logging & Monitoring
 
-- **VictoriaLogs + Grafana**: Primary centralized logging and operational alerting. Structured JSON logs are shipped by Vector and queried in Grafana. The logging stack tolerates missing warning/critical webhook URLs by falling back to disabled local sinks so observability deploys do not block on notification wiring. This is the current production observability backbone.
+- **VictoriaLogs + Grafana**: Primary centralized logging, provisioned dashboards, and operational alerting. Structured JSON logs are shipped by Vector and queried in Grafana. Repo-owned dashboards and `vmalert` rules are synced by `deploy-logging` so observability config changes apply with normal logging-node deploys. The logging stack tolerates missing warning/critical webhook URLs by falling back to disabled local sinks so observability deploys do not block on notification wiring. This is the current production observability backbone.
 - **Sentry**: Primary exception monitoring and developer-facing error triage. Frontend SDKs are already configured; backend exception capture should be added so Sentry becomes the system of record for application errors.
 - **Alerting model**: Page on aggregated service symptoms in Grafana; send exception issues from Sentry primarily to Slack unless they meet a paging threshold. See [54-production-alerting.md](54-production-alerting.md).
 

--- a/internal/api/middleware/logging.go
+++ b/internal/api/middleware/logging.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/assembledhq/143/internal/models"
@@ -74,6 +75,7 @@ func Logging(logger zerolog.Logger, reporter observability.Reporter) func(http.H
 			start := time.Now()
 			rw := &responseWriter{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(rw, r)
+			duration := time.Since(start)
 
 			logEvent := logger.Info()
 			if rw.status >= http.StatusInternalServerError {
@@ -87,7 +89,9 @@ func Logging(logger zerolog.Logger, reporter observability.Reporter) func(http.H
 				Str("path", r.URL.Path).
 				Str("request_id", chiMiddleware.GetReqID(r.Context())).
 				Int("status", rw.status).
-				Dur("duration", time.Since(start))
+				Str("status_class", strconv.Itoa(rw.status/100)+"xx").
+				Dur("duration", duration).
+				Float64("duration_ms", observability.DurationMillis(duration))
 
 			if rw.status >= http.StatusBadRequest {
 				if rw.errorResponse != nil && rw.errorResponse.Error.Code != "" {

--- a/internal/api/middleware/logging_test.go
+++ b/internal/api/middleware/logging_test.go
@@ -169,6 +169,29 @@ func TestLogging_ErrorResponsesAreLoggedAtErrorLevel(t *testing.T) {
 	}
 }
 
+func TestLogging_EmitsNumericDurationMilliseconds(t *testing.T) {
+	t.Parallel()
+
+	var logBuffer bytes.Buffer
+	logger := zerolog.New(&logBuffer)
+	handler := Logging(logger, nil)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	var logEvent map[string]any
+	require.NoError(t, json.Unmarshal(logBuffer.Bytes(), &logEvent), "logging middleware should emit valid JSON log event")
+	require.Contains(t, logEvent, "duration", "logging middleware should keep the existing zerolog duration field")
+	require.Equal(t, "2xx", logEvent["status_class"], "logging middleware should emit status_class for request-rate dashboards")
+	durationMS, ok := logEvent["duration_ms"].(float64)
+	require.True(t, ok, "logging middleware should emit numeric duration_ms for LogsQL percentile queries")
+	require.GreaterOrEqual(t, durationMS, float64(0), "duration_ms should be non-negative")
+}
+
 func TestLogging_CapturesOnlyServerErrorsForObservability(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -666,6 +666,69 @@ func TestJobStore_OldestPendingSessionJobAge_ReturnsWrappedErrors(t *testing.T) 
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestJobStore_QueueHealthSamples(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewJobStore(mock)
+	mock.ExpectQuery("SELECT\\s+queue,\\s+job_type").
+		WillReturnRows(pgxmock.NewRows([]string{
+			"queue",
+			"job_type",
+			"pending_runnable",
+			"pending_deferred",
+			"running",
+			"dead_letter",
+			"oldest_runnable_age_seconds",
+		}).AddRow("agent", "run_agent", int64(3), int64(2), int64(1), int64(0), float64(42)).
+			AddRow("default", "open_pr", int64(0), int64(1), int64(0), int64(2), nil))
+
+	samples, err := store.QueueHealthSamples(context.Background())
+	require.NoError(t, err, "QueueHealthSamples should not return an error")
+	require.Equal(t, []JobQueueHealthSample{
+		{
+			Queue:                    "agent",
+			JobType:                  "run_agent",
+			PendingRunnable:          3,
+			PendingDeferred:          2,
+			Running:                  1,
+			DeadLetter:               0,
+			OldestRunnableAgeSeconds: 42,
+		},
+		{
+			Queue:                    "default",
+			JobType:                  "open_pr",
+			PendingRunnable:          0,
+			PendingDeferred:          1,
+			Running:                  0,
+			DeadLetter:               2,
+			OldestRunnableAgeSeconds: 0,
+		},
+	}, samples, "QueueHealthSamples should return grouped queue health rows")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestJobStore_QueueHealthSamples_ReturnsWrappedErrors(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewJobStore(mock)
+	mock.ExpectQuery("SELECT\\s+queue,\\s+job_type").
+		WillReturnError(errors.New("query failed"))
+
+	samples, err := store.QueueHealthSamples(context.Background())
+	require.Error(t, err, "QueueHealthSamples should return query errors")
+	require.Contains(t, err.Error(), "queue health samples", "QueueHealthSamples should wrap the operation context")
+	require.Nil(t, samples, "QueueHealthSamples should return nil samples on error")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestJobStore_CountRunningOwnedByNode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -41,6 +41,19 @@ type JobStore struct {
 	logger   zerolog.Logger
 }
 
+// JobQueueHealthSample is an ops-oriented queue snapshot grouped by queue and
+// job type. It intentionally spans orgs so dashboards can show platform-wide
+// pressure rather than one tenant's view.
+type JobQueueHealthSample struct {
+	Queue                    string
+	JobType                  string
+	PendingRunnable          int64
+	PendingDeferred          int64
+	Running                  int64
+	DeadLetter               int64
+	OldestRunnableAgeSeconds float64
+}
+
 func NewJobStore(db DBTX) *JobStore {
 	return &JobStore{db: db, logger: zerolog.Nop()}
 }
@@ -134,6 +147,76 @@ func (s *JobStore) OldestPendingSessionJobAge(ctx context.Context) (time.Duratio
 		return 0, false, fmt.Errorf("oldest pending session job age: %w", err)
 	}
 	return time.Since(runnableAt), true, nil
+}
+
+// QueueHealthSamples returns platform-wide queue health grouped by queue and
+// job type for the worker ops sampler.
+// lint:allow-no-orgid reason="platform health sampler intentionally aggregates queue pressure across orgs"
+func (s *JobStore) QueueHealthSamples(ctx context.Context) ([]JobQueueHealthSample, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT
+			queue,
+			job_type,
+			COUNT(*) FILTER (WHERE status = 'pending' AND run_at <= now()) AS pending_runnable,
+			COUNT(*) FILTER (WHERE status = 'pending' AND run_at > now()) AS pending_deferred,
+			COUNT(*) FILTER (WHERE status = 'running') AS running,
+			COUNT(*) FILTER (WHERE status = 'dead_letter') AS dead_letter,
+			EXTRACT(EPOCH FROM now() - MIN(run_at) FILTER (WHERE status = 'pending' AND run_at <= now()))::double precision AS oldest_runnable_age_seconds
+		FROM jobs
+		WHERE status IN ('pending', 'running', 'dead_letter')
+		GROUP BY queue, job_type
+		ORDER BY pending_runnable DESC, running DESC, queue ASC, job_type ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("queue health samples: %w", err)
+	}
+	defer rows.Close()
+
+	var samples []JobQueueHealthSample
+	for rows.Next() {
+		var sample JobQueueHealthSample
+		var oldest any
+		if err := rows.Scan(
+			&sample.Queue,
+			&sample.JobType,
+			&sample.PendingRunnable,
+			&sample.PendingDeferred,
+			&sample.Running,
+			&sample.DeadLetter,
+			&oldest,
+		); err != nil {
+			return nil, fmt.Errorf("scan queue health sample: %w", err)
+		}
+		switch v := oldest.(type) {
+		case nil:
+		case float64:
+			sample.OldestRunnableAgeSeconds = v
+		case float32:
+			sample.OldestRunnableAgeSeconds = float64(v)
+		case int64:
+			sample.OldestRunnableAgeSeconds = float64(v)
+		case int:
+			sample.OldestRunnableAgeSeconds = float64(v)
+		case pgtype.Float8:
+			if v.Valid {
+				sample.OldestRunnableAgeSeconds = v.Float64
+			}
+		case pgtype.Numeric:
+			oldestFloat, err := v.Float64Value()
+			if err != nil {
+				return nil, fmt.Errorf("scan queue health sample oldest runnable age: %w", err)
+			}
+			if oldestFloat.Valid {
+				sample.OldestRunnableAgeSeconds = oldestFloat.Float64
+			}
+		default:
+			return nil, fmt.Errorf("scan queue health sample: unsupported oldest runnable age type %T", oldest)
+		}
+		samples = append(samples, sample)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("queue health samples rows: %w", err)
+	}
+	return samples, nil
 }
 
 type jobQuerier interface {

--- a/internal/observability/duration.go
+++ b/internal/observability/duration.go
@@ -1,0 +1,11 @@
+package observability
+
+import "time"
+
+// DurationMillis converts a time.Duration into milliseconds as a float64,
+// preserving microsecond precision. Used as the canonical numeric duration
+// field in structured logs so LogsQL percentile/range queries work without
+// re-parsing zerolog's Dur string formatting.
+func DurationMillis(d time.Duration) float64 {
+	return float64(d.Microseconds()) / 1000
+}

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/observability"
 	"github.com/assembledhq/143/internal/services/github/identity"
 	"github.com/assembledhq/143/internal/services/integration"
 	"github.com/assembledhq/143/internal/services/linear"
@@ -89,6 +90,28 @@ const canonicalTimeoutLogMessage = "session exceeded configured timeout"
 // stall the loser's cleanup, long enough that a healthy IsAlive (typically
 // sub-100ms) succeeds with margin.
 const sandboxRaceProbeTimeout = 3 * time.Second
+
+func logAgentRunFinished(log zerolog.Logger, run *models.Session, outcome string, runStartedAt time.Time, addFields func(*zerolog.Event)) {
+	event := log.Info().
+		Str("agent_type", string(run.AgentType)).
+		Str("outcome", outcome).
+		Float64("duration_ms", observability.DurationMillis(time.Since(runStartedAt)))
+	if addFields != nil {
+		addFields(event)
+	}
+	event.Msg("agent run finished")
+}
+
+func logAgentRunFailed(log zerolog.Logger, run *models.Session, err error, outcome string, runStartedAt time.Time, addFields func(*zerolog.Event)) {
+	event := log.Error().Err(err).
+		Str("agent_type", string(run.AgentType)).
+		Str("outcome", outcome).
+		Float64("duration_ms", observability.DurationMillis(time.Since(runStartedAt)))
+	if addFields != nil {
+		addFields(event)
+	}
+	event.Msg("agent run failed")
+}
 
 // diagnoseAcquireHoldRaceLoss decides whether a lost AcquireTurnHold is a
 // genuine duplicate run (winner is alive) or a stale orphan from a crashed
@@ -1647,11 +1670,17 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		if wasCancelled || (stopReason == StopReasonNone && errors.Is(ctx.Err(), context.Canceled)) {
 			log.Info().Msg("session cancelled by user")
 			o.handleCancelledSession(ctx, run, sandbox, result, run.CurrentTurn+1, log)
+			logAgentRunFinished(log, run, "cancelled", runStartedAt, func(event *zerolog.Event) {
+				event.Str("stop_reason", string(models.RuntimeStopReasonUserCancel))
+			})
 			return fmt.Errorf("session cancelled: %w", ctx.Err())
 		}
 		if stopReason != StopReasonNone {
 			log.Info().Str("stop_reason", string(stopReason)).Msg("session stopped by runtime policy")
 			o.handlePolicyStoppedSession(ctx, run, sandbox, result, run.CurrentTurn+1, stopReason, log)
+			logAgentRunFinished(log, run, "runtime_policy_stopped", runStartedAt, func(event *zerolog.Event) {
+				event.Str("stop_reason", string(stopReason))
+			})
 			return nil
 		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
@@ -1660,6 +1689,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 			return fmt.Errorf("%w after %s: %w", ErrSessionTimedOut, elapsed, err)
 		}
 		o.failRun(ctx, run, err.Error())
+		logAgentRunFailed(log, run, err, "failed", runStartedAt, nil)
 		o.enqueueJob(ctx, run.OrgID, "agent", "analyze_failure", map[string]interface{}{
 			"session_id": run.ID.String(),
 			"org_id":     run.OrgID.String(),
@@ -1672,11 +1702,17 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if wasCancelled {
 		log.Info().Msg("agent exited after cancel, snapshotting and returning to idle")
 		o.handleCancelledSession(ctx, run, sandbox, result, run.CurrentTurn+1, log)
+		logAgentRunFinished(log, run, "cancelled", runStartedAt, func(event *zerolog.Event) {
+			event.Str("stop_reason", string(models.RuntimeStopReasonUserCancel))
+		})
 		return nil
 	}
 	if stopReason != StopReasonNone {
 		log.Info().Str("stop_reason", string(stopReason)).Msg("agent exited after runtime policy stop")
 		o.handlePolicyStoppedSession(ctx, run, sandbox, result, run.CurrentTurn+1, stopReason, log)
+		logAgentRunFinished(log, run, "runtime_policy_stopped", runStartedAt, func(event *zerolog.Event) {
+			event.Str("stop_reason", string(stopReason))
+		})
 		return nil
 	}
 
@@ -1732,6 +1768,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		log.Info().
 			Int("turn", turnNumber).
 			Msg("interactive session turn completed and returned to idle")
+		logAgentRunFinished(log, run, "idle", runStartedAt, func(event *zerolog.Event) {
+			event.
+				Str("status", "idle").
+				Float64("confidence", result.ConfidenceScore).
+				Float64("threshold", confidenceThresholds.AutoProceed)
+		})
 		return nil
 	}
 
@@ -1752,11 +1794,12 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		}
 	}
 
-	log.Info().
-		Str("status", status).
-		Float64("confidence", result.ConfidenceScore).
-		Float64("threshold", confidenceThresholds.AutoProceed).
-		Msg("agent run finished")
+	logAgentRunFinished(log, run, status, runStartedAt, func(event *zerolog.Event) {
+		event.
+			Str("status", status).
+			Float64("confidence", result.ConfidenceScore).
+			Float64("threshold", confidenceThresholds.AutoProceed)
+	})
 
 	// 12. Enqueue follow-up job based on confidence.
 	if result.ConfidenceScore >= confidenceThresholds.AutoProceed {
@@ -2968,7 +3011,16 @@ func (o *Orchestrator) failRunWithCategory(ctx context.Context, run *models.Sess
 // fits the "transient slowness" case and we accept the small false-positive
 // rate where a session is structurally too large to ever fit.
 func (o *Orchestrator) failTimedOutSession(run *models.Session, elapsed time.Duration, turnNumber int, underlyingErr error, log zerolog.Logger) {
-	event := log.Error().Err(underlyingErr).Dur("elapsed", elapsed)
+	// Single canonical log per timeout: includes the canonical message that
+	// SessionTimeoutBurst alerts key off, plus the platform-health fields
+	// (agent_type, outcome, duration_ms) that the platform-health dashboard
+	// uses. Emitting only one event keeps the alert and dashboard counts in
+	// sync — a separate "agent run failed" event would double-count timeouts.
+	event := log.Error().Err(underlyingErr).
+		Str("agent_type", string(run.AgentType)).
+		Str("outcome", "timeout").
+		Float64("duration_ms", observability.DurationMillis(elapsed)).
+		Dur("elapsed", elapsed)
 	if turnNumber > 0 {
 		event = event.Int("turn", turnNumber)
 	}

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -949,6 +949,7 @@ type testDeps struct {
 	identityResolver *identity.Resolver
 	sandboxAuth      agent.SandboxAuthServer
 	users            agent.UserLookup
+	logger           *zerolog.Logger
 }
 
 func defaultDeps() testDeps {
@@ -992,6 +993,10 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 	if d.snapshots != nil {
 		snapshotStore = d.snapshots
 	}
+	logger := zerolog.Nop()
+	if d.logger != nil {
+		logger = *d.logger
+	}
 	return agent.NewOrchestrator(agent.OrchestratorConfig{
 		Provider:          d.provider,
 		Adapters:          map[models.AgentType]agent.AgentAdapter{d.adapter.Name(): d.adapter},
@@ -1016,9 +1021,24 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 		SandboxAuth:       d.sandboxAuth,
 		Users:             d.users,
 		NodeID:            d.nodeID,
-		Logger:            zerolog.Nop(),
+		Logger:            logger,
 		MaxConcurrent:     3,
 	})
+}
+
+func findLogEvent(t *testing.T, logs *bytes.Buffer, message string) map[string]any {
+	t.Helper()
+	for _, line := range bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var event map[string]any
+		require.NoError(t, json.Unmarshal(line, &event), "RunAgent should emit JSON logs")
+		if event["message"] == message {
+			return event
+		}
+	}
+	return nil
 }
 
 // --- Tests ---
@@ -1071,6 +1091,72 @@ func TestRunAgent_SuccessfulRun(t *testing.T) {
 
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
+}
+
+func TestRunAgent_SuccessLogIncludesPlatformHealthFields(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	d := defaultDeps()
+	d.logger = &logger
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should complete successfully")
+
+	completion := findLogEvent(t, &logs, "agent run finished")
+	require.NotNil(t, completion, "RunAgent should emit agent run finished log")
+	require.Equal(t, string(models.AgentTypeClaudeCode), completion["agent_type"], "completion log should include agent type")
+	require.Equal(t, "completed", completion["outcome"], "completion log should include platform outcome")
+	durationMS, ok := completion["duration_ms"].(float64)
+	require.True(t, ok, "completion log should include numeric duration_ms")
+	require.GreaterOrEqual(t, durationMS, float64(0), "completion duration should be non-negative")
+}
+
+func TestRunAgent_InteractiveSuccessLogIncludesPlatformHealthFields(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	run := testRun(orgID, issue.ID)
+	run.Origin = models.SessionOriginManual
+	run.InteractionMode = models.SessionInteractionModeInteractive
+	run.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	d := defaultDeps()
+	d.logger = &logger
+	d.issues.issue = issue
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("snapshot-bytes"))), nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return &agent.AgentResult{
+			Summary:         "Initial manual turn complete",
+			ConfidenceScore: 0.92,
+			ExitCode:        0,
+		}, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.NoError(t, err, "interactive RunAgent should complete successfully")
+
+	completion := findLogEvent(t, &logs, "agent run finished")
+	require.NotNil(t, completion, "interactive RunAgent should emit agent run finished log")
+	require.Equal(t, string(models.AgentTypeClaudeCode), completion["agent_type"], "interactive completion log should include agent type")
+	require.Equal(t, "idle", completion["outcome"], "interactive completion log should include idle outcome")
+	require.Equal(t, "idle", completion["status"], "interactive completion log should include idle status")
+	durationMS, ok := completion["duration_ms"].(float64)
+	require.True(t, ok, "interactive completion log should include numeric duration_ms")
+	require.GreaterOrEqual(t, durationMS, float64(0), "interactive completion duration should be non-negative")
 }
 
 func TestRunAgent_MarksFinalOutputLogAsTranscriptDuplicate(t *testing.T) {
@@ -2199,6 +2285,34 @@ func TestRunAgent_FailedExecution(t *testing.T) {
 
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
+}
+
+func TestRunAgent_FailureLogIncludesPlatformHealthFields(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	d := defaultDeps()
+	d.logger = &logger
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return nil, errors.New("agent crashed: OOM killed")
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.RunAgent(context.Background(), run)
+	require.Error(t, err, "RunAgent should fail when the adapter fails")
+
+	failure := findLogEvent(t, &logs, "agent run failed")
+	require.NotNil(t, failure, "RunAgent should emit agent run failed log")
+	require.Equal(t, string(models.AgentTypeClaudeCode), failure["agent_type"], "failure log should include agent type")
+	require.Equal(t, "failed", failure["outcome"], "failure log should include platform outcome")
+	durationMS, ok := failure["duration_ms"].(float64)
+	require.True(t, ok, "failure log should include numeric duration_ms")
+	require.GreaterOrEqual(t, durationMS, float64(0), "failure duration should be non-negative")
 }
 
 func TestRunAgent_LowConfidence(t *testing.T) {
@@ -4879,7 +4993,10 @@ func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
 
 	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
 
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
 	d := defaultDeps()
+	d.logger = &logger
 	d.cancels = cancelReg
 	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader([]byte("cancel-snapshot"))), nil
@@ -4927,6 +5044,11 @@ func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
 
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
+
+	completion := findLogEvent(t, &logs, "agent run finished")
+	require.NotNil(t, completion, "cancelled RunAgent should emit agent run finished log")
+	require.Equal(t, "cancelled", completion["outcome"], "cancelled completion log should include cancelled outcome")
+	require.Equal(t, string(models.RuntimeStopReasonUserCancel), completion["stop_reason"], "cancelled completion log should include user cancel stop reason")
 }
 
 func TestRunAgent_CancelWithoutSnapshotMarksCancelled(t *testing.T) {
@@ -5117,6 +5239,46 @@ func TestResolveSessionTimeout_FallsBackWhenOrgStoreNil(t *testing.T) {
 
 // --- DeadlineExceeded handling in RunAgent / ContinueSession ---
 
+func TestRunAgent_TimeoutLogIncludesPlatformHealthFields(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	startedAt := time.Now().Add(-10 * time.Minute)
+	run.StartedAt = &startedAt
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	d := defaultDeps()
+	d.logger = &logger
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return nil, context.DeadlineExceeded
+	}
+
+	orch := buildOrchestrator(d)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+	defer cancel()
+
+	err := orch.RunAgent(ctx, run)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSessionTimedOut)
+
+	timeout := findLogEvent(t, &logs, "session exceeded configured timeout")
+	require.NotNil(t, timeout, "timeout RunAgent should emit the canonical timeout log line")
+	require.Equal(t, string(models.AgentTypeClaudeCode), timeout["agent_type"], "timeout log should include agent type")
+	require.Equal(t, "timeout", timeout["outcome"], "timeout log should include platform outcome")
+	durationMS, ok := timeout["duration_ms"].(float64)
+	require.True(t, ok, "timeout log should include numeric duration_ms")
+	require.GreaterOrEqual(t, durationMS, float64(0), "timeout duration should be non-negative")
+
+	// The canonical timeout log is the only failure event emitted on this
+	// path. Emitting a second "agent run failed" log would double-count
+	// timeouts in dashboards/alerts that key off either message.
+	require.Nil(t, findLogEvent(t, &logs, "agent run failed"), "timeout path should not also emit agent run failed log")
+}
+
 func TestRunAgent_DeadlineExceededClassifiesAsTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -5246,7 +5408,10 @@ func TestRunAgent_GracefullyStopsAndPreservesCheckpointOnNoProgress(t *testing.T
 
 	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
 
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
 	d := defaultDeps()
+	d.logger = &logger
 	d.orgs = &mockOrgStore{org: models.Organization{ID: orgID, Settings: settings}}
 	d.cancels = cancelReg
 	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
@@ -5281,6 +5446,11 @@ func TestRunAgent_GracefullyStopsAndPreservesCheckpointOnNoProgress(t *testing.T
 	require.Len(t, failures, 1, "policy stop should persist a structured failure explanation")
 	require.Equal(t, agent.FailureCategoryTimeout, failures[0].category, "policy stop should use the timeout family category")
 	require.Contains(t, failures[0].explanation, "saved a resumable checkpoint", "policy stop should explain that the latest state was preserved")
+
+	completion := findLogEvent(t, &logs, "agent run finished")
+	require.NotNil(t, completion, "policy-stopped RunAgent should emit agent run finished log")
+	require.Equal(t, "runtime_policy_stopped", completion["outcome"], "policy stop completion log should include policy outcome")
+	require.Equal(t, string(models.RuntimeStopReasonNoProgress), completion["stop_reason"], "policy stop completion log should include runtime stop reason")
 }
 
 func TestRunAgent_DoesNotPublishCheckpointWithoutSnapshotStore(t *testing.T) {

--- a/internal/services/agent/runtime_sampler.go
+++ b/internal/services/agent/runtime_sampler.go
@@ -78,10 +78,18 @@ func (s *RuntimeSampler) Run(ctx context.Context) {
 func (s *RuntimeSampler) tick(ctx context.Context) {
 	active := s.tracker.Snapshot()
 	if len(active) == 0 {
+		s.logAggregateHealthSample(0, 0, runtimeSampleAggregate{})
 		return
 	}
 
 	sem := make(chan struct{}, runtimeSamplerMaxConcurrency)
+	// Each goroutine sends exactly one runtimeSampleResult: either the
+	// normal return value of sampleOne, or — if sampleOne panics before
+	// returning — a sampleFailed result from the deferred recovery. The
+	// channel is therefore buffered to exactly len(active) and closed
+	// after wg.Wait, so the aggregation loop terminates cleanly without
+	// blocking on a missing send.
+	results := make(chan runtimeSampleResult, len(active))
 	var wg sync.WaitGroup
 	for _, c := range active {
 		wg.Add(1)
@@ -99,15 +107,70 @@ func (s *RuntimeSampler) tick(ctx context.Context) {
 						Str("container_id", c.Sandbox.ID).
 						Bytes("stack", debug.Stack()).
 						Msg("runtime stats sample panicked")
+					results <- runtimeSampleResult{sampleFailed: true}
 				}
 			}()
-			s.sampleOne(ctx, c)
+			results <- s.sampleOne(ctx, c)
 		}(c)
 	}
 	wg.Wait()
+	close(results)
+
+	var sampleFailures int
+	var agg runtimeSampleAggregate
+	var observed int
+	for result := range results {
+		if result.sampleFailed {
+			sampleFailures++
+			continue
+		}
+		observed++
+		agg.memorySum += result.memoryUtil
+		agg.cpuSum += result.cpuUtil
+		if result.memoryUtil > agg.maxMemoryUtil {
+			agg.maxMemoryUtil = result.memoryUtil
+		}
+		if result.cpuUtil > agg.maxCPUUtil {
+			agg.maxCPUUtil = result.cpuUtil
+		}
+	}
+	if observed > 0 {
+		agg.meanMemoryUtil = agg.memorySum / float64(observed)
+		agg.meanCPUUtil = agg.cpuSum / float64(observed)
+	}
+	s.logAggregateHealthSample(len(active), sampleFailures, agg)
 }
 
-func (s *RuntimeSampler) sampleOne(ctx context.Context, c ActiveContainer) {
+// runtimeSampleAggregate carries the rollup statistics emitted on each tick.
+// Mean is included alongside max so a dashboard can tell "one container at
+// 95%" from "every container at 95%" — the max collapses both cases otherwise.
+type runtimeSampleAggregate struct {
+	maxMemoryUtil  float64
+	maxCPUUtil     float64
+	meanMemoryUtil float64
+	meanCPUUtil    float64
+	memorySum      float64
+	cpuSum         float64
+}
+
+func (s *RuntimeSampler) logAggregateHealthSample(activeContainers, sampleFailures int, agg runtimeSampleAggregate) {
+	s.logger.Info().
+		Int("active_containers", activeContainers).
+		Int("sample_failures", sampleFailures).
+		Float64("max_memory_util", agg.maxMemoryUtil).
+		Float64("max_cpu_util", agg.maxCPUUtil).
+		Float64("mean_memory_util", agg.meanMemoryUtil).
+		Float64("mean_cpu_util", agg.meanCPUUtil).
+		Msg("platform health: runtime sample")
+}
+
+type runtimeSampleResult struct {
+	sampleFailed bool
+	memoryUtil   float64
+	cpuUtil      float64
+}
+
+func (s *RuntimeSampler) sampleOne(ctx context.Context, c ActiveContainer) runtimeSampleResult {
 	sampleCtx, cancel := context.WithTimeout(ctx, runtimeSampleTimeout)
 	defer cancel()
 
@@ -124,7 +187,7 @@ func (s *RuntimeSampler) sampleOne(ctx context.Context, c ActiveContainer) {
 		s.logger.Debug().Err(err).
 			Str("container_id", c.Sandbox.ID).
 			Msg("runtime stats sample failed")
-		return
+		return runtimeSampleResult{sampleFailed: !errors.Is(err, ErrSandboxNotFound)}
 	}
 
 	memMiB := float64(stats.MemoryBytes) / (1024 * 1024)
@@ -137,6 +200,7 @@ func (s *RuntimeSampler) sampleOne(ctx context.Context, c ActiveContainer) {
 		cpuUtil = clamp01(stats.CPUCores / c.CPULimit)
 	}
 	s.metrics.RecordSample(ctx, c.Sandbox.OrgID, memMiB, stats.CPUCores, memUtil, cpuUtil)
+	return runtimeSampleResult{memoryUtil: memUtil, cpuUtil: cpuUtil}
 }
 
 func clamp01(v float64) float64 {

--- a/internal/services/agent/runtime_sampler_test.go
+++ b/internal/services/agent/runtime_sampler_test.go
@@ -1,8 +1,11 @@
 package agent_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -101,6 +104,83 @@ func TestRuntimeSampler_SamplesActiveContainers(t *testing.T) {
 	prov.mu.Lock()
 	defer prov.mu.Unlock()
 	require.Contains(t, prov.calls, "ctr-A")
+}
+
+func TestRuntimeSampler_LogsAggregateHealthSample(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{
+		stats: agent.RuntimeStats{
+			MemoryBytes:      768 * 1024 * 1024,
+			MemoryLimitBytes: 1024 * 1024 * 1024,
+			CPUCores:         0.50,
+		},
+	}
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	cfg := agent.SandboxConfig{CPULimit: 1, MemoryLimitMB: 1024}
+	sb := &agent.Sandbox{ID: "ctr-health", Provider: "docker", OrgID: orgID.String()}
+	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
+
+	var logs bytes.Buffer
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(&logs))
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.Run(ctx)
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "platform health: runtime sample")
+	}, time.Second, 10*time.Millisecond, "runtime sampler should emit aggregate platform-health logs")
+	cancel()
+
+	var event map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n")) {
+		var candidate map[string]any
+		require.NoError(t, json.Unmarshal(line, &candidate), "runtime sampler should emit JSON logs")
+		if candidate["message"] == "platform health: runtime sample" {
+			event = candidate
+			break
+		}
+	}
+	require.NotNil(t, event, "runtime health log should be present")
+	require.Equal(t, "platform health: runtime sample", event["message"], "runtime health log should have the canonical message")
+	require.Equal(t, float64(1), event["active_containers"], "runtime health log should include active container count")
+	require.Equal(t, float64(0), event["sample_failures"], "runtime health log should include sample failure count")
+	require.InDelta(t, 0.75, event["max_memory_util"].(float64), 0.001, "runtime health log should include max memory utilization")
+	require.InDelta(t, 0.50, event["max_cpu_util"].(float64), 0.001, "runtime health log should include max CPU utilization")
+	require.InDelta(t, 0.75, event["mean_memory_util"].(float64), 0.001, "runtime health log should include mean memory utilization to distinguish single-container outliers from across-the-board pressure")
+	require.InDelta(t, 0.50, event["mean_cpu_util"].(float64), 0.001, "runtime health log should include mean CPU utilization")
+}
+
+func TestRuntimeSampler_LogsAggregateHealthSampleWhenIdle(t *testing.T) {
+	t.Parallel()
+	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
+	prov := &fakeStatsProvider{}
+
+	var logs bytes.Buffer
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(&logs))
+	ctx, cancel := context.WithCancel(context.Background())
+	go s.Run(ctx)
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "platform health: runtime sample")
+	}, time.Second, 10*time.Millisecond, "runtime sampler should emit idle platform-health logs")
+	cancel()
+
+	var event map[string]any
+	for _, line := range bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n")) {
+		var candidate map[string]any
+		require.NoError(t, json.Unmarshal(line, &candidate), "runtime sampler should emit JSON logs")
+		if candidate["message"] == "platform health: runtime sample" {
+			event = candidate
+			break
+		}
+	}
+	require.NotNil(t, event, "runtime health log should be present even with no active containers")
+	require.Equal(t, float64(0), event["active_containers"], "idle runtime health log should report zero active containers")
+	require.Equal(t, float64(0), event["sample_failures"], "idle runtime health log should report zero sample failures")
+	require.Equal(t, float64(0), event["max_memory_util"], "idle runtime health log should report zero memory utilization")
+	require.Equal(t, float64(0), event["max_cpu_util"], "idle runtime health log should report zero CPU utilization")
+	require.Equal(t, float64(0), event["mean_memory_util"], "idle runtime health log should report zero mean memory utilization")
+	require.Equal(t, float64(0), event["mean_cpu_util"], "idle runtime health log should report zero mean CPU utilization")
+	require.Equal(t, int64(0), prov.called.Load(), "idle runtime sampler should not call stats provider")
 }
 
 func TestRuntimeSampler_StoppedContainerIsNotSampled(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1366,11 +1366,21 @@ func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger)
 
 		_, createErr := services.PR.CreatePR(ctx, &run, params...)
 		if createErr != nil {
-			// Always log the raw error — only a curated subset is shown in
-			// the UI, so the worker log is the source of truth for ops.
-			logger.Error().Err(createErr).
-				Str("session_id", runID.String()).
-				Msg("open_pr failed")
+			// ErrNoChanges is a benign terminal outcome (session ran fine
+			// but produced no diff), so log at info to keep `open_pr failed`
+			// a real-error signal that dashboards/alerts can key off without
+			// false positives.
+			if errors.Is(createErr, ghservice.ErrNoChanges) {
+				logger.Info().
+					Str("session_id", runID.String()).
+					Msg("open_pr: no changes to push")
+			} else {
+				// Always log the raw error — only a curated subset is shown in
+				// the UI, so the worker log is the source of truth for ops.
+				logger.Error().Err(createErr).
+					Str("session_id", runID.String()).
+					Msg("open_pr failed")
+			}
 			msg := userFacingPRError(createErr)
 			if stateErr := stores.Sessions.UpdatePRCreationState(ctx, orgID, runID, models.PRCreationStateFailed, msg); stateErr != nil {
 				logger.Error().Err(stateErr).Msg("failed to mark PR creation as failed")

--- a/internal/worker/platform_health.go
+++ b/internal/worker/platform_health.go
@@ -1,0 +1,53 @@
+package worker
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/db"
+)
+
+type queueHealthStore interface {
+	QueueHealthSamples(ctx context.Context) ([]db.JobQueueHealthSample, error)
+}
+
+// RunQueueHealthSampler emits low-volume structured logs that feed the
+// platform health dashboard. It is worker-local but queries the shared job
+// table for platform-wide queue pressure.
+func RunQueueHealthSampler(ctx context.Context, store queueHealthStore, logger zerolog.Logger, interval time.Duration) {
+	if store == nil || interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	emitQueueHealthSample(ctx, store, logger)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			emitQueueHealthSample(ctx, store, logger)
+		}
+	}
+}
+
+func emitQueueHealthSample(ctx context.Context, store queueHealthStore, logger zerolog.Logger) {
+	samples, err := store.QueueHealthSamples(ctx)
+	if err != nil {
+		logger.Warn().Err(err).Msg("platform health: failed to sample job queue")
+		return
+	}
+	for _, sample := range samples {
+		logger.Info().
+			Str("queue", sample.Queue).
+			Str("job_type", sample.JobType).
+			Int64("pending_runnable", sample.PendingRunnable).
+			Int64("pending_deferred", sample.PendingDeferred).
+			Int64("running", sample.Running).
+			Int64("dead_letter", sample.DeadLetter).
+			Float64("oldest_runnable_age_seconds", sample.OldestRunnableAgeSeconds).
+			Msg("platform health: job queue sample")
+	}
+}

--- a/internal/worker/platform_health_test.go
+++ b/internal/worker/platform_health_test.go
@@ -1,0 +1,64 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/db"
+)
+
+type stubQueueHealthStore struct {
+	samples []db.JobQueueHealthSample
+	err     error
+}
+
+func (s *stubQueueHealthStore) QueueHealthSamples(ctx context.Context) ([]db.JobQueueHealthSample, error) {
+	return s.samples, s.err
+}
+
+func TestRunQueueHealthSamplerEmitsStructuredSamples(t *testing.T) {
+	t.Parallel()
+
+	store := &stubQueueHealthStore{samples: []db.JobQueueHealthSample{
+		{
+			Queue:                    "agent",
+			JobType:                  "run_agent",
+			PendingRunnable:          3,
+			PendingDeferred:          2,
+			Running:                  1,
+			DeadLetter:               0,
+			OldestRunnableAgeSeconds: 42,
+		},
+	}}
+	var logs bytes.Buffer
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		RunQueueHealthSampler(ctx, store, zerolog.New(&logs), time.Hour)
+		close(done)
+	}()
+	require.Eventually(t, func() bool {
+		return bytes.Contains(logs.Bytes(), []byte("platform health: job queue sample"))
+	}, time.Second, 10*time.Millisecond, "queue sampler should emit an initial health sample")
+	cancel()
+	<-done
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(logs.Bytes()), &event), "queue health sample should be valid JSON")
+	require.Equal(t, "platform health: job queue sample", event["message"], "queue sampler should use the canonical log message")
+	require.Equal(t, "agent", event["queue"], "queue sampler should include queue")
+	require.Equal(t, "run_agent", event["job_type"], "queue sampler should include job type")
+	require.Equal(t, float64(3), event["pending_runnable"], "queue sampler should include runnable pending count")
+	require.Equal(t, float64(2), event["pending_deferred"], "queue sampler should include deferred pending count")
+	require.Equal(t, float64(1), event["running"], "queue sampler should include running count")
+	require.Equal(t, float64(0), event["dead_letter"], "queue sampler should include dead-letter count")
+	require.Equal(t, float64(42), event["oldest_runnable_age_seconds"], "queue sampler should include oldest runnable age")
+}


### PR DESCRIPTION
## Summary
- Provisions two Grafana dashboards (`errors.json`, `platform-health.json`) and adds repo-owned `vmalert` rules for PR pipeline and session reaper failures, all synced to the logging node by `deploy-logging`.
- Emits structured "platform health" log signals from the new queue health sampler and the runtime sampler (max + mean memory/CPU util), plus per-outcome `agent run finished`/`agent run failed` logs with `agent_type`, `outcome`, and `duration_ms` (also added to the API logging middleware as `status_class` and numeric `duration_ms`).
- Fixes invalid LogsQL `status:[500,599]` to `status:range[500,599]` in vmalert rules and the design doc; downgrades benign `open_pr` no-changes from error to info so PR-failure alerts stay clean.
- Adds `internal/observability.DurationMillis` helper and folds the canonical timeout log into a single emission so timeouts are not double-counted across alerts/dashboards.

## Test plan
- [ ] `make lint` passes
- [ ] `go test ./internal/observability/... ./internal/api/middleware/... ./internal/services/agent/... ./internal/db/... ./internal/worker/... ./deploy/...` passes
- [ ] Deploy to logging node and confirm both dashboards load, vmalert reloads new rules, and Vector is collecting from logging-node containers
- [ ] Trigger a sample 5xx, a sample agent run failure, and a sample PR-creation failure and verify each appears on the corresponding dashboard panel and alert evaluation

Generated with Claude Code
