### PR TITLE
[codex] Fix deterministic agent resume fallback

### DIFF
--- a/internal/services/agent/adapter.go
+++ b/internal/services/agent/adapter.go
@@ -17,6 +17,32 @@ import (
 	"github.com/assembledhq/143/internal/models"
 )
 
+// SessionResumeMode declares how an adapter handles continuation turns. The
+// orchestrator reads this to decide whether to ship a bare follow-up message
+// (and let the agent CLI load its own conversation history) or to embed
+// conversation history in the prompt itself.
+type SessionResumeMode int
+
+const (
+	// ResumeUnsupported: adapter has no headless resume mechanism. Continuation
+	// turns rely on the restored sandbox filesystem state. Adapters in this
+	// mode may set result.AgentSessionID for observability, but the value is
+	// never fed back into the CLI.
+	ResumeUnsupported SessionResumeMode = iota
+
+	// ResumeBySessionID: adapter resumes a specific prior session by ID
+	// captured from that session's stream output. Adapters in this mode MUST:
+	//   1. Set result.AgentSessionID from a stream event during Execute().
+	//   2. When prompt.Continuation && prompt.ResumeSessionID != "", construct
+	//      a deterministic resume command using that ID.
+	//   3. When prompt.Continuation && prompt.ResumeSessionID == "", run a
+	//      fresh exec from prompt.SystemPrompt + prompt.UserPrompt. Adapters
+	//      MUST NOT fall back to non-deterministic flags like --last,
+	//      --continue, or --resume latest, which pick up whatever session
+	//      happens to be newest in the local agent storage.
+	ResumeBySessionID
+)
+
 // AgentAdapter is the contract that all coding agent integrations implement.
 // Each adapter knows how to prepare a prompt and execute a specific agent CLI
 // (e.g., Claude Code, Codex) inside a sandbox.
@@ -31,6 +57,10 @@ type AgentAdapter interface {
 	// Execute runs the agent inside the provided sandbox and streams log
 	// entries to logCh. The channel is closed by the caller after Execute returns.
 	Execute(ctx context.Context, sandbox *Sandbox, prompt *AgentPrompt, logCh chan<- LogEntry) (*AgentResult, error)
+
+	// ResumeMode declares how this adapter handles continuation turns. See
+	// SessionResumeMode for the per-mode contract.
+	ResumeMode() SessionResumeMode
 }
 
 // AgentInput contains everything the agent needs to understand and fix an issue.

--- a/internal/services/agent/adapters/amp.go
+++ b/internal/services/agent/adapters/amp.go
@@ -34,6 +34,14 @@ func (a *AmpAdapter) Name() models.AgentType {
 	return models.AgentTypeAmp
 }
 
