### PR TITLE
Allow follow-up messages to resume completed/failed threads

### DIFF
--- a/internal/api/handlers/session_threads_test.go
+++ b/internal/api/handlers/session_threads_test.go
@@ -23,11 +23,12 @@ import (
 // --- Mock stores implementing the thread service interfaces ---
 
 type mockThreadStore struct {
-	createFn        func(ctx context.Context, t *models.SessionThread, max int) error
-	getByIDFn       func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
-	listBySessionFn func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
-	claimIdleFn     func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
-	updateStatusFn  func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
+	createFn         func(ctx context.Context, t *models.SessionThread, max int) error
+	getByIDFn        func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
+	listBySessionFn  func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
+	claimIdleFn      func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
+	claimForResumeFn func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
+	updateStatusFn   func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
 }
 
 func (m *mockThreadStore) Create(ctx context.Context, t *models.SessionThread, max int) error {
@@ -56,6 +57,13 @@ func (m *mockThreadStore) ClaimIdleForSession(ctx context.Context, orgID, sessio
 		return m.claimIdleFn(ctx, orgID, sessionID, threadID)
 	}
 	return models.SessionThread{}, fmt.Errorf("not idle")
+}
+
+func (m *mockThreadStore) ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, _ int) (models.SessionThread, error) {
+	if m.claimForResumeFn != nil {
+		return m.claimForResumeFn(ctx, orgID, sessionID, threadID)
+	}
+	return models.SessionThread{}, fmt.Errorf("not resumable")
 }
 
 func (m *mockThreadStore) UpdateStatus(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -4617,9 +4617,11 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// ClaimForResume also fails (no row returned).
+				// ClaimForResume also fails (no row returned). Carries an
+				// extra @statuses arg now that the resumable-status set is
+				// bound at runtime.
 				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
 				mock.ExpectRollback()
 			},
@@ -4692,7 +4694,7 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
 				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
 				mock.ExpectRollback().WillReturnError(fmt.Errorf("rollback failed"))
 			},
@@ -4801,9 +4803,10 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				// ClaimForResume succeeds.
+				// ClaimForResume succeeds. Carries an extra @statuses arg
+				// now that the resumable-status set is bound at runtime.
 				mock.ExpectQuery("UPDATE sessions SET status").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
 							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
@@ -4935,8 +4938,8 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
 							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
@@ -5015,8 +5018,8 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
 							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
@@ -5081,8 +5084,8 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
 							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",
@@ -5147,8 +5150,8 @@ func TestSessionHandler_SendMessage(t *testing.T) {
 				mock.ExpectQuery("UPDATE sessions SET status").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionColumns))
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						addSessionRow(pgxmock.NewRows(sessionColumns),
 							sessionID, uuid.New(), orgID, "claude-code", "running", "semi", "low",

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -993,19 +993,22 @@ func (s *SessionStore) ClaimIdle(ctx context.Context, orgID, sessionID uuid.UUID
 // ClaimForResume atomically transitions a resumable paused session to running
 // so it can continue from a follow-up message. Used when a user sends a
 // message to a completed/failed/cancelled/pr_created session, or to a paused
-// session waiting on guidance/input.
+// session waiting on guidance/input. The set of resumable statuses lives in
+// models.ResumableSessionStatuses so the session and thread paths share a
+// single source of truth.
 // Sessions whose sandbox snapshot has been destroyed cannot be resumed.
 func (s *SessionStore) ClaimForResume(ctx context.Context, orgID, sessionID uuid.UUID) (models.Session, error) {
 	query := `
 		UPDATE sessions
 		SET status = 'running', completed_at = NULL, last_activity_at = now()
-		WHERE id = @id AND org_id = @org_id AND status IN ('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance')
+		WHERE id = @id AND org_id = @org_id AND status = ANY(@statuses)
 		  AND sandbox_state != 'destroyed'
 		RETURNING ` + sessionSelectColumns
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
-		"id":     sessionID,
-		"org_id": orgID,
+		"id":       sessionID,
+		"org_id":   orgID,
+		"statuses": sessionStatusStrings(models.ResumableSessionStatuses),
 	})
 	if err != nil {
 		return models.Session{}, fmt.Errorf("claim terminal session for resume: %w", err)
@@ -1050,6 +1053,29 @@ func (s *SessionStore) UpdateRevisionContext(ctx context.Context, orgID, session
 		"revision_context": revisionContext,
 	})
 	return err
+}
+
+// sessionStatusStrings converts a slice of typed SessionStatus values into the
+// raw []string form pgx needs to bind a postgres text[] parameter. Used by
+// queries that match against models.ResumableSessionStatuses so the typed
+// constant remains the single source of truth.
+func sessionStatusStrings(statuses []models.SessionStatus) []string {
+	out := make([]string, len(statuses))
+	for i, s := range statuses {
+		out[i] = string(s)
+	}
+	return out
+}
+
+// threadStatusStrings is the thread-status counterpart to sessionStatusStrings.
+// Used by SessionThreadStore queries that match against
+// models.ResumableThreadStatuses.
+func threadStatusStrings(statuses []models.ThreadStatus) []string {
+	out := make([]string, len(statuses))
+	for i, s := range statuses {
+		out[i] = string(s)
+	}
+	return out
 }
 
 var (

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -1053,8 +1053,8 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 			name: "resumes completed session successfully",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
 				now := time.Now()
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(
 							newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)...,
@@ -1066,8 +1066,8 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 		{
 			name: "returns error when no matching row",
 			setupMock: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(sessionTestColumns))
 			},
 			wantErr: true,
@@ -1078,8 +1078,8 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = string(models.SessionStatusRunning)
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
 					)
@@ -1092,8 +1092,8 @@ func TestSessionStore_ClaimForResume(t *testing.T) {
 				now := time.Now()
 				row := newAgentSessionRow(uuid.New(), uuid.New(), uuid.New(), now)
 				row[4] = string(models.SessionStatusRunning)
-				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status IN \\('completed', 'pr_created', 'failed', 'cancelled', 'awaiting_input', 'needs_human_guidance'\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+				mock.ExpectQuery("UPDATE sessions\\s+SET status = 'running', completed_at = NULL, last_activity_at = now\\(\\)\\s+WHERE id = @id AND org_id = @org_id AND status = ANY\\(@statuses\\)\\s+AND sandbox_state != 'destroyed'\\s+RETURNING").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(sessionTestColumns).AddRow(row...),
 					)

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -258,17 +258,14 @@ func (s *SessionThreadStore) ClaimIdle(ctx context.Context, orgID, threadID uuid
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionThread])
 }
 
-// ErrThreadRunningLimitReached signals that the requested thread is idle and
-// could otherwise be claimed, but the session has already reached the maximum
-// allowed number of concurrent running siblings.
+// ErrThreadRunningLimitReached signals that the requested thread is otherwise
+// claimable (idle, or in a resumable status), but the session has already
+// reached the maximum allowed number of concurrent running siblings.
 var ErrThreadRunningLimitReached = fmt.Errorf("session running thread limit reached")
 
 // ClaimIdleForSession atomically transitions an idle thread to running while
-// enforcing the session-wide running-thread cap. The CTE locks every thread
-// row in the session before evaluating sibling state so concurrent sends to
-// different idle tabs serialize on the database row locks. Allows up to
-// maxRunning sibling tabs (including this one) to be active at the same time;
-// callers should pass models.MaxRunningThreadsPerSession.
+// enforcing the session-wide running-thread cap. See claimForSession for the
+// shared CTE/cap mechanics.
 //
 // Returns ErrThreadRunningLimitReached when the target thread is idle but
 // adding it would exceed maxRunning. Callers should distinguish this from
