### PR TITLE
Fix preview DATABASE_URL host/port injection so migrator can connect

### DIFF
--- a/internal/services/preview/provider.go
+++ b/internal/services/preview/provider.go
@@ -153,7 +153,5 @@ type InfraHandle struct {
 	InfraName   string
 	Template    string
 	ContainerID string
-	Host        string
-	Port        int
 	Credential  InfraCredential
 }

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -543,7 +543,7 @@ func (d *DockerPreviewProvider) PreviewStatus(ctx context.Context, handle string
 	for name, ih := range state.infra {
 		infraList = append(infraList, infraInfo{
 			name: name, template: ih.Template, containerID: ih.ContainerID,
-			host: ih.Host, port: ih.Port,
+			host: ih.Credential.Host, port: ih.Credential.Port,
 		})
 	}
 	d.mu.RUnlock()
@@ -588,15 +588,15 @@ func (d *DockerPreviewProvider) provisionInfra(
 		return nil, fmt.Errorf("resolve sandbox network: %w", err)
 	}
 
-	cred, err := generateInfraCredential(infraName)
-	if err != nil {
-		return nil, fmt.Errorf("generate credential for %q: %w", infraName, err)
-	}
 	handlePrefix := previewHandle
 	if len(handlePrefix) > 12 {
 		handlePrefix = handlePrefix[:12]
 	}
 	containerName := fmt.Sprintf("preview-%s-%s", infraName, handlePrefix)
+	cred, err := buildInfraCredential(infraName, containerName, tmpl.DefaultPort)
+	if err != nil {
+		return nil, fmt.Errorf("generate credential for %q: %w", infraName, err)
+	}
 
 	// Ensure the image is on the host before asking Docker to create the
 	// container. Worker hosts only pre-pull the 143-server / 143-sandbox /
@@ -650,8 +650,6 @@ func (d *DockerPreviewProvider) provisionInfra(
 		InfraName:   infraName,
 		Template:    infraCfg.Template,
 		ContainerID: resp.ID,
-		Host:        containerName,
-		Port:        tmpl.DefaultPort,
 		Credential:  cred,
 	}, nil
 }
@@ -1312,12 +1310,19 @@ func resolveCredentialTemplate(template string, cred preview.InfraCredential) st
 	return r.Replace(template)
 }
 
-func generateInfraCredential(infraName string) (preview.InfraCredential, error) {
+// buildInfraCredential constructs a fully-populated InfraCredential. All five
+// fields (Host, Port, Username, Password, Database) must be set on the
+// returned value — resolveCredentialTemplate substitutes every one of them
+// into the inject_env DSN and a zero Host/Port silently produces a broken URL
+// that the consuming service tries to dial against localhost.
+func buildInfraCredential(infraName, host string, port int) (preview.InfraCredential, error) {
 	password, err := preview.RandomHex(16)
 	if err != nil {
 		return preview.InfraCredential{}, fmt.Errorf("generate infra credential password: %w", err)
 	}
 	return preview.InfraCredential{
+		Host:     host,
+		Port:     port,
 		Username: fmt.Sprintf("preview_%s", infraName),
 		Password: password,
 		Database: "preview_db",

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -399,10 +399,17 @@ func TestResolveCredentialTemplate(t *testing.T) {
 	require.Equal(t, "postgres://preview_db:secret@preview-db-abc123:5432/preview_db", result)
 }
 
-func TestGenerateInfraCredential(t *testing.T) {
+// TestBuildInfraCredential_PopulatesAllFields locks in the invariant that the
+// constructor populates every field consumed by resolveCredentialTemplate. A
+// previous bug left Host/Port unset and produced a DSN with empty host/port,
+// which the migrator silently dialed against [::1]:5432 instead of the real
+// container.
+func TestBuildInfraCredential_PopulatesAllFields(t *testing.T) {
 	t.Parallel()
-	cred, err := generateInfraCredential("db")
+	cred, err := buildInfraCredential("db", "preview-db-abc123", 5432)
 	require.NoError(t, err)
+	require.Equal(t, "preview-db-abc123", cred.Host)
+	require.Equal(t, 5432, cred.Port)
 	require.Equal(t, "preview_db", cred.Username)
 	require.Equal(t, "preview_db", cred.Database)
 	require.Len(t, cred.Password, 32) // 16 bytes → 32 hex chars
@@ -461,25 +468,25 @@ func TestBuildServiceEnvs(t *testing.T) {
 		},
 	}
 
-	infraCreds := map[string]preview.InfraCredential{
-		"db": {
-			Host:     "preview-db-abc",
-			Port:     5432,
-			Username: "preview_db",
-			Password: "secret",
-			Database: "preview_db",
-		},
-	}
+	// Build the credential via the production constructor so this test
+	// exercises the same wiring as provisionInfra. A prior version of this
+	// test hand-rolled the InfraCredential literal with Host/Port set, which
+	// hid a bug where the production path stored a credential with empty
+	// Host/Port and produced an unconnectable DATABASE_URL.
+	cred, err := buildInfraCredential("db", "preview-db-abc", 5432)
+	require.NoError(t, err)
+	infraCreds := map[string]preview.InfraCredential{"db": cred}
+	expectedDSN := fmt.Sprintf("postgres://preview_db:%s@preview-db-abc:5432/preview_db", cred.Password)
 
 	envs := d.buildServiceEnvs(cfg, infraCreds, nil)
 
 	// web should have NODE_ENV + DATABASE_URL
 	require.Equal(t, "development", envs["web"]["NODE_ENV"])
-	require.Equal(t, "postgres://preview_db:secret@preview-db-abc:5432/preview_db", envs["web"]["DATABASE_URL"])
+	require.Equal(t, expectedDSN, envs["web"]["DATABASE_URL"])
 
 	// worker should have WORKER_THREADS + DATABASE_URL
 	require.Equal(t, "2", envs["worker"]["WORKER_THREADS"])
-	require.Equal(t, "postgres://preview_db:secret@preview-db-abc:5432/preview_db", envs["worker"]["DATABASE_URL"])
+	require.Equal(t, expectedDSN, envs["worker"]["DATABASE_URL"])
 }
 
 // TestBuildServiceEnvs_ExtraEnvOverrides verifies that platform-level extras


### PR DESCRIPTION
## Summary
- Fixes preview env injection where `DATABASE_URL` ended up with an empty host and port (`@:0/`), causing the migrator/seed/server to dial `[::1]:5432` instead of the postgres container.
- Consolidates `Host`/`Port` to live only on `InfraCredential` (removed from `InfraHandle`) and replaces `generateInfraCredential` with `buildInfraCredential(infraName, host, port)` so partial initialization is a compile-time impossibility.
- Adds `TestBuildInfraCredential_PopulatesAllFields` and rewires `TestBuildServiceEnvs` to build credentials via the production constructor — the prior hand-rolled literal masked the bug.

## Test plan
- [x] `go test ./internal/services/preview/...` passes
- [x] `go build ./...` clean, `go vet` clean
- [x] Verified both new tests fail with the original failure mode (`@:0/` DSN) when Host/Port are removed from the constructor
- [ ] Trigger a preview from a session and confirm migrations + seed + server boot successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