+// ResumeMode reports that Amp has no headless resume mechanism. Continuation
+// turns rely on the restored sandbox filesystem state. The session_id Amp
+// emits in its stream is captured for observability only and is never fed
+// back into the CLI.
+func (a *AmpAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeUnsupported
+}
+
 // PreparePrompt constructs the prompts for Amp based on the issue context.
 func (a *AmpAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
 	if input == nil {

--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -59,6 +59,13 @@ func (a *ClaudeCodeAdapter) Name() models.AgentType {
 	return models.AgentTypeClaudeCode
 }
 
+// ResumeMode reports that Claude Code resumes prior turns by explicit session
+// ID (captured from the `result` event's `session_id` field and threaded back
+// into `claude --resume <id>`).
+func (a *ClaudeCodeAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeBySessionID
+}
+
 // PreparePrompt constructs the system and user prompts for Claude Code
 // based on the issue context.
 func (a *ClaudeCodeAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
@@ -93,19 +100,26 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 	if prompt.ReasoningEffort != "" {
 		effortArg = fmt.Sprintf(" --effort %s", prompt.ReasoningEffort)
 	}
-	if prompt.Continuation {
-		// Subsequent turn: resume the latest session with --continue.
-		// The prompt is a positional argument to --print.
+	if prompt.Continuation && prompt.ResumeSessionID != "" {
+		// Subsequent turn with a known session ID: deterministic resume by
+		// session id captured from a prior turn's `result` event. We avoid
+		// `--continue`, which resumes whatever Claude session is newest in
+		// the local data dir and is non-deterministic when stale entries
+		// are present.
 		msg := shellEscapeDouble(prompt.UserMessage)
 		cmd = fmt.Sprintf(
-			"claude --print --output-format stream-json --verbose%s --continue \"%s\"",
+			"claude --print --output-format stream-json --verbose%s --resume %s \"%s\"",
 			effortArg,
+			shellEscapeSingle(prompt.ResumeSessionID),
 			msg,
 		)
 	} else {
-		// First turn: write prompt file under $HOME (not WorkDir so it
-		// doesn't pollute the cloned repo's git status) and pipe it into
-		// claude via stdin.
+		// Fresh exec — used for first turns and as the fallback for
+		// continuation turns when the session ID was never captured (the
+		// orchestrator embeds the prior conversation history into UserPrompt
+		// in that case so the agent has the full context). Write the prompt
+		// under $HOME (not WorkDir, which would pollute git status) and pipe
+		// it into claude via stdin.
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
 		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {

--- a/internal/services/agent/adapters/claude_code_test.go
+++ b/internal/services/agent/adapters/claude_code_test.go
@@ -306,7 +306,7 @@ func TestClaudeCodeAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	require.Contains(t, err.Error(), "sandbox provider not found")
 }
 
-func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
+func TestClaudeCodeAdapter_Execute_ContinuationWithSessionIDUsesResumeByID(t *testing.T) {
 	t.Parallel()
 
 	provider := testutil.NewMockSandboxProvider()
@@ -329,6 +329,47 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	adapter := NewClaudeCodeAdapter(zerolog.Nop())
 	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
+		UserMessage:     "Please tighten the guard clause.",
+		MaxTokens:       50_000,
+		Continuation:    true,
+		ResumeSessionID: "claude-session-abc",
+	}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.NoError(t, err, "continuation should succeed")
+	require.NotNil(t, result, "continuation should return a result")
+	require.NotContains(t, provider.ExecCalls[0], "--continue", "continuation must not use --continue, which is non-deterministic")
+	require.Contains(t, provider.ExecCalls[0], "--resume claude-session-abc", "continuation should resume by explicit session ID")
+	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
+	require.False(t, exists, "deterministic resume should not write a fresh prompt file")
+}
+
+func TestClaudeCodeAdapter_Execute_ContinuationWithoutSessionIDFallsBackToFreshExec(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if strings.HasPrefix(cmd, "claude") {
+			_, _ = stdout.Write([]byte(`{"type":"assistant","content":"continuing the session"}`))
+			return 0, nil
+		}
+		if strings.HasPrefix(cmd, "git rev-parse") {
+			_, _ = stdout.Write([]byte("true\n"))
+			return 0, nil
+		}
+		if strings.HasPrefix(cmd, "git diff") {
+			return 0, nil
+		}
+		return 0, nil
+	}
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
+	prompt := &agent.AgentPrompt{
+		SystemPrompt: "system",
+		UserPrompt:   "history-embedded user prompt",
 		UserMessage:  "Please tighten the guard clause.",
 		MaxTokens:    50_000,
 		Continuation: true,
@@ -337,11 +378,53 @@ func TestClaudeCodeAdapter_Execute_ContinuationUsesContinueMode(t *testing.T) {
 	ctx := WithSandboxProvider(context.Background(), provider)
 
 	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
-	require.NoError(t, err, "continuation should succeed")
+	require.NoError(t, err, "continuation should succeed when falling back to fresh exec")
 	require.NotNil(t, result, "continuation should return a result")
-	require.Contains(t, provider.ExecCalls[0], "--continue", "continuation should use Claude's continue mode")
-	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
-	require.False(t, exists, "continuation should not write a fresh prompt file")
+	require.NotContains(t, provider.ExecCalls[0], "--continue", "continuation must not use --continue, which is non-deterministic")
+	require.NotContains(t, provider.ExecCalls[0], "--resume", "continuation without an id must not pass --resume")
+	contents, exists := provider.Files["/home/sandbox/.143-prompt.md"]
+	require.True(t, exists, "fresh exec must write the system+user prompt to a file")
+	require.Contains(t, string(contents), "history-embedded user prompt", "prompt file should carry the orchestrator-provided history-embedded user prompt")
+}
+
+func TestClaudeCodeAdapter_ResumeMode(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	require.Equal(t, agent.ResumeBySessionID, adapter.ResumeMode())
+}
+
+func TestClaudeCodeAdapter_Execute_CapturesResultEventSessionID(t *testing.T) {
+	t.Parallel()
+
+	provider := testutil.NewMockSandboxProvider()
+	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
+		if strings.HasPrefix(cmd, "claude") {
+			// Claude Code emits the session id on its terminal `result` event.
+			_, _ = stdout.Write([]byte(`{"type":"assistant","content":"done"}` + "\n" +
+				`{"type":"result","content":"summary","session_id":"claude-session-xyz"}`))
+			return 0, nil
+		}
+		if strings.HasPrefix(cmd, "git rev-parse") {
+			_, _ = stdout.Write([]byte("true\n"))
+			return 0, nil
+		}
+		if strings.HasPrefix(cmd, "git diff") {
+			return 0, nil
+		}
+		return 0, nil
+	}
+
+	adapter := NewClaudeCodeAdapter(zerolog.Nop())
+	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
+	prompt := &agent.AgentPrompt{SystemPrompt: "system", UserPrompt: "user", MaxTokens: 50_000}
+	logCh := make(chan agent.LogEntry, 10)
+	ctx := WithSandboxProvider(context.Background(), provider)
+
+	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "claude-session-xyz", result.AgentSessionID, "result event's session_id must populate AgentSessionID for next-turn resume")
 }
 
 func TestClaudeCodeAdapter_Execute_IncludesReasoningEffortOverride(t *testing.T) {

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -32,6 +32,13 @@ func (a *CodexAdapter) Name() models.AgentType {
 	return models.AgentTypeCodex
 }
 
+// ResumeMode reports that Codex resumes prior turns by explicit session ID
+// (captured from the `thread.started` event Codex emits at the start of each
+// `--json` run and threaded back into `codex exec resume <id>`).
+func (a *CodexAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeBySessionID
+}
+
 // PreparePrompt constructs the prompts for Codex CLI based on the issue context.
 // Reuses the shared buildSystemPrompt() and buildUserPrompt() functions.
 func (a *CodexAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
@@ -70,26 +77,24 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	if prompt.ReasoningEffort != "" {
 		reasoningArg = fmt.Sprintf(" -c '%s'", shellEscapeSingle(fmt.Sprintf(`model_reasoning_effort="%s"`, prompt.ReasoningEffort)))
 	}
-	if prompt.Continuation {
-		// Subsequent turn: resume the latest restored session state.
+	if prompt.Continuation && prompt.ResumeSessionID != "" {
+		// Subsequent turn with a known session ID: deterministic resume by
+		// thread/session id captured from a prior turn's `thread.started`
+		// event. We avoid `codex exec resume --last` because `--last` reads
+		// whichever rollout file is newest in ~/.codex/sessions, which is
+		// non-deterministic when stale entries are present.
 		msg := shellEscapeDouble(prompt.UserMessage)
-		if prompt.ResumeSessionID != "" {
-			cmd = fmt.Sprintf(
-				"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s %s \"%s\"",
-				reasoningArg,
-				shellEscapeCodex(prompt.ResumeSessionID),
-				msg,
-			)
-		} else {
-			cmd = fmt.Sprintf(
-				"codex exec resume --last --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s \"%s\"",
-				reasoningArg,
-				msg,
-			)
-		}
+		cmd = fmt.Sprintf(
+			"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s %s \"%s\"",
+			reasoningArg,
+			shellEscapeCodex(prompt.ResumeSessionID),
+			msg,
+		)
 	} else {
-		// First turn: write prompt file and run fresh. Put it under $HOME
-		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
+		// Fresh exec — used for first turns and as the fallback for
+		// continuation turns when the session ID was never captured (the
+		// orchestrator embeds the prior conversation history into UserPrompt
+		// in that case so the agent has the full context).
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
 		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
@@ -236,6 +241,18 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 	}
 
 	switch event.Type {
+	case "thread.started":
+		// Capture the Codex thread/session ID so `codex exec resume <id>` can
+		// deterministically resume this conversation on the next turn.
+		if event.ThreadID != "" {
+			result.AgentSessionID = event.ThreadID
+		}
+		logCh <- agent.LogEntry{
+			Timestamp: time.Now(),
+			Level:     "debug",
+			Message:   string(line),
+		}
+
 	case "message", "text", "assistant":
 		content := event.Content
 		if content == "" {
@@ -517,6 +534,11 @@ type codexStreamEvent struct {
 	Error string          `json:"error,omitempty"`
 	Item  *codexItem      `json:"item,omitempty"`
 	Usage json.RawMessage `json:"usage,omitempty"`
+	// ThreadID is emitted by Codex on the `thread.started` event at the start
+	// of each `--json` run. Codex's CLI exposes its conversation state under
+	// the `thread` name; `codex exec resume <id>` accepts this same value as
+	// the rollout/session identifier for deterministic resumes.
+	ThreadID string `json:"thread_id,omitempty"`
 }
 
 // parseCodexStreamOutput processes the streaming JSONL output from Codex CLI,

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -742,12 +742,12 @@ func TestCodexAdapter_Execute_MissingSandboxProvider(t *testing.T) {
 	require.Contains(t, err.Error(), "sandbox provider not found")
 }
 
-func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *testing.T) {
+func TestCodexAdapter_Execute_ContinuationWithoutSessionIDFallsBackToFreshExec(t *testing.T) {
 	t.Parallel()
 
 	provider := testutil.NewMockSandboxProvider()
 	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
-		if strings.HasPrefix(cmd, "codex exec resume") {
+		if strings.HasPrefix(cmd, "codex exec ") {
 			_, _ = stdout.Write([]byte(`{"type":"message","content":"continuing prior session"}`))
 			return 0, nil
 		}
@@ -765,6 +765,8 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	adapter := NewCodexAdapter(zerolog.Nop())
 	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
+		SystemPrompt: "system",
+		UserPrompt:   "history-embedded user prompt",
 		UserMessage:  "Please tighten the test case.",
 		MaxTokens:    50_000,
 		Continuation: true,
@@ -773,11 +775,42 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDUsesResumeLast(t *test
 	ctx := WithSandboxProvider(context.Background(), provider)
 
 	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
-	require.NoError(t, err, "continuation should succeed without an explicit session ID")
+	require.NoError(t, err, "continuation should succeed when falling back to fresh exec")
 	require.NotNil(t, result, "continuation should return a result")
-	require.Contains(t, provider.ExecCalls[0], "codex exec resume --last --dangerously-bypass-approvals-and-sandbox", "continuation without a session ID should resume the latest restored Codex session")
-	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
-	require.False(t, exists, "continuation should not write a fresh prompt file")
+	require.NotContains(t, provider.ExecCalls[0], "codex exec resume", "continuation without a session ID must not use the non-deterministic resume path")
+	require.NotContains(t, provider.ExecCalls[0], "--last", "the --last fallback must not be used")
+	require.Contains(t, provider.ExecCalls[0], "codex exec --dangerously-bypass-approvals-and-sandbox", "continuation without a session ID should run a fresh codex exec")
+	contents, exists := provider.Files["/home/sandbox/.143-prompt.md"]
+	require.True(t, exists, "fresh exec must write the system+user prompt to a file")
+	require.Contains(t, string(contents), "history-embedded user prompt", "prompt file should carry the orchestrator-provided history-embedded user prompt")
+}
+
+func TestCodexAdapter_ParseStreamLine_CapturesThreadStartedSessionID(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 4)
+	var summaryParts []string
+	lastByType := make(map[string]string)
+	lastAssistant := ""
+
+	parseCodexStreamLine(
+		[]byte(`{"type":"thread.started","thread_id":"019d049e-f7f8-7b71-bb08-e174ba50c73c"}`),
+		result,
+		logCh,
+		&summaryParts,
+		lastByType,
+		&lastAssistant,
+	)
+
+	require.Equal(t, "019d049e-f7f8-7b71-bb08-e174ba50c73c", result.AgentSessionID, "thread.started should populate AgentSessionID for downstream resume")
+}
+
+func TestCodexAdapter_ResumeMode(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewCodexAdapter(zerolog.Nop())
+	require.Equal(t, agent.ResumeBySessionID, adapter.ResumeMode())
 }
 
 func TestCodexAdapter_Execute_IncludesReasoningEffortOverride(t *testing.T) {

--- a/internal/services/agent/adapters/gemini_cli.go
+++ b/internal/services/agent/adapters/gemini_cli.go
@@ -34,6 +34,13 @@ func (a *GeminiCLIAdapter) Name() models.AgentType {
 	return models.AgentTypeGeminiCLI
 }
 
+// ResumeMode reports that Gemini resumes prior turns by explicit session ID
+// (captured from any stream event carrying `session_id` and threaded back
+// into `gemini --resume <id>`).
+func (a *GeminiCLIAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeBySessionID
+}
+
 // PreparePrompt constructs the prompts for Gemini CLI based on the issue context.
 func (a *GeminiCLIAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
 	if input == nil {
@@ -62,24 +69,23 @@ func (a *GeminiCLIAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, 
 	}
 
 	var cmd string
-	if prompt.Continuation {
-		// Subsequent turn: resume the latest restored session state.
+	if prompt.Continuation && prompt.ResumeSessionID != "" {
+		// Subsequent turn with a known session ID: deterministic resume by
+		// session id captured from a prior turn's stream output. We avoid
+		// `--resume latest`, which picks up whichever Gemini session is
+		// newest in the local session storage and is non-deterministic when
+		// stale entries are present.
 		msg := shellEscapeDouble(prompt.UserMessage)
-		if prompt.ResumeSessionID != "" {
-			cmd = fmt.Sprintf(
-				"gemini --resume %s --approval-mode=yolo --output-format stream-json -p \"%s\"",
-				shellEscapeSingle(prompt.ResumeSessionID),
-				msg,
-			)
-		} else {
-			cmd = fmt.Sprintf(
-				"gemini --resume latest --approval-mode=yolo --output-format stream-json -p \"%s\"",
-				msg,
-			)
-		}
+		cmd = fmt.Sprintf(
+			"gemini --resume %s --approval-mode=yolo --output-format stream-json -p \"%s\"",
+			shellEscapeSingle(prompt.ResumeSessionID),
+			msg,
+		)
 	} else {
-		// First turn: write prompt file and run fresh. Put it under $HOME
-		// (not WorkDir) so it doesn't pollute the cloned repo's git status.
+		// Fresh exec — used for first turns and as the fallback for
+		// continuation turns when the session ID was never captured (the
+		// orchestrator embeds the prior conversation history into UserPrompt
+		// in that case so the agent has the full context).
 		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
 		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
@@ -170,6 +176,17 @@ func parseGeminiStreamLine(line []byte, result *agent.AgentResult, logCh chan<- 
 		*summaryParts = append(*summaryParts, text)
 		tryExtractConfidence(text, result)
 		return
+	}
+
+	// Capture session_id from whichever event carries it. Gemini's stream
+	// shape varies across versions (session-lifecycle, result, or usage
+	// events have all carried it at different times, in both snake_case
+	// and camelCase), so we accept it wherever it appears rather than
+	// gating on event.Type or a single field name.
+	if id := event.SessionID; id != "" {
+		result.AgentSessionID = id
+	} else if id := event.SessionIDCamel; id != "" {
+		result.AgentSessionID = id
 	}
 
 	// Handle legacy single-object JSON format (no type field).
@@ -381,6 +398,13 @@ type geminiStreamEvent struct {
 		OutputTokens int `json:"outputTokens"`
 	} `json:"stats,omitempty"`
 	Error string `json:"error,omitempty"`
+	// SessionID is captured from any event that carries it (Gemini emits
+	// this on session-lifecycle and result events) so `gemini --resume <id>`
+	// can deterministically resume this conversation on the next turn.
+	// Both snake_case and camelCase variants are accepted because Gemini's
+	// stream-json schema has shipped both spellings across versions.
+	SessionID      string `json:"session_id,omitempty"`
+	SessionIDCamel string `json:"sessionId,omitempty"`
 }
 
 // parseGeminiStreamOutput processes the streaming JSONL output from Gemini CLI,

--- a/internal/services/agent/adapters/gemini_cli_test.go
+++ b/internal/services/agent/adapters/gemini_cli_test.go
@@ -680,12 +680,12 @@ func TestGeminiCLIAdapter_Execute_StreamingOutput(t *testing.T) {
 	require.Equal(t, 1, toolUseCount, "should have 1 tool_use log entry")
 }
 
-func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *testing.T) {
+func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDFallsBackToFreshExec(t *testing.T) {
 	t.Parallel()
 
 	provider := newMockProvider()
 	provider.ExecFn = func(ctx context.Context, sb *agent.Sandbox, cmd string, stdout, stderr io.Writer) (int, error) {
-		if strings.HasPrefix(cmd, "gemini --resume") {
+		if strings.HasPrefix(cmd, "gemini") {
 			_, _ = stdout.Write([]byte(`{"type":"text","content":"continuing gemini session"}`))
 			return 0, nil
 		}
@@ -703,6 +703,8 @@ func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *
 	adapter := NewGeminiCLIAdapter(zerolog.Nop())
 	sandbox := &agent.Sandbox{ID: "test", WorkDir: "/workspace", HomeDir: "/home/sandbox", Metadata: map[string]string{agent.SandboxMetadataBaseCommitSHA: "abc123"}}
 	prompt := &agent.AgentPrompt{
+		SystemPrompt: "system",
+		UserPrompt:   "history-embedded user prompt",
 		UserMessage:  "Please include a regression test.",
 		MaxTokens:    50_000,
 		Continuation: true,
@@ -712,9 +714,58 @@ func TestGeminiCLIAdapter_Execute_ContinuationWithoutSessionIDUsesResumeMode(t *
 	ctx := WithSandboxProvider(context.Background(), provider)
 
 	result, err := adapter.Execute(ctx, sandbox, prompt, logCh)
-	require.NoError(t, err, "continuation should succeed without an explicit Gemini session ID")
+	require.NoError(t, err, "continuation should succeed when falling back to fresh exec")
 	require.NotNil(t, result, "continuation should return a result")
-	require.Contains(t, provider.ExecCalls[0], "gemini --resume", "continuation without a session ID should still use Gemini resume mode")
-	_, exists := provider.Files["/home/sandbox/.143-prompt.md"]
-	require.False(t, exists, "continuation should not write a fresh prompt file")
+	require.NotContains(t, provider.ExecCalls[0], "--resume", "continuation without a session ID must not use --resume (latest is non-deterministic)")
+	contents, exists := provider.Files["/home/sandbox/.143-prompt.md"]
+	require.True(t, exists, "fresh exec must write the system+user prompt to a file")
+	require.Contains(t, string(contents), "history-embedded user prompt", "prompt file should carry the orchestrator-provided history-embedded user prompt")
+}
+
+func TestGeminiCLIAdapter_ParseStreamLine_CapturesSessionID(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 4)
+	var summaryParts []string
+	lastAssistant := ""
+
+	parseGeminiStreamLine(
+		[]byte(`{"type":"result","content":"done","session_id":"gemini-session-xyz"}`),
+		result,
+		logCh,
+		&summaryParts,
+		&lastAssistant,
+	)
+
+	require.Equal(t, "gemini-session-xyz", result.AgentSessionID, "session_id on any event should populate AgentSessionID for downstream resume")
+}
+
+func TestGeminiCLIAdapter_ParseStreamLine_CapturesCamelCaseSessionIDOnLifecycleEvent(t *testing.T) {
+	t.Parallel()
+
+	result := &agent.AgentResult{}
+	logCh := make(chan agent.LogEntry, 4)
+	var summaryParts []string
+	lastAssistant := ""
+
+	// Older / different Gemini stream shapes emit session id under
+	// `sessionId` (camelCase) on a session-lifecycle event; capture must
+	// not depend on the exact event type or the exact field spelling.
+	parseGeminiStreamLine(
+		[]byte(`{"type":"session_started","sessionId":"gemini-session-camel"}`),
+		result,
+		logCh,
+		&summaryParts,
+		&lastAssistant,
+	)
+
+	require.Equal(t, "gemini-session-camel", result.AgentSessionID, "camelCase sessionId on a lifecycle event must populate AgentSessionID")
+}
+
+func TestGeminiCLIAdapter_ResumeMode(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewGeminiCLIAdapter(zerolog.Nop())
+	require.Equal(t, agent.ResumeBySessionID, adapter.ResumeMode())
 }

--- a/internal/services/agent/adapters/pi.go
+++ b/internal/services/agent/adapters/pi.go
@@ -34,6 +34,12 @@ func (a *PiAdapter) Name() models.AgentType {
 	return models.AgentTypePi
 }
 
+// ResumeMode reports that Pi has no headless resume mechanism. Continuation
+// turns rely on the restored sandbox filesystem state.
+func (a *PiAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeUnsupported
+}
+
 // PreparePrompt constructs the prompts for Pi based on the issue context.
 func (a *PiAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
 	if input == nil {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -2520,8 +2520,19 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 
 		commands := canonicalCommands(latestMsg, session.AgentType)
 		hasThreadAgentSessionID := session.AgentSessionID != nil && *session.AgentSessionID != ""
-		if threadScopedExecution && !hasThreadAgentSessionID {
-			input := &AgentInput{
+		resumeMode := adapter.ResumeMode()
+		// missingResumeID covers the case where the adapter resumes by
+		// session id but no id was captured from a prior turn — e.g. the
+		// session predates session-id capture, or capture failed. Without
+		// the id, the adapter falls back to a fresh exec, so we must embed
+		// the conversation history into the prompt or the agent loses
+		// context. Threaded first turns are handled by the next branch.
+		missingResumeID := resumeMode == ResumeBySessionID && !hasThreadAgentSessionID && !threadScopedExecution
+		// Both snapshot-path branches that go through PreparePrompt feed it
+		// the same context; capture once here so a future field addition
+		// can't drift between the two callers.
+		buildSnapshotContinueInput := func() *AgentInput {
+			return &AgentInput{
 				Issue:        promptIssue,
 				LinkedIssues: linkedIssues,
 				Manual:       session.Origin == models.SessionOriginManual,
@@ -2547,11 +2558,28 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 				RevisionContext:   revisionContext,
 				IntegrationSkills: integrationSkills,
 			}
-			prompt, err = adapter.PreparePrompt(ctx, input)
+		}
+		if threadScopedExecution && !hasThreadAgentSessionID {
+			prompt, err = adapter.PreparePrompt(ctx, buildSnapshotContinueInput())
 			if err != nil {
 				o.failRun(ctx, session, fmt.Sprintf("prepare prompt for thread: %s", err))
 				return fmt.Errorf("prepare prompt for thread: %w", err)
 			}
+		} else if missingResumeID {
+			basePrompt, err := adapter.PreparePrompt(ctx, buildSnapshotContinueInput())
+			if err != nil {
+				o.failRun(ctx, session, fmt.Sprintf("prepare prompt for resume fallback: %s", err))
+				return fmt.Errorf("prepare prompt for resume fallback: %w", err)
+			}
+			// Override UserPrompt with conversation history so the agent has
+			// prior context when running a fresh exec. The snapshot already
+			// restored the workspace, so do not ask the agent to re-apply the
+			// stored diff.
+			basePrompt.UserPrompt = o.buildRestoredWorkspaceResumeContext(session, promptIssue, messages, userMessage)
+			basePrompt.Continuation = false
+			basePrompt.RevisionContext = revisionContext
+			prompt = basePrompt
+			log.Info().Msg("continuing session with embedded history (no captured agent session id)")
 		} else {
 			var resumeSessionID string
 			if hasThreadAgentSessionID {
@@ -2915,27 +2943,7 @@ func (o *Orchestrator) buildResumeContext(session *models.Session, issue *models
 
 	b.WriteString("This is a continuation of a previous session. The previous workspace state is not available, so you are starting from a fresh clone.\n\n")
 
-	// Include the original issue description for context (especially
-	// important for non-manual sessions that may have no prior messages).
-	if issue != nil && issue.Description != nil && *issue.Description != "" {
-		b.WriteString("## Original issue\n\n**")
-		b.WriteString(issue.Title)
-		b.WriteString("**\n\n")
-		b.WriteString(*issue.Description)
-		b.WriteString("\n\n")
-	}
-
-	// Include conversation history if available.
-	if len(messages) > 1 { // >1 because the latest user message is always present
-		b.WriteString("## Previous conversation history\n\n")
-		for _, msg := range messages[:len(messages)-1] {
-			role := "User"
-			if msg.Role == models.MessageRoleAssistant {
-				role = "Assistant"
-			}
-			b.WriteString(fmt.Sprintf("**%s:** %s\n\n", role, msg.Content))
-		}
-	}
+	writeResumeIssueAndHistory(&b, issue, messages)
 
 	// Include the stored diff if available, truncating if very large.
 	if session.Diff != nil && *session.Diff != "" {
@@ -2965,6 +2973,53 @@ func (o *Orchestrator) buildResumeContext(session *models.Session, issue *models
 	b.WriteString(latestUserMessage)
 
 	return b.String()
+}
+
+// buildRestoredWorkspaceResumeContext constructs the user prompt for a
+// snapshot-backed continuation where the agent CLI cannot resume by session ID.
+// The workspace already contains the previous turn's files, so it includes
+// conversation context without asking the agent to re-apply the stored diff.
+func (o *Orchestrator) buildRestoredWorkspaceResumeContext(session *models.Session, issue *models.Issue, messages []models.SessionMessage, latestUserMessage string) string {
+	var b bytes.Buffer
+
+	b.WriteString("This is a continuation of a previous session. The previous workspace state has been restored from the last saved snapshot, so treat the files on disk as the current state.\n\n")
+
+	writeResumeIssueAndHistory(&b, issue, messages)
+
+	if session.ResultSummary != nil && *session.ResultSummary != "" {
+		b.WriteString("## Previous session summary\n\n")
+		b.WriteString(*session.ResultSummary)
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString("## New message\n\n")
+	b.WriteString(latestUserMessage)
+
+	return b.String()
+}
+
+func writeResumeIssueAndHistory(b *bytes.Buffer, issue *models.Issue, messages []models.SessionMessage) {
+	// Include the original issue description for context (especially
+	// important for non-manual sessions that may have no prior messages).
+	if issue != nil && issue.Description != nil && *issue.Description != "" {
+		b.WriteString("## Original issue\n\n**")
+		b.WriteString(issue.Title)
+		b.WriteString("**\n\n")
+		b.WriteString(*issue.Description)
+		b.WriteString("\n\n")
+	}
+
+	// Include conversation history if available.
+	if len(messages) > 1 { // >1 because the latest user message is always present
+		b.WriteString("## Previous conversation history\n\n")
+		for _, msg := range messages[:len(messages)-1] {
+			role := "User"
+			if msg.Role == models.MessageRoleAssistant {
+				role = "Assistant"
+			}
+			b.WriteString(fmt.Sprintf("**%s:** %s\n\n", role, msg.Content))
+		}
+	}
 }
 
 func manualSessionReferences(issue *models.Issue) []models.SessionInputReference {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -28,11 +28,14 @@ import (
 
 // mockAgentAdapter implements agent.AgentAdapter.
 type mockAgentAdapter struct {
-	name      models.AgentType
-	executeFn func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error)
+	name       models.AgentType
+	resumeMode agent.SessionResumeMode
+	executeFn  func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error)
 }
 
 func (m *mockAgentAdapter) Name() models.AgentType { return m.name }
+
+func (m *mockAgentAdapter) ResumeMode() agent.SessionResumeMode { return m.resumeMode }
 
 func (m *mockAgentAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
 	return &agent.AgentPrompt{
@@ -61,6 +64,8 @@ type capturingAdapter struct {
 }
 
 func (c *capturingAdapter) Name() models.AgentType { return c.name }
+
+func (c *capturingAdapter) ResumeMode() agent.SessionResumeMode { return agent.ResumeBySessionID }
 
 func (c *capturingAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) (*agent.AgentPrompt, error) {
 	c.captured = input
@@ -2819,6 +2824,88 @@ func TestContinueSession_UsesBuildRunResultInUpdateTurnComplete(t *testing.T) {
 	require.NotEmpty(t, updates[0].snapshotKey, "ContinueSession should persist a snapshot key")
 	require.NotNil(t, updates[0].result, "ContinueSession should build a session result for UpdateTurnComplete")
 	require.NotNil(t, updates[0].result.Diff, "ContinueSession should pass the diff through to UpdateTurnComplete")
+}
+
+func TestContinueSession_EmbedsHistoryWhenResumeBySessionIDAdapterHasNoCapturedSessionID(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.AgentType = models.AgentTypeClaudeCode
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	// Snapshot present (Path A) but no captured agent session id — exactly
+	// the case where the adapter would otherwise lose conversation context.
+	snapshotKey := "existing-snapshot"
+	session.SnapshotKey = &snapshotKey
+	session.AgentSessionID = nil
+	priorDiff := "diff --git a/main.go b/main.go\n+fixed already\n"
+	session.Diff = &priorDiff
+
+	d := defaultDeps()
+	d.adapter = &mockAgentAdapter{
+		name:       models.AgentTypeClaudeCode,
+		resumeMode: agent.ResumeBySessionID,
+	}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 1,
+			Role:       models.MessageRoleUser,
+			Content:    "Please review my changes.",
+		},
+		{
+			ID:         2,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 1,
+			Role:       models.MessageRoleAssistant,
+			Content:    "I found two issues: a missing nil check and an unbounded loop.",
+		},
+		{
+			ID:         3,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "please fix both of these issues",
+		},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.snapshots.data = map[string][]byte{snapshotKey: []byte("restored-snapshot")}
+
+	var promptSeen *agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		promptSeen = prompt
+		return &agent.AgentResult{Summary: "fixed", ConfidenceScore: 0.9, ExitCode: 0}, nil
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, nil)
+	require.NoError(t, err, "ContinueSession should succeed via the embedded-history fallback")
+	require.NotNil(t, promptSeen, "adapter must have been invoked")
+	require.False(t, promptSeen.Continuation, "fallback must run a fresh exec, not a Continuation turn")
+	require.Empty(t, promptSeen.ResumeSessionID, "fallback must not set a ResumeSessionID — there is none")
+	require.Contains(t, promptSeen.UserPrompt, "Previous conversation history", "fallback must embed conversation history into the prompt")
+	require.Contains(t, promptSeen.UserPrompt, "Please review my changes.", "fallback must include the prior user turn")
+	require.Contains(t, promptSeen.UserPrompt, "missing nil check", "fallback must include the prior assistant turn so 'fix both issues' is interpretable")
+	require.Contains(t, promptSeen.UserPrompt, "please fix both of these issues", "fallback must include the new user message as the trailing instruction")
+	require.NotContains(t, promptSeen.UserPrompt, "starting from a fresh clone", "snapshot fallback must not claim the restored workspace is a fresh clone")
+	require.NotContains(t, promptSeen.UserPrompt, "Please re-apply these changes", "snapshot fallback must not ask the agent to re-apply a diff that is already present in the restored snapshot")
+	require.NotContains(t, promptSeen.UserPrompt, priorDiff, "snapshot fallback must not include the prior diff as work to re-apply")
 }
 
 func TestContinueSession_UsesThreadExecutionOptions(t *testing.T) {

--- a/internal/services/pm/adapter.go
+++ b/internal/services/pm/adapter.go
@@ -45,3 +45,10 @@ func (a *PMAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput) 
 func (a *PMAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
 	return a.inner.Execute(ctx, sandbox, prompt, logCh)
 }
+
+// ResumeMode delegates to the inner adapter — PM runs are scheduled on top of
+// whichever coding agent the org configured, and resume capability is a
+// property of that underlying CLI.
+func (a *PMAdapter) ResumeMode() agent.SessionResumeMode {
+	return a.inner.ResumeMode()
+}

--- a/internal/services/pm/adapter_pm_test.go
+++ b/internal/services/pm/adapter_pm_test.go
@@ -33,6 +33,10 @@ func (m *pmInnerAdapterMock) Execute(ctx context.Context, sandbox *agent.Sandbox
 	return m.executeResult, nil
 }
 
+func (m *pmInnerAdapterMock) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeUnsupported
+}
+
 func TestPMAdapterPreparePrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/pm/project_analyze_test.go
+++ b/internal/services/pm/project_analyze_test.go
@@ -25,6 +25,7 @@ func (m *mockAdapter) PreparePrompt(ctx context.Context, input *agent.AgentInput
 func (m *mockAdapter) Execute(ctx context.Context, sb *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
 	return &agent.AgentResult{}, nil
 }
+func (m *mockAdapter) ResumeMode() agent.SessionResumeMode { return agent.ResumeUnsupported }
 
 // mockSandbox is a minimal stub for agent.SandboxProvider.
 type mockSandbox struct{}

--- a/internal/services/pm/review_fixes_test.go
+++ b/internal/services/pm/review_fixes_test.go
@@ -171,6 +171,8 @@ func (a *reviewAdapter) Execute(_ context.Context, _ *agent.Sandbox, _ *agent.Ag
 	return &agent.AgentResult{}, nil
 }
 
+func (a *reviewAdapter) ResumeMode() agent.SessionResumeMode { return agent.ResumeUnsupported }
+
 func marshalOrgSettingsForReview(t *testing.T, settings models.OrgSettings) []byte {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
This PR makes coding-agent continuation deterministic by adding adapter-declared resume modes and requiring Claude Code, Codex, and Gemini to resume only by captured session ID.
It captures Codex thread IDs and Gemini/Claude session IDs from stream events, removes nondeterministic latest-session fallbacks, and preserves unsupported Amp/Pi behavior.
For older sessions with snapshots but no captured agent session ID, the orchestrator now embeds conversation history without telling the agent to re-apply an already-restored diff.

## Validation
- go test ./internal/services/agent -run TestContinueSession_EmbedsHistoryWhenResumeBySessionIDAdapterHasNoCapturedSessionID -count=1
- go test ./internal/services/agent ./internal/services/agent/adapters ./internal/services/pm
- go vet ./...
- go build ./...
- go test ./...
