### PR TITLE
Route continue_session to the requested thread, not the highest-turn sibling

### DIFF
--- a/internal/db/jobs.go
+++ b/internal/db/jobs.go
@@ -39,12 +39,19 @@ func RunAgentPayload(run *models.Session) map[string]string {
 }
 
 // ContinueSessionDedupeKey returns the dedupe key used for continue_session
-// enqueues. Thread-level because concurrent tabs are allowed to queue follow-up
-// turns independently; worker-side locking still serializes actual shared-
-// sandbox execution when needed. See RunAgentDedupeKey for the partial-index
-// rationale.
-func ContinueSessionDedupeKey(threadID uuid.UUID) string {
-	return "continue_session:" + threadID.String()
+// enqueues. Thread-level: each thread/tab gets its own dedupe scope so a
+// concurrent send to thread B is not silently dropped while thread A is
+// running. Rapid-fire sends to the same thread still collapse (the partial
+// unique index turns the duplicate INSERT into a no-op, and the orchestrator's
+// post-turn drain picks the queued messages up). Worker-side AcquireTurnHold
+// serializes actual shared-sandbox execution when both threads run.
+//
+// Callers without a thread context (legacy session-level handlers, PR health
+// repair) pass the session ID instead — that key occupies a different dedupe
+// scope from any thread key (different UUID), which is intentional. See
+// RunAgentDedupeKey for the partial-index rationale.
+func ContinueSessionDedupeKey(scopeID uuid.UUID) string {
+	return "continue_session:" + scopeID.String()
 }
 
 type JobStore struct {

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -972,6 +972,37 @@ func latestUserMessage(messages []models.SessionMessage) *models.SessionMessage 
 	return nil
 }
 
+// latestUserMessageInScope returns the most recent user message bound to the
+// requested scope. When threadID is nil the scope is the session-level
+// conversation (messages with no thread); when threadID is non-nil the scope
+// is that specific thread.
+//
+// The scoped form exists because session_messages.ListBySession orders rows by
+// (turn_number, id) — and per-thread turn counters are independent — so the
+// globally-last user row in the slice is not necessarily the last message the
+// user actually sent. ContinueSession must scope to the thread the worker
+// payload identified, otherwise a sibling thread with a higher turn_number
+// will steal the run.
+func latestUserMessageInScope(messages []models.SessionMessage, threadID *uuid.UUID) *models.SessionMessage {
+	matchesScope := func(m models.SessionMessage) bool {
+		if threadID == nil {
+			return m.ThreadID == nil
+		}
+		return m.ThreadID != nil && *m.ThreadID == *threadID
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		m := messages[i]
+		if m.Role != models.MessageRoleUser {
+			continue
+		}
+		if !matchesScope(m) {
+			continue
+		}
+		return &messages[i]
+	}
+	return nil
+}
+
 // unprocessedUserMessages returns the consecutive trailing user messages for
 // a given thread scope — i.e. all user messages after the most recent
 // in-scope assistant message. When threadID is nil the scope is the
@@ -2205,7 +2236,23 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("fetch session messages: %w", err)
 	}
 
