### PR TITLE
Fail deploys fast on missing pubkey instead of phantom password retries

### DIFF
--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -46,8 +46,13 @@ esac
 
 echo "Deploying role=$ROLE tag=$TAG to $HOST..."
 
-SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
-SCP_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+# BatchMode=yes prevents ssh from falling through to interactive password auth
+# when the github-actions pubkey isn't in the host's authorized_keys yet — the
+# deploy fails immediately with `Permission denied (publickey)` instead of
+# looking like a stuck retry. Remediation when this fires:
+#   make sync-keys APPLY=true
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+SCP_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 
 repair_deploy_sudoers() {
   bash "$SCRIPT_DIR/repair-deploy-sudoers.sh" "$ROLE" "$HOST" "$SSH_KEY"

--- a/deploy/scripts/sync-keys.sh
+++ b/deploy/scripts/sync-keys.sh
@@ -51,7 +51,7 @@ if [ "$APPLY" = false ]; then
   echo ""
 fi
 
-SSH_OPTS=(-o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
+SSH_OPTS=(-o BatchMode=yes -o StrictHostKeyChecking=accept-new -i "$SSH_KEY")
 
 FAILED=0
 for HOST in "${HOSTS[@]}"; do


### PR DESCRIPTION
## Summary
- Add `BatchMode=yes` to the SSH/SCP options in `deploy/scripts/deploy.sh` and `deploy/scripts/sync-keys.sh` so a host whose `~deploy/.ssh/authorized_keys` is missing the github-actions pubkey errors immediately with `Permission denied (publickey)` instead of falling through to password auth and emitting two confusing `Permission denied, please try again.` lines in CI before the real failure.
- Inline a one-line remediation pointer (`make sync-keys APPLY=true`) so the next person hitting this can fix it without spelunking. `repair-deploy-sudoers.sh` already used `BatchMode=yes`; this aligns the rest of the deploy hot path.

## Test plan
- [ ] Run `make sync-keys APPLY=true` against the fleet so the github-actions key lands on the logging host (87.99.129.197).
- [ ] Re-run the failing `Build & Deploy` workflow and confirm the logging step now succeeds.
- [ ] Sanity-check that a deliberately broken SSH key produces an immediate `Permission denied (publickey)` rather than retrying password auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)