@@ -276,6 +273,66 @@ var ErrThreadRunningLimitReached = fmt.Errorf("session running thread limit reac
 // case, queueing a pending message is appropriate; in the latter, the user is
 // trying to send to a tab whose own turn is still in flight.
 func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error) {
+	return s.claimForSession(ctx, claimForSessionArgs{
+		orgID:             orgID,
+		sessionID:         sessionID,
+		threadID:          threadID,
+		maxRunning:        maxRunning,
+		claimableStatuses: []string{string(models.ThreadStatusIdle)},
+		extraSetClauses:   "started_at = now(),",
+	})
+}
+
+// ClaimForResumeInSession atomically transitions a thread in a resumable
+// terminal/paused status (completed, failed, cancelled, awaiting_input) back
+// to running so a follow-up message can continue it. Mirrors
+// SessionStore.ClaimForResume at the thread layer; the resumable-status set
+// lives in models.ResumableThreadStatuses.
+//
+// Honors the same session-wide running-thread cap as ClaimIdleForSession and
+// surfaces ErrThreadRunningLimitReached the same way, so callers can keep one
+// "limit hit, queue instead" branch regardless of which claim path failed.
+//
+// Does not reset started_at — the original thread start time remains the
+// authoritative "first activity" stamp. completed_at is cleared so the row
+// reflects the new in-flight turn rather than the previous terminal state.
+func (s *SessionThreadStore) ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error) {
+	return s.claimForSession(ctx, claimForSessionArgs{
+		orgID:             orgID,
+		sessionID:         sessionID,
+		threadID:          threadID,
+		maxRunning:        maxRunning,
+		claimableStatuses: threadStatusStrings(models.ResumableThreadStatuses),
+		extraSetClauses:   "completed_at = NULL,",
+	})
+}
+
+// claimForSessionArgs bundles inputs for claimForSession so each call site
+// stays readable and additions (e.g. a future "preserve cancel_requested_at"
+// flag) don't ripple across positional argument lists.
+type claimForSessionArgs struct {
+	orgID, sessionID, threadID uuid.UUID
+	maxRunning                 int
+	// claimableStatuses is the set of current thread statuses from which the
+	// claim is allowed to fire. ClaimIdleForSession passes ['idle']; the
+	// resume path passes models.ResumableThreadStatuses.
+	claimableStatuses []string
+	// extraSetClauses is interpolated verbatim into the UPDATE SET clause and
+	// must end in a trailing comma when non-empty. Kept as a controlled string
+	// rather than a parameter list because the assignments differ structurally
+	// (started_at = now() vs completed_at = NULL); the values are not user
+	// input.
+	extraSetClauses string
+}
+
+// claimForSession is the shared core of ClaimIdleForSession and
+// ClaimForResumeInSession. The CTE locks every thread row in the session
+// before evaluating sibling state so concurrent sends to different tabs
+// serialize on the database row locks. Allows up to maxRunning sibling tabs
+// (including this one) to be active at the same time; callers should pass
+// models.MaxRunningThreadsPerSession.
+func (s *SessionThreadStore) claimForSession(ctx context.Context, args claimForSessionArgs) (models.SessionThread, error) {
+	maxRunning := args.maxRunning
 	if maxRunning <= 0 {
 		maxRunning = models.MaxRunningThreadsPerSession
 	}
@@ -285,25 +342,25 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 			FROM session_threads
 			WHERE org_id = @org_id AND session_id = @session_id
 			FOR UPDATE
-		), target_idle AS (
+		), target_claimable AS (
 			SELECT 1
 			FROM locked_threads
-			WHERE id = @id AND status = 'idle'
+			WHERE id = @id AND status = ANY(@claimable_statuses)
 		), running_count AS (
 			SELECT count(*) AS n
 			FROM locked_threads
 			WHERE id <> @id
 			  AND status IN ('pending', 'running', 'awaiting_input')
 		), eligible AS (
-			-- target is idle AND adding it (siblings + 1) stays at-or-under
+			-- target is claimable AND adding it (siblings + 1) stays at-or-under
 			-- max_running, i.e. siblings_active < max_running.
 			SELECT 1
-			FROM target_idle, running_count
+			FROM target_claimable, running_count
 			WHERE running_count.n < @max_running
 		)
 		UPDATE session_threads
 		SET status = 'running',
-		    started_at = now(),
+		    ` + args.extraSetClauses + `
 		    last_activity_at = now(),
 		    cancel_requested_at = NULL
 		WHERE id = @id
@@ -313,26 +370,27 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 		RETURNING ` + sessionThreadSelectColumns
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
-		"id":          threadID,
-		"org_id":      orgID,
-		"session_id":  sessionID,
-		"max_running": maxRunning,
+		"id":                 args.threadID,
+		"org_id":             args.orgID,
+		"session_id":         args.sessionID,
+		"max_running":        maxRunning,
+		"claimable_statuses": args.claimableStatuses,
 	})
 	if err != nil {
-		return models.SessionThread{}, fmt.Errorf("claim idle session thread: %w", err)
+		return models.SessionThread{}, fmt.Errorf("claim session thread: %w", err)
 	}
 	thread, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[models.SessionThread])
 	if err != nil {
 		// pgx.ErrNoRows means the WHERE-with-EXISTS predicate did not match.
-		// Best-effort distinguish "limit reached" from "not idle" by
-		// re-inspecting state without holding the FOR UPDATE lock. A sibling
-		// can transition between the failed claim and this lookup; on that
-		// race we surface the original ErrNoRows and the caller maps it to
-		// "thread not idle". Acceptable trade-off: the worst case is the user
-		// sees the busy-tab affordance instead of the queued-message one for
-		// one cycle, then retries.
+		// Best-effort distinguish "limit reached" from "status not claimable"
+		// by re-inspecting state without holding the FOR UPDATE lock. A
+		// sibling can transition between the failed claim and this lookup; on
+		// that race we surface the original ErrNoRows and the caller maps it
+		// to "thread not claimable in this status". Acceptable trade-off: the
+		// worst case is the user sees the busy-tab affordance instead of the
+		// queued-message one for one cycle, then retries.
 		if errors.Is(err, pgx.ErrNoRows) {
-			limited, lookupErr := s.isAtRunningLimit(ctx, orgID, sessionID, threadID, maxRunning)
+			limited, lookupErr := s.isAtRunningLimit(ctx, args.orgID, args.sessionID, args.threadID, maxRunning, args.claimableStatuses)
 			if lookupErr == nil && limited {
 				return models.SessionThread{}, ErrThreadRunningLimitReached
 			}
@@ -342,16 +400,17 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 	return thread, nil
 }
 
-// isAtRunningLimit returns true when the target thread is idle (so otherwise
-// claimable) but the session already has maxRunning sibling threads active.
-// Used by ClaimIdleForSession to differentiate "limit reached" from "thread
-// status changed under us" without holding the FOR UPDATE lock.
+// isAtRunningLimit returns true when the target thread is in a claimable
+// status (so otherwise eligible) but the session already has maxRunning
+// sibling threads active. Used by claimForSession to differentiate
+// "limit reached" from "status changed under us" without holding the
+// FOR UPDATE lock.
 //
 // Uses COALESCE on the target subquery so a deleted-out-from-under-us row
 // scans as the empty string instead of erroring on NULL → string. In that
 // case we report "not limited" — the caller will fall through to its
 // generic ErrNoRows path which the service maps to ErrThreadNotFound.
-func (s *SessionThreadStore) isAtRunningLimit(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (bool, error) {
+func (s *SessionThreadStore) isAtRunningLimit(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int, claimableStatuses []string) (bool, error) {
 	var targetStatus string
 	var siblingActive int
 	err := s.db.QueryRow(ctx, `
@@ -364,7 +423,15 @@ func (s *SessionThreadStore) isAtRunningLimit(ctx context.Context, orgID, sessio
 	if err != nil {
 		return false, err
 	}
-	return targetStatus == string(models.ThreadStatusIdle) && siblingActive >= maxRunning, nil
+	if siblingActive < maxRunning {
+		return false, nil
+	}
+	for _, claimable := range claimableStatuses {
+		if targetStatus == claimable {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // CountActive returns the number of threads in pending/running/awaiting_input

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -263,6 +263,19 @@ func (s *SessionThreadStore) ClaimIdle(ctx context.Context, orgID, threadID uuid
 // reached the maximum allowed number of concurrent running siblings.
 var ErrThreadRunningLimitReached = fmt.Errorf("session running thread limit reached")
 
+// claimMode names the two ways a thread row can transition into 'running': a
+// fresh claim from idle (the start of a new turn) versus a resume from a
+// terminal/paused status (continuing after the user sent a follow-up). The
+// SET clauses differ structurally between the two — the typed enum keeps the
+// branching compiler-checked and ensures the SQL fragment that lands in the
+// query never originates from caller-controlled input.
+type claimMode int
+
+const (
+	claimModeIdle claimMode = iota
+	claimModeResume
+)
+
 // ClaimIdleForSession atomically transitions an idle thread to running while
 // enforcing the session-wide running-thread cap. See claimForSession for the
 // shared CTE/cap mechanics.
@@ -278,8 +291,8 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 		sessionID:         sessionID,
 		threadID:          threadID,
 		maxRunning:        maxRunning,
+		mode:              claimModeIdle,
 		claimableStatuses: []string{string(models.ThreadStatusIdle)},
-		extraSetClauses:   "started_at = now(),",
 	})
 }
 
@@ -296,33 +309,53 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 // Does not reset started_at — the original thread start time remains the
 // authoritative "first activity" stamp. completed_at is cleared so the row
 // reflects the new in-flight turn rather than the previous terminal state.
+// failure_explanation and failure_category are intentionally preserved as
+// audit history of the prior run; mirrors SessionStore.ClaimForResume, which
+// also leaves session-level failure fields untouched on resume.
 func (s *SessionThreadStore) ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error) {
 	return s.claimForSession(ctx, claimForSessionArgs{
 		orgID:             orgID,
 		sessionID:         sessionID,
 		threadID:          threadID,
 		maxRunning:        maxRunning,
+		mode:              claimModeResume,
 		claimableStatuses: threadStatusStrings(models.ResumableThreadStatuses),
-		extraSetClauses:   "completed_at = NULL,",
 	})
 }
 
 // claimForSessionArgs bundles inputs for claimForSession so each call site
