### PR TITLE
Stop misclassifying sandbox errors as ChatGPT auth expiry

### DIFF
--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"sort"
@@ -15,6 +16,24 @@ import (
 
 	"github.com/assembledhq/143/internal/models"
 )
+
+// ErrCodexAuthInvalid marks errors that genuinely indicate the user's ChatGPT
+// credential is unusable: refresh token revoked, refresh failed and cached
+// access token already expired, no usable subscription credential. Errors
+// from sandbox-side operations (Docker exec, file write) are NOT wrapped
+// with this sentinel. The orchestrator branches on errors.Is so that only
+// true auth failures show the "re-authenticate with ChatGPT" banner.
+var ErrCodexAuthInvalid = errors.New("codex auth invalid")
+
+// wrapCodexAuthInvalid tags err as a genuine auth failure so callers can
+// distinguish it from sandbox/transport errors via errors.Is. Returns nil
+// when err is nil so it is safe to use in a return chain.
+func wrapCodexAuthInvalid(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrCodexAuthInvalid, err)
+}
 
 // AuthError is returned by CheckAuth and parsePlan's auth-detection heuristic
 // when an agent run cannot authenticate. Callers can errors.As to distinguish
@@ -1009,7 +1028,7 @@ func (e *AgentEnv) InjectCodexAuthForUser(ctx context.Context, orgID uuid.UUID, 
 	// bypass round-robin entirely.
 	cfg, err := e.codexAuth.GetValidToken(ctx, orgID)
 	if err != nil {
-		return false, fmt.Errorf("get codex auth token: %w", err)
+		return false, wrapCodexAuthInvalid(fmt.Errorf("get codex auth token: %w", err))
 	}
 	if cfg == nil {
 		// No OAuth token — not an error, agent will use API key.
@@ -1040,7 +1059,7 @@ func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, scope m
 				Msg("codex subscription needs refresh but no refresher is configured; using cached token")
 			return &cfg, nil
 		}
-		return nil, fmt.Errorf("codex subscription %s is expired and no refresh provider is configured", credID)
+		return nil, wrapCodexAuthInvalid(fmt.Errorf("codex subscription %s is expired and no refresh provider is configured", credID))
 	}
 
 	refreshed, err := refresher.RefreshTokenByID(ctx, scope, credID)
@@ -1052,7 +1071,7 @@ func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, scope m
 				Msg("codex subscription refresh failed; using cached token")
 			return &cfg, nil
 		}
-		return nil, fmt.Errorf("refresh codex subscription %s: %w", credID, err)
+		return nil, wrapCodexAuthInvalid(fmt.Errorf("refresh codex subscription %s: %w", credID, err))
 	}
 	if refreshed == nil {
 		if !cfg.IsExpired() {
@@ -1061,7 +1080,7 @@ func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, scope m
 				Msg("codex subscription refresh returned no token; using cached token")
 			return &cfg, nil
 		}
-		return nil, fmt.Errorf("refresh codex subscription %s returned no token", credID)
+		return nil, wrapCodexAuthInvalid(fmt.Errorf("refresh codex subscription %s returned no token", credID))
 	}
 	return refreshed, nil
 }

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -1487,6 +1487,73 @@ func TestAgentEnvInjectCodexAuth(t *testing.T) {
 	}
 }
 
