### PR TITLE
Auto-repair deploy sudoers on legacy hosts to avoid teardown reprovision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SANDBOX_STAMP := sandbox/.build-stamp
 SANDBOX_SOURCES := sandbox/Dockerfile sandbox/versions.json
 
-.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging provision-redis deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
+.PHONY: dev dev-ngrok dev-local dev-frontend-only setup test test-race test-coverage test-pr test-coverage-diff test-main test-integration migrate-up migrate-down build frontend-dev frontend-lint frontend-typecheck frontend-check lint lint-bootstrap lint-schema lint-stores lint-tenancy hooks-install hooks-uninstall secrets-setup secrets-encrypt secrets-decrypt secrets-edit secrets-rotate provision-app provision-worker provision-db provision-logging provision-redis repair-deploy-sudoers deploy deploy-app deploy-worker deploy-db deploy-logging deploy-fleet logs logs-query setup-readonly-user db-psql db-query
 
 GOLANGCI_LINT_VERSION ?= v2.10.1
 GOLANGCI_LINT_BIN := $(CURDIR)/bin/golangci-lint
@@ -398,6 +398,17 @@ provision-redis:
 	@test -n "$(HOST)" || { echo "HOST is required. Usage: make provision-redis HOST=<ip> [SSH_KEY=<path>]"; exit 1; }
 	$(check-ssh-key)
 	./deploy/scripts/provision.sh redis $(HOST) $(SSH_KEY) $(if $(REPROVISION),--reprovision)
+
+# Refresh deploy's narrow sudoers grant on an existing host without tearing
+# down containers. Use when deploy fails on a legacy host with
+# "sudo: a password is required" from a deploy-time helper.
+# Usage:
+#   make repair-deploy-sudoers ROLE=app HOST=87.99.150.138
+repair-deploy-sudoers:
+	@test -n "$(ROLE)" || { echo "ROLE is required. Usage: make repair-deploy-sudoers ROLE=<app|worker|db|logging|redis> HOST=<ip> [SSH_KEY=<path>]"; exit 1; }
+	@test -n "$(HOST)" || { echo "HOST is required. Usage: make repair-deploy-sudoers ROLE=<app|worker|db|logging|redis> HOST=<ip> [SSH_KEY=<path>]"; exit 1; }
+	$(check-ssh-key)
+	bash ./deploy/scripts/repair-deploy-sudoers.sh $(ROLE) $(HOST) $(SSH_KEY)
 
 # Deploy (update) an already-provisioned node.
 # HOST is optional — falls back to the matching role in FLEET_HOSTS from .env.production.enc.

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -225,7 +225,10 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	require.NoError(t, err, "repair-deploy-sudoers.sh should exist for legacy hosts that are missing the deploy sudoers entry")
 	repairText := string(repair)
 	require.Contains(t, repairText, "/etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should update the deploy sudoers file")
-	require.Contains(t, repairText, "visudo -cf /etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should validate sudoers before returning success")
+	require.Contains(t, repairText, "mktemp /etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should stage sudoers in the target directory before replacing the live file")
+	require.Contains(t, repairText, "visudo -cf \"$TMP\"", "repair-deploy-sudoers.sh should validate the staged sudoers file before installing it")
+	require.Contains(t, repairText, "mv \"$TMP\" /etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should atomically replace sudoers only after validation succeeds")
+	require.NotContains(t, repairText, "cat > /etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh must not write directly to the live sudoers file")
 	require.Contains(t, repairText, "deploy ALL=(root) NOPASSWD: DEPLOY_CMDS", "repair-deploy-sudoers.sh should install the same narrow command alias used by provisioning")
 	require.NotContains(t, repairText, "NOPASSWD:ALL", "repair-deploy-sudoers.sh must not repair legacy hosts by granting blanket passwordless sudo")
 

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -204,6 +204,8 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	require.Contains(t, deployText, `db) LOG_MAX_SIZE="500m"`, "deploy.sh should give the db role a larger log cap — postgres logging is verbose and the db host has no Vector log shipping, so the local docker log is the only copy")
 	require.Contains(t, deployText, `*)  LOG_MAX_SIZE="100m"`, "deploy.sh should default non-db roles to a 100m cap")
 	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh", "deploy.sh should invoke install-log-rotation.sh via deploy+sudo (not root SSH) — matches the sandbox-firewall.sh pattern and avoids depending on root SSH at routine deploy time")
