### PR TITLE
[codex] Queue messages during active turns

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2867,16 +2867,14 @@ export function SessionDetailContent({ id }: { id: string }) {
     () => comments.filter((comment) => !comment.resolved).slice(0, MAX_RESOLVE_REVIEW_COMMENTS_PER_MESSAGE),
     [comments],
   );
-  // Composer gating: per the design (docs/design/implemented/68-sandbox-agent-tabs-and-threads.md),
-  // Phase 2 supports concurrent threads in one sandbox. The composer is locked
-  // only while the *selected* thread is running — sibling threads being active
-  // (which makes session.status === "running") must not block sending into an
-  // idle thread, since the backend admits concurrent sends up to the per-session
-  // running cap. Pending/skipped/destroyed at the session level still block.
+  // Composer gating: messages may be sent at any point while the session or
+  // thread is running. The backend queues mid-turn sends and the orchestrator
+  // drains the queue once the in-flight turn completes. Pending/skipped at
+  // the session level and a destroyed sandbox still block — those are
+  // genuinely unrecoverable, not just busy.
   const composerCanSendMessage = session?.status !== "skipped" &&
     session?.status !== "pending" &&
-    session?.sandbox_state !== "destroyed" &&
-    (!activeThread || activeThread.status === "idle");
+    session?.sandbox_state !== "destroyed";
   const composerIsRunning = activeThread ? activeThread.status === "running" : session?.status === "running";
   const composerIsSnapshotExpired = session?.sandbox_state === "destroyed";
   const composerAgentType = activeThread?.agent_type ?? session?.agent_type ?? "codex";

--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -634,25 +634,37 @@ func TestSessionThreadHandler_SendThreadMessage(t *testing.T) {
 			expectedError: "NOT_FOUND",
 		},
 		{
-			name:           "thread not idle",
+			// Sending to a thread that is mid-turn now succeeds: the message
+			// is queued (created + pending_message_count incremented) and
+			// will be picked up when the in-flight turn completes. The
+			// composer never sees a NOT_IDLE bounce.
+			name:           "thread busy queues without enqueue",
 			sessionIDParam: sessionID.String(),
 			threadIDParam:  threadID.String(),
-			body:           `{"message":"continue"}`,
+			body:           `{"message":"please continue"}`,
 			setupDeps: func(deps *threadTestDeps) {
 				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{}, fmt.Errorf("no rows")
 				}
 				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{
-						ID:        threadID,
-						SessionID: sessionID,
-						OrgID:     orgID,
-						Status:    models.ThreadStatusRunning,
+						ID:          threadID,
+						SessionID:   sessionID,
+						OrgID:       orgID,
+						Status:      models.ThreadStatusRunning,
+						CurrentTurn: 1,
 					}, nil
 				}
+				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					msg.ID = 42
+					return nil
+				}
+				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+					t.Fatalf("queue-only path must not enqueue")
+					return uuid.UUID{}, nil
+				}
 			},
-			expectedCode:  http.StatusConflict,
-			expectedError: "NOT_IDLE",
+			expectedCode: http.StatusCreated,
 		},
 		{
 			name:           "enqueue failure",

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -329,6 +329,10 @@ type SessionThreadStore interface {
 	UpdateStatus(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
 	CompleteTurn(ctx context.Context, orgID, threadID uuid.UUID, turnNumber int, agentSessionID string) error
 	UpdateResult(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus, result *models.SessionResult) error
+	// ClearPendingMessages resets the queued-message counter once the
+	// orchestrator has re-enqueued a continue_session to drain the queue.
+	// Called from drainQueuedMessages after the in-flight turn completes.
+	ClearPendingMessages(ctx context.Context, orgID, threadID uuid.UUID) error
 }
 
 type SessionIssueLinkStore interface {
@@ -849,6 +853,53 @@ func latestUserMessage(messages []models.SessionMessage) *models.SessionMessage 
 		}
 	}
 	return nil
+}
+
+// unprocessedUserMessages returns the consecutive trailing user messages for
+// a given thread scope — i.e. all user messages after the most recent
+// in-scope assistant message. When threadID is nil the scope is the
+// session-level conversation (messages with no thread); when threadID is
+// non-nil the scope is that specific thread.
+//
+// Used by ContinueSession to bundle rapid-fire mid-turn user sends into a
+// single agent invocation. Without this, the orchestrator processes only
+// the very latest user message and silently drops earlier queued ones.
+// Returned messages are in oldest-first order.
+func unprocessedUserMessages(messages []models.SessionMessage, threadID *uuid.UUID) []models.SessionMessage {
+	return unprocessedUserMessagesThrough(messages, threadID, 1<<63-1)
+}
+
+// unprocessedUserMessagesThrough is the boundary-aware form used when a later
+// assistant message may already exist in the timeline. Mid-turn queued user
+// rows are inserted before the in-flight turn's assistant row; when the drain
+// job starts, that assistant must not hide the queued users.
+func unprocessedUserMessagesThrough(messages []models.SessionMessage, threadID *uuid.UUID, latestUserMessageID int64) []models.SessionMessage {
+	matchesScope := func(m models.SessionMessage) bool {
+		if threadID == nil {
+			return m.ThreadID == nil
+		}
+		return m.ThreadID != nil && *m.ThreadID == *threadID
+	}
+	var pending []models.SessionMessage
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.ID > latestUserMessageID {
+			continue
+		}
+		if !matchesScope(m) {
+			continue
+		}
+		if m.Role == models.MessageRoleAssistant {
+			break
+		}
+		if m.Role == models.MessageRoleUser {
+			pending = append(pending, m)
+		}
+	}
+	for i, j := 0, len(pending)-1; i < j; i, j = i+1, j-1 {
+		pending[i], pending[j] = pending[j], pending[i]
+	}
+	return pending
 }
 
 func canonicalReferences(message *models.SessionMessage) []models.SessionInputReference {
@@ -2043,14 +2094,29 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("no user message found")
 	}
 	threadID := latestMsg.ThreadID
