### PR TITLE
Fix perpetual loading skeleton on idle session threads

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -859,6 +859,146 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
   });
 
+  it('clears the skeleton and enables the composer on an idle thread while a sibling thread is running', async () => {
+    // Regression: in the user-reported scenario the session.status was
+    // "running" (because a sibling thread was running) while the selected
+    // thread was a freshly-created idle one. Two bugs combined: the skeleton
+    // never cleared (because `activeSet.has("running")` was truthy) and the
+    // composer was disabled by a leftover Phase 1 gate that required
+    // session.status !== "running". Phase 2 supports concurrent threads, so
+    // an idle thread must be sendable regardless of sibling activity.
+    const sessionId = 'session-running-sibling';
+    const threads: SessionThread[] = [
+      {
+        id: 'thread-main',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Main',
+        status: 'running',
+        current_turn: 1,
+        created_at: '2026-05-04T07:00:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+      {
+        id: 'thread-codex2',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Codex 2',
+        status: 'idle',
+        current_turn: 0,
+        created_at: '2026-05-04T07:01:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    ];
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            id: sessionId,
+            status: 'running',
+            sandbox_state: 'ready',
+            threads,
+          },
+        } satisfies SingleResponse<Session & { threads: SessionThread[] }>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/messages', () => {
+        return HttpResponse.json({
+          data: [] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/logs', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    await user.click(await screen.findByRole('tab', { name: /Codex 2/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
+    });
+    const composer = screen.getByPlaceholderText('Send a message to Codex 2...');
+    expect(composer).toBeEnabled();
+  });
+
+  it('does not shimmer forever for a freshly-created idle thread', async () => {
+    // Regression: opening a brand-new secondary thread (idle, zero messages)
+    // on a session whose overall status was still in `activeSet`
+    // (e.g. "idle"/"running") used to keep the skeleton visible forever,
+    // because the skeleton condition consulted session.status instead of the
+    // selected thread's status. The skeleton must clear once the thread's
+    // data has loaded so the empty-state composer becomes reachable.
+    const sessionId = 'session-new-thread-skeleton';
+    const threads: SessionThread[] = [
+      {
+        id: 'thread-main',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Main',
+        status: 'idle',
+        current_turn: 1,
+        created_at: '2026-05-04T07:00:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+      {
+        id: 'thread-codex2',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Codex 2',
+        status: 'idle',
+        current_turn: 0,
+        created_at: '2026-05-04T07:01:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    ];
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            id: sessionId,
+            status: 'idle',
+            sandbox_state: 'ready',
+            threads,
+          },
+        } satisfies SingleResponse<Session & { threads: SessionThread[] }>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/messages', () => {
+        return HttpResponse.json({
+          data: [] as SessionMessage[],
+          meta: {},
+        } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/logs', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    await user.click(await screen.findByRole('tab', { name: /Codex 2/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText('Send a message to Codex 2...')).toBeInTheDocument();
+  });
+
   it('restores the saved scroll position when reopening an existing session', async () => {
     const idleSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -139,7 +139,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { prMergedAccent } from "@/lib/pr-status-styles";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
-import { activeSet } from "@/lib/session-status-groups";
+import { activeSet, workingStatusesSet } from "@/lib/session-status-groups";
 
 const PREVIEW_ORIGIN_TEMPLATE =
   process.env.NEXT_PUBLIC_PREVIEW_ORIGIN_TEMPLATE ||
@@ -1732,14 +1732,14 @@ function ChatPanel({
     queryKey: activeThreadId ? queryKeys.sessions.threadMessages(sessionId, activeThreadId) : ["session", sessionId, "thread", "none", "messages"],
     queryFn: () => api.sessions.getThreadMessages(sessionId, activeThreadId!),
     enabled: !!activeThreadId,
-    refetchInterval: activeThread && ["pending", "running", "awaiting_input"].includes(activeThread.status) ? 3000 : false,
+    refetchInterval: activeThread && workingStatusesSet.has(activeThread.status) ? 3000 : false,
   });
 
   const threadLogsQuery = useQuery({
     queryKey: activeThreadId ? queryKeys.sessions.threadLogs(sessionId, activeThreadId) : ["session", sessionId, "thread", "none", "logs"],
     queryFn: () => api.sessions.getThreadLogs(sessionId, activeThreadId!),
     enabled: !!activeThreadId,
-    refetchInterval: activeThread && ["pending", "running", "awaiting_input"].includes(activeThread.status) ? 3000 : false,
+    refetchInterval: activeThread && workingStatusesSet.has(activeThread.status) ? 3000 : false,
   });
 
   // Fetch the linked primary issue to display its description as the initial prompt.
@@ -1842,12 +1842,19 @@ function ChatPanel({
   const hasLoadedTimelineInputs = activeThreadId
     ? threadMessagesQuery.isFetched && threadLogsQuery.isFetched
     : timelineQuery.isFetched && (!hasIssue || issueQuery.isFetched);
-  // Skeleton only while we'd reasonably expect content: timeline still loading,
-  // or session is active. Terminal sessions with empty timelines must not shimmer forever.
+  // Skeleton only while we'd reasonably expect content: data still loading, or
+  // the relevant scope is actively working. For a thread-scoped view, "working"
+  // is the selected thread's status — a freshly-created idle thread on an
+  // otherwise-running session must show its empty-state composer, not a
+  // perpetual skeleton. Terminal sessions with empty timelines must not
+  // shimmer forever either.
+  const expectingMoreContent = activeThread
+    ? workingStatusesSet.has(activeThread.status)
+    : activeSet.has(session.status);
   const showLoadingSkeleton =
     timelineEntries.length === 0 &&
     session.status !== "pending" &&
-    (!hasLoadedTimelineInputs || activeSet.has(session.status));
+    (!hasLoadedTimelineInputs || expectingMoreContent);
 
   const persistScrollPosition = useCallback((scrollTop: number) => {
     if (typeof window === "undefined" || !viewerScope) return;
@@ -2787,10 +2794,16 @@ export function SessionDetailContent({ id }: { id: string }) {
     () => comments.filter((comment) => !comment.resolved).slice(0, MAX_RESOLVE_REVIEW_COMMENTS_PER_MESSAGE),
     [comments],
   );
+  // Composer gating: per the design (docs/design/implemented/68-sandbox-agent-tabs-and-threads.md),
+  // Phase 2 supports concurrent threads in one sandbox. The composer is locked
+  // only while the *selected* thread is running — sibling threads being active
+  // (which makes session.status === "running") must not block sending into an
+  // idle thread, since the backend admits concurrent sends up to the per-session
+  // running cap. Pending/skipped/destroyed at the session level still block.
   const composerCanSendMessage = session?.status !== "skipped" &&
     session?.status !== "pending" &&
     session?.sandbox_state !== "destroyed" &&
-    (!activeThread || (session?.status !== "running" && activeThread.status === "idle"));
+    (!activeThread || activeThread.status === "idle");
   const composerIsRunning = activeThread ? activeThread.status === "running" : session?.status === "running";
   const composerIsSnapshotExpired = session?.sandbox_state === "destroyed";
   const composerAgentType = activeThread?.agent_type ?? session?.agent_type ?? "codex";

--- a/frontend/src/lib/session-status-groups.ts
+++ b/frontend/src/lib/session-status-groups.ts
@@ -4,8 +4,15 @@
 export const activeStatuses = ["pending", "running", "idle", "awaiting_input", "needs_human_guidance"];
 export const doneStatuses = ["completed", "pr_created", "failed", "cancelled", "skipped"];
 
+// "Working" means the agent is actively processing or about to: skeleton
+// shimmer, refetch polling, and "Agent is working..." indicators all key off
+// this set. Distinct from `activeStatuses`, which also counts idle/awaiting
+// states where the user holds the turn.
+export const workingStatuses = ["pending", "running", "awaiting_input"];
+
 export const activeSet = new Set(activeStatuses);
 export const workingSet = new Set(["pending", "running"]);
+export const workingStatusesSet = new Set(workingStatuses);
 
 /** Map a filter tab value to the comma-separated status string for the API. */
 export function filterToStatusParam(filter: string | null, extraPassthrough?: string[]): string | undefined {


### PR DESCRIPTION
## Summary
- Fix the session details page shimmering forever when the selected thread was idle but the session was in `activeSet` (e.g. `running` because a sibling thread was working) — the skeleton condition now keys off the active thread's working status, not the session's overall status.
- Drop the leftover Phase 1 `session.status !== "running"` clause from `composerCanSendMessage`. Per the agent-tabs design doc, Phase 2 admits concurrent threads, so an idle thread must be sendable regardless of sibling activity.
- Extract `["pending", "running", "awaiting_input"]` to a shared `workingStatusesSet` constant in `session-status-groups.ts` and reuse it for the refetch intervals and the new skeleton predicate.

## Test plan
- [x] `vitest run frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx` (172/172 pass), including two new regressions: idle thread on idle session clears skeleton, and idle thread on running-sibling session both clears skeleton and enables the composer.
- [x] `tsc --noEmit` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)