### PR TITLE
Resolve preview-infra container names from sandboxes via dnsmasq sidecar

### DIFF
--- a/Dockerfile.dnsmasq
+++ b/Dockerfile.dnsmasq
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+#
+# sandbox-dns — DNS resolver for sandbox containers.
+#
+# Sandboxes bind-mount /etc/143/sandbox-resolv.conf over /etc/resolv.conf to
+# bypass Docker's embedded resolver at 127.0.0.11 (gVisor netstack can't
+# reach it). That breaks resolution of preview-infrastructure container
+# names (e.g. preview-db-<handle>) which only exist in the embedded resolver.
+#
+# This image runs dnsmasq on the same user-defined bridge as the sandboxes
+# and the preview-infra containers. It forwards every query upstream to
+# 127.0.0.11, which it CAN reach because it isn't a gVisor sandbox — Docker's
+# embedded DNS answers container names directly and forwards everything else
+# upstream to the daemon's configured DNS. Sandboxes only need to send plain
+# UDP/53 to this container's bridge IP, which gVisor handles fine.
+#
+# We build our own image rather than depending on a third-party dnsmasq
+# image so the supply chain is auditable: ~10MB final size, one apk install,
+# no out-of-tree code.
+FROM alpine:3.20
+
+RUN apk add --no-cache dnsmasq
+
+# Don't set USER here — dnsmasq must start as root to bind UDP/53, and
+# drops to the `nobody` user automatically after binding (default behavior;
+# overridable via --user but we don't need to).
+ENTRYPOINT ["dnsmasq"]
+
+# --no-daemon: stay in the foreground so Docker can supervise the process.
+# --no-resolv: ignore the container's /etc/resolv.conf (which itself points
+#              at 127.0.0.11; without --server below dnsmasq would loop).
+# --server=127.0.0.11: forward all queries to Docker's embedded resolver.
+# --cache-size=1000: small bump from the 150 default; cheap and helps when
+#                    sandboxes do bursts of repeated lookups during boot.
+# --max-cache-ttl=60: cap how long an A-record stays in the cache. Docker's
+#                     embedded DNS hands out long TTLs (~600s) for container
+#                     names; a destroyed preview-db whose IP is recycled to
+#                     a new container would otherwise resolve to the old IP
+#                     for up to 10 minutes. 60s keeps the worst-case stale
+#                     window inside one connection retry budget while still
+#                     shielding 127.0.0.11 from per-query traffic.
+CMD ["--no-daemon", "--no-resolv", "--server=127.0.0.11", "--cache-size=1000", "--max-cache-ttl=60"]

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -2,6 +2,7 @@ package deploy_test
 
 import (
 	"encoding/json"
+	"net/netip"
 	"os"
 	"strings"
 	"testing"
@@ -269,4 +270,53 @@ func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
 	dashboardProvider, err := os.ReadFile("../deploy/grafana/provisioning/dashboards/dashboards.yml")
 	require.NoError(t, err, "test should read Grafana dashboard provider config")
 	require.Contains(t, string(dashboardProvider), "disableDeletion: false", "Grafana dashboard provisioning should remove dashboards deleted from the repo")
+}
+
+// Sandbox DNS resolution depends on three values agreeing across three
+// files:
+//
+//   - the bridge subnet pinned by provision.sh (so sandbox-dns can claim a
+//     stable IP),
+//   - the sandbox-dns container's static ipv4_address in the worker compose
+//     file,
+//   - the nameserver line written into /etc/143/sandbox-resolv.conf, which
+//     every sandbox bind-mounts as /etc/resolv.conf.
+//
+// If any of these drifts independently, sandboxes silently lose DNS for
+// preview-infrastructure container names and every preview start fails at
+// the first migration. Lock the alignment in CI so a future renumbering
+// has to touch all three files in the same PR.
+func TestSandboxDNSConfigAlignment(t *testing.T) {
+	t.Parallel()
+
+	const (
+		sandboxSubnet = "172.30.0.0/24"
+		sandboxDNSIP  = "172.30.0.2"
+	)
+
+	prefix, err := netip.ParsePrefix(sandboxSubnet)
+	require.NoError(t, err, "test constant for sandbox subnet should be a valid CIDR")
+	dnsAddr, err := netip.ParseAddr(sandboxDNSIP)
+	require.NoError(t, err, "test constant for sandbox-dns IP should be a valid address")
+	require.True(t, prefix.Contains(dnsAddr), "sandbox-dns IP %s must lie inside the pinned subnet %s", sandboxDNSIP, sandboxSubnet)
+
+	provisionScript, err := os.ReadFile("../deploy/scripts/provision.sh")
+	require.NoError(t, err, "test should read the provisioning script")
+	provisionText := string(provisionScript)
+	require.Contains(t, provisionText, "--subnet "+sandboxSubnet, "provision.sh should create 143-sandbox with the pinned subnet so sandbox-dns gets a predictable static IP")
+	require.Contains(t, provisionText, `"$EXISTING_SANDBOX_SUBNET" != "`+sandboxSubnet+`"`, "provision.sh should fail loudly when an existing 143-sandbox network has a different subnet — silent reuse breaks the static-IP mapping")
+	require.Contains(t, provisionText, "nameserver "+sandboxDNSIP, "provision.sh should write sandbox-dns's IP into /etc/143/sandbox-resolv.conf")
+
+	compose, err := os.ReadFile("../docker-compose.worker.yml")
+	require.NoError(t, err, "test should read the worker compose file")
+	composeText := string(compose)
+	require.Contains(t, composeText, "ipv4_address: "+sandboxDNSIP, "worker compose should pin sandbox-dns to the same static IP that sandbox-resolv.conf points at")
+	require.Contains(t, composeText, "name: 143-sandbox", "worker compose should attach sandbox-dns to the externally-managed 143-sandbox bridge, not a compose-private network")
+	require.Contains(t, composeText, "external: true", "worker compose should declare the sandbox network as external — the bridge is created by provision.sh, not compose")
+
+	dockerfile, err := os.ReadFile("../Dockerfile.dnsmasq")
+	require.NoError(t, err, "test should read the dnsmasq Dockerfile")
+	dockerfileText := string(dockerfile)
+	require.Contains(t, dockerfileText, "--server=127.0.0.11", "dnsmasq must forward to Docker's embedded resolver — that's the only place preview-infra container names are registered")
+	require.Contains(t, dockerfileText, "--no-resolv", "dnsmasq must ignore its own /etc/resolv.conf (which itself points at 127.0.0.11) to avoid a forwarding loop")
 }

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -208,6 +208,18 @@ if [ "$ROLE" = "worker" ]; then
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh \
      || { rm -f /opt/143/deploy/scripts/sandbox-firewall.sh.new; exit 1; }"
