### PR TITLE
Cap docker container log file growth across the fleet

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -175,6 +175,50 @@ func TestLoggingDesignDocsTrackProvisionedDashboardsAndAlerts(t *testing.T) {
 	require.Contains(t, designText, "deploy/vmalert/rules/production-alerts.yml", "logging design doc should track repo-owned alert rules")
 }
 
+// Docker's json-file driver grows unbounded by default, so a chatty
+// container will fill the disk on its own. The fix: install-log-rotation.sh
+// merges log-driver/log-opts into /etc/docker/daemon.json (preserving any
+// gVisor runtimes block on workers) and restarts docker only when the
+// content actually changes. Pin the wiring here so a future refactor
+// doesn't silently strip it off and leave us in the unbounded-growth
+// state. db keeps its own larger cap because the db host is the only
+// role without Vector log shipping (postgres logs are local-only) AND
+// postgresql.conf logs every connection, every query >500ms, and every
+// lock wait — a smaller cap would lose the forensic trail during an
+// incident.
+func TestDeployConfiguresDockerLogRotation(t *testing.T) {
+	t.Parallel()
+
+	helper, err := os.ReadFile("../deploy/scripts/install-log-rotation.sh")
+	require.NoError(t, err, "install-log-rotation.sh should exist as the single source of truth for daemon.json log-rotation logic")
+	helperText := string(helper)
+	require.Contains(t, helperText, "/etc/docker/daemon.json", "install-log-rotation.sh should target daemon.json (not a per-container override) so dynamically-spawned sandbox containers also inherit the cap")
+	require.Contains(t, helperText, `"log-driver"`, "install-log-rotation.sh should write the json-file log-driver into daemon.json")
+	require.Contains(t, helperText, "systemctl restart docker", "install-log-rotation.sh must restart docker on change — log-driver/log-opts only take effect for newly created containers, so existing services need to inherit the cap on the next recreate")
+	require.Contains(t, helperText, "mv ", "install-log-rotation.sh should write atomically (tempfile + rename) — a SIGKILL between truncate and write under a plain `>` would leave a zero-byte daemon.json that docker rejects")
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+	require.Contains(t, deployText, "install-log-rotation.sh", "deploy.sh should sync and invoke the install-log-rotation.sh helper on every deploy")
+	require.Contains(t, deployText, `db) LOG_MAX_SIZE="500m"`, "deploy.sh should give the db role a larger log cap — postgres logging is verbose and the db host has no Vector log shipping, so the local docker log is the only copy")
+	require.Contains(t, deployText, `*)  LOG_MAX_SIZE="100m"`, "deploy.sh should default non-db roles to a 100m cap")
+	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh", "deploy.sh should invoke install-log-rotation.sh via deploy+sudo (not root SSH) — matches the sandbox-firewall.sh pattern and avoids depending on root SSH at routine deploy time")
+
+	bootstrap, err := os.ReadFile("../deploy/scripts/bootstrap.sh")
+	require.NoError(t, err, "test should read bootstrap.sh")
+	require.Contains(t, string(bootstrap), "/opt/143/deploy/scripts/install-log-rotation.sh *", "bootstrap.sh sudoers Cmnd_Alias must allow install-log-rotation.sh — without it the deploy+sudo path in deploy.sh fails on app/worker hosts")
+
+	provision, err := os.ReadFile("../deploy/scripts/provision.sh")
+	require.NoError(t, err, "test should read provision.sh")
+	provisionText := string(provision)
+	require.Contains(t, provisionText, "install-log-rotation.sh", "provision.sh should invoke install-log-rotation.sh after staging deploy/ so newly-provisioned hosts have rotation in place before services start (closes the provision-to-first-deploy unbounded-growth window)")
+	// db/logging/redis bootstraps don't run bootstrap.sh, so each must
+	// install its own /etc/sudoers.d/99-deploy or the deploy+sudo path
+	// breaks on those roles.
+	require.GreaterOrEqual(t, strings.Count(provisionText, "/opt/143/deploy/scripts/install-log-rotation.sh *"), 3, "provision.sh inline bootstraps for db, logging, and redis must each grant deploy NOPASSWD sudo for install-log-rotation.sh")
+}
+
 func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -34,7 +34,8 @@ Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/runsc install -- --ignore-cgroups --host-uds=open, \
     /usr/bin/systemctl restart docker, \
     /usr/bin/apt-get install -y --no-install-recommends iptables-persistent, \