-	latestMsg := latestUserMessage(messages)
+	// Scope the latest-user-message lookup to the thread the worker enqueued
+	// for. ListBySession orders rows by (turn_number, id) and per-thread turn
+	// counters are independent, so the globally-last user row in the slice is
+	// not necessarily the most recently sent message — a sibling thread that's
+	// further along in turns can sit "after" a brand-new user message in the
+	// returned ordering. Without this scoping, ContinueSession would re-run
+	// the wrong (already-answered) thread and orphan the new message.
+	//
+	// When opts is nil (RecoverSession path: worker crash mid-turn rehydrates
+	// without a thread hint) we preserve the legacy global lookup so a
+	// threaded session can still recover its in-flight turn.
+	var latestMsg *models.SessionMessage
+	if opts != nil && opts.ThreadID != nil {
+		latestMsg = latestUserMessageInScope(messages, opts.ThreadID)
+	} else {
+		latestMsg = latestUserMessage(messages)
+	}
 	if latestMsg == nil || strings.TrimSpace(latestMsg.Content) == "" {
 		o.failRun(ctx, session, "no user message found for continue_session")
 		return fmt.Errorf("no user message found")

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -74,6 +74,49 @@ func TestLatestUserMessage(t *testing.T) {
 	require.Equal(t, "latest user", message.Content, "latestUserMessage should scan from newest to oldest")
 }
 
+func TestLatestUserMessageInScope_ThreadScopedSelection(t *testing.T) {
+	t.Parallel()
+
+	threadA := uuid.New()
+	threadB := uuid.New()
+
+	// Regression: ListBySession orders messages by (turn_number, id), and
+	// per-thread turn counters are independent — so a sibling thread's old
+	// message at a high turn_number can sort *after* a brand-new message at
+	// thread B's low turn_number. The unscoped helper would return the
+	// wrong row; the scoped helper must pick the latest user message
+	// belonging to the requested thread.
+	messages := []models.SessionMessage{
+		{ID: 1052, Role: models.MessageRoleUser, Content: "B turn 1", ThreadID: &threadB},
+		{ID: 1122, Role: models.MessageRoleUser, Content: "B turn 2", ThreadID: &threadB},
+		{ID: 1046, Role: models.MessageRoleUser, Content: "A turn 9", ThreadID: &threadA},
+		{ID: 1048, Role: models.MessageRoleAssistant, Content: "A reply", ThreadID: &threadA},
+		{ID: 1069, Role: models.MessageRoleAssistant, Content: "A later reply", ThreadID: &threadA},
+	}
+
+	scoped := latestUserMessageInScope(messages, &threadB)
+	require.NotNil(t, scoped, "should find a user message in thread B's scope")
+	require.Equal(t, "B turn 2", scoped.Content, "scoped lookup should return thread B's most recent user, not thread A's higher-turn row")
+
+	scopedA := latestUserMessageInScope(messages, &threadA)
+	require.NotNil(t, scopedA)
+	require.Equal(t, "A turn 9", scopedA.Content, "scoped lookup should return thread A's most recent user when asked for thread A")
+}
+
+func TestLatestUserMessageInScope_NoThreadFallback(t *testing.T) {
+	t.Parallel()
+
+	threadA := uuid.New()
+	messages := []models.SessionMessage{
+		{ID: 1, Role: models.MessageRoleUser, Content: "session-level"},
+		{ID: 2, Role: models.MessageRoleUser, Content: "thread A", ThreadID: &threadA},
+	}
+
+	got := latestUserMessageInScope(messages, nil)
+	require.NotNil(t, got)
+	require.Equal(t, "session-level", got.Content, "nil scope should ignore threaded messages and return the latest no-thread user")
+}
+
 func TestUnprocessedUserMessages_SessionScope(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3104,6 +3104,7 @@ func TestContinueSession_UsesThreadExecutionOptions(t *testing.T) {
 		ModelOverride:        &threadModel,
 		ThreadAgentSessionID: nil,
 		ResultAgentSessionID: &threadAgentSessionID,
+		ThreadID:             &threadID,
 	})
 	require.NoError(t, err, "ContinueSession should execute with the thread-selected adapter")
 	require.Equal(t, threadModel, createdCfg.Env["GEMINI_MODEL"], "ContinueSession should apply the thread model to the thread agent env")
@@ -4126,7 +4127,7 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	}
 
 	orch := buildOrchestrator(d)
-	err := orch.ContinueSession(context.Background(), session, nil)
+	err := orch.ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{ThreadID: &threadID})
 	require.NoError(t, err, "continue_session should succeed")
 
 	turnUpdates := d.sessions.getTurnUpdates()
