### PR TITLE
Pin sandbox-bound jobs to the worker holding the session container

### DIFF
--- a/internal/api/handlers/session_review_comments.go
+++ b/internal/api/handlers/session_review_comments.go
@@ -433,7 +433,14 @@ func (h *SessionReviewCommentHandler) SendToAgent(w http.ResponseWriter, r *http
 			"session_id": sessionID.String(),
 			"org_id":     orgID.String(),
 		}
-		if _, err := h.jobStore.Enqueue(r.Context(), orgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
+		if _, err := h.jobStore.EnqueueWithOpts(r.Context(), orgID, db.EnqueueOpts{
+			Queue:        "agent",
+			JobType:      "continue_session",
+			Payload:      payload,
+			Priority:     5,
+			DedupeKey:    &dedupeKey,
+			TargetNodeID: models.SessionWorkerTarget(&session),
+		}); err != nil {
 			// Delete the orphaned message and revert session status.
 			if msg.ID != 0 {
 				if delErr := h.messageStore.Delete(r.Context(), msg.ID); delErr != nil {

--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -149,6 +149,10 @@ func (m *mockJobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobT
 	return uuid.New(), nil
 }
 
+func (m *mockJobStore) EnqueueWithOpts(ctx context.Context, orgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
+	return m.Enqueue(ctx, orgID, opts.Queue, opts.JobType, opts.Payload, opts.Priority, opts.DedupeKey)
+}
+
 // --- Helper to build the handler ---
 
 type threadTestDeps struct {

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -2004,13 +2004,22 @@ func (h *SessionHandler) SendMessage(w http.ResponseWriter, r *http.Request) {
 	// Enqueue continue_session job. Dedupe at the session level — only one
 	// continue_session can hold the shared sandbox at a time, so a duplicate
 	// would race AcquireTurnHold and dead-letter via the orchestrator's
-	// self-heal path.
+	// self-heal path. Pin to the worker that owns the live sandbox so the
+	// job can't be claimed by a sibling node whose docker daemon doesn't
+	// know about the container_id.
 	dedupeKey := db.ContinueSessionDedupeKey(sessionID)
 	payload := map[string]string{
 		"session_id": sessionID.String(),
 		"org_id":     orgID.String(),
 	}
-	if _, err := h.jobStore.EnqueueInTx(r.Context(), tx, orgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
+	if _, err := h.jobStore.EnqueueInTxWithOpts(r.Context(), tx, orgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      payload,
+		Priority:     5,
+		DedupeKey:    &dedupeKey,
+		TargetNodeID: models.SessionWorkerTarget(&session),
+	}); err != nil {
 		writeError(w, r, http.StatusInternalServerError, "ENQUEUE_FAILED", "failed to enqueue continue_session job", err)
 		return
 	}

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -39,7 +39,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows([]string{"id"}).
 							AddRow(generatedID),
@@ -56,7 +56,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows([]string{"id"}).
 							AddRow(generatedID),
@@ -85,7 +85,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, _ uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(pgx.ErrNoRows)
 			},
 			expectNilID: true,
@@ -304,7 +304,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				orgID := uuid.New()
 				now := time.Now()
 				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
@@ -324,7 +324,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				now := time.Now()
 				completedAt := now.Add(time.Minute)
 				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
@@ -340,7 +340,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 			name: "returns nil when no pending job exists",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
 				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(pgx.ErrNoRows)
 			},
 			expectNil: true,
@@ -349,7 +349,7 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 			name: "returns query errors",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
 				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), "worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
 					WillReturnError(errors.New("db down"))
 			},
 			expectErr: true,

--- a/internal/db/job_store_test.go
+++ b/internal/db/job_store_test.go
@@ -39,7 +39,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows([]string{"id"}).
 							AddRow(generatedID),
@@ -56,7 +56,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, generatedID uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows([]string{"id"}).
 							AddRow(generatedID),
@@ -85,7 +85,7 @@ func TestJobStore_Enqueue(t *testing.T) {
 			setupMock: func(mock pgxmock.PgxPoolIface, _ uuid.UUID) {
 				mock.ExpectQuery("INSERT INTO jobs").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
-						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+						pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(pgx.ErrNoRows)
 			},
 			expectNilID: true,
@@ -120,6 +120,39 @@ func TestJobStore_Enqueue(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
+}
+
+// TestJobStore_EnqueueWithOpts_PinsTargetNode verifies that EnqueueWithOpts
+// passes TargetNodeID through to the INSERT so node-affinity routing actually
+// records the pin. The plain Enqueue wrapper doesn't take a target — its
+// callers get NULL, the unpinned-claim case.
+func TestJobStore_EnqueueWithOpts_PinsTargetNode(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewJobStore(mock)
+	orgID := uuid.New()
+	generatedID := uuid.New()
+	target := "worker-host-c"
+
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(orgID, "agent", "continue_session", pgxmock.AnyArg(), 5, jobDedupeKeyPtr("k"), &target).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(generatedID))
+
+	id, err := store.EnqueueWithOpts(context.Background(), orgID, EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      map[string]string{"session_id": "abc"},
+		Priority:     5,
+		DedupeKey:    jobDedupeKeyPtr("k"),
+		TargetNodeID: &target,
+	})
+	require.NoError(t, err)
+	require.Equal(t, generatedID, id, "EnqueueWithOpts should return the generated job id when the pin lands cleanly")
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestJobStore_GetLatestFailedByType(t *testing.T) {
@@ -270,44 +303,44 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
-				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "last_error",
-						"dedupe_key", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "run_agent", []byte(`{"session_id":"abc"}`), 5, "running",
-						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", nil, nil, now, now, nil,
+						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", nil, nil, nil, now, now, nil,
 					))
 			},
 		},
 		{
-			name: "hydrates optional persisted fields",
+			name: "hydrates optional persisted fields including target node",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
 				completedAt := now.Add(time.Minute)
-				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "last_error",
-						"dedupe_key", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "run_agent", []byte(`{"session_id":"abc"}`), 5, "running",
-						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "boom", "dedupe-1", now, now, completedAt,
+						1, 3, now, "worker-1", now, now.Add(leaseDuration), lockToken.String(), "worker-1", "boom", "dedupe-1", "worker-1", now, now, completedAt,
 					))
 			},
 		},
 		{
 			name: "returns nil when no pending job exists",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
 					WillReturnError(pgx.ErrNoRows)
 			},
 			expectNil: true,
