### PR TITLE
[codex] Refresh Linear OAuth tokens

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1073,14 +1073,28 @@ func buildServices(
 		Integrations:       integrationStore,
 		IntegrationsWriter: integrationStore,
 		Credentials:        credentialStore,
+		CredentialsWriter:  credentialStore,
 		Issues:             issueStore,
 		Sessions:           sessionStore,
 		IssueLinks:         db.NewSessionIssueLinkStore(pool),
 		Orgs:               orgStore,
 		Jobs:               jobStore,
-		AppBaseURL:         cfg.FrontendURL,
+		OAuthClient: linear.OAuthClientCreds{
+			ClientID:     cfg.LinearOAuthClientID,
+			ClientSecret: cfg.LinearOAuthClientSecret,
+		},
+		AppBaseURL: cfg.FrontendURL,
 	})
 	prService.SetLinearMilestoneEnqueuer(linear.MilestoneEnqueuerFor(jobStore, logger))
+	// Wire the linear service into the agent env so sandbox-bound
+	// LINEAR_ACCESS_TOKEN is resolved through the refresh path. Without
+	// this, sessions that start within the refresh window of a token's
+	// expiry would inject a soon-to-be-stale token and the agent's
+	// 143-tools would 401 mid-turn. SetLinearTokens is a no-op when called
+	// before linearService is built, but the orchestrator construction
+	// happens on the same goroutine after linear.Build returns, so this
+	// ordering is deterministic.
+	agentEnv.SetLinearTokens(linearService)
 
 	// Runtime resource sampler. Optional capability — only providers that
 	// implement RuntimeStatsProvider produce samples. Disabled when the

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -66,9 +66,14 @@ type githubAppService interface {
 // --- Linear types ---
 
 type linearTokenResponse struct {
-	AccessToken string `json:"access_token"`
-	TokenType   string `json:"token_type"`
-	Scope       string `json:"scope"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	// ExpiresIn is the access token TTL in seconds. Legacy installs created
+	// before Linear's refresh-token rollout can have credential rows with a
+	// zero ExpiresAt, which the runtime treats as "no known expiry".
+	ExpiresIn int `json:"expires_in"`
 }
 
 type linearOrganization struct {
@@ -438,6 +443,10 @@ func (h *IntegrationHandler) StartLinearOAuth(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Linear returns refresh_token + expires_in from the standard auth-code
+	// exchange for OAuth apps on the refresh-token system. Keep this to
+	// documented Linear scopes only; adding generic OAuth scopes such as
+	// offline_access makes Linear reject the authorize URL as invalid_scope.
 	params := url.Values{
 		"client_id":     {h.linearClientID},
 		"redirect_uri":  {h.linearRedirectURL()},
@@ -476,10 +485,14 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 
 	linearConfig := models.LinearConfig{
 		AccessToken:   token.AccessToken,
+		RefreshToken:  token.RefreshToken,
 		TokenType:     token.TokenType,
 		Scope:         token.Scope,
 		WorkspaceID:   workspaceID,
 		WorkspaceName: workspaceName,
+	}
+	if token.ExpiresIn > 0 {
+		linearConfig.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
 	}
 	if err := h.credentialStore.Upsert(r.Context(), orgID, linearConfig); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "SAVE_CREDENTIAL_FAILED", "failed to store linear credential", err)

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/api/middleware"
+	"github.com/assembledhq/143/internal/crypto"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
@@ -310,7 +311,7 @@ func TestIntegrationHandler_StartLinearOAuth_RedirectsToLinearAuthorize(t *testi
 	require.Equal(t, "linear-client-id", parsed.Query().Get("client_id"), "redirect should include configured client id")
 	require.Equal(t, "code", parsed.Query().Get("response_type"), "redirect should request auth code flow")
 	require.Equal(t, "http://localhost:8080/api/v1/integrations/linear/callback", parsed.Query().Get("redirect_uri"), "redirect should include API callback URL")
-	require.Equal(t, "read,write", parsed.Query().Get("scope"), "redirect should request Linear read and write scopes")
+	require.Equal(t, "read,write", parsed.Query().Get("scope"), "redirect should request only Linear's documented read and write scopes")
 	require.NotEmpty(t, parsed.Query().Get("state"), "redirect should include oauth state")
 
 	setCookie := w.Result().Header.Get("Set-Cookie")
@@ -353,6 +354,8 @@ func TestIntegrationHandler_ExchangeLinearCode_UsesFormEncodedBody(t *testing.T)
 
 	require.NoError(t, err, "exchangeLinearCode should parse a successful token response")
 	require.Equal(t, "linear-token", token.AccessToken, "exchangeLinearCode should return the access token")
+	require.Equal(t, "linear-refresh", token.RefreshToken, "exchangeLinearCode should capture the refresh token")
+	require.Equal(t, 86400, token.ExpiresIn, "exchangeLinearCode should capture the expires_in TTL so callers can compute ExpiresAt")
 }
 
 func TestIntegrationHandler_StartLinearOAuth_NotConfigured(t *testing.T) {
@@ -371,6 +374,121 @@ func TestIntegrationHandler_StartLinearOAuth_NotConfigured(t *testing.T) {
 	handler.StartLinearOAuth(w, req)
 	require.Equal(t, http.StatusServiceUnavailable, w.Code)
 	require.Contains(t, w.Body.String(), "LINEAR_OAUTH_NOT_CONFIGURED")
+}
+
+// TestIntegrationHandler_HandleLinearOAuthCallback_PersistsRefreshTokenAndExpiry
+// is the round-trip integration test for Linear's refresh-token response:
+// when Linear includes refresh_token + expires_in, those fields must end
+// up inside the persisted LinearConfig JSON. Without this test, a future
+// refactor that drops the merge (e.g. forgets to map ExpiresIn to ExpiresAt)
+// would compile, pass unit tests, and silently regress the entire refresh
+// capability — every new connection would look healthy until the access
+// token aged out.
+//
+// The fakeCrypto is nil so OrgCredentialStore uses DevEncrypt — a
+// reversible "v0:<plaintext>" wrapper. We capture the encrypted bytes
+// from pgxmock, strip the prefix, and assert on the JSON fields. This
+// is the highest-value test in this file because it verifies the
+// refresh-flow plumbing end-to-end through the OAuth callback rather
+// than via a unit mock.
+func TestIntegrationHandler_HandleLinearOAuthCallback_PersistsRefreshTokenAndExpiry(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	credentialStore := db.NewOrgCredentialStore(mock, nil)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.String() {
+		case "https://api.linear.app/oauth/token":
+			respBody := `{"access_token":"lin_at","refresh_token":"lin_rt","token_type":"Bearer","scope":"read,write","expires_in":7200}`
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(bytes.NewBufferString(respBody))}, nil
+		case "https://api.linear.app/graphql":
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: io.NopCloser(bytes.NewBufferString(`{"data":{"viewer":{"organization":{"id":"lin-org-1","name":"Acme"}}}}`))}, nil
+		default:
+			return nil, errors.New("unexpected request URL")
+		}
+	})
+
+	handler := NewIntegrationHandler(store, credentialStore, "linear-client-id", "linear-client-secret", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+
+	// Custom matcher captures the encrypted credential blob so we can
+	// decrypt and assert on the JSON. argMatcher must be the 4th
+	// pgxmock arg (the @config bytes) per OrgCredentialStore.UpsertWithLabel.
+	var capturedConfigBytes []byte
+	configCapture := pgxmock.QueryMatcherFunc(func(_ string, _ string) error { return nil })
+	_ = configCapture
+	mock.ExpectQuery("INSERT INTO org_credentials").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), capturingArg(&capturedConfigBytes), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations/linear/callback?code=test-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{Name: "linear_integration_oauth_state", Value: "test-state"})
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.HandleLinearOAuthCallback(w, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code)
+	require.NoError(t, mock.ExpectationsWereMet())
+
+	// Decrypt the captured bytes (DevEncrypt = "v0:" prefix + plaintext).
+	require.NotEmpty(t, capturedConfigBytes, "callback should have written the credential")
+	plaintext, err := crypto.DevDecrypt(capturedConfigBytes)
+	require.NoError(t, err, "captured bytes should be DevEncrypt'd")
+
+	var persisted models.LinearConfig
+	require.NoError(t, json.Unmarshal(plaintext, &persisted), "persisted config should decode as LinearConfig")
+
+	require.Equal(t, "lin_at", persisted.AccessToken, "access_token must be persisted")
+	require.Equal(t, "lin_rt", persisted.RefreshToken, "refresh_token must be persisted — without this the whole refresh flow breaks")
+	require.Equal(t, "Bearer", persisted.TokenType)
+	require.Equal(t, "read,write", persisted.Scope)
+	require.Equal(t, "lin-org-1", persisted.WorkspaceID)
+	require.Equal(t, "Acme", persisted.WorkspaceName)
+	// expires_in=7200 → ExpiresAt ~2h from now. Allow a generous skew
+	// because the callback computes ExpiresAt = time.Now()+expires_in
+	// and the test reads ExpiresAt some milliseconds later.
+	require.WithinDuration(t, time.Now().Add(2*time.Hour), persisted.ExpiresAt, 30*time.Second, "ExpiresAt must reflect expires_in=7200")
+}
+
+// capturingArg returns a pgxmock argument matcher that records the value
+// it sees into the supplied byte slice pointer. Used for asserting on
+// encrypted config payloads that we want to decrypt and inspect.
+func capturingArg(dest *[]byte) pgxmock.Argument {
+	return capturingArgImpl{dest: dest}
+}
+
+type capturingArgImpl struct {
+	dest *[]byte
+}
+
+func (c capturingArgImpl) Match(v interface{}) bool {
+	switch b := v.(type) {
+	case []byte:
+		*c.dest = append((*c.dest)[:0], b...)
+	case string:
+		*c.dest = append((*c.dest)[:0], []byte(b)...)
+	default:
+		return false
+	}
+	return true
 }
 
 func TestIntegrationHandler_HandleLinearOAuthCallback_SavesCredentialAndIntegration(t *testing.T) {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -229,12 +229,17 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		Integrations:       integrationStore,
 		IntegrationsWriter: integrationStore,
 		Credentials:        credentialStore,
+		CredentialsWriter:  credentialStore,
 		Issues:             issueStore,
 		Sessions:           sessionStore,
 		IssueLinks:         sessionIssueLinkStore,
 		Orgs:               orgStore,
 		Jobs:               jobStore,
-		AppBaseURL:         cfg.FrontendURL,
+		OAuthClient: linear.OAuthClientCreds{
+			ClientID:     cfg.LinearOAuthClientID,
+			ClientSecret: cfg.LinearOAuthClientSecret,
+		},
+		AppBaseURL: cfg.FrontendURL,
 	})
 	if sessionStreams != nil {
 		// Republish session status on every link change so the detail view

--- a/internal/db/org_credentials.go
+++ b/internal/db/org_credentials.go
@@ -350,6 +350,81 @@ func (s *OrgCredentialStore) UpsertByID(ctx context.Context, orgID uuid.UUID, id
 	return err
 }
 
+// UpdateLinearConfigIfRefreshTokenMatches updates the singleton Linear
+// credential only if its stored refresh token still matches the token the
+// caller just redeemed. The row is locked for the read/compare/write so a
+// reconnect or peer refresh cannot be overwritten by a stale refresh response.
+//
+// Returns the current row config with updated=false when the refresh token has
+// changed. Callers should use that config for race recovery rather than
+// retrying the stale token chain.
+func (s *OrgCredentialStore) UpdateLinearConfigIfRefreshTokenMatches(ctx context.Context, orgID uuid.UUID, expectedRefreshToken string, cfg models.LinearConfig) (models.LinearConfig, bool, error) {
+	txStarter, ok := s.db.(TxStarter)
+	if !ok {
+		return models.LinearConfig{}, false, fmt.Errorf("org credential store db does not support transactions")
+	}
+	tx, err := txStarter.Begin(ctx)
+	if err != nil {
+		return models.LinearConfig{}, false, fmt.Errorf("begin linear credential refresh update: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	query := `
+		SELECT ` + credentialColumns + `
+		FROM org_credentials
+		WHERE org_id = @org_id
+		  AND provider = @provider
+		  AND label = ''
+		  AND status != 'disabled'
+		FOR UPDATE`
+	rows, err := tx.Query(ctx, query, pgx.NamedArgs{
+		"org_id":   orgID,
+		"provider": string(models.ProviderLinear),
+	})
+	if err != nil {
+		return models.LinearConfig{}, false, fmt.Errorf("query linear credential for refresh update: %w", err)
+	}
+	row, err := pgx.CollectOneRow(rows, pgx.RowToStructByNameLax[models.OrgCredential])
+	if err != nil {
+		return models.LinearConfig{}, false, fmt.Errorf("load linear credential for refresh update: %w", err)
+	}
+
+	currentCred, err := s.decryptRow(row)
+	if err != nil {
+		return models.LinearConfig{}, false, err
+	}
+	current, ok := currentCred.Config.(models.LinearConfig)
+	if !ok {
+		return models.LinearConfig{}, false, fmt.Errorf("linear credential config is wrong type: got %T", currentCred.Config)
+	}
+	if current.RefreshToken != expectedRefreshToken {
+		if err := tx.Commit(ctx); err != nil {
+			return models.LinearConfig{}, false, fmt.Errorf("commit skipped linear credential refresh update: %w", err)
+		}
+		return current, false, nil
+	}
+
+	encrypted, err := s.marshalAndEncrypt(cfg)
+	if err != nil {
+		return models.LinearConfig{}, false, err
+	}
+	tag, err := tx.Exec(ctx, `UPDATE org_credentials SET config = @config, status = 'active', updated_at = now() WHERE id = @id AND org_id = @org_id`, pgx.NamedArgs{
+		"id":     row.ID,
+		"org_id": orgID,
+		"config": encrypted,
+	})
+	if err != nil {
+		return models.LinearConfig{}, false, fmt.Errorf("update linear credential after refresh: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return models.LinearConfig{}, false, pgx.ErrNoRows
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return models.LinearConfig{}, false, fmt.Errorf("commit linear credential refresh update: %w", err)
+	}
+	return cfg, true, nil
+}
+
 // Get decrypts and returns the unlabeled credential for an (org, provider).
 // Convention: a provider that stores a single credential per org (e.g. an
 // Anthropic API key) uses label=""; providers with multiple rows per org

--- a/internal/db/org_credentials_test.go
+++ b/internal/db/org_credentials_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -445,6 +446,87 @@ func TestOrgCredentialStore_UpsertWithLabel_NonCodingProvider(t *testing.T) {
 	})
 	require.NoError(t, err, "UpsertWithLabel should not return an error for non-coding providers")
 	require.NoError(t, mock.ExpectationsWereMet(), "no MAX(priority) query should be issued for non-coding providers")
+}
+
+func TestOrgCredentialStore_UpdateLinearConfigIfRefreshTokenMatches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates when refresh token matches", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		credentialID := uuid.New()
+		now := time.Now().UTC()
+		priorJSON, err := json.Marshal(models.LinearConfig{
+			AccessToken:  "lin_at_old",
+			RefreshToken: "lin_rt_old",
+			ExpiresAt:    now.Add(time.Minute),
+		})
+		require.NoError(t, err, "prior config should marshal")
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(`SELECT .* FROM org_credentials .* FOR UPDATE`).
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(credColumns).
+				AddRow(credentialID, orgID, string(models.ProviderLinear), "", crypto.DevEncrypt(priorJSON), "active", nil, nil, nil, now, now))
+		mock.ExpectExec(`UPDATE org_credentials SET config = .* WHERE id = .* AND org_id = .*`).
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		mock.ExpectCommit()
+
+		store := NewOrgCredentialStore(mock, nil)
+		merged := models.LinearConfig{
+			AccessToken:  "lin_at_new",
+			RefreshToken: "lin_rt_new",
+			ExpiresAt:    now.Add(2 * time.Hour),
+		}
+		current, updated, err := store.UpdateLinearConfigIfRefreshTokenMatches(context.Background(), orgID, "lin_rt_old", merged)
+		require.NoError(t, err, "matching refresh token should update")
+		require.True(t, updated, "matching refresh token should report updated")
+		require.Equal(t, merged, current, "matching refresh token should return the persisted config")
+		require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+	})
+
+	t.Run("skips update when refresh token changed", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "creating mock pool should not error")
+		defer mock.Close()
+
+		orgID := uuid.New()
+		credentialID := uuid.New()
+		now := time.Now().UTC()
+		reconnected := models.LinearConfig{
+			AccessToken:   "lin_at_reconnected",
+			RefreshToken:  "lin_rt_reconnected",
+			ExpiresAt:     now.Add(2 * time.Hour),
+			WorkspaceID:   "wks-new",
+			WorkspaceName: "Reconnected Workspace",
+		}
+		currentJSON, err := json.Marshal(reconnected)
+		require.NoError(t, err, "current config should marshal")
+
+		mock.ExpectBegin()
+		mock.ExpectQuery(`SELECT .* FROM org_credentials .* FOR UPDATE`).
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows(credColumns).
+				AddRow(credentialID, orgID, string(models.ProviderLinear), "", crypto.DevEncrypt(currentJSON), "active", nil, nil, nil, now, now))
+		mock.ExpectCommit()
+
+		store := NewOrgCredentialStore(mock, nil)
+		current, updated, err := store.UpdateLinearConfigIfRefreshTokenMatches(context.Background(), orgID, "lin_rt_old", models.LinearConfig{
+			AccessToken:  "lin_at_from_old_chain",
+			RefreshToken: "lin_rt_from_old_chain",
+			ExpiresAt:    now.Add(2 * time.Hour),
+		})
+		require.NoError(t, err, "changed refresh token should not error")
+		require.False(t, updated, "changed refresh token should report no update")
+		require.Equal(t, reconnected, current, "changed refresh token should return the current row for race recovery")
+		require.NoError(t, mock.ExpectationsWereMet(), "no UPDATE should be issued when the refresh token changed")
+	})
 }
 
 func TestOrgCredentialStore_Get(t *testing.T) {

--- a/internal/models/credentials.go
+++ b/internal/models/credentials.go
@@ -204,11 +204,41 @@ type SentryConfig struct {
 
 type LinearConfig struct {
 	WebhookSecret string `json:"webhook_secret,omitempty"`
-	AccessToken   string `json:"access_token,omitempty"` // #nosec G117 -- JSON config field
-	TokenType     string `json:"token_type,omitempty"`
-	Scope         string `json:"scope,omitempty"`
-	WorkspaceID   string `json:"workspace_id,omitempty"`
-	WorkspaceName string `json:"workspace_name,omitempty"`
+	AccessToken   string `json:"access_token,omitempty"`  // #nosec G117 -- JSON config field
+	RefreshToken  string `json:"refresh_token,omitempty"` // #nosec G117 -- JSON config field
+	// ExpiresAt is the absolute expiry of AccessToken. Zero value means
+	// "unknown TTL" — applies to legacy connections created before Linear's
+	// refresh-token rollout, where we stored only an access token with no
+	// expires_in. IsExpired / NeedsRefresh treat zero as "never
+	// expires" so legacy rows continue to work until the user reconnects.
+	ExpiresAt     time.Time `json:"expires_at,omitempty"`
+	TokenType     string    `json:"token_type,omitempty"`
+	Scope         string    `json:"scope,omitempty"`
+	WorkspaceID   string    `json:"workspace_id,omitempty"`
+	WorkspaceName string    `json:"workspace_name,omitempty"`
+}
+
+// IsExpired returns true if the access token has a known expiry that has
+// already passed. Connections without expiry info (legacy rows where Linear
+// did not return expires_in) report false so existing tokens keep working
+// until they hit a real 401.
+func (c LinearConfig) IsExpired() bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().After(c.ExpiresAt)
+}
+
+// NeedsRefresh returns true if the access token has a known expiry within the
+// given window. Connections with no expiry are legacy "use until 401" rows and
+// do not proactively refresh. A known-expiring row without a refresh token
+// still reports true so callers can force the reconnect path instead of
+// returning a token they know is stale or about to go stale.
+func (c LinearConfig) NeedsRefresh(window time.Duration) bool {
+	if c.ExpiresAt.IsZero() {
+		return false
+	}
+	return time.Now().Add(window).After(c.ExpiresAt)
 }
 
 type SlackConfig struct {

--- a/internal/models/credentials_test.go
+++ b/internal/models/credentials_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -272,6 +273,71 @@ func TestParseProviderConfig_Linear(t *testing.T) {
 	lc, ok := cfg.(LinearConfig)
 	require.True(t, ok, "config should be LinearConfig")
 	require.Equal(t, "linear_secret", lc.WebhookSecret, "should parse webhook_secret")
+}
+
+func TestParseProviderConfig_Linear_WithRefreshFields(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	input := fmt.Sprintf(
+		`{"access_token":"lin_at","refresh_token":"lin_rt","expires_at":%q,"token_type":"Bearer","scope":"read,write"}`,
+		expiresAt.Format(time.RFC3339),
+	)
+	cfg, err := ParseProviderConfig(ProviderLinear, []byte(input))
+	require.NoError(t, err)
+
+	lc, ok := cfg.(LinearConfig)
+	require.True(t, ok)
+	require.Equal(t, "lin_at", lc.AccessToken)
+	require.Equal(t, "lin_rt", lc.RefreshToken)
+	require.True(t, expiresAt.Equal(lc.ExpiresAt), "expires_at should round-trip")
+	require.Equal(t, "Bearer", lc.TokenType)
+	require.Equal(t, "read,write", lc.Scope)
+}
+
+func TestLinearConfig_IsExpired(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      LinearConfig
+		expected bool
+	}{
+		{"expired token", LinearConfig{ExpiresAt: time.Now().Add(-1 * time.Hour)}, true},
+		{"valid token", LinearConfig{ExpiresAt: time.Now().Add(1 * time.Hour)}, false},
+		{"legacy token without expiry", LinearConfig{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, tt.cfg.IsExpired())
+		})
+	}
+}
+
+func TestLinearConfig_NeedsRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      LinearConfig
+		window   time.Duration
+		expected bool
+	}{
+		{"expires within window", LinearConfig{RefreshToken: "rt", ExpiresAt: time.Now().Add(2 * time.Minute)}, 5 * time.Minute, true},
+		{"expires outside window", LinearConfig{RefreshToken: "rt", ExpiresAt: time.Now().Add(1 * time.Hour)}, 5 * time.Minute, false},
+		{"already expired", LinearConfig{RefreshToken: "rt", ExpiresAt: time.Now().Add(-1 * time.Minute)}, 5 * time.Minute, true},
+		{"known expiry without refresh token still needs reconnect", LinearConfig{ExpiresAt: time.Now().Add(2 * time.Minute)}, 5 * time.Minute, true},
+		{"legacy: no refresh token, no expiry", LinearConfig{AccessToken: "lin"}, 5 * time.Minute, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expected, tt.cfg.NeedsRefresh(tt.window))
+		})
+	}
 }
 
 func TestParseProviderConfig_UnknownProvider(t *testing.T) {

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -51,8 +51,15 @@ type AgentEnv struct {
 	orgs              OrgStore
 	orgSettingsCache  *OrgSettingsCache
 	codexAuth         CodexAuthProvider
-	provider          SandboxProvider
-	logger            zerolog.Logger
+	// linearTokens, when set, supplies the LINEAR_ACCESS_TOKEN env var via a
+	// refresh-aware resolver. Without it, the sandbox falls back to reading
+	// the raw credential row (legacy path; the access token may have aged
+	// out by the time the sandbox runs). Production wiring always sets this
+	// to *linear.Service so the orchestrator gets the same refresh-on-expiry
+	// guarantee that worker handlers do.
+	linearTokens LinearTokenResolver
+	provider     SandboxProvider
+	logger       zerolog.Logger
 
 	// recentPicks remembers the credential id chosen for each (orgID, userID,
 	// provider) tuple by the most recent pickFromCodingProvider call. It feeds
@@ -111,8 +118,24 @@ type AgentEnvDeps struct {
 	Orgs              OrgStore                 // optional — enables agent_config overrides
 	OrgSettingsCache  *OrgSettingsCache        // optional — caches agent_config lookups
 	CodexAuth         CodexAuthProvider        // optional — enables ChatGPT OAuth for Codex
-	Provider          SandboxProvider          // required for InjectCodexAuth
-	Logger            zerolog.Logger
+	// LinearTokens optionally supplies a refresh-aware Linear access token
+	// for the sandbox env. When set, the orchestrator injects the result of
+	// GetValidAccessToken (rotating expired tokens transparently). Without
+	// it, the sandbox falls back to the raw credential read — fine for
+	// tests and pre-refresh-flow installs, but those env vars can be stale
+	// for any session that starts within refreshWindow of expiry.
+	LinearTokens LinearTokenResolver
+	Provider     SandboxProvider // required for InjectCodexAuth
+	Logger       zerolog.Logger
+}
+
+// LinearTokenResolver is the narrow surface AgentEnv needs from the Linear
+// service to inject a fresh access token into the sandbox. The signature
+// returns "" with nil error to mean "this org has no Linear integration
+// installed" so env.go can distinguish that from "we tried to refresh and
+// it failed" without importing Linear-specific sentinels.
+type LinearTokenResolver interface {
+	GetValidAccessToken(ctx context.Context, orgID uuid.UUID) (string, error)
 }
 
 // NewAgentEnv constructs an AgentEnv. The Provider is required; all other
@@ -127,10 +150,25 @@ func NewAgentEnv(deps AgentEnvDeps) *AgentEnv {
 		orgs:              deps.Orgs,
 		orgSettingsCache:  deps.OrgSettingsCache,
 		codexAuth:         deps.CodexAuth,
+		linearTokens:      deps.LinearTokens,
 		provider:          deps.Provider,
 		logger:            deps.Logger,
 		recentPicks:       make(map[pickKey]pickRecord),
 	}
+}
+
+// SetLinearTokens installs (or replaces) the Linear refresh-aware token
+// resolver after construction. NewAgentEnv is called early during process
+// boot (before stores like *db.SessionIssueLinkStore exist), but the
+// linear service depends on those stores, so it is built later. Rather
+// than deferring NewAgentEnv to the latest possible moment, the
+// orchestrator wiring calls SetLinearTokens once linear.Build has
+// returned. Safe to call with nil to detach the resolver in tests.
+func (e *AgentEnv) SetLinearTokens(r LinearTokenResolver) {
+	if e == nil {
+		return
+	}
+	e.linearTokens = r
 }
 
 // CodingCredentialShedder is the subset of CodingCredentialStore the agent
@@ -440,10 +478,31 @@ func (e *AgentEnv) Resolve(ctx context.Context, orgID uuid.UUID, agentType model
 			merged["SENTRY_ORG_SLUG"] = ic.Sentry.OrgSlug
 		}
 	}
-	if ic.Linear != nil {
-		if ic.Linear.AccessToken != "" {
-			merged["LINEAR_ACCESS_TOKEN"] = ic.Linear.AccessToken
+	// Linear access token injection. The refresh-aware resolver is preferred:
+	// it rotates a near-expiring token before sandbox-start so the agent
+	// can run a multi-minute turn without crossing the access-token expiry
+	// boundary. The raw fetchIntegrationCredentials read is the fallback
+	// for test wiring that doesn't supply a resolver — those callers
+	// accept that the env var may be stale.
+	//
+	// Hard refresh failures (revoked refresh token, missing OAuth client
+	// config) deliberately leave LINEAR_ACCESS_TOKEN unset rather than
+	// injecting a known-bad token: a missing env var causes the agent's
+	// 143-tools to report "linear not configured", which is more honest
+	// than a 401 from inside the agent's tool call.
+	switch {
+	case e.linearTokens != nil:
+		token, err := e.linearTokens.GetValidAccessToken(ctx, orgID)
+		switch {
+		case err != nil:
+			e.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Msg("env: linear token resolution failed; sandbox will run without LINEAR_ACCESS_TOKEN until next reconnect")
+		case token != "":
+			merged["LINEAR_ACCESS_TOKEN"] = token
 		}
+	case ic.Linear != nil && ic.Linear.AccessToken != "":
+		merged["LINEAR_ACCESS_TOKEN"] = ic.Linear.AccessToken
 	}
 	if ic.Notion != nil {
 		if ic.Notion.AccessToken != "" {

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -414,6 +414,117 @@ func TestAgentEnvResolveExportsCredentialsAndIntegrations(t *testing.T) {
 	}
 }
 
+// fakeLinearTokens implements LinearTokenResolver for env tests. The
+// scripted return values let each test pin "refresh succeeds with new
+// token" / "no integration installed" / "refresh exploded" without
+// involving the real linear service.
+type fakeLinearTokens struct {
+	token string
+	err   error
+	calls int
+}
+
+func (f *fakeLinearTokens) GetValidAccessToken(_ context.Context, _ uuid.UUID) (string, error) {
+	f.calls++
+	return f.token, f.err
+}
+
+func TestAgentEnvResolveLinearTokenInjection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	orgID := uuid.New()
+	userID := uuid.New()
+
+	t.Run("resolver returns rotated token; raw cached token is ignored", func(t *testing.T) {
+		t.Parallel()
+		// Cache holds an old token; resolver returns the rotated one. The
+		// resolver path must win — that's the entire point of plumbing
+		// refresh-aware token resolution into env injection.
+		env := NewAgentEnv(AgentEnvDeps{
+			Credentials: &envCredentialProvider{
+				creds: map[models.ProviderName]*models.DecryptedCredential{
+					models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant"}},
+					models.ProviderLinear:    {Config: models.LinearConfig{AccessToken: "stale-cached-token"}},
+				},
+			},
+			UserCredentials: &envUserCredentialProvider{},
+			Provider:        &envSandboxProvider{},
+			Logger:          zerolog.Nop(),
+		})
+		resolver := &fakeLinearTokens{token: "rotated-token"}
+		env.SetLinearTokens(resolver)
+
+		got := env.Resolve(ctx, orgID, models.AgentTypeClaudeCode, &userID)
+		require.Equal(t, "rotated-token", got["LINEAR_ACCESS_TOKEN"], "rotated token from resolver must override the cached row")
+		require.Equal(t, 1, resolver.calls, "resolver must be consulted")
+	})
+
+	t.Run("resolver returns empty for missing integration; env var is not set", func(t *testing.T) {
+		t.Parallel()
+		env := NewAgentEnv(AgentEnvDeps{
+			Credentials: &envCredentialProvider{
+				creds: map[models.ProviderName]*models.DecryptedCredential{
+					models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant"}},
+				},
+			},
+			UserCredentials: &envUserCredentialProvider{},
+			Provider:        &envSandboxProvider{},
+			Logger:          zerolog.Nop(),
+		})
+		env.SetLinearTokens(&fakeLinearTokens{token: "", err: nil})
+
+		got := env.Resolve(ctx, orgID, models.AgentTypeClaudeCode, &userID)
+		_, present := got["LINEAR_ACCESS_TOKEN"]
+		require.False(t, present, "no integration → no LINEAR_ACCESS_TOKEN env var")
+	})
+
+	t.Run("resolver hard failure leaves LINEAR_ACCESS_TOKEN unset rather than injecting a known-bad cached token", func(t *testing.T) {
+		t.Parallel()
+		// Even with a cached token in the credential store, a refresh hard
+		// failure (revoked refresh token) must NOT inject the cached token —
+		// the agent would just 401 in the sandbox. Better to omit the env
+		// var so 143-tools reports "linear not configured" cleanly.
+		env := NewAgentEnv(AgentEnvDeps{
+			Credentials: &envCredentialProvider{
+				creds: map[models.ProviderName]*models.DecryptedCredential{
+					models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant"}},
+					models.ProviderLinear:    {Config: models.LinearConfig{AccessToken: "doomed-cached-token"}},
+				},
+			},
+			UserCredentials: &envUserCredentialProvider{},
+			Provider:        &envSandboxProvider{},
+			Logger:          zerolog.Nop(),
+		})
+		env.SetLinearTokens(&fakeLinearTokens{err: errors.New("refresh token revoked")})
+
+		got := env.Resolve(ctx, orgID, models.AgentTypeClaudeCode, &userID)
+		_, present := got["LINEAR_ACCESS_TOKEN"]
+		require.False(t, present, "resolver error must NOT fall through to the stale cached token")
+	})
+
+	t.Run("no resolver wired; falls back to raw cached token", func(t *testing.T) {
+		t.Parallel()
+		// Backward-compat path: tests / wiring that never called
+		// SetLinearTokens must keep the legacy behavior of injecting the
+		// raw stored access token. New production wiring always sets the
+		// resolver, so this branch is only exercised by older fixtures.
+		env := NewAgentEnv(AgentEnvDeps{
+			Credentials: &envCredentialProvider{
+				creds: map[models.ProviderName]*models.DecryptedCredential{
+					models.ProviderAnthropic: {Config: models.AnthropicConfig{APIKey: "sk-ant"}},
+					models.ProviderLinear:    {Config: models.LinearConfig{AccessToken: "legacy-token"}},
+				},
+			},
+			UserCredentials: &envUserCredentialProvider{},
+			Provider:        &envSandboxProvider{},
+			Logger:          zerolog.Nop(),
+		})
+
+		got := env.Resolve(ctx, orgID, models.AgentTypeClaudeCode, &userID)
+		require.Equal(t, "legacy-token", got["LINEAR_ACCESS_TOKEN"])
+	})
+}
+
 func TestAgentEnvResolveAppliesCachedAgentConfigOverrides(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/linear/build.go
+++ b/internal/services/linear/build.go
@@ -21,14 +21,26 @@ type BuildDeps struct {
 	Integrations       IntegrationReader
 	IntegrationsWriter IntegrationWriter
 	Credentials        CredentialReader
-	Issues             *db.IssueStore
-	Sessions           *db.SessionStore
-	IssueLinks         *db.SessionIssueLinkStore
-	Orgs               *db.OrganizationStore
-	Jobs               *db.JobStore
-	JobQueueName       string
-	JobPriority        int
-	ClientFactory      ClientFactory
+	// CredentialsWriter persists rotated OAuth tokens after a successful
+	// refresh. Required for the refresh-on-expiry flow to be durable;
+	// without it, refreshed tokens would be lost when the process restarts
+	// and the integration would silently churn refresh tokens at Linear.
+	CredentialsWriter CredentialWriter
+	Issues            *db.IssueStore
+	Sessions          *db.SessionStore
+	IssueLinks        *db.SessionIssueLinkStore
+	Orgs              *db.OrganizationStore
+	Jobs              *db.JobStore
+	JobQueueName      string
+	JobPriority       int
+	ClientFactory     ClientFactory
+	// OAuthClient holds LINEAR_OAUTH_CLIENT_ID and LINEAR_OAUTH_CLIENT_SECRET.
+	// Required for refresh-token redemption: Linear treats /oauth/token as a
+	// confidential-client endpoint and rejects refreshes without these.
+	// Without OAuthClient set, GetValidToken on an expiring credential
+	// surfaces ErrOAuthClientNotConfigured, which the operator must fix by
+	// populating the env vars rather than the user reconnecting.
+	OAuthClient OAuthClientCreds
 	// AppBaseURL is the absolute origin (e.g. cfg.FrontendURL) we send to
 	// Linear inside attachment URLs and comment bodies. Empty falls back to
 	// a relative path which Linear renders as plain text — production
@@ -119,11 +131,22 @@ func Build(deps BuildDeps) *Service {
 		return models.ParseOrgSettings(org.Settings)
 	}
 
+	if deps.OAuthClient.ClientID == "" || deps.OAuthClient.ClientSecret == "" {
+		// Logged at warn (not fatal) so MODE=worker / MODE=api dev rigs that
+		// don't have Linear OAuth provisioned can still boot. Refresh on
+		// expiring tokens will fail with ErrOAuthClientNotConfigured, which
+		// is preferable to crashing the process.
+		deps.Logger.Warn().
+			Msg("linear.Build: OAuthClient is incomplete; refresh-token rotation will fail until LINEAR_OAUTH_CLIENT_ID / LINEAR_OAUTH_CLIENT_SECRET are configured")
+	}
+
 	svc := NewService(Config{
 		Logger:             deps.Logger,
 		Integrations:       deps.Integrations,
 		IntegrationsWriter: deps.IntegrationsWriter,
 		Credentials:        deps.Credentials,
+		CredentialsWriter:  deps.CredentialsWriter,
+		OAuthClient:        deps.OAuthClient,
 		Issues:             deps.Issues,
 		Links:              deps.IssueLinks,
 		TeamKeys:           db.NewLinearTeamKeyStore(deps.Pool),

--- a/internal/services/linear/refresh.go
+++ b/internal/services/linear/refresh.go
@@ -198,6 +198,15 @@ type CredentialWriter interface {
 	Upsert(ctx context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error
 }
 
+// CredentialCASWriter is the production-safe refresh persistence surface.
+// It updates the Linear credential only if the stored refresh token still
+// matches the token we just redeemed. A mismatch means a user reconnect or
+// another process has already written a newer token chain, and the refresh
+// path must use that current row rather than overwriting it.
+type CredentialCASWriter interface {
+	UpdateLinearConfigIfRefreshTokenMatches(ctx context.Context, orgID uuid.UUID, expectedRefreshToken string, cfg models.LinearConfig) (models.LinearConfig, bool, error)
+}
+
 // OAuthClientCreds holds the client credentials Linear requires to redeem a
 // refresh token at /oauth/token. They are the same values used by the
 // authorization-code exchange in the API handlers (LINEAR_OAUTH_CLIENT_ID /
@@ -281,6 +290,9 @@ func (s *Service) loadLinearCredential(ctx context.Context, orgID uuid.UUID) (mo
 			return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", ErrIntegrationNotFound)
 		}
 		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", err)
+	}
+	if integration.Status != models.IntegrationStatusActive && integration.Status != models.IntegrationStatusError {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", ErrIntegrationNotFound)
 	}
 	if s.credentials == nil {
 		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear credential: credentials store not wired")
@@ -511,7 +523,16 @@ func (s *Service) refreshLinearToken(ctx context.Context, orgID uuid.UUID, obser
 		s.observeRefreshOutcome(refreshOutcomeRefreshed)
 		return merged, nil
 	}
-	if err := s.credentialsWriter.Upsert(ctx, orgID, merged); err != nil {
+	casWriter, ok := s.credentialsWriter.(CredentialCASWriter)
+	if !ok {
+		s.logger.Error().
+			Str("org_id", orgID.String()).
+			Msg("linear: credentialsWriter does not support compare-and-swap refresh persistence")
+		s.observeRefreshOutcome(refreshOutcomeTransientFailure)
+		return latest, fmt.Errorf("persist refreshed linear credential: credentials writer does not support compare-and-swap")
+	}
+	current, updated, err := casWriter.UpdateLinearConfigIfRefreshTokenMatches(ctx, orgID, latest.RefreshToken, merged)
+	if err != nil {
 		// The refresh succeeded at Linear (the old refresh token has been
 		// consumed and a new pair issued), but we couldn't persist. The
 		// new refresh token is now lost — the next call will try to use
@@ -525,6 +546,17 @@ func (s *Service) refreshLinearToken(ctx context.Context, orgID uuid.UUID, obser
 			Msg("linear: refresh succeeded at Linear but persisting the rotated tokens failed; the row's refresh token is now stale and will hit invalid_grant on next call")
 		s.observeRefreshOutcome(refreshOutcomeTransientFailure)
 		return latest, fmt.Errorf("persist refreshed linear credential: %w", err)
+	}
+	if !updated {
+		if current.AccessToken != "" && !current.IsExpired() {
+			s.logger.Info().
+				Str("org_id", orgID.String()).
+				Msg("linear: refresh raced with a newer credential write; using current token without overwriting it")
+			s.observeRefreshOutcome(refreshOutcomeRotatedByPeer)
+			return current, nil
+		}
+		s.observeRefreshOutcome(refreshOutcomeTransientFailure)
+		return latest, fmt.Errorf("persist refreshed linear credential: stored refresh token changed before write")
 	}
 
 	// A successful refresh implies the integration is healthy again. Clear

--- a/internal/services/linear/refresh.go
+++ b/internal/services/linear/refresh.go
@@ -90,6 +90,11 @@ type refreshMetrics struct {
 // is package-level (not per-Service) because OTel instruments are
 // per-process; per-Service init would re-register on every test that
 // constructs a fresh Service.
+//
+// Test note: the cached counter binds to whatever MeterProvider was
+// installed on first use. Tests that swap MeterProviders mid-run will
+// keep recording into the original meter — acceptable because metrics
+// are best-effort observability and not asserted on by tests.
 var (
 	metricsOnce sync.Once
 	metrics     *refreshMetrics
@@ -433,6 +438,15 @@ func (s *Service) refreshLinearToken(ctx context.Context, orgID uuid.UUID, obser
 		s.observeRefreshOutcome(refreshOutcomeRotatedByPeer)
 		return latest, nil
 	}
+	// Even on the force-refresh path (skipFreshCheck), if the re-read shows
+	// a different access token than the caller observed, a peer already
+	// rotated under the lock. POSTing our (now-stale) refresh token would
+	// just consume Linear's freshly-issued refresh token and yield a third
+	// rotation. Use the peer's token instead.
+	if skipFreshCheck && latest.AccessToken != "" && latest.AccessToken != observed.AccessToken && !latest.IsExpired() {
+		s.observeRefreshOutcome(refreshOutcomeRotatedByPeer)
+		return latest, nil
+	}
 	if latest.RefreshToken == "" {
 		// Another goroutine zeroed the refresh token (likely after detecting
 		// revocation). Nothing useful we can do here.
@@ -762,11 +776,10 @@ func (s *Service) ForceRefreshToken(ctx context.Context, orgID uuid.UUID) (strin
 // expiring token serialize through one refresh rather than fanning out
 // N refresh requests at Linear.
 func (s *Service) withRefreshableClient(ctx context.Context, orgID uuid.UUID, fn func(Client) error) error {
-	integration, token, err := s.GetValidToken(ctx, orgID)
+	_, token, err := s.GetValidToken(ctx, orgID)
 	if err != nil {
 		return err
 	}
-	_ = integration
 
 	client, err := s.clientFactory(ctx, token)
 	if err != nil {
@@ -824,15 +837,20 @@ func (s *Service) markRefreshTokenRevoked(ctx context.Context, orgID uuid.UUID, 
 		zeroed := current
 		zeroed.RefreshToken = ""
 		if zeroed.ExpiresAt.IsZero() {
+			// A revoked row with zero ExpiresAt would be misclassified as
+			// a legacy "use until 401" credential by NeedsRefresh, masking
+			// the revocation. Stamp a past expiry so the typed-revocation
+			// signal — RefreshToken="" + ExpiresAt!=0 — survives the next
+			// GetValidToken call and routes through ErrNoRefreshToken.
+			// The integration row's status (set by MarkIntegrationUnauthorized
+			// below) is what the UI surfaces; ExpiresAt here is purely
+			// internal classification.
 			zeroed.ExpiresAt = time.Now().Add(-time.Second)
 		}
-		// We intentionally leave AccessToken in place so worker handlers
-		// that hold an in-memory client built from this config can still
-		// surface the more-specific 401 path themselves rather than
-		// failing earlier with "empty access token". We also preserve a
-		// known expiry (or stamp one in the past for unusual zero-expiry
-		// rows) so subsequent GetValidToken calls do not mistake the
-		// revoked row for a legacy use-until-401 credential.
+		// AccessToken is left in place so worker handlers that hold an
+		// in-memory client built from this config still surface the
+		// more-specific 401 path rather than failing earlier with
+		// "empty access token".
 		if err := s.credentialsWriter.Upsert(ctx, orgID, zeroed); err != nil {
 			s.logger.Warn().Err(err).
 				Str("org_id", orgID.String()).

--- a/internal/services/linear/refresh.go
+++ b/internal/services/linear/refresh.go
@@ -1,0 +1,840 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	otelmetric "go.opentelemetry.io/otel/metric"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// refreshOutcome labels the result attribute on the refresh metric. Kept
+// as a typed string so a typo in a call site fails the type checker
+// instead of producing a silently-different label string in production.
+type refreshOutcome string
+
+const (
+	// refreshOutcomeFresh: cached token returned without an /oauth/token
+	// round trip. The hot path; should dominate by orders of magnitude.
+	refreshOutcomeFresh refreshOutcome = "fresh"
+	// refreshOutcomeRefreshed: proactive refresh succeeded and the new
+	// access/refresh pair was persisted.
+	refreshOutcomeRefreshed refreshOutcome = "refreshed"
+	// refreshOutcomeRotatedByPeer: another node won the refresh race;
+	// we re-read the row and used their rotated token instead of
+	// declaring revocation. A spike here indicates >1 process/pod is
+	// hammering the same org's credential — usually the worker + API
+	// for the same MODE=all deploy.
+	refreshOutcomeRotatedByPeer refreshOutcome = "rotated_by_peer"
+	// refreshOutcomeRevoked: Linear returned invalid_grant; refresh
+	// token is dead, integration flipped to errored, user must
+	// reconnect. Should be rare in steady state.
+	refreshOutcomeRevoked refreshOutcome = "revoked"
+	// refreshOutcomeOAuthMisconfigured: invalid_client from /oauth/token
+	// (rotated CLIENT_SECRET, typo, etc.). Operator action required —
+	// graphs spiking here mean a deploy broke things and EVERY org's
+	// next refresh will fail until env vars are corrected.
+	refreshOutcomeOAuthMisconfigured refreshOutcome = "oauth_misconfigured"
+	// refreshOutcomeNoRefreshToken: legacy install hit the refresh
+	// window. Expected in low volume during the refresh-token rollout;
+	// should taper to zero once all orgs have reconnected.
+	refreshOutcomeNoRefreshToken refreshOutcome = "no_refresh_token"
+	// refreshOutcomeCachedFallback: refresh failed transiently (network
+	// blip, Linear 5xx) but the cached token is still inside its
+	// validity window so we returned it. Sustained presence indicates
+	// Linear-side incident or our own connectivity issue.
+	refreshOutcomeCachedFallback refreshOutcome = "cached_fallback"
+	// refreshOutcomeTransientFailure: refresh failed and the cached
+	// token is also expired, so the call returned an error to the
+	// caller. The most user-impacting bucket — every count here is a
+	// session that ran without a Linear token.
+	refreshOutcomeTransientFailure refreshOutcome = "transient_failure"
+	// refreshOutcomeForceRefresh: post-401 force refresh from
+	// withRefreshableClient, regardless of whether it succeeded (the
+	// retry's success/failure shows up in the GraphQL-side metrics,
+	// not here). Counts retries themselves so we can spot a Linear
+	// outage that forces every read to take the slow path.
+	refreshOutcomeForceRefresh refreshOutcome = "force_refresh"
+)
+
+// linearMeterName is the OTel meter scope for refresh-token metrics.
+// Matches the scoping convention from internal/metrics/billing.go's
+// meterName constant.
+const linearMeterName = "github.com/assembledhq/143/linear"
+
+// refreshMetrics groups the OTel instruments produced by ensureRefreshMetrics.
+// Stored on the package-level metricsHolder so every Service in the process
+// shares one set of registered instruments — registering twice produces
+// duplicate counters with the same name, which OTel SDKs handle by emitting
+// noisy warnings.
+type refreshMetrics struct {
+	totalCounter otelmetric.Int64Counter
+}
+
+// metricsHolder lazily wires the refresh OTel instruments on first use,
+// using sync.Once so concurrent Services don't double-register. The Once
+// is package-level (not per-Service) because OTel instruments are
+// per-process; per-Service init would re-register on every test that
+// constructs a fresh Service.
+var (
+	metricsOnce sync.Once
+	metrics     *refreshMetrics
+	metricsErr  error
+)
+
+// ensureRefreshMetrics returns the cached refreshMetrics instruments,
+// registering them on first call. A registration failure is recorded once
+// and observeRefreshOutcome becomes a no-op for the rest of the process —
+// metrics are best-effort observability, never load-bearing for
+// correctness.
+func ensureRefreshMetrics() (*refreshMetrics, error) {
+	metricsOnce.Do(func() {
+		meter := otel.Meter(linearMeterName)
+		counter, err := meter.Int64Counter(
+			"linear.refresh_token.total",
+			otelmetric.WithDescription("Linear OAuth refresh-token rotation outcomes, labeled by result"),
+			otelmetric.WithUnit("{event}"),
+		)
+		if err != nil {
+			metricsErr = err
+			return
+		}
+		metrics = &refreshMetrics{totalCounter: counter}
+	})
+	return metrics, metricsErr
+}
+
+// observeRefreshOutcome bumps the linear.refresh_token.total counter with
+// the outcome label. Best-effort: metric registration failures (rare;
+// typically only happens with a misconfigured MeterProvider) silently
+// drop the observation rather than perturbing the refresh path's error
+// contract.
+//
+// org_id is intentionally NOT a label dimension. Adding it would cause
+// counter cardinality to grow with the org count, which OTel handles
+// poorly above ~10K labels per metric. Per-org refresh history is
+// available via structured logs (the Info log on successful refresh
+// includes org_id) and the integrations table's status column.
+func (s *Service) observeRefreshOutcome(outcome refreshOutcome) {
+	m, err := ensureRefreshMetrics()
+	if err != nil || m == nil {
+		return
+	}
+	m.totalCounter.Add(context.Background(), 1, otelmetric.WithAttributes(
+		attribute.String("outcome", string(outcome)),
+	))
+}
+
+// linearTokenURL is the OAuth token endpoint used for both the initial
+// authorization-code exchange (handlers/integrations.go) and the
+// refresh-token rotation done here. Kept in a single place so a future
+// region/staging override can be threaded through both sites.
+const linearTokenURL = "https://api.linear.app/oauth/token" // #nosec G101 -- OAuth endpoint URL, not credentials
+
+// refreshGrantType is the OAuth 2.0 grant type for token refresh.
+const refreshGrantType = "refresh_token"
+
+// refreshWindow is how far before a token's stated expiry we proactively
+// refresh. Five minutes is comfortably longer than any plausible round-trip
+// + clock-skew envelope between this process, Linear, and the credential
+// store, while still leaving a wide margin for the agent sandbox to consume
+// the token before it expires mid-call.
+const refreshWindow = 5 * time.Minute
+
+// refreshHTTPTimeout caps a single refresh round-trip. Linear's /oauth/token
+// is normally sub-second; the cap exists so a wedged endpoint can't hold the
+// per-org refresh mutex forever and stall every concurrent caller.
+const refreshHTTPTimeout = 10 * time.Second
+
+// refreshErrorBodyLimit caps how much of the refresh-endpoint response body
+// we read on error. Linear errors are tiny JSON shapes; reading a bounded
+// prefix prevents a hostile or pathological response from consuming memory
+// while still surfacing the operator-actionable head of the error message.
+const refreshErrorBodyLimit = 8192
+
+// ErrNoRefreshToken is returned when GetValidToken needs to refresh an
+// expired access token but the credential row has no refresh token. This
+// happens for legacy installs created before refresh-token fields were
+// stored. Callers receiving this error should surface a "reconnect Linear"
+// banner — refresh is not recoverable without user interaction.
+var ErrNoRefreshToken = errors.New("linear credential has no refresh token; reconnect required")
+
+// ErrRefreshTokenRevoked is returned when Linear rejects our refresh token
+// (typically a 400 invalid_grant or a 401). The caller has already zeroed
+// the refresh token from storage and flipped the integration to errored;
+// callers should surface "reconnect Linear" to the user. Not retryable.
+var ErrRefreshTokenRevoked = errors.New("linear refresh token revoked; reconnect required")
+
+// ErrOAuthClientNotConfigured is returned when GetValidToken needs to refresh
+// but the linear service was constructed without the OAuth client_id /
+// client_secret. This is a misconfiguration, not a user-recoverable state —
+// the operator must populate LINEAR_OAUTH_CLIENT_ID / LINEAR_OAUTH_CLIENT_SECRET.
+var ErrOAuthClientNotConfigured = errors.New("linear oauth client not configured; cannot refresh token")
+
+// CredentialWriter is the narrow surface the refresh path needs to persist
+// rotated tokens. Implemented by *db.OrgCredentialStore in production. Held
+// as a separate interface from CredentialReader so test harnesses that only
+// need read access can omit the writer.
+type CredentialWriter interface {
+	Upsert(ctx context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error
+}
+
+// OAuthClientCreds holds the client credentials Linear requires to redeem a
+// refresh token at /oauth/token. They are the same values used by the
+// authorization-code exchange in the API handlers (LINEAR_OAUTH_CLIENT_ID /
+// LINEAR_OAUTH_CLIENT_SECRET).
+type OAuthClientCreds struct {
+	ClientID     string
+	ClientSecret string
+}
+
+// linearTokenRefreshResponse parses Linear's /oauth/token response shape for
+// both authorization-code and refresh-token grants. The response is JSON; the
+// API handlers' linearTokenResponse mirrors this shape and the two should
+// stay aligned (any new field that affects long-lived state — e.g. an
+// id_token-style claim — must be persisted in both flows or the refresh path
+// will silently strip it).
+type linearTokenRefreshResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	TokenType    string `json:"token_type"`
+	Scope        string `json:"scope"`
+	ExpiresIn    int    `json:"expires_in"`
+}
+
+// orgRefreshMu returns a per-org mutex used to serialize concurrent refresh
+// attempts within this process. Linear is org-singleton (one credential row
+// per org), so per-org granularity is the correct lock unit.
+//
+// Race-safety: refreshMuRegistry is an atomic.Pointer. NewService stores
+// a fresh sync.Map up front; direct &Service{} construction (tests) leaves
+// the pointer nil, in which case we CAS in a registry. CAS losers throw
+// away their fresh map and use the winner's — so all goroutines end up
+// using the same sync.Map and there is no torn-write window.
+//
+// Cross-process coordination: per-process locks cannot prevent two nodes
+// from racing to refresh the same credential. Linear rotates the refresh
+// token on every redemption, so the slower node will see invalid_grant on
+// its POST. refreshLinearToken handles this race by re-reading the
+// credential after a refresh failure and falling back to the
+// just-persisted token if a peer node won the race.
+func (s *Service) orgRefreshMu(orgID uuid.UUID) *sync.Mutex {
+	reg := s.refreshMuRegistry.Load()
+	if reg == nil {
+		fresh := &sync.Map{}
+		// CompareAndSwap from nil: if another goroutine raced us, theirs
+		// wins and we discard `fresh`. Either way, a subsequent Load is
+		// guaranteed non-nil.
+		s.refreshMuRegistry.CompareAndSwap(nil, fresh)
+		reg = s.refreshMuRegistry.Load()
+	}
+	val, _ := reg.LoadOrStore(orgID.String(), &sync.Mutex{})
+	return val.(*sync.Mutex)
+}
+
+// loadLinearCredential reads the org's Linear integration row and parses the
+// stored credential into a typed LinearConfig. Returns ErrIntegrationNotFound
+// (wrapped) when the org has no Linear integration row at all. Callers that
+// only need the access token should prefer integrationFor / GetValidToken;
+// this is the shared inner helper that returns the full typed config so the
+// refresh path can read RefreshToken and ExpiresAt.
+//
+// Nil-safe two-layer guard, mirroring the auth_status.go pattern: nil
+// receiver and nil integrations reader return ErrIntegrationNotFound
+// rather than panicking so api-only / MODE=worker wiring paths that
+// didn't hook up the integrations store degrade to "no integration
+// installed" instead of crashing on first use.
+//
+// A nil credentials reader is NOT treated as ErrIntegrationNotFound —
+// it would mask a misconfigured wiring path (integrations exists but
+// credentials store is missing) as "user has no Linear" and silently
+// drop the connection. We let the credentials.Get call proceed and
+// the resulting nil-pointer surfaces as a real wiring bug instead.
+// Tests that supply integrations but not credentials are exercising
+// the integration-lookup path and stop before reaching credentials.
+func (s *Service) loadLinearCredential(ctx context.Context, orgID uuid.UUID) (models.Integration, models.LinearConfig, error) {
+	if s == nil || s.integrations == nil {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", ErrIntegrationNotFound)
+	}
+	integration, err := s.integrations.GetByOrgAndProvider(ctx, orgID, "linear")
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", ErrIntegrationNotFound)
+		}
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear integration: %w", err)
+	}
+	if s.credentials == nil {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear credential: credentials store not wired")
+	}
+	cred, err := s.credentials.Get(ctx, orgID, models.ProviderLinear)
+	if err != nil {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("lookup linear credential: %w", err)
+	}
+	if cred == nil {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("linear credential not found")
+	}
+	cfg, ok := cred.Config.(models.LinearConfig)
+	if !ok {
+		return models.Integration{}, models.LinearConfig{}, fmt.Errorf("linear credential config is wrong type: got %T", cred.Config)
+	}
+	return integration, cfg, nil
+}
+
+// GetValidAccessToken is the sandbox-injection convenience wrapper around
+// GetValidToken. It returns ONLY the access token (the integration row is
+// dropped) and suppresses the "no Linear integration installed" case to
+// ("", nil) so callers can check `token == ""` without importing
+// linear-specific sentinels.
+//
+// All other errors (transport failure, refresh-token revoked, OAuth client
+// misconfigured) propagate as-is — callers who want to distinguish them
+// can errors.Is against the package-level sentinels. Callers that need
+// the integration row alongside the token should use the full
+// GetValidToken instead.
+func (s *Service) GetValidAccessToken(ctx context.Context, orgID uuid.UUID) (string, error) {
+	_, token, err := s.GetValidToken(ctx, orgID)
+	if errors.Is(err, ErrIntegrationNotFound) {
+		return "", nil
+	}
+	return token, err
+}
+
+// GetValidToken returns the integration row plus a Linear access token that
+// is valid right now: if the cached token's expiry is within the refresh
+// window and a refresh token is available, it transparently rotates the
+// token at Linear and persists the new access/refresh pair before returning.
+//
+// Behavior contract:
+//
+//   - Legacy installs (no refresh token, zero ExpiresAt): returns the cached
+//     token unchanged. Refresh is impossible without a refresh token; user must
+//     reconnect when the token finally hits a hard 401.
+//   - Healthy installs with valid token: returns cached token (no API call).
+//   - Healthy installs near expiry: refreshes, persists, returns new token.
+//   - Refresh-time network/transient errors: falls back to the cached token
+//     IFF it is not yet expired. Otherwise returns the error.
+//   - Refresh token revoked: zeroes the refresh token, marks the integration
+//     errored (so the UI shows "reconnect"), and returns ErrRefreshTokenRevoked.
+//
+// Error contract: on any non-nil error, the returned integration row is
+// the zero value. Callers ignoring the error and reading integration.ID
+// will see uuid.Nil rather than a half-populated row that lies about
+// which integration the credential belonged to.
+//
+// Concurrency: per-org mutex serializes intra-process refreshes. Multi-node
+// races are detected and recovered (see refreshLinearToken).
+func (s *Service) GetValidToken(ctx context.Context, orgID uuid.UUID) (models.Integration, string, error) {
+	integration, cfg, err := s.loadLinearCredential(ctx, orgID)
+	if err != nil {
+		return models.Integration{}, "", err
+	}
+	if !cfg.NeedsRefresh(refreshWindow) {
+		// Either still well within validity, or a legacy install with no
+		// refresh capability. Either way, the cached token is what callers
+		// should use.
+		if cfg.AccessToken == "" {
+			return models.Integration{}, "", fmt.Errorf("linear credential has empty access token")
+		}
+		s.observeRefreshOutcome(refreshOutcomeFresh)
+		return integration, cfg.AccessToken, nil
+	}
+
+	refreshed, err := s.refreshLinearToken(ctx, orgID, cfg, false /* skipFreshCheck */)
+	if err != nil {
+		// Graceful degradation: a transient refresh failure (network blip,
+		// Linear 5xx) shouldn't take down the calling code path if the
+		// cached token is still inside its validity window. The next call
+		// will re-attempt refresh; meanwhile callers get a token that may
+		// be slightly closer to expiry but still works.
+		//
+		// Hard failures (revoked token, no refresh token, missing OAuth
+		// client) are NOT papered over — falling back to the cached token
+		// would just queue up a 401 on the next call, and the user needs
+		// to reconnect (or the operator needs to fix env vars).
+		hardFailure := errors.Is(err, ErrRefreshTokenRevoked) ||
+			errors.Is(err, ErrNoRefreshToken) ||
+			errors.Is(err, ErrOAuthClientNotConfigured)
+		if !hardFailure && !cfg.IsExpired() && cfg.AccessToken != "" {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Time("expires_at", cfg.ExpiresAt).
+				Msg("linear: token refresh failed; falling back to cached token still inside validity window")
+			s.observeRefreshOutcome(refreshOutcomeCachedFallback)
+			return integration, cfg.AccessToken, nil
+		}
+		return models.Integration{}, "", err
+	}
+	return integration, refreshed.AccessToken, nil
+}
+
+// refreshLinearToken performs the actual /oauth/token POST under the per-org
+// mutex. Re-reads the credential after acquiring the lock so two goroutines
+// that both observed NeedsRefresh do not both consume the refresh token
+// (Linear rotates refresh tokens; double-redemption fails the slower one).
+//
+// When skipFreshCheck is false (the proactive refresh path), a re-read
+// inside the lock that finds an already-fresh token short-circuits without
+// burning a refresh-token redemption — this is the deduplication that
+// makes per-org locking actually save round trips.
+//
+// When skipFreshCheck is true (the post-401 ForceRefreshToken path), the
+// fresh-check is bypassed: the caller just observed a 401, so whatever the
+// row claims about expiry is wrong and a redundant POST is required.
+//
+// On a 4xx response that signals a revoked refresh token, this method:
+//  1. Zeroes the RefreshToken field in the persisted credential so subsequent
+//     calls fall through to the "no refresh token" branch instead of looping.
+//  2. Calls MarkIntegrationUnauthorized so the UI shows the reconnect banner.
+//  3. Returns ErrRefreshTokenRevoked.
+//
+// The pre-zero re-read is a deliberate cross-node race recovery: if a peer
+// process refreshed between our NeedsRefresh check and our 4xx response,
+// its rotated token is now in the row and we should use it instead of
+// concluding "revoked".
+func (s *Service) refreshLinearToken(ctx context.Context, orgID uuid.UUID, observed models.LinearConfig, skipFreshCheck bool) (models.LinearConfig, error) {
+	if observed.RefreshToken == "" {
+		s.observeRefreshOutcome(refreshOutcomeNoRefreshToken)
+		return observed, ErrNoRefreshToken
+	}
+	if s.oauthClient.ClientID == "" || s.oauthClient.ClientSecret == "" {
+		s.observeRefreshOutcome(refreshOutcomeOAuthMisconfigured)
+		return observed, ErrOAuthClientNotConfigured
+	}
+
+	mu := s.orgRefreshMu(orgID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Re-read after acquiring the lock. A concurrent goroutine on this
+	// process (or another node) may have already rotated the token. If so,
+	// avoid burning a refresh-token redemption on a redundant call.
+	_, latest, err := s.loadLinearCredential(ctx, orgID)
+	if err != nil {
+		return observed, err
+	}
+	if !skipFreshCheck && !latest.NeedsRefresh(refreshWindow) && latest.AccessToken != "" {
+		// Another goroutine in this process refreshed under the lock;
+		// not strictly a peer-node race (we never POSTed) but the
+		// outcome is the same: we're using a token a peer rotated.
+		s.observeRefreshOutcome(refreshOutcomeRotatedByPeer)
+		return latest, nil
+	}
+	if latest.RefreshToken == "" {
+		// Another goroutine zeroed the refresh token (likely after detecting
+		// revocation). Nothing useful we can do here.
+		s.observeRefreshOutcome(refreshOutcomeNoRefreshToken)
+		return latest, ErrNoRefreshToken
+	}
+
+	refreshed, postErr := s.postLinearRefresh(ctx, latest.RefreshToken)
+	if postErr != nil {
+		// invalid_client → operator misconfiguration. Bubble up as
+		// ErrOAuthClientNotConfigured so callers get a single, clearer
+		// failure mode regardless of whether the misconfiguration was
+		// "client_secret env var unset" (caught by the up-front guard)
+		// or "client_secret rotated upstream and our deploy is stale"
+		// (caught here, only after a real /oauth/token exchange). The
+		// row is left alone — the next refresh after a config fix will
+		// just succeed.
+		if errors.Is(postErr, errLinearRefreshClientMisconfigured) {
+			s.logger.Error().
+				Err(postErr).
+				Str("org_id", orgID.String()).
+				Msg("linear: /oauth/token rejected our client credentials; check LINEAR_OAUTH_CLIENT_ID / LINEAR_OAUTH_CLIENT_SECRET")
+			s.observeRefreshOutcome(refreshOutcomeOAuthMisconfigured)
+			return latest, ErrOAuthClientNotConfigured
+		}
+		// Cross-node race recovery: if Linear rejected the *user's*
+		// refresh token specifically (invalid_grant), re-check the row
+		// in case a peer node already rotated it. A 4xx here is
+		// suspicious but not authoritative — only after re-read confirms
+		// no fresh token landed do we conclude the user must reconnect.
+		if errors.Is(postErr, errLinearRefreshRejected) {
+			if _, raceLatest, rerr := s.loadLinearCredential(ctx, orgID); rerr == nil {
+				if raceLatest.AccessToken != "" && !raceLatest.IsExpired() && raceLatest.AccessToken != latest.AccessToken {
+					s.logger.Info().
+						Str("org_id", orgID.String()).
+						Msg("linear: refresh raced with another node; using newly-persisted token")
+					s.observeRefreshOutcome(refreshOutcomeRotatedByPeer)
+					return raceLatest, nil
+				}
+			}
+			// Confirmed revocation. Persist a config with the refresh token
+			// zeroed so future GetValidToken calls don't loop on a doomed
+			// refresh, and flip the integration to errored.
+			s.markRefreshTokenRevoked(ctx, orgID, latest)
+			s.observeRefreshOutcome(refreshOutcomeRevoked)
+			return latest, ErrRefreshTokenRevoked
+		}
+		s.observeRefreshOutcome(refreshOutcomeTransientFailure)
+		return latest, postErr
+	}
+
+	merged := mergeRefreshedConfig(latest, refreshed, s.logger, orgID)
+	if s.credentialsWriter == nil {
+		// No writer configured — expected in unit-test wiring that exercises
+		// the refresh-decision logic without persistence. Production is
+		// covered by a Build-time guarantee (BuildDeps.CredentialsWriter is
+		// always set), so this branch should never execute in a real deploy.
+		// Debug-level so test runs don't drown the log; if you ever see
+		// this in production logs, the metric tag is refreshOutcomeRefreshed
+		// (the refresh itself succeeded — just untracked).
+		s.logger.Debug().Str("org_id", orgID.String()).Msg("linear: refresh succeeded but credentialsWriter is nil; refreshed token will not be persisted (test-only path)")
+		s.observeRefreshOutcome(refreshOutcomeRefreshed)
+		return merged, nil
+	}
+	if err := s.credentialsWriter.Upsert(ctx, orgID, merged); err != nil {
+		// The refresh succeeded at Linear (the old refresh token has been
+		// consumed and a new pair issued), but we couldn't persist. The
+		// new refresh token is now lost — the next call will try to use
+		// the old (already-consumed) one and fail with invalid_grant,
+		// triggering revocation handling. Logged loudly so operators
+		// chasing a "we keep getting revoked despite working refreshes"
+		// support thread can land on this line.
+		s.logger.Error().
+			Err(err).
+			Str("org_id", orgID.String()).
+			Msg("linear: refresh succeeded at Linear but persisting the rotated tokens failed; the row's refresh token is now stale and will hit invalid_grant on next call")
+		s.observeRefreshOutcome(refreshOutcomeTransientFailure)
+		return latest, fmt.Errorf("persist refreshed linear credential: %w", err)
+	}
+
+	// A successful refresh implies the integration is healthy again. Clear
+	// any prior "Linear rejected the access token" banner left over from a
+	// pre-reconnect 401. Best-effort; failures here are logged inside the
+	// helper and never block the refresh.
+	s.ClearIntegrationUnauthorized(ctx, orgID)
+
+	// Per-refresh logging is intentionally Debug, not Info: at scale (one
+	// refresh per org per ~hour) Info would dominate worker log volume
+	// without telling operators anything they couldn't see in the metric.
+	// The metric counter (linear.refresh_token.total{outcome="refreshed"})
+	// is the primary observability surface for refresh health.
+	s.logger.Debug().
+		Str("org_id", orgID.String()).
+		Bool("refresh_token_rotated", refreshed.RefreshToken != "" && refreshed.RefreshToken != latest.RefreshToken).
+		Int("expires_in_seconds", refreshed.ExpiresIn).
+		Time("expires_at", merged.ExpiresAt).
+		Msg("linear: access token refreshed")
+
+	s.observeRefreshOutcome(refreshOutcomeRefreshed)
+	return merged, nil
+}
+
+// errLinearRefreshRejected is the sentinel returned by postLinearRefresh
+// when Linear's /oauth/token responds with a 4xx that names the *refresh
+// token itself* as the problem (i.e. invalid_grant). Lifted out of
+// refreshLinearToken so the caller can distinguish it from generic
+// transport errors and apply the cross-node-race recovery branch.
+//
+// Critically, this is NOT used for invalid_client — that signals a
+// misconfigured LINEAR_OAUTH_CLIENT_SECRET, and treating it as
+// "refresh token revoked" would zero every org's refresh token after a
+// rotated-secret deploy, producing self-inflicted mass revocation.
+var errLinearRefreshRejected = errors.New("linear refresh rejected by server")
+
+// errLinearRefreshClientMisconfigured is returned when Linear's /oauth/token
+// reports invalid_client. This means our LINEAR_OAUTH_CLIENT_ID /
+// LINEAR_OAUTH_CLIENT_SECRET are wrong (rotated upstream, typo in the
+// secrets file, etc.), not that the user's refresh token is bad. The
+// caller must NOT zero the row's refresh token; the operator fixes the
+// env var, the next refresh succeeds, and no user has to reconnect.
+var errLinearRefreshClientMisconfigured = errors.New("linear oauth client_id/client_secret rejected by server")
+
+// linearOAuthErrorBody is the standard OAuth 2.0 error response shape
+// (RFC 6749 §5.2). Linear conforms to this; we parse it to disambiguate
+// "your refresh token is revoked" (invalid_grant) from "your client
+// credentials are wrong" (invalid_client) and a few others. Unparseable
+// bodies fall through to a generic "rejected" classification — the safe
+// default that does NOT zero the refresh token.
+type linearOAuthErrorBody struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// classifyOAuthErrorBody parses an OAuth error response and returns the
+// sentinel that best describes the cause. Returns nil if the body is empty
+// or cannot be parsed (caller falls back to a non-revocation generic
+// error — the safe default).
+//
+// Per RFC 6749 §5.2 the relevant codes for refresh-token grants are:
+//
+//   - invalid_grant: refresh token expired/revoked/reused → revocation.
+//   - invalid_client: client auth failed → server-side misconfiguration.
+//   - invalid_request, unsupported_grant_type, invalid_scope: protocol
+//     errors that indicate a bug on our side, not a revoked token. We
+//     surface these as generic errors, not revocation.
+//   - unauthorized_client: client not allowed to use refresh_token grant.
+//     Same shape as invalid_client — the user's token isn't to blame.
+func classifyOAuthErrorBody(body []byte) error {
+	var parsed linearOAuthErrorBody
+	if len(body) == 0 || json.Unmarshal(body, &parsed) != nil || parsed.Error == "" {
+		return nil
+	}
+	switch parsed.Error {
+	case "invalid_grant":
+		return errLinearRefreshRejected
+	case "invalid_client", "unauthorized_client":
+		return errLinearRefreshClientMisconfigured
+	}
+	return nil
+}
+
+// postLinearRefresh issues the /oauth/token POST. Returns the parsed response
+// on success; errLinearRefreshRejected (wrapped) on a 4xx that signals a
+// revoked refresh token; or a generic error for transport / 5xx failures.
+//
+// Linear treats refresh requests as confidential-client OAuth, so client_id
+// and client_secret are sent in the request body alongside the refresh
+// token. Form encoding mirrors the authorization-code exchange in
+// handlers/integrations.go.
+func (s *Service) postLinearRefresh(ctx context.Context, refreshToken string) (linearTokenRefreshResponse, error) {
+	data := url.Values{
+		"grant_type":    {refreshGrantType},
+		"refresh_token": {refreshToken},
+		"client_id":     {s.oauthClient.ClientID},
+		"client_secret": {s.oauthClient.ClientSecret},
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, refreshHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, linearTokenURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return linearTokenRefreshResponse{}, fmt.Errorf("create linear refresh request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	httpClient := s.refreshHTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return linearTokenRefreshResponse{}, fmt.Errorf("linear refresh request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, refreshErrorBodyLimit))
+	if readErr != nil {
+		return linearTokenRefreshResponse{}, fmt.Errorf("read linear refresh response: %w", readErr)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// fall through to parse
+	case resp.StatusCode == http.StatusUnauthorized,
+		resp.StatusCode == http.StatusBadRequest,
+		resp.StatusCode == http.StatusForbidden:
+		// 4xx from /oauth/token has multiple distinct causes per RFC 6749 §5.2.
+		// We MUST distinguish them: a `invalid_grant` revocation requires
+		// zeroing the user's refresh token, while `invalid_client` means
+		// the operator botched LINEAR_OAUTH_CLIENT_SECRET and zeroing the
+		// row would be self-inflicted mass revocation (one bad deploy
+		// would force every connected org to manually reconnect).
+		//
+		// Unrecognized error codes fall through to the generic 4xx bucket
+		// that does NOT zero the row — safer to leave the refresh token
+		// in place for the next attempt than to invalidate it on an
+		// ambiguous response.
+		if classified := classifyOAuthErrorBody(body); classified != nil {
+			return linearTokenRefreshResponse{}, fmt.Errorf("%w (status %d): %s", classified, resp.StatusCode, truncateErrorMessage(string(body)))
+		}
+		return linearTokenRefreshResponse{}, fmt.Errorf("linear refresh rejected with unrecognized error (status %d): %s", resp.StatusCode, truncateErrorMessage(string(body)))
+	default:
+		return linearTokenRefreshResponse{}, fmt.Errorf("linear refresh failed (status %d): %s", resp.StatusCode, truncateErrorMessage(string(body)))
+	}
+
+	var parsed linearTokenRefreshResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return linearTokenRefreshResponse{}, fmt.Errorf("parse linear refresh response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return linearTokenRefreshResponse{}, fmt.Errorf("linear refresh response missing access_token")
+	}
+	return parsed, nil
+}
+
+// mergeRefreshedConfig produces the LinearConfig to persist after a
+// successful refresh. It preserves the bookkeeping fields (workspace
+// metadata, webhook secret) and only overwrites the auth fields the refresh
+// response speaks to. This is important because Linear's refresh response
+// does not echo workspace_id / workspace_name back, and overwriting them
+// with empty strings would corrupt the row.
+//
+// Linear may rotate the refresh token: if the response includes a new one
+// we persist it. If the response omits refresh_token (some OAuth providers
+// do this when the token is unchanged), we keep the existing one.
+//
+// expires_in handling: a successful refresh response without expires_in is
+// against the spirit of RFC 6749 §5.1 but technically allowed. Earlier
+// versions zeroed ExpiresAt on this path, which silently demoted the row
+// to "use until 401" mode and disabled future proactive refreshes — a
+// successful refresh that effectively turned refresh-on-expiry off forever.
+// We now preserve the prior ExpiresAt instead. This means we'll re-refresh
+// at the same window we would have otherwise; in the worst case (response
+// systemically lacks expires_in) we end up refreshing more often than
+// strictly necessary, which is far less harmful than silently going stale.
+// A warning is logged so operators chasing "why does this org keep
+// refreshing every minute?" can find this branch.
+func mergeRefreshedConfig(prior models.LinearConfig, refreshed linearTokenRefreshResponse, logger zerolog.Logger, orgID uuid.UUID) models.LinearConfig {
+	merged := prior
+	merged.AccessToken = refreshed.AccessToken
+	if refreshed.RefreshToken != "" {
+		merged.RefreshToken = refreshed.RefreshToken
+	}
+	if refreshed.TokenType != "" {
+		merged.TokenType = refreshed.TokenType
+	}
+	if refreshed.Scope != "" {
+		merged.Scope = refreshed.Scope
+	}
+	if refreshed.ExpiresIn > 0 {
+		merged.ExpiresAt = time.Now().Add(time.Duration(refreshed.ExpiresIn) * time.Second)
+	} else {
+		// Preserve the prior ExpiresAt (or zero, if it was a legacy install
+		// being upgraded mid-flight). See doc above.
+		logger.Warn().
+			Str("org_id", orgID.String()).
+			Time("preserved_expires_at", merged.ExpiresAt).
+			Msg("linear: refresh response omitted expires_in; preserving prior ExpiresAt rather than demoting row to use-until-401 mode")
+	}
+	return merged
+}
+
+// ForceRefreshToken rotates the access token regardless of whether the
+// cached one is within the refresh window. Used as the second line of
+// defense after a 401 from a Linear API call: if our proactively-refreshed
+// token was still rejected, the row is likely stale because another node
+// rotated the refresh token (race) or the token aged out faster than its
+// stated expiry (clock skew, server-side rotation policy change). A force
+// refresh re-reads the row, then either returns a freshly-rotated token or
+// surfaces ErrRefreshTokenRevoked when there really is no recovery.
+//
+// Returns ("", error) when refresh is impossible (no refresh token,
+// missing OAuth client config, or upstream revocation). Callers should
+// treat any error here as "let the original 401 propagate" rather than
+// hiding it.
+func (s *Service) ForceRefreshToken(ctx context.Context, orgID uuid.UUID) (string, error) {
+	_, cfg, err := s.loadLinearCredential(ctx, orgID)
+	if err != nil {
+		return "", err
+	}
+	refreshed, err := s.refreshLinearToken(ctx, orgID, cfg, true /* skipFreshCheck */)
+	if err != nil {
+		return "", err
+	}
+	return refreshed.AccessToken, nil
+}
+
+// withRefreshableClient runs fn against a freshly-built Linear client and,
+// on ErrUnauthorized, rebuilds the client from a force-refreshed token and
+// retries fn exactly once. This is the canonical pattern for read-only
+// service-layer entry points that hit Linear: the proactive refresh in
+// GetValidToken handles the common case, and this retry handles the
+// remainder (cross-node refresh-token races, clock skew, mid-chain
+// expiry).
+//
+// MUTATIONS MUST NOT USE THIS WRAPPER. Linear's GraphQL mutations are not
+// uniformly idempotent — e.g. CreateComment without a prior commentID
+// produces a fresh comment on each call. A retry after a partial failure
+// could append duplicate comments or attachments. The mutation paths in
+// writes.go retain their existing "let the worker handler catch
+// ErrUnauthorized and call MarkIntegrationUnauthorized" contract.
+//
+// Concurrency note: the retry path takes the same per-org refresh mutex
+// inside refreshLinearToken, so concurrent reads racing on the same
+// expiring token serialize through one refresh rather than fanning out
+// N refresh requests at Linear.
+func (s *Service) withRefreshableClient(ctx context.Context, orgID uuid.UUID, fn func(Client) error) error {
+	integration, token, err := s.GetValidToken(ctx, orgID)
+	if err != nil {
+		return err
+	}
+	_ = integration
+
+	client, err := s.clientFactory(ctx, token)
+	if err != nil {
+		return fmt.Errorf("build linear client: %w", err)
+	}
+
+	firstErr := fn(client)
+	if firstErr == nil || !errors.Is(firstErr, ErrUnauthorized) {
+		return firstErr
+	}
+
+	// First call hit a 401 despite our proactive refresh. Try a forced
+	// refresh once. If it fails, return the original 401 — that error is
+	// the more actionable one for callers (it triggers the existing
+	// MarkIntegrationUnauthorized path in worker handlers), and the
+	// refresh error would mask it.
+	s.observeRefreshOutcome(refreshOutcomeForceRefresh)
+	refreshedToken, refreshErr := s.ForceRefreshToken(ctx, orgID)
+	if refreshErr != nil {
+		s.logger.Debug().
+			Err(refreshErr).
+			Str("org_id", orgID.String()).
+			Msg("linear: force refresh after 401 failed; surfacing original ErrUnauthorized")
+		return firstErr
+	}
+
+	retryClient, err := s.clientFactory(ctx, refreshedToken)
+	if err != nil {
+		return fmt.Errorf("build linear client (post-refresh): %w", err)
+	}
+	if retryErr := fn(retryClient); retryErr != nil {
+		if errors.Is(retryErr, ErrUnauthorized) {
+			s.logger.Warn().
+				Str("org_id", orgID.String()).
+				Msg("linear: 401 persisted after force-refresh; access token genuinely revoked")
+		}
+		return retryErr
+	}
+	s.logger.Info().
+		Str("org_id", orgID.String()).
+		Msg("linear: successfully recovered from 401 via force-refresh + retry")
+	return nil
+}
+
+// markRefreshTokenRevoked persists a config with the refresh token zeroed
+// and flips the integration row to errored. Splitting the two writes is
+// deliberate: the credential write removes our ability to keep retrying a
+// dead refresh token (subsequent GetValidToken sees RefreshToken=="" and
+// returns ErrNoRefreshToken cleanly), while MarkIntegrationUnauthorized
+// surfaces the human-readable banner. Both are best-effort: a failure on
+// either side logs and continues so the caller's original error contract
+// (ErrRefreshTokenRevoked) isn't perturbed by a side-channel write hiccup.
+func (s *Service) markRefreshTokenRevoked(ctx context.Context, orgID uuid.UUID, current models.LinearConfig) {
+	if s.credentialsWriter != nil {
+		zeroed := current
+		zeroed.RefreshToken = ""
+		zeroed.ExpiresAt = time.Time{}
+		// We intentionally leave AccessToken in place so worker handlers
+		// that hold an in-memory client built from this config can still
+		// surface the more-specific 401 path themselves rather than
+		// failing earlier with "empty access token". The integration is
+		// already being flipped to errored below, so the banner appears
+		// either way.
+		if err := s.credentialsWriter.Upsert(ctx, orgID, zeroed); err != nil {
+			s.logger.Warn().Err(err).
+				Str("org_id", orgID.String()).
+				Msg("linear: failed to zero refresh_token after revocation; subsequent calls may loop on dead refresh token until next reconnect")
+		}
+	}
+	s.MarkIntegrationUnauthorized(ctx, orgID)
+}

--- a/internal/services/linear/refresh.go
+++ b/internal/services/linear/refresh.go
@@ -823,13 +823,16 @@ func (s *Service) markRefreshTokenRevoked(ctx context.Context, orgID uuid.UUID, 
 	if s.credentialsWriter != nil {
 		zeroed := current
 		zeroed.RefreshToken = ""
-		zeroed.ExpiresAt = time.Time{}
+		if zeroed.ExpiresAt.IsZero() {
+			zeroed.ExpiresAt = time.Now().Add(-time.Second)
+		}
 		// We intentionally leave AccessToken in place so worker handlers
 		// that hold an in-memory client built from this config can still
 		// surface the more-specific 401 path themselves rather than
-		// failing earlier with "empty access token". The integration is
-		// already being flipped to errored below, so the banner appears
-		// either way.
+		// failing earlier with "empty access token". We also preserve a
+		// known expiry (or stamp one in the past for unusual zero-expiry
+		// rows) so subsequent GetValidToken calls do not mistake the
+		// revoked row for a legacy use-until-401 credential.
 		if err := s.credentialsWriter.Upsert(ctx, orgID, zeroed); err != nil {
 			s.logger.Warn().Err(err).
 				Str("org_id", orgID.String()).

--- a/internal/services/linear/refresh_test.go
+++ b/internal/services/linear/refresh_test.go
@@ -72,6 +72,21 @@ func (f *fakeCredentialStore) Upsert(_ context.Context, orgID uuid.UUID, cfg mod
 	return nil
 }
 
+func (f *fakeCredentialStore) UpdateLinearConfigIfRefreshTokenMatches(_ context.Context, orgID uuid.UUID, expectedRefreshToken string, cfg models.LinearConfig) (models.LinearConfig, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upsertHits = append(f.upsertHits, cfg)
+	if f.upsertErr != nil {
+		return models.LinearConfig{}, false, f.upsertErr
+	}
+	current := f.configs[orgID]
+	if current.RefreshToken != expectedRefreshToken {
+		return current, false, nil
+	}
+	f.configs[orgID] = cfg
+	return cfg, true, nil
+}
+
 func (f *fakeCredentialStore) snapshot(orgID uuid.UUID) models.LinearConfig {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -464,6 +479,39 @@ func TestGetValidAccessToken_MissingIntegrationReturnsEmptyNilForEnvInjection(t 
 	token, err := svc.GetValidAccessToken(context.Background(), orgID)
 	require.NoError(t, err)
 	require.Empty(t, token, `"" + nil signals "no Linear installed" so env.go skips the env var`)
+}
+
+// TestGetValidAccessToken_InactiveIntegrationReturnsEmptyNilForEnvInjection
+// covers the disconnect path: DisconnectIntegration leaves the credential row
+// in place and flips the integration row to inactive. Env injection must treat
+// that exactly like "not installed" so a user-initiated disconnect cannot keep
+// refreshing and injecting LINEAR_ACCESS_TOKEN into new sandboxes.
+func TestGetValidAccessToken_InactiveIntegrationReturnsEmptyNilForEnvInjection(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			OrgID:  orgID,
+			Status: models.IntegrationStatusInactive,
+		},
+	}
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_disconnected",
+		RefreshToken: "lin_rt_disconnected",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		t.Fatal("inactive integrations must not refresh or inject Linear tokens")
+		return 0, ""
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	token, err := svc.GetValidAccessToken(context.Background(), orgID)
+	require.NoError(t, err, "inactive integration should be suppressed for env injection")
+	require.Empty(t, token, "inactive integration should not produce LINEAR_ACCESS_TOKEN")
+	require.Zero(t, stub.calls.Load(), "inactive integration should not call Linear's refresh endpoint")
 }
 
 // TestGetValidToken_RaceLossesUseRotatedToken simulates the multi-node
@@ -875,6 +923,49 @@ func TestGetValidToken_RefreshSucceeded_PersistFails_FallsBackToCachedToken(t *t
 	require.NoError(t, err, "transient persist failure with valid cached token should fall back, not propagate")
 	require.Equal(t, "lin_at_old", token, "cached token returned because the rotated one couldn't be persisted")
 	require.Equal(t, 1, creds.upsertCount(), "exactly one persist attempt expected (so the failure is observable in metrics/logs)")
+}
+
+// TestGetValidToken_RefreshSucceeded_DoesNotOverwriteReconnectedCredential
+// pins the compare-and-swap requirement for refresh persistence. If a user
+// reconnects Linear while this goroutine is waiting on /oauth/token, the
+// refreshed pair derived from the old refresh token must not overwrite the
+// newer reconnect credential.
+func TestGetValidToken_RefreshSucceeded_DoesNotOverwriteReconnectedCredential(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:   "lin_at_old",
+		RefreshToken:  "lin_rt_old",
+		ExpiresAt:     time.Now().Add(1 * time.Minute),
+		WorkspaceID:   "wks-old",
+		WorkspaceName: "Old Workspace",
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		require.Equal(t, "lin_rt_old", form.Get("refresh_token"), "refresh should start from the originally observed refresh token")
+		creds.mu.Lock()
+		creds.configs[orgID] = models.LinearConfig{
+			AccessToken:   "lin_at_reconnected",
+			RefreshToken:  "lin_rt_reconnected",
+			ExpiresAt:     time.Now().Add(2 * time.Hour),
+			WorkspaceID:   "wks-new",
+			WorkspaceName: "Reconnected Workspace",
+		}
+		creds.mu.Unlock()
+		return http.StatusOK, `{"access_token":"lin_at_from_old_chain","refresh_token":"lin_rt_from_old_chain","expires_in":7200}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err, "refresh race with reconnect should recover by using the current row")
+	require.Equal(t, "lin_at_reconnected", token, "caller should receive the newer reconnected token, not the old token chain")
+
+	persisted := creds.snapshot(orgID)
+	require.Equal(t, "lin_at_reconnected", persisted.AccessToken, "refresh must not overwrite a reconnected access token")
+	require.Equal(t, "lin_rt_reconnected", persisted.RefreshToken, "refresh must not overwrite a reconnected refresh token")
+	require.Equal(t, "wks-new", persisted.WorkspaceID, "refresh must not restore stale workspace metadata")
+	require.Equal(t, 1, creds.upsertCount(), "refresh should attempt one guarded persistence")
 }
 
 // TestMarkRefreshTokenRevoked_PersistFailureStillFlipsIntegration