+	require.Contains(t, deployText, "repair-deploy-sudoers.sh", "deploy.sh should try the narrow root repair path when a legacy host is missing the deploy sudoers entry")
+	require.Contains(t, deployText, "Retrying docker log rotation after sudoers repair", "deploy.sh should retry install-log-rotation.sh after repairing sudoers so a single deploy can recover legacy hosts")
 
 	bootstrap, err := os.ReadFile("../deploy/scripts/bootstrap.sh")
 	require.NoError(t, err, "test should read bootstrap.sh")
@@ -213,10 +215,23 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	require.NoError(t, err, "test should read provision.sh")
 	provisionText := string(provision)
 	require.Contains(t, provisionText, "install-log-rotation.sh", "provision.sh should invoke install-log-rotation.sh after staging deploy/ so newly-provisioned hosts have rotation in place before services start (closes the provision-to-first-deploy unbounded-growth window)")
+	require.GreaterOrEqual(t, strings.Count(provisionText, "/usr/bin/chown -R deploy\\:deploy /opt/143/deploy/scripts"), 3, "provision.sh inline bootstraps for db, logging, and redis must allow deploy to fix root-owned deploy/scripts before syncing helpers")
 	// db/logging/redis bootstraps don't run bootstrap.sh, so each must
 	// install its own /etc/sudoers.d/99-deploy or the deploy+sudo path
 	// breaks on those roles.
 	require.GreaterOrEqual(t, strings.Count(provisionText, "/opt/143/deploy/scripts/install-log-rotation.sh *"), 3, "provision.sh inline bootstraps for db, logging, and redis must each grant deploy NOPASSWD sudo for install-log-rotation.sh")
+
+	repair, err := os.ReadFile("../deploy/scripts/repair-deploy-sudoers.sh")
+	require.NoError(t, err, "repair-deploy-sudoers.sh should exist for legacy hosts that are missing the deploy sudoers entry")
+	repairText := string(repair)
+	require.Contains(t, repairText, "/etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should update the deploy sudoers file")
+	require.Contains(t, repairText, "visudo -cf /etc/sudoers.d/99-deploy", "repair-deploy-sudoers.sh should validate sudoers before returning success")
+	require.Contains(t, repairText, "deploy ALL=(root) NOPASSWD: DEPLOY_CMDS", "repair-deploy-sudoers.sh should install the same narrow command alias used by provisioning")
+	require.NotContains(t, repairText, "NOPASSWD:ALL", "repair-deploy-sudoers.sh must not repair legacy hosts by granting blanket passwordless sudo")
+
+	makefile, err := os.ReadFile("../Makefile")
+	require.NoError(t, err, "test should read Makefile")
+	require.Contains(t, string(makefile), "repair-deploy-sudoers:", "Makefile should expose the no-teardown sudoers repair as an operator target")
 }
 
 func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -49,6 +49,10 @@ echo "Deploying role=$ROLE tag=$TAG to $HOST..."
 SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 
+repair_deploy_sudoers() {
+  bash "$SCRIPT_DIR/repair-deploy-sudoers.sh" "$ROLE" "$HOST" "$SSH_KEY"
+}
+
 # --- Refresh secrets from .env.production.enc ---
 if [ -z "${SOPS_AGE_KEY:-}" ]; then
   AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
@@ -180,15 +184,19 @@ if [ "$ROLE" = "worker" ]; then
   # concurrent run). rename(2) gives the new contents a fresh inode.
   if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
       deploy@"$HOST":/opt/143/deploy/scripts/sandbox-firewall.sh.new; then
-    echo "ERROR: scp of sandbox-firewall.sh failed."
-    echo "  Hint: the worker likely has root-owned files under /opt/143/deploy/scripts AND"
-    echo "  the 'deploy' user lacks NOPASSWD sudo. One-time fix on the worker host:"
-    echo "    1) Log in as root (provider console) and run:"
-    echo "       echo 'deploy ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/99-deploy"
-    echo "       chmod 440 /etc/sudoers.d/99-deploy"
-    echo "       chown -R deploy:deploy /opt/143/deploy"
-    echo "    2) Re-run the deploy."
-    exit 1
+    echo "sandbox-firewall.sh sync failed; trying no-teardown deploy sudoers repair..."
+    if repair_deploy_sudoers; then
+      ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+        "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+      scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-firewall.sh" \
+        deploy@"$HOST":/opt/143/deploy/scripts/sandbox-firewall.sh.new
+    else
+      echo "ERROR: scp of sandbox-firewall.sh failed and sudoers repair via root SSH did not complete."
+      echo "  Run once from a machine with root SSH access:"
+      echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+      echo "  Then re-run the deploy."
+      exit 1
+    fi
   fi
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh \
@@ -221,9 +229,19 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
 if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
     deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new; then
