### PR TITLE
Pre-create /var/log/143 with deploy ownership in bootstrap

### DIFF
--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -13,6 +13,12 @@ mkdir -p /home/deploy/.ssh /opt/143
 chown -R deploy:deploy /home/deploy/.ssh /opt/143
 chmod 700 /home/deploy/.ssh
 
+# Detached worker rollovers (WORKER_DEPLOY_DETACH=1) write progress + status
+# files here. /var/log is root-owned so the deploy user can't mkdir it
+# itself; provision once with deploy ownership.
+mkdir -p /var/log/143
+chown deploy:deploy /var/log/143
+
 # Docker (idempotent)
 command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
 


### PR DESCRIPTION
## Summary
- Pre-create `/var/log/143` with `deploy:deploy` ownership in `bootstrap.sh` so detached worker rollovers (`WORKER_DEPLOY_DETACH=1`) can write their progress and status files. The deploy user runs `mkdir -p /var/log/143` over SSH and was failing with "Permission denied" since `/var/log` is root-owned.

## Test plan
- [ ] Re-bootstrap worker hosts: `ssh root@<worker-ip> 'bash -s -- worker' < deploy/scripts/bootstrap.sh`
- [ ] Re-run the failing CI deploy and confirm worker rollover proceeds past the mkdir step and writes `/var/log/143/deploy-worker-<sha>.log` + `.status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
