### PR TITLE
[codex] Allow deploys without log rotation repair

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -206,6 +206,8 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh", "deploy.sh should invoke install-log-rotation.sh via deploy+sudo (not root SSH) — matches the sandbox-firewall.sh pattern and avoids depending on root SSH at routine deploy time")
 	require.Contains(t, deployText, "repair-deploy-sudoers.sh", "deploy.sh should try the narrow root repair path when a legacy host is missing the deploy sudoers entry")
 	require.Contains(t, deployText, "Retrying docker log rotation after sudoers repair", "deploy.sh should retry install-log-rotation.sh after repairing sudoers so a single deploy can recover legacy hosts")
+	require.Contains(t, deployText, "WARNING: docker log rotation was not updated on this deploy; continuing.", "deploy.sh should keep routine deploys moving when a legacy host cannot be sudoers-repaired from CI")
+	require.NotContains(t, deployText, "ERROR: install-log-rotation.sh failed and sudoers repair via root SSH did not complete.", "deploy.sh should not fail the whole deploy solely because optional log-rotation repair is unavailable")
 
 	bootstrap, err := os.ReadFile("../deploy/scripts/bootstrap.sh")
 	require.NoError(t, err, "test should read bootstrap.sh")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -53,6 +53,13 @@ repair_deploy_sudoers() {
   bash "$SCRIPT_DIR/repair-deploy-sudoers.sh" "$ROLE" "$HOST" "$SSH_KEY"
 }
 
+warn_log_rotation_skipped() {
+  echo "WARNING: docker log rotation was not updated on this deploy; continuing."
+  echo "  The service deploy will continue, but local Docker json-file logs may remain unbounded."
+  echo "  To repair the host when root SSH is available, run:"
+  echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+}
+
 # --- Refresh secrets from .env.production.enc ---
 if [ -z "${SOPS_AGE_KEY:-}" ]; then
   AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
@@ -221,6 +228,7 @@ case "$ROLE" in
   *)  LOG_MAX_SIZE="100m" ;;
 esac
 LOG_MAX_FILE="5"
+LOG_ROTATION_READY=1
 
 # Sync install-log-rotation.sh: stage to .new, atomic rename. Same ETXTBSY
 # avoidance as sandbox-firewall.sh — a lingering FD on the old inode would
@@ -236,40 +244,40 @@ if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.s
     scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
       deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new
   else
-    echo "ERROR: scp of install-log-rotation.sh failed and sudoers repair via root SSH did not complete."
-    echo "  Run once from a machine with root SSH access:"
-    echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
-    echo "  Then re-run the deploy."
-    exit 1
+    warn_log_rotation_skipped
+    LOG_ROTATION_READY=0
   fi
 fi
-ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-  "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
-   && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh \
-   || { rm -f /opt/143/deploy/scripts/install-log-rotation.sh.new; exit 1; }"
+if [ "$LOG_ROTATION_READY" -eq 1 ]; then
+  if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
+     && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh \
+     || { rm -f /opt/143/deploy/scripts/install-log-rotation.sh.new; exit 1; }"; then
+    warn_log_rotation_skipped
+    LOG_ROTATION_READY=0
+  fi
+fi
 
-echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
-# `sudo -n` so missing-sudoers fails fast instead of hanging on a password
-# prompt CI can't satisfy. The error path tells the operator how to fix.
-run_log_rotation() {
-  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"
-}
-if ! run_log_rotation; then
-  echo "install-log-rotation.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
-  if repair_deploy_sudoers; then
-    echo "Retrying docker log rotation after sudoers repair..."
-    if ! run_log_rotation; then
-      echo "ERROR: install-log-rotation.sh still failed after repairing deploy sudoers."
-      exit 1
+if [ "$LOG_ROTATION_READY" -eq 1 ]; then
+  echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
+  # `sudo -n` so missing-sudoers fails fast instead of hanging on a password
+  # prompt CI can't satisfy. If the repair path also isn't available, keep the
+  # deploy moving: log rotation is an operational hardening step, not the app
+  # or database rollout itself.
+  run_log_rotation() {
+    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+      "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"
+  }
+  if ! run_log_rotation; then
+    echo "install-log-rotation.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+    if repair_deploy_sudoers; then
+      echo "Retrying docker log rotation after sudoers repair..."
+      if ! run_log_rotation; then
+        warn_log_rotation_skipped
+      fi
+    else
+      warn_log_rotation_skipped
     fi
-  else
-    echo "ERROR: install-log-rotation.sh failed and sudoers repair via root SSH did not complete."
-    echo "  This host likely predates the deploy sudoers entry."
-    echo "  Run once from a machine with root SSH access:"
-    echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
-    echo "  Then re-run the deploy."
-    exit 1
   fi
 fi
 

--- a/docs/design/10-infrastructure.md
+++ b/docs/design/10-infrastructure.md
@@ -1,6 +1,6 @@
 # Design: Infrastructure & Deployment
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-04-21
+> **Status:** Partially Implemented | **Last reviewed:** 2026-05-05
 
 This document describes how 143.dev is packaged, deployed, and scaled.
 
@@ -227,6 +227,15 @@ CMD ["./server"]
 **Sandbox Dockerfile**: See `sandbox/Dockerfile` for the full definition. The image installs all three agent CLIs (Claude Code, Codex, Gemini) at pinned versions from `sandbox/versions.json` via `sandbox/install-agents.sh`. Build with `docker build -t 143-sandbox:latest sandbox/`. CI also builds this image, and local Docker development builds it through the `sandbox` compose target.
 
 This image is used by the Docker sandbox provider. It runs under **gVisor** (`runsc` runtime) by default for syscall-level isolation. The same image works with both `runsc` (gVisor) and `runc` (standard Docker) — no image changes needed when switching runtimes.
+
+### Deploy-Time Host Hardening
+
+Fleet deploys attempt to keep host hardening in place as they roll services:
+
+- Docker `json-file` log rotation is installed through `deploy/scripts/install-log-rotation.sh`, which merges the desired `log-driver` and `log-opts` into `/etc/docker/daemon.json` and restarts Docker only when the file changes.
+- The deploy user receives a narrow `NOPASSWD` sudoers grant during provisioning so routine deploys can run the log-rotation helper and worker firewall helper without broad root access.
+- Existing hosts that predate a sudoers entry are repaired through `deploy/scripts/repair-deploy-sudoers.sh` when root SSH is available.
+- If a routine deploy cannot repair sudoers from CI, Docker log-rotation update failure is warning-only. The service rollout continues, and operators can run `make repair-deploy-sudoers ROLE=<role> HOST=<host>` later from a machine with root SSH access.
 
 **gVisor Setup (Production)**:
 


### PR DESCRIPTION
## Summary
Fixes fleet deploys on legacy hosts where the deploy user can SSH but passwordless sudo repair cannot be completed from CI. Docker log-rotation setup still syncs, tries deploy sudo, and attempts the narrow root repair path, but unrepaired log-rotation failure now warns and lets the service rollout continue. The deploy config test now guards that warning-only fallback, and the infrastructure design doc records the host-hardening contract.

## Validation
- `bash -n deploy/scripts/deploy.sh`
- `go vet ./...`
- `go build ./...`
- `go test ./...`