-    /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
+    /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
 
 deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
 SUDOERS

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -195,6 +195,57 @@ if [ "$ROLE" = "worker" ]; then
      || { rm -f /opt/143/deploy/scripts/sandbox-firewall.sh.new; exit 1; }"
 fi
 
+# --- Docker log rotation (idempotent) ---
+# Cap container log file growth so a chatty container can't fill the disk.
+# Docker's default json-file driver has no size limit. Logs ship to
+# VictoriaLogs (Vector → 30d retention) on app/worker/logging hosts; the
+# local file is just a buffer plus a crash-recovery window. db and redis
+# hosts have no Vector — the local file is the only copy — so db gets a
+# larger cap because postgresql.conf logs every connection, every query
+# >500ms, and every lock wait, and the entire trail is local-only.
+#
+# Sync the helper, then call it via deploy+sudo (matches sandbox-firewall.sh
+# pattern). The script is idempotent and only restarts docker when the
+# content of /etc/docker/daemon.json actually changes, so steady-state
+# deploys cost nothing.
+case "$ROLE" in
+  db) LOG_MAX_SIZE="500m" ;;  # postgres logs are verbose AND local-only
+  *)  LOG_MAX_SIZE="100m" ;;
+esac
+LOG_MAX_FILE="5"
+
+# Sync install-log-rotation.sh: stage to .new, atomic rename. Same ETXTBSY
+# avoidance as sandbox-firewall.sh — a lingering FD on the old inode would
+# break the subsequent `sudo install-log-rotation.sh` exec.
+ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+  "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
+    deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new; then
+  echo "ERROR: scp of install-log-rotation.sh failed."
+  echo "  Hint: same root-owned-files issue as sandbox-firewall.sh; fix per above."
+  exit 1
+fi
+ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+  "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
+   && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh \
+   || { rm -f /opt/143/deploy/scripts/install-log-rotation.sh.new; exit 1; }"
+
+echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
+# `sudo -n` so missing-sudoers fails fast instead of hanging on a password
+# prompt CI can't satisfy. The error path tells the operator how to fix.
+if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"; then
+  echo "ERROR: install-log-rotation.sh failed under deploy+sudo."
+  echo "  If this host was provisioned before the install-log-rotation.sh sudoers"
+  echo "  entry was added, the fix is one of:"
+  echo "    a) re-run \`make provision-$ROLE HOST=$HOST REPROVISION=true\` to refresh sudoers"
+  echo "       (heavy: tears down containers), or"
+  echo "    b) SSH as root once and append the entry to /etc/sudoers.d/99-deploy:"
+  echo "         /opt/143/deploy/scripts/install-log-rotation.sh *"
+  echo "       then re-run visudo -cf /etc/sudoers.d/99-deploy and re-run this deploy."
+  exit 1
+fi
+
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \
   bash << 'REMOTE'