--- a/internal/services/linear/refresh_test.go
+++ b/internal/services/linear/refresh_test.go
@@ -538,6 +538,50 @@ func TestForceRefreshToken_AlwaysAttemptsRefresh(t *testing.T) {
 	require.EqualValues(t, 1, stub.calls.Load())
 }
 
+// TestForceRefreshToken_SkipsPOSTWhenPeerAlreadyRotated covers the
+// efficiency fix: if the in-lock re-read shows the access token already
+// changed under us (peer node rotated between our 401 and our lock
+// acquisition), we should use the peer's token instead of POSTing our
+// stale refresh token. POSTing would consume Linear's freshly-issued
+// refresh token for a redundant third rotation.
+func TestForceRefreshToken_SkipsPOSTWhenPeerAlreadyRotated(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	// The caller observed AccessToken "lin_at_caller_saw" before getting
+	// a 401. By the time refreshLinearToken acquires the per-org lock and
+	// re-reads, the store reflects a peer-node rotation to "lin_at_peer".
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_peer",
+		RefreshToken: "lin_rt_peer",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		t.Fatal("must not POST when the in-lock re-read shows a peer-rotated token")
+		return 0, ""
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	// Drive refreshLinearToken directly through ForceRefreshToken, but
+	// pre-load `observed` with the caller's pre-rotation view so the
+	// in-lock re-read genuinely diverges. ForceRefreshToken's first
+	// loadLinearCredential currently sees the post-rotation row, so
+	// observed.AccessToken == latest.AccessToken and the new branch
+	// wouldn't fire — to actually exercise the new path we drop one
+	// level and call refreshLinearToken with skipFreshCheck=true and
+	// the older `observed` config.
+	older := models.LinearConfig{
+		AccessToken:  "lin_at_caller_saw",
+		RefreshToken: "lin_rt_caller_saw",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute),
+	}
+	got, err := svc.refreshLinearToken(context.Background(), orgID, older, true /* skipFreshCheck */)
+	require.NoError(t, err)
+	require.Equal(t, "lin_at_peer", got.AccessToken, "must use the peer-rotated token, not POST our stale refresh token")
+	require.Zero(t, stub.calls.Load(), "no /oauth/token request expected when peer already rotated")
+}
+
 // TestWithRefreshableClient_RetriesOnce_SucceedsOnSecondTry is the
 // integration test for the on-401 retry loop in withRefreshableClient.
 // First call returns ErrUnauthorized, force-refresh runs, second call