-// stays readable and additions (e.g. a future "preserve cancel_requested_at"
-// flag) don't ripple across positional argument lists.
+// stays readable and additions don't ripple across positional argument lists.
 type claimForSessionArgs struct {
 	orgID, sessionID, threadID uuid.UUID
 	maxRunning                 int
+	// mode selects the per-claim SET clause; see claimModeSetClause.
+	mode claimMode
 	// claimableStatuses is the set of current thread statuses from which the
 	// claim is allowed to fire. ClaimIdleForSession passes ['idle']; the
 	// resume path passes models.ResumableThreadStatuses.
 	claimableStatuses []string
-	// extraSetClauses is interpolated verbatim into the UPDATE SET clause and
-	// must end in a trailing comma when non-empty. Kept as a controlled string
-	// rather than a parameter list because the assignments differ structurally
-	// (started_at = now() vs completed_at = NULL); the values are not user
-	// input.
-	extraSetClauses string
+}
+
+// claimModeSetClause returns the mode-specific SQL fragment that goes into
+// the UPDATE SET clause of claimForSession's query. Concentrating the mapping
+// here keeps the query template free of branch-on-mode logic and makes it
+// trivially evident to a reader (and to a static analyzer) that no
+// caller-controlled string ever lands in the SQL.
+func claimModeSetClause(mode claimMode) string {
+	switch mode {
+	case claimModeIdle:
+		// Fresh claim of an idle row — record when this turn started so
+		// time-on-task surfaces have a precise begin stamp.
+		return "started_at = now(),"
+	case claimModeResume:
+		// Resume of a terminal/paused row — clear the stale completed_at
+		// from the previous turn so the row reflects the new in-flight one.
+		return "completed_at = NULL,"
+	default:
+		// Unreachable in normal code paths; panic is preferable to silently
+		// emitting an UPDATE that does the wrong thing.
+		panic(fmt.Sprintf("claimForSession: unknown claimMode %d", mode))
+	}
 }
 
 // claimForSession is the shared core of ClaimIdleForSession and
@@ -331,6 +364,12 @@ type claimForSessionArgs struct {
 // serialize on the database row locks. Allows up to maxRunning sibling tabs
 // (including this one) to be active at the same time; callers should pass
 // models.MaxRunningThreadsPerSession.
+//
+// Cap-math note: running_count excludes the target via id <> @id. A target
+// that is itself in an active status (awaiting_input is the only such case
+// in the resumable set) therefore does not count toward siblings — which is
+// correct, because resuming such a target does not increase the session's
+// total active occupancy. The cap is enforced strictly against siblings.
 func (s *SessionThreadStore) claimForSession(ctx context.Context, args claimForSessionArgs) (models.SessionThread, error) {
 	maxRunning := args.maxRunning
 	if maxRunning <= 0 {
@@ -360,7 +399,7 @@ func (s *SessionThreadStore) claimForSession(ctx context.Context, args claimForS
 		)
 		UPDATE session_threads
 		SET status = 'running',
-		    ` + args.extraSetClauses + `
+		    ` + claimModeSetClause(args.mode) + `
 		    last_activity_at = now(),
 		    cancel_requested_at = NULL
 		WHERE id = @id

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -364,7 +364,7 @@ func TestSessionThreadStore_ClaimIdleForSessionClearsCancelRequestedAt(t *testin
 	now := time.Now()
 
 	mock.ExpectQuery("UPDATE session_threads[\\s\\S]*SET status = 'running',[\\s\\S]*cancel_requested_at = NULL").
-		WithArgs(anyArgs(4)...).
+		WithArgs(anyArgs(5)...).
 		WillReturnRows(
 			pgxmock.NewRows(sessionThreadTestColumns).
 				AddRow(newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)...),
@@ -448,9 +448,10 @@ func TestSessionThreadStore_ClaimIdleForSessionRejectsAtLimit(t *testing.T) {
 
 	// First query: the CTE-based UPDATE finds no eligible row because the
 	// session already has MaxRunningThreadsPerSession siblings active. Returns
-	// no rows.
+	// no rows. Carries 5 named args: id, org_id, session_id, max_running,
+	// claimable_statuses.
 	mock.ExpectQuery("UPDATE session_threads").
-		WithArgs(anyArgs(4)...).
+		WithArgs(anyArgs(5)...).
 		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns))
 
 	// Second query: isAtRunningLimit re-inspects state outside the FOR UPDATE
@@ -486,17 +487,88 @@ func TestSessionThreadStore_ClaimIdleForSessionLocksSiblings(t *testing.T) {
 	row[17] = &now
 
 	// Pin the guard explicitly: the CTE locks every session_threads row,
-	// requires target.status = 'idle', counts active siblings, and admits
-	// only when the cap is not yet reached. A regression that drops the
-	// idle check or reverses the cap inequality must not pass.
-	mock.ExpectQuery(`(?s)WITH locked_threads AS.*FOR UPDATE.*target_idle.*status\s*=\s*'idle'.*running_count.*id\s*<>\s*@id.*'pending',\s*'running',\s*'awaiting_input'.*eligible.*running_count\.n\s*<\s*@max_running.*UPDATE session_threads\s+SET status = 'running'.*EXISTS\s*\(\s*SELECT 1 FROM eligible\s*\).*RETURNING`).
-		WithArgs(anyArgs(4)...).
+	// requires target.status to match the claimable-statuses list, counts
+	// active siblings, and admits only when the cap is not yet reached. A
+	// regression that drops the status check or reverses the cap inequality
+	// must not pass.
+	mock.ExpectQuery(`(?s)WITH locked_threads AS.*FOR UPDATE.*target_claimable.*status\s*=\s*ANY\(@claimable_statuses\).*running_count.*id\s*<>\s*@id.*'pending',\s*'running',\s*'awaiting_input'.*eligible.*running_count\.n\s*<\s*@max_running.*UPDATE session_threads\s+SET status = 'running'.*EXISTS\s*\(\s*SELECT 1 FROM eligible\s*\).*RETURNING`).
+		WithArgs(anyArgs(5)...).
 		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns).AddRow(row...))
 
 	thread, err := store.ClaimIdleForSession(context.Background(), orgID, sessionID, threadID, models.MaxRunningThreadsPerSession)
 	require.NoError(t, err, "ClaimIdleForSession should claim an eligible idle thread")
 	require.Equal(t, threadID, thread.ID, "ClaimIdleForSession should return the claimed thread")
 	require.Equal(t, models.ThreadStatusRunning, thread.Status, "ClaimIdleForSession should return the running status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionThreadStore_ClaimForResumeInSession(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionThreadStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	now := time.Now()
+	row := newSessionThreadRow(threadID, sessionID, orgID, "Backend", now)
+	row[8] = models.ThreadStatusRunning
+	row[11] = &now
+	row[17] = &now
+
+	// Pin the resume claim's distinguishing properties: it should clear
+	// completed_at (so the row reflects the new in-flight turn rather than
+	// the previous terminal state), preserve started_at (the original
+	// thread start time stays meaningful), and only fire when status is in
+	// the resumable set. The 5 named args mirror ClaimIdleForSession;
+	// claimable_statuses carries models.ResumableThreadStatuses.
+	mock.ExpectQuery(`(?s)WITH locked_threads AS.*FOR UPDATE.*target_claimable.*status\s*=\s*ANY\(@claimable_statuses\).*UPDATE session_threads\s+SET status = 'running',\s+completed_at = NULL,\s+last_activity_at = now\(\),\s+cancel_requested_at = NULL.*EXISTS\s*\(\s*SELECT 1 FROM eligible\s*\).*RETURNING`).
+		WithArgs(anyArgs(5)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns).AddRow(row...))
+
+	thread, err := store.ClaimForResumeInSession(context.Background(), orgID, sessionID, threadID, models.MaxRunningThreadsPerSession)
+	require.NoError(t, err, "ClaimForResumeInSession should resume a thread in a resumable terminal status")
+	require.Equal(t, threadID, thread.ID, "ClaimForResumeInSession should return the resumed thread")
+	require.Equal(t, models.ThreadStatusRunning, thread.Status, "ClaimForResumeInSession should leave the thread in running status")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionThreadStore_ClaimForResumeInSessionRejectsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionThreadStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+
+	// First query: the resume CTE finds no eligible row because the
+	// per-session running cap is full.
+	mock.ExpectQuery("UPDATE session_threads").
+		WithArgs(anyArgs(5)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns))
+
+	// Second query: isAtRunningLimit re-inspects without the FOR UPDATE
+	// lock. Target is in a resumable status (completed) and sibling_active
+	// equals max_running, so the store maps the empty result to
+	// ErrThreadRunningLimitReached — same sentinel ClaimIdleForSession
+	// surfaces, so the service can collapse both into a single "queue
+	// against still-unclaimed thread" branch.
+	mock.ExpectQuery(`SELECT\s+COALESCE`).
+		WithArgs(anyArgs(3)...).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"target_status", "sibling_active"}).
+				AddRow(string(models.ThreadStatusCompleted), models.MaxRunningThreadsPerSession),
+		)
+
+	_, err = store.ClaimForResumeInSession(context.Background(), orgID, sessionID, threadID, models.MaxRunningThreadsPerSession)
+	require.ErrorIs(t, err, ErrThreadRunningLimitReached, "ClaimForResumeInSession should surface the running-limit sentinel when at cap")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/models/session_enums.go
+++ b/internal/models/session_enums.go
@@ -43,6 +43,19 @@ var (
 	ActiveStatuses = []SessionStatus{SessionStatusPending, SessionStatusRunning, SessionStatusIdle, SessionStatusAwaitingInput, SessionStatusNeedsHumanGuidance}
 	// DoneStatuses are terminal statuses.
 	DoneStatuses = []SessionStatus{SessionStatusCompleted, SessionStatusPRCreated, SessionStatusFailed, SessionStatusCancelled, SessionStatusSkipped}
+
+	// ResumableSessionStatuses are the non-idle statuses from which a session
+	// can be re-claimed via SessionStore.ClaimForResume to continue a follow-up
+	// message. Mirrors the SQL status list inline in ClaimForResume; both must
+	// stay in sync.
+	ResumableSessionStatuses = []SessionStatus{
+		SessionStatusCompleted,
+		SessionStatusPRCreated,
+		SessionStatusFailed,
+		SessionStatusCancelled,
+		SessionStatusAwaitingInput,
+		SessionStatusNeedsHumanGuidance,
+	}
 )
 
 // SessionOrigin captures how a session was created. This is provenance only;