-  echo "ERROR: scp of install-log-rotation.sh failed."
-  echo "  Hint: same root-owned-files issue as sandbox-firewall.sh; fix per above."
-  exit 1
+  echo "install-log-rotation.sh sync failed; trying no-teardown deploy sudoers repair..."
+  if repair_deploy_sudoers; then
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+      "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+    scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
+      deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new
+  else
+    echo "ERROR: scp of install-log-rotation.sh failed and sudoers repair via root SSH did not complete."
+    echo "  Run once from a machine with root SSH access:"
+    echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+    echo "  Then re-run the deploy."
+    exit 1
+  fi
 fi
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
@@ -233,17 +251,26 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
 echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
 # `sudo -n` so missing-sudoers fails fast instead of hanging on a password
 # prompt CI can't satisfy. The error path tells the operator how to fix.
-if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"; then
-  echo "ERROR: install-log-rotation.sh failed under deploy+sudo."
-  echo "  If this host was provisioned before the install-log-rotation.sh sudoers"
-  echo "  entry was added, the fix is one of:"
-  echo "    a) re-run \`make provision-$ROLE HOST=$HOST REPROVISION=true\` to refresh sudoers"
-  echo "       (heavy: tears down containers), or"
-  echo "    b) SSH as root once and append the entry to /etc/sudoers.d/99-deploy:"
-  echo "         /opt/143/deploy/scripts/install-log-rotation.sh *"
-  echo "       then re-run visudo -cf /etc/sudoers.d/99-deploy and re-run this deploy."
-  exit 1
+run_log_rotation() {
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"
+}
+if ! run_log_rotation; then
+  echo "install-log-rotation.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+  if repair_deploy_sudoers; then
+    echo "Retrying docker log rotation after sudoers repair..."
+    if ! run_log_rotation; then
+      echo "ERROR: install-log-rotation.sh still failed after repairing deploy sudoers."
+      exit 1
+    fi
+  else
+    echo "ERROR: install-log-rotation.sh failed and sudoers repair via root SSH did not complete."
+    echo "  This host likely predates the deploy sudoers entry."
+    echo "  Run once from a machine with root SSH access:"
+    echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+    echo "  Then re-run the deploy."
+    exit 1
+  fi
 fi
 
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -202,6 +202,7 @@ if [ "$ROLE" = "db" ]; then
     # extra root SSH hop.
     cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/systemctl restart docker, \
     /opt/143/deploy/scripts/install-log-rotation.sh *
 
@@ -234,6 +235,7 @@ elif [ "$ROLE" = "logging" ]; then
     # sync with bootstrap.sh.
     cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/grafana, \
     /usr/bin/systemctl restart docker, \
@@ -260,6 +262,7 @@ elif [ "$ROLE" = "redis" ]; then
     # can cap docker container log files without an extra root SSH hop.
     cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/systemctl restart docker, \
     /opt/143/deploy/scripts/install-log-rotation.sh *
 