-	userMessage := latestMsg.Content
-	var planMode bool
-
-	// Detect plan mode prefix and strip it, wrapping with plan instructions.
+	// Bundle every trailing user message in scope into the prompt seed so
+	// rapid mid-turn sends are all delivered to the agent. The latest
+	// message remains the "carrier" for thread_id, references, and
+	// plan-mode detection — earlier queued messages contribute only their
+	// text content. When only a single user message is unprocessed, this
+	// reduces to the legacy single-message behavior.
 	const planModePrefix = "[PLAN_MODE]\n"
-	if strings.HasPrefix(userMessage, planModePrefix) {
-		planMode = true
-		originalMessage := strings.TrimPrefix(userMessage, planModePrefix)
+	pendingMsgs := unprocessedUserMessagesThrough(messages, threadID, latestMsg.ID)
+	planMode := strings.HasPrefix(latestMsg.Content, planModePrefix)
+	var userMessage string
+	if len(pendingMsgs) <= 1 {
+		userMessage = strings.TrimPrefix(latestMsg.Content, planModePrefix)
+	} else {
+		var sb strings.Builder
+		for i, m := range pendingMsgs {
+			if i > 0 {
+				sb.WriteString("\n\n---\n\n")
+			}
+			sb.WriteString(strings.TrimPrefix(m.Content, planModePrefix))
+		}
+		userMessage = sb.String()
+	}
+	if planMode {
 		userMessage = "You are in PLAN MODE. Instead of making changes directly, create a detailed implementation plan for the following request. Describe:\n" +
 			"1. What files need to be changed and why\n" +
 			"2. What specific changes are needed in each file\n" +
@@ -2058,7 +2124,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			"4. Any potential risks or considerations\n\n" +
 			"Do NOT make any file changes or use any tools that modify files. Only output the plan as a structured markdown response. " +
 			"The user will review the plan and either approve it or request adjustments before you proceed.\n\n" +
-			"User's request:\n" + originalMessage
+			"User's request:\n" + userMessage
 	}
 	_ = planMode // used by adapters that support explicit plan mode
 	revisionContext, revErr := ParseRevisionContext(session.RevisionContext)
@@ -2396,6 +2462,15 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	if o.usageTracker != nil {
 		usageEventID = o.usageTracker.ContainerStarted(ctx, session.OrgID, session.ID, sandbox, sandboxCfg, containerStartedAt)
 	}
+	drainAfterRelease := false
+	defer func() {
+		if !drainAfterRelease {
+			return
+		}
+		drainCtx, drainCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer drainCancel()
+		o.drainQueuedMessages(drainCtx, session, latestMsg, threadID, log)
+	}()
 	defer func() {
 		exitReason := containerExitReason(ctx, err)
 		if o.usageTracker != nil {
@@ -2684,6 +2759,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		if wasCancelled || (stopReason == StopReasonNone && errors.Is(ctx.Err(), context.Canceled)) {
 			log.Info().Msg("session cancelled by user during continue")
 			o.handleCancelledSession(ctx, session, sandbox, result, turnNumber, log)
+			drainAfterRelease = true
 			return fmt.Errorf("session cancelled: %w", ctx.Err())
 		}
 		if stopReason != StopReasonNone {
@@ -2704,6 +2780,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	if wasCancelled {
 		log.Info().Msg("agent exited after cancel during continue, returning to idle")
 		o.handleCancelledSession(ctx, session, sandbox, result, turnNumber, log)
+		drainAfterRelease = true
 		return nil
 	}
 	if stopReason != StopReasonNone {
@@ -2768,8 +2845,119 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("update turn complete: %w", err)
 	}
 
+	drainAfterRelease = true
+
 	log.Info().Int("turn", turnNumber).Msg("session turn completed, now idle")
 	return nil
+}
+
+// drainQueuedMessages re-enqueues a continue_session when a user message
+// arrived during the just-completed turn. Mid-turn sends are accepted by
+// both the session-level fast path (sessions.go) and the thread service's
+// queue-only path (thread/service.go); without this drain those messages
+// would sit in the database with no agent picking them up.
+//
+// Called from both the success path and the cancel-back-to-idle path of
+// ContinueSession. The session's current status is re-fetched so a drain
+// from the cancel path that ended up terminal (snapshot failed → cancelled)
+// does not enqueue a job the worker would just refuse. All failure modes
+// are logged-only because the next user-triggered send will pick up the
+// queued message anyway.
+func (o *Orchestrator) drainQueuedMessages(ctx context.Context, session *models.Session, processed *models.SessionMessage, threadID *uuid.UUID, log zerolog.Logger) {
+	if processed == nil || o.jobs == nil || o.sessionMessages == nil {
+		return
+	}
+	messages, err := o.sessionMessages.ListBySession(ctx, session.OrgID, session.ID)
+	if err != nil {
+		log.Warn().Err(err).Msg("failed to fetch messages for post-turn queue drain")
+		return
+	}
+	hasQueued := false
+	for _, m := range messages {
+		if m.Role != models.MessageRoleUser || m.ID <= processed.ID {
+			continue
+		}
+		// On the thread path, a queued message is bound to the same thread —
+		// we drain only the matching thread's queue. On the session path
+		// threadID is nil and we accept any user message that matches the
+		// session-level scope (no thread).
+		if threadID != nil {
+			if m.ThreadID == nil || *m.ThreadID != *threadID {
+				continue
+			}
+		} else if m.ThreadID != nil {
+			continue
+		}
+		hasQueued = true
+		break
+	}
+	if !hasQueued {
+		return
+	}
+
+	// Confirm the session is in a state that can accept another turn before
+	// enqueueing. Skipping the GetByID would still be safe (the worker would
+	// refuse a job for a terminal session), but it would create a noisy
+	// dead-letter trail on every cancelled run that left the session marked
+	// failed/cancelled.
+	current, getErr := o.sessions.GetByID(ctx, session.OrgID, session.ID)
+	if getErr != nil {
+		log.Warn().Err(getErr).Msg("failed to fetch session for queue drain status check")
+		return
+	}
+	if !drainAcceptableStatus(current.Status) {
+		return
+	}
+
+	if threadID != nil && o.sessionThreads != nil {
+		if err := o.sessionThreads.ClearPendingMessages(ctx, session.OrgID, *threadID); err != nil {
+			log.Warn().Err(err).Str("thread_id", threadID.String()).Msg("failed to clear pending_message_count after drain")
+		}
+	}
+	payload := map[string]string{
+		"session_id": session.ID.String(),
+		"org_id":     session.OrgID.String(),
+	}
+	if threadID != nil {
+		payload["thread_id"] = threadID.String()
+	}
+	dedupeKey := continueSessionDrainDedupeKey(session.ID, processed.ID)
+	if _, err := o.jobs.Enqueue(ctx, session.OrgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
+		log.Warn().Err(err).Msg("failed to enqueue continue_session for queued messages")
+	}
+}
+
+// drainAcceptableStatus returns true for session states that can absorb
+// another continue_session turn: running (the in-flight job will pick the
+// queued message up via latest-message reads) and idle (a fresh
+// continue_session can claim it). Terminal states are skipped — a queued
+// message after a failed/cancelled session waits for the user to take an
+// explicit action.
+func drainAcceptableStatus(status string) bool {
+	switch status {
+	case string(models.SessionStatusIdle),
+		string(models.SessionStatusRunning),
+		string(models.SessionStatusAwaitingInput),
+		string(models.SessionStatusNeedsHumanGuidance):
+		return true
+	}
+	return false
+}
+
+// continueSessionDedupeKey mirrors db.ContinueSessionDedupeKey. The agent
+// package deliberately avoids importing the db package; this helper keeps
+// the dedupe-key shape in lockstep without taking on the dependency. Keep
+// these two definitions identical or the dedupe will silently break.
+func continueSessionDedupeKey(sessionID uuid.UUID) string {
+	return "continue_session:" + sessionID.String()
+}
+
+// continueSessionDrainDedupeKey intentionally differs from
+// continueSessionDedupeKey because drainQueuedMessages runs while the current
+// continue_session job is still in status='running'. Reusing the active key
+// would hit the jobs dedupe index and turn the enqueue into a no-op.
+func continueSessionDrainDedupeKey(sessionID uuid.UUID, processedMessageID int64) string {
+	return fmt.Sprintf("continue_session_drain:%s:%d", sessionID.String(), processedMessageID)
 }
 
 // setupFreshSandbox clones the session's repository into the sandbox when no

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -1,0 +1,318 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
+)
+
+// drainStubMessages is a minimal SessionMessageStore stub for drain tests.
+// The orchestrator's drain only calls ListBySession.
+type drainStubMessages struct {
+	messages []models.SessionMessage
+	err      error
+}
+
+func (s *drainStubMessages) Create(context.Context, *models.SessionMessage) error {
+	return nil
+}
+
+func (s *drainStubMessages) ListBySession(context.Context, uuid.UUID, uuid.UUID) ([]models.SessionMessage, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.messages, nil
+}
+
+// drainStubSessions returns a configurable session row from GetByID. The
+// drain only consults GetByID; the rest of the SessionStore surface is
+// stubbed with zero values.
+type drainStubSessions struct {
+	session models.Session
+	err     error
+}
+
+func (s *drainStubSessions) GetByID(context.Context, uuid.UUID, uuid.UUID) (models.Session, error) {
+	if s.err != nil {
+		return models.Session{}, s.err
+	}
+	return s.session, nil
+}
+
+// All other SessionStore methods are no-op zero-returning stubs; the drain
+// path never calls them.
+func (s *drainStubSessions) UpdateStatus(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateResult(context.Context, uuid.UUID, uuid.UUID, string, *models.SessionResult) error {
+	return nil
+}
+func (s *drainStubSessions) CountRunningByOrg(context.Context, uuid.UUID) (int, error) {
+	return 0, nil
+}
+func (s *drainStubSessions) UpdateTurnComplete(context.Context, uuid.UUID, uuid.UUID, int, *models.SessionResult, string, string) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateSnapshotInfo(context.Context, uuid.UUID, uuid.UUID, string, string) error {
+	return nil
+}
+func (s *drainStubSessions) BeginRuntime(context.Context, uuid.UUID, uuid.UUID, models.CheckpointCapability, time.Time, time.Time, time.Time) error {
+	return nil
+}
+func (s *drainStubSessions) RecordRuntimeProgress(context.Context, uuid.UUID, uuid.UUID, models.RuntimeProgressType, models.RuntimeProgressStrength, time.Time) error {
+	return nil
+}
+func (s *drainStubSessions) GrantRuntimeExtension(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Time, time.Time, time.Time, int) (bool, error) {
+	return false, nil
+}
+func (s *drainStubSessions) PublishCheckpoint(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, string, models.CheckpointKind, models.CheckpointCapability, int64, time.Time, *string, models.RuntimeStopReason) (bool, error) {
+	return false, nil
+}
+func (s *drainStubSessions) UpdateRecoveryState(context.Context, uuid.UUID, uuid.UUID, models.RecoveryState, *time.Time, *time.Time, bool) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateSandboxState(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateWorkingBranch(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateBaseCommitSHA(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (s *drainStubSessions) SetGitIdentity(context.Context, uuid.UUID, uuid.UUID, string, *uuid.UUID) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateFailure(context.Context, uuid.UUID, uuid.UUID, string, string, []string, bool) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateTitle(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+func (s *drainStubSessions) UpdateRevisionContext(context.Context, uuid.UUID, uuid.UUID, []byte) error {
+	return nil
+}
+func (s *drainStubSessions) AcquireTurnHold(context.Context, uuid.UUID, uuid.UUID, string) (string, error) {
+	return "", nil
+}
+func (s *drainStubSessions) SetWorkerNodeIDForContainer(context.Context, uuid.UUID, uuid.UUID, string, string) error {
+	return nil
+}
+func (s *drainStubSessions) ReleaseTurnHold(context.Context, uuid.UUID, uuid.UUID) (bool, string, error) {
+	return false, "", nil
+}
+func (s *drainStubSessions) FinalizeContainerDestroy(context.Context, uuid.UUID, uuid.UUID, string) (bool, error) {
+	return false, nil
+}
+func (s *drainStubSessions) ClearContainerID(context.Context, uuid.UUID, uuid.UUID, string) (bool, error) {
+	return false, nil
+}
+func (s *drainStubSessions) ContainerHoldState(context.Context, uuid.UUID, uuid.UUID, string) (bool, bool, error) {
+	return false, false, nil
+}
+
+// drainStubJobs records every continue_session enqueue so tests can assert
+// whether the drain fired and inspect the payload.
+type drainStubJobs struct {
+	enqueues []drainStubEnqueue
+	err      error
+}
+
+type drainStubEnqueue struct {
+	queue     string
+	jobType   string
+	payload   any
+	dedupeKey string
+}
+
+func (j *drainStubJobs) Enqueue(_ context.Context, _ uuid.UUID, queue, jobType string, payload any, _ int, dedupeKey *string) (uuid.UUID, error) {
+	if j.err != nil {
+		return uuid.Nil, j.err
+	}
+	key := ""
+	if dedupeKey != nil {
+		key = *dedupeKey
+	}
+	j.enqueues = append(j.enqueues, drainStubEnqueue{
+		queue:     queue,
+		jobType:   jobType,
+		payload:   payload,
+		dedupeKey: key,
+	})
+	return uuid.New(), nil
+}
+
+func (j *drainStubJobs) OldestPendingSessionJobAge(context.Context) (time.Duration, bool, error) {
+	return 0, false, nil
+}
+
+// drainStubThreads records ClearPendingMessages calls so tests can assert
+// the counter is reset whenever a queued thread message is drained.
+type drainStubThreads struct {
+	clearedThreadIDs []uuid.UUID
+	clearErr         error
+}
+
+func (t *drainStubThreads) UpdateStatus(context.Context, uuid.UUID, uuid.UUID, models.ThreadStatus) error {
+	return nil
+}
+func (t *drainStubThreads) CompleteTurn(context.Context, uuid.UUID, uuid.UUID, int, string) error {
+	return nil
+}
+func (t *drainStubThreads) UpdateResult(context.Context, uuid.UUID, uuid.UUID, models.ThreadStatus, *models.SessionResult) error {
+	return nil
+}
+func (t *drainStubThreads) ClearPendingMessages(_ context.Context, _, threadID uuid.UUID) error {
+	if t.clearErr != nil {
+		return t.clearErr
+	}
+	t.clearedThreadIDs = append(t.clearedThreadIDs, threadID)
+	return nil
+}
+
+func newDrainOrchestrator(messages *drainStubMessages, sessions *drainStubSessions, jobs *drainStubJobs, threads *drainStubThreads) *Orchestrator {
+	o := &Orchestrator{
+		sessionMessages: messages,
+		sessions:        sessions,
+		jobs:            jobs,
+		logger:          zerolog.Nop(),
+	}
+	if threads != nil {
+		o.sessionThreads = threads
+	}
+	return o
+}
+
+func TestDrainQueuedMessages_NoNewerMessages(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	processed := &models.SessionMessage{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser}
+
+	messages := &drainStubMessages{messages: []models.SessionMessage{
+		{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser},
+	}}
+	sessions := &drainStubSessions{session: models.Session{Status: "idle"}}
+	jobs := &drainStubJobs{}
+	o := newDrainOrchestrator(messages, sessions, jobs, nil)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, nil, zerolog.Nop())
+
+	require.Empty(t, jobs.enqueues, "drain must not enqueue when no message is newer than the processed one")
+}
+
+func TestDrainQueuedMessages_EnqueuesForSessionScope(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	processed := &models.SessionMessage{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser}
+
+	messages := &drainStubMessages{messages: []models.SessionMessage{
+		{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser},
+		{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, Content: "queued"},
+	}}
+	sessions := &drainStubSessions{session: models.Session{Status: "idle"}}
+	jobs := &drainStubJobs{}
+	o := newDrainOrchestrator(messages, sessions, jobs, nil)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, nil, zerolog.Nop())
+
+	require.Len(t, jobs.enqueues, 1, "drain must enqueue continue_session when a newer user message exists")
+	require.Equal(t, "agent", jobs.enqueues[0].queue)
+	require.Equal(t, "continue_session", jobs.enqueues[0].jobType)
+	require.Equal(t, continueSessionDrainDedupeKey(sessionID, processed.ID), jobs.enqueues[0].dedupeKey,
+		"drain must not reuse the active continue_session dedupe key while that job is still running")
+	payload, ok := jobs.enqueues[0].payload.(map[string]string)
+	require.True(t, ok, "payload should be string-keyed")
+	require.Equal(t, sessionID.String(), payload["session_id"])
+	_, hasThread := payload["thread_id"]
+	require.False(t, hasThread, "session-scope drain must not include a thread_id")
+}
+
+func TestDrainQueuedMessages_ThreadScopeIgnoresOtherThreads(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadA := uuid.New()
+	threadB := uuid.New()
+	processed := &models.SessionMessage{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadA}
+
+	messages := &drainStubMessages{messages: []models.SessionMessage{
+		{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadA},
+		{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadB, Content: "other thread"},
+	}}
+	sessions := &drainStubSessions{session: models.Session{Status: "idle"}}
+	jobs := &drainStubJobs{}
+	threads := &drainStubThreads{}
+	o := newDrainOrchestrator(messages, sessions, jobs, threads)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, &threadA, zerolog.Nop())
+
+	require.Empty(t, jobs.enqueues, "drain must ignore newer messages on a different thread")
+	require.Empty(t, threads.clearedThreadIDs, "no clear should fire when there is nothing to drain")
+}
+
+func TestDrainQueuedMessages_ThreadScopeClearsAndEnqueues(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadA := uuid.New()
+	processed := &models.SessionMessage{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadA}
+
+	messages := &drainStubMessages{messages: []models.SessionMessage{
+		{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadA},
+		{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, ThreadID: &threadA, Content: "queued"},
+	}}
+	sessions := &drainStubSessions{session: models.Session{Status: "idle"}}
+	jobs := &drainStubJobs{}
+	threads := &drainStubThreads{}
+	o := newDrainOrchestrator(messages, sessions, jobs, threads)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, &threadA, zerolog.Nop())
+
+	require.Equal(t, []uuid.UUID{threadA}, threads.clearedThreadIDs, "pending_message_count must be cleared for the drained thread")
+	require.Len(t, jobs.enqueues, 1, "thread-scope drain must enqueue continue_session")
+	payload := jobs.enqueues[0].payload.(map[string]string)
+	require.Equal(t, threadA.String(), payload["thread_id"], "thread-scope drain must propagate thread_id")
+}
+
+func TestDrainQueuedMessages_SkipsTerminalSessionStatus(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	processed := &models.SessionMessage{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser}
+
+	messages := &drainStubMessages{messages: []models.SessionMessage{
+		{ID: 5, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser},
+		{ID: 6, OrgID: orgID, SessionID: sessionID, Role: models.MessageRoleUser, Content: "queued"},
+	}}
+	sessions := &drainStubSessions{session: models.Session{Status: "failed"}}
+	jobs := &drainStubJobs{}
+	o := newDrainOrchestrator(messages, sessions, jobs, nil)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{ID: sessionID, OrgID: orgID}, processed, nil, zerolog.Nop())
+
+	require.Empty(t, jobs.enqueues, "drain must skip enqueue when the session has reached a terminal status")
+}
+
+func TestDrainQueuedMessages_NilProcessedNoOp(t *testing.T) {
+	t.Parallel()
+
+	jobs := &drainStubJobs{}
+	o := newDrainOrchestrator(&drainStubMessages{}, &drainStubSessions{}, jobs, nil)
+
+	o.drainQueuedMessages(context.Background(), &models.Session{}, nil, nil, zerolog.Nop())
+
+	require.Empty(t, jobs.enqueues, "drain must no-op when no message was processed")
+}

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -74,6 +74,96 @@ func TestLatestUserMessage(t *testing.T) {
 	require.Equal(t, "latest user", message.Content, "latestUserMessage should scan from newest to oldest")
 }
 
+func TestUnprocessedUserMessages_SessionScope(t *testing.T) {
+	t.Parallel()
+
+	// Trailing user messages with no thread are returned in chronological
+	// order; messages preceding the most recent assistant are excluded.
+	pending := unprocessedUserMessages([]models.SessionMessage{
+		{Role: models.MessageRoleUser, Content: "old (already processed)"},
+		{Role: models.MessageRoleAssistant, Content: "assistant reply"},
+		{Role: models.MessageRoleUser, Content: "queued one"},
+		{Role: models.MessageRoleUser, Content: "queued two"},
+	}, nil)
+
+	require.Len(t, pending, 2, "should return only messages after the latest in-scope assistant")
+	require.Equal(t, "queued one", pending[0].Content, "should be oldest-first")
+	require.Equal(t, "queued two", pending[1].Content)
+}
+
+func TestUnprocessedUserMessages_ThreadScope(t *testing.T) {
+	t.Parallel()
+
+	threadA := uuid.New()
+	threadB := uuid.New()
+
+	// Thread B's activity (its own user + assistant exchange) sits between
+	// the two thread-A user messages, but it must not break the thread-A
+	// scan: cross-thread messages are skipped, and only a same-thread
+	// assistant terminates the trailing window.
+	pending := unprocessedUserMessages([]models.SessionMessage{
+		{Role: models.MessageRoleUser, Content: "A first", ThreadID: &threadA},
+		{Role: models.MessageRoleAssistant, Content: "A reply", ThreadID: &threadA},
+		{Role: models.MessageRoleUser, Content: "B prompt", ThreadID: &threadB},
+		{Role: models.MessageRoleAssistant, Content: "B reply", ThreadID: &threadB},
+		{Role: models.MessageRoleUser, Content: "A queued one", ThreadID: &threadA},
+		{Role: models.MessageRoleUser, Content: "A queued two", ThreadID: &threadA},
+	}, &threadA)
+
+	require.Len(t, pending, 2, "thread-scoped scan should ignore cross-thread activity")
+	require.Equal(t, "A queued one", pending[0].Content)
+	require.Equal(t, "A queued two", pending[1].Content)
+}
+
+func TestUnprocessedUserMessages_IgnoresAssistantAfterLatestUserBoundary(t *testing.T) {
+	t.Parallel()
+
+	threadID := uuid.New()
+	latestQueuedUserID := int64(12)
+
+	pending := unprocessedUserMessagesThrough([]models.SessionMessage{
+		{ID: 9, Role: models.MessageRoleAssistant, Content: "previous reply", ThreadID: &threadID},
+		{ID: 10, Role: models.MessageRoleUser, Content: "queued one", ThreadID: &threadID},
+		{ID: 11, Role: models.MessageRoleUser, Content: "queued two", ThreadID: &threadID},
+		{ID: latestQueuedUserID, Role: models.MessageRoleUser, Content: "queued three", ThreadID: &threadID},
+		{ID: 13, Role: models.MessageRoleAssistant, Content: "reply from the in-flight turn", ThreadID: &threadID},
+	}, &threadID, latestQueuedUserID)
+
+	require.Equal(t, []models.SessionMessage{
+		{ID: 10, Role: models.MessageRoleUser, Content: "queued one", ThreadID: &threadID},
+		{ID: 11, Role: models.MessageRoleUser, Content: "queued two", ThreadID: &threadID},
+		{ID: latestQueuedUserID, Role: models.MessageRoleUser, Content: "queued three", ThreadID: &threadID},
+	}, pending, "queued users before a later assistant should all be delivered to the next turn")
+}
+
+func TestUnprocessedUserMessages_NoMessages(t *testing.T) {
+	t.Parallel()
+
+	require.Empty(t, unprocessedUserMessages(nil, nil), "nil input returns empty")
+	require.Empty(t, unprocessedUserMessages([]models.SessionMessage{
+		{Role: models.MessageRoleAssistant, Content: "no trailing user"},
+	}, nil), "no trailing user message returns empty")
+}
+
+func TestDrainAcceptableStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{"idle", "running", "awaiting_input", "needs_human_guidance"} {
+		require.True(t, drainAcceptableStatus(status), "status %q should accept a drain enqueue", status)
+	}
+	for _, status := range []string{"completed", "failed", "cancelled", "skipped", "pr_created", "pending", ""} {
+		require.False(t, drainAcceptableStatus(status), "status %q should not accept a drain enqueue", status)
+	}
+}
+
+func TestContinueSessionDedupeKey(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.MustParse("00000000-0000-0000-0000-000000000abc")
+	require.Equal(t, "continue_session:"+id.String(), continueSessionDedupeKey(id),
+		"local helper must mirror db.ContinueSessionDedupeKey verbatim")
+}
+
 func TestCanonicalReferences_FiltersInvalidEntries(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -237,6 +237,10 @@ type mockSessionStore struct {
 	containerHoldingPages [][]models.Session
 	containerHoldingErr   error
 	containerHoldingCalls int
+
+	// getByIDFn lets individual tests stub the session row that drain and
+	// other helpers query for status. Defaults to an empty Session when nil.
+	getByIDFn func(orgID, sessionID uuid.UUID) (models.Session, error)
 }
 
 type failureUpdate struct {
@@ -447,6 +451,11 @@ func (m *mockSessionStore) UpdateFailure(ctx context.Context, orgID, runID uuid.
 }
 
 func (m *mockSessionStore) GetByID(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.getByIDFn != nil {
+		return m.getByIDFn(orgID, sessionID)
+	}
 	return models.Session{}, nil
 }
 
@@ -980,6 +989,10 @@ func (m *mockSessionThreadStore) CompleteTurn(_ context.Context, _, _ uuid.UUID,
 }
 
 func (m *mockSessionThreadStore) UpdateResult(_ context.Context, _, _ uuid.UUID, _ models.ThreadStatus, _ *models.SessionResult) error {
+	return nil
+}
+
+func (m *mockSessionThreadStore) ClearPendingMessages(_ context.Context, _, _ uuid.UUID) error {
 	return nil
 }
 

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -357,6 +357,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	}
 
 	thread, err := s.threadStore.ClaimIdleForSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
+	queueOnly := false
 	if err != nil {
 		if errors.Is(err, db.ErrThreadRunningLimitReached) {
 			return nil, ErrRunningLimitReached
@@ -369,16 +370,29 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		if existing.SessionID != input.SessionID {
 			return nil, ErrThreadNotFound
 		}
-		// The target tab itself is busy with its own turn. The composer
-		// should fall back to queueing — we cannot interleave two turns on
-		// one thread.
-		return nil, ErrThreadNotIdle
+		// The thread itself is busy with its own turn. Queue the message
+		// against the busy thread; the orchestrator drains pending messages
+		// when the in-flight turn completes (see ContinueSession). Resolving
+		// review comments while the thread is mid-turn is not supported —
+		// the resolution pass is keyed on the in-flight turn's pass number,
+		// and we cannot atomically commit it alongside a queued message
+		// that will not be consumed until a later turn.
+		if resolvingComments {
+			return nil, ErrThreadNotIdle
+		}
+		if !threadStatusCanQueue(existing.Status) {
+			return nil, ErrThreadNotIdle
+		}
+		thread = existing
+		queueOnly = true
 	}
 
 	// Verify thread belongs to the session.
 	if thread.SessionID != input.SessionID {
-		if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after session mismatch")
+		if !queueOnly {
+			if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
+				s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after session mismatch")
+			}
 		}
 		return nil, ErrThreadNotFound
 	}
@@ -388,12 +402,19 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	// records the pre-claim status so revertAfterSendFailure can put the
 	// session back exactly where it was; an empty string signals "do not
 	// touch the session" (sibling-running case).
-	claimedSession, revertStatus, claimErr := s.claimSessionForSend(ctx, input.OrgID, input.SessionID)
-	if claimErr != nil {
-		if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-			s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after parent session claim failure")
+	// Skipped on the queue-only path: the thread is already running, which
+	// already implies the session is running.
+	var claimedSession models.Session
+	revertStatus := ""
+	if !queueOnly {
+		var claimErr error
+		claimedSession, revertStatus, claimErr = s.claimSessionForSend(ctx, input.OrgID, input.SessionID)
+		if claimErr != nil {
+			if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
+				s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after parent session claim failure")
+			}
+			return nil, claimErr
 		}
-		return nil, claimErr
 	}
 
 	content := input.Message
@@ -401,12 +422,21 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		content = "[PLAN_MODE]\n" + content
 	}
 
+	// On the queue-only path the thread is mid-turn, so its in-flight turn is
+	// CurrentTurn+1 and the queued message belongs to the turn after that
+	// (CurrentTurn+2). For the normal claim path, the thread just transitioned
+	// to running and this turn is CurrentTurn+1.
+	turnNumber := thread.CurrentTurn + 1
+	if queueOnly {
+		turnNumber = thread.CurrentTurn + 2
+	}
+
 	msg := &models.SessionMessage{
 		SessionID:  thread.SessionID,
 		OrgID:      input.OrgID,
 		ThreadID:   &input.ThreadID,
 		UserID:     input.UserID,
-		TurnNumber: thread.CurrentTurn + 1,
+		TurnNumber: turnNumber,
 		Role:       models.MessageRoleUser,
 		Content:    content,
 		References: input.References,
@@ -432,7 +462,9 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		err = s.messageStore.Create(ctx, msg)
 	}
 	if err != nil {
-		s.revertAfterSendFailure(ctx, input.OrgID, input.SessionID, input.ThreadID, revertStatus, "message creation failure")
+		if !queueOnly {
+			s.revertAfterSendFailure(ctx, input.OrgID, input.SessionID, input.ThreadID, revertStatus, "message creation failure")
+		}
 		// Comment-validation errors are surfaced verbatim so the handler can
 		// match on *db.ErrReviewCommentsNotInSession; everything else gets
 		// wrapped with a "create message" prefix to preserve historical log
@@ -442,6 +474,22 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 			return nil, err
 		}
 		return nil, fmt.Errorf("create message: %w", err)
+	}
+
+	// Queue-only path: bump pending_message_count so the UI's "queued (N)"
+	// affordance reflects the buildup, then return without enqueueing a new
+	// continue_session — the in-flight job will drain the queue when it
+	// finishes (see ContinueSession's post-turn drain).
+	if queueOnly {
+		if incErr := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); incErr != nil {
+			s.logger.Warn().Err(incErr).
+				Str("thread_id", input.ThreadID.String()).
+				Msg("failed to increment pending_message_count for queued message")
+		}
+		return &SendMessageResult{
+			Message:          msg,
+			ResolvedComments: resolvedComments,
+		}, nil
 	}
 
 	// Reuse the session continuation worker for phase 1. The latest user