@@ -4150,6 +4151,82 @@ func TestContinueSession_PersistsTurnResultAndReturnsToIdle(t *testing.T) {
 	require.Equal(t, threadID, *d.logs.logs[0].ThreadID, "persisted output logs should keep the triggering thread id")
 	require.NotNil(t, d.logs.markedThreadID, "duplicate marker should preserve the thread id")
 	require.Equal(t, threadID, *d.logs.markedThreadID, "duplicate marker should use the triggering thread id")
+}
+
+// TestContinueSession_RoutesToRequestedThreadAcrossSiblingTurns is the
+// regression test for the multi-tab dispatch bug: a sibling thread further
+// along in turns (Main on turn 9 with assistant replies through turn 11) used
+// to "win" the orchestrator's latest-user-message lookup over a brand-new
+// message on a younger thread (Codex 2 turn 2), causing the new message to be
+// orphaned and the wrong thread to be re-run. Locks the contract that when
+// the worker plumbs opts.ThreadID through, ContinueSession executes for that
+// thread and writes the assistant reply against it — even when sibling
+// threads have higher turn_numbers in the (turn_number, id)-ordered slice
+// returned by ListBySession.
+func TestContinueSession_RoutesToRequestedThreadAcrossSiblingTurns(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	mainThreadID := uuid.New()  // Main: many turns, last user already answered
+	codexThreadID := uuid.New() // Codex 2: brand-new tab, user just sent
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 11
+	session.SnapshotKey = strPtr("snapshots/test/session.tar")
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	// Insertion order matches the ordering the real DB returns from
+	// ListBySession (ORDER BY turn_number ASC, id ASC). Each thread keeps its
+	// own turn counter, so the (turn=2, id=1052) row from Codex 2 sorts before
+	// the (turn=9, id=1046) row from Main even though Codex 2's message is
+	// chronologically newer. Pre-fix, latestUserMessage walked from the end
+	// of this slice and returned the Main turn-9 row — orphaning the Codex 2
+	// message and re-running an already-answered Main turn.
+	d.messages.messages = []models.SessionMessage{
+		{ID: 1052, SessionID: session.ID, OrgID: orgID, ThreadID: &codexThreadID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "please fix the tests"},
+		{ID: 1046, SessionID: session.ID, OrgID: orgID, ThreadID: &mainThreadID, TurnNumber: 9, Role: models.MessageRoleUser, Content: "main turn 9 (already answered)"},
+		{ID: 1048, SessionID: session.ID, OrgID: orgID, ThreadID: &mainThreadID, TurnNumber: 9, Role: models.MessageRoleAssistant, Content: "main turn 9 reply"},
+		{ID: 1069, SessionID: session.ID, OrgID: orgID, ThreadID: &mainThreadID, TurnNumber: 11, Role: models.MessageRoleAssistant, Content: "main turn 11 reply"},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		require.Equal(t, "please fix the tests", prompt.UserMessage,
+			"continue_session for Codex 2 must run with Codex 2's user message, not the higher-turn Main message that sorts last in the (turn_number, id) ordering")
+		return &agent.AgentResult{
+			Summary:         "Codex 2 reply",
+			ConfidenceScore: 0.7,
+			ExitCode:        0,
+		}, nil
+	}
+	d.snapshots.data = map[string][]byte{
+		*session.SnapshotKey: []byte("restored-snapshot"),
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{
+		ThreadID: &codexThreadID,
+	})
+	require.NoError(t, err, "ContinueSession should succeed for the Codex 2 thread")
+
+	messages := d.messages.getMessages()
+	require.Len(t, messages, 5, "an assistant reply should be appended to the timeline")
+	reply := messages[4]
+	require.Equal(t, models.MessageRoleAssistant, reply.Role)
+	require.Equal(t, "Codex 2 reply", reply.Content, "assistant reply content should come from the Codex 2 turn")
+	require.NotNil(t, reply.ThreadID, "assistant reply must be attributed to a thread, not session-level")
+	require.Equal(t, codexThreadID, *reply.ThreadID,
+		"assistant reply must be tagged with the Codex 2 thread, not Main — pre-fix this was the load-bearing assertion that failed in prod")
 }
 
 func TestContinueSession_FreshResumeClaudeTokenFailureFallsBackToAPIKey(t *testing.T) {
@@ -5036,7 +5113,7 @@ func TestContinueSession_SetWorkerNodeIDFailureResetsThread(t *testing.T) {
 	d.sessionThreads = &mockSessionThreadStore{}
 	d.issues.issue = issue
 	d.messages.messages = []models.SessionMessage{
-		{ID: 1, SessionID: session.ID, OrgID: orgID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "retry me"},
+		{ID: 1, SessionID: session.ID, OrgID: orgID, ThreadID: &threadID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "retry me"},
 	}
 
 	orch := buildOrchestrator(d)

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -416,6 +416,15 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 			}
 			return nil, claimErr
 		}
+		if revertStatus == "" {
+			if resolvingComments {
+				if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
+					s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to release sibling-queued thread after unsupported comment resolution")
+				}
+				return nil, ErrThreadNotIdle
+			}
+			return s.queueClaimedThreadBehindSibling(ctx, input, thread)
+		}
 	}
 
 	content := input.Message
@@ -496,10 +505,9 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	// Reuse the session continuation worker for phase 1. The latest user
 	// message carries thread_id, so the orchestrator attributes assistant
 	// messages and streamed logs back to this tab while still operating on the