--- a/internal/services/linear/refresh_test.go
+++ b/internal/services/linear/refresh_test.go
@@ -1,0 +1,858 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// fakeCredentialStore implements both CredentialReader and CredentialWriter
+// for the refresh tests. Holds a single LinearConfig per org keyed by orgID;
+// captures Upsert calls so tests can assert what was persisted across
+// concurrent refreshes.
+type fakeCredentialStore struct {
+	mu         sync.Mutex
+	configs    map[uuid.UUID]models.LinearConfig
+	upsertHits []models.LinearConfig
+	getErr     error // when set, every Get returns this error
+	upsertErr  error // when set, every Upsert returns this error after recording the hit
+}
+
+func newFakeCredentialStore() *fakeCredentialStore {
+	return &fakeCredentialStore{configs: map[uuid.UUID]models.LinearConfig{}}
+}
+
+func (f *fakeCredentialStore) Get(_ context.Context, orgID uuid.UUID, _ models.ProviderName) (*models.DecryptedCredential, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	cfg, ok := f.configs[orgID]
+	if !ok {
+		return nil, nil
+	}
+	return &models.DecryptedCredential{
+		ID:     uuid.New(),
+		OrgID:  orgID,
+		Config: cfg,
+	}, nil
+}
+
+func (f *fakeCredentialStore) Upsert(_ context.Context, orgID uuid.UUID, cfg models.ProviderConfig) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	lc, ok := cfg.(models.LinearConfig)
+	if !ok {
+		return fmt.Errorf("expected LinearConfig, got %T", cfg)
+	}
+	// Record the attempt regardless of upsertErr so tests can distinguish
+	// "didn't try to write" from "tried, but the store rejected it."
+	f.upsertHits = append(f.upsertHits, lc)
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.configs[orgID] = lc
+	return nil
+}
+
+func (f *fakeCredentialStore) snapshot(orgID uuid.UUID) models.LinearConfig {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.configs[orgID]
+}
+
+func (f *fakeCredentialStore) upsertCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.upsertHits)
+}
+
+// roundTripFunc implements http.RoundTripper from a closure.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// stubLinearOAuthServer returns an http.Client whose RoundTripper services
+// /oauth/token requests with the supplied response builder. callCount tracks
+// how many requests landed so tests can assert serialization.
+type stubLinearOAuthServer struct {
+	calls   atomic.Int64
+	respond func(form url.Values) (status int, body string)
+}
+
+func (s *stubLinearOAuthServer) httpClient() *http.Client {
+	return &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.URL.String() != linearTokenURL {
+			return nil, fmt.Errorf("unexpected URL %s", req.URL.String())
+		}
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, err
+		}
+		s.calls.Add(1)
+		status, respBody := s.respond(form)
+		return &http.Response{
+			StatusCode: status,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(respBody)),
+		}, nil
+	})}
+}
+
+// newRefreshTestService wires a Service with the minimum surface refresh
+// tests need: stub integration + credential stores, a fake HTTP transport
+// for /oauth/token, and a logger that drops output.
+func newRefreshTestService(t *testing.T, intg *fakeIntegrationStore, creds *fakeCredentialStore, oauthClient *stubLinearOAuthServer) *Service {
+	t.Helper()
+	svc := &Service{
+		logger:             zerolog.Nop(),
+		integrations:       intg,
+		integrationsWriter: intg,
+		credentials:        creds,
+		credentialsWriter:  creds,
+		oauthClient: OAuthClientCreds{
+			ClientID:     "test-client",
+			ClientSecret: "test-secret",
+		},
+	}
+	if oauthClient != nil {
+		svc.refreshHTTPClient = oauthClient.httpClient()
+	} else {
+		svc.refreshHTTPClient = &http.Client{}
+	}
+	return svc
+}
+
+func newActiveLinearIntegrationStore(orgID uuid.UUID) *fakeIntegrationStore {
+	return &fakeIntegrationStore{
+		row: models.Integration{
+			ID:     uuid.New(),
+			OrgID:  orgID,
+			Status: models.IntegrationStatusActive,
+			Config: json.RawMessage(`{"workspace_id":"wks-1"}`),
+		},
+	}
+}
+
+// TestGetValidToken_NoRefreshNeeded verifies the fast path: a healthy
+// credential whose ExpiresAt is well outside the refresh window is
+// returned as-is, no /oauth/token traffic. This is the single most common
+// case in production and any regression here means we'd hammer Linear's
+// OAuth endpoint on every API call.
+func TestGetValidToken_NoRefreshNeeded(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_active",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+		WorkspaceID:  "wks-1",
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		t.Fatal("refresh endpoint should not be called for a fresh token")
+		return 0, ""
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "lin_at_active", token)
+	require.Zero(t, stub.calls.Load(), "no refresh expected")
+	require.Zero(t, creds.upsertCount(), "credential row must not be rewritten on the fast path")
+}
+
+// TestGetValidToken_LegacyNoRefreshToken asserts that legacy credentials
+// with no refresh token and zero ExpiresAt keep working — they return the
+// cached token, never attempt refresh, and never error. This is the migration
+// path: existing connections stay live until the user reconnects, at which
+// point they get the new fields.
+func TestGetValidToken_LegacyNoRefreshToken(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken: "lin_at_legacy",
+		// no RefreshToken, no ExpiresAt — the legacy shape.
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		t.Fatal("legacy credential must never trigger a refresh request")
+		return 0, ""
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "lin_at_legacy", token)
+	require.Zero(t, stub.calls.Load())
+}
+
+// TestGetValidToken_KnownExpiryNoRefreshTokenRequiresReconnect covers rows
+// that know the access token expiry but lack a refresh token. Once they are
+// inside the refresh window, returning the cached token would knowingly hand
+// callers a stale or soon-stale credential. The correct behavior is to force
+// the reconnect path through ErrNoRefreshToken.
+func TestGetValidToken_KnownExpiryNoRefreshTokenRequiresReconnect(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken: "lin_at_expiring",
+		ExpiresAt:   time.Now().Add(2 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		t.Fatal("refresh endpoint should not be called without a refresh token")
+		return 0, ""
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.ErrorIs(t, err, ErrNoRefreshToken, "known-expiring credentials without refresh token should force reconnect")
+	require.Empty(t, token, "caller must not receive a known-expiring cached token")
+	require.Zero(t, stub.calls.Load(), "no refresh request is possible without a refresh token")
+}
+
+// TestGetValidToken_RefreshSucceeds covers the canonical happy path:
+// token is within the refresh window, refresh-token grant is exchanged for
+// a new access/refresh pair, the rotated row is persisted, and the new
+// access token is returned to the caller.
+func TestGetValidToken_RefreshSucceeds(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:   "lin_at_old",
+		RefreshToken:  "lin_rt_old",
+		ExpiresAt:     time.Now().Add(2 * time.Minute), // within 5min refresh window
+		WorkspaceID:   "wks-1",
+		WorkspaceName: "Acme",
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		require.Equal(t, "refresh_token", form.Get("grant_type"))
+		require.Equal(t, "lin_rt_old", form.Get("refresh_token"))
+		require.Equal(t, "test-client", form.Get("client_id"))
+		require.Equal(t, "test-secret", form.Get("client_secret"))
+		return http.StatusOK, `{"access_token":"lin_at_new","refresh_token":"lin_rt_new","token_type":"Bearer","scope":"read,write","expires_in":7200}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "lin_at_new", token, "caller should receive the rotated access token")
+
+	persisted := creds.snapshot(orgID)
+	require.Equal(t, "lin_at_new", persisted.AccessToken)
+	require.Equal(t, "lin_rt_new", persisted.RefreshToken, "rotated refresh token must be persisted")
+	require.Equal(t, "wks-1", persisted.WorkspaceID, "workspace metadata must be preserved across refresh")
+	require.Equal(t, "Acme", persisted.WorkspaceName)
+	require.True(t, persisted.ExpiresAt.After(time.Now().Add(time.Hour)), "expires_at should be far in the future")
+	require.EqualValues(t, 1, stub.calls.Load(), "exactly one refresh request expected")
+}
+
+// TestGetValidToken_RefreshConcurrentSerializesPerOrg asserts the
+// per-org mutex actually prevents N concurrent goroutines from each
+// burning a refresh-token redemption against Linear. After the first
+// goroutine refreshes, the others should observe the rotated row,
+// double-check inside the lock, and skip the refresh entirely.
+func TestGetValidToken_RefreshConcurrentSerializesPerOrg(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_old",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+		WorkspaceID:  "wks-1",
+	}
+	respond := func(form url.Values) (int, string) {
+		return http.StatusOK, `{"access_token":"lin_at_new","refresh_token":"lin_rt_new","token_type":"Bearer","expires_in":7200}`
+	}
+	stub := &stubLinearOAuthServer{respond: respond}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	const concurrency = 16
+	var wg sync.WaitGroup
+	tokens := make([]string, concurrency)
+	errs := make([]error, concurrency)
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, tok, err := svc.GetValidToken(context.Background(), orgID)
+			tokens[i] = tok
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "goroutine %d failed", i)
+		require.Equalf(t, "lin_at_new", tokens[i], "goroutine %d got stale token", i)
+	}
+	require.EqualValues(t, 1, stub.calls.Load(), "concurrent callers must coalesce onto a single refresh request")
+}
+
+// TestGetValidToken_RefreshTokenRevoked covers the hard-failure path:
+// Linear returns 400 invalid_grant, refresh.go must zero the persisted
+// refresh token (so future calls don't loop), flip the integration row
+// to errored (so the UI shows reconnect), and return ErrRefreshTokenRevoked.
+func TestGetValidToken_RefreshTokenRevoked(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_revoked",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+		WorkspaceID:  "wks-1",
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusBadRequest, `{"error":"invalid_grant","error_description":"refresh token has been revoked"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRefreshTokenRevoked)
+
+	persisted := creds.snapshot(orgID)
+	require.Empty(t, persisted.RefreshToken, "refresh token must be zeroed so future calls fall through to the no-refresh-token branch")
+	require.Equal(t, "wks-1", persisted.WorkspaceID, "workspace metadata must survive the revocation write")
+
+	require.NotEmpty(t, intg.statusCfgCalls, "MarkIntegrationUnauthorized should fire so the UI shows the reconnect banner")
+	require.Equal(t, string(models.IntegrationStatusError), intg.statusCfgCalls[0].status)
+}
+
+// TestGetValidToken_RefreshFailureWithValidCachedTokenFallsBack asserts
+// that a transient refresh failure (e.g. Linear 5xx) does NOT take down
+// the calling code path when the cached token is still inside its
+// validity window. The next call will retry; meanwhile the worker's read
+// completes with the cached token.
+func TestGetValidToken_RefreshFailureWithValidCachedTokenFallsBack(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	// Inside the 5-minute refresh window but still valid, so fall-back
+	// should kick in on a transient refresh failure.
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(2 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusInternalServerError, `{"error":"upstream"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err, "transient 5xx on refresh should fall back to the still-valid cached token")
+	require.Equal(t, "lin_at_old", token)
+}
+
+// TestGetValidToken_RefreshFailureWithExpiredCachedTokenSurfacesError
+// pins the harder side of the same edge case: if the cached token has
+// already expired (we entered the refresh window late, or the server
+// has been down longer than the validity tail), there's no safe
+// fallback and the error must propagate so the caller can react.
+func TestGetValidToken_RefreshFailureWithExpiredCachedTokenSurfacesError(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_dead",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute), // already expired
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusInternalServerError, `{"error":"upstream"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.Error(t, err, "cannot fall back to an already-expired token")
+	require.NotErrorIs(t, err, ErrRefreshTokenRevoked, "5xx is transient, not revocation")
+}
+
+// TestGetValidToken_OAuthClientNotConfigured asserts that a service built
+// without OAuth client credentials surfaces ErrOAuthClientNotConfigured
+// rather than panicking or silently returning a stale token. Triggered
+// only when the credential needs refresh; healthy tokens still work.
+func TestGetValidToken_OAuthClientNotConfigured(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	svc := &Service{
+		logger:             zerolog.Nop(),
+		integrations:       intg,
+		integrationsWriter: intg,
+		credentials:        creds,
+		credentialsWriter:  creds,
+		oauthClient:        OAuthClientCreds{}, // intentionally empty
+		refreshHTTPClient:  &http.Client{},
+	}
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.ErrorIs(t, err, ErrOAuthClientNotConfigured)
+}
+
+// TestGetValidToken_NoIntegration verifies that when an org has never
+// installed Linear, GetValidToken returns ErrIntegrationNotFound. The
+// integration store reports pgx.ErrNoRows; loadLinearCredential maps that
+// to the typed sentinel callers can branch on.
+func TestGetValidToken_NoIntegration(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := &fakeIntegrationStore{notFoundErr: pgx.ErrNoRows}
+	creds := newFakeCredentialStore()
+	svc := newRefreshTestService(t, intg, creds, nil)
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrIntegrationNotFound)
+}
+
+// TestGetValidAccessToken_MissingIntegrationReturnsEmptyNilForEnvInjection
+// pins the contract that env.go relies on: the convenience wrapper must
+// suppress the "no integration" sentinel so callers can branch on `token == ""`
+// without importing linear-specific errors.
+func TestGetValidAccessToken_MissingIntegrationReturnsEmptyNilForEnvInjection(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := &fakeIntegrationStore{notFoundErr: pgx.ErrNoRows}
+	creds := newFakeCredentialStore()
+	svc := newRefreshTestService(t, intg, creds, nil)
+
+	token, err := svc.GetValidAccessToken(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Empty(t, token, `"" + nil signals "no Linear installed" so env.go skips the env var`)
+}
+
+// TestGetValidToken_RaceLossesUseRotatedToken simulates the multi-node
+// race: this process's refresh attempt 401s because a peer node already
+// rotated, but the rotated token is now in the row. refreshLinearToken's
+// post-rejection re-read should pick that up and return the peer's
+// freshly-persisted token instead of declaring revocation.
+//
+// Note: in the current implementation the race-recovery branch only
+// re-reads from the same store, so we simulate a peer-node rotation by
+// having the OAuth stub mutate the store mid-flight. This is the closest
+// we can get to a multi-process race in a single-process unit test.
+func TestGetValidToken_RaceLossesUseRotatedToken(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_old",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		// Simulate: by the time our request lands at Linear, a peer node
+		// already rotated and persisted a new token. Mutate the store to
+		// reflect that, then return the 4xx that would arrive for our
+		// now-stale refresh token.
+		creds.mu.Lock()
+		creds.configs[orgID] = models.LinearConfig{
+			AccessToken:  "lin_at_peer_rotated",
+			RefreshToken: "lin_rt_peer_rotated",
+			ExpiresAt:    time.Now().Add(2 * time.Hour),
+		}
+		creds.mu.Unlock()
+		return http.StatusBadRequest, `{"error":"invalid_grant"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err, "race recovery should pick up the peer-rotated token")
+	require.Equal(t, "lin_at_peer_rotated", token)
+
+	require.Empty(t, intg.statusCfgCalls, "MarkIntegrationUnauthorized must NOT fire when the peer already recovered")
+}
+
+// TestForceRefreshToken_AlwaysAttemptsRefresh exercises the post-401
+// recovery path: even when the cached token is well outside the refresh
+// window, ForceRefreshToken still POSTs to Linear (because the worker
+// just observed a 401, which means our window-based proactive logic is
+// wrong about this token).
+func TestForceRefreshToken_AlwaysAttemptsRefresh(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	// Token claims 2 hours of validity but the call site got a 401, so
+	// force-refresh must fire regardless.
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_dead_despite_clock",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(2 * time.Hour),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		require.Equal(t, "refresh_token", form.Get("grant_type"))
+		return http.StatusOK, `{"access_token":"lin_at_forced","refresh_token":"lin_rt","expires_in":7200}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	token, err := svc.ForceRefreshToken(context.Background(), orgID)
+	require.NoError(t, err)
+	require.Equal(t, "lin_at_forced", token)
+	require.EqualValues(t, 1, stub.calls.Load())
+}
+
+// TestWithRefreshableClient_RetriesOnce_SucceedsOnSecondTry is the
+// integration test for the on-401 retry loop in withRefreshableClient.
+// First call returns ErrUnauthorized, force-refresh runs, second call
+// succeeds. Asserts that fn() is called exactly twice and the new token
+// flows through to the second client build.
+func TestWithRefreshableClient_RetriesOnce_SucceedsOnSecondTry(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_stale",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    time.Now().Add(2 * time.Hour), // not in refresh window
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusOK, `{"access_token":"lin_at_recovered","refresh_token":"lin_rt","expires_in":7200}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	tokensSeen := make([]string, 0, 2)
+	svc.clientFactory = func(_ context.Context, token string) (Client, error) {
+		tokensSeen = append(tokensSeen, token)
+		return &fakeRetryClient{
+			fail401On: len(tokensSeen) == 1, // 401 the first build only
+		}, nil
+	}
+
+	calls := 0
+	err := svc.withRefreshableClient(context.Background(), orgID, func(c Client) error {
+		calls++
+		// Trigger the same 401 path the real graphQLClient uses.
+		_, err := c.ListTeamKeys(context.Background())
+		return err
+	})
+	require.NoError(t, err, "retry should succeed")
+	require.Equal(t, 2, calls, "fn must be invoked exactly twice (first 401, then success)")
+	require.Equal(t, []string{"lin_at_stale", "lin_at_recovered"}, tokensSeen, "second client build must use the refreshed token")
+}
+
+// TestWithRefreshableClient_DoesNotRetryNon401 prevents accidental
+// retries on errors that aren't ErrUnauthorized. A retry on, say, a 5xx
+// would double a Linear API call that may already have partially
+// succeeded — for reads it's harmless, but the contract is "only retry
+// on 401" so the helper stays predictable for any future mutation that
+// might opt in.
+func TestWithRefreshableClient_DoesNotRetryNon401(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken: "lin_at",
+		ExpiresAt:   time.Now().Add(2 * time.Hour),
+	}
+	svc := newRefreshTestService(t, intg, creds, nil)
+
+	calls := 0
+	svc.clientFactory = func(_ context.Context, _ string) (Client, error) {
+		return &fakeRetryClient{returnGenericErr: true}, nil
+	}
+
+	err := svc.withRefreshableClient(context.Background(), orgID, func(c Client) error {
+		calls++
+		_, err := c.ListTeamKeys(context.Background())
+		return err
+	})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUnauthorized)
+	require.Equal(t, 1, calls, "non-401 errors must NOT trigger a retry")
+}
+
+// fakeRetryClient is the smallest possible Client surface for the retry
+// tests: ListTeamKeys honors the test-controlled flags and every other
+// method panics so the tests that exercise it stay focused.
+type fakeRetryClient struct {
+	fail401On        bool
+	returnGenericErr bool
+}
+
+func (f *fakeRetryClient) FetchIssue(context.Context, string) (*FetchedIssue, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) ListTeamKeys(context.Context) ([]TeamKeyInfo, error) {
+	if f.fail401On {
+		return nil, ErrUnauthorized
+	}
+	if f.returnGenericErr {
+		return nil, errors.New("graphql validation failed")
+	}
+	return []TeamKeyInfo{{TeamID: "t1", Key: "ABC"}}, nil
+}
+func (f *fakeRetryClient) CreateOrUpdateAttachment(context.Context, AttachmentWriteInput) (AttachmentResult, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) CreateComment(context.Context, string, string) (string, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) UpdateComment(context.Context, string, string) error {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) FindRecentBotCommentByURL(context.Context, string, string) (string, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) WorkflowStateForType(context.Context, string, []string, string) (*WorkflowState, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) UpdateIssueState(context.Context, string, string) error {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) IssueRecentHumanEdits(context.Context, string, time.Time) (bool, error) {
+	panic("not used in retry tests")
+}
+func (f *fakeRetryClient) HasGitHubIntegrationAttachment(context.Context, string) (bool, error) {
+	panic("not used in retry tests")
+}
+
+// TestMergeRefreshedConfig_PreservesMetadataAndRotatesAuth pins the
+// merge contract that the rest of the refresh flow depends on:
+// workspace metadata is sticky (Linear's refresh response doesn't echo
+// it back), but the auth fields rotate from the response. Without this
+// test, a future refactor could accidentally persist a config that
+// loses workspace_id and breaks every detection that relied on it.
+func TestMergeRefreshedConfig_PreservesMetadataAndRotatesAuth(t *testing.T) {
+	t.Parallel()
+	prior := models.LinearConfig{
+		WebhookSecret: "secret",
+		AccessToken:   "lin_at_old",
+		RefreshToken:  "lin_rt_old",
+		TokenType:     "Bearer",
+		Scope:         "read,write",
+		ExpiresAt:     time.Now().Add(-1 * time.Hour),
+		WorkspaceID:   "wks-1",
+		WorkspaceName: "Acme",
+	}
+	resp := linearTokenRefreshResponse{
+		AccessToken:  "lin_at_new",
+		RefreshToken: "lin_rt_new",
+		TokenType:    "Bearer",
+		Scope:        "read,write",
+		ExpiresIn:    7200,
+	}
+	merged := mergeRefreshedConfig(prior, resp, zerolog.Nop(), uuid.New())
+
+	require.Equal(t, "lin_at_new", merged.AccessToken)
+	require.Equal(t, "lin_rt_new", merged.RefreshToken)
+	require.Equal(t, "secret", merged.WebhookSecret, "webhook secret must survive the rotation")
+	require.Equal(t, "wks-1", merged.WorkspaceID)
+	require.Equal(t, "Acme", merged.WorkspaceName)
+	require.True(t, merged.ExpiresAt.After(time.Now().Add(time.Hour)), "ExpiresAt should be ~2h in the future")
+}
+
+// TestMergeRefreshedConfig_RefreshTokenOmittedKeepsExisting covers the
+// OAuth-spec edge case where a refresh response omits refresh_token to
+// indicate "unchanged." We must keep the prior refresh token, not zero
+// it out — otherwise the next call would lose its ability to refresh.
+func TestMergeRefreshedConfig_RefreshTokenOmittedKeepsExisting(t *testing.T) {
+	t.Parallel()
+	prior := models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_keep",
+	}
+	resp := linearTokenRefreshResponse{
+		AccessToken: "lin_at_new",
+		ExpiresIn:   7200,
+		// RefreshToken intentionally empty
+	}
+	merged := mergeRefreshedConfig(prior, resp, zerolog.Nop(), uuid.New())
+	require.Equal(t, "lin_rt_keep", merged.RefreshToken, "omitted refresh_token must NOT zero the prior one")
+}
+
+// TestMergeRefreshedConfig_ExpiresInOmittedPreservesPriorExpiry pins the
+// fix for a subtle bug: an earlier version zeroed ExpiresAt when the
+// refresh response omitted expires_in, silently demoting the row to
+// "use until 401" mode forever (NeedsRefresh returns false on a zero
+// ExpiresAt, so future proactive refreshes never fire). Now we preserve
+// the prior expiry so the next refresh-window check still triggers
+// correctly.
+func TestMergeRefreshedConfig_ExpiresInOmittedPreservesPriorExpiry(t *testing.T) {
+	t.Parallel()
+	priorExpiry := time.Now().Add(2 * time.Minute) // inside refresh window
+	prior := models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt",
+		ExpiresAt:    priorExpiry,
+	}
+	resp := linearTokenRefreshResponse{
+		AccessToken: "lin_at_new",
+		// ExpiresIn intentionally zero
+	}
+	merged := mergeRefreshedConfig(prior, resp, zerolog.Nop(), uuid.New())
+	require.True(t, priorExpiry.Equal(merged.ExpiresAt), "prior ExpiresAt must be preserved when refresh response omits expires_in")
+	require.True(t, merged.NeedsRefresh(refreshWindow), "preserved-expiry row must still report NeedsRefresh so next call retries")
+}
+
+// TestGetValidToken_RefreshOAuthClientMisconfigured pins the
+// most important non-blocker from review: an invalid_client response
+// from /oauth/token (e.g. CLIENT_SECRET rotated upstream) MUST NOT
+// zero the refresh token. The earlier any-4xx-is-revocation logic
+// would have produced self-inflicted mass revocation across every
+// connected org — a deploy with a bad secret bricks all installs.
+func TestGetValidToken_RefreshOAuthClientMisconfigured(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_should_survive",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		// Linear's response for wrong client_id/secret per RFC 6749 §5.2.
+		return http.StatusUnauthorized, `{"error":"invalid_client","error_description":"client authentication failed"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrOAuthClientNotConfigured, "invalid_client must surface as a config error, not a revocation")
+	require.NotErrorIs(t, err, ErrRefreshTokenRevoked, "user's refresh token must NOT be classified as revoked when our own client creds are wrong")
+
+	persisted := creds.snapshot(orgID)
+	require.Equal(t, "lin_rt_should_survive", persisted.RefreshToken, "refresh token must survive an invalid_client response so the next deploy with correct creds can recover")
+	require.Empty(t, intg.statusCfgCalls, "MarkIntegrationUnauthorized must NOT fire — the user did nothing wrong")
+}
+
+// TestGetValidToken_UnrecognizedOAuthErrorDoesNotRevoke covers the
+// safe-default branch: a 4xx with an OAuth error code we don't know
+// (e.g. invalid_request, or a Linear-specific extension) gets
+// classified as a generic transient error, not revocation. The cached
+// token is used as fallback if still valid — exactly the same behavior
+// as a 5xx blip, which is the right cautious posture.
+func TestGetValidToken_UnrecognizedOAuthErrorDoesNotRevoke(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_should_survive",
+		ExpiresAt:    time.Now().Add(2 * time.Minute), // still valid → fallback path
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusBadRequest, `{"error":"unsupported_grant_type"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err, "unrecognized 4xx with cached token still valid should fall back, not error out")
+	require.Equal(t, "lin_at_old", token)
+
+	persisted := creds.snapshot(orgID)
+	require.Equal(t, "lin_rt_should_survive", persisted.RefreshToken, "refresh token must survive unrecognized OAuth errors")
+	require.Empty(t, intg.statusCfgCalls, "no revocation flip on unrecognized errors")
+}
+
+// TestGetValidToken_RefreshSucceeded_PersistFails_FallsBackToCachedToken
+// covers the painful path described in the refreshLinearToken docstring:
+// Linear rotated the tokens at their side, but our DB write fails, so
+// the new refresh token is now lost server-side. Two assertions matter:
+//
+//  1. The caller does NOT get an error: the cached access token is
+//     still valid (we only refresh inside refreshWindow), so failing
+//     the call would needlessly break a session over a transient DB
+//     blip.
+//  2. The Upsert WAS attempted (records a hit), so a future audit
+//     could correlate the metric against the failed write.
+//
+// The next call's behavior is documented but not tested here: it'll
+// try the consumed refresh token, get invalid_grant, and the
+// revocation path takes over — the system self-heals into the
+// reconnect flow if the DB issue persists.
+func TestGetValidToken_RefreshSucceeded_PersistFails_FallsBackToCachedToken(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.upsertErr = errors.New("db connection lost")
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_old",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusOK, `{"access_token":"lin_at_new","refresh_token":"lin_rt_new","expires_in":7200}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.NoError(t, err, "transient persist failure with valid cached token should fall back, not propagate")
+	require.Equal(t, "lin_at_old", token, "cached token returned because the rotated one couldn't be persisted")
+	require.Equal(t, 1, creds.upsertCount(), "exactly one persist attempt expected (so the failure is observable in metrics/logs)")
+}
+
+// TestMarkRefreshTokenRevoked_PersistFailureStillFlipsIntegration
+// covers the operational concern that even a flaky credentials writer
+// must not block the integration row from being flipped to errored —
+// otherwise the UI would show "active" indefinitely while every API
+// call 401'd.
+func TestMarkRefreshTokenRevoked_PersistFailureStillFlipsIntegration(t *testing.T) {
+	t.Parallel()
+	orgID := uuid.New()
+	intg := newActiveLinearIntegrationStore(orgID)
+	creds := newFakeCredentialStore()
+	creds.upsertErr = errors.New("db write failed")
+	creds.configs[orgID] = models.LinearConfig{
+		AccessToken:  "lin_at_old",
+		RefreshToken: "lin_rt_revoked",
+		ExpiresAt:    time.Now().Add(1 * time.Minute),
+	}
+	stub := &stubLinearOAuthServer{respond: func(form url.Values) (int, string) {
+		return http.StatusBadRequest, `{"error":"invalid_grant"}`
+	}}
+	svc := newRefreshTestService(t, intg, creds, stub)
+
+	_, _, err := svc.GetValidToken(context.Background(), orgID)
+	require.ErrorIs(t, err, ErrRefreshTokenRevoked, "revocation classification must survive the credential write failure")
+
+	require.NotEmpty(t, intg.statusCfgCalls, "integration row must be flipped to errored even when zeroing the refresh token failed — otherwise the UI banner never shows")
+	require.Equal(t, string(models.IntegrationStatusError), intg.statusCfgCalls[0].status)
+}

--- a/internal/services/linear/refresh_test.go
+++ b/internal/services/linear/refresh_test.go
@@ -348,6 +348,10 @@ func TestGetValidToken_RefreshTokenRevoked(t *testing.T) {
 
 	require.NotEmpty(t, intg.statusCfgCalls, "MarkIntegrationUnauthorized should fire so the UI shows the reconnect banner")
 	require.Equal(t, string(models.IntegrationStatusError), intg.statusCfgCalls[0].status)
+
+	_, token, err := svc.GetValidToken(context.Background(), orgID)
+	require.ErrorIs(t, err, ErrNoRefreshToken, "subsequent calls after revocation should stay in the reconnect path")
+	require.Empty(t, token, "subsequent calls after revocation must not return the stale access token")
 }
 
 // TestGetValidToken_RefreshFailureWithValidCachedTokenFallsBack asserts

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -107,6 +109,34 @@ type Service struct {
 	// self-healing within the TTL and the alternative (LISTEN/NOTIFY for
 	// cross-pod invalidation) wasn't worth the wiring for a 60s ceiling.
 	teamKeyCache *teamKeyAllowlistCache
+
+	// credentialsWriter persists rotated tokens after a successful refresh.
+	// Optional: when nil, GetValidToken still refreshes in-memory but logs a
+	// warning that the new token will not survive the process. Production
+	// always wires *db.OrgCredentialStore via Build; tests that don't
+	// exercise refresh can leave it nil.
+	credentialsWriter CredentialWriter
+	// oauthClient holds LINEAR_OAUTH_CLIENT_ID / LINEAR_OAUTH_CLIENT_SECRET.
+	// Required for the refresh-token path; without these, GetValidToken on a
+	// credential that needs refreshing returns ErrOAuthClientNotConfigured.
+	oauthClient OAuthClientCreds
+	// refreshHTTPClient is the HTTP client used for the /oauth/token POST.
+	// Tests inject a stubbed transport; production uses an http.Client with
+	// refreshHTTPTimeout.
+	refreshHTTPClient *http.Client
+	// refreshMuRegistry holds per-org sync.Mutex values keyed by orgID
+	// string. Wrapped in atomic.Pointer so direct &Service{} construction
+	// (used widely in tests) stays race-free without forcing every test
+	// to remember to allocate a sync.Map. NewService eagerly populates
+	// the pointer; orgRefreshMu falls back to a CAS-installed registry
+	// when the pointer is nil. A prior sync.Once-based lazy init was
+	// race-prone: goroutines that observed a non-nil registry skipped
+	// the Once.Do call entirely, losing the happens-before relationship
+	// that makes Once safe.
+	//
+	// Growth: bounded by the working set of orgs that refresh; entries
+	// are *sync.Mutex (tiny). No eviction needed at any realistic scale.
+	refreshMuRegistry atomic.Pointer[sync.Map]
 }
 
 // jobEnqueuerHolder / linksChangedHolder wrap the function values stored in
@@ -301,14 +331,31 @@ type Config struct {
 	Integrations       IntegrationReader
 	IntegrationsWriter IntegrationWriter
 	Credentials        CredentialReader
-	Issues             *db.IssueStore
-	Links              *db.SessionIssueLinkStore
-	TeamKeys           *db.LinearTeamKeyStore
-	ProviderState      *db.LinearProviderStateStore
-	StateEvents        *db.LinearStateEventStore
-	Sessions           *db.SessionStore
-	ClientFactory      ClientFactory
-	OrgSettingsLoader  OrgSettingsLoader
+	// CredentialsWriter persists rotated OAuth tokens after a successful
+	// refresh. Optional in tests; production must always wire one (Build
+	// passes *db.OrgCredentialStore here) or refreshed tokens will live
+	// only inside the calling process.
+	CredentialsWriter CredentialWriter
+	Issues            *db.IssueStore
+	Links             *db.SessionIssueLinkStore
+	TeamKeys          *db.LinearTeamKeyStore
+	ProviderState     *db.LinearProviderStateStore
+	StateEvents       *db.LinearStateEventStore
+	Sessions          *db.SessionStore
+	ClientFactory     ClientFactory
+	OrgSettingsLoader OrgSettingsLoader
+	// OAuthClient is required when callers expect refresh-on-expiry to work:
+	// without ClientID + ClientSecret, GetValidToken returns
+	// ErrOAuthClientNotConfigured for any credential that has reached the
+	// refresh window. Tests that never exercise refresh can leave both
+	// fields zero; production must always populate from
+	// LINEAR_OAUTH_CLIENT_ID / LINEAR_OAUTH_CLIENT_SECRET.
+	OAuthClient OAuthClientCreds
+	// RefreshHTTPClient overrides the default HTTP client used for the
+	// /oauth/token POST. Tests inject a stubbed transport; production
+	// callers can leave nil to get the package default with
+	// refreshHTTPTimeout.
+	RefreshHTTPClient *http.Client
 	// Pool is used by HandleMilestone / HandleStateTransition to begin a tx
 	// for SELECT ... FOR UPDATE on the provider-state row, so two concurrent
 	// milestone events for the same link can't both create a rolling
@@ -334,12 +381,23 @@ func NewService(cfg Config) *Service {
 	if cache == nil {
 		cache = &teamKeyAllowlistCache{}
 	}
-	return &Service{
+	httpClient := cfg.RefreshHTTPClient
+	if httpClient == nil {
+		// Per-call timeout context wraps each request inside postLinearRefresh,
+		// so the http.Client itself doesn't need a global Timeout. Leaving
+		// Timeout zero lets the per-call deadline be the single source of
+		// truth and avoids a confusing "two timeouts compete" interaction.
+		httpClient = &http.Client{}
+	}
+	svc := &Service{
 		teamKeyCache:       cache,
 		logger:             cfg.Logger,
 		integrations:       cfg.Integrations,
 		integrationsWriter: cfg.IntegrationsWriter,
 		credentials:        cfg.Credentials,
+		credentialsWriter:  cfg.CredentialsWriter,
+		oauthClient:        cfg.OAuthClient,
+		refreshHTTPClient:  httpClient,
 		issues:             cfg.Issues,
 		links:              cfg.Links,
 		teamKeys:           cfg.TeamKeys,
@@ -351,6 +409,8 @@ func NewService(cfg Config) *Service {
 		pool:               cfg.Pool,
 		appBaseURL:         strings.TrimRight(cfg.AppBaseURL, "/"),
 	}
+	svc.refreshMuRegistry.Store(&sync.Map{})
+	return svc
 }
 
 // maxProviderStateLockedDuration bounds how long a single milestone or
@@ -514,33 +574,31 @@ func (s *Service) Enabled(ctx context.Context, orgID uuid.UUID) bool {
 // the wrap added by integrationFor.
 var ErrIntegrationNotFound = errors.New("linear integration not found")
 
-// integrationFor returns the integration row + linear access token for an
-// org. Both must be present for any read/write to Linear; if either is
-// missing, callers should treat it as a silent no-op.
+// integrationFor returns the integration row + a Linear access token that is
+// valid right now. It delegates to GetValidToken, which transparently
+// rotates the access token via the refresh-token flow when the cached token
+// is within refreshWindow of expiry.
+//
+// This is the single read-plus-refresh entry point that every service-layer
+// caller (RefreshTeamKeys, ResolvePrimary, mid-session linking, the
+// session-create inline path) routes through, so there is exactly one place
+// in the code where stale tokens become fresh tokens.
+//
+// Behavior on edge cases:
+//
+//   - Missing integration row: returns ErrIntegrationNotFound (wrapped).
+//   - Legacy connection without refresh-token fields: returns the cached token
+//     unchanged. The token works until Linear revokes it, at which point
+//     the caller's 401 path triggers MarkIntegrationUnauthorized and the
+//     user reconnects; the new connection captures a refresh token.
+//   - Refresh-token revoked: the refresh path zeroes the row's refresh
+//     token and flips the integration to errored, then returns
+//     ErrRefreshTokenRevoked. Callers should not retry.
+//   - Transient refresh failure (network blip, 5xx): returns the cached
+//     token if still inside its validity window; otherwise propagates the
+//     error so the caller can decide whether to retry.
 func (s *Service) integrationFor(ctx context.Context, orgID uuid.UUID) (models.Integration, string, error) {
-	integration, err := s.integrations.GetByOrgAndProvider(ctx, orgID, "linear")
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return models.Integration{}, "", fmt.Errorf("lookup linear integration: %w", ErrIntegrationNotFound)
-		}
-		return models.Integration{}, "", fmt.Errorf("lookup linear integration: %w", err)
-	}
-	cred, err := s.credentials.Get(ctx, orgID, models.ProviderLinear)
-	if err != nil {
-		return integration, "", fmt.Errorf("lookup linear credential: %w", err)
-	}
-	if cred == nil {
-		return integration, "", fmt.Errorf("linear credential not found")
-	}
-	cfg, ok := cred.Config.(models.LinearConfig)
-	if !ok {
-		// Include the observed concrete type so operators chasing this
-		// don't have to repro to find out what we got. Most common cause
-		// is a credential row that was written through the wrong provider
-		// path (e.g. GitHub config saved under a Linear credential).
-		return integration, "", fmt.Errorf("linear credential config is wrong type: got %T", cred.Config)
-	}
-	return integration, cfg.AccessToken, nil
+	return s.GetValidToken(ctx, orgID)
 }
 
 // TeamKeyAllowlist returns the org's cached team-key allowlist as a map for
@@ -615,19 +673,32 @@ func (s *Service) InvalidateTeamKeyCache(orgID uuid.UUID) {
 
 // RefreshTeamKeys pulls the team list from Linear and replaces the cache.
 // Called after OAuth install and on a 24h cron. Idempotent.
+//
+// The Linear-side read goes through withRefreshableClient so an expired
+// token rotates transparently and a 401 mid-call triggers exactly one
+// force-refresh + retry. The integration row is read up front (before
+// withRefreshableClient) because we need the integration ID to scope the
+// team-key replace; that read goes through GetValidToken too so a missing
+// integration short-circuits cleanly.
 func (s *Service) RefreshTeamKeys(ctx context.Context, orgID uuid.UUID) error {
-	integration, token, err := s.integrationFor(ctx, orgID)
+	integration, _, err := s.GetValidToken(ctx, orgID)
 	if err != nil {
 		return err
 	}
-	client, err := s.clientFactory(ctx, token)
+
+	var teams []TeamKeyInfo
+	err = s.withRefreshableClient(ctx, orgID, func(client Client) error {
+		got, listErr := client.ListTeamKeys(ctx)
+		if listErr != nil {
+			return fmt.Errorf("list linear team keys: %w", listErr)
+		}
+		teams = got
+		return nil
+	})
 	if err != nil {
-		return fmt.Errorf("build linear client: %w", err)
+		return err
 	}
-	teams, err := client.ListTeamKeys(ctx)
-	if err != nil {
-		return fmt.Errorf("list linear team keys: %w", err)
-	}
+
 	rows := make([]db.LinearTeamKey, 0, len(teams))
 	workspaceID := ""
 	for _, t := range teams {
@@ -672,18 +743,21 @@ func (s *Service) RefreshTeamKeys(ctx context.Context, orgID uuid.UUID) error {
 // a different workspace should expect URL-based detection to break for
 // historical references. Slug changes warrant an integration health note.
 func (s *Service) ResolvePrimary(ctx context.Context, orgID uuid.UUID, hit Detected) (*ResolvedIssue, error) {
-	integration, token, err := s.integrationFor(ctx, orgID)
+	integration, _, err := s.GetValidToken(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
-	client, err := s.clientFactory(ctx, token)
-	if err != nil {
-		return nil, fmt.Errorf("build linear client: %w", err)
-	}
 
-	fetched, err := client.FetchIssue(ctx, hit.Identifier)
-	if err != nil {
-		return nil, fmt.Errorf("fetch linear issue %q: %w", hit.Identifier, err)
+	var fetched *FetchedIssue
+	if err := s.withRefreshableClient(ctx, orgID, func(client Client) error {
+		got, fetchErr := client.FetchIssue(ctx, hit.Identifier)
+		if fetchErr != nil {
+			return fmt.Errorf("fetch linear issue %q: %w", hit.Identifier, fetchErr)
+		}
+		fetched = got
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	if hit.Workspace != "" && fetched.WorkspaceSlug != "" && !strings.EqualFold(hit.Workspace, fetched.WorkspaceSlug) {


### PR DESCRIPTION
Adds Linear OAuth refresh-token persistence and a refresh-aware token resolver so API, worker, and sandbox env paths use fresh LINEAR_ACCESS_TOKEN values instead of stale cached tokens. Handles proactive refresh, post-401 force refresh for read paths, per-org refresh serialization, revoked-token reconnect signaling, OAuth-client misconfiguration handling, and observability metrics. Keeps Linear OAuth authorization on documented scopes while still persisting refresh_token/expires_in from the token response, and treats known-expiring credentials without refresh tokens as reconnect-required. Validated with `go vet ./...`, `go build ./...`, and `go test ./...` using local Go caches under `.context`.