@@ -304,6 +317,19 @@ func (s ThreadStatus) Validate() error {
 	default:
 		return fmt.Errorf("invalid ThreadStatus: %q", s)
 	}
+}
+
+// ResumableThreadStatuses are the non-idle thread statuses from which a thread
+// can be re-claimed to continue a follow-up message. Intentionally narrower
+// than ResumableSessionStatuses: threads do not have pr_created or
+// needs_human_guidance counterparts. Kept here so the thread store and service
+// share one source of truth, mirroring how ResumableSessionStatuses is wired
+// into the session path.
+var ResumableThreadStatuses = []ThreadStatus{
+	ThreadStatusCompleted,
+	ThreadStatusFailed,
+	ThreadStatusCancelled,
+	ThreadStatusAwaitingInput,
 }
 
 // MaxThreadsPerSession is the maximum number of threads allowed in a single session.

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -1048,8 +1048,11 @@ func TestPRServiceCreateRepairRevisionSessionAndResumeRepairSession(t *testing.T
 				mock.ExpectQuery("UPDATE sessions").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(pgx.ErrNoRows)
+				// ClaimForResume now binds the resumable-status set as a
+				// runtime parameter, so the query carries an extra @statuses
+				// arg compared to the legacy hardcoded IN (...) shape.
 				mock.ExpectQuery("UPDATE sessions").
-					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).AddRow(newPRHealthSessionRow(parentSession.ID, pr.OrgID, now, string(models.SessionStatusRunning))...))
 				mock.ExpectExec("UPDATE sessions.+SET revision_context").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -383,7 +383,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		return nil, err
 	}
 	if outcome == threadClaimQueueLimitReached {
-		return s.queueMessageOnIdleThread(ctx, input)
+		return s.queueMessageWaitingForSlot(ctx, input)
 	}
 	queueOnly := outcome == threadClaimQueueMidTurn
 
@@ -525,7 +525,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	}, nil
 }
 
-// queueMessageOnIdleThread queues a follow-up against a thread that could
+// queueMessageWaitingForSlot queues a follow-up against a thread that could
 // not get a running slot because the session-wide running-thread cap is
 // already saturated. Accepts both idle threads and threads in a resumable
 // terminal/paused status — both behave identically from the queue's
@@ -534,7 +534,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 // no continue_session is enqueued because no slot is available — the next
 // sibling to finish will pick the work up via the orchestrator's drain,
 // which will idle-claim or resume-claim the thread as appropriate.
-func (s *Service) queueMessageOnIdleThread(ctx context.Context, input SendMessageInput) (*SendMessageResult, error) {
+func (s *Service) queueMessageWaitingForSlot(ctx context.Context, input SendMessageInput) (*SendMessageResult, error) {
 	thread, err := s.threadStore.GetByID(ctx, input.OrgID, input.ThreadID)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrThreadNotFound, err)

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -78,6 +78,7 @@ type ThreadStore interface {
 	GetByID(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
 	ListBySession(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
 	ClaimIdleForSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error)
+	ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error)
 	UpdateStatus(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
 	IncrementPendingMessages(ctx context.Context, orgID, threadID uuid.UUID) error
 	MarkCancelRequested(ctx context.Context, orgID, threadID uuid.UUID) error
@@ -326,23 +327,43 @@ func (s *Service) GetThread(ctx context.Context, orgID, sessionID, threadID uuid
 	return thread, nil
 }
 
-// SendMessage claims an idle thread, creates a message, and enqueues a
-// continue_session job. When ResolveReviewCommentIDs is non-empty, the
-// message create and the comment resolution share a single transaction so
-// the user-visible invariant — "submitted comments disappear once the
-// follow-up message is sent" — holds even if the request fails partway
-// through.
+// threadClaimOutcome enumerates the four possible results of
+// claimThreadForSend so the caller's branching is explicit. The "claimed"
+// outcomes are split from the "queue" outcomes because the post-claim flow
+// (session claim, message create, enqueue) only applies when the thread row
+// has actually moved to running.
+type threadClaimOutcome int
+
+const (
+	// threadClaimClaimed: thread row transitioned from idle (or a resumable
+	// terminal status) to running and is ready to receive a new turn.
+	threadClaimClaimed threadClaimOutcome = iota
+	// threadClaimQueueMidTurn: thread is mid-turn (pending/running); the
+	// orchestrator drains the message queue when the in-flight turn ends.
+	threadClaimQueueMidTurn
+	// threadClaimQueueLimitReached: thread is otherwise claimable but the
+	// session has already hit MaxRunningThreadsPerSession. Caller queues the
+	// message against the still-idle thread; the next sibling to finish will
+	// pick the work up via the orchestrator's drain.
+	threadClaimQueueLimitReached
+)
+
+// SendMessage claims an idle thread (or resumes a paused/terminal one),
+// creates a message, and enqueues a continue_session job. When
+// ResolveReviewCommentIDs is non-empty, the message create and the comment
+// resolution share a single transaction so the user-visible invariant —
+// "submitted comments disappear once the follow-up message is sent" — holds
+// even if the request fails partway through.
 //
-// ClaimIdleForSession serializes sibling-thread admission in the database
-// while allowing up to MaxRunningThreadsPerSession concurrent tabs. The
-// session-level claim mirrors the legacy session-message handler in
-// internal/api/handlers/sessions.go: try ClaimIdle first, fall back to
-// ClaimForResume for terminal/paused statuses (completed, pr_created,
-// failed, cancelled, awaiting_input, needs_human_guidance), and only return
-// ErrSessionNotResumable when neither succeeds. When another tab has already
-// moved the session into running state, ClaimIdle's failure is treated as a
-// no-op since the orchestrator's idempotent UpdateStatus("running") handles
-// the rest.
+// claimThreadForSend serializes sibling-thread admission in the database
+// while allowing up to MaxRunningThreadsPerSession concurrent tabs. It
+// mirrors the session-level claimSessionForSend ordering: try the idle
+// claim first, fall back to the resume claim for terminal/paused statuses
+// (completed, failed, cancelled, awaiting_input), and only fail with
+// ErrThreadNotIdle when neither succeeds. When another tab has already moved
+// the session into running state, ClaimIdle's failure is treated as a no-op
+// at the session layer since the orchestrator's idempotent
+// UpdateStatus("running") handles the rest.
 //
 // On any downstream failure (message create, comment resolve, question
 // answer, enqueue) we best-effort revert the thread to idle and the session
@@ -357,46 +378,14 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		return nil, ErrReviewCommentsNotConfigured
 	}
 
-	thread, err := s.threadStore.ClaimIdleForSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
-	queueOnly := false
+	thread, outcome, err := s.claimThreadForSend(ctx, input, resolvingComments)
 	if err != nil {
-		if errors.Is(err, db.ErrThreadRunningLimitReached) {
-			return s.queueMessageOnIdleThread(ctx, input)
-		}
-		// Check if thread exists at all to provide a better error.
-		existing, lookupErr := s.threadStore.GetByID(ctx, input.OrgID, input.ThreadID)
-		if lookupErr != nil {
-			return nil, fmt.Errorf("%w: %w", ErrThreadNotFound, lookupErr)
-		}
-		if existing.SessionID != input.SessionID {
-			return nil, ErrThreadNotFound
-		}
-		// The thread itself is busy with its own turn. Queue the message
-		// against the busy thread; the orchestrator drains pending messages
-		// when the in-flight turn completes (see ContinueSession). Resolving
-		// review comments while the thread is mid-turn is not supported —
-		// the resolution pass is keyed on the in-flight turn's pass number,
-		// and we cannot atomically commit it alongside a queued message
-		// that will not be consumed until a later turn.
-		if resolvingComments {
-			return nil, ErrThreadNotIdle
-		}
-		if !threadStatusCanQueue(existing.Status) {
-			return nil, ErrThreadNotIdle
-		}
-		thread = existing
-		queueOnly = true
+		return nil, err
 	}
-
-	// Verify thread belongs to the session.
-	if thread.SessionID != input.SessionID {
-		if !queueOnly {
-			if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-				s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after session mismatch")
-			}
-		}
-		return nil, ErrThreadNotFound
+	if outcome == threadClaimQueueLimitReached {
+		return s.queueMessageOnIdleThread(ctx, input)
 	}
+	queueOnly := outcome == threadClaimQueueMidTurn
 
 	// Try claiming an idle session first, then fall back to resuming a
 	// terminal/paused session — same order as sessions.SendMessage. revertStatus
@@ -411,16 +400,12 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		var claimErr error
 		claimedSession, revertStatus, claimErr = s.claimSessionForSend(ctx, input.OrgID, input.SessionID)
 		if claimErr != nil {
-			if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-				s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to revert thread to idle after parent session claim failure")
-			}
+			s.releaseThread(ctx, input.OrgID, input.ThreadID, "parent session claim failure")
 			return nil, claimErr
 		}
 		if revertStatus == "" {
 			if resolvingComments {
-				if revertErr := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); revertErr != nil {
-					s.logger.Error().Err(revertErr).Str("thread_id", input.ThreadID.String()).Msg("failed to release sibling-queued thread after unsupported comment resolution")
-				}
+				s.releaseThread(ctx, input.OrgID, input.ThreadID, "sibling-queued thread cannot resolve comments")
 				return nil, ErrThreadNotIdle
 			}
 			return s.queueClaimedThreadBehindSibling(ctx, input, thread)
@@ -540,12 +525,15 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	}, nil
 }
 
