### PR TITLE
Fix logging deploy failing on root-owned vmalert/grafana dirs

### DIFF
--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -29,6 +29,8 @@ usermod -aG docker deploy
 cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/grafana, \
     /usr/bin/runsc install -- --ignore-cgroups --host-uds=open, \
     /usr/bin/systemctl restart docker, \
     /usr/bin/apt-get install -y --no-install-recommends iptables-persistent, \

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -145,6 +145,14 @@ if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; the
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vector.yaml" deploy@"$HOST":/opt/143/deploy/
 fi
 if [ "$ROLE" = "logging" ]; then
+  # Older logging hosts may have root-owned vmalert/grafana dirs from a prior
+  # provision step; without ownership the deploy user can't unlink the entries
+  # in `rm -rf` below. Mirror the worker pattern: try a non-interactive sudo
+  # chown (narrowly granted in deploy/scripts/bootstrap.sh), tolerate failure
+  # so the rm still runs on hosts where files are already deploy-owned.
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n chown -R deploy:deploy /opt/143/deploy/vmalert 2>&1 | sed 's/^/  chown: /' || true; \
+     sudo -n chown -R deploy:deploy /opt/143/deploy/grafana 2>&1 | sed 's/^/  chown: /' || true"
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "rm -rf /opt/143/deploy/grafana/provisioning /opt/143/deploy/vmalert/rules && mkdir -p /opt/143/deploy/grafana /opt/143/deploy/vmalert"
   scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/grafana/provisioning" deploy@"$HOST":/opt/143/deploy/grafana/
   scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vmalert/rules" deploy@"$HOST":/opt/143/deploy/vmalert/


### PR DESCRIPTION
## Summary
- `make deploy-logging` was failing with `rm: cannot remove '/opt/143/deploy/vmalert/rules': Permission denied` because the parent dir on the logging host was root-owned (likely manual ops, not a code path — cloud-init copies as deploy).
- Mirror the worker-role pattern in `deploy.sh`: run `sudo -n chown -R deploy:deploy …` for `vmalert` and `grafana` before the `rm -rf`, with `|| true` so deploys still work on hosts where files are already deploy-owned.
- Add the two chown commands to the narrow sudoers allowlist in `bootstrap.sh`. No new security boundary — deploy is already root-equivalent via the docker group; the narrow sudoers list is for auditability (per the existing comment at bootstrap.sh:24-28).

## Operational note
Existing logging hosts need a one-time fix to pick this up:
```sh
ssh root@<logging-host> 'bash -s -- logging' < deploy/scripts/bootstrap.sh
ssh root@<logging-host> 'chown -R deploy:deploy /opt/143/deploy'
```

## Test plan
- [ ] Re-run bootstrap on the logging host
- [ ] One-time `chown -R deploy:deploy /opt/143/deploy` on the logging host
- [ ] `make deploy-logging` completes without the permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)