### PR TITLE
Resolve review comments atomically on the thread send path

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2855,7 +2855,10 @@ export function SessionDetailContent({ id }: { id: string }) {
   const sendMutation = useMutation({
     mutationFn: (vars: SendMutationArgs) => {
       if (vars.activeThreadId) {
-        return api.sessions.sendThreadMessage(id, vars.activeThreadId, vars.body)
+        return api.sessions.sendThreadMessage(id, vars.activeThreadId, {
+          ...vars.body,
+          resolveReviewCommentIDs: vars.resolvedIDs.length > 0 ? vars.resolvedIDs : undefined,
+        })
           .then((response) => ({ response, resolvedIDs: vars.resolvedIDs }));
       }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -378,7 +378,7 @@ export const api = {
       get<import('./types').SingleResponse<import('./types').SessionThread>>(`/api/v1/sessions/${sessionId}/threads/${threadId}`),
     createThread: (sessionId: string, body: { agent_type?: string; model?: string; label: string; instructions?: string; file_scope?: string[] }) =>
       post<import('./types').SingleResponse<import('./types').SessionThread>>(`/api/v1/sessions/${sessionId}/threads`, body),
-    sendThreadMessage: (sessionId: string, threadId: string, body: { message: string; images?: string[]; references?: import('./types').SessionInputReference[]; commands?: import('./types').SessionInputCommand[]; planMode?: boolean }) =>
+    sendThreadMessage: (sessionId: string, threadId: string, body: { message: string; images?: string[]; references?: import('./types').SessionInputReference[]; commands?: import('./types').SessionInputCommand[]; planMode?: boolean; resolveReviewCommentIDs?: string[] }) =>
       post<import('./types').SingleResponse<import('./types').SessionMessage>>(
         `/api/v1/sessions/${sessionId}/threads/${threadId}/messages`,
         {
@@ -387,6 +387,7 @@ export const api = {
           references: body.references && body.references.length > 0 ? body.references : undefined,
           commands: body.commands && body.commands.length > 0 ? body.commands : undefined,
           plan_mode: body.planMode || undefined,
+          resolve_review_comment_ids: body.resolveReviewCommentIDs && body.resolveReviewCommentIDs.length > 0 ? body.resolveReviewCommentIDs : undefined,
         },
       ),
     endThread: (sessionId: string, threadId: string) =>

--- a/internal/api/handlers/org_id_lint_test.go
+++ b/internal/api/handlers/org_id_lint_test.go
@@ -78,7 +78,7 @@ func TestHandlersMustUseOrgIDFromContext(t *testing.T) {
 		"SessionFileHandler.GetFileContext":        "delegates to getSessionContainer which uses OrgIDFromContext",
 		"SessionComposerHandler.ListSlashCommands": "built-in catalog is not org-scoped; project discovery branch delegates to buildProjectSlashCommandGroup which uses OrgIDFromContext",
 		"SessionHandler.StreamLogs":                "EventSource cannot send X-Active-Org-ID; delegates to streamOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
-		"resolveCommentsError.write":               "internal error-rendering helper; org scoping happens upstream in SendMessage where the error was produced",
+		"parseReviewCommentIDsError.write":         "internal error-rendering helper; org scoping happens upstream in SendMessage where the error was produced",
 		"UploadHandler.ServeUpload":                "<img>/<a> tag fetches cannot send X-Active-Org-ID; authorizes off the path-encoded org-id + UserFromContext membership check rather than active-org context",
 		"UsageHandler.ExportCSV":                   "window.open downloads cannot send X-Active-Org-ID; delegates to exportOrgID which calls OrgIDFromContext and additionally honours a membership-validated ?org_id= query fallback",
 

--- a/internal/api/handlers/review_comment_send.go
+++ b/internal/api/handlers/review_comment_send.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+
+	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/models"
+)
+
+// maxReviewCommentResolveIDsPerMessage caps how many review comments a single
+// follow-up message may resolve atomically. Used by both session-level
+// SendMessage and thread-level SendThreadMessage so the resolve-with-message
+// surface stays uniform across send paths.
+const maxReviewCommentResolveIDsPerMessage = 50
+
+// parseAndDedupeReviewCommentIDs validates and deduplicates the wire-level
+// resolve_review_comment_ids body field. The cap is enforced first so a
+// runaway client can't make us parse a million UUIDs before we reject. Order
+// is preserved on first occurrence so the error message and downstream
+// audits emit IDs in a deterministic order.
+//
+// Returns a parseReviewCommentIDsError carrying the HTTP shape of the failure
+// when the input is malformed, so handlers can render the response without
+// duplicating the error-mapping logic.
+func parseAndDedupeReviewCommentIDs(raw []string) ([]uuid.UUID, *parseReviewCommentIDsError) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	if len(raw) > maxReviewCommentResolveIDsPerMessage {
+		return nil, &parseReviewCommentIDsError{
+			status:  http.StatusBadRequest,
+			code:    "TOO_MANY_REVIEW_COMMENT_IDS",
+			message: fmt.Sprintf("at most %d review comment ids may be resolved per message", maxReviewCommentResolveIDsPerMessage),
+		}
+	}
+	seen := make(map[uuid.UUID]struct{}, len(raw))
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, s := range raw {
+		parsed, err := uuid.Parse(s)
+		if err != nil {
+			return nil, &parseReviewCommentIDsError{
+				status:  http.StatusBadRequest,
+				code:    "INVALID_REVIEW_COMMENT_ID",
+				message: "invalid review comment id: " + s,
+			}
+		}
+		if _, dup := seen[parsed]; dup {
+			continue
+		}
+		seen[parsed] = struct{}{}
+		out = append(out, parsed)
+	}
+	return out, nil
+}
+
+// parseReviewCommentIDsError is the HTTP shape of a body-parsing failure for
+// resolve_review_comment_ids. Pure (no http.ResponseWriter dependency) so the
+// helper can stay free of net/http coupling at the parse stage.
+type parseReviewCommentIDsError struct {
+	status  int
+	code    string
+	message string
+}
+
+func (e *parseReviewCommentIDsError) write(w http.ResponseWriter, r *http.Request) {
+	writeError(w, r, e.status, e.code, e.message)
+}
+
+// renderReviewCommentResolveError maps the structured errors returned by the
+// resolve flow (db sentinel for missing IDs, the in-package "not configured"
+// case) to HTTP responses. Both SendMessage and SendThreadMessage use this so
+// the wire shape stays identical across the two surfaces.
+//
+// Returns true iff the error was recognized and an HTTP response was written;
+// callers should fall back to a generic 500 otherwise.
+func renderReviewCommentResolveError(w http.ResponseWriter, r *http.Request, err error) bool {
+	if err == nil {
+		return false
+	}
+	var notInSession *db.ErrReviewCommentsNotInSession
+	if errors.As(err, &notInSession) {
+		const maxMissingInError = 5
+		ids := notInSession.Missing
+		if len(ids) > maxMissingInError {
+			ids = ids[:maxMissingInError]
+		}
+		strs := make([]string, 0, len(ids))
+		for _, id := range ids {
+			strs = append(strs, id.String())
+		}
+		writeError(w, r, http.StatusBadRequest, "INVALID_REVIEW_COMMENT_IDS",
+			"review comment ids do not belong to this session: "+strings.Join(strs, ", "))
+		return true
+	}
+	return false
+}
+
+// currentResolutionPass returns the pass number to record on a comment that
+// is being resolved during the current request. Matches the semantics used
+// by the PATCH /review-comments handler: the user's resolving action belongs
+// to the session's current turn (with a fallback to 1 for not-yet-started
+// sessions where CurrentTurn is still 0).
+func currentResolutionPass(session *models.Session) int {
+	if session == nil || session.CurrentTurn == 0 {
+		return 1
+	}
+	return session.CurrentTurn
+}
+
+// emitReviewCommentResolutionAudits records one audit row per comment whose
+// resolved state actually changed. Mirrors the audit shape emitted by the
+// direct PATCH /review-comments handler so audit consumers see consistent
+// before/after values regardless of which surface triggered the resolution.
+// The resolved_via_message flag lets consumers tell the two surfaces apart.
+//
+// Lives at the package level (not on a handler receiver) because both
+// session-level SendMessage and thread-level SendThreadMessage emit the
+// same shape — keeping a single source of truth here avoids audit drift
+// between the two surfaces as they evolve.
+func emitReviewCommentResolutionAudits(
+	emitter *db.AuditEmitter,
+	logger zerolog.Logger,
+	r *http.Request,
+	sessionID uuid.UUID,
+	messageID int64,
+	resolved []models.SessionReviewComment,
+) {
+	if len(resolved) == 0 {
+		return
+	}
+	entries := make([]userAuditEntry, 0, len(resolved))
+	for _, c := range resolved {
+		resID := c.ID.String()
+		sid := sessionID
+		entries = append(entries, userAuditEntry{
+			Action:       models.AuditActionSessionReviewCommentUpdated,
+			ResourceType: models.AuditResourceSessionReviewComment,
+			ResourceID:   &resID,
+			SessionID:    &sid,
+			Details: marshalAuditDetails(logger, map[string]any{
+				"review_comment_id":    c.ID.String(),
+				"session_id":           sid.String(),
+				"file_path":            c.FilePath,
+				"line_number":          c.LineNumber,
+				"diff_side":            c.DiffSide,
+				"pass_number":          c.PassNumber,
+				"body_length":          len(c.Body),
+				"resolved_via_message": true,
+				"message_id":           messageID,
+				"changes": map[string]any{
+					"resolved": auditChange(false, true),
+				},
+			}),
+		})
+	}
+	// One INSERT regardless of N — keeps post-commit latency O(1) in the
+	// number of attached comments.
+	emitUserAuditsWithSession(emitter, r, entries)
+}

--- a/internal/api/handlers/session_threads.go
+++ b/internal/api/handlers/session_threads.go
@@ -14,6 +14,7 @@ import (
 	"github.com/assembledhq/143/internal/services/thread"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 )
 
 // ThreadService defines the interface for thread business logic.
@@ -21,7 +22,7 @@ type ThreadService interface {
 	CreateThread(ctx context.Context, input thread.CreateThreadInput) (*models.SessionThread, error)
 	ListThreads(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
 	GetThread(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
-	SendMessage(ctx context.Context, input thread.SendMessageInput) (*models.SessionMessage, error)
+	SendMessage(ctx context.Context, input thread.SendMessageInput) (*thread.SendMessageResult, error)
 	EndThread(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
 	GetMessages(ctx context.Context, orgID, sessionID, threadID uuid.UUID) ([]models.SessionMessage, error)
 	GetLogs(ctx context.Context, orgID, sessionID, threadID uuid.UUID) ([]models.SessionLog, error)
@@ -32,11 +33,27 @@ type ThreadService interface {
 }
 
 type SessionThreadHandler struct {
-	svc ThreadService
+	svc    ThreadService
+	audit  *db.AuditEmitter
+	logger zerolog.Logger
 }
 
 func NewSessionThreadHandler(svc ThreadService) *SessionThreadHandler {
 	return &SessionThreadHandler{svc: svc}
+}
+
+// SetAuditEmitter wires the audit emitter used by SendThreadMessage to record
+// review-comment resolutions. Optional — when unset, the resolution still
+// happens (it's an in-tx side effect of the message create) but no audit row
+// is written. Mirrors SessionHandler.SetAuditEmitter.
+func (h *SessionThreadHandler) SetAuditEmitter(audit *db.AuditEmitter) {
+	h.audit = audit
+}
+
+// SetLogger wires the logger used for marshaling audit details. Optional —
+// the zerolog Nop value is harmless when unset.
+func (h *SessionThreadHandler) SetLogger(logger zerolog.Logger) {
+	h.logger = logger
 }
 
 // CreateThread handles POST /sessions/{id}/threads — adds a new agent thread
@@ -161,11 +178,12 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 	}
 
 	var body struct {
-		Message    string                        `json:"message"`
-		Images     []string                      `json:"images"`
-		References models.SessionInputReferences `json:"references"`
-		Commands   models.SessionInputCommands   `json:"commands"`
-		PlanMode   bool                          `json:"plan_mode"`
+		Message                 string                        `json:"message"`
+		Images                  []string                      `json:"images"`
+		References              models.SessionInputReferences `json:"references"`
+		Commands                models.SessionInputCommands   `json:"commands"`
+		PlanMode                bool                          `json:"plan_mode"`
+		ResolveReviewCommentIDs []string                      `json:"resolve_review_comment_ids"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body")
@@ -177,24 +195,48 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 		return
 	}
 
+	// Parse and dedupe optional review-comment IDs to resolve atomically with
+	// the message create. Mirrors session-level SendMessage so the wire shape
+	// stays uniform across send paths — see review_comment_send.go for the
+	// shared parser.
+	resolveCommentIDs, parseErr := parseAndDedupeReviewCommentIDs(body.ResolveReviewCommentIDs)
+	if parseErr != nil {
+		parseErr.write(w, r)
+		return
+	}
+
 	user := middleware.UserFromContext(r.Context())
 	var userID *uuid.UUID
 	if user != nil {
 		userID = &user.ID
 	}
 
-	msg, err := h.svc.SendMessage(r.Context(), thread.SendMessageInput{
-		SessionID:  sessionID,
-		OrgID:      orgID,
-		ThreadID:   threadID,
-		UserID:     userID,
-		Message:    body.Message,
-		Images:     body.Images,
-		References: body.References,
-		Commands:   body.Commands,
-		PlanMode:   body.PlanMode,
+	result, err := h.svc.SendMessage(r.Context(), thread.SendMessageInput{
+		SessionID:               sessionID,
+		OrgID:                   orgID,
+		ThreadID:                threadID,
+		UserID:                  userID,
+		Message:                 body.Message,
+		Images:                  body.Images,
+		References:              body.References,
+		Commands:                body.Commands,
+		PlanMode:                body.PlanMode,
+		ResolveReviewCommentIDs: resolveCommentIDs,
 	})
 	if err != nil {
+		// Comment-resolution errors take priority over the generic switch
+		// because they're more specific (the request shape is well-formed,
+		// but the comment IDs are bad). renderReviewCommentResolveError
+		// handles ErrReviewCommentsNotInSession; the not-configured sentinel
+		// is mapped explicitly here so the status/code match session-level
+		// SendMessage.
+		if errors.Is(err, thread.ErrReviewCommentsNotConfigured) {
+			writeError(w, r, http.StatusBadRequest, "REVIEW_COMMENTS_NOT_CONFIGURED", "review comment resolution is not configured for this server")
+			return
+		}
+		if renderReviewCommentResolveError(w, r, err) {
+			return
+		}
 		switch {
 		case errors.Is(err, thread.ErrThreadNotFound):
 			writeError(w, r, http.StatusNotFound, "NOT_FOUND", "thread not found")
@@ -212,7 +254,13 @@ func (h *SessionThreadHandler) SendThreadMessage(w http.ResponseWriter, r *http.
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *msg})
+	// Audit one row per resolved comment after the tx commits — same shape
+	// as session-level SendMessage so audit consumers see consistent
+	// before/after values regardless of which surface triggered the
+	// resolution.
+	emitReviewCommentResolutionAudits(h.audit, h.logger, r, sessionID, result.Message.ID, result.ResolvedComments)
+
+	writeJSON(w, http.StatusCreated, models.SingleResponse[models.SessionMessage]{Data: *result.Message})
 }
 
 // GetThreadMessages handles GET /sessions/{id}/threads/{tid}/messages —

--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -681,6 +681,41 @@ func TestSessionThreadHandler_SendThreadMessage(t *testing.T) {
 			expectedCode:   http.StatusBadRequest,
 			expectedError:  "INVALID_BODY",
 		},
+		{
+			// Malformed comment IDs are caught at the wire-level parser
+			// before any service work happens — same shape session-level
+			// SendMessage uses, so the two surfaces stay consistent.
+			name:           "malformed comment ID rejected by parser",
+			sessionIDParam: sessionID.String(),
+			threadIDParam:  threadID.String(),
+			body:           `{"message":"hi","resolve_review_comment_ids":["not-a-uuid"]}`,
+			setupDeps:      func(deps *threadTestDeps) {},
+			expectedCode:   http.StatusBadRequest,
+			expectedError:  "INVALID_REVIEW_COMMENT_ID",
+		},
+		{
+			// When the service is wired without a resolver but the client
+			// sends comment IDs, surface a 400 with REVIEW_COMMENTS_NOT_CONFIGURED
+			// so the client can disable the feature flag rather than retrying.
+			// The default newThreadHandler does not call SetReviewCommentResolver.
+			name:           "resolve IDs rejected when resolver not wired",
+			sessionIDParam: sessionID.String(),
+			threadIDParam:  threadID.String(),
+			body:           `{"message":"hi","resolve_review_comment_ids":["00000000-0000-4000-8000-000000000000"]}`,
+			setupDeps: func(deps *threadTestDeps) {
+				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{
+						ID:          threadID,
+						SessionID:   sessionID,
+						OrgID:       orgID,
+						Status:      models.ThreadStatusRunning,
+						CurrentTurn: 1,
+					}, nil
+				}
+			},
+			expectedCode:  http.StatusBadRequest,
+			expectedError: "REVIEW_COMMENTS_NOT_CONFIGURED",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1744,12 +1744,6 @@ func (h *SessionHandler) AnswerQuestion(w http.ResponseWriter, r *http.Request) 
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.SessionQuestion]{Data: question})
 }
 
-// maxReviewCommentResolveIDsPerMessage caps how many review comments a single
-// SendMessage call can resolve. Each resolved comment emits one audit row
-// after the tx commits, so the cap keeps the post-commit tail bounded even
-// under unusual client behavior. The realistic typical attached-count is 1–3.
-const maxReviewCommentResolveIDsPerMessage = 50
-
 // SendMessage handles POST /sessions/{id}/messages — sends a follow-up message
 // to an idle multi-turn session and enqueues a continue_session job.
 func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
@@ -1805,31 +1799,14 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	// /review-comments/{id}, which restricts edits to the comment's author.
 	// Both surfaces share the same audit action so a downstream consumer can
 	// still distinguish via the resolved_via_message flag in audit details.
-	var resolveCommentIDs []uuid.UUID
-	if len(body.ResolveReviewCommentIDs) > 0 {
-		if h.reviewCommentStore == nil {
-			writeError(w, r, http.StatusBadRequest, "REVIEW_COMMENTS_NOT_CONFIGURED", "review comment resolution is not configured for this server")
-			return
-		}
-		if len(body.ResolveReviewCommentIDs) > maxReviewCommentResolveIDsPerMessage {
-			writeError(w, r, http.StatusBadRequest, "TOO_MANY_REVIEW_COMMENT_IDS",
-				fmt.Sprintf("at most %d review comment ids may be resolved per message", maxReviewCommentResolveIDsPerMessage))
-			return
-		}
-		seen := make(map[uuid.UUID]struct{}, len(body.ResolveReviewCommentIDs))
-		resolveCommentIDs = make([]uuid.UUID, 0, len(body.ResolveReviewCommentIDs))
-		for _, raw := range body.ResolveReviewCommentIDs {
-			parsed, err := uuid.Parse(raw)
-			if err != nil {
-				writeError(w, r, http.StatusBadRequest, "INVALID_REVIEW_COMMENT_ID", "invalid review comment id: "+raw)
-				return
-			}
-			if _, dup := seen[parsed]; dup {
-				continue
-			}
-			seen[parsed] = struct{}{}
-			resolveCommentIDs = append(resolveCommentIDs, parsed)
-		}
+	if len(body.ResolveReviewCommentIDs) > 0 && h.reviewCommentStore == nil {
+		writeError(w, r, http.StatusBadRequest, "REVIEW_COMMENTS_NOT_CONFIGURED", "review comment resolution is not configured for this server")
+		return
+	}
+	resolveCommentIDs, parseErr := parseAndDedupeReviewCommentIDs(body.ResolveReviewCommentIDs)
+	if parseErr != nil {
+		parseErr.write(w, r)
+		return
 	}
 
 	// When plan mode is requested, prefix the message so the orchestrator
@@ -1925,10 +1902,13 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 			writeError(w, r, http.StatusInternalServerError, "CREATE_FAILED", "failed to create message", err)
 			return
 		}
-		resolvedComments, rerr := resolveSessionReviewComments(
-			r.Context(), txReviewCommentStore, orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
+		resolvedComments, rerr := txReviewCommentStore.ValidateAndResolveByIDs(
+			r.Context(), orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
 		if rerr != nil {
-			rerr.write(w, r)
+			if renderReviewCommentResolveError(w, r, rerr) {
+				return
+			}
+			writeError(w, r, http.StatusInternalServerError, "REVIEW_COMMENT_RESOLVE_FAILED", "failed to resolve review comments", rerr)
 			return
 		}
 		if err := tx.Commit(r.Context()); err != nil {
@@ -1992,11 +1972,14 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 
 	var resolvedComments []models.SessionReviewComment
 	if txReviewCommentStore != nil {
-		var rerr *resolveCommentsError
-		resolvedComments, rerr = resolveSessionReviewComments(
-			r.Context(), txReviewCommentStore, orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
+		var rerr error
+		resolvedComments, rerr = txReviewCommentStore.ValidateAndResolveByIDs(
+			r.Context(), orgID, sessionID, resolveCommentIDs, currentResolutionPass(&session))
 		if rerr != nil {
-			rerr.write(w, r)
+			if renderReviewCommentResolveError(w, r, rerr) {
+				return
+			}
+			writeError(w, r, http.StatusInternalServerError, "REVIEW_COMMENT_RESOLVE_FAILED", "failed to resolve review comments", rerr)
 			return
 		}
 	}
@@ -2098,140 +2081,17 @@ func (h *SessionHandler) maybeLinkLinearMidSession(ctx context.Context, orgID, s
 	}()
 }
 
-// currentResolutionPass returns the pass number to record on a comment that
-// is being resolved during the current request, matching the semantics used
-// by the PATCH /review-comments handler: the user's resolving action belongs
-// to the session's current turn (with a fallback to 1 for not-yet-started
-// sessions where CurrentTurn is still 0).
-func currentResolutionPass(session *models.Session) int {
-	if session == nil || session.CurrentTurn == 0 {
-		return 1
-	}
-	return session.CurrentTurn
-}
-
-// resolveCommentsError carries the HTTP shape of a failure inside the
-// resolve-comments helper, so the helper can stay pure (no http.ResponseWriter
-// dependency) and SendMessage controls when the response is written. underlying
-// is included only when there's a real error worth logging.
-type resolveCommentsError struct {
-	status     int
-	code       string
-	message    string
-	underlying error
-}
-
-func (e *resolveCommentsError) write(w http.ResponseWriter, r *http.Request) {
-	if e.underlying != nil {
-		writeError(w, r, e.status, e.code, e.message, e.underlying)
-		return
-	}
-	writeError(w, r, e.status, e.code, e.message)
-}
-
-// resolveSessionReviewComments validates that every requested ID belongs to
-// the session and resolves the still-open ones, returning the rows whose
-// state actually changed. Already-resolved IDs are silently skipped (the
-// underlying store filters on resolved=false). The helper is pure: it does
-// not write to the response, so the caller decides when (and whether) to
-// surface failures to the HTTP client and to abandon the surrounding tx.
-//
-// The store argument must already be tx-scoped — the validation lookup and
-// the resolve UPDATE share the same tx so other writers can't slip a comment
-// in between the existence check and the update.
-func resolveSessionReviewComments(
-	ctx context.Context,
-	store *db.SessionReviewCommentStore,
-	orgID, sessionID uuid.UUID,
-	ids []uuid.UUID,
-	resolvedByPass int,
-) ([]models.SessionReviewComment, *resolveCommentsError) {
-	if len(ids) == 0 || store == nil {
-		return nil, nil
-	}
-	existing, err := store.ListByIDs(ctx, orgID, sessionID, ids)
-	if err != nil {
-		return nil, &resolveCommentsError{
-			status: http.StatusInternalServerError, code: "REVIEW_COMMENT_LOOKUP_FAILED",
-			message: "failed to look up review comments", underlying: err,
-		}
-	}
-	if len(existing) != len(ids) {
-		// Surface the missing IDs (capped) so misbehaving clients can debug
-		// without leaking other tenants' data — IDs not scoped to this org+
-		// session are functionally indistinguishable from "doesn't exist".
-		found := make(map[uuid.UUID]struct{}, len(existing))
-		for _, c := range existing {
-			found[c.ID] = struct{}{}
-		}
-		const maxMissingInError = 5
-		missing := make([]string, 0, maxMissingInError)
-		for _, id := range ids {
-			if _, ok := found[id]; ok {
-				continue
-			}
-			if len(missing) == maxMissingInError {
-				break
-			}
-			missing = append(missing, id.String())
-		}
-		return nil, &resolveCommentsError{
-			status: http.StatusBadRequest, code: "INVALID_REVIEW_COMMENT_IDS",
-			message: "review comment ids do not belong to this session: " + strings.Join(missing, ", "),
-		}
-	}
-	resolved, err := store.ResolveByIDs(ctx, orgID, sessionID, ids, resolvedByPass)
-	if err != nil {
-		return nil, &resolveCommentsError{
-			status: http.StatusInternalServerError, code: "REVIEW_COMMENT_RESOLVE_FAILED",
-			message: "failed to resolve review comments", underlying: err,
-		}
-	}
-	return resolved, nil
-}
-
 // emitReviewCommentResolutionAudits records one audit row per comment whose
-// resolved state actually changed. Mirrors the audit shape emitted by the
-// direct PATCH /review-comments handler so audit consumers see consistent
-// before/after values regardless of which surface triggered the resolution.
-// The resolved_via_message flag lets consumers tell the two surfaces apart.
+// resolved state actually changed. Wraps the shared audit emitter on the
+// SessionHandler so this surface stays consistent with the rest of
+// SendMessage's audit shape.
 func (h *SessionHandler) emitReviewCommentResolutionAudits(
 	r *http.Request,
 	sessionID uuid.UUID,
 	messageID int64,
 	resolved []models.SessionReviewComment,
 ) {
-	if len(resolved) == 0 {
-		return
-	}
-	entries := make([]userAuditEntry, 0, len(resolved))
-	for _, c := range resolved {
-		resID := c.ID.String()
-		sid := sessionID
-		entries = append(entries, userAuditEntry{
-			Action:       models.AuditActionSessionReviewCommentUpdated,
-			ResourceType: models.AuditResourceSessionReviewComment,
-			ResourceID:   &resID,
-			SessionID:    &sid,
-			Details: marshalAuditDetails(h.logger, map[string]any{
-				"review_comment_id":    c.ID.String(),
-				"session_id":           sid.String(),
-				"file_path":            c.FilePath,
-				"line_number":          c.LineNumber,
-				"diff_side":            c.DiffSide,
-				"pass_number":          c.PassNumber,
-				"body_length":          len(c.Body),
-				"resolved_via_message": true,
-				"message_id":           messageID,
-				"changes": map[string]any{
-					"resolved": auditChange(false, true),
-				},
-			}),
-		})
-	}
-	// One INSERT regardless of N — keeps post-commit latency O(1) in the
-	// number of attached comments.
-	emitUserAuditsWithSession(h.audit, r, entries)
+	emitReviewCommentResolutionAudits(h.audit, h.logger, r, sessionID, messageID, resolved)
 }
 
 // ListMessages handles GET /sessions/{id}/messages — returns the conversation messages.

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -5829,148 +5829,85 @@ func TestCurrentResolutionPass(t *testing.T) {
 	}
 }
 
-func TestResolveCommentsError_Write(t *testing.T) {
+// TestParseAndDedupeReviewCommentIDs covers the shared helper used by both
+// session-level SendMessage and thread-level SendThreadMessage. The
+// behaviors under test (cap, dedupe, malformed UUID rejection) are uniform
+// across both surfaces; the deeper validate-and-resolve tests live in the db
+// package against ValidateAndResolveByIDs.
+func TestParseAndDedupeReviewCommentIDs(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name       string
-		err        *resolveCommentsError
-		expectCode string
-	}{
-		{
-			name: "writes plain error",
-			err: &resolveCommentsError{
-				status: http.StatusBadRequest, code: "BAD_COMMENTS", message: "bad comments",
-			},
-			expectCode: "BAD_COMMENTS",
-		},
-		{
-			name: "writes underlying error",
-			err: &resolveCommentsError{
-				status: http.StatusInternalServerError, code: "COMMENT_LOOKUP_FAILED", message: "lookup failed", underlying: errors.New("db down"),
-			},
-			expectCode: "COMMENT_LOOKUP_FAILED",
-		},
-	}
+	t.Run("returns nil for empty input", func(t *testing.T) {
+		t.Parallel()
+		out, perr := parseAndDedupeReviewCommentIDs(nil)
+		require.Nil(t, perr)
+		require.Nil(t, out)
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	t.Run("rejects malformed UUID before any work", func(t *testing.T) {
+		t.Parallel()
+		out, perr := parseAndDedupeReviewCommentIDs([]string{"not-a-uuid"})
+		require.NotNil(t, perr)
+		require.Equal(t, "INVALID_REVIEW_COMMENT_ID", perr.code)
+		require.Equal(t, http.StatusBadRequest, perr.status)
+		require.Empty(t, out)
+	})
 
-			req := httptest.NewRequest(http.MethodPost, "/", nil)
-			w := httptest.NewRecorder()
-			tt.err.write(w, req)
-			require.Equal(t, tt.err.status, w.Code, "resolveCommentsError should write the configured HTTP status")
-			require.Contains(t, w.Body.String(), tt.expectCode, "response should include the configured error code")
-		})
-	}
+	t.Run("rejects too many IDs", func(t *testing.T) {
+		t.Parallel()
+		raw := make([]string, maxReviewCommentResolveIDsPerMessage+1)
+		for i := range raw {
+			raw[i] = uuid.New().String()
+		}
+		out, perr := parseAndDedupeReviewCommentIDs(raw)
+		require.NotNil(t, perr)
+		require.Equal(t, "TOO_MANY_REVIEW_COMMENT_IDS", perr.code)
+		require.Equal(t, http.StatusBadRequest, perr.status)
+		require.Empty(t, out)
+	})
+
+	t.Run("dedupes preserving first occurrence", func(t *testing.T) {
+		t.Parallel()
+		a := uuid.New()
+		b := uuid.New()
+		out, perr := parseAndDedupeReviewCommentIDs([]string{a.String(), b.String(), a.String()})
+		require.Nil(t, perr)
+		require.Equal(t, []uuid.UUID{a, b}, out)
+	})
 }
 
-func TestResolveSessionReviewComments(t *testing.T) {
+func TestRenderReviewCommentResolveError(t *testing.T) {
 	t.Parallel()
 
-	t.Run("no-op for empty IDs or missing store", func(t *testing.T) {
+	t.Run("returns false for nil error", func(t *testing.T) {
 		t.Parallel()
-
-		orgID := uuid.New()
-		sessionID := uuid.New()
-		resolved, rerr := resolveSessionReviewComments(context.Background(), nil, orgID, sessionID, []uuid.UUID{uuid.New()}, 1)
-		require.Nil(t, rerr, "nil store should be a no-op")
-		require.Empty(t, resolved, "nil store should not resolve comments")
-
-		mock, err := pgxmock.NewPool()
-		require.NoError(t, err, "pgxmock pool should initialize")
-		defer mock.Close()
-
-		store := db.NewSessionReviewCommentStore(mock)
-		resolved, rerr = resolveSessionReviewComments(context.Background(), store, orgID, sessionID, nil, 1)
-		require.Nil(t, rerr, "empty ID list should be a no-op")
-		require.Empty(t, resolved, "empty ID list should not resolve comments")
-		require.NoError(t, mock.ExpectationsWereMet(), "empty ID list should not query the store")
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		require.False(t, renderReviewCommentResolveError(w, req, nil))
+		require.Equal(t, http.StatusOK, w.Code, "no body should be written")
 	})
 
-	t.Run("returns lookup errors", func(t *testing.T) {
+	t.Run("returns false for unrelated errors", func(t *testing.T) {
 		t.Parallel()
-
-		mock, err := pgxmock.NewPool()
-		require.NoError(t, err, "pgxmock pool should initialize")
-		defer mock.Close()
-
-		orgID := uuid.New()
-		sessionID := uuid.New()
-		commentID := uuid.New()
-		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
-			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnError(errors.New("connection refused"))
-
-		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, []uuid.UUID{commentID}, 1)
-		require.Empty(t, resolved, "lookup failure should not return resolved comments")
-		require.NotNil(t, rerr, "lookup failure should return a structured error")
-		require.Equal(t, "REVIEW_COMMENT_LOOKUP_FAILED", rerr.code, "lookup failure should use the lookup error code")
-		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		require.False(t, renderReviewCommentResolveError(w, req, errors.New("connection refused")))
+		require.Equal(t, http.StatusOK, w.Code, "unrelated errors should not be written by this helper")
 	})
 
-	t.Run("caps missing ID details", func(t *testing.T) {
+	t.Run("renders ErrReviewCommentsNotInSession with capped IDs", func(t *testing.T) {
 		t.Parallel()
-
-		mock, err := pgxmock.NewPool()
-		require.NoError(t, err, "pgxmock pool should initialize")
-		defer mock.Close()
-
-		now := time.Now()
-		orgID := uuid.New()
-		sessionID := uuid.New()
-		userID := uuid.New()
 		ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()}
-		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
-			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnRows(
-				pgxmock.NewRows(reviewCommentColumns).
-					AddRow(ids[0], sessionID, orgID, userID, "main.go",
-						1, "right", "exists", false, (*time.Time)(nil), (*int)(nil),
-						1, now, now),
-			)
-
-		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, ids, 1)
-		require.Empty(t, resolved, "missing IDs should not resolve comments")
-		require.NotNil(t, rerr, "missing IDs should return a structured error")
-		require.Equal(t, "INVALID_REVIEW_COMMENT_IDS", rerr.code, "missing IDs should use the invalid IDs error code")
-		require.NotContains(t, rerr.message, ids[0].String(), "existing IDs should not be reported as missing")
-		require.Contains(t, rerr.message, ids[1].String(), "first missing ID should be reported")
-		require.Contains(t, rerr.message, ids[5].String(), "fifth missing ID should be reported")
-		require.NotContains(t, rerr.message, ids[6].String(), "missing ID details should be capped")
-		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
-	})
-
-	t.Run("returns resolve errors", func(t *testing.T) {
-		t.Parallel()
-
-		mock, err := pgxmock.NewPool()
-		require.NoError(t, err, "pgxmock pool should initialize")
-		defer mock.Close()
-
-		now := time.Now()
-		orgID := uuid.New()
-		sessionID := uuid.New()
-		userID := uuid.New()
-		commentID := uuid.New()
-		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
-			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnRows(
-				pgxmock.NewRows(reviewCommentColumns).
-					AddRow(commentID, sessionID, orgID, userID, "main.go",
-						1, "right", "exists", false, (*time.Time)(nil), (*int)(nil),
-						1, now, now),
-			)
-		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
-			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-			WillReturnError(errors.New("connection refused"))
-
-		resolved, rerr := resolveSessionReviewComments(context.Background(), db.NewSessionReviewCommentStore(mock), orgID, sessionID, []uuid.UUID{commentID}, 2)
-		require.Empty(t, resolved, "resolve failure should not return resolved comments")
-		require.NotNil(t, rerr, "resolve failure should return a structured error")
-		require.Equal(t, "REVIEW_COMMENT_RESOLVE_FAILED", rerr.code, "resolve failure should use the resolve error code")
-		require.NoError(t, mock.ExpectationsWereMet(), "all store expectations should be met")
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/", nil)
+		require.True(t, renderReviewCommentResolveError(w, req, &db.ErrReviewCommentsNotInSession{Missing: ids}))
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		body := w.Body.String()
+		require.Contains(t, body, "INVALID_REVIEW_COMMENT_IDS")
+		require.Contains(t, body, ids[0].String(), "first missing ID should appear")
+		require.Contains(t, body, ids[4].String(), "fifth missing ID should appear")
+		require.NotContains(t, body, ids[5].String(), "missing ID details should be capped at 5")
+		require.NotContains(t, body, ids[6].String(), "missing ID details should be capped at 5")
 	})
 }
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -281,7 +281,15 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 	if threadCanceller != nil {
 		threadSvc.SetCanceller(threadCanceller)
 	}
+	// Wire review-comment resolution so SendThreadMessage can resolve
+	// comments atomically with the message create — same invariant the
+	// session-level SendMessage already enforces. Without this, the
+	// "submitted comments stick around for the next turn" bug surfaces on
+	// any session whose follow-up flows through a thread tab.
+	threadSvc.SetReviewCommentResolver(pool, sessionReviewCommentStore)
 	sessionThreadHandler := handlers.NewSessionThreadHandler(threadSvc)
+	sessionThreadHandler.SetAuditEmitter(auditEmitter)
+	sessionThreadHandler.SetLogger(logger)
 	pmHandler := handlers.NewPMHandler(pmPlanStore, pmDecisionLogStore, jobStore, orgStore)
 	priorityHandler := handlers.NewPriorityHandler(priorityScoreStore, complexityEstimateStore, jobStore)
 	ingestionWebhookHandler := handlers.NewIngestionWebhookHandler(webhookDeliveryStore, integrationStore, credentialStore, ingestionSvc, logger)

--- a/internal/db/session_review_comment_store.go
+++ b/internal/db/session_review_comment_store.go
@@ -108,6 +108,64 @@ func (s *SessionReviewCommentStore) ListByIDs(ctx context.Context, orgID, sessio
 	return pgx.CollectRows(rows, pgx.RowToStructByName[models.SessionReviewComment])
 }
 
+// ErrReviewCommentsNotInSession is returned by ValidateAndResolveByIDs when
+// one or more requested IDs do not belong to the org+session pair (either
+// they don't exist or they belong to another session). The error wraps the
+// missing IDs so callers can surface them to the client without leaking
+// other tenants' data via existence-vs-not-found probing.
+type ErrReviewCommentsNotInSession struct {
+	Missing []uuid.UUID
+}
+
+func (e *ErrReviewCommentsNotInSession) Error() string {
+	return fmt.Sprintf("review comment ids do not belong to this session (%d missing)", len(e.Missing))
+}
+
+// ValidateAndResolveByIDs validates that every id belongs to the org+session
+// pair and then resolves the still-open ones in the same call, returning the
+// rows whose state actually changed. When run against a tx-scoped store, the
+// validation lookup and the resolve UPDATE share a transaction so other
+// writers cannot slip a comment in between the existence check and the
+// update — keeping the "either both happen or neither does" invariant that
+// the SendMessage flow relies on.
+//
+// Returns *ErrReviewCommentsNotInSession (wrapping the missing IDs) when one
+// or more IDs do not belong to this session; callers can surface the missing
+// list without doing their own existence comparison. Already-resolved IDs
+// are silently skipped (the underlying UPDATE filters on resolved=false).
+func (s *SessionReviewCommentStore) ValidateAndResolveByIDs(
+	ctx context.Context,
+	orgID, sessionID uuid.UUID,
+	ids []uuid.UUID,
+	resolvedByPass int,
+) ([]models.SessionReviewComment, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	existing, err := s.ListByIDs(ctx, orgID, sessionID, ids)
+	if err != nil {
+		return nil, fmt.Errorf("validate review comments: %w", err)
+	}
+	if len(existing) != len(ids) {
+		found := make(map[uuid.UUID]struct{}, len(existing))
+		for _, c := range existing {
+			found[c.ID] = struct{}{}
+		}
+		missing := make([]uuid.UUID, 0, len(ids)-len(existing))
+		for _, id := range ids {
+			if _, ok := found[id]; !ok {
+				missing = append(missing, id)
+			}
+		}
+		return nil, &ErrReviewCommentsNotInSession{Missing: missing}
+	}
+	resolved, err := s.ResolveByIDs(ctx, orgID, sessionID, ids, resolvedByPass)
+	if err != nil {
+		return nil, fmt.Errorf("resolve review comments: %w", err)
+	}
+	return resolved, nil
+}
+
 // ResolveByIDs marks the listed comments as resolved if they aren't already,
 // returning the rows whose state actually changed. Already-resolved comments
 // are silently skipped, which makes the operation idempotent: callers can

--- a/internal/db/session_review_comment_store_test.go
+++ b/internal/db/session_review_comment_store_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -649,6 +650,136 @@ func TestSessionReviewCommentStore_ResolveByIDs(t *testing.T) {
 
 		_, err = store.ResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{id1}, 1)
 		require.Error(t, err, "should propagate db errors")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestSessionReviewCommentStore_ValidateAndResolveByIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-op for empty IDs", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		store := NewSessionReviewCommentStore(mock)
+		resolved, err := store.ValidateAndResolveByIDs(context.Background(), uuid.New(), uuid.New(), nil, 1)
+		require.NoError(t, err, "empty ID list should be a no-op")
+		require.Empty(t, resolved, "empty ID list should not resolve comments")
+		require.NoError(t, mock.ExpectationsWereMet(), "empty ID list should not query the store")
+	})
+
+	t.Run("propagates lookup errors", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(errors.New("connection refused"))
+
+		store := NewSessionReviewCommentStore(mock)
+		resolved, err := store.ValidateAndResolveByIDs(context.Background(), uuid.New(), uuid.New(), []uuid.UUID{uuid.New()}, 1)
+		require.Error(t, err, "lookup failure should surface")
+		require.Empty(t, resolved, "lookup failure should not return resolved comments")
+		var notInSession *ErrReviewCommentsNotInSession
+		require.False(t, errors.As(err, &notInSession), "lookup error should NOT be classified as not-in-session")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("returns ErrReviewCommentsNotInSession for foreign IDs", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		now := time.Now()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		// Caller asks about three IDs but only two belong to the session.
+		ids := []uuid.UUID{uuid.New(), uuid.New(), uuid.New()}
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(ids[0], sessionID, orgID, userID, "main.go", 1, "right", "first", false, (*time.Time)(nil), (*int)(nil), 1, now, now).
+					AddRow(ids[1], sessionID, orgID, userID, "main.go", 2, "right", "second", false, (*time.Time)(nil), (*int)(nil), 1, now, now),
+			)
+		// No UPDATE expected: validation fails before the resolve runs.
+
+		store := NewSessionReviewCommentStore(mock)
+		resolved, err := store.ValidateAndResolveByIDs(context.Background(), orgID, sessionID, ids, 1)
+		require.Error(t, err)
+		require.Empty(t, resolved)
+		var notInSession *ErrReviewCommentsNotInSession
+		require.True(t, errors.As(err, &notInSession), "foreign ID should produce ErrReviewCommentsNotInSession")
+		require.Equal(t, []uuid.UUID{ids[2]}, notInSession.Missing, "missing IDs should be reported in input order")
+		require.NoError(t, mock.ExpectationsWereMet(), "resolve UPDATE must not run when validation fails")
+	})
+
+	t.Run("resolves valid IDs and returns rows that flipped", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		now := time.Now()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentID := uuid.New()
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(commentID, sessionID, orgID, userID, "main.go", 1, "right", "fix this", false, (*time.Time)(nil), (*int)(nil), 1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(commentID, sessionID, orgID, userID, "main.go", 1, "right", "fix this", true, &now, srcIntPtr(2), 1, now, now),
+			)
+
+		store := NewSessionReviewCommentStore(mock)
+		resolved, err := store.ValidateAndResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{commentID}, 2)
+		require.NoError(t, err)
+		require.Len(t, resolved, 1, "the one valid+open comment should be returned as resolved")
+		require.Equal(t, commentID, resolved[0].ID)
+		require.True(t, resolved[0].Resolved)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("propagates resolve errors", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		now := time.Now()
+		orgID := uuid.New()
+		sessionID := uuid.New()
+		userID := uuid.New()
+		commentID := uuid.New()
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(srcColumns).
+					AddRow(commentID, sessionID, orgID, userID, "main.go", 1, "right", "fix this", false, (*time.Time)(nil), (*int)(nil), 1, now, now),
+			)
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnError(errors.New("connection refused"))
+
+		store := NewSessionReviewCommentStore(mock)
+		resolved, err := store.ValidateAndResolveByIDs(context.Background(), orgID, sessionID, []uuid.UUID{commentID}, 1)
+		require.Error(t, err)
+		require.Empty(t, resolved)
+		var notInSession *ErrReviewCommentsNotInSession
+		require.False(t, errors.As(err, &notInSession), "DB-level resolve error should NOT be classified as not-in-session")
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 }

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -35,6 +35,12 @@ var (
 	// failed). Surfaced to clients so the cancel button can be hidden when
 	// it would do nothing.
 	ErrThreadNotCancellable = errors.New("thread is not cancellable")
+	// ErrReviewCommentsNotConfigured is returned when SendMessage is called
+	// with ResolveReviewCommentIDs but the service was constructed without
+	// the review-comment plumbing (txStarter + reviewCommentStore). Handlers
+	// should surface this as a 400 — the client requested a feature the
+	// server isn't running.
+	ErrReviewCommentsNotConfigured = errors.New("review comment resolution is not configured")
 )
 
 // SessionStore defines the session DB operations needed by the thread service.
@@ -98,28 +104,49 @@ type CreateThreadInput struct {
 }
 
 // SendMessageInput holds the input for sending a message to a thread.
+//
+// ResolveReviewCommentIDs, when non-empty, are validated and flipped to
+// resolved=true atomically with the message create — preserving the
+// "addressing comments" → "send follow-up" → "comments resolved" invariant
+// that the session-level SendMessage already guarantees. Requires the
+// service to be wired with SetTxStarter and SetReviewCommentStore; handler
+// layers should reject the request with a 400 when those are absent.
 type SendMessageInput struct {
-	SessionID  uuid.UUID
-	OrgID      uuid.UUID
-	ThreadID   uuid.UUID
-	UserID     *uuid.UUID
-	Message    string
-	Images     []string
-	References models.SessionInputReferences
-	Commands   models.SessionInputCommands
-	PlanMode   bool
+	SessionID               uuid.UUID
+	OrgID                   uuid.UUID
+	ThreadID                uuid.UUID
+	UserID                  *uuid.UUID
+	Message                 string
+	Images                  []string
+	References              models.SessionInputReferences
+	Commands                models.SessionInputCommands
+	PlanMode                bool
+	ResolveReviewCommentIDs []uuid.UUID
+}
+
+// SendMessageResult carries everything callers need to finish handling a
+// successful thread-message send: the created message, plus any review
+// comments that were resolved as part of the same transaction. The handler
+// uses ResolvedComments to emit one audit row per resolved comment after
+// the tx commits — matching the post-commit audit pattern of session-level
+// SendMessage.
+type SendMessageResult struct {
+	Message          *models.SessionMessage
+	ResolvedComments []models.SessionReviewComment
 }
 
 // Service handles thread business logic.
 type Service struct {
-	threadStore  ThreadStore
-	sessionStore SessionStore
-	messageStore MessageStore
-	logStore     LogStore
-	jobStore     JobStore
-	fileEvents   FileEventStore  // optional — enables overlap and attribution surfaces
-	canceller    ThreadCanceller // optional — enables in-flight SIGINT
-	logger       zerolog.Logger
+	threadStore        ThreadStore
+	sessionStore       SessionStore
+	messageStore       MessageStore
+	logStore           LogStore
+	jobStore           JobStore
+	fileEvents         FileEventStore                // optional — enables overlap and attribution surfaces
+	canceller          ThreadCanceller               // optional — enables in-flight SIGINT
+	txStarter          db.TxStarter                  // optional — required for SendMessage with ResolveReviewCommentIDs
+	reviewCommentStore *db.SessionReviewCommentStore // optional — required for SendMessage with ResolveReviewCommentIDs
+	logger             zerolog.Logger
 }
 
 // NewService creates a new thread service. fileEvents and canceller are
@@ -155,6 +182,18 @@ func (s *Service) SetFileEventStore(store FileEventStore) {
 // orchestrator's thread-scoped cancel registry once it is constructed.
 func (s *Service) SetCanceller(c ThreadCanceller) {
 	s.canceller = c
+}
+
+// SetReviewCommentResolver wires the plumbing required to resolve review
+// comments atomically with a thread-scoped message send. Both arguments must
+// be non-nil for SendMessage to honor ResolveReviewCommentIDs; if either is
+// missing, SendMessage rejects requests carrying comment IDs with
+// ErrReviewCommentsNotConfigured. Kept as a single setter so the
+// "configured" predicate is unambiguous (versus two independently-nilable
+// fields).
+func (s *Service) SetReviewCommentResolver(txStarter db.TxStarter, store *db.SessionReviewCommentStore) {
+	s.txStarter = txStarter
+	s.reviewCommentStore = store
 }
 
 // isSessionAlreadyRunning is the fallback predicate used by SendMessage when
@@ -261,7 +300,11 @@ func (s *Service) GetThread(ctx context.Context, orgID, sessionID, threadID uuid
 }
 
 // SendMessage claims an idle thread, creates a message, and enqueues a
-// continue_session job.
+// continue_session job. When ResolveReviewCommentIDs is non-empty, the
+// message create and the comment resolution share a single transaction so
+// the user-visible invariant — "submitted comments disappear once the
+// follow-up message is sent" — holds even if the request fails partway
+// through.
 //
 // ClaimIdleForSession serializes sibling-thread admission in the database
 // while allowing up to MaxRunningThreadsPerSession concurrent tabs. The
@@ -269,7 +312,16 @@ func (s *Service) GetThread(ctx context.Context, orgID, sessionID, threadID uuid
 // running, the session is already in 'running' state and the orchestrator's
 // idempotent UpdateStatus("running") handles the rest. If subsequent message
 // creation or job enqueue fails we best-effort revert the thread to idle.
-func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*models.SessionMessage, error) {
+func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*SendMessageResult, error) {
+	// Reject early — before any state mutation — when the caller asked to
+	// resolve comments but the service was constructed without the plumbing
+	// to do so. Pushing this check above the claim avoids leaving the thread
+	// stuck in 'running' if the configuration is wrong.
+	resolvingComments := len(input.ResolveReviewCommentIDs) > 0
+	if resolvingComments && (s.txStarter == nil || s.reviewCommentStore == nil) {
+		return nil, ErrReviewCommentsNotConfigured
+	}
+
 	thread, err := s.threadStore.ClaimIdleForSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
 	if err != nil {
 		if errors.Is(err, db.ErrThreadRunningLimitReached) {
@@ -335,12 +387,21 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*mod
 		msg.Attachments = input.Images
 	}
 
-	if err := s.messageStore.Create(ctx, msg); err != nil {
-		if revertErr := s.sessionStore.UpdateStatus(ctx, input.OrgID, input.SessionID, string(models.SessionStatusIdle)); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("session_id", input.SessionID.String()).Msg("failed to revert session to idle after thread message creation failure")
-		}
-		if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after message creation failure")
+	var resolvedComments []models.SessionReviewComment
+	if resolvingComments {
+		resolvedComments, err = s.createMessageWithResolvedComments(ctx, msg, input)
+	} else {
+		err = s.messageStore.Create(ctx, msg)
+	}
+	if err != nil {
+		s.revertAfterSendFailure(ctx, input.OrgID, input.SessionID, input.ThreadID, "message creation failure")
+		// Comment-validation errors are surfaced verbatim so the handler can
+		// match on *db.ErrReviewCommentsNotInSession; everything else gets
+		// wrapped with a "create message" prefix to preserve historical log
+		// shape for the no-comments path.
+		var notInSession *db.ErrReviewCommentsNotInSession
+		if errors.As(err, &notInSession) {
+			return nil, err
 		}
 		return nil, fmt.Errorf("create message: %w", err)
 	}
@@ -358,16 +419,108 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*mod
 		"org_id":     input.OrgID.String(),
 	}
 	if _, err := s.jobStore.Enqueue(ctx, input.OrgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
-		if revertErr := s.sessionStore.UpdateStatus(ctx, input.OrgID, input.SessionID, string(models.SessionStatusIdle)); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("session_id", input.SessionID.String()).Msg("failed to revert session to idle after thread enqueue failure")
-		}
-		if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after enqueue failure")
-		}
+		// Note: we do NOT roll back the resolved comments here. The message
+		// has been committed and is durably in the timeline; the orchestrator
+		// will retry the enqueue on the next dedupe-eligible event. Reverting
+		// the resolved comments would create a worse inconsistency where the
+		// user sees their addressed comments re-appear despite the message
+		// already being in the conversation.
+		s.revertAfterSendFailure(ctx, input.OrgID, input.SessionID, input.ThreadID, "enqueue failure")
 		return nil, fmt.Errorf("%w: %w", ErrEnqueueFailed, err)
 	}
 
-	return msg, nil
+	return &SendMessageResult{
+		Message:          msg,
+		ResolvedComments: resolvedComments,
+	}, nil
+}
+
+// createMessageWithResolvedComments wraps the message insert and the
+// review-comment resolution in a single transaction so the
+// "addressing-comments → message-sent → comments-resolved" invariant cannot
+// be violated by a partial failure between the two writes.
+//
+// Pre-condition: caller has already verified s.txStarter and
+// s.reviewCommentStore are non-nil (via the ErrReviewCommentsNotConfigured
+// guard at the top of SendMessage).
+func (s *Service) createMessageWithResolvedComments(
+	ctx context.Context,
+	msg *models.SessionMessage,
+	input SendMessageInput,
+) ([]models.SessionReviewComment, error) {
+	// Fetch the session inside the same critical section to read CurrentTurn
+	// for the resolution pass. We use the post-claim session state (the
+	// ClaimIdle above already moved it to 'running' if it was idle), so the
+	// recorded pass matches what session-level SendMessage records on the
+	// same path.
+	session, err := s.sessionStore.GetByID(ctx, input.OrgID, input.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("get session for resolution pass: %w", err)
+	}
+
+	tx, err := s.txStarter.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	committed := false
+	defer func() {
+		if committed {
+			return
+		}
+		if rollbackErr := tx.Rollback(ctx); rollbackErr != nil {
+			s.logger.Error().Err(rollbackErr).
+				Str("session_id", input.SessionID.String()).
+				Str("thread_id", input.ThreadID.String()).
+				Msg("failed to rollback thread send-message transaction")
+		}
+	}()
+
+	txMessageStore := db.NewSessionMessageStore(tx)
+	txCommentStore := db.NewSessionReviewCommentStore(tx)
+
+	if err := txMessageStore.Create(ctx, msg); err != nil {
+		return nil, err
+	}
+	resolved, err := txCommentStore.ValidateAndResolveByIDs(
+		ctx, input.OrgID, input.SessionID, input.ResolveReviewCommentIDs, resolutionPass(&session))
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit tx: %w", err)
+	}
+	committed = true
+	return resolved, nil
+}
+
+// revertAfterSendFailure puts the session and thread back to idle on a
+// best-effort basis after a SendMessage failure. Logs each revert error
+// individually so partial reverts are debuggable, but never returns —
+// callers always have a primary error to surface.
+func (s *Service) revertAfterSendFailure(ctx context.Context, orgID, sessionID, threadID uuid.UUID, reason string) {
+	if revertErr := s.sessionStore.UpdateStatus(ctx, orgID, sessionID, string(models.SessionStatusIdle)); revertErr != nil {
+		s.logger.Error().Err(revertErr).
+			Str("session_id", sessionID.String()).
+			Str("reason", reason).
+			Msg("failed to revert session to idle after thread send failure")
+	}
+	if revertErr := s.threadStore.UpdateStatus(ctx, orgID, threadID, models.ThreadStatusIdle); revertErr != nil {
+		s.logger.Error().Err(revertErr).
+			Str("thread_id", threadID.String()).
+			Str("reason", reason).
+			Msg("failed to revert thread to idle after send failure")
+	}
+}
+
+// resolutionPass mirrors handlers.currentResolutionPass: the comment is
+// being addressed during the current session turn (with a fallback to 1 for
+// not-yet-started sessions). Kept in this package to avoid an import cycle
+// with handlers; the two functions intentionally stay in lockstep.
+func resolutionPass(session *models.Session) int {
+	if session == nil || session.CurrentTurn == 0 {
+		return 1
+	}
+	return session.CurrentTurn
 }
 
 // EndThread transitions an active thread to completed.

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -2,6 +2,7 @@ package thread
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
+	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
@@ -687,10 +689,10 @@ func TestService_SendMessage(t *testing.T) {
 			svc, deps := newTestService(t)
 			tt.setupDeps(deps)
 
-			msg, err := svc.SendMessage(context.Background(), tt.input)
+			result, err := svc.SendMessage(context.Background(), tt.input)
 			if tt.expectErr != nil {
 				require.ErrorIs(t, err, tt.expectErr, "should return expected error")
-				require.Nil(t, msg, "should not return a message on error")
+				require.Nil(t, result, "should not return a result on error")
 				return
 			}
 			if tt.name == "message creation failure reverts to idle" {
@@ -698,10 +700,160 @@ func TestService_SendMessage(t *testing.T) {
 				return
 			}
 			require.NoError(t, err, "should not return an error")
-			require.NotNil(t, msg, "should return a message")
-			require.Equal(t, models.MessageRoleUser, msg.Role, "should set role to user")
+			require.NotNil(t, result, "should return a result")
+			require.NotNil(t, result.Message, "should return a message")
+			require.Equal(t, models.MessageRoleUser, result.Message.Role, "should set role to user")
 		})
 	}
+}
+
+// TestService_SendMessage_ResolvesReviewComments exercises the
+// comment-resolution path end-to-end against a real tx, using pgxmock as
+// the txStarter and a real db.SessionReviewCommentStore so the SQL
+// invariants (INSERT message → SELECT comments → UPDATE comments → COMMIT)
+// run inside a single transaction. Mirrors the session-level
+// TestSessionHandler_SendMessage_ResolvesReviewComments coverage so the
+// thread send path inherits the same atomic guarantee.
+func TestService_SendMessage_ResolvesReviewComments(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now()
+
+	commentRowColumns := []string{
+		"id", "session_id", "org_id", "user_id", "file_path",
+		"line_number", "diff_side", "body", "resolved", "resolved_at", "resolved_by_pass",
+		"pass_number", "created_at", "updated_at",
+	}
+
+	primeClaim := func(deps *testDeps) {
+		deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 1, Status: models.ThreadStatusRunning}, nil
+		}
+		// GetByID is called once per resolution path to pick up CurrentTurn
+		// for the resolution pass; CurrentTurn=2 → resolved_by_pass=2.
+		deps.sessionStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+			return models.Session{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusRunning), CurrentTurn: 2}, nil
+		}
+	}
+
+	t.Run("rejects when resolver is not configured", func(t *testing.T) {
+		t.Parallel()
+		svc, deps := newTestService(t)
+		primeClaim(deps)
+		// No SetReviewCommentResolver — the service should fail-fast before
+		// claiming any state.
+		_, err := svc.SendMessage(context.Background(), SendMessageInput{
+			SessionID:               sessionID,
+			OrgID:                   orgID,
+			ThreadID:                threadID,
+			Message:                 "hi",
+			ResolveReviewCommentIDs: []uuid.UUID{uuid.New()},
+		})
+		require.ErrorIs(t, err, ErrReviewCommentsNotConfigured, "missing plumbing should be a configuration error, not a 500")
+	})
+
+	t.Run("commits message and resolution in the same tx", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		commentID := uuid.New()
+		commentUserID := uuid.New()
+
+		// Tx-bracketed SQL: BEGIN → INSERT message → SELECT comments → UPDATE
+		// comments → COMMIT. Any reordering breaks the atomic guarantee, so
+		// pgxmock's default in-order matching is exactly the contract we want.
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(7), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(commentRowColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						42, "right", "fix this", false, (*time.Time)(nil), (*int)(nil),
+						1, now, now),
+			)
+		resolvedAt := now
+		resolvedByPass := 2
+		mock.ExpectQuery("UPDATE session_review_comments SET resolved = true").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows(commentRowColumns).
+					AddRow(commentID, sessionID, orgID, commentUserID, "main.go",
+						42, "right", "fix this", true, &resolvedAt, &resolvedByPass,
+						1, now, now),
+			)
+		mock.ExpectCommit()
+
+		svc, deps := newTestService(t)
+		primeClaim(deps)
+		svc.SetReviewCommentResolver(mock, db.NewSessionReviewCommentStore(mock))
+
+		result, err := svc.SendMessage(context.Background(), SendMessageInput{
+			SessionID:               sessionID,
+			OrgID:                   orgID,
+			ThreadID:                threadID,
+			Message:                 "address review",
+			ResolveReviewCommentIDs: []uuid.UUID{commentID},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.Equal(t, int64(7), result.Message.ID)
+		require.Len(t, result.ResolvedComments, 1, "the resolved comment should come back so the handler can audit it")
+		require.Equal(t, commentID, result.ResolvedComments[0].ID)
+		require.True(t, result.ResolvedComments[0].Resolved)
+		require.Equal(t, 2, *result.ResolvedComments[0].ResolvedByPass, "pass should match session.CurrentTurn at send time")
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("rolls back when a comment ID is not in the session", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		commentID := uuid.New()
+
+		// BEGIN → INSERT message → SELECT (returns 0 rows → validation fails)
+		// → ROLLBACK. The insert MUST be rolled back even though it succeeded
+		// at the SQL level — that's the whole point of the atomic guarantee.
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(7), now))
+		mock.ExpectQuery("SELECT .+ FROM session_review_comments WHERE id = ANY").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(commentRowColumns)) // no rows match
+		mock.ExpectRollback()
+
+		svc, deps := newTestService(t)
+		primeClaim(deps)
+		svc.SetReviewCommentResolver(mock, db.NewSessionReviewCommentStore(mock))
+
+		result, err := svc.SendMessage(context.Background(), SendMessageInput{
+			SessionID:               sessionID,
+			OrgID:                   orgID,
+			ThreadID:                threadID,
+			Message:                 "address review",
+			ResolveReviewCommentIDs: []uuid.UUID{commentID},
+		})
+		require.Nil(t, result)
+		require.Error(t, err)
+		var notInSession *db.ErrReviewCommentsNotInSession
+		require.True(t, errors.As(err, &notInSession), "validation error should surface unwrapped so the handler can render the missing IDs")
+		require.Equal(t, []uuid.UUID{commentID}, notInSession.Missing)
+		require.NoError(t, mock.ExpectationsWereMet(), "the message insert MUST be rolled back when validation fails")
+	})
 }
 
 func TestService_EndThread(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes a bug where review comments stuck around for the next turn whenever a session's follow-up went through a thread tab — the thread send endpoint dropped `resolve_review_comment_ids` so comments stayed unresolved on the backend and re-attached on the next message.
- Pushes the "create message + resolve comments" atomic invariant down into `thread.Service.SendMessage` (the layer that owns message creation in the threaded world), wrapping insert + validate + resolve in one tx via a new `*db.SessionReviewCommentStore.ValidateAndResolveByIDs` primitive.
- Extracts the parser, audit emitter, and error-mapping helpers into a shared `review_comment_send.go` so session-level and thread-level sends produce identical wire shapes; collapses ~115 lines of duplication out of `sessions.go`.
- Wires `txStarter` + review-comment store into `thread.Service` and the audit emitter into `SessionThreadHandler` in `router.go`; surfaces a new `ErrReviewCommentsNotConfigured` sentinel for fail-fast 400s when the resolver isn't wired.

## Test plan
- [x] `go test ./...` — all 49 backend packages pass, including new pgxmock-driven `TestService_SendMessage_ResolvesReviewComments` that asserts BEGIN → INSERT → SELECT → UPDATE → COMMIT ordering and rollback on validation failure.
- [x] `go test ./internal/db/...` covers new `ValidateAndResolveByIDs` cases (empty, lookup error, foreign-ID rejection without UPDATE, happy path, resolve error).
- [x] `npm test` on `sessions/[id]/page.test.tsx` — all 170 tests pass; frontend wires `resolveReviewCommentIDs` through `sendThreadMessage`.
- [ ] Manual: in a session with a live thread tab, add a review comment, send a follow-up, verify the comment disappears from the composer instead of re-attaching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)