-// queueMessageOnIdleThread queues a follow-up against an idle thread that
-// could not get a running slot because the session-wide running-thread cap is
-// already saturated. The message is appended to the thread's pending queue
-// and pending_message_count is bumped so the composer can show "queued (N)";
+// queueMessageOnIdleThread queues a follow-up against a thread that could
+// not get a running slot because the session-wide running-thread cap is
+// already saturated. Accepts both idle threads and threads in a resumable
+// terminal/paused status — both behave identically from the queue's
+// perspective: the message is appended to the thread's pending queue and
+// pending_message_count is bumped so the composer can show "queued (N)";
 // no continue_session is enqueued because no slot is available — the next
-// sibling to finish will pick the work up via the orchestrator's drain.
+// sibling to finish will pick the work up via the orchestrator's drain,
+// which will idle-claim or resume-claim the thread as appropriate.
 func (s *Service) queueMessageOnIdleThread(ctx context.Context, input SendMessageInput) (*SendMessageResult, error) {
 	thread, err := s.threadStore.GetByID(ctx, input.OrgID, input.ThreadID)
 	if err != nil {
@@ -554,7 +542,7 @@ func (s *Service) queueMessageOnIdleThread(ctx context.Context, input SendMessag
 	if thread.SessionID != input.SessionID {
 		return nil, ErrThreadNotFound
 	}
-	if thread.Status != models.ThreadStatusIdle {
+	if thread.Status != models.ThreadStatusIdle && !threadStatusIsResumable(thread.Status) {
 		return nil, ErrThreadNotIdle
 	}
 
@@ -626,6 +614,104 @@ func threadStatusCanQueue(status models.ThreadStatus) bool {
 	default:
 		return false
 	}
+}
+
+// claimThreadForSend is the thread-layer counterpart to claimSessionForSend:
+// try ClaimIdleForSession first, fall back to ClaimForResumeInSession when
+// the thread is in a resumable terminal/paused status, and otherwise route
+// the message to the appropriate queue path.
+//
+// The four return paths (claimed-from-idle, claimed-from-resume,
+// queue-mid-turn, queue-limit-reached, error) are collapsed into a
+// (thread, outcome, err) triple so SendMessage can branch with a single
+// switch instead of three nested error checks. resolvingComments is passed
+// through because the queue-mid-turn path cannot honor comment resolution —
+// the resolution pass is keyed on the in-flight turn's pass number, and we
+// cannot atomically commit it alongside a queued message that will not be
+// consumed until a later turn. Resume claims do not have this problem
+// because the resumed turn IS the in-flight one.
+func (s *Service) claimThreadForSend(ctx context.Context, input SendMessageInput, resolvingComments bool) (models.SessionThread, threadClaimOutcome, error) {
+	// 1. Try the idle claim first — happy path for a thread that has been
+	//    sitting idle waiting for the next user message.
+	thread, err := s.threadStore.ClaimIdleForSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
+	if err == nil {
+		if thread.SessionID != input.SessionID {
+			s.releaseThread(ctx, input.OrgID, input.ThreadID, "session mismatch after idle claim")
+			return models.SessionThread{}, 0, ErrThreadNotFound
+		}
+		return thread, threadClaimClaimed, nil
+	}
+	if errors.Is(err, db.ErrThreadRunningLimitReached) {
+		return models.SessionThread{}, threadClaimQueueLimitReached, nil
+	}
+
+	// 2. Idle claim failed for status reasons. Inspect the thread to decide
+	//    between queueing mid-turn, resuming a paused/terminal status, or
+	//    rejecting the send outright. A non-ErrNoRows error here is a real
+	//    DB failure and is surfaced as-is.
+	existing, lookupErr := s.threadStore.GetByID(ctx, input.OrgID, input.ThreadID)
+	if lookupErr != nil {
+		return models.SessionThread{}, 0, fmt.Errorf("%w: %w", ErrThreadNotFound, lookupErr)
+	}
+	if existing.SessionID != input.SessionID {
+		return models.SessionThread{}, 0, ErrThreadNotFound
+	}
+
+	// 3. Thread is mid-turn (pending/running): queue the message against the
+	//    in-flight turn. Comment resolution is not supported on this path.
+	if threadStatusCanQueue(existing.Status) {
+		if resolvingComments {
+			return models.SessionThread{}, 0, ErrThreadNotIdle
+		}
+		return existing, threadClaimQueueMidTurn, nil
+	}
+
+	// 4. Thread is in a resumable terminal/paused status: try to bring it
+	//    back to running, mirroring SessionStore.ClaimForResume.
+	if threadStatusIsResumable(existing.Status) {
+		resumed, resumeErr := s.threadStore.ClaimForResumeInSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
+		if resumeErr == nil {
+			return resumed, threadClaimClaimed, nil
+		}
+		if errors.Is(resumeErr, db.ErrThreadRunningLimitReached) {
+			return models.SessionThread{}, threadClaimQueueLimitReached, nil
+		}
+		// pgx.ErrNoRows here means the status changed under us between the
+		// inspect and the resume claim (e.g. a sibling claim raced us). Map
+		// to ErrThreadNotIdle so the user sees a consistent affordance and
+		// can retry.
+		if errors.Is(resumeErr, pgx.ErrNoRows) {
+			return models.SessionThread{}, 0, ErrThreadNotIdle
+		}
+		return models.SessionThread{}, 0, fmt.Errorf("claim thread for resume: %w", resumeErr)
+	}
+
+	// 5. Anything else (unexpected status) is treated as not-idle.
+	return models.SessionThread{}, 0, ErrThreadNotIdle
+}
+
+// releaseThread is a small wrapper around UpdateStatus(idle) so failure
+// branches that need to undo a claim can do so without duplicating the
+// error-logging boilerplate. Failures here are always best-effort — the
+// caller already has a primary error to surface.
+func (s *Service) releaseThread(ctx context.Context, orgID, threadID uuid.UUID, reason string) {
+	if revertErr := s.threadStore.UpdateStatus(ctx, orgID, threadID, models.ThreadStatusIdle); revertErr != nil {
+		s.logger.Error().Err(revertErr).
+			Str("thread_id", threadID.String()).
+			Str("reason", reason).
+			Msg("failed to revert thread to idle")
+	}
+}
+
+// threadStatusIsResumable mirrors models.ResumableThreadStatuses without
+// allocating per-call: hot path of SendMessage on a non-idle thread.
+func threadStatusIsResumable(status models.ThreadStatus) bool {
+	for _, resumable := range models.ResumableThreadStatuses {
+		if status == resumable {
+			return true
+		}
+	}
+	return false
 }
 
 // claimSessionForSend mirrors the ClaimIdle → ClaimForResume → fail ordering

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -378,7 +378,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 		return nil, ErrReviewCommentsNotConfigured
 	}
 
-	thread, outcome, err := s.claimThreadForSend(ctx, input, resolvingComments)
+	thread, preClaimThreadStatus, outcome, err := s.claimThreadForSend(ctx, input, resolvingComments)
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 				s.releaseThread(ctx, input.OrgID, input.ThreadID, "sibling-queued thread cannot resolve comments")
 				return nil, ErrThreadNotIdle
 			}
-			return s.queueClaimedThreadBehindSibling(ctx, input, thread)
+			return s.queueClaimedThreadBehindSibling(ctx, input, thread, preClaimThreadStatus)
 		}
 	}
 
