### PR TITLE
Dedupe PR check runs from parallel workflow runs

### DIFF
--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -769,7 +769,35 @@ func (s *PRService) listCheckRunsForRef(ctx context.Context, token, owner, repo,
 	if err := json.Unmarshal(body, &resp); err != nil {
 		return nil, fmt.Errorf("decode GitHub check runs: %w", err)
 	}
-	return resp.CheckRuns, nil
+	return dedupeCheckRunsByName(resp.CheckRuns), nil
+}
+
+// dedupeCheckRunsByName collapses check runs that share a display name down to
+// the most recent one. GitHub's filter=latest only dedupes within a single
+// workflow run, so a repo whose workflow triggers on both `pull_request` and
+// `push` ends up with two parallel runs on the same SHA — each emits its own
+// "Backend Test", "Frontend Test", etc. and the unfiltered list shows every
+// job twice. Highest ID wins because GitHub allocates check_run IDs
+// monotonically, so the newer workflow run's state replaces the older one.
+func dedupeCheckRunsByName(checkRuns []gitHubCheckRun) []gitHubCheckRun {
+	if len(checkRuns) <= 1 {
+		return checkRuns
+	}
+	bestIdx := make(map[string]int, len(checkRuns))
+	for i, check := range checkRuns {
+		key := strings.ToLower(strings.TrimSpace(check.Name))
+		if existing, ok := bestIdx[key]; !ok || checkRuns[i].ID > checkRuns[existing].ID {
+			bestIdx[key] = i
+		}
+	}
+	deduped := make([]gitHubCheckRun, 0, len(bestIdx))
+	for i, check := range checkRuns {
+		key := strings.ToLower(strings.TrimSpace(check.Name))
+		if bestIdx[key] == i {
+			deduped = append(deduped, check)
+		}
+	}
+	return deduped
 }
 
 func (s *PRService) fetchCheckRunAnnotations(ctx context.Context, token, owner, repo string, checkRunID int64) ([]string, error) {

--- a/internal/services/github/pr_health_test.go
+++ b/internal/services/github/pr_health_test.go
@@ -308,6 +308,73 @@ func TestClassifyCheckRunCategory(t *testing.T) {
 	}
 }
 
+func TestDedupeCheckRunsByName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []gitHubCheckRun
+		expected []gitHubCheckRun
+	}{
+		{
+			name:     "empty input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name:     "single check passes through",
+			input:    []gitHubCheckRun{{ID: 1, Name: "Backend Test"}},
+			expected: []gitHubCheckRun{{ID: 1, Name: "Backend Test"}},
+		},
+		{
+			name: "parallel pull_request and push runs collapse to newer ID",
+			input: []gitHubCheckRun{
+				{ID: 100, Name: "Backend Test", Status: "completed", Conclusion: "failure"},
+				{ID: 101, Name: "Backend Test", Status: "in_progress"},
+				{ID: 102, Name: "Frontend Test", Status: "completed", Conclusion: "success"},
+				{ID: 103, Name: "Frontend Test", Status: "in_progress"},
+				{ID: 104, Name: "Detect Changes", Status: "completed", Conclusion: "success"},
+			},
+			expected: []gitHubCheckRun{
+				{ID: 101, Name: "Backend Test", Status: "in_progress"},
+				{ID: 103, Name: "Frontend Test", Status: "in_progress"},
+				{ID: 104, Name: "Detect Changes", Status: "completed", Conclusion: "success"},
+			},
+		},
+		{
+			name: "name match is case- and whitespace-insensitive",
+			input: []gitHubCheckRun{
+				{ID: 10, Name: "  Backend Test "},
+				{ID: 11, Name: "backend test"},
+			},
+			expected: []gitHubCheckRun{{ID: 11, Name: "backend test"}},
+		},
+		{
+			name: "winners appear in input order",
+			input: []gitHubCheckRun{
+				{ID: 5, Name: "Lint"},
+				{ID: 6, Name: "Build"},
+				{ID: 7, Name: "Lint"},
+				{ID: 4, Name: "Test"},
+			},
+			expected: []gitHubCheckRun{
+				{ID: 6, Name: "Build"},
+				{ID: 7, Name: "Lint"},
+				{ID: 4, Name: "Test"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := dedupeCheckRunsByName(tt.input)
+			require.Equal(t, tt.expected, got, "dedupeCheckRunsByName should keep highest-ID check per name")
+		})
+	}
+}
+
 func TestBuildPRHealthSummaryText(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- The PR health hover was showing every CI job twice (Backend Test, Frontend Test, etc.) because `ci.yml` triggers on both `pull_request` and `push`, so each push produces two parallel workflow runs on the same SHA — and GitHub's `filter=latest` only dedupes within a single workflow run.
- `listCheckRunsForRef` now collapses check runs by name, keeping the highest ID (GitHub allocates check_run IDs monotonically, so this is the newer workflow run's state). All downstream consumers — health summary, failing-test count, indeterminate-signal detection, enrichment annotations — benefit automatically.
- Added `TestDedupeCheckRunsByName` covering the parallel-runs case, single/empty inputs, case- and whitespace-insensitive matching, and ordering.

## Test plan
- [x] `go test ./internal/services/github/...`
- [x] `make lint`
- [ ] After merge, verify the PR health hover for an open PR shows each CI job exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)