@@ -473,6 +521,15 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		ResolvedComments: resolvedComments,
 		AnsweredQuestion: answeredQuestion,
 	}, nil
+}
+
+func threadStatusCanQueue(status models.ThreadStatus) bool {
+	switch status {
+	case models.ThreadStatusPending, models.ThreadStatusRunning:
+		return true
+	default:
+		return false
+	}
 }
 
 // claimSessionForSend mirrors the ClaimIdle → ClaimForResume → fail ordering

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -18,11 +18,12 @@ import (
 // --- Mock stores ---
 
 type mockThreadStore struct {
-	createFn        func(ctx context.Context, t *models.SessionThread, max int) error
-	getByIDFn       func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
-	listBySessionFn func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
-	claimIdleFn     func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
-	updateStatusFn  func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
+	createFn           func(ctx context.Context, t *models.SessionThread, max int) error
+	getByIDFn          func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
+	listBySessionFn    func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
+	claimIdleFn        func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
+	updateStatusFn     func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
+	incrementPendingFn func(ctx context.Context, orgID, threadID uuid.UUID) error
 }
 
 func (m *mockThreadStore) Create(ctx context.Context, t *models.SessionThread, max int) error {
@@ -61,6 +62,9 @@ func (m *mockThreadStore) UpdateStatus(ctx context.Context, orgID, threadID uuid
 }
 
 func (m *mockThreadStore) IncrementPendingMessages(ctx context.Context, orgID, threadID uuid.UUID) error {
+	if m.incrementPendingFn != nil {
+		return m.incrementPendingFn(ctx, orgID, threadID)
+	}
 	return nil
 }
 
@@ -598,12 +602,56 @@ func TestService_SendMessage(t *testing.T) {
 			expectErr: ErrThreadNotFound,
 		},
 		{
-			name: "thread not idle",
+			// When the target thread is mid-turn, SendMessage queues the
+			// message (creates the row + bumps pending_message_count) instead
+			// of rejecting. The orchestrator drains the queue when the
+			// in-flight turn completes.
+			name: "thread busy queues message",
 			input: SendMessageInput{
 				SessionID: sessionID,
 				OrgID:     orgID,
 				ThreadID:  threadID,
-				Message:   "hi",
+				Message:   "queued",
+			},
+			setupDeps: func(deps *testDeps) {
+				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{}, fmt.Errorf("no rows")
+				}
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusRunning}, nil
+				}
+				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					require.Equal(t, "queued", msg.Content)
+					require.Equal(t, 5, msg.TurnNumber, "queued message belongs to the turn after the in-flight one")
+					msg.ID = 7
+					return nil
+				}
+				deps.threadStore.incrementPendingFn = func(_ context.Context, _, tid uuid.UUID) error {
+					require.Equal(t, threadID, tid)
+					return nil
+				}
+				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+					t.Fatalf("queue-only path must not enqueue a continue_session job")
+					return uuid.UUID{}, nil
+				}
+				deps.sessionStore.claimIdleFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+					t.Fatalf("queue-only path must not re-claim the parent session")
+					return models.Session{}, nil
+				}
+			},
+		},
+		{
+			// Resolving review comments on a queued send is rejected: the
+			// resolution pass is keyed on the in-flight turn and we cannot
+			// atomically commit it alongside a message that won't be
+			// consumed until a later turn.
+			name: "thread busy with comment resolution rejected",
+			input: SendMessageInput{
+				SessionID:               sessionID,
+				OrgID:                   orgID,
+				ThreadID:                threadID,
+				Message:                 "addressed comments",
+				ResolveReviewCommentIDs: []uuid.UUID{uuid.New()},
 			},
 			setupDeps: func(deps *testDeps) {
 				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
@@ -611,6 +659,32 @@ func TestService_SendMessage(t *testing.T) {
 				}
 				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, Status: models.ThreadStatusRunning}, nil
+				}
+			},
+			expectErr: ErrReviewCommentsNotConfigured,
+		},
+		{
+			name: "completed thread rejected instead of queued",
+			input: SendMessageInput{
+				SessionID: sessionID,
+				OrgID:     orgID,
+				ThreadID:  threadID,
+				Message:   "queued",
+			},
+			setupDeps: func(deps *testDeps) {
+				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{}, fmt.Errorf("no rows")
+				}
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusCompleted}, nil
+				}
+				deps.messageStore.createFn = func(_ context.Context, _ *models.SessionMessage) error {
+					t.Fatalf("terminal threads must not create queued messages")
+					return nil
+				}
+				deps.threadStore.incrementPendingFn = func(_ context.Context, _, _ uuid.UUID) error {
+					t.Fatalf("terminal threads must not bump pending_message_count")
+					return nil
 				}
 			},
 			expectErr: ErrThreadNotIdle,


### PR DESCRIPTION
Allow users to send messages while a session or thread is already running by queueing busy-thread sends and draining them after the active turn releases its sandbox hold. The orchestrator now bundles queued user messages, uses a drain-specific dedupe key so follow-up jobs are not collapsed by the running job, and clears thread pending counters after scheduling the drain. Terminal threads are rejected instead of accepting queued messages that cannot be processed, and the session composer no longer blocks on running state unless the session is pending, skipped, or destroyed. Validated with `go vet ./...`, `go build ./...`, `go test ./...`, and frontend `npm run typecheck`, `npm run lint`, `npm run build`.