### PR TITLE
Pause session and PR SSE streams when the tab is hidden

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -136,6 +136,7 @@ import { PRHealthBanner } from "@/components/pr-health-banner";
 import { MobileBackButton } from "@/components/mobile-back-button";
 import { useAuth } from "@/hooks/use-auth";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { useDocumentVisible } from "@/hooks/use-document-visible";
 import { prMergedAccent } from "@/lib/pr-status-styles";
 import { cn, sessionTitle, formatTimeAgo } from "@/lib/utils";
 import { activeSet, workingStatusesSet } from "@/lib/session-status-groups";
@@ -1736,6 +1737,7 @@ function ChatPanel({
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
+  const isDocumentVisible = useDocumentVisible();
   const viewerScope = useMemo(
     () => (user ? { userId: user.id, orgId: user.org_id } : null),
     [user],
@@ -1950,7 +1952,13 @@ function ChatPanel({
   }, [queryClient, sessionId]);
 
   useEffect(() => {
-    if (!isActive) return;
+    // Pause the SSE stream while the tab is hidden. EventSource handlers fire
+    // even in a hidden tab and trigger setState/re-renders on this large
+    // component, which steals main-thread time from any tab the user just
+    // switched to (notably "View PR" → github.com). On reconnect, the existing
+    // onerror path already invalidates the timeline/thread queries so the user
+    // sees fresh state when they return.
+    if (!isActive || !isDocumentVisible) return;
 
     let eventSource: EventSource | null = null;
     let cancelled = false;
@@ -2024,7 +2032,7 @@ function ChatPanel({
         clearTimeout(reconnectTimer.current);
       }
     };
-  }, [sessionId, apiBase, isActive, mergeLogs, mergeSessionStatusUpdate, queryClient, activeThreadId]);
+  }, [sessionId, apiBase, isActive, isDocumentVisible, mergeLogs, mergeSessionStatusUpdate, queryClient, activeThreadId]);
 
   // Track whether the user is scrolled near the bottom.
   const handleScroll = useCallback(() => {
@@ -2278,6 +2286,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [prAuthPrompt, setPRAuthPrompt] = useState<PRAuthPromptState | null>(null);
   const resumeAttemptRef = useRef<string | null>(null);
   const apiBase = process.env.NEXT_PUBLIC_API_URL || "";
+  const isDocumentVisible = useDocumentVisible();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["session", id],
@@ -2395,12 +2404,19 @@ export function SessionDetailContent({ id }: { id: string }) {
   const { data: prData } = useQuery({
     queryKey: ["session", id, "pr"],
     queryFn: () => api.sessions.getPR(id),
+    // Updates flow in via mutation invalidations and the session SSE stream
+    // (pr_creation_state / pr_push_state); a small staleTime suppresses
+    // redundant refetches on remount or unrelated cache invalidations.
+    staleTime: 30_000,
   });
   const pullRequestId = prData?.data?.id;
   const { data: prHealthData, isLoading: isPRHealthLoading } = useQuery({
     queryKey: ["pull-request", pullRequestId, "health"],
     queryFn: () => api.pullRequests.getHealth(pullRequestId!),
     enabled: !!pullRequestId && prData?.data?.status === "open",
+    // Pushed via the PULL_REQUEST_UPDATED SSE event, so a longer staleTime is
+    // safe — refetches on focus/remount won't fire a redundant network call.
+    staleTime: 30_000,
   });
   const prHealth = prHealthData?.data;
   const prStatus = prData?.data?.status;
@@ -2558,7 +2574,11 @@ export function SessionDetailContent({ id }: { id: string }) {
     },
   });
   useEffect(() => {
-    if (!pullRequestId || prData?.data?.status !== "open") {
+    // Pause the PR health SSE stream while the tab is hidden — same reasoning
+    // as the session log stream above. The onerror branch already invalidates
+    // the health query on disconnect, so reconnecting on visibility refreshes
+    // the cached health to whatever happened while we were away.
+    if (!pullRequestId || prData?.data?.status !== "open" || !isDocumentVisible) {
       return;
     }
 
@@ -2610,7 +2630,7 @@ export function SessionDetailContent({ id }: { id: string }) {
         clearTimeout(reconnectTimer);
       }
     };
-  }, [apiBase, prData?.data?.status, pullRequestId, queryClient]);
+  }, [apiBase, prData?.data?.status, pullRequestId, queryClient, isDocumentVisible]);
   const previousSessionStatusRef = useRef<string | undefined>(undefined);
   useEffect(() => {
     const currentStatus = session?.status;

--- a/frontend/src/hooks/use-document-visible.ts
+++ b/frontend/src/hooks/use-document-visible.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useDocumentVisible(): boolean {
+  const [visible, setVisible] = useState<boolean>(() =>
+    typeof document === "undefined" ? true : document.visibilityState === "visible",
+  );
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onChange = () => setVisible(document.visibilityState === "visible");
+    document.addEventListener("visibilitychange", onChange);
+    return () => document.removeEventListener("visibilitychange", onChange);
+  }, []);
+
+  return visible;
+}


### PR DESCRIPTION
## Summary
- Diagnosed a slow "View PR" → github.com new-tab load: both `EventSource` SSE streams (session log + PR health) kept firing handlers in the hidden source tab, rerendering the 4k-line `session-detail-content.tsx` and stealing main-thread time from the new tab.
- Added a `useDocumentVisible` hook and gated both SSE useEffects on visibility — streams close on hide and reconnect on visible. Existing `onerror` branches already invalidate the relevant queries so state refreshes on return.
- Added `staleTime: 30_000` to `prData` and `prHealth` queries to suppress redundant refetches on remount or unrelated invalidations (both are pushed via SSE / mutation invalidations, not polled).

## Test plan
- [ ] Open a session with an active SSE stream, switch to another tab, confirm via DevTools Network panel that the `/sessions/:id/stream` and `/pull-requests/stream` connections close
- [ ] Switch back, confirm streams reconnect and timeline/health data is fresh
- [ ] Click "View PR" on a running session and verify github.com loads noticeably faster than before
- [ ] Verify no regressions in real-time log streaming or PR health updates while the tab is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)