-	// single shared sandbox. Dedupe at the thread level so a concurrent send
-	// to a sibling tab is not silently swallowed by the partial unique index;
-	// worker-side AcquireTurnHold serializes the actual shared-sandbox
-	// execution when both threads run.
+	// single shared sandbox. Dedupe at the thread level so rapid-fire sends to
+	// this tab collapse, while sibling sends that arrive during another tab's
+	// turn are queued without enqueueing a second shared-sandbox job.
 	dedupeKey := db.ContinueSessionDedupeKey(thread.ID)
 	payload := map[string]string{
 		"session_id": thread.SessionID.String(),
@@ -574,6 +582,39 @@ func (s *Service) queueMessageOnIdleThread(ctx context.Context, input SendMessag
 	}
 	if err := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
 		return nil, fmt.Errorf("increment queued message count: %w", err)
+	}
+	return &SendMessageResult{Message: msg}, nil
+}
+
+func (s *Service) queueClaimedThreadBehindSibling(ctx context.Context, input SendMessageInput, thread models.SessionThread) (*SendMessageResult, error) {
+	if err := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); err != nil {
+		return nil, fmt.Errorf("release thread for queued sibling message: %w", err)
+	}
+
+	content := input.Message
+	if input.PlanMode {
+		content = "[PLAN_MODE]\n" + content
+	}
+	msg := &models.SessionMessage{
+		SessionID:  thread.SessionID,
+		OrgID:      input.OrgID,
+		ThreadID:   &input.ThreadID,
+		UserID:     input.UserID,
+		TurnNumber: thread.CurrentTurn + 1,
+		Role:       models.MessageRoleUser,
+		Content:    content,
+		References: input.References,
+		Commands:   input.Commands,
+	}
+	if len(input.Images) > 0 {
+		msg.Attachments = input.Images
+	}
+
+	if err := s.messageStore.Create(ctx, msg); err != nil {
+		return nil, fmt.Errorf("create queued sibling message: %w", err)
+	}
+	if err := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
+		return nil, fmt.Errorf("increment queued sibling message count: %w", err)
 	}
 	return &SendMessageResult{Message: msg}, nil
 }

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -496,10 +496,11 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	// Reuse the session continuation worker for phase 1. The latest user
 	// message carries thread_id, so the orchestrator attributes assistant
 	// messages and streamed logs back to this tab while still operating on the
-	// single shared sandbox. Dedupe at the session level — only one
-	// continue_session can hold the shared sandbox at a time, regardless of
-	// which thread fired it.
-	dedupeKey := db.ContinueSessionDedupeKey(thread.SessionID)
+	// single shared sandbox. Dedupe at the thread level so a concurrent send
+	// to a sibling tab is not silently swallowed by the partial unique index;
+	// worker-side AcquireTurnHold serializes the actual shared-sandbox
+	// execution when both threads run.
+	dedupeKey := db.ContinueSessionDedupeKey(thread.ID)
 	payload := map[string]string{
 		"session_id": thread.SessionID.String(),
 		"thread_id":  input.ThreadID.String(),

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -540,7 +540,7 @@ func TestService_SendMessage(t *testing.T) {
 					require.IsType(t, map[string]string{}, payload, "thread message payload should be string keyed")
 					require.Equal(t, threadID.String(), payload.(map[string]string)["thread_id"], "thread id should be included for worker attribution")
 					require.NotNil(t, dedupeKey, "continue-session enqueue should carry a dedupe key")
-					require.Equal(t, db.ContinueSessionDedupeKey(sessionID), *dedupeKey, "continue-session dedupe should be keyed by session so concurrent tabs serialize on the shared sandbox")
+					require.Equal(t, db.ContinueSessionDedupeKey(threadID), *dedupeKey, "continue-session dedupe should be keyed by thread so a concurrent send to a sibling tab is not silently swallowed; worker-side AcquireTurnHold still serializes shared-sandbox execution")
 					return uuid.New(), nil
 				}
 			},

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -569,7 +569,7 @@ func TestService_SendMessage(t *testing.T) {
 			},
 		},
 		{
-			name: "proceeds when parent session is already running due to sibling",
+			name: "queues without enqueue when parent session is already running due to sibling",
 			input: SendMessageInput{
 				SessionID: sessionID,
 				OrgID:     orgID,
@@ -580,10 +580,10 @@ func TestService_SendMessage(t *testing.T) {
 				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 1, Status: models.ThreadStatusRunning}, nil
 				}
-				// Phase 2: parent session ClaimIdle fails because a sibling
-				// tab already moved the session into running state. The
-				// service should treat this as a no-op and proceed instead
-				// of failing the user's send.
+				// The parent session ClaimIdle fails because a sibling tab
+				// already moved the session into running state. The service must
+				// queue this message for the requested thread without enqueueing a
+				// second continue_session job for the shared sandbox.
 				deps.sessionStore.claimIdleFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
 					return models.Session{}, fmt.Errorf("session already running")
 				}