--- a/deploy/scripts/install-log-rotation.sh
+++ b/deploy/scripts/install-log-rotation.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Install/update Docker log rotation in /etc/docker/daemon.json.
+#
+# Docker's default json-file driver has no size limit, so a chatty
+# container will fill the disk on its own. This script merges
+# log-driver + log-opts into the existing daemon.json (preserving any
+# other keys, notably gVisor's runtimes block on workers), writes the
+# result atomically, and restarts docker only when the content actually
+# changed — so steady-state deploys cost nothing.
+#
+# Runs as root (invoked via `sudo` from deploy.sh / bootstrap.sh). Listed
+# in /etc/sudoers.d/99-deploy so the deploy user can call it with no
+# password and no broader privileges.
+#
+# Usage:
+#   install-log-rotation.sh <max-size> <max-file>
+# Example:
+#   install-log-rotation.sh 100m 5
+
+set -euo pipefail
+
+MAX_SIZE="${1:?max-size required (e.g. 100m)}"
+MAX_FILE="${2:?max-file required (e.g. 5)}"
+
+DAEMON_JSON="/etc/docker/daemon.json"
+CURRENT='{}'
+[ -s "$DAEMON_JSON" ] && CURRENT="$(cat "$DAEMON_JSON")"
+
+# Single python script with a MODE switch so DESIRED and CURRENT_NORM use
+# identical pretty-print parameters — anything else risks a false diff
+# (different key ordering, indent, etc.) that would force a needless
+# docker restart on every deploy.
+PYCODE='
+import json, os
+cur = json.loads(os.environ["CUR"])
+if os.environ["MODE"] == "merge":
+    opts = dict(cur.get("log-opts", {}))
+    opts["max-size"] = os.environ["MS"]
+    opts["max-file"] = os.environ["MF"]
+    cur["log-driver"] = "json-file"
+    cur["log-opts"] = opts
+print(json.dumps(cur, sort_keys=True, indent=2))
+'
+DESIRED="$(MODE=merge MS="$MAX_SIZE" MF="$MAX_FILE" CUR="$CURRENT" python3 -c "$PYCODE")"
+CURRENT_NORM="$(MODE=normalize CUR="$CURRENT" python3 -c "$PYCODE")"
+
+if [ "$CURRENT_NORM" = "$DESIRED" ]; then
+  echo "log-rotation: daemon.json already configured (max-size=$MAX_SIZE, max-file=$MAX_FILE); skipping docker restart."
+  exit 0
+fi
+
+echo "log-rotation: updating $DAEMON_JSON (max-size=$MAX_SIZE, max-file=$MAX_FILE)..."
+mkdir -p /etc/docker
+# Atomic rename: a SIGKILL between truncate and write under a plain `>`
+# would leave a zero-byte daemon.json that docker rejects on next start.
+# Writing to .new and renaming guarantees the file is either old-good or
+# new-good, never partial.
+TMP="$(mktemp /etc/docker/daemon.json.new.XXXXXX)"
+trap 'rm -f "$TMP"' EXIT
+printf '%s\n' "$DESIRED" > "$TMP"
+chmod 0644 "$TMP"
+mv "$TMP" "$DAEMON_JSON"
+trap - EXIT
+
+# log-driver / log-opts only take effect for newly created containers, so
+# existing services keep their old (unbounded) logs until next recreate.
+# Restart docker so the daemon picks up the new config; the next compose
+# up / rolling deploy then recreates containers with the cap. Skipping
+# this would leave the running fleet exposed until an unrelated deploy
+# happens to cycle each container.
+systemctl restart docker
+echo "log-rotation: docker restarted with new log-driver config."

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -194,6 +194,21 @@ if [ "$ROLE" = "db" ]; then
     chmod 700 /home/deploy/.ssh
     command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
     usermod -aG docker deploy
+    # Narrow NOPASSWD sudo for the deploy user. Keep entries in sync with
+    # bootstrap.sh — anything used by deploy/scripts/deploy.sh on a db
+    # host has to be listed here. db doesn't need runsc / sandbox-firewall
+    # / iptables-persistent, but must allow install-log-rotation.sh so the
+    # routine deploy path can cap docker container log files without an
+    # extra root SSH hop.
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/systemctl restart docker, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    chmod 440 /etc/sudoers.d/99-deploy
+    visudo -cf /etc/sudoers.d/99-deploy
     cat > /etc/sysctl.d/99-postgres.conf <<SYSCTL
 vm.overcommit_memory = 2
 vm.overcommit_ratio = 80
@@ -213,6 +228,21 @@ elif [ "$ROLE" = "logging" ]; then
     chmod 700 /home/deploy/.ssh
     command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
     usermod -aG docker deploy