+// TestAgentEnvInjectCodexAuth_ErrorClassification verifies that
+// InjectCodexAuth tags genuine auth failures with ErrCodexAuthInvalid while
+// leaving sandbox/transport errors un-tagged. The orchestrator branches on
+// this sentinel to decide whether to surface a "re-authenticate with ChatGPT"
+// CTA or a generic retry CTA — misclassification (e.g. labeling a Docker
+// "no such container" as auth-expired) sends users to redo OAuth when their
+// credential is fine.
+func TestAgentEnvInjectCodexAuth_ErrorClassification(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	sandbox := &Sandbox{HomeDir: "/home/test"}
+
+	tests := []struct {
+		name          string
+		codexAuth     CodexAuthProvider
+		provider      *envSandboxProvider
+		wantAuthError bool
+	}{
+		{
+			name:          "GetValidToken failure is auth-shaped",
+			codexAuth:     envCodexAuthProvider{err: errors.New("refresh token revoked")},
+			provider:      &envSandboxProvider{},
+			wantAuthError: true,
+		},
+		{
+			name:          "Docker exec failure is NOT auth-shaped",
+			codexAuth:     envCodexAuthProvider{token: &models.OpenAIChatGPTConfig{AccessToken: "access", IDToken: "id"}},
+			provider:      &envSandboxProvider{execErr: errors.New("Error response from daemon: No such container: abc123")},
+			wantAuthError: false,
+		},
+		{
+			name:          "mkdir non-zero exit is NOT auth-shaped",
+			codexAuth:     envCodexAuthProvider{token: &models.OpenAIChatGPTConfig{AccessToken: "access", IDToken: "id"}},
+			provider:      &envSandboxProvider{execExitCode: 1},
+			wantAuthError: false,
+		},
+		{
+			name:      "WriteFile failure is NOT auth-shaped",
+			codexAuth: envCodexAuthProvider{token: &models.OpenAIChatGPTConfig{AccessToken: "access", IDToken: "id"}},
+			provider: &envSandboxProvider{writeErrByPath: map[string]error{
+				"/home/test/.codex/auth.json": errors.New("disk full"),
+			}},
+			wantAuthError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			env := NewAgentEnv(AgentEnvDeps{
+				CodexAuth: tt.codexAuth,
+				Provider:  tt.provider,
+				Logger:    zerolog.Nop(),
+			})
+
+			_, err := env.InjectCodexAuth(ctx, orgID, sandbox)
+			require.Error(t, err)
+			require.Equal(t, tt.wantAuthError, errors.Is(err, ErrCodexAuthInvalid),
+				"errors.Is(err, ErrCodexAuthInvalid) mismatch for %s — got err=%v", tt.name, err)
+		})
+	}
+}
+
 func TestAgentEnvInjectCodexAuthForUser_RefreshesUnifiedSubscriptionByID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/failure.go
+++ b/internal/services/agent/failure.go
@@ -19,6 +19,12 @@ const (
 	FailureCategoryComplexity     = "complexity"
 	FailureCategoryCodexAuth      = "codex_auth_expired"
 	FailureCategoryClaudeCodeAuth = "claude_code_auth_expired"
+	// FailureCategoryCodexAuthInject is set when codex auth.json injection
+	// into the sandbox failed for non-auth reasons (Docker container missing,
+	// exec/write transport error, etc). Distinct from codex_auth_expired so
+	// the UI does not push the user to re-authenticate when the credential
+	// is fine.
+	FailureCategoryCodexAuthInject = "codex_auth_inject_failed"
 	// FailureCategoryTimeout marks a session that hit its configured
 	// wall-clock limit. Set explicitly by the orchestrator timeout path so
 	// classification does not depend on error-text matching in classifyFailure.

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -2217,6 +2217,54 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		sandboxCfg.Env["HOME"] = sandboxCfg.HomeDir
 	}
 	reusedExisting := session.ContainerID != nil && *session.ContainerID != ""
+	// Liveness check on reuse: a recorded container_id only means "someone
+	// (preview, prior turn) wrote it" — it does NOT prove the container is
+	// still alive. If the container was destroyed without going through
+	// FinalizeContainerDestroy / ClearContainerID (worker rollover, docker
+	// daemon eviction, OOM kill, ad-hoc cleanup), the row holds a stale ID
+	// pointing at a dead container. The reuse branch below then builds a
+	// Sandbox{} from that ID and the first downstream Docker exec fails
+	// with "No such container", historically misclassified as a Codex auth
+	// expiry. Probe IsAlive up front; if dead, CAS-clear via ClearContainerID
+	// and return ErrStaleSandboxIDCleared so the worker retries against a
+	// clean row (the next attempt sees container_id=NULL and falls through
+	// to hydrate-from-snapshot or fresh-create).
+	//
+	// On probe error we conservatively keep going (treat as alive) — the
+	// downstream operation will surface a real failure if the container is
+	// gone, and we'd rather not retry-loop against a transient docker hiccup.
+	if reusedExisting {
+		probeCtx, cancel := context.WithTimeout(ctx, sandboxRaceProbeTimeout)
+		alive, aliveErr := o.provider.IsAlive(probeCtx, &Sandbox{ID: *session.ContainerID, Provider: "docker"})
+		cancel()
+		switch {
+		case aliveErr != nil:
+			log.Warn().Err(aliveErr).
+				Str("container_id", *session.ContainerID).
+				Msg("IsAlive probe on recorded container_id failed during continue_session reuse; assuming alive and proceeding")
+		case !alive:
+			cleared, clearErr := o.sessions.ClearContainerID(ctx, session.OrgID, session.ID, *session.ContainerID)
+			if clearErr != nil {
+				log.Warn().Err(clearErr).
+					Str("stale_container_id", *session.ContainerID).
+					Msg("ClearContainerID failed during continue_session reuse liveness check; falling through to reuse path which will surface the underlying docker error")
+				break
+			}
+			if !cleared {
+				log.Info().
+					Str("stale_container_id", *session.ContainerID).
+					Msg("ClearContainerID CAS lost during continue_session reuse liveness check (a new holder acquired between probe and clear); proceeding with the now-active row")
+				break
+			}
+			log.Warn().
+				Str("stale_container_id", *session.ContainerID).
+				Msg("cleared stale orphan container_id during continue_session reuse liveness check; signaling retry to re-enter against the clean row")
+			if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
+				log.Error().Err(revertErr).Msg("failed to revert session to pending after stale container_id cleared")
+			}
+			return ErrStaleSandboxIDCleared
+		}
+	}
 	integrationSkills := o.BuildIntegrationSkills(ctx, session.OrgID)
 	var authState *sandboxGitHubAuthState
 	var authErr error