+
+  # Sync Dockerfile.dnsmasq alongside the worker compose file. The
+  # sandbox-dns service is built locally on each worker (see
+  # docker-compose.worker.yml) and the build context is /opt/143, so the
+  # Dockerfile must live next to the compose file before `docker compose
+  # up` runs. Atomic-rename via .new for the same ETXTBSY-class reasons
+  # noted on sandbox-firewall.sh above.
+  scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/Dockerfile.dnsmasq" \
+    deploy@"$HOST":/opt/143/Dockerfile.dnsmasq.new
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "mv /opt/143/Dockerfile.dnsmasq.new /opt/143/Dockerfile.dnsmasq \
+     || { rm -f /opt/143/Dockerfile.dnsmasq.new; exit 1; }"
 fi
 
 # --- Docker log rotation (idempotent) ---

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -391,9 +391,34 @@ PULL_APP
       set -euo pipefail
       su - deploy -c 'docker pull ghcr.io/assembledhq/143-server:latest'
       su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
-      # Ensure the shared sandbox egress network exists (idempotent).
+      # Ensure the shared sandbox bridge exists with a pinned subnet.
+      #
+      # The subnet is hard-coded to 172.30.0.0/24 so sandbox-dns can be
+      # given the stable static IP 172.30.0.2 in docker-compose.worker.yml,
+      # which /etc/143/sandbox-resolv.conf below points at. Without a pinned
+      # subnet Docker auto-assigns from its default pool and the static IP
+      # mapping breaks.
+      #
       # enable_icc=false blocks one sandbox from TCP-connecting to another.
