### PR TITLE
Filter 143's own OAuth-attributed moves from Linear human-edit guard

### DIFF
--- a/internal/services/linear/client.go
+++ b/internal/services/linear/client.go
@@ -419,13 +419,23 @@ func (c *graphQLClient) UpdateIssueState(ctx context.Context, issueID, stateID s
 // state within the given window. Reads from Linear's issue history; we only
 // count entries that look like state transitions performed by users (not
 // integrations or webhooks).
+//
+// Self-attribution guard: history entries whose actor matches the OAuth
+// token's own viewer are filtered out. Linear attributes API-driven moves
+// to the user who authorized the OAuth integration (with botActor=null), so
+// without this filter our own previous transition would read as a "human
+// edit" on the next milestone for the same session and skip every follow-up
+// move (e.g. session-start → "In Progress" suppresses the subsequent PR-open
+// → "In Review" within the 10-min window). The viewer lookup is folded into
+// the same GraphQL request to avoid an extra round trip.
 func (c *graphQLClient) IssueRecentHumanEdits(ctx context.Context, issueID string, since time.Time) (bool, error) {
 	query := `query($id: String!) {
+		viewer { id }
 		issue(id: $id) {
 			history(first: 10) {
 				nodes {
 					createdAt
-					actor { name displayName }
+					actor { id name displayName }
 					botActor { name }
 					fromState { id }
 					toState { id }
@@ -435,11 +445,15 @@ func (c *graphQLClient) IssueRecentHumanEdits(ctx context.Context, issueID strin
 	}`
 	var result struct {
 		Data struct {
+			Viewer *struct {
+				ID string `json:"id"`
+			} `json:"viewer"`
 			Issue *struct {
 				History struct {
 					Nodes []struct {
 						CreatedAt string `json:"createdAt"`
 						Actor     *struct {
+							ID          string `json:"id"`
 							Name        string `json:"name"`
 							DisplayName string `json:"displayName"`
 						} `json:"actor"`
@@ -463,6 +477,10 @@ func (c *graphQLClient) IssueRecentHumanEdits(ctx context.Context, issueID strin
 	if result.Data.Issue == nil {
 		return false, nil
 	}
+	selfActorID := ""
+	if result.Data.Viewer != nil {
+		selfActorID = result.Data.Viewer.ID
+	}
 	for _, h := range result.Data.Issue.History.Nodes {
 		if h.FromState == nil || h.ToState == nil {
 			continue
@@ -473,6 +491,11 @@ func (c *graphQLClient) IssueRecentHumanEdits(ctx context.Context, issueID strin
 		}
 		// Skip transitions performed by bots/integrations.
 		if h.BotActor != nil && h.BotActor.Name != "" {
+			continue
+		}
+		// Skip transitions attributed to our own OAuth actor — these are
+		// 143's prior writes, not human edits worth deferring to.
+		if h.Actor != nil && selfActorID != "" && h.Actor.ID == selfActorID {
 			continue
 		}
 		if h.Actor != nil && h.Actor.Name != "" {

--- a/internal/services/linear/client_test.go
+++ b/internal/services/linear/client_test.go
@@ -404,12 +404,16 @@ func TestGraphQLClientIssueRecentHumanEdits(t *testing.T) {
 	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
 	client := newGraphQLClientForTest(t, func(t *testing.T, req linearGraphQLRequest, w http.ResponseWriter) {
 		require.Contains(t, req.Query, "history(first: 10)", "IssueRecentHumanEdits should query issue history")
+		require.Contains(t, req.Query, "viewer { id }", "IssueRecentHumanEdits should fetch viewer id for self-attribution filtering")
 		writeGraphQLResponse(t, w, `{
-			"data": {"issue": {"history": {"nodes": [
-				{"createdAt": "2026-04-27T11:45:00Z", "actor": null, "botActor": {"name": "GitHub"}, "fromState": {"id": "a"}, "toState": {"id": "b"}},
-				{"createdAt": "2026-04-27T11:50:00Z", "actor": {"name": "Ada", "displayName": "Ada"}, "botActor": null, "fromState": {"id": "b"}, "toState": {"id": "c"}},
-				{"createdAt": "2026-04-27T11:55:00Z", "actor": {"name": "Ignored"}, "botActor": null, "fromState": null, "toState": {"id": "d"}}
-			]}}}
+			"data": {
+				"viewer": {"id": "viewer-self"},
+				"issue": {"history": {"nodes": [
+					{"createdAt": "2026-04-27T11:45:00Z", "actor": null, "botActor": {"name": "GitHub"}, "fromState": {"id": "a"}, "toState": {"id": "b"}},
+					{"createdAt": "2026-04-27T11:50:00Z", "actor": {"id": "actor-ada", "name": "Ada", "displayName": "Ada"}, "botActor": null, "fromState": {"id": "b"}, "toState": {"id": "c"}},
+					{"createdAt": "2026-04-27T11:55:00Z", "actor": {"id": "actor-ignored", "name": "Ignored"}, "botActor": null, "fromState": null, "toState": {"id": "d"}}
+				]}}
+			}
 		}`)
 	})
 
@@ -418,12 +422,38 @@ func TestGraphQLClientIssueRecentHumanEdits(t *testing.T) {
 	require.True(t, edited, "IssueRecentHumanEdits should detect recent human state transitions")
 }
 
+func TestGraphQLClientIssueRecentHumanEditsIgnoresSelfActor(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 27, 12, 0, 0, 0, time.UTC)
+	client := newGraphQLClientForTest(t, func(t *testing.T, req linearGraphQLRequest, w http.ResponseWriter) {
+		require.Contains(t, req.Query, "viewer { id }", "IssueRecentHumanEdits should fetch viewer id for self-attribution filtering")
+		// Linear attributes OAuth-driven moves to the authorizing user with
+		// botActor=null. The only state transition in the window is one
+		// 143 itself made — IssueRecentHumanEdits must NOT flag this as a
+		// human edit, otherwise the next milestone (e.g. PR-open after
+		// session-start) gets suppressed within the 10-min cooldown.
+		writeGraphQLResponse(t, w, `{
+			"data": {
+				"viewer": {"id": "viewer-self"},
+				"issue": {"history": {"nodes": [
+					{"createdAt": "2026-04-27T11:55:00Z", "actor": {"id": "viewer-self", "name": "John Doe", "displayName": "John"}, "botActor": null, "fromState": {"id": "a"}, "toState": {"id": "b"}}
+				]}}
+			}
+		}`)
+	})
+
+	edited, err := client.IssueRecentHumanEdits(context.Background(), "issue-1", now.Add(-20*time.Minute))
+	require.NoError(t, err, "IssueRecentHumanEdits should parse history")
+	require.False(t, edited, "IssueRecentHumanEdits should ignore transitions performed by our own OAuth actor")
+}
+
 func TestGraphQLClientIssueRecentHumanEditsNoIssue(t *testing.T) {
 	t.Parallel()
 
 	client := newGraphQLClientForTest(t, func(t *testing.T, req linearGraphQLRequest, w http.ResponseWriter) {
 		require.Contains(t, req.Query, "history(first: 10)", "IssueRecentHumanEdits should query issue history")
-		writeGraphQLResponse(t, w, `{"data":{"issue":null}}`)
+		writeGraphQLResponse(t, w, `{"data":{"viewer":{"id":"viewer-self"},"issue":null}}`)
 	})
 
 	edited, err := client.IssueRecentHumanEdits(context.Background(), "issue-1", time.Now())


### PR DESCRIPTION
## Summary
- Linear attributes OAuth-driven state moves to the user who authorized the integration with botActor=null, so IssueRecentHumanEdits was reading 143's own prior transition as a "human edit" and suppressing every follow-up milestone (e.g. session-start → "In Progress" blocked PR-open → "In Review") within the 10-minute cooldown — surfacing as a "Linear sync skipped: user_recent_edit" chip on sessions that should have synced.
- Fold viewer.id into the same GraphQL request (no extra round trip) and skip history entries whose actor.id matches the viewer; falls back to the previous behavior if viewer is absent.
- Trade-off: manual moves by the OAuth-authorizing user no longer trigger the cooldown for that one user; manual moves by every other teammate still do.

## Test plan
- [x] go test ./internal/services/linear/... (existing tests + new TestGraphQLClientIssueRecentHumanEditsIgnoresSelfActor)
- [ ] Dogfood: open a session that hits multiple milestones within 10 minutes, confirm Linear state advances on each milestone instead of stopping after the first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