@@ -591,10 +591,22 @@ func TestService_SendMessage(t *testing.T) {
 					return models.Session{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusRunning)}, nil
 				}
 				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					require.Equal(t, "hi", msg.Content, "queued sibling message should preserve content")
+					require.Equal(t, 2, msg.TurnNumber, "queued sibling message should use the claimed thread's next turn")
 					msg.ID = 99
 					return nil
 				}
+				deps.threadStore.updateStatusFn = func(_ context.Context, _, tid uuid.UUID, status models.ThreadStatus) error {
+					require.Equal(t, threadID, tid, "sibling-running queue should release the claimed thread")
+					require.Equal(t, models.ThreadStatusIdle, status, "sibling-running queue should leave the thread idle with pending messages")
+					return nil
+				}
+				deps.threadStore.incrementPendingFn = func(_ context.Context, _, tid uuid.UUID) error {
+					require.Equal(t, threadID, tid, "sibling-running queue should increment the requested thread")
+					return nil
+				}
 				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+					t.Fatalf("sibling-running send must queue only and must not enqueue a concurrent continue_session job")
 					return uuid.New(), nil
 				}
 			},
@@ -816,7 +828,7 @@ func TestService_SendMessage(t *testing.T) {
 			expectErr: ErrEnqueueFailed,
 		},
 		{
-			name: "enqueue failure does not revert sibling-owned session to idle",
+			name: "sibling-owned session queues without touching job store",
 			input: SendMessageInput{
 				SessionID: sessionID,
 				OrgID:     orgID,
@@ -837,11 +849,19 @@ func TestService_SendMessage(t *testing.T) {
 					msg.ID = 42
 					return nil
 				}
+				deps.threadStore.updateStatusFn = func(_ context.Context, _, _ uuid.UUID, status models.ThreadStatus) error {
+					require.Equal(t, models.ThreadStatusIdle, status, "sibling-owned send should release the claimed thread")
+					return nil
+				}
+				deps.threadStore.incrementPendingFn = func(_ context.Context, _, tid uuid.UUID) error {
+					require.Equal(t, threadID, tid, "sibling-owned send should increment pending messages")
+					return nil
+				}
 				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
-					return uuid.Nil, fmt.Errorf("queue down")
+					t.Fatalf("sibling-owned send must not enqueue a concurrent continue_session job")
+					return uuid.Nil, nil
 				}
 			},
-			expectErr: ErrEnqueueFailed,
 		},
 		{
 			name: "resumes a completed session via ClaimForResume",

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1045,6 +1045,7 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 		logger.Info().
 			Str("session_id", sessionID.String()).
 			Str("org_id", orgID.String()).
+			Str("thread_id", input.ThreadID).
 			Int("current_turn", session.CurrentTurn).
 			Dur("session_timeout", sessionTimeout).
 			Dur("runtime_ceiling", runtimeCeiling).


### PR DESCRIPTION
## Summary
- Multi-tab session bug: ListBySession orders rows by `(turn_number, id)` and threads have independent turn counters, so the orchestrator's global `latestUserMessage` was picking the sibling thread with the highest turn_number instead of the thread the worker enqueued for. New messages on a younger tab were orphaned while an already-answered message on Main got re-run (prod session `508dcbb9...`).
- Scopes the lookup to `opts.ThreadID` when set; falls back to global for the `RecoverSession` path that intentionally passes nil.
- Keys the thread service's `continue_session` enqueue by `thread.ID` instead of `session.ID` so a concurrent sibling send is not silently swallowed by the partial unique index. Worker-side `AcquireTurnHold` continues to serialize shared-sandbox execution.
- Adds `thread_id` to the worker's "starting continue_session job" log line and a regression test that reproduces the prod scenario end-to-end through `ContinueSession`.

## Test plan
- [x] `go test ./internal/...` passes
- [x] New `TestContinueSession_RoutesToRequestedThreadAcrossSiblingTurns` fails before the fix and passes after
- [ ] Verify on prod: send a fresh message to a non-primary thread and confirm the assistant reply lands on that thread's timeline