@@ -565,16 +565,17 @@ func (s *Service) queueMessageWaitingForSlot(ctx context.Context, input SendMess
 		msg.Attachments = input.Images
 	}
 
-	if err := s.messageStore.Create(ctx, msg); err != nil {
+	answeredQuestion, err := s.createQueuedMessage(ctx, msg, input, thread.Status)
+	if err != nil {
 		return nil, fmt.Errorf("create queued message: %w", err)
 	}
 	if err := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
 		return nil, fmt.Errorf("increment queued message count: %w", err)
 	}
-	return &SendMessageResult{Message: msg}, nil
+	return &SendMessageResult{Message: msg, AnsweredQuestion: answeredQuestion}, nil
 }
 
-func (s *Service) queueClaimedThreadBehindSibling(ctx context.Context, input SendMessageInput, thread models.SessionThread) (*SendMessageResult, error) {
+func (s *Service) queueClaimedThreadBehindSibling(ctx context.Context, input SendMessageInput, thread models.SessionThread, preClaimStatus models.ThreadStatus) (*SendMessageResult, error) {
 	if err := s.threadStore.UpdateStatus(ctx, input.OrgID, input.ThreadID, models.ThreadStatusIdle); err != nil {
 		return nil, fmt.Errorf("release thread for queued sibling message: %w", err)
 	}
@@ -598,13 +599,22 @@ func (s *Service) queueClaimedThreadBehindSibling(ctx context.Context, input Sen
 		msg.Attachments = input.Images
 	}
 
-	if err := s.messageStore.Create(ctx, msg); err != nil {
+	answeredQuestion, err := s.createQueuedMessage(ctx, msg, input, preClaimStatus)
+	if err != nil {
 		return nil, fmt.Errorf("create queued sibling message: %w", err)
 	}
 	if err := s.threadStore.IncrementPendingMessages(ctx, input.OrgID, input.ThreadID); err != nil {
 		return nil, fmt.Errorf("increment queued sibling message count: %w", err)
 	}
-	return &SendMessageResult{Message: msg}, nil
+	return &SendMessageResult{Message: msg, AnsweredQuestion: answeredQuestion}, nil
+}
+
+func (s *Service) createQueuedMessage(ctx context.Context, msg *models.SessionMessage, input SendMessageInput, threadStatus models.ThreadStatus) (*models.SessionQuestion, error) {
+	if threadStatus != models.ThreadStatusAwaitingInput || input.UserID == nil || s.questionStore == nil {
+		return nil, s.messageStore.Create(ctx, msg)
+	}
+	_, answeredQuestion, err := s.createMessageInTx(ctx, msg, input, models.Session{}, true)
+	return answeredQuestion, err
 }
 
 func threadStatusCanQueue(status models.ThreadStatus) bool {
@@ -623,26 +633,27 @@ func threadStatusCanQueue(status models.ThreadStatus) bool {
 //
 // The four return paths (claimed-from-idle, claimed-from-resume,
 // queue-mid-turn, queue-limit-reached, error) are collapsed into a
-// (thread, outcome, err) triple so SendMessage can branch with a single
-// switch instead of three nested error checks. resolvingComments is passed
-// through because the queue-mid-turn path cannot honor comment resolution —
-// the resolution pass is keyed on the in-flight turn's pass number, and we
-// cannot atomically commit it alongside a queued message that will not be
-// consumed until a later turn. Resume claims do not have this problem
-// because the resumed turn IS the in-flight one.
-func (s *Service) claimThreadForSend(ctx context.Context, input SendMessageInput, resolvingComments bool) (models.SessionThread, threadClaimOutcome, error) {
+// return tuple also carries the pre-claim thread status so queued answer
+// paths can distinguish a thread resumed from awaiting_input from a generic
+// running thread. resolvingComments is passed through because the
+// queue-mid-turn path cannot honor comment resolution — the resolution pass
+// is keyed on the in-flight turn's pass number, and we cannot atomically
+// commit it alongside a queued message that will not be consumed until a
+// later turn. Resume claims do not have this problem because the resumed
+// turn IS the in-flight one.
+func (s *Service) claimThreadForSend(ctx context.Context, input SendMessageInput, resolvingComments bool) (models.SessionThread, models.ThreadStatus, threadClaimOutcome, error) {
 	// 1. Try the idle claim first — happy path for a thread that has been
 	//    sitting idle waiting for the next user message.
 	thread, err := s.threadStore.ClaimIdleForSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
 	if err == nil {
 		if thread.SessionID != input.SessionID {
 			s.releaseThread(ctx, input.OrgID, input.ThreadID, "session mismatch after idle claim")
-			return models.SessionThread{}, 0, ErrThreadNotFound
+			return models.SessionThread{}, "", 0, ErrThreadNotFound
 		}
-		return thread, threadClaimClaimed, nil
+		return thread, models.ThreadStatusIdle, threadClaimClaimed, nil
 	}
 	if errors.Is(err, db.ErrThreadRunningLimitReached) {
-		return models.SessionThread{}, threadClaimQueueLimitReached, nil
+		return models.SessionThread{}, "", threadClaimQueueLimitReached, nil
 	}
 
 	// 2. Idle claim failed for status reasons. Inspect the thread to decide
@@ -651,19 +662,19 @@ func (s *Service) claimThreadForSend(ctx context.Context, input SendMessageInput
 	//    DB failure and is surfaced as-is.
 	existing, lookupErr := s.threadStore.GetByID(ctx, input.OrgID, input.ThreadID)
 	if lookupErr != nil {
-		return models.SessionThread{}, 0, fmt.Errorf("%w: %w", ErrThreadNotFound, lookupErr)
+		return models.SessionThread{}, "", 0, fmt.Errorf("%w: %w", ErrThreadNotFound, lookupErr)
 	}
 	if existing.SessionID != input.SessionID {
-		return models.SessionThread{}, 0, ErrThreadNotFound
+		return models.SessionThread{}, "", 0, ErrThreadNotFound
 	}
 
 	// 3. Thread is mid-turn (pending/running): queue the message against the
 	//    in-flight turn. Comment resolution is not supported on this path.
 	if threadStatusCanQueue(existing.Status) {
 		if resolvingComments {
-			return models.SessionThread{}, 0, ErrThreadNotIdle
+			return models.SessionThread{}, "", 0, ErrThreadNotIdle
 		}
-		return existing, threadClaimQueueMidTurn, nil
+		return existing, existing.Status, threadClaimQueueMidTurn, nil
 	}
 
 	// 4. Thread is in a resumable terminal/paused status: try to bring it
@@ -671,23 +682,23 @@ func (s *Service) claimThreadForSend(ctx context.Context, input SendMessageInput
 	if threadStatusIsResumable(existing.Status) {
 		resumed, resumeErr := s.threadStore.ClaimForResumeInSession(ctx, input.OrgID, input.SessionID, input.ThreadID, models.MaxRunningThreadsPerSession)
 		if resumeErr == nil {
-			return resumed, threadClaimClaimed, nil
+			return resumed, existing.Status, threadClaimClaimed, nil
 		}
 		if errors.Is(resumeErr, db.ErrThreadRunningLimitReached) {
-			return models.SessionThread{}, threadClaimQueueLimitReached, nil
+			return models.SessionThread{}, "", threadClaimQueueLimitReached, nil
 		}
 		// pgx.ErrNoRows here means the status changed under us between the
 		// inspect and the resume claim (e.g. a sibling claim raced us). Map
 		// to ErrThreadNotIdle so the user sees a consistent affordance and
 		// can retry.
 		if errors.Is(resumeErr, pgx.ErrNoRows) {
-			return models.SessionThread{}, 0, ErrThreadNotIdle
+			return models.SessionThread{}, "", 0, ErrThreadNotIdle
 		}
-		return models.SessionThread{}, 0, fmt.Errorf("claim thread for resume: %w", resumeErr)
+		return models.SessionThread{}, "", 0, fmt.Errorf("claim thread for resume: %w", resumeErr)
 	}
 
 	// 5. Anything else (unexpected status) is treated as not-idle.
-	return models.SessionThread{}, 0, ErrThreadNotIdle
+	return models.SessionThread{}, "", 0, ErrThreadNotIdle
 }
 
 // releaseThread is a small wrapper around UpdateStatus(idle) so failure

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -701,46 +701,7 @@ func TestService_SendMessage(t *testing.T) {
 			expectErr: ErrReviewCommentsNotConfigured,
 		},
 		{
-			name: "completed thread resumes via ClaimForResumeInSession",
-			input: SendMessageInput{
-				SessionID: sessionID,
-				OrgID:     orgID,
-				ThreadID:  threadID,
-				Message:   "follow up after completion",
-			},
-			setupDeps: func(deps *testDeps) {
-				// Idle claim fails because the thread is sitting in a
-				// terminal state, not idle. The service then inspects the
-				// thread and falls back to ClaimForResumeInSession — same
-				// pattern as the session-level ClaimIdle → ClaimForResume
-				// fallback in claimSessionForSend.
-				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
-					return models.SessionThread{}, fmt.Errorf("no rows")
-				}
-				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
-					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusCompleted}, nil
-				}
-				resumeCalled := false
-				deps.threadStore.claimForResumeFn = func(_ context.Context, _, sid, tid uuid.UUID) (models.SessionThread, error) {
-					resumeCalled = true
-					require.Equal(t, sessionID, sid, "should resume against the requested session")
-					require.Equal(t, threadID, tid, "should resume the requested thread")
-					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusRunning}, nil
-				}
-				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
-					require.True(t, resumeCalled, "message create should run after the resume claim succeeded")
-					msg.ID = 99
-					require.Equal(t, 4, msg.TurnNumber, "resumed thread should advance to the next turn after CurrentTurn")
-					return nil
-				}
-				deps.threadStore.incrementPendingFn = func(_ context.Context, _, _ uuid.UUID) error {
-					t.Fatalf("resumed threads should run a new turn, not queue a pending message")
-					return nil
-				}
-			},
-		},
-		{
-			name: "completed thread resume hitting cap queues against still-idle thread",
+			name: "resume cap-saturated thread queues the message instead of rejecting",
 			input: SendMessageInput{
 				SessionID: sessionID,
 				OrgID:     orgID,
@@ -751,7 +712,9 @@ func TestService_SendMessage(t *testing.T) {
 				// Resume path hits the same per-session running cap as the
 				// idle claim path. The service should treat this identically
 				// to the idle-cap case: queue the message against the still-
-				// unclaimed thread instead of failing.
+				// unclaimed thread instead of failing. Per-status coverage of
+				// the resume happy path lives in
+				// TestService_SendMessage_ResumesAcrossAllResumableStatuses.
 				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{}, fmt.Errorf("no rows")
 				}
@@ -1132,6 +1095,66 @@ func TestService_SendMessage(t *testing.T) {
 			if tt.name == "running limit reached queues the message instead of rejecting it" {
 				require.Equal(t, []uuid.UUID{threadID}, deps.threadStore.pendingCalls, "queued send should increment the pending message count for that thread")
 			}
+		})
+	}
+}
+
+// TestService_SendMessage_ResumesAcrossAllResumableStatuses pins the
+// invariant that the resumable-status set is the source of truth for
+// "thread accepts a follow-up message via ClaimForResumeInSession". A
+// future change that narrows ResumableThreadStatuses (or adds a status to
+// it without wiring the resume path) must not pass silently — this test
+// exercises every status the model declares resumable and verifies the
+// resume claim fires for each.
+func TestService_SendMessage_ResumesAcrossAllResumableStatuses(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+
+	// Drive the test off models.ResumableThreadStatuses directly so the
+	// guard fails the moment that constant changes shape.
+	for _, status := range models.ResumableThreadStatuses {
+		status := status
+		t.Run(string(status), func(t *testing.T) {
+			t.Parallel()
+
+			svc, deps := newTestService(t)
+			deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+				return models.SessionThread{}, fmt.Errorf("no rows")
+			}
+			deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+				return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 5, Status: status}, nil
+			}
+			resumeCalled := false
+			deps.threadStore.claimForResumeFn = func(_ context.Context, _, sid, tid uuid.UUID) (models.SessionThread, error) {
+				resumeCalled = true
+				require.Equal(t, sessionID, sid, "should resume against the requested session")
+				require.Equal(t, threadID, tid, "should resume the requested thread")
+				return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 5, Status: models.ThreadStatusRunning}, nil
+			}
+			deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+				require.True(t, resumeCalled, "message create should run after the resume claim succeeded")
+				msg.ID = 1
+				require.Equal(t, 6, msg.TurnNumber, "resumed thread should advance to the next turn after CurrentTurn")
+				return nil
+			}
+			deps.threadStore.incrementPendingFn = func(_ context.Context, _, _ uuid.UUID) error {
+				t.Fatalf("resumed threads should run a new turn, not queue a pending message")
+				return nil
+			}
+
+			result, err := svc.SendMessage(context.Background(), SendMessageInput{
+				SessionID: sessionID,
+				OrgID:     orgID,
+				ThreadID:  threadID,
+				Message:   "follow up",
+			})
+			require.NoError(t, err, "resume path should accept a follow-up for status %q", status)
+			require.NotNil(t, result, "resume path should return a result for status %q", status)
+			require.NotNil(t, result.Message, "resume path should return a message for status %q", status)
+			require.True(t, resumeCalled, "resume claim must fire for status %q", status)
 		})
 	}
 }

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -22,6 +22,7 @@ type mockThreadStore struct {
 	getByIDFn          func(ctx context.Context, orgID, threadID uuid.UUID) (models.SessionThread, error)
 	listBySessionFn    func(ctx context.Context, orgID, sessionID uuid.UUID) ([]models.SessionThread, error)
 	claimIdleFn        func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
+	claimForResumeFn   func(ctx context.Context, orgID, sessionID, threadID uuid.UUID) (models.SessionThread, error)
 	updateStatusFn     func(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error
 	incrementPendingFn func(ctx context.Context, orgID, threadID uuid.UUID) error
 	pendingCalls       []uuid.UUID
@@ -53,6 +54,13 @@ func (m *mockThreadStore) ClaimIdleForSession(ctx context.Context, orgID, sessio
 		return m.claimIdleFn(ctx, orgID, sessionID, threadID)
 	}
 	return models.SessionThread{}, fmt.Errorf("not idle")
+}
+
+func (m *mockThreadStore) ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, _ int) (models.SessionThread, error) {
+	if m.claimForResumeFn != nil {
+		return m.claimForResumeFn(ctx, orgID, sessionID, threadID)
+	}
+	return models.SessionThread{}, fmt.Errorf("not resumable")
 }
 
 func (m *mockThreadStore) UpdateStatus(ctx context.Context, orgID, threadID uuid.UUID, status models.ThreadStatus) error {
@@ -693,30 +701,75 @@ func TestService_SendMessage(t *testing.T) {
 			expectErr: ErrReviewCommentsNotConfigured,
 		},
 		{
-			name: "completed thread rejected instead of queued",
+			name: "completed thread resumes via ClaimForResumeInSession",
 			input: SendMessageInput{
 				SessionID: sessionID,
 				OrgID:     orgID,
 				ThreadID:  threadID,
-				Message:   "queued",
+				Message:   "follow up after completion",
 			},
 			setupDeps: func(deps *testDeps) {
+				// Idle claim fails because the thread is sitting in a
+				// terminal state, not idle. The service then inspects the
+				// thread and falls back to ClaimForResumeInSession — same
+				// pattern as the session-level ClaimIdle → ClaimForResume
+				// fallback in claimSessionForSend.
 				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{}, fmt.Errorf("no rows")
 				}
 				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
 					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusCompleted}, nil
 				}