--- a/deploy/scripts/repair-deploy-sudoers.sh
+++ b/deploy/scripts/repair-deploy-sudoers.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Refresh the deploy user's narrow NOPASSWD sudoers grant on an already-running
+# host without tearing down containers. This is the no-reprovision repair path
+# for legacy hosts that predate newer deploy-time sudo call sites.
+#
+# Usage:
+#   repair-deploy-sudoers.sh <role> <host> <ssh-key-path>
+
+if [ "$#" -ne 3 ]; then
+  echo "Usage: $0 <role> <host> <ssh-key-path>" >&2
+  exit 2
+fi
+
+ROLE="$1"
+HOST="$2"
+SSH_KEY="$3"
+
+case "$ROLE" in
+  app|worker|db|logging|redis) ;;
+  *)
+    echo "Unknown role: $ROLE (expected: app, worker, db, logging, redis)" >&2
+    exit 2
+    ;;
+esac
+
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+
+echo "Repairing deploy sudoers for role=$ROLE on $HOST via root SSH..."
+ssh "${SSH_OPTS[@]}" root@"$HOST" "ROLE=$ROLE" bash <<'REMOTE'
+set -euo pipefail
+
+case "$ROLE" in
+  app|worker)
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/grafana, \
+    /usr/bin/runsc install -- --ignore-cgroups --host-uds=open, \
+    /usr/bin/systemctl restart docker, \
+    /usr/bin/apt-get install -y --no-install-recommends iptables-persistent, \
+    /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    ;;
+  logging)
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/grafana, \
+    /usr/bin/systemctl restart docker, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    ;;
+  db|redis)
+    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+Cmnd_Alias DEPLOY_CMDS = \
+    /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
+    /usr/bin/systemctl restart docker, \
+    /opt/143/deploy/scripts/install-log-rotation.sh *
+
+deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
+SUDOERS
+    ;;
+esac
+
+chmod 440 /etc/sudoers.d/99-deploy
+visudo -cf /etc/sudoers.d/99-deploy
+
+if id deploy >/dev/null 2>&1; then
+  for path in \
+    /opt/143/deploy/scripts \
+    /opt/143/deploy/vmalert \
+    /opt/143/deploy/grafana
+  do
+    [ -e "$path" ] && chown -R deploy:deploy "$path"
+  done
+fi
+
+echo "Deploy sudoers repaired for $ROLE."
+REMOTE

--- a/deploy/scripts/repair-deploy-sudoers.sh
+++ b/deploy/scripts/repair-deploy-sudoers.sh
@@ -31,9 +31,12 @@ echo "Repairing deploy sudoers for role=$ROLE on $HOST via root SSH..."
 ssh "${SSH_OPTS[@]}" root@"$HOST" "ROLE=$ROLE" bash <<'REMOTE'
 set -euo pipefail
 
+TMP="$(mktemp /etc/sudoers.d/99-deploy.XXXXXX)"
+trap 'rm -f "$TMP"' EXIT
+
 case "$ROLE" in
   app|worker)
-    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+    cat > "$TMP" <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
@@ -48,7 +51,7 @@ deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
 SUDOERS
     ;;
   logging)
-    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+    cat > "$TMP" <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/vmalert, \
@@ -60,7 +63,7 @@ deploy ALL=(root) NOPASSWD: DEPLOY_CMDS
 SUDOERS
     ;;
   db|redis)
-    cat > /etc/sudoers.d/99-deploy <<'SUDOERS'
+    cat > "$TMP" <<'SUDOERS'
 Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/chown -R deploy\:deploy /opt/143/deploy/scripts, \
     /usr/bin/systemctl restart docker, \
@@ -71,8 +74,10 @@ SUDOERS
     ;;
 esac
 
-chmod 440 /etc/sudoers.d/99-deploy
-visudo -cf /etc/sudoers.d/99-deploy
+chmod 440 "$TMP"
+visudo -cf "$TMP"
+mv "$TMP" /etc/sudoers.d/99-deploy
+trap - EXIT
 
 if id deploy >/dev/null 2>&1; then
   for path in \


### PR DESCRIPTION
## Summary
- Adds `deploy/scripts/repair-deploy-sudoers.sh`, which uses a one-shot root SSH to rewrite the narrow `/etc/sudoers.d/99-deploy` grant (with role-specific `DEPLOY_CMDS`) and validates it with `visudo`, so legacy hosts can recover without a container-tearing reprovision.
- `deploy.sh` now invokes the repair automatically when `sandbox-firewall.sh`/`install-log-rotation.sh` syncs or the rotation install fail under `deploy+sudo`, then retries — falling back to a clear `make repair-deploy-sudoers` instruction if root SSH is not available.
- Adds `chown -R deploy:deploy /opt/143/deploy/scripts` to the `db`/`logging`/`redis` provision-time `DEPLOY_CMDS` so the existing inline chown step keeps working post-repair, plus a `make repair-deploy-sudoers ROLE=… HOST=…` target and tests pinning all of the above.

## Test plan
- [ ] `make test` (covers updated `deploy_config_test.go` assertions)
- [ ] On a legacy host, run a deploy and confirm the auto-repair path executes and the deploy completes without manual intervention