+    # Narrow NOPASSWD sudo for the deploy user. Logging hosts also need
+    # the chown grants because deploy.sh sometimes needs to fix root-owned
+    # vmalert/grafana dirs left over from prior provisioning. Keep in
+    # sync with bootstrap.sh.
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/grafana, \
+    /usr/bin/systemctl restart docker, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    chmod 440 /etc/sudoers.d/99-deploy
+    visudo -cf /etc/sudoers.d/99-deploy
     echo "Bootstrap complete (logging)."
 BOOTSTRAP_LOGGING
 elif [ "$ROLE" = "redis" ]; then
@@ -225,6 +255,18 @@ elif [ "$ROLE" = "redis" ]; then
     chmod 700 /home/deploy/.ssh
     command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
     usermod -aG docker deploy
+    # Narrow NOPASSWD sudo for the deploy user. Keep in sync with
+    # bootstrap.sh — install-log-rotation.sh is required so deploy.sh
+    # can cap docker container log files without an extra root SSH hop.
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/systemctl restart docker, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    chmod 440 /etc/sudoers.d/99-deploy
+    visudo -cf /etc/sudoers.d/99-deploy
     cat > /etc/sysctl.d/99-redis.conf <<SYSCTL
 vm.overcommit_memory = 1
 net.core.somaxconn = 512
@@ -244,7 +286,19 @@ if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; the
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" root@"$HOST":/opt/143/
 fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
-ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143"
+ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh"
+
+# Step 2a: Cap docker container log files (max-size/max-file in
+# /etc/docker/daemon.json) BEFORE step 5 starts services. Closes the
+# provision-to-first-deploy window where new containers would log
+# unboundedly. db gets a larger cap because postgres logs every
+# connection / slow query / lock wait, and the db host has no Vector log
+# shipping — the local docker log is the only copy of that trail.
+case "$ROLE" in
+  db) LOG_MAX_SIZE="500m" ;;
+  *)  LOG_MAX_SIZE="100m" ;;
+esac
+ssh "${SSH_OPTS[@]}" root@"$HOST" "/opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE 5"
 
 # Step 2b: Sync authorized keys from deploy/authorized_keys/*.pub
 # Replaces authorized_keys on the host with exactly the keys in the repo.


### PR DESCRIPTION
## Summary
- New `deploy/scripts/install-log-rotation.sh` merges `log-driver`/`log-opts` into `/etc/docker/daemon.json` (preserving any gVisor runtimes block), writes atomically (`mktemp` + `mv`), and restarts docker only when content actually changes.
- Per-role caps: db gets `max-size=500m`, others get `100m`, all with `max-file=5`. db gets the larger cap because postgresql.conf logs every connection / slow query >500ms / lock wait, AND the db host is the only role with no Vector log shipping, so the local docker log is the only copy of that trail.
- Wired in three places: `bootstrap.sh` sudoers Cmnd_Alias (app/worker), inline `BOOTSTRAP_DB`/`BOOTSTRAP_LOGGING`/`BOOTSTRAP_REDIS` in `provision.sh` (so non-bootstrap.sh roles also get a narrow sudoers entry), and a new step 2a in `provision.sh` that runs the helper as root after staging `deploy/`. Routine deploys invoke it via `deploy@host` + `sudo -n` from `deploy.sh`, with a clear migration message if the sudoers entry is missing on a pre-PR host.

## Test plan
- [ ] `go test ./deploy/...` passes (new `TestDeployConfiguresDockerLogRotation` plus all 8 existing deploy tests).
- [ ] `make deploy-fleet` against a single non-prod host: confirm daemon.json gains `log-driver: json-file` + `log-opts`, and that a second deploy is a no-op (no docker restart).
- [ ] On a fresh provision: confirm `install-log-rotation.sh` runs in step 2a and daemon.json is correct before any container starts.
- [ ] On an existing pre-PR host: confirm deploy fails fast with the two-option migration instructions when the sudoers entry is absent; after re-provision, deploy succeeds via deploy+sudo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
