### PR TITLE
Fix race in platform-health sampler tests

### DIFF
--- a/internal/services/agent/runtime_sampler_test.go
+++ b/internal/services/agent/runtime_sampler_test.go
@@ -122,8 +122,8 @@ func TestRuntimeSampler_LogsAggregateHealthSample(t *testing.T) {
 	sb := &agent.Sandbox{ID: "ctr-health", Provider: "docker", OrgID: orgID.String()}
 	tracker.ContainerStarted(context.Background(), orgID, sessionID, sb, cfg, time.Now())
 
-	var logs bytes.Buffer
-	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(&logs))
+	logs := &syncBuffer{}
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(logs))
 	ctx, cancel := context.WithCancel(context.Background())
 	go s.Run(ctx)
 	require.Eventually(t, func() bool {
@@ -155,8 +155,8 @@ func TestRuntimeSampler_LogsAggregateHealthSampleWhenIdle(t *testing.T) {
 	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())
 	prov := &fakeStatsProvider{}
 
-	var logs bytes.Buffer
-	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(&logs))
+	logs := &syncBuffer{}
+	s := agent.NewRuntimeSampler(tracker, prov, newMetrics(t), 10*time.Millisecond, zerolog.New(logs))
 	ctx, cancel := context.WithCancel(context.Background())
 	go s.Run(ctx)
 	require.Eventually(t, func() bool {
@@ -332,6 +332,31 @@ type wrappedErr struct {
 
 func (w *wrappedErr) Error() string { return w.prefix + ": " + w.err.Error() }
 func (w *wrappedErr) Unwrap() error { return w.err }
+
+// syncBuffer is a thread-safe bytes.Buffer wrapper for capturing zerolog output
+// when a writer goroutine and an Eventually reader goroutine touch the same buffer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.buf.Bytes()...)
+}
 
 func TestUsageTrackerSnapshot_IsCopy(t *testing.T) {
 	t.Parallel()

--- a/internal/worker/platform_health_test.go
+++ b/internal/worker/platform_health_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,13 +37,13 @@ func TestRunQueueHealthSamplerEmitsStructuredSamples(t *testing.T) {
 			OldestRunnableAgeSeconds: 42,
 		},
 	}}
-	var logs bytes.Buffer
+	logs := &syncBuffer{}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	done := make(chan struct{})
 	go func() {
-		RunQueueHealthSampler(ctx, store, zerolog.New(&logs), time.Hour)
+		RunQueueHealthSampler(ctx, store, zerolog.New(logs), time.Hour)
 		close(done)
 	}()
 	require.Eventually(t, func() bool {
@@ -61,4 +62,23 @@ func TestRunQueueHealthSamplerEmitsStructuredSamples(t *testing.T) {
 	require.Equal(t, float64(1), event["running"], "queue sampler should include running count")
 	require.Equal(t, float64(0), event["dead_letter"], "queue sampler should include dead-letter count")
 	require.Equal(t, float64(42), event["oldest_runnable_age_seconds"], "queue sampler should include oldest runnable age")
+}
+
+// syncBuffer is a thread-safe bytes.Buffer wrapper for capturing zerolog output
+// when a writer goroutine and an Eventually reader goroutine touch the same buffer.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.buf.Bytes()...)
 }


### PR DESCRIPTION
## Summary
- The runtime sampler and queue-health sampler tests shared a `bytes.Buffer` between the zerolog writer goroutine and the `require.Eventually` reader, which the race detector caught and cascaded into every parallel test in `internal/worker`.
- Replaced the raw buffer with a mutex-guarded `syncBuffer` (Write/String/Bytes) in both test files; no production code changed.

## Test plan
- [x] `go test -race -count=1 ./internal/services/agent/ ./internal/worker/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)