### PR TITLE
Drop invalid offline_access scope from Linear OAuth

### DIFF
--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -443,17 +443,11 @@ func (h *IntegrationHandler) StartLinearOAuth(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// offline_access is the documented Linear scope that triggers refresh_token
-	// + expires_in in the token response. Without it, Linear treats the token
-	// as long-lived but the refresh path here is unrecoverable on revocation —
-	// the user has to manually reconnect after every revocation event. The
-	// rest of the refresh machinery in internal/services/linear/refresh.go is
-	// a no-op until this scope is granted.
 	params := url.Values{
 		"client_id":     {h.linearClientID},
 		"redirect_uri":  {h.linearRedirectURL()},
 		"response_type": {"code"},
-		"scope":         {"read,write,offline_access"},
+		"scope":         {"read,write"},
 		"state":         {state},
 	}
 

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -311,7 +311,7 @@ func TestIntegrationHandler_StartLinearOAuth_RedirectsToLinearAuthorize(t *testi
 	require.Equal(t, "linear-client-id", parsed.Query().Get("client_id"), "redirect should include configured client id")
 	require.Equal(t, "code", parsed.Query().Get("response_type"), "redirect should request auth code flow")
 	require.Equal(t, "http://localhost:8080/api/v1/integrations/linear/callback", parsed.Query().Get("redirect_uri"), "redirect should include API callback URL")
-	require.Equal(t, "read,write,offline_access", parsed.Query().Get("scope"), "redirect must include offline_access so Linear issues a refresh_token; without it the refresh path in internal/services/linear cannot recover from token revocation and users have to manually reconnect")
+	require.Equal(t, "read,write", parsed.Query().Get("scope"), "redirect must request only the scopes Linear accepts; offline_access is not a valid Linear scope and Linear returns refresh_token automatically")
 	require.NotEmpty(t, parsed.Query().Get("state"), "redirect should include oauth state")
 
 	setCookie := w.Result().Header.Get("Set-Cookie")


### PR DESCRIPTION
## Summary
- Linear rejects `offline_access` with `Invalid scope: offline_access` on the authorize redirect, blocking users from connecting or reconnecting their Linear integration.
- Linear's actual scopes are `read`/`write`/`issues:create`/`comments:create`/`timeSchedule:write`/`admin`, and Linear returns `refresh_token` + `expires_in` automatically without any special scope, so requesting `read,write` is sufficient and the existing refresh machinery in `internal/services/linear/refresh.go` keeps working.
- Updates the corresponding test assertion.

## Test plan
- [x] `go test ./internal/api/handlers/ -run TestIntegrationHandler_StartLinearOAuth`
- [ ] After deploy, reconnect Linear from the integrations page and verify the authorize redirect succeeds and a refresh token is stored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
