### PR TITLE
Fix dead "Fix tests" button when a repair is already running on the same session

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2440,6 +2440,18 @@ export function SessionDetailContent({ id }: { id: string }) {
 
       if (response.data.session_id !== id) {
         router.push(`/sessions/${response.data.session_id}`);
+        return;
+      }
+      // Same-session response: without explicit feedback the click looks
+      // dead. Reused-in-flight is the common case (repair already running on
+      // this session and the failing-tests count hasn't dropped yet, so the
+      // button is still rendered) — surface a toast so the user knows the
+      // request was handled.
+      if (response.data.reused_in_flight) {
+        const label = response.data.repair_action_type === "fix_tests"
+          ? "Fix tests session is already in progress"
+          : "Resolve conflicts session is already in progress";
+        toast.info(label);
       }
     },
     onError: (err) => {

--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -27,6 +27,7 @@ type SessionReviewCommentHandler struct {
 	store        *db.SessionReviewCommentStore
 	sessionStore *db.SessionStore
 	messageStore *db.SessionMessageStore
+	threadStore  *db.SessionThreadStore
 	jobStore     *db.JobStore
 	logger       zerolog.Logger
 	audit        *db.AuditEmitter
@@ -40,10 +41,15 @@ func NewSessionReviewCommentHandler(store *db.SessionReviewCommentStore, session
 	}
 }
 
-// SetMessageAndJobStores wires the message and job stores needed by SendToAgent
-// to send messages directly without a second frontend call.
-func (h *SessionReviewCommentHandler) SetMessageAndJobStores(messageStore *db.SessionMessageStore, jobStore *db.JobStore) {
+// SetMessageAndJobStores wires the message, thread, and job stores needed by
+// SendToAgent to send messages directly without a second frontend call. The
+// thread store is required so the synthesized "address these review comments"
+// message lands on the session's primary thread; without it the message has
+// thread_id=NULL and the per-thread timeline query skips it, leaving the
+// click looking like a no-op.
+func (h *SessionReviewCommentHandler) SetMessageAndJobStores(messageStore *db.SessionMessageStore, threadStore *db.SessionThreadStore, jobStore *db.JobStore) {
 	h.messageStore = messageStore
+	h.threadStore = threadStore
 	h.jobStore = jobStore
 }
 
@@ -384,9 +390,30 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 			userID = &user.ID
 		}
 
+		// Attribute the synthesized review-comment prompt to the session's
+		// primary thread. ClaimIdle doesn't hydrate session.PrimaryThreadID,
+		// so look it up here. ListBySession orders by created_at ASC so the
+		// first entry is the seeded "Main" thread.
+		var threadID *uuid.UUID
+		if h.threadStore != nil {
+			threads, err := h.threadStore.ListBySession(r.Context(), orgID, sessionID)
+			if err != nil {
+				if revertErr := h.sessionStore.UpdateStatus(r.Context(), orgID, sessionID, string(models.SessionStatusIdle)); revertErr != nil {
+					h.logger.Error().Err(revertErr).Str("session_id", sessionID.String()).Msg("failed to revert session to idle after thread lookup failure")
+				}
+				writeError(w, r, http.StatusInternalServerError, "THREAD_LOOKUP_FAILED", "failed to look up session threads")
+				return
+			}
+			if len(threads) > 0 {
+				id := threads[0].ID
+				threadID = &id
+			}
+		}
+
 		msg := &models.SessionMessage{
 			SessionID:  sessionID,
 			OrgID:      orgID,
+			ThreadID:   threadID,
 			UserID:     userID,
 			TurnNumber: session.CurrentTurn + 1,
 			Role:       models.MessageRoleUser,

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -395,7 +395,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	auditLogHandler := handlers.NewAuditLogHandler(auditLogStore)
 	sessionReviewCommentHandler := handlers.NewSessionReviewCommentHandler(sessionReviewCommentStore, sessionStore, logger)
 	sessionReviewCommentHandler.SetAuditEmitter(auditEmitter)
-	sessionReviewCommentHandler.SetMessageAndJobStores(sessionMessageStore, jobStore)
+	sessionReviewCommentHandler.SetMessageAndJobStores(sessionMessageStore, sessionThreadStore, jobStore)
 	// Initialize the session-files snapshot cache so that file-context reads
 	// keep working after the live container is torn down. The cache is
 	// best-effort: a build error here is logged and the handler falls back

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -554,6 +554,7 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 
 	txSessions := db.NewSessionStore(tx)
 	txMessages := db.NewSessionMessageStore(tx)
+	txThreads := db.NewSessionThreadStore(tx)
 	txPRs := db.NewPullRequestStore(tx)
 
 	claimed, claimErr := txSessions.ClaimIdle(ctx, pr.OrgID, session.ID)
@@ -566,9 +567,27 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 	if err := txSessions.UpdateRevisionContext(ctx, pr.OrgID, claimed.ID, revisionContext); err != nil {
 		return nil, err
 	}
+	// The session's primary thread is the "Main" tab seeded at session
+	// creation. Without attributing the repair message to that thread, the
+	// session-detail UI's per-thread timeline query (ListByThread) skips it
+	// and the user sees the click do nothing in the conversation view —
+	// SessionStore.ClaimIdle/ClaimForResume don't hydrate PrimaryThreadID
+	// from the row, so we look it up here. ListBySession orders by
+	// created_at ASC, matching the convention that the first-created thread
+	// is "Main".
+	threads, err := txThreads.ListBySession(ctx, pr.OrgID, claimed.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list session threads for repair message: %w", err)
+	}
+	var threadID *uuid.UUID
+	if len(threads) > 0 {
+		id := threads[0].ID
+		threadID = &id
+	}
 	msg := &models.SessionMessage{
 		SessionID:  claimed.ID,
 		OrgID:      pr.OrgID,
+		ThreadID:   threadID,
 		UserID:     &userID,
 		TurnNumber: claimed.CurrentTurn + 1,
 		Role:       models.MessageRoleUser,

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -990,6 +990,7 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 		{
 			name: "resume repair session",
 			run: func(t *testing.T, mock pgxmock.PgxPoolIface, service *PRService, pr models.PullRequest, parentSession models.Session, userID uuid.UUID, now time.Time) {
+				threadID := uuid.New()
 				mock.ExpectBegin()
 				mock.ExpectQuery("UPDATE sessions").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
@@ -1000,10 +1001,24 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 				mock.ExpectExec("UPDATE sessions.+SET revision_context").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+				mock.ExpectQuery("SELECT .+ FROM session_threads WHERE org_id .+ AND session_id").
+					WithArgs(pr.OrgID, parentSession.ID).
+					WillReturnRows(
+						pgxmock.NewRows(prHealthSessionThreadColumns).
+							AddRow(newPRHealthSessionThreadRow(threadID, parentSession.ID, pr.OrgID, now)...),
+					)
 				mock.ExpectQuery("INSERT INTO session_messages").
 					WithArgs(
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+						parentSession.ID,
+						pr.OrgID,
+						uuidPtrArg{want: threadID},
+						pgxmock.AnyArg(),
+						1,
+						models.MessageRoleUser,
+						"Please resolve the conflicts.",
+						pgxmock.AnyArg(),
+						pgxmock.AnyArg(),
+						pgxmock.AnyArg(),
 						pgxmock.AnyArg(),
 					).
 					WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(1), now))
@@ -1571,6 +1586,15 @@ var prRepairRunTestColumns = []string{
 	"id", "org_id", "pull_request_id", "session_id", "action_type", "health_version", "active", "obsoleted_by_version", "created_at", "updated_at",
 }
 
+var prHealthSessionThreadColumns = []string{
+	"id", "session_id", "org_id", "agent_type", "model_override",
+	"label", "instructions", "file_scope", "status", "agent_session_id",
+	"current_turn", "last_activity_at",
+	"confidence_score", "result_summary", "diff", "failure_explanation", "failure_category",
+	"started_at", "completed_at", "created_at",
+	"base_snapshot_key", "cost_cents", "pending_message_count", "cancel_requested_at",
+}
+
 var prHealthSessionColumns = []string{
 	"id", "primary_issue_id", "org_id", "origin", "interaction_mode", "validation_policy", "agent_type", "status", "autonomy_level", "token_mode",
 	"complexity_tier", "confidence_score", "confidence_reasoning", "risk_factors",
@@ -1611,6 +1635,26 @@ func newPRHealthSessionRow(sessionID, orgID uuid.UUID, now time.Time, status str
 		false, false, false, (*string)(nil), models.LinearPrepareStateNone,
 		nil, nil, nil, now,
 	}
+}
+
+func newPRHealthSessionThreadRow(threadID, sessionID, orgID uuid.UUID, now time.Time) []any {
+	return []any{
+		threadID, sessionID, orgID, "claude_code", nil,
+		"Main", nil, nil, models.ThreadStatusIdle, nil,
+		0, nil,
+		nil, nil, nil, nil, nil,
+		nil, nil, now,
+		nil, float64(0), 0, nil,
+	}
+}
+
+type uuidPtrArg struct {
+	want uuid.UUID
+}
+
+func (a uuidPtrArg) Match(value any) bool {
+	got, ok := value.(*uuid.UUID)
+	return ok && got != nil && *got == a.want
 }
 
 func setPRHealthSessionRowValue(row []any, column string, value any) {


### PR DESCRIPTION
## Summary
- "Fix tests" silently no-ops when a repair is already running on the same session: backend correctly returns `reused_in_flight` with the same `session_id`, but the frontend's `onSuccess` only navigates on a different id. Show an info toast in that case.
- The repair prompt also wasn't showing up in the conversation: `resumeRepairSession` built the `SessionMessage` without `ThreadID`, and `ClaimIdle`/`ClaimForResume` don't hydrate `session.PrimaryThreadID`, so the per-thread timeline query (`ListByThread`) skipped it. Look up the primary thread in the same transaction and attribute the message to it.

## Test plan
- [ ] Click "Fix tests" on a PR — repair message appears in the timeline.
- [ ] Click "Fix tests" again while the repair is still running — toast shows "Fix tests session is already in progress".
- [x] `go test ./internal/services/github/...` passes.
- [x] Frontend `npm run typecheck` and `page.test.tsx` (172 tests) pass.