@@ -3462,8 +3510,13 @@ func (o *Orchestrator) failTimedOutSession(run *models.Session, elapsed time.Dur
 	}, log)
 }
 
-// ensureCodexAuth injects Codex auth credentials into the sandbox, failing the
-// run with a codex_auth_expired category if injection fails or no creds exist.
+// ensureCodexAuth injects Codex auth credentials into the sandbox. On failure
+// it distinguishes between genuine auth invalidity (refresh-token revoked,
+// no usable credential) — surfaced as codex_auth_expired with a re-authenticate
+// CTA — and sandbox/transport errors during injection (Docker container gone,
+// exec/write failure) — surfaced as codex_auth_inject_failed with a retry CTA.
+// Auth-side errors are tagged at the source via wrapCodexAuthInvalid in env.go;
+// anything else is treated as transient infra.
 func (o *Orchestrator) ensureCodexAuth(ctx context.Context, run *models.Session, sandbox *Sandbox, env map[string]string) error {
 	if env["OPENAI_API_KEY"] != "" && o.env != nil && o.env.unifiedCodingCredentialIsAPIKey(ctx, run.OrgID, run.TriggeredByUserID, models.ProviderOpenAI) {
 		return nil
@@ -3471,11 +3524,20 @@ func (o *Orchestrator) ensureCodexAuth(ctx context.Context, run *models.Session,
 
 	injected, err := o.env.InjectCodexAuthForUser(ctx, run.OrgID, run.TriggeredByUserID, sandbox)
 	if err != nil {
+		if errors.Is(err, ErrCodexAuthInvalid) {
+			o.failRunWithCategory(ctx, run,
+				fmt.Sprintf("codex auth injection failed: %s", err),
+				FailureCategoryCodexAuth,
+				"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
+				[]string{"Re-authenticate with ChatGPT from the session page to sign in again"},
+			)
+			return fmt.Errorf("codex auth injection: %w", err)
+		}
 		o.failRunWithCategory(ctx, run,
 			fmt.Sprintf("codex auth injection failed: %s", err),
-			FailureCategoryCodexAuth,
-			"Your ChatGPT authentication has expired or was revoked. Please re-authenticate to continue using Codex.",
-			[]string{"Re-authenticate with ChatGPT from the session page to sign in again"},
+			FailureCategoryCodexAuthInject,
+			"Could not inject ChatGPT credentials into the sandbox because of an infrastructure error (Docker exec or file write failed). Your ChatGPT authentication itself is still valid — retry the session.",
+			[]string{"Retry the session — the underlying sandbox error is usually transient", "If retries keep failing, check the worker logs for Docker errors"},
 		)
 		return fmt.Errorf("codex auth injection: %w", err)
 	}

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3065,6 +3065,120 @@ func TestContinueSession_RepairedSlashCommandsOnReusePath(t *testing.T) {
 	require.NoError(t, err, "ContinueSession should succeed on the reuse path when slash commands need repair")
 }
 
+// TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead verifies the
+// defensive liveness probe in the reuse path. When session.container_id points
+// at a container that no longer exists (worker rollover / docker eviction
+// destroyed it without going through FinalizeContainerDestroy), the
+// continue_session must NOT proceed to attach to the dead container — that
+// path historically misclassified the resulting Docker error as a Codex auth
+// expiry. Instead, ClearContainerID is called and ErrStaleSandboxIDCleared is
+// returned so the worker retries against a clean row.
+func TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	stale := "stale-container-8d0c678c"
+	session.ContainerID = &stale
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "follow-up",
+		},
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		require.Equal(t, stale, sb.ID, "IsAlive must probe the recorded container_id")
+		return false, nil
+	}
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		require.Equal(t, stale, expected, "ClearContainerID must guard the CAS on the recorded id")
+		return true, nil
+	}
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		t.Fatalf("provider.Create must not run when liveness probe rejects the recorded container_id; the worker will retry")
+		return nil, nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		t.Fatalf("adapter.Execute must not run when the session bailed out for a stale-orphan retry")
+		return nil, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared,
+		"ContinueSession reuse path with dead recorded container_id must return ErrStaleSandboxIDCleared so the worker retries")
+	require.Equal(t, 1, d.sessions.clearContainerIDCalls, "ClearContainerID must be called exactly once")
+}
+
+// TestContinueSession_ReusePathProceedsWhenIsAliveErrors covers the
+// conservative fallback: a transient docker / probe error must NOT trigger
+// the orphan-clear path. The reuse continues and any real failure surfaces
+// through the normal downstream code (so a brief docker hiccup doesn't tear
+// down a session row that's actually fine).
+func TestContinueSession_ReusePathProceedsWhenIsAliveErrors(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	existing := "preview-container-abc"
+	session.ContainerID = &existing
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "follow-up",
+		},
+	}
+	d.provider.IsAliveFn = func(ctx context.Context, sb *agent.Sandbox) (bool, error) {
+		return false, errors.New("docker connection refused")
+	}
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		t.Fatalf("ClearContainerID must NOT be called when IsAlive errored; transient probe failures fall through")
+		return false, nil
+	}
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		t.Fatalf("provider.Create must not be called on the reuse path")
+		return nil, nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		return &agent.AgentResult{
+			Summary:             "done",
+			ConfidenceScore:     0.9,
+			ConfidenceReasoning: "ok",
+			ExitCode:            0,
+		}, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.NoError(t, err, "transient IsAlive probe error must NOT bail out — reuse continues so transient docker hiccups don't reset the session row")
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "ClearContainerID must not be invoked on probe-error path")
+}
+
 func TestRunAgent_LogStreamingWithQuestion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Two fixes to the codex auth-injection failure path that were causing users to re-authenticate with ChatGPT when their auth was actually fine:

