### PR TITLE
Null worker_node_id with container_id to unstick post-crash sessions

### DIFF
--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -1904,6 +1904,11 @@ func (s *SessionStore) SetWorkerNodeIDForContainer(ctx context.Context, orgID, s
 		return fmt.Errorf("set worker node id for container: %w", err)
 	}
 	if tag.RowsAffected() == 0 {
+		// Two CAS conditions can produce this: container_id no longer matches
+		// expectedContainerID (a concurrent hydrate/destroy raced us), or
+		// worker_node_id is already held by a different worker. The IDs are
+		// not in this string because callers surface it as a user-facing chat
+		// message; callers log the structured IDs separately for ops.
 		return fmt.Errorf("session container ownership changed before worker ownership could be recorded")
 	}
 	return nil
@@ -1932,8 +1937,14 @@ func (s *SessionStore) SetWorkerNodeIDForContainer(ctx context.Context, orgID, s
 // FinalizeContainerDestroy instead, which additionally flips sandbox_state
 // to 'snapshotted'.
 func (s *SessionStore) ClearContainerID(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (cleared bool, err error) {
+	// worker_node_id is paired with container_id ownership: once the container
+	// is gone, the recorded owner is by definition stale. Leaving it set would
+	// trip up the next turn's SetWorkerNodeIDForContainer CAS (which rejects
+	// a different worker stamping over a stale value) and silently fail the
+	// turn — symmetrical to FinalizeContainerDestroy, which clears both.
 	query := `UPDATE sessions
 		SET container_id = NULL,
+		    worker_node_id = NULL,
 		    turn_holding_container = FALSE
 		WHERE id = @id
 		  AND org_id = @org_id

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -2034,9 +2034,10 @@ func TestSessionStore_ClearContainerID_CAS_Clears(t *testing.T) {
 
 	store := NewSessionStore(mock)
 	// WHERE clause must pin container_id = @expected AND no preview hold,
-	// and the SET must also reset turn_holding_container=FALSE so a
-	// crashed-turn flag doesn't get stranded.
-	mock.ExpectExec(`UPDATE sessions\s+SET container_id = NULL,\s+turn_holding_container = FALSE\s+WHERE id = @id\s+AND org_id = @org_id\s+AND container_id = @expected\s+AND NOT EXISTS`).
+	// and the SET must reset turn_holding_container=FALSE so a crashed-turn
+	// flag doesn't get stranded AND null worker_node_id so the next turn's
+	// SetWorkerNodeIDForContainer CAS isn't rejected by a stale owner.
+	mock.ExpectExec(`UPDATE sessions\s+SET container_id = NULL,\s+worker_node_id = NULL,\s+turn_holding_container = FALSE\s+WHERE id = @id\s+AND org_id = @org_id\s+AND container_id = @expected\s+AND NOT EXISTS`).
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
@@ -2079,6 +2080,52 @@ func TestSessionStore_ClearContainerID_DBError(t *testing.T) {
 	_, err = store.ClearContainerID(context.Background(), uuid.New(), uuid.New(), "abc")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "clear container id")
+}
+
+// TestSessionStore_ClearContainerID_UnsticksStaleWorkerOwnership locks in the
+// invariant fixed by 000114_session_worker_node_id_unstuck: ClearContainerID
+// MUST null worker_node_id along with container_id, so the next turn (on a
+// possibly different worker) can stamp ownership without being rejected by a
+// stale value.
+//
+// The bug: pre-fix, ClearContainerID nulled container_id but left worker_node_id
+// pointing at the dead worker. The next ContinueSession's SetWorkerNodeIDForContainer
+// CAS — which requires worker_node_id IS NULL/empty OR equal to ours — failed
+// with "session container ownership changed before worker ownership could be
+// recorded", and the user-facing turn failed.
+//
+// If a future cleanup drops the worker_node_id null in ClearContainerID, this
+// test fails because the second ExpectExec's regex no longer matches the SQL.
+func TestSessionStore_ClearContainerID_UnsticksStaleWorkerOwnership(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	// Step 1: orphan reconciler clears the row left behind by a crashed worker.
+	// The SQL must null both container_id and worker_node_id.
+	mock.ExpectExec(`UPDATE sessions\s+SET container_id = NULL,\s+worker_node_id = NULL,\s+turn_holding_container = FALSE`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	cleared, err := store.ClearContainerID(context.Background(), orgID, sessionID, "container-from-dead-worker")
+	require.NoError(t, err)
+	require.True(t, cleared)
+
+	// Step 2: a new turn on a *different* worker stamps fresh ownership.
+	// CAS predicate is `worker_node_id IS NULL/'' OR equal to ours` — the
+	// preceding clear set it to NULL, so this matches the row.
+	mock.ExpectExec(`UPDATE sessions\s+SET worker_node_id = @worker_node_id`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	err = store.SetWorkerNodeIDForContainer(context.Background(), orgID, sessionID, "container-on-new-worker", "worker-new")
+	require.NoError(t, err, "SetWorkerNodeIDForContainer must succeed for a new worker after ClearContainerID")
+
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSessionStore_ListOrphanedContainers(t *testing.T) {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1608,6 +1608,10 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	}()
 	if o.nodeID != "" {
 		if err := o.sessions.SetWorkerNodeIDForContainer(ctx, run.OrgID, run.ID, sandbox.ID, o.nodeID); err != nil {
+			log.Error().Err(err).
+				Str("container_id", sandbox.ID).
+				Str("worker_node_id", o.nodeID).
+				Msg("persist session worker ownership: CAS failed (container_id moved or worker_node_id held by another worker)")
 			o.failRun(ctx, run, fmt.Sprintf("persist session worker ownership: %s", err))
 			return fmt.Errorf("persist session worker ownership: %w", err)
 		}
@@ -2435,6 +2439,10 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	}()
 	if o.nodeID != "" {
 		if err := o.sessions.SetWorkerNodeIDForContainer(ctx, session.OrgID, session.ID, sandbox.ID, o.nodeID); err != nil {
+			log.Error().Err(err).
+				Str("container_id", sandbox.ID).
+				Str("worker_node_id", o.nodeID).
+				Msg("persist session worker ownership: CAS failed (container_id moved or worker_node_id held by another worker)")
 			if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusIdle)); revertErr != nil {
 				log.Error().Err(revertErr).Msg("failed to revert session to idle after worker ownership persistence failure")
 			}

--- a/migrations/000114_session_worker_node_id_unstuck.down.sql
+++ b/migrations/000114_session_worker_node_id_unstuck.down.sql
@@ -1,0 +1,5 @@
+-- No-op: the up migration is a backfill that nulls a column. There's no
+-- meaningful rollback since the prior values were stale by definition (rows
+-- with container_id IS NULL have no live container, so any worker_node_id
+-- recorded against them was a leftover from a crashed turn).
+SELECT 1;

--- a/migrations/000114_session_worker_node_id_unstuck.up.sql
+++ b/migrations/000114_session_worker_node_id_unstuck.up.sql
@@ -1,0 +1,16 @@
+-- Backfill: clear stale worker_node_id values left behind by ClearContainerID.
+--
+-- Before this migration, ClearContainerID nulled container_id but did not null
+-- worker_node_id, so a session whose previous worker crashed mid-turn (and was
+-- then reconciled at startup) ended up with container_id=NULL but worker_node_id
+-- still pointing at the dead worker. The next ContinueSession on a different
+-- worker would then fail SetWorkerNodeIDForContainer's CAS with
+-- "session container ownership changed before worker ownership could be recorded"
+-- and the session got stuck.
+--
+-- ClearContainerID now nulls both columns, so new occurrences are prevented.
+-- This statement unsticks rows already in the bad state.
+UPDATE sessions
+SET worker_node_id = NULL
+WHERE container_id IS NULL
+  AND worker_node_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- `ClearContainerID` (orphan-reconciler / race-loss diagnosis path) was nulling `container_id` but leaving `worker_node_id` pointing at the crashed worker. The next `ContinueSession` on a different worker then failed `SetWorkerNodeIDForContainer`'s CAS with `session container ownership changed before worker ownership could be recorded`, surfaced to the user as a turn failure (e.g. session `5cf02c0c-808d-4de6-a873-05fd4ddc1ad4`).
- Fix: `ClearContainerID` now nulls both columns, mirroring `FinalizeContainerDestroy`. Migration `000114` unsticks rows already in the bad state. The two orchestrator call sites now log `container_id` + `worker_node_id` structurally so any future hits are diagnosable from Grafana without leaking IDs into the user-facing chat message.
- Added a regression test (`TestSessionStore_ClearContainerID_UnsticksStaleWorkerOwnership`) that sequences `ClearContainerID` → `SetWorkerNodeIDForContainer` from a different worker and asserts success; documents the bug so a future cleanup can't silently regress it.

## Test plan
- [x] `go test ./internal/db/... ./internal/services/agent/... ./internal/services/preview/... ./internal/api/...`
- [x] `go build ./...`
- [ ] After merge, verify migration 000114 ran (one-shot) and that any previously-stuck sessions can resume turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)