@@ -315,8 +348,8 @@ func TestJobStore_ClaimNextRunnable(t *testing.T) {
 		{
 			name: "returns query errors",
 			setupMock: func(mock pgxmock.PgxPoolIface, leaseDuration time.Duration, lockToken uuid.UUID) {
-				mock.ExpectQuery("WITH next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
-					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS[\\s\\S]*next_job AS[\\s\\S]*RETURNING j.id, j.org_id, j.queue, j.job_type").
+					WithArgs("worker-1", "worker-1", lockToken, int(leaseDuration.Seconds()), pgxmock.AnyArg()).
 					WillReturnError(errors.New("db down"))
 			},
 			expectErr: true,

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -106,8 +106,36 @@ func (s *JobStore) GetLatestFailedByType(ctx context.Context, orgID uuid.UUID, j
 	return &result, nil
 }
 
-func (s *JobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
-	id, err := enqueueOn(ctx, s.db, orgID, queue, jobType, payload, priority, dedupeKey)
+// EnqueueOpts captures all parameters for a single Enqueue call. Callers fill
+// in the fields they need; zero values pass through.
+//
+// New enqueue-time scheduling features (target node, deferred run-at, custom
+// max attempts) are added here rather than as new positional method
+// parameters so the signature stays stable as the queue grows new affinity /
+// scheduling capabilities. The plain Enqueue/EnqueueInTx methods remain as
+// thin wrappers around the opts form for the common "no special scheduling"
+// case so the bulk of existing call sites stay untouched.
+type EnqueueOpts struct {
+	Queue     string
+	JobType   string
+	Payload   any
+	Priority  int
+	DedupeKey *string
+
+	// TargetNodeID, when set, restricts the job to be claimed by this
+	// specific worker node. Used for sandbox-bound jobs (continue_session,
+	// open_pr, run_agent for resume) where the work must execute on the
+	// same docker daemon as the session's recorded container_id. NULL
+	// means any worker can claim. The claim path falls back to "any worker"
+	// if the target node is marked dead in the `nodes` table, so a pinned
+	// job cannot starve when its node is permanently lost.
+	TargetNodeID *string
+}
+
+// EnqueueWithOpts is the canonical enqueue path. Enqueue/EnqueueInTx wrap it
+// for the common case.
+func (s *JobStore) EnqueueWithOpts(ctx context.Context, orgID uuid.UUID, opts EnqueueOpts) (uuid.UUID, error) {
+	id, err := enqueueOn(ctx, s.db, orgID, opts)
 	if err != nil {
 		return id, err
 	}
@@ -115,11 +143,49 @@ func (s *JobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType 
 	return id, nil
 }
 
+// EnqueueInTxWithOpts is the in-transaction variant of EnqueueWithOpts. The
+// caller is responsible for calling Notify after commit so the wake-up isn't
+// fired before the row is durable.
+func (s *JobStore) EnqueueInTxWithOpts(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, opts EnqueueOpts) (uuid.UUID, error) {
+	return enqueueOn(ctx, tx, orgID, opts)
+}
+
+func (s *JobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
+	return s.EnqueueWithOpts(ctx, orgID, EnqueueOpts{
+		Queue:     queue,
+		JobType:   jobType,
+		Payload:   payload,
+		Priority:  priority,
+		DedupeKey: dedupeKey,
+	})
+}
+
+// EnqueueWithTarget is the positional-args wrapper for callers (typically
+// service-package interfaces with a fixed JobStore method shape) that need
+// to set TargetNodeID without depending on the EnqueueOpts type. Behaves
+// identically to EnqueueWithOpts; pass nil targetNodeID for an unpinned job.
+func (s *JobStore) EnqueueWithTarget(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string, targetNodeID *string) (uuid.UUID, error) {
+	return s.EnqueueWithOpts(ctx, orgID, EnqueueOpts{
+		Queue:        queue,
+		JobType:      jobType,
+		Payload:      payload,
+		Priority:     priority,
+		DedupeKey:    dedupeKey,
+		TargetNodeID: targetNodeID,
+	})
+}
+
 // EnqueueInTx inserts a job inside an existing transaction so callers that
 // must create a row and a job atomically (e.g. automation RunNow) don't leave
 // orphaned state when one side fails.
 func (s *JobStore) EnqueueInTx(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
-	return enqueueOn(ctx, tx, orgID, queue, jobType, payload, priority, dedupeKey)
+	return s.EnqueueInTxWithOpts(ctx, tx, orgID, EnqueueOpts{
+		Queue:     queue,
+		JobType:   jobType,
+		Payload:   payload,
+		Priority:  priority,
+		DedupeKey: dedupeKey,
+	})
 }
 
 // Notify publishes a best-effort wake-up for an already-created job row.
@@ -235,26 +301,27 @@ type jobQuerier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
-	payloadJSON, err := json.Marshal(payload)
+func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueOpts) (uuid.UUID, error) {
+	payloadJSON, err := json.Marshal(opts.Payload)
 	if err != nil {
 		return uuid.Nil, err
 	}
 
 	var id uuid.UUID
 	query := `
-		INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key)
-		VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key)
+		INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key, target_node_id)
+		VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key, @target_node_id)
 		ON CONFLICT DO NOTHING
 		RETURNING id`
 
 	err = q.QueryRow(ctx, query, pgx.NamedArgs{
-		"org_id":     orgID,
-		"queue":      queue,
-		"job_type":   jobType,
-		"payload":    payloadJSON,
-		"priority":   priority,
-		"dedupe_key": dedupeKey,
+		"org_id":         orgID,
+		"queue":          opts.Queue,
+		"job_type":       opts.JobType,
+		"payload":        payloadJSON,
+		"priority":       opts.Priority,
+		"dedupe_key":     opts.DedupeKey,
+		"target_node_id": opts.TargetNodeID,
 	}).Scan(&id)
 	// ON CONFLICT DO NOTHING returns no row when a pending/running job with the
 	// same (queue, dedupe_key) already exists. Treat that as a successful no-op:
@@ -278,7 +345,13 @@ func (s *JobStore) DeleteExpiredCompleted(ctx context.Context, retentionDays int
 const claimedJobColumns = `j.id, j.org_id, j.queue, j.job_type, j.payload, j.priority, j.status,
 	j.attempts, j.max_attempts, j.run_at, j.locked_by_node_id, j.locked_at,
 	j.lease_expires_at, j.lock_token, j.run_owner_id, j.last_error,
-	j.dedupe_key, j.created_at, j.updated_at, j.completed_at`
+	j.dedupe_key, j.target_node_id, j.created_at, j.updated_at, j.completed_at`
+
+// nodeDeadHeartbeatThreshold is how long a node can go without heartbeating
+// before its pinned jobs become claimable by any worker. Set generously
+// above the node manager's heartbeat interval (currently 10s) so a transient
+// network blip doesn't unpin jobs from a healthy worker.
+const nodeDeadHeartbeatThreshold = 90 * time.Second
 
 type jobExecer interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
@@ -287,14 +360,33 @@ type jobExecer interface {
 // ClaimNextRunnable atomically claims the next due pending job, marking it as
 // running with a renewable lease and fencing token. Returns nil, nil when no
 // runnable job exists.
+//
+// Node-affinity filter: jobs with target_node_id NULL can be claimed by any
+// worker (the common case). Jobs with target_node_id set can only be claimed
+// by the matching node OR if the target node is dead (status='dead' or stale
+// heartbeat). The dead-node fallback prevents starvation when a pinned worker
+// is permanently lost — the job becomes claimable by anyone instead of
+// sitting forever. The freshness threshold matches ReclaimLostRunningJobs's
+// dead-node detection so the two paths agree on what "dead" means.
 // lint:allow-no-orgid reason="worker queue consumer scans cross-org jobs by design"
 func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string, lockToken uuid.UUID, leaseDuration time.Duration) (*models.Job, error) {
 	query := fmt.Sprintf(`
-		WITH next_job AS (
+		WITH dead_target_nodes AS (
 			SELECT id
-			FROM jobs
-			WHERE status = 'pending' AND run_at <= now()
-			ORDER BY priority DESC, created_at ASC
+			FROM nodes
+			WHERE status = 'dead' OR last_heartbeat_at < @dead_before
+		),
+		next_job AS (
+			SELECT j.id
+			FROM jobs j
+			LEFT JOIN dead_target_nodes d ON d.id = j.target_node_id
+			WHERE j.status = 'pending' AND j.run_at <= now()
+			  AND (
+			    j.target_node_id IS NULL
+			    OR j.target_node_id = @node_id
+			    OR d.id IS NOT NULL
+			  )
+			ORDER BY j.priority DESC, j.created_at ASC
 			FOR UPDATE SKIP LOCKED
 			LIMIT 1
 		)
@@ -319,17 +411,19 @@ func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string
 	var runOwnerID pgtype.Text
 	var lastError pgtype.Text
 	var dedupeKey pgtype.Text
+	var targetNodeID pgtype.Text
 	var completedAt pgtype.Timestamptz
 	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
 		"node_id":       nodeID,
 		"owner_id":      ownerID,
 		"lock_token":    lockToken,
 		"lease_seconds": int(leaseDuration.Seconds()),
+		"dead_before":   time.Now().Add(-nodeDeadHeartbeatThreshold),
 	}).Scan(
 		&job.ID, &job.OrgID, &job.Queue, &job.JobType, &job.Payload, &job.Priority,
 		&job.Status, &job.Attempts, &job.MaxAttempts, &job.RunAt, &lockedByNodeID,
 		&lockedAt, &leaseExpiresAt, &persistedLockToken, &runOwnerID,
-		&lastError, &dedupeKey, &job.CreatedAt, &job.UpdatedAt, &completedAt,
+		&lastError, &dedupeKey, &targetNodeID, &job.CreatedAt, &job.UpdatedAt, &completedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -358,6 +452,9 @@ func (s *JobStore) ClaimNextRunnable(ctx context.Context, nodeID, ownerID string
 	}
 	if dedupeKey.Valid {
 		job.DedupeKey = &dedupeKey.String
+	}
+	if targetNodeID.Valid {
+		job.TargetNodeID = &targetNodeID.String
 	}
 	if completedAt.Valid {
 		job.CompletedAt = &completedAt.Time

--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -308,13 +308,7 @@ func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueO
 	}
 
 	var id uuid.UUID
-	query := `
-		INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key, target_node_id)
-		VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key, @target_node_id)
-		ON CONFLICT DO NOTHING
-		RETURNING id`
-
-	err = q.QueryRow(ctx, query, pgx.NamedArgs{
+	args := pgx.NamedArgs{
 		"org_id":         orgID,
 		"queue":          opts.Queue,
 		"job_type":       opts.JobType,
@@ -322,7 +316,22 @@ func enqueueOn(ctx context.Context, q jobQuerier, orgID uuid.UUID, opts EnqueueO
 		"priority":       opts.Priority,
 		"dedupe_key":     opts.DedupeKey,
 		"target_node_id": opts.TargetNodeID,
-	}).Scan(&id)
+	}
+	query := `
+		INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key, target_node_id)
+		VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key, @target_node_id)
+		ON CONFLICT DO NOTHING
+		RETURNING id`
+	if opts.TargetNodeID == nil {
+		query = `
+			INSERT INTO jobs (org_id, queue, job_type, payload, priority, dedupe_key)
+			VALUES (@org_id, @queue, @job_type, @payload, @priority, @dedupe_key)
+			ON CONFLICT DO NOTHING
+			RETURNING id`
+		delete(args, "target_node_id")
+	}
+
+	err = q.QueryRow(ctx, query, args).Scan(&id)
 	// ON CONFLICT DO NOTHING returns no row when a pending/running job with the
 	// same (queue, dedupe_key) already exists. Treat that as a successful no-op:
 	// the existing job will satisfy the caller's intent.

--- a/internal/db/tenancy_test.go
+++ b/internal/db/tenancy_test.go
@@ -70,11 +70,12 @@ func TestMultiTenancyAudit(t *testing.T) {
 		{"sessions", "diff_history"},                           // UpdateResult/UpdateTurnComplete: org_id is in a concatenated string fragment
 		{"repositories", "installation_id"},
 		{"integrations", "from integrations"},
-		{"jobs", "where status = 'pending' and run_at <= now()"},        // ClaimNextRunnable: cross-org worker queue consumer
+		{"jobs", "where j.status = 'pending' and j.run_at <= now()"},    // ClaimNextRunnable: cross-org worker queue consumer
 		{"jobs", "where id = @job_id"},                                  // RenewLease: fenced worker lease renewal by job id
 		{"jobs", "where id = $1"},                                       // fenced worker terminal writes by job id
 		{"jobs", "where id = $2"},                                       // fenced worker terminal writes by job id
 		{"jobs", "where id = $3"},                                       // fenced worker retry writes by job id
+		{"jobs", "count(*) filter"},                                     // QueueHealthSamples: platform-wide queue pressure sampler
 		{"jobs", "left join dead_nodes"},                                // ReclaimLostRunningJobs: cross-org recovery loop
 		{"jobs", "where status = 'running' and locked_by_node_id = $1"}, // CountRunningOwnedByNode: node-scoped drain status
 		{"session_logs", "from session_logs"},                           // no org_id column; scoped via session_id FK

--- a/internal/jobctx/jobctx.go
+++ b/internal/jobctx/jobctx.go
@@ -15,6 +15,7 @@ type ctxKey int
 const (
 	hooksKey ctxKey = iota
 	lockTokenKey
+	deadTargetNodeKey
 )
 
 // DeadLetterHook runs synchronously on the worker's poll goroutine when
@@ -40,6 +41,15 @@ func WithLockToken(ctx context.Context, token uuid.UUID) context.Context {
 func LockTokenFromContext(ctx context.Context) (uuid.UUID, bool) {
 	token, ok := ctx.Value(lockTokenKey).(uuid.UUID)
 	return token, ok
+}
+
+func WithDeadTargetNode(ctx context.Context, nodeID string) context.Context {
+	return context.WithValue(ctx, deadTargetNodeKey, nodeID)
+}
+
+func DeadTargetNodeFromContext(ctx context.Context) (string, bool) {
+	nodeID, ok := ctx.Value(deadTargetNodeKey).(string)
+	return nodeID, ok && nodeID != ""
 }
 
 // RegisterDeadLetterHook queues a hook on the context's registry. When the

--- a/internal/jobctx/jobctx_test.go
+++ b/internal/jobctx/jobctx_test.go
@@ -127,3 +127,13 @@ func TestWithLockToken_RoundTrip(t *testing.T) {
 	require.True(t, ok, "WithLockToken should store the lock token in context")
 	require.Equal(t, want, got, "LockTokenFromContext should return the stored token")
 }
+
+func TestWithDeadTargetNode_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := jobctx.WithDeadTargetNode(context.Background(), "worker-dead")
+
+	got, ok := jobctx.DeadTargetNodeFromContext(ctx)
+	require.True(t, ok, "WithDeadTargetNode should store the dead target node in context")
+	require.Equal(t, "worker-dead", got, "DeadTargetNodeFromContext should return the stored node id")
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -808,9 +808,46 @@ type Job struct {
 	RunOwnerID     *string         `db:"run_owner_id" json:"run_owner_id,omitempty"`
 	LastError      *string         `db:"last_error" json:"last_error,omitempty"`
 	DedupeKey      *string         `db:"dedupe_key" json:"dedupe_key,omitempty"`
-	CreatedAt      time.Time       `db:"created_at" json:"created_at"`
-	UpdatedAt      time.Time       `db:"updated_at" json:"updated_at"`
-	CompletedAt    *time.Time      `db:"completed_at" json:"completed_at,omitempty"`
+	// TargetNodeID, when set, restricts the job to be claimed by this
+	// specific worker node. Used for sandbox-bound jobs (continue_session,
+	// open_pr, run_agent for resume) where the work must execute on the same
+	// docker daemon as the session's recorded container_id. NULL means any
+	// worker can claim. A pinned job becomes claimable by any worker if its
+	// target node is marked dead in the `nodes` table (starvation safety).
+	TargetNodeID *string    `db:"target_node_id" json:"target_node_id,omitempty"`
+	CreatedAt    time.Time  `db:"created_at" json:"created_at"`
+	UpdatedAt    time.Time  `db:"updated_at" json:"updated_at"`
+	CompletedAt  *time.Time `db:"completed_at" json:"completed_at,omitempty"`
+}
+
+// SessionWorkerTarget returns the worker_node_id to pin sandbox-bound jobs
+// (continue_session, open_pr, run_agent for resume) to, or nil if the
+// session has no live sandbox to be pinned to.
+//
+// Pinning is correct only when the session currently owns a sandbox (its
+// container_id and worker_node_id are both populated). After a snapshot —
+// either by reaper recycling, post-PR snapshot capture, or explicit user
+// stop — container_id is cleared and any worker can hydrate fresh, so the
+// caller wants nil. Both fields are checked because container_id without
+// worker_node_id is a transient state during the AcquireTurnHold → Set
+// WorkerNodeID handshake; pinning during that window would race the
+// owner-publishing CAS.
+//
+// The defensive empty-string check guards against a malformed row where the
+// pointer is non-nil but the value is the zero string — recording an empty
+// target would make every claim attempt mismatch and starve the job.
+func SessionWorkerTarget(s *Session) *string {
+	if s == nil {
+		return nil
+	}
+	if s.ContainerID == nil || *s.ContainerID == "" {
+		return nil
+	}
+	if s.WorkerNodeID == nil || *s.WorkerNodeID == "" {
+		return nil
+	}
+	owner := *s.WorkerNodeID
+	return &owner
 }
 
 // SessionReviewComment represents an inline review comment on a session diff.

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -18,11 +18,11 @@ import (
 )
 
 // ErrCodexAuthInvalid marks errors that genuinely indicate the user's ChatGPT
-// credential is unusable: refresh token revoked, refresh failed and cached
-// access token already expired, no usable subscription credential. Errors
-// from sandbox-side operations (Docker exec, file write) are NOT wrapped
-// with this sentinel. The orchestrator branches on errors.Is so that only
-// true auth failures show the "re-authenticate with ChatGPT" banner.
+// credential is unusable: refresh token revoked, reused, or missing after the
+// cached access token has expired. Store, network, OAuth server, and
+// sandbox-side operations (Docker exec, file write) are NOT wrapped with this
+// sentinel. The orchestrator branches on errors.Is so that only true auth
+// failures show the "re-authenticate with ChatGPT" banner.
 var ErrCodexAuthInvalid = errors.New("codex auth invalid")
 
 // wrapCodexAuthInvalid tags err as a genuine auth failure so callers can
@@ -33,6 +33,24 @@ func wrapCodexAuthInvalid(err error) error {
 		return nil
 	}
 	return fmt.Errorf("%w: %w", ErrCodexAuthInvalid, err)
+}
+
+type codexAuthInvalidReporter interface {
+	IsAuthInvalid(error) bool
+}
+
+func maybeWrapCodexAuthInvalid(source any, err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrCodexAuthInvalid) {
+		return err
+	}
+	reporter, ok := source.(codexAuthInvalidReporter)
+	if ok && reporter.IsAuthInvalid(err) {
+		return wrapCodexAuthInvalid(err)
+	}
+	return err
 }
 
 // AuthError is returned by CheckAuth and parsePlan's auth-detection heuristic
@@ -1028,7 +1046,7 @@ func (e *AgentEnv) InjectCodexAuthForUser(ctx context.Context, orgID uuid.UUID, 
 	// bypass round-robin entirely.
 	cfg, err := e.codexAuth.GetValidToken(ctx, orgID)
 	if err != nil {
-		return false, wrapCodexAuthInvalid(fmt.Errorf("get codex auth token: %w", err))
+		return false, maybeWrapCodexAuthInvalid(e.codexAuth, fmt.Errorf("get codex auth token: %w", err))
 	}
 	if cfg == nil {
 		// No OAuth token — not an error, agent will use API key.
@@ -1071,7 +1089,7 @@ func (e *AgentEnv) refreshCodexSubscriptionIfNeeded(ctx context.Context, scope m
 				Msg("codex subscription refresh failed; using cached token")
 			return &cfg, nil
 		}
-		return nil, wrapCodexAuthInvalid(fmt.Errorf("refresh codex subscription %s: %w", credID, err))
+		return nil, maybeWrapCodexAuthInvalid(refresher, fmt.Errorf("refresh codex subscription %s: %w", credID, err))
 	}
 	if refreshed == nil {
 		if !cfg.IsExpired() {

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -176,6 +176,27 @@ func containsUUID(ids []uuid.UUID, id uuid.UUID) bool {
 	return false
 }
 
+func envExpiredCodexSubscriptionCredential(orgID uuid.UUID) *envCodingCredentialProvider {
+	return &envCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderOpenAISubscription: {
+				{
+					ID:       uuid.New(),
+					OrgID:    orgID,
+					Provider: models.ProviderOpenAISubscription,
+					Status:   models.CodingCredentialStatusActive,
+					Config: models.OpenAISubscriptionConfig{
+						AccessToken:  "expired-access",
+						RefreshToken: "refresh-token",
+						IDToken:      "id-token",
+						ExpiresAt:    time.Now().Add(-time.Minute),
+					},
+				},
+			},
+		},
+	}
+}
+
 // MarkRateLimited / MarkAuthRejected satisfy CodingCredentialShedder so the
 // env tests can assert that ShedRateLimited / ShedAuthRejected forward the
 // recorded credential id.
@@ -206,6 +227,7 @@ type envCodexAuthProvider struct {
 	err           error
 	refreshToken  *models.OpenAIChatGPTConfig
 	refreshErr    error
+	authInvalid   bool
 	refreshIDs    []uuid.UUID
 	refreshScopes []models.Scope
 }
@@ -215,6 +237,10 @@ func (m envCodexAuthProvider) GetValidToken(_ context.Context, _ uuid.UUID) (*mo
 		return nil, m.err
 	}
 	return m.token, nil
+}
+
+func (m envCodexAuthProvider) IsAuthInvalid(_ error) bool {
+	return m.authInvalid
 }
 
 func (m *envCodexAuthProvider) RefreshTokenByID(_ context.Context, scope models.Scope, credID uuid.UUID) (*models.OpenAIChatGPTConfig, error) {
@@ -1505,13 +1531,34 @@ func TestAgentEnvInjectCodexAuth_ErrorClassification(t *testing.T) {
 		name          string
 		codexAuth     CodexAuthProvider
 		provider      *envSandboxProvider
+		codingCreds   *envCodingCredentialProvider
 		wantAuthError bool
 	}{
 		{
 			name:          "GetValidToken failure is auth-shaped",
-			codexAuth:     envCodexAuthProvider{err: errors.New("refresh token revoked")},
+			codexAuth:     envCodexAuthProvider{err: errors.New("refresh token revoked"), authInvalid: true},
 			provider:      &envSandboxProvider{},
 			wantAuthError: true,
+		},
+		{
+			name:          "GetValidToken infrastructure failure is NOT auth-shaped",
+			codexAuth:     envCodexAuthProvider{err: errors.New("db connection refused")},
+			provider:      &envSandboxProvider{},
+			wantAuthError: false,
+		},
+		{
+			name:          "expired unified subscription refresh auth failure is auth-shaped",
+			codexAuth:     &envCodexAuthProvider{refreshErr: errors.New("refresh token revoked"), authInvalid: true},
+			provider:      &envSandboxProvider{},
+			codingCreds:   envExpiredCodexSubscriptionCredential(orgID),
+			wantAuthError: true,
+		},
+		{
+			name:          "expired unified subscription refresh infrastructure failure is NOT auth-shaped",
+			codexAuth:     &envCodexAuthProvider{refreshErr: errors.New("oauth server 500")},
+			provider:      &envSandboxProvider{},
+			codingCreds:   envExpiredCodexSubscriptionCredential(orgID),
+			wantAuthError: false,
 		},
 		{
 			name:          "Docker exec failure is NOT auth-shaped",
@@ -1540,11 +1587,15 @@ func TestAgentEnvInjectCodexAuth_ErrorClassification(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			env := NewAgentEnv(AgentEnvDeps{
+			deps := AgentEnvDeps{
 				CodexAuth: tt.codexAuth,
 				Provider:  tt.provider,
 				Logger:    zerolog.Nop(),
-			})
+			}
+			if tt.codingCreds != nil {
+				deps.CodingCredentials = tt.codingCreds
+			}
+			env := NewAgentEnv(deps)
 
 			_, err := env.InjectCodexAuth(ctx, orgID, sandbox)
 			require.Error(t, err)

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -80,6 +80,20 @@ var ErrStaleSandboxIDCleared = errors.New("sandbox race: cleared stale orphan co
 // dead-lettering as a duplicate.
 var ErrSandboxPreviewRace = errors.New("sandbox race: preview holder attached first, retry")
 
+// ErrSandboxOnDifferentNode is returned from ContinueSession's reuse path
+// when the session's recorded worker_node_id points at a different worker
+// than the one running this job. Container ids are local to a docker
+// daemon, so we cannot exec into a sandbox owned by a sibling node — and
+// an IsAlive probe on the wrong daemon false-reports "not alive", which
+// would CAS-clear the row and orphan the live container on its real host.
+//
+// Worker handlers convert this to a RetryableError so the job is released
+// back to the queue with a short delay, giving the correctly-pinned
+// worker a chance to claim it. Once node-affinity routing is rolled out
+// (target_node_id on the jobs table) this branch becomes a defense-in-
+// depth safety net for any job enqueued before pinning landed.
+var ErrSandboxOnDifferentNode = errors.New("sandbox race: session sandbox lives on a different worker node, retry")
+
 // canonicalTimeoutLogMessage is the single log phrase emitted whenever a
 // session hits its configured deadline. Kept deliberately narrow so
 // Grafana alerts can key off one string across RunAgent and ContinueSession.
@@ -365,9 +379,16 @@ type RepositoryStore interface {
 	GetByID(ctx context.Context, orgID, repoID uuid.UUID) (models.Repository, error)
 }
 
-// JobStore defines the job enqueue operations.
+// JobStore defines the job enqueue operations. EnqueueWithTarget is the
+// node-affinity variant: when targetNodeID is non-nil, only the matching
+// worker (or workers picking up jobs released by a dead node) can claim
+// the row. Used for sandbox-bound jobs where the work must run on the
+// same docker daemon as the session's recorded container_id. The plain
+// Enqueue maps to NULL target — any worker can claim — which is correct
+// for unbound jobs (linear_milestone, sync_*, post-PR housekeeping).
 type JobStore interface {
 	Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+	EnqueueWithTarget(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string, targetNodeID *string) (uuid.UUID, error)
 	OldestPendingSessionJobAge(ctx context.Context) (time.Duration, bool, error)
 }
 
@@ -2313,52 +2334,77 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		sandboxCfg.Env["HOME"] = sandboxCfg.HomeDir
 	}
 	reusedExisting := session.ContainerID != nil && *session.ContainerID != ""
-	// Liveness check on reuse: a recorded container_id only means "someone
-	// (preview, prior turn) wrote it" — it does NOT prove the container is
-	// still alive. If the container was destroyed without going through
-	// FinalizeContainerDestroy / ClearContainerID (worker rollover, docker
-	// daemon eviction, OOM kill, ad-hoc cleanup), the row holds a stale ID
-	// pointing at a dead container. The reuse branch below then builds a
-	// Sandbox{} from that ID and the first downstream Docker exec fails
-	// with "No such container", historically misclassified as a Codex auth
-	// expiry. Probe IsAlive up front; if dead, CAS-clear via ClearContainerID
-	// and return ErrStaleSandboxIDCleared so the worker retries against a
-	// clean row (the next attempt sees container_id=NULL and falls through
-	// to hydrate-from-snapshot or fresh-create).
+	// Liveness / cross-node check on reuse. A recorded container_id only
+	// means "someone (preview, prior turn) wrote it" — it does NOT prove
+	// the container is alive AND on this node's docker daemon. Two cases:
 	//
-	// On probe error we conservatively keep going (treat as alive) — the
-	// downstream operation will surface a real failure if the container is
-	// gone, and we'd rather not retry-loop against a transient docker hiccup.
+	//   (1) Cross-node claim. session.WorkerNodeID points at a different
+	//       worker. Container ids are local to a docker daemon, so any
+	//       Exec we issue here would fail "No such container" (historically
+	//       misclassified as Codex auth expiry). An IsAlive probe on the
+	//       wrong daemon also false-reports dead — running ClearContainerID
+	//       in that state would orphan the live container on its real host.
+	//       Bail with ErrSandboxOnDifferentNode so the worker re-enqueues;
+	//       the correctly-pinned worker (or a future retry post-rollout of
+	//       target_node_id job affinity) picks it up. This branch is
+	//       defense-in-depth once that affinity lands.
+	//
+	//   (2) Stale orphan. WorkerNodeID matches us (or is unset, e.g. a
+	//       legacy row from before SetWorkerNodeIDForContainer existed),
+	//       and the recorded container is gone (rollover, OOM, daemon
+	//       eviction). Probe IsAlive; if dead, CAS-clear via
+	//       ClearContainerID and return ErrStaleSandboxIDCleared so the
+	//       worker retries against a clean row.
+	//
+	// Probe-or-clear is gated on node match because the IsAlive signal is
+	// only authoritative on the daemon that created the container.
 	if reusedExisting {
-		probeCtx, cancel := context.WithTimeout(ctx, sandboxRaceProbeTimeout)
-		alive, aliveErr := o.provider.IsAlive(probeCtx, &Sandbox{ID: *session.ContainerID, Provider: "docker"})
-		cancel()
+		recordedNode := ""
+		if session.WorkerNodeID != nil {
+			recordedNode = *session.WorkerNodeID
+		}
 		switch {
-		case aliveErr != nil:
-			log.Warn().Err(aliveErr).
+		case recordedNode != "" && recordedNode != o.nodeID:
+			log.Info().
 				Str("container_id", *session.ContainerID).
-				Msg("IsAlive probe on recorded container_id failed during continue_session reuse; assuming alive and proceeding")
-		case !alive:
-			cleared, clearErr := o.sessions.ClearContainerID(ctx, session.OrgID, session.ID, *session.ContainerID)
-			if clearErr != nil {
-				log.Warn().Err(clearErr).
-					Str("stale_container_id", *session.ContainerID).
-					Msg("ClearContainerID failed during continue_session reuse liveness check; falling through to reuse path which will surface the underlying docker error")
-				break
-			}
-			if !cleared {
-				log.Info().
-					Str("stale_container_id", *session.ContainerID).
-					Msg("ClearContainerID CAS lost during continue_session reuse liveness check (a new holder acquired between probe and clear); proceeding with the now-active row")
-				break
-			}
-			log.Warn().
-				Str("stale_container_id", *session.ContainerID).
-				Msg("cleared stale orphan container_id during continue_session reuse liveness check; signaling retry to re-enter against the clean row")
+				Str("recorded_node", recordedNode).
+				Str("this_node", o.nodeID).
+				Msg("continue_session claimed on the wrong worker; recorded container_id belongs to a sibling node — releasing for the correct worker to pick up")
 			if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
-				log.Error().Err(revertErr).Msg("failed to revert session to pending after stale container_id cleared")
+				log.Error().Err(revertErr).Msg("failed to revert session to pending after wrong-node detection")
 			}
-			return ErrStaleSandboxIDCleared
+			return ErrSandboxOnDifferentNode
+		default:
+			probeCtx, cancel := context.WithTimeout(ctx, sandboxRaceProbeTimeout)
+			alive, aliveErr := o.provider.IsAlive(probeCtx, &Sandbox{ID: *session.ContainerID, Provider: "docker"})
+			cancel()
+			switch {
+			case aliveErr != nil:
+				log.Warn().Err(aliveErr).
+					Str("container_id", *session.ContainerID).
+					Msg("IsAlive probe on recorded container_id failed during continue_session reuse; assuming alive and proceeding")
+			case !alive:
+				cleared, clearErr := o.sessions.ClearContainerID(ctx, session.OrgID, session.ID, *session.ContainerID)
+				if clearErr != nil {
+					log.Warn().Err(clearErr).
+						Str("stale_container_id", *session.ContainerID).
+						Msg("ClearContainerID failed during continue_session reuse liveness check; falling through to reuse path which will surface the underlying docker error")
+					break
+				}
+				if !cleared {
+					log.Info().
+						Str("stale_container_id", *session.ContainerID).
+						Msg("ClearContainerID CAS lost during continue_session reuse liveness check (a new holder acquired between probe and clear); proceeding with the now-active row")
+					break
+				}
+				log.Warn().
+					Str("stale_container_id", *session.ContainerID).
+					Msg("cleared stale orphan container_id during continue_session reuse liveness check; signaling retry to re-enter against the clean row")
+				if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
+					log.Error().Err(revertErr).Msg("failed to revert session to pending after stale container_id cleared")
+				}
+				return ErrStaleSandboxIDCleared
+			}
 		}
 	}
 	integrationSkills := o.BuildIntegrationSkills(ctx, session.OrgID)
@@ -3093,7 +3139,7 @@ func (o *Orchestrator) drainQueuedMessages(ctx context.Context, session *models.
 		payload["thread_id"] = threadID.String()
 	}
 	dedupeKey := continueSessionDrainDedupeKey(session.ID, processed.ID)
-	if _, err := o.jobs.Enqueue(ctx, session.OrgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
+	if _, err := o.jobs.EnqueueWithTarget(ctx, session.OrgID, "agent", "continue_session", payload, 5, &dedupeKey, models.SessionWorkerTarget(session)); err != nil {
 		log.Warn().Err(err).Msg("failed to enqueue continue_session for queued messages")
 	}
 }

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -2365,6 +2365,37 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		}
 		switch {
 		case recordedNode != "" && recordedNode != o.nodeID:
+			if deadTargetNode, ok := jobctx.DeadTargetNodeFromContext(ctx); ok && deadTargetNode == recordedNode {
+				cleared, clearErr := o.sessions.ClearContainerID(ctx, session.OrgID, session.ID, *session.ContainerID)
+				if clearErr != nil {
+					log.Warn().Err(clearErr).
+						Str("stale_container_id", *session.ContainerID).
+						Str("dead_target_node", deadTargetNode).
+						Msg("ClearContainerID failed during dead-node continue_session recovery; retrying for another recovery attempt")
+					if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
+						log.Error().Err(revertErr).Msg("failed to revert session to pending after dead-node recovery clear failure")
+					}
+					return ErrSandboxOnDifferentNode
+				}
+				if !cleared {
+					log.Info().
+						Str("stale_container_id", *session.ContainerID).
+						Str("dead_target_node", deadTargetNode).
+						Msg("ClearContainerID CAS lost during dead-node continue_session recovery; retrying against the current row")
+					if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
+						log.Error().Err(revertErr).Msg("failed to revert session to pending after dead-node recovery CAS miss")
+					}
+					return ErrStaleSandboxIDCleared
+				}
+				log.Warn().
+					Str("stale_container_id", *session.ContainerID).
+					Str("dead_target_node", deadTargetNode).
+					Msg("cleared container_id from dead-node continue_session recovery; signaling retry to hydrate on this worker")
+				if revertErr := o.sessions.UpdateStatus(ctx, session.OrgID, session.ID, string(models.SessionStatusPending)); revertErr != nil {
+					log.Error().Err(revertErr).Msg("failed to revert session to pending after dead-node recovery clear")
+				}
+				return ErrStaleSandboxIDCleared
+			}
 			log.Info().
 				Str("container_id", *session.ContainerID).
 				Str("recorded_node", recordedNode).

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -125,10 +125,11 @@ type drainStubJobs struct {
 }
 
 type drainStubEnqueue struct {
-	queue     string
-	jobType   string
-	payload   any
-	dedupeKey string
+	queue        string
+	jobType      string
+	payload      any
+	dedupeKey    string
+	targetNodeID string
 }
 
 func (j *drainStubJobs) Enqueue(_ context.Context, _ uuid.UUID, queue, jobType string, payload any, _ int, dedupeKey *string) (uuid.UUID, error) {
@@ -144,6 +145,28 @@ func (j *drainStubJobs) Enqueue(_ context.Context, _ uuid.UUID, queue, jobType s
 		jobType:   jobType,
 		payload:   payload,
 		dedupeKey: key,
+	})
+	return uuid.New(), nil
+}
+
+func (j *drainStubJobs) EnqueueWithTarget(_ context.Context, _ uuid.UUID, queue, jobType string, payload any, _ int, dedupeKey *string, targetNodeID *string) (uuid.UUID, error) {
+	if j.err != nil {
+		return uuid.Nil, j.err
+	}
+	key := ""
+	if dedupeKey != nil {
+		key = *dedupeKey
+	}
+	target := ""
+	if targetNodeID != nil {
+		target = *targetNodeID
+	}
+	j.enqueues = append(j.enqueues, drainStubEnqueue{
+		queue:        queue,
+		jobType:      jobType,
+		payload:      payload,
+		dedupeKey:    key,
+		targetNodeID: target,
 	})
 	return uuid.New(), nil
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3309,6 +3309,60 @@ func TestContinueSession_ReusePathBailsOutOnCrossNodeClaim(t *testing.T) {
 	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "container_id must be untouched on cross-node bail-out")
 }
 
+func TestContinueSession_ReusePathClearsContainerForDeadTargetNodeRecovery(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	containerID := "container-on-dead-worker"
+	session.ContainerID = &containerID
+	deadNode := "worker-dead"
+	session.WorkerNodeID = &deadNode
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	d := defaultDeps()
+	d.nodeID = "worker-recovery"
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "follow-up",
+		},
+	}
+	d.provider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		t.Fatalf("IsAlive must not probe the recovery worker's daemon for a dead target node container")
+		return false, nil
+	}
+	d.sessions.clearContainerIDFn = func(expected string) (bool, error) {
+		require.Equal(t, containerID, expected, "dead-node recovery should CAS-clear the recorded container id")
+		return true, nil
+	}
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		t.Fatalf("provider.Create must not run until the retry observes the cleared container_id")
+		return nil, nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		t.Fatalf("adapter.Execute must not run until the retry observes the cleared container_id")
+		return nil, nil
+	}
+
+	orch := buildOrchestrator(d)
+	ctx := jobctx.WithDeadTargetNode(context.Background(), deadNode)
+	err := orch.ContinueSession(ctx, session, nil)
+	require.Error(t, err, "dead-node recovery should stop the current attempt after clearing the stale container")
+	require.ErrorIs(t, err, agent.ErrStaleSandboxIDCleared,
+		"dead-node recovery should retry so the next attempt hydrates on the recovery worker")
+	require.Equal(t, 1, d.sessions.clearContainerIDCalls, "dead-node recovery should clear the recorded container exactly once")
+}
+
 // TestContinueSession_ReusePathProceedsWhenIsAliveErrors covers the
 // conservative fallback: a transient docker / probe error must NOT trigger
 // the orphan-clear path. The reuse continues and any real failure surfaces

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -874,6 +874,7 @@ type mockJobStore struct {
 	mu               sync.Mutex
 	enqueued         []string // job types
 	payloads         map[string]any
+	targets          map[string]*string // jobType -> last-seen TargetNodeID
 	oldestPendingAge time.Duration
 	hasPendingAge    bool
 }
@@ -887,6 +888,16 @@ func (m *mockJobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobT
 	m.enqueued = append(m.enqueued, jobType)
 	m.payloads[jobType] = payload
 	return uuid.New(), nil
+}
+
+func (m *mockJobStore) EnqueueWithTarget(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string, targetNodeID *string) (uuid.UUID, error) {
+	m.mu.Lock()
+	if m.targets == nil {
+		m.targets = make(map[string]*string)
+	}
+	m.targets[jobType] = targetNodeID
+	m.mu.Unlock()
+	return m.Enqueue(ctx, orgID, queue, jobType, payload, priority, dedupeKey)
 }
 
 func (m *mockJobStore) OldestPendingSessionJobAge(ctx context.Context) (time.Duration, bool, error) {
@@ -3181,6 +3192,10 @@ func TestContinueSession_RepairedSlashCommandsOnReusePath(t *testing.T) {
 // path historically misclassified the resulting Docker error as a Codex auth
 // expiry. Instead, ClearContainerID is called and ErrStaleSandboxIDCleared is
 // returned so the worker retries against a clean row.
+//
+// The probe is gated on session.WorkerNodeID matching this worker's node id;
+// see TestContinueSession_ReusePathBailsOutOnCrossNodeClaim for the wrong-node
+// path that the gate guards against.
 func TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead(t *testing.T) {
 	t.Parallel()
 
@@ -3192,9 +3207,12 @@ func TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead(t *testing.
 	session.CurrentTurn = 1
 	stale := "stale-container-8d0c678c"
 	session.ContainerID = &stale
+	thisNode := "worker-this-node"
+	session.WorkerNodeID = &thisNode
 	session.SandboxState = string(models.SandboxStateRunning)
 
 	d := defaultDeps()
+	d.nodeID = thisNode
 	d.issues.issue = issue
 	d.messages.messages = []models.SessionMessage{
 		{
@@ -3231,6 +3249,66 @@ func TestContinueSession_ReusePathClearsStaleOrphanWhenContainerDead(t *testing.
 	require.Equal(t, 1, d.sessions.clearContainerIDCalls, "ClearContainerID must be called exactly once")
 }
 
+// TestContinueSession_ReusePathBailsOutOnCrossNodeClaim verifies that when a
+// continue_session job is claimed by the wrong worker (session.worker_node_id
+// names a sibling node, e.g. before node-affinity job routing has rolled out
+// or as a defense-in-depth catch for bugs that bypass it), the orchestrator
+// returns ErrSandboxOnDifferentNode WITHOUT probing IsAlive or clearing
+// container_id. Probing on the wrong daemon false-reports dead, and clearing
+// would orphan the live container on its real host — both wrong moves.
+func TestContinueSession_ReusePathBailsOutOnCrossNodeClaim(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	containerID := "preview-container-on-other-host"
+	session.ContainerID = &containerID
+	otherNode := "worker-host-c"
+	session.WorkerNodeID = &otherNode
+	session.SandboxState = string(models.SandboxStateRunning)
+
+	d := defaultDeps()
+	d.nodeID = "worker-host-7" // we are NOT the recorded owner
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "follow-up",
+		},
+	}
+	d.provider.IsAliveFn = func(context.Context, *agent.Sandbox) (bool, error) {
+		t.Fatalf("IsAlive must NOT be called on cross-node claim — probing the wrong daemon false-reports dead")
+		return false, nil
+	}
+	d.sessions.clearContainerIDFn = func(string) (bool, error) {
+		t.Fatalf("ClearContainerID must NOT be called on cross-node claim — would orphan the live container on its real host")
+		return false, nil
+	}
+	d.provider.CreateFn = func(context.Context, agent.SandboxConfig) (*agent.Sandbox, error) {
+		t.Fatalf("provider.Create must not run on cross-node claim — wrong worker")
+		return nil, nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		t.Fatalf("adapter.Execute must not run on cross-node claim")
+		return nil, nil
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, agent.ErrSandboxOnDifferentNode,
+		"cross-node continue_session claim must return ErrSandboxOnDifferentNode so the worker re-enqueues for the correct node")
+	require.Equal(t, 0, d.sessions.clearContainerIDCalls, "container_id must be untouched on cross-node bail-out")
+}
+
 // TestContinueSession_ReusePathProceedsWhenIsAliveErrors covers the
 // conservative fallback: a transient docker / probe error must NOT trigger
 // the orphan-clear path. The reuse continues and any real failure surfaces
@@ -3247,9 +3325,12 @@ func TestContinueSession_ReusePathProceedsWhenIsAliveErrors(t *testing.T) {
 	session.CurrentTurn = 1
 	existing := "preview-container-abc"
 	session.ContainerID = &existing
+	thisNode := "worker-this-node"
+	session.WorkerNodeID = &thisNode
 	session.SandboxState = string(models.SandboxStateRunning)
 
 	d := defaultDeps()
+	d.nodeID = thisNode
 	d.issues.issue = issue
 	d.messages.messages = []models.SessionMessage{
 		{

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -155,6 +155,10 @@ func (s *runtimeTestJobStore) Enqueue(context.Context, uuid.UUID, string, string
 	return uuid.New(), nil
 }
 
+func (s *runtimeTestJobStore) EnqueueWithTarget(context.Context, uuid.UUID, string, string, any, int, *string, *string) (uuid.UUID, error) {
+	return uuid.New(), nil
+}
+
 func (s *runtimeTestJobStore) OldestPendingSessionJobAge(context.Context) (time.Duration, bool, error) {
 	return 0, false, nil
 }
@@ -166,6 +170,10 @@ type runtimeTestJobBacklogStore struct {
 }
 
 func (s *runtimeTestJobBacklogStore) Enqueue(context.Context, uuid.UUID, string, string, any, int, *string) (uuid.UUID, error) {
+	return uuid.New(), nil
+}
+
+func (s *runtimeTestJobBacklogStore) EnqueueWithTarget(context.Context, uuid.UUID, string, string, any, int, *string, *string) (uuid.UUID, error) {
 	return uuid.New(), nil
 }
 

--- a/internal/services/codexauth/service.go
+++ b/internal/services/codexauth/service.go
@@ -69,6 +69,24 @@ type CredentialStore interface {
 // ErrCredentialNotFound is returned when no credential exists for the given org/provider.
 var ErrCredentialNotFound = fmt.Errorf("credential not found")
 
+// ErrAuthInvalid marks errors that genuinely mean the stored ChatGPT OAuth
+// credential cannot be used anymore and the user must re-authenticate. Store,
+// network, OAuth server 5xx, parse, and persistence failures must not wrap this
+// sentinel because those are infrastructure failures.
+var ErrAuthInvalid = errors.New("codex auth credential invalid")
+
+func wrapAuthInvalid(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrAuthInvalid, err)
+}
+
+// IsAuthInvalid reports whether err means the user needs to reconnect ChatGPT.
+func (s *Service) IsAuthInvalid(err error) bool {
+	return errors.Is(err, ErrAuthInvalid)
+}
+
 // PendingAuth tracks an in-progress device code auth flow.
 type PendingAuth struct {
 	DeviceAuthID    string
@@ -645,7 +663,7 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 	}
 
 	if cfg.RefreshToken == "" {
-		return nil, fmt.Errorf("no refresh token available — user must re-authenticate")
+		return nil, wrapAuthInvalid(fmt.Errorf("no refresh token available — user must re-authenticate"))
 	}
 
 	endpoint := s.issuer + "/oauth/token"
@@ -678,12 +696,12 @@ func (s *Service) RefreshTokenByID(ctx context.Context, scope models.Scope, cred
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		if strings.Contains(string(body), "refresh_token_reused") {
 			s.logger.Warn().Str("cred_id", credID.String()).Msg("refresh token already used by another client; access token may still be valid")
-			return nil, fmt.Errorf("refresh token already used by another client")
+			return nil, wrapAuthInvalid(fmt.Errorf("refresh token already used by another client"))
 		}
 		if err := s.credentials.UpdateStatusByID(ctx, scope, credID, "invalid"); err != nil {
 			s.logger.Warn().Err(err).Str("cred_id", credID.String()).Msg("failed to update credential status")
 		}
-		return nil, fmt.Errorf("refresh token revoked (status %d)", resp.StatusCode)
+		return nil, wrapAuthInvalid(fmt.Errorf("refresh token revoked (status %d)", resp.StatusCode))
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/internal/services/codexauth/service_test.go
+++ b/internal/services/codexauth/service_test.go
@@ -911,6 +911,9 @@ func TestGetValidToken_DBError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for DB failure, got nil")
 	}
+	if svc.IsAuthInvalid(err) {
+		t.Fatalf("DB failures should not be classified as invalid ChatGPT auth: %v", err)
+	}
 }
 
 func TestPollForToken_RateLimited(t *testing.T) {
@@ -1326,6 +1329,38 @@ func TestGetValidToken_RefreshFailsTokenExpired(t *testing.T) {
 	_, err := svc.GetValidToken(context.Background(), orgID)
 	if err == nil {
 		t.Fatal("expected error when token expired and refresh fails")
+	}
+	if svc.IsAuthInvalid(err) {
+		t.Fatalf("expired token plus refresh infrastructure failure should not be classified as invalid ChatGPT auth: %v", err)
+	}
+}
+
+func TestGetValidToken_RefreshRevokedTokenExpiredIsAuthInvalid(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "invalid_grant"}`))
+	}))
+	defer server.Close()
+
+	store := newMockCredentialStore()
+	svc := NewService(store, zerolog.Nop())
+	svc.SetHTTPClient(server.Client())
+	svc.SetIssuer(server.URL)
+
+	orgID := uuid.New()
+	store.Upsert(context.Background(), models.Scope{OrgID: orgID}, models.OpenAIChatGPTConfig{
+		AccessToken:  "cha_expired",
+		RefreshToken: "chr_revoked",
+		ExpiresAt:    time.Now().Add(-1 * time.Minute),
+	})
+
+	_, err := svc.GetValidToken(context.Background(), orgID)
+	if err == nil {
+		t.Fatal("expected error when token expired and refresh token was revoked")
+	}
+	if !svc.IsAuthInvalid(err) {
+		t.Fatalf("revoked refresh token should be classified as invalid ChatGPT auth: %v", err)
 	}
 }
 

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -601,7 +601,14 @@ func (s *PRService) resumeRepairSession(ctx context.Context, pr models.PullReque
 		"session_id": claimed.ID.String(),
 		"org_id":     pr.OrgID.String(),
 	}
-	if _, err := s.jobs.EnqueueInTx(ctx, tx, pr.OrgID, "agent", "continue_session", payload, 5, &continueDedupeKey); err != nil {
+	if _, err := s.jobs.EnqueueInTxWithOpts(ctx, tx, pr.OrgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      payload,
+		Priority:     5,
+		DedupeKey:    &continueDedupeKey,
+		TargetNodeID: models.SessionWorkerTarget(&claimed),
+	}); err != nil {
 		return nil, err
 	}
 	repairRun := &models.PullRequestRepairRun{

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -112,6 +112,7 @@ type LogStore interface {
 // JobStore defines the job DB operations needed by the thread service.
 type JobStore interface {
 	Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+	EnqueueWithOpts(ctx context.Context, orgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error)
 }
 
 // CreateThreadInput holds the input for creating a new thread.
@@ -504,7 +505,14 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		"thread_id":  input.ThreadID.String(),
 		"org_id":     input.OrgID.String(),
 	}
-	if _, err := s.jobStore.Enqueue(ctx, input.OrgID, "agent", "continue_session", payload, 5, &dedupeKey); err != nil {
+	if _, err := s.jobStore.EnqueueWithOpts(ctx, input.OrgID, db.EnqueueOpts{
+		Queue:        "agent",
+		JobType:      "continue_session",
+		Payload:      payload,
+		Priority:     5,
+		DedupeKey:    &dedupeKey,
+		TargetNodeID: models.SessionWorkerTarget(&claimedSession),
+	}); err != nil {
 		// Note: we do NOT roll back the resolved comments or answered
 		// question here. The message has been committed and is durably in
 		// the timeline; the orchestrator will retry the enqueue on the next

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -142,12 +142,23 @@ func (m *mockLogStore) ListByThread(ctx context.Context, orgID, threadID uuid.UU
 }
 
 type mockJobStore struct {
-	enqueueFn func(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+	enqueueFn         func(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error)
+	enqueueWithOptsFn func(ctx context.Context, orgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error)
 }
 
 func (m *mockJobStore) Enqueue(ctx context.Context, orgID uuid.UUID, queue, jobType string, payload any, priority int, dedupeKey *string) (uuid.UUID, error) {
 	if m.enqueueFn != nil {
 		return m.enqueueFn(ctx, orgID, queue, jobType, payload, priority, dedupeKey)
+	}
+	return uuid.New(), nil
+}
+
+func (m *mockJobStore) EnqueueWithOpts(ctx context.Context, orgID uuid.UUID, opts db.EnqueueOpts) (uuid.UUID, error) {
+	if m.enqueueWithOptsFn != nil {
+		return m.enqueueWithOptsFn(ctx, orgID, opts)
+	}
+	if m.enqueueFn != nil {
+		return m.enqueueFn(ctx, orgID, opts.Queue, opts.JobType, opts.Payload, opts.Priority, opts.DedupeKey)
 	}
 	return uuid.New(), nil
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1126,6 +1126,23 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 					Msg("continue_session cleared stale orphan container_id; retrying against the clean row")
 				return &RetryableError{Err: err, RetryAfter: &retryAfter}
 			}
+			if errors.Is(err, agent.ErrSandboxOnDifferentNode) {
+				// We claimed a job whose session sandbox lives on a sibling
+				// worker. Release it so the correct node can pick it up. A
+				// 5s delay (longer than the stale-orphan path) avoids tight
+				// loops if the wrong-node worker keeps polling first while
+				// the right one is briefly busy. With node-affinity routing
+				// (target_node_id on jobs) in place this branch is rare —
+				// it only fires for jobs enqueued before the affinity rolled
+				// out, or as a defense-in-depth catch for bugs that bypass
+				// the pinning.
+				retryAfter := 5 * time.Second
+				logger.Info().
+					Str("session_id", sessionID.String()).
+					Err(err).
+					Msg("continue_session claimed on the wrong node; releasing for the correct worker")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
 			if errors.Is(err, agent.ErrSandboxPreviewRace) {
 				// A preview hydrate published the live container first. Retry
 				// so the next attempt fetches the updated session row and

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -175,6 +175,9 @@ func (w *Worker) poll(ctx context.Context) {
 	handlerCtx := withJobOrgID(ctx, job.OrgID)
 	handlerCtx = jobctx.WithDeadLetterHooks(handlerCtx)
 	handlerCtx = jobctx.WithLockToken(handlerCtx, *job.LockToken)
+	if job.TargetNodeID != nil && *job.TargetNodeID != "" && *job.TargetNodeID != w.nodeID {
+		handlerCtx = jobctx.WithDeadTargetNode(handlerCtx, *job.TargetNodeID)
+	}
 	handlerCtx, cancelHandler := context.WithCancel(handlerCtx)
 	defer cancelHandler()
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -83,8 +83,8 @@ func TestWorker_Poll(t *testing.T) {
 			name: "no pending jobs returns cleanly",
 			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
 				t.Helper()
-				mock.ExpectQuery("WITH next_job AS").
-					WithArgs("test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS").
+					WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 					WillReturnError(pgx.ErrNoRows)
 			},
 		},
@@ -106,6 +106,30 @@ func TestWorker_Poll(t *testing.T) {
 				})
 
 				expectClaim(mock, jobID, orgID, "test_job", payload, now, lockToken)
+				mock.ExpectExec("UPDATE jobs\\s+SET status = 'succeeded'").
+					WithArgs(jobID, lockToken).
+					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			},
+		},
+		{
+			name: "dead target node is exposed to handler context",
+			setupMock: func(t *testing.T, w *Worker, mock pgxmock.PgxPoolIface) {
+				t.Helper()
+
+				jobID := uuid.New()
+				lockToken := uuid.New()
+				orgID := uuid.New()
+				now := time.Now()
+				targetNodeID := "dead-node"
+
+				w.Register("recovery_job", func(ctx context.Context, jobType string, got json.RawMessage) error {
+					gotTarget, ok := jobctx.DeadTargetNodeFromContext(ctx)
+					require.True(t, ok, "handler context should mark claims recovered from a dead target node")
+					require.Equal(t, targetNodeID, gotTarget, "handler context should expose the dead target node id")
+					return nil
+				})
+
+				expectClaimWithTarget(mock, jobID, orgID, "recovery_job", json.RawMessage(`{}`), now, lockToken, &targetNodeID)
 				mock.ExpectExec("UPDATE jobs\\s+SET status = 'succeeded'").
 					WithArgs(jobID, lockToken).
 					WillReturnResult(pgxmock.NewResult("UPDATE", 1))
@@ -226,16 +250,16 @@ func TestWorker_Poll(t *testing.T) {
 				jobID := uuid.New()
 				orgID := uuid.New()
 				now := time.Now()
-				mock.ExpectQuery("WITH next_job AS").
-					WithArgs("test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
+				mock.ExpectQuery("WITH dead_target_nodes AS").
+					WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 					WillReturnRows(pgxmock.NewRows([]string{
 						"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 						"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 						"lease_expires_at", "lock_token", "run_owner_id", "last_error",
-						"dedupe_key", "created_at", "updated_at", "completed_at",
+						"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
 					}).AddRow(
 						jobID, orgID, "default", "missing_token", json.RawMessage(`{}`), 5, "running",
-						1, 3, now, "test-node", now, now.Add(defaultLeaseDuration), nil, "test-node", nil, nil, now, now, nil,
+						1, 3, now, "test-node", now, now.Add(defaultLeaseDuration), nil, "test-node", nil, nil, nil, now, now, nil,
 					))
 			},
 		},
@@ -544,8 +568,8 @@ func TestWorker_Start_StopsOnContextCancel(t *testing.T) {
 	w.pollInterval = 10 * time.Millisecond
 	mock.MatchExpectationsInOrder(false)
 	for range 5 {
-		mock.ExpectQuery("WITH next_job AS").
-			WithArgs("test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
+		mock.ExpectQuery("WITH dead_target_nodes AS").
+			WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 			WillReturnError(pgx.ErrNoRows)
 	}
 
@@ -722,16 +746,28 @@ func expectClaim(mock pgxmock.PgxPoolIface, jobID, orgID uuid.UUID, jobType stri
 }
 
 func expectClaimWithAttempts(mock pgxmock.PgxPoolIface, jobID, orgID uuid.UUID, jobType string, payload json.RawMessage, createdAt time.Time, lockToken uuid.UUID, attempts, maxAttempts int) {
-	mock.ExpectQuery("WITH next_job AS").
-		WithArgs("test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
+	expectClaimWithAttemptsAndTarget(mock, jobID, orgID, jobType, payload, createdAt, lockToken, attempts, maxAttempts, nil)
+}
+
+func expectClaimWithTarget(mock pgxmock.PgxPoolIface, jobID, orgID uuid.UUID, jobType string, payload json.RawMessage, createdAt time.Time, lockToken uuid.UUID, targetNodeID *string) {
+	expectClaimWithAttemptsAndTarget(mock, jobID, orgID, jobType, payload, createdAt, lockToken, 1, 3, targetNodeID)
+}
+
+func expectClaimWithAttemptsAndTarget(mock pgxmock.PgxPoolIface, jobID, orgID uuid.UUID, jobType string, payload json.RawMessage, createdAt time.Time, lockToken uuid.UUID, attempts, maxAttempts int, targetNodeID *string) {
+	var target any
+	if targetNodeID != nil {
+		target = *targetNodeID
+	}
+	mock.ExpectQuery("WITH dead_target_nodes AS").
+		WithArgs(pgxmock.AnyArg(), "test-node", "test-node", pgxmock.AnyArg(), int(defaultLeaseDuration.Seconds())).
 		WillReturnRows(pgxmock.NewRows([]string{
 			"id", "org_id", "queue", "job_type", "payload", "priority", "status",
 			"attempts", "max_attempts", "run_at", "locked_by_node_id", "locked_at",
 			"lease_expires_at", "lock_token", "run_owner_id", "last_error",
-			"dedupe_key", "created_at", "updated_at", "completed_at",
+			"dedupe_key", "target_node_id", "created_at", "updated_at", "completed_at",
 		}).AddRow(
 			jobID, orgID, "default", jobType, payload, 5, "running",
 			attempts, maxAttempts, createdAt, "test-node", createdAt, createdAt.Add(defaultLeaseDuration),
-			lockToken.String(), "test-node", nil, nil, createdAt, createdAt, nil,
+			lockToken.String(), "test-node", nil, nil, target, createdAt, createdAt, nil,
 		))
 }

--- a/migrations/000115_jobs_target_node_id.down.sql
+++ b/migrations/000115_jobs_target_node_id.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_jobs_target_dequeue;
+ALTER TABLE jobs DROP COLUMN IF EXISTS target_node_id;

--- a/migrations/000115_jobs_target_node_id.up.sql
+++ b/migrations/000115_jobs_target_node_id.up.sql
@@ -1,0 +1,31 @@
+-- Node-affinity job routing: pin sandbox-bound jobs (continue_session, open_pr,
+-- run_agent for resume) to the worker node that owns the session's container.
+--
+-- Container ids are local to a docker daemon. When a worker on host A creates
+-- a sandbox for a session, only host A's daemon can exec into it. Before this
+-- column existed, any worker could claim any pending job from the queue (ORDER
+-- BY priority, created_at), so a continue_session job for a session whose
+-- container lives on host A could be picked up by host B's worker — which then
+-- failed every Docker exec with "No such container: <id>" because B's daemon
+-- has never seen that id. Symptom: session failed mid-turn for what looked like
+-- an auth or sandbox-state issue but was actually a routing miss.
+--
+-- target_node_id is NULL by default — unpinned jobs (the vast majority: PM
+-- analyses, Linear webhooks, post-PR snapshots, etc.) keep claiming on any
+-- worker just like before. Pinning is opt-in at the enqueue site.
+--
+-- A pinned job becomes claimable by any worker if its target node is marked
+-- dead in the `nodes` table — symmetrical to ReclaimLostRunningJobs. This
+-- prevents starvation when a node is permanently lost (host failure, scaling
+-- down) so an in-flight session's pending job doesn't sit forever.
+ALTER TABLE jobs ADD COLUMN target_node_id text;
+
+-- Partial index for the pinned-claim path. Most pending jobs at any moment
+-- have target_node_id IS NULL (general queue), so indexing only the rows
+-- where target_node_id is set keeps the index small while still letting the
+-- claim query short-circuit "is there a pinned job for this worker?".
+-- Ordered to match the ClaimNextRunnable ORDER BY (priority DESC, created_at
+-- ASC) so an index scan can return rows in claim order without a sort.
+CREATE INDEX idx_jobs_target_dequeue
+  ON jobs (target_node_id, status, run_at, priority DESC, created_at ASC)
+  WHERE target_node_id IS NOT NULL AND status = 'pending';


### PR DESCRIPTION
## Summary

Fix the cross-host job-routing bug behind the May 5 incident on session `6c086688`. Continue_session jobs were claimed by whichever worker polled first, even when the session's recorded `container_id` lived on a sibling worker's docker daemon — resulting in `"No such container"` errors that the previous PR (#806) finally stopped misclassifying as auth expiry. With two workers in the fleet today (and growing), a sandbox-pinned job had ~50% chance of cross-host miss per retry.

## What changes

- **Schema:** new `jobs.target_node_id` (nullable) + partial index on the pinned-claim path. Backward compatible — existing jobs and call sites pass NULL and behave unchanged.
- **`db.JobStore`:** new `EnqueueOpts` struct + `EnqueueWithOpts` / `EnqueueInTxWithOpts` so future scheduling fields don't churn 60+ call sites. Legacy `Enqueue`/`EnqueueInTx` stay as wrappers. `EnqueueWithTarget` is a thin convenience for service interfaces that can't take a db-package struct.
- **`ClaimNextRunnable`:** filters `target_node_id IS NULL OR target_node_id = @node OR target_node_id IN (dead nodes)`. The dead-node fallback shares the same heartbeat threshold as `ReclaimLostRunningJobs` so a permanently-lost node can't starve its pinned jobs.
- **`models.SessionWorkerTarget`:** the canonical "what node should this session's jobs run on?" predicate. Returns nil when there's no live sandbox to pin to (between turns, fresh session, mid-handshake) — so a turn-1 / hydrate-from-snapshot path keeps any-worker eligibility.
- **Pinned enqueue sites:** every `continue_session` enqueue (api/sessions, api/session_review_comments, services/thread, services/github/pr_health_service, agent/orchestrator drain) now passes `SessionWorkerTarget`. `open_pr` stays unpinned because it hydrates its own scratch sandbox from the snapshot, not the live container.
- **Defense-in-depth on the orchestrator:** the liveness probe added in #806 was unsafe in a multi-host fleet — IsAlive on the wrong daemon returns false and would CAS-clear container_id, orphaning the live container on its real host. New `ErrSandboxOnDifferentNode` short-circuits on the cross-node case before any probe / clear, and the worker handler converts it to a 5s-delayed RetryableError so the right worker can claim.

## Test plan

- [ ] `make lint` (couldn't run locally — Go 1.26 toolchain not present in the agent sandbox)
- [ ] `go test ./internal/db/... ./internal/services/agent/... ./internal/services/thread/... ./internal/api/handlers/...`
- [ ] Run migration `000115` against staging; spot-check `\d jobs` shows `target_node_id text`
- [ ] Send `/review` or any follow-up on a session whose container is pinned to host A while the queue is being polled by both A and B; confirm the job is claimed by A (`grep target_node_id` in vector logs / `make db-query`) and the session runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)