-      su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
+      # Intra-bridge traffic from a sandbox to preview-infra and to
+      # sandbox-dns is allowed by an explicit RETURN rule installed in
+      # DOCKER-USER by sandbox-firewall.sh.
+      # docker inspect returns "" on a missing network (with exit 1 swallowed
+      # by `|| true`) and the subnet string on an existing one. Distinguishing
+      # the two via a single call keeps us from spawning two `su - deploy`
+      # login shells per provision.
+      EXISTING_SANDBOX_SUBNET=$(su - deploy -c 'docker network inspect 143-sandbox -f "{{range .IPAM.Config}}{{.Subnet}}{{end}}" 2>/dev/null' || true)
+      if [ -z "$EXISTING_SANDBOX_SUBNET" ]; then
+        su - deploy -c 'docker network create --driver bridge --subnet 172.30.0.0/24 --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
+      elif [ "$EXISTING_SANDBOX_SUBNET" != "172.30.0.0/24" ]; then
+        echo "ERROR: 143-sandbox network has subnet '$EXISTING_SANDBOX_SUBNET'; expected 172.30.0.0/24." >&2
+        echo "  This worker was provisioned before the pinned-subnet change. To upgrade:" >&2
+        echo "    1. docker compose -f /opt/143/docker-compose.worker.yml down" >&2
+        echo "    2. docker network rm 143-sandbox" >&2
+        echo "    3. Re-run provision-worker for this host." >&2
+        echo "  Step 1 will drain in-flight coding turns; plan for a maintenance window." >&2
+        exit 1
+      fi
       # Install iptables-persistent so the egress block survives reboots.
       apt-get install -y --no-install-recommends iptables-persistent >/dev/null 2>&1 || true
       # Apply sandbox egress firewall. Script is idempotent and reads the
@@ -405,13 +430,19 @@ PULL_APP
       # /etc/resolv.conf. Required because user-defined Docker networks inject
       # 127.0.0.11 (Docker's embedded DNS) into resolv.conf, and gVisor's
       # netstack can't reach it. HostConfig.DNS doesn't help — it only changes
-      # the upstream the embedded resolver forwards to. Bind-mounting our own
-      # resolv.conf bypasses 127.0.0.11 entirely. Future: point this at a
-      # host-local DNS forwarder (dnsmasq on 172.19.0.1) for filtering/logging.
+      # the upstream the embedded resolver forwards to.
+      #
+      # Points at the sandbox-dns container's static IP (172.30.0.2 on the
+      # 143-sandbox bridge). sandbox-dns is a non-gVisor container that CAN
+      # reach 127.0.0.11 normally and forwards every query there, so preview-
+      # infrastructure container names (preview-db-<handle>, etc.) resolve
+      # via Docker's embedded resolver while public lookups continue to work
+      # through the daemon's upstream forwarders. Bringing up sandbox-dns is
+      # gated by docker-compose.worker.yml depends_on, so by the time the
+      # worker is taking traffic this address is answering.
       mkdir -p /etc/143
       cat > /etc/143/sandbox-resolv.conf <<RESOLV
-nameserver 1.1.1.1
-nameserver 8.8.8.8
+nameserver 172.30.0.2
 options edns0 trust-ad ndots:0
 RESOLV
       chmod 644 /etc/143/sandbox-resolv.conf

--- a/deploy/scripts/sandbox-firewall.sh
+++ b/deploy/scripts/sandbox-firewall.sh
@@ -6,6 +6,20 @@
 # otherwise pivot to internal infra (DB, monitoring, metadata API) that
 # happens to be reachable from the worker host.
 #
+# Carves out intra-bridge traffic via a RETURN rule so sandboxes can still
+# reach preview-infrastructure containers (postgres, etc.) and the
+# sandbox-dns resolver, all of which sit on the same 143-sandbox bridge.
+#
+# Verification after first deploy on a new worker (the RETURN rule only
+# helps if intra-bridge traffic actually traverses DOCKER-USER — some
+# Docker versions enforce enable_icc=false in an earlier chain):
+#
+#   docker exec -it <sandbox-container> sh -c 'nc -zv 172.30.0.2 53 && \
+#       nc -zv preview-db-<handle> 5432'
+#
+# If either connection refuses, the fix is to remove enable_icc=false from
+# the network and rely on these iptables rules alone for sandbox isolation.
+#
 # Idempotent: drops any prior rules tagged with our comment before re-adding.
 # Safe to call on every deploy and on boot.
 #
@@ -66,6 +80,21 @@ for dest in "${BLOCKED_DESTS[@]}"; do
   iptables -I DOCKER-USER -s "$SUBNET" -d "$dest" \
     -m comment --comment "$COMMENT_TAG" -j DROP
 done
+
+# Allow intra-bridge traffic so sandbox containers can reach the preview-
+# infrastructure containers (postgres, etc.) and the sandbox-dns resolver,
+# all of which sit on the same 143-sandbox bridge. The DROP rules above
+# block 172.16/12, which the bridge subnet itself is part of, so without
+# this carve-out every intra-bridge request gets dropped.
+#
+# RETURN — not ACCEPT — exits DOCKER-USER and returns to the FORWARD
+# chain so the rest of FORWARD still applies. The bridge is created with
+# enable_icc=false to isolate sandbox-from-sandbox; this rule operates
+# below that layer and does not undo it.
+#
+# Inserted last so iptables -I lands it at position 1, ahead of the DROPs.
+iptables -I DOCKER-USER -s "$SUBNET" -d "$SUBNET" \
+  -m comment --comment "$COMMENT_TAG" -j RETURN
 
 # Persist across reboots if iptables-persistent is installed.
 if command -v netfilter-persistent >/dev/null 2>&1; then

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -37,6 +37,43 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     restart: "no"
 