- **Stop misclassifying sandbox errors as auth expiry.** `ensureCodexAuth` previously labeled every error from `InjectCodexAuthForUser` as `codex_auth_expired` with a "re-authenticate with ChatGPT" CTA, even when the underlying error was a Docker `No such container` from a stale sandbox id. Genuine auth failures (refresh-token revoked, no usable subscription, GetValidToken failure) are now tagged at the source via a new `ErrCodexAuthInvalid` sentinel; everything else lands in a new `codex_auth_inject_failed` category with a retry CTA.
- **Defensive liveness probe in `ContinueSession`'s reuse path.** A recorded `container_id` only proves "someone wrote it" — not that the container is still alive. If a container was destroyed without going through `FinalizeContainerDestroy`/`ClearContainerID` (worker rollover, daemon restart, OOM), the next continue_session would attach to the dead id and surface a fake auth expiry. Now we `IsAlive`-probe before reuse and, if dead, CAS-clear via `ClearContainerID` and return `ErrStaleSandboxIDCleared` so the worker retries against a clean row. Mirrors the existing `diagnoseAcquireHoldRaceLoss` pattern. Probe errors fall through (don't tear down a row over a transient docker hiccup).

## Test plan

- [ ] `make lint` passes
- [ ] `go test ./internal/services/agent/...` passes (added `TestAgentEnvInjectCodexAuth_ErrorClassification`, `TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead`, `TestContinueSession_ReusePathProceedsWhenIsAliveErrors`)
- [ ] Trigger a continue_session against a session whose recorded `container_id` was destroyed out-of-band; confirm the job retries cleanly instead of failing with a misleading auth banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
