### PR TITLE
Self-heal Grafana datasource provisioning across uid changes

### DIFF
--- a/deploy/grafana/provisioning/datasources/alertmanager.yml
+++ b/deploy/grafana/provisioning/datasources/alertmanager.yml
@@ -1,7 +1,12 @@
 apiVersion: 1
 
+deleteDatasources:
+  - name: Alertmanager
+    orgId: 1
+
 datasources:
   - name: Alertmanager
+    uid: alertmanager
     type: alertmanager
     access: proxy
     url: http://alertmanager:9093

--- a/deploy/grafana/provisioning/datasources/victorialogs.yml
+++ b/deploy/grafana/provisioning/datasources/victorialogs.yml
@@ -1,4 +1,9 @@
 apiVersion: 1
+
+deleteDatasources:
+  - name: VictoriaLogs
+    orgId: 1
+
 datasources:
   - name: VictoriaLogs
     uid: victorialogs


### PR DESCRIPTION
## Summary
- Adds `deleteDatasources` blocks to both `victorialogs.yml` and `alertmanager.yml` so Grafana drops + reinserts the row on each startup, making provisioning idempotent against uid/type drift in the persistent `grafana-data` volume.
- Fixes the Grafana crash loop ("Datasource provisioning error: data source not found") that was triggered by adding `uid: victorialogs` in #758 while the volume still held a stale auto-generated uid — and that took down `make logs`.
- Assigns a stable `uid: alertmanager` so future dashboards/alerts can reference it predictably.

## Test plan
- [ ] `make deploy-logging` succeeds and `143-grafana-1` reaches `Up` (no `Restarting`).
- [ ] `make logs` opens the tunnel and `http://localhost:9999` loads Grafana.
- [ ] Existing dashboards (`errors`, `platform-health`) render data via the VictoriaLogs datasource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)