+  # DNS resolver for sandbox containers. Sandboxes bind-mount their
+  # /etc/resolv.conf to point at this container's static IP on the
+  # 143-sandbox bridge (172.30.0.2), which forwards to Docker's embedded
+  # resolver at 127.0.0.11 — the only place preview-infra container names
+  # (preview-db-<handle>, etc.) are registered. See Dockerfile.dnsmasq for
+  # the rationale. Built locally on each worker; the build context is just
+  # the Dockerfile, so no source tree on the host is required.
+  sandbox-dns:
+    build:
+      context: .
+      dockerfile: Dockerfile.dnsmasq
+    image: 143-sandbox-dns:local
+    networks:
+      sandbox:
+        # Static IP so /etc/143/sandbox-resolv.conf can hard-code it. Pinned
+        # to the network's first usable host after the gateway (.1).
+        ipv4_address: 172.30.0.2
+    healthcheck:
+      # Resolve a name from dnsmasq's own /etc/hosts via the local listener.
+      # Doesn't touch upstream, so the check stays green when the bridge
+      # gateway or 127.0.0.11 is briefly unhealthy — we only fail when
+      # dnsmasq itself isn't answering.
+      test: ["CMD-SHELL", "nslookup localhost 127.0.0.1 >/dev/null 2>&1"]
+      interval: 15s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 64M
+          cpus: "0.2"
+        reservations:
+          memory: 16M
+          cpus: "0.05"
+
   worker:
     image: ghcr.io/assembledhq/143-server:${IMAGE_TAG:-latest}
     depends_on:
@@ -44,6 +81,11 @@ services:
         condition: service_started
       gvisor-check:
         condition: service_completed_successfully
+      # Block worker startup until sandbox-dns is answering queries.
+      # Sandboxes spawned by an early worker would otherwise come up with no
+      # working DNS and fail their first preview-infra lookup.
+      sandbox-dns:
+        condition: service_healthy
     # NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL are per-host
     # identity. They live in /opt/143/.env.local and are concatenated into
     # /opt/143/.env by provision.sh / deploy.sh so docker compose can
@@ -114,3 +156,12 @@ services:
         limits:
           memory: 2G
           cpus: "1.0"
+
+# The 143-sandbox bridge is created out-of-band by deploy/scripts/provision.sh
+# (with a pinned --subnet of 172.30.0.0/24 so sandbox-dns can have a stable
+# IP). Declared external here so compose attaches to the existing network
+# instead of creating its own.
+networks:
+  sandbox:
+    external: true
+    name: 143-sandbox


### PR DESCRIPTION
## Summary

- Preview start was failing with `lookup preview-db-<handle>: no such host` because the bind-mounted sandbox `/etc/resolv.conf` (PR #407) points at public DNS, while `DATABASE_URL` (post-#799) now contains a Docker-internal container name that only the embedded resolver at 127.0.0.11 knows.
- Adds a `sandbox-dns` dnsmasq sidecar on the `143-sandbox` bridge at static IP `172.30.0.2` that forwards to 127.0.0.11 from a non-gVisor namespace where it can be reached, plus a pinned `172.30.0.0/24` subnet, an intra-bridge `RETURN` rule in `DOCKER-USER` so the 172.16/12 egress block does not catch sandbox-to-preview-infra traffic, and a `TestSandboxDNSConfigAlignment` that locks the subnet/IP/resolv.conf agreement in CI.
- Existing workers will fail `provision-worker` with the maintenance steps printed inline (`compose down` → `docker network rm 143-sandbox` → re-provision); new workers come up clean. The `DOCKER-USER` RETURN rule depends on intra-bridge traffic actually reaching that chain (some Docker versions enforce `enable_icc=false` earlier) — verification command lives in `sandbox-firewall.sh`'s docstring.

## Test plan

- [ ] `go test ./deploy/...` (covers new `TestSandboxDNSConfigAlignment` plus existing provision/cloud-init contract tests)
- [ ] `make lint`
- [ ] On first upgraded worker after maintenance: `docker exec -it <sandbox> sh -c 'nc -zv 172.30.0.2 53 && nc -zv preview-db-<handle> 5432'` — both should connect; if either is refused, drop `enable_icc=false` from the bridge per the runbook note.
- [ ] Trigger a preview from a session and confirm the migrator gets past `running migrations...` (the failure point in the original report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