-				deps.messageStore.createFn = func(_ context.Context, _ *models.SessionMessage) error {
-					t.Fatalf("terminal threads must not create queued messages")
+				resumeCalled := false
+				deps.threadStore.claimForResumeFn = func(_ context.Context, _, sid, tid uuid.UUID) (models.SessionThread, error) {
+					resumeCalled = true
+					require.Equal(t, sessionID, sid, "should resume against the requested session")
+					require.Equal(t, threadID, tid, "should resume the requested thread")
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusRunning}, nil
+				}
+				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					require.True(t, resumeCalled, "message create should run after the resume claim succeeded")
+					msg.ID = 99
+					require.Equal(t, 4, msg.TurnNumber, "resumed thread should advance to the next turn after CurrentTurn")
 					return nil
 				}
 				deps.threadStore.incrementPendingFn = func(_ context.Context, _, _ uuid.UUID) error {
-					t.Fatalf("terminal threads must not bump pending_message_count")
+					t.Fatalf("resumed threads should run a new turn, not queue a pending message")
 					return nil
 				}
 			},
-			expectErr: ErrThreadNotIdle,
+		},
+		{
+			name: "completed thread resume hitting cap queues against still-idle thread",
+			input: SendMessageInput{
+				SessionID: sessionID,
+				OrgID:     orgID,
+				ThreadID:  threadID,
+				Message:   "follow up after completion",
+			},
+			setupDeps: func(deps *testDeps) {
+				// Resume path hits the same per-session running cap as the
+				// idle claim path. The service should treat this identically
+				// to the idle-cap case: queue the message against the still-
+				// unclaimed thread instead of failing.
+				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{}, fmt.Errorf("no rows")
+				}
+				deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 3, Status: models.ThreadStatusCompleted}, nil
+				}
+				deps.threadStore.claimForResumeFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{}, db.ErrThreadRunningLimitReached
+				}
+				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					msg.ID = 100
+					return nil
+				}
+				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+					require.Fail(t, "queued resume message should not enqueue a continue_session")
+					return uuid.Nil, nil
+				}
+			},
 		},
 		{
 			name: "running limit reached queues the message instead of rejecting it",

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -1336,6 +1336,145 @@ func TestService_SendMessage_ResolvesReviewComments(t *testing.T) {
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
+	t.Run("answers latest pending question when awaiting_input thread queues at running limit", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "should create pgx mock")
+		defer mock.Close()
+
+		userID := uuid.New()
+		questionID := uuid.New()
+		answerText := "ship it"
+		answeredAt := now
+
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(21), now))
+		mock.ExpectQuery("UPDATE session_questions").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows([]string{
+					"id", "session_id", "org_id", "question_text", "options", "context",
+					"blocks_phase", "answer_text", "answered_by", "answered_at", "status", "created_at",
+				}).AddRow(questionID, sessionID, orgID, "continue?", []string{"ship it", "stop"}, (*string)(nil),
+					(*string)(nil), &answerText, &userID, &answeredAt, "answered", now),
+			)
+		mock.ExpectCommit()
+
+		svc, deps := newTestService(t)
+		deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{}, fmt.Errorf("no rows")
+		}
+		deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 4, Status: models.ThreadStatusAwaitingInput}, nil
+		}
+		deps.threadStore.claimForResumeFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{}, db.ErrThreadRunningLimitReached
+		}
+		deps.threadStore.incrementPendingFn = func(_ context.Context, _, tid uuid.UUID) error {
+			require.Equal(t, threadID, tid, "queued awaiting_input answer should increment the requested thread")
+			return nil
+		}
+		deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+			require.Fail(t, "queued awaiting_input answer should wait for a running slot instead of enqueueing immediately")
+			return uuid.Nil, nil
+		}
+		svc.SetReviewCommentResolver(mock, db.NewSessionReviewCommentStore(mock))
+		svc.SetQuestionStore(db.NewSessionQuestionStore(mock))
+
+		result, err := svc.SendMessage(context.Background(), SendMessageInput{
+			SessionID: sessionID,
+			OrgID:     orgID,
+			ThreadID:  threadID,
+			UserID:    &userID,
+			Message:   answerText,
+		})
+		require.NoError(t, err, "queued awaiting_input answer should be accepted")
+		require.NotNil(t, result, "queued awaiting_input answer should return a result")
+		require.NotNil(t, result.AnsweredQuestion, "queued awaiting_input answer should return the answered question for audit")
+		require.Equal(t, questionID, result.AnsweredQuestion.ID, "queued awaiting_input answer should report the answered question")
+		require.Equal(t, "answered", result.AnsweredQuestion.Status, "queued awaiting_input answer should mark the question answered")
+		require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
+	})
+
+	t.Run("answers latest pending question when awaiting_input thread queues behind sibling", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err, "should create pgx mock")
+		defer mock.Close()
+
+		userID := uuid.New()
+		questionID := uuid.New()
+		answerText := "continue"
+		answeredAt := now
+
+		mock.ExpectBegin()
+		mock.ExpectQuery("INSERT INTO session_messages").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+				pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(int64(22), now))
+		mock.ExpectQuery("UPDATE session_questions").
+			WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+			WillReturnRows(
+				pgxmock.NewRows([]string{
+					"id", "session_id", "org_id", "question_text", "options", "context",
+					"blocks_phase", "answer_text", "answered_by", "answered_at", "status", "created_at",
+				}).AddRow(questionID, sessionID, orgID, "continue?", []string{"continue", "stop"}, (*string)(nil),
+					(*string)(nil), &answerText, &userID, &answeredAt, "answered", now),
+			)
+		mock.ExpectCommit()
+
+		svc, deps := newTestService(t)
+		deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{}, fmt.Errorf("no rows")
+		}
+		deps.threadStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 2, Status: models.ThreadStatusAwaitingInput}, nil
+		}
+		deps.threadStore.claimForResumeFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+			return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 2, Status: models.ThreadStatusRunning}, nil
+		}
+		deps.sessionStore.claimIdleFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+			return models.Session{}, fmt.Errorf("session already running")
+		}
+		deps.sessionStore.getByIDFn = func(_ context.Context, _, _ uuid.UUID) (models.Session, error) {
+			return models.Session{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusRunning)}, nil
+		}
+		deps.threadStore.updateStatusFn = func(_ context.Context, _, tid uuid.UUID, status models.ThreadStatus) error {
+			require.Equal(t, threadID, tid, "sibling-queued awaiting_input answer should release the claimed thread")
+			require.Equal(t, models.ThreadStatusIdle, status, "sibling-queued awaiting_input answer should leave the thread idle")
+			return nil
+		}
+		deps.threadStore.incrementPendingFn = func(_ context.Context, _, tid uuid.UUID) error {
+			require.Equal(t, threadID, tid, "sibling-queued awaiting_input answer should increment the requested thread")
+			return nil
+		}
+		deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, _, _ string, _ any, _ int, _ *string) (uuid.UUID, error) {
+			require.Fail(t, "sibling-queued awaiting_input answer should not enqueue a second continue_session")
+			return uuid.Nil, nil
+		}
+		svc.SetReviewCommentResolver(mock, db.NewSessionReviewCommentStore(mock))
+		svc.SetQuestionStore(db.NewSessionQuestionStore(mock))
+
+		result, err := svc.SendMessage(context.Background(), SendMessageInput{
+			SessionID: sessionID,
+			OrgID:     orgID,
+			ThreadID:  threadID,
+			UserID:    &userID,
+			Message:   answerText,
+		})
+		require.NoError(t, err, "sibling-queued awaiting_input answer should be accepted")
+		require.NotNil(t, result, "sibling-queued awaiting_input answer should return a result")
+		require.NotNil(t, result.AnsweredQuestion, "sibling-queued awaiting_input answer should return the answered question for audit")
+		require.Equal(t, questionID, result.AnsweredQuestion.ID, "sibling-queued awaiting_input answer should report the answered question")
+		require.Equal(t, "answered", result.AnsweredQuestion.Status, "sibling-queued awaiting_input answer should mark the question answered")
+		require.NoError(t, mock.ExpectationsWereMet(), "all transaction expectations should be met")
+	})
+
 	t.Run("rolls back when a comment ID is not in the session", func(t *testing.T) {
 		t.Parallel()
 		mock, err := pgxmock.NewPool()


### PR DESCRIPTION
## Summary
- Threads in `completed`/`failed`/`cancelled`/`awaiting_input` previously rejected follow-up messages with "thread must be idle"; sessions already handled this via `ClaimIdle → ClaimForResume` fallback, and threads now mirror that pattern through a new `ClaimForResumeInSession` plus a `claimThreadForSend` helper.
- Centralizes the resumable-status sets in `models.ResumableSessionStatuses` / `ResumableThreadStatuses`, binds them as runtime parameters via `status = ANY(@statuses)` so the SQL and Go layers share one source of truth, and factors the locked-thread + running-cap CTE into a private `claimForSession` helper used by both the idle and resume claim paths.
- `queueMessageOnIdleThread` was widened to accept resumable statuses too, so a cap-saturated session that wants to resume a terminal thread queues correctly instead of erroring.

## Test plan
- [x] `go test ./...` — all touched packages pass (one pre-existing unrelated migration-version test fails on `main` too)
- [x] `make lint` — 0 issues
- [x] Added DB-level tests for `ClaimForResumeInSession` (happy path + cap-saturated path) and a service-level test for "completed thread resumes via ClaimForResumeInSession"

🤖 Generated with [Claude Code](https://claude.com/claude-code)