### PR TITLE
Surface Linear API auth/4xx detail and emit reconnect signal

### DIFF
--- a/internal/services/integration/linear.go
+++ b/internal/services/integration/linear.go
@@ -510,6 +510,10 @@ func (l *LinearTaskManager) doGraphQL(ctx context.Context, query string, variabl
 		return &LinearRateLimitError{RetryAfter: resp.Header.Get("Retry-After")}
 	}
 	if resp.StatusCode == http.StatusUnauthorized {
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxLinearErrorBodyBytes))
+		if msg := linearErrorBodyMessage(bodyBytes); msg != "" {
+			return fmt.Errorf("%w: %s", ErrLinearUnauthorized, truncateLinearErrorMessage(msg))
+		}
 		return ErrLinearUnauthorized
 	}
 	if resp.StatusCode != http.StatusOK {
@@ -520,11 +524,8 @@ func (l *LinearTaskManager) doGraphQL(ctx context.Context, query string, variabl
 		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxLinearErrorBodyBytes))
 		// If the body is a GraphQL error envelope, prefer the structured
 		// message — it's far more readable than the raw JSON.
-		if msg := parseGraphQLErrorMessage(bodyBytes); msg != "" {
+		if msg := linearErrorBodyMessage(bodyBytes); msg != "" {
 			return fmt.Errorf("linear API returned %d: %s", resp.StatusCode, truncateLinearErrorMessage(msg))
-		}
-		if trimmed := bytes.TrimSpace(bodyBytes); len(trimmed) > 0 {
-			return fmt.Errorf("linear API returned %d: %s", resp.StatusCode, truncateLinearErrorMessage(string(trimmed)))
 		}
 		return fmt.Errorf("linear API returned %d", resp.StatusCode)
 	}
@@ -608,6 +609,16 @@ func parseGraphQLErrorMessage(body []byte) string {
 		if e.Message != "" {
 			return e.Message
 		}
+	}
+	return ""
+}
+
+func linearErrorBodyMessage(body []byte) string {
+	if msg := parseGraphQLErrorMessage(body); msg != "" {
+		return msg
+	}
+	if trimmed := bytes.TrimSpace(body); len(trimmed) > 0 {
+		return string(trimmed)
 	}
 	return ""
 }

--- a/internal/services/integration/linear.go
+++ b/internal/services/integration/linear.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"time"
+	"unicode/utf8"
 
 	"github.com/assembledhq/143/internal/services/ingestion"
 )
@@ -503,26 +506,110 @@ func (l *LinearTaskManager) doGraphQL(ctx context.Context, query string, variabl
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return &LinearRateLimitError{RetryAfter: resp.Header.Get("Retry-After")}
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return ErrLinearUnauthorized
+	}
 	if resp.StatusCode != http.StatusOK {
+		// Capture and surface what Linear actually said. The 4xx body is
+		// where the diagnosable detail lives — masking it as bare "linear API
+		// returned 400" forces ops into log spelunking that won't yield more
+		// than what the body already carries.
+		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, maxLinearErrorBodyBytes))
+		// If the body is a GraphQL error envelope, prefer the structured
+		// message — it's far more readable than the raw JSON.
+		if msg := parseGraphQLErrorMessage(bodyBytes); msg != "" {
+			return fmt.Errorf("linear API returned %d: %s", resp.StatusCode, truncateLinearErrorMessage(msg))
+		}
+		if trimmed := bytes.TrimSpace(bodyBytes); len(trimmed) > 0 {
+			return fmt.Errorf("linear API returned %d: %s", resp.StatusCode, truncateLinearErrorMessage(string(trimmed)))
+		}
 		return fmt.Errorf("linear API returned %d", resp.StatusCode)
 	}
 
-	// Check for GraphQL errors.
+	// Check for GraphQL errors in a 200 response body.
 	var raw json.RawMessage
 	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
 		return fmt.Errorf("decode linear response: %w", err)
 	}
 
-	var errCheck struct {
+	if msg := parseGraphQLErrorMessage(raw); msg != "" {
+		return fmt.Errorf("linear graphql error: %s", truncateLinearErrorMessage(msg))
+	}
+
+	return json.Unmarshal(raw, target)
+}
+
+// ErrLinearUnauthorized is returned when Linear rejects the access token with
+// a 401. Callers (and the sandbox CLI wrapper) match on this with errors.Is to
+// surface a "reconnect Linear" signal to the user instead of an opaque
+// "linear API returned 401" string.
+var ErrLinearUnauthorized = errors.New("linear unauthorized")
+
+// LinearRateLimitError carries the Retry-After hint from a 429 response so
+// retry orchestration upstream can space its attempts; matches the shape the
+// services/linear client uses so the two surfaces stay legible together.
+type LinearRateLimitError struct {
+	RetryAfter string
+}
+
+func (e *LinearRateLimitError) Error() string {
+	if e.RetryAfter != "" {
+		return fmt.Sprintf("linear rate limit exceeded (retry-after=%s)", e.RetryAfter)
+	}
+	return "linear rate limit exceeded"
+}
+
+// maxLinearErrorBodyBytes caps how much of a non-2xx response body we read
+// before composing an error. Linear can return small JSON envelopes or the
+// occasional HTML error page from its edge — 4 KiB is enough for the actual
+// message and keeps a wedged proxy from turning every retry into a megabyte
+// of error text in worker logs.
+const maxLinearErrorBodyBytes = 4 * 1024
+
+// maxLinearErrorMessageLen is the per-message cap applied after parsing.
+// Linear validation traces can run multi-KB; this keeps logs small while
+// retaining the operator-actionable head of the message.
+const maxLinearErrorMessageLen = 512
+
+func truncateLinearErrorMessage(s string) string {
+	if len(s) <= maxLinearErrorMessageLen {
+		return s
+	}
+	cut := maxLinearErrorMessageLen
+	// Step back to a valid UTF-8 rune boundary so the cap doesn't split a
+	// multi-byte rune and corrupt the error string.
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut] + "…[truncated]"
+}
+
+// parseGraphQLErrorMessage returns the first non-empty errors[].message from a
+// GraphQL response envelope, or "" if the body isn't an envelope or has no
+// errors. Used both for 200 responses (where Linear may report query errors
+// in the body) and for 4xx responses (where it sometimes returns the same
+// envelope with auth/validation errors).
+func parseGraphQLErrorMessage(body []byte) string {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return ""
+	}
+	var envelope struct {
 		Errors []struct {
 			Message string `json:"message"`
 		} `json:"errors"`
 	}
-	if err := json.Unmarshal(raw, &errCheck); err == nil && len(errCheck.Errors) > 0 {
-		return fmt.Errorf("linear graphql error: %s", errCheck.Errors[0].Message)
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return ""
 	}
-
-	return json.Unmarshal(raw, target)
+	for _, e := range envelope.Errors {
+		if e.Message != "" {
+			return e.Message
+		}
+	}
+	return ""
 }
 
 func linearNodeToSummary(node linearIssueNode) TaskSummary {

--- a/internal/services/integration/linear_test.go
+++ b/internal/services/integration/linear_test.go
@@ -3,8 +3,10 @@ package integration
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -586,4 +588,139 @@ func TestLinearTaskManager_UpdateTask_LabelNotFound(t *testing.T) {
 	require.Error(t, err, "UpdateTask should fail when a label name can't be resolved")
 	require.Contains(t, err.Error(), `label "nonexistent" not found`,
 		"error should indicate which label wasn't found")
+}
+
+func TestLinearTaskManager_DoGraphQL_UnauthorizedMapsToErrLinearUnauthorized(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "dead-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err, "GetTask should surface a 401 from Linear")
+	require.ErrorIs(t, err, ErrLinearUnauthorized,
+		"401 from Linear should map to ErrLinearUnauthorized so callers can detect dead tokens with errors.Is")
+}
+
+func TestLinearTaskManager_DoGraphQL_RateLimitReturnsTypedError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "test-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err, "GetTask should surface a 429 from Linear")
+	var rl *LinearRateLimitError
+	require.True(t, errors.As(err, &rl),
+		"429 from Linear should map to *LinearRateLimitError so retry orchestration can read Retry-After")
+	require.Equal(t, "30", rl.RetryAfter, "RateLimitError should preserve the Retry-After header")
+}
+
+func TestLinearTaskManager_DoGraphQL_NonOKBodySurfacedInError(t *testing.T) {
+	t.Parallel()
+
+	// Linear sometimes returns a 4xx with a GraphQL error envelope explaining
+	// why the request was rejected (auth, schema, validation). The transport
+	// must read and surface that body so the next 4xx debug doesn't require
+	// reproducing the request locally to discover what Linear actually said.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Authentication required: invalid token"}]}`))
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "test-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err, "GetTask should surface a 400 from Linear")
+	require.Contains(t, err.Error(), "linear API returned 400",
+		"error should keep the status code so log searches by code still work")
+	require.Contains(t, err.Error(), "Authentication required: invalid token",
+		"error should include the GraphQL message Linear returned in the 4xx body")
+}
+
+func TestLinearTaskManager_DoGraphQL_NonOKPlainBodySurfaced(t *testing.T) {
+	t.Parallel()
+
+	// Non-GraphQL bodies (HTML error pages from edge proxies, plain-text
+	// nginx errors) should still be surfaced verbatim — they're often the
+	// only signal that the request never reached Linear's GraphQL handler.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("upstream connect error"))
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "test-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err, "GetTask should surface a 502 from Linear")
+	require.Contains(t, err.Error(), "linear API returned 502")
+	require.Contains(t, err.Error(), "upstream connect error",
+		"non-JSON 4xx/5xx bodies should be included verbatim so edge-proxy failures are diagnosable")
+}
+
+func TestLinearTaskManager_DoGraphQL_GraphQLErrorIn200Surfaced(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Field 'foo' is not defined"}]}`))
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "test-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err, "GetTask should fail when Linear returns a GraphQL error envelope")
+	require.Contains(t, err.Error(), "linear graphql error",
+		"errors[].message in 200 responses should be surfaced via the existing prefix")
+	require.Contains(t, err.Error(), "Field 'foo' is not defined")
+}
+
+func TestLinearTaskManager_DoGraphQL_LongErrorMessagesAreTruncated(t *testing.T) {
+	t.Parallel()
+
+	long := strings.Repeat("X", 2000)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"` + long + `"}]}`))
+	}))
+	defer server.Close()
+
+	tm := NewLinearTaskManager(LinearManagerConfig{
+		AuthToken: "test-token",
+		APIURL:    server.URL,
+	})
+
+	_, err := tm.GetTask(context.Background(), "ENG-123")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "[truncated]",
+		"oversize Linear error messages should be truncated to bound log line size")
+	require.Less(t, len(err.Error()), 1024,
+		"truncated error should fit comfortably inside a single log line")
 }

--- a/internal/services/integration/linear_test.go
+++ b/internal/services/integration/linear_test.go
@@ -595,6 +595,7 @@ func TestLinearTaskManager_DoGraphQL_UnauthorizedMapsToErrLinearUnauthorized(t *
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errors":[{"message":"Authentication required, not authenticated"}]}`))
 	}))
 	defer server.Close()
 
@@ -607,6 +608,8 @@ func TestLinearTaskManager_DoGraphQL_UnauthorizedMapsToErrLinearUnauthorized(t *
 	require.Error(t, err, "GetTask should surface a 401 from Linear")
 	require.ErrorIs(t, err, ErrLinearUnauthorized,
 		"401 from Linear should map to ErrLinearUnauthorized so callers can detect dead tokens with errors.Is")
+	require.Contains(t, err.Error(), "Authentication required, not authenticated",
+		"401 from Linear should preserve the GraphQL auth detail for CLI and logs")
 }
 
 func TestLinearTaskManager_DoGraphQL_RateLimitReturnsTypedError(t *testing.T) {

--- a/internal/services/mcp/tools.go
+++ b/internal/services/mcp/tools.go
@@ -3,12 +3,36 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/assembledhq/143/internal/services/integration"
 )
+
+// taskManagerError formats a TaskManager error into an ErrorResult with a
+// dedicated branch for unauthorized integrations. The unauthorized variant
+// uses a stable, greppable prefix ("linear unauthorized:") so:
+//
+//  1. The agent gets a clear "stop trying Linear; ask the user to reconnect"
+//     signal instead of a generic "linear API returned 4xx".
+//  2. Sandbox stdout — captured into session logs and shipped to VictoriaLogs
+//     by the worker — is searchable for orgs whose Linear OAuth has fallen
+//     over, without a structured logger needing org_id (the sandbox doesn't
+//     have it).
+//
+// providerName is the integration name ("linear", future "jira", etc.) so the
+// signal is provider-tagged in the output.
+func taskManagerError(action, providerName string, err error) *ToolCallResult {
+	if errors.Is(err, integration.ErrLinearUnauthorized) {
+		return ErrorResult(fmt.Sprintf(
+			"%s unauthorized: %s access token has expired or been revoked. Ask the user to reconnect %s in the integrations settings before retrying %s.",
+			providerName, providerName, providerName, action,
+		))
+	}
+	return ErrorResult(fmt.Sprintf("%s failed: %s", action, err))
+}
 
 // ToolRegistry builds MCP tool definitions from an integration registry and
 // dispatches tool calls to the appropriate integration method.
@@ -447,7 +471,7 @@ func (tr *ToolRegistry) callTaskManager(ctx context.Context, tm integration.Task
 		}
 		results, err := tm.ListTasks(ctx, filter)
 		if err != nil {
-			return ErrorResult(fmt.Sprintf("list tasks failed: %s", err))
+			return taskManagerError("list tasks", tm.Name(), err)
 		}
 		return jsonResult(results)
 
@@ -460,7 +484,7 @@ func (tr *ToolRegistry) callTaskManager(ctx context.Context, tm integration.Task
 		}
 		detail, err := tm.GetTask(ctx, p.TaskID)
 		if err != nil {
-			return ErrorResult(fmt.Sprintf("get task failed: %s", err))
+			return taskManagerError("get task", tm.Name(), err)
 		}
 		return jsonResult(detail)
 
@@ -473,7 +497,7 @@ func (tr *ToolRegistry) callTaskManager(ctx context.Context, tm integration.Task
 		}
 		related, err := tm.FindRelated(ctx, p.TaskID)
 		if err != nil {
-			return ErrorResult(fmt.Sprintf("find related failed: %s", err))
+			return taskManagerError("find related", tm.Name(), err)
 		}
 		return jsonResult(related)
 
@@ -493,7 +517,7 @@ func (tr *ToolRegistry) callTaskManager(ctx context.Context, tm integration.Task
 			Comment:  p.Comment,
 		}
 		if err := tm.UpdateTask(ctx, p.TaskID, update); err != nil {
-			return ErrorResult(fmt.Sprintf("update task failed: %s", err))
+			return taskManagerError("update task", tm.Name(), err)
 		}
 		return TextResult("task updated successfully")
 
@@ -517,7 +541,7 @@ func (tr *ToolRegistry) callTaskManager(ctx context.Context, tm integration.Task
 		}
 		task, err := tm.CreateTask(ctx, spec)
 		if err != nil {
-			return ErrorResult(fmt.Sprintf("create task failed: %s", err))
+			return taskManagerError("create task", tm.Name(), err)
 		}
 		return jsonResult(task)
 

--- a/internal/services/mcp/tools.go
+++ b/internal/services/mcp/tools.go
@@ -26,12 +26,28 @@ import (
 // signal is provider-tagged in the output.
 func taskManagerError(action, providerName string, err error) *ToolCallResult {
 	if errors.Is(err, integration.ErrLinearUnauthorized) {
+		detail := taskManagerUnauthorizedDetail(providerName, err)
 		return ErrorResult(fmt.Sprintf(
-			"%s unauthorized: %s access token has expired or been revoked. Ask the user to reconnect %s in the integrations settings before retrying %s.",
-			providerName, providerName, providerName, action,
+			"%s unauthorized: %s. Ask the user to reconnect %s in the integrations settings before retrying %s.",
+			providerName, detail, providerName, action,
 		))
 	}
 	return ErrorResult(fmt.Sprintf("%s failed: %s", action, err))
+}
+
+func taskManagerUnauthorizedDetail(providerName string, err error) string {
+	fallback := fmt.Sprintf("%s access token has expired or been revoked", providerName)
+	text := strings.TrimSpace(err.Error())
+	sentinel := integration.ErrLinearUnauthorized.Error()
+	idx := strings.Index(text, sentinel)
+	if idx == -1 {
+		return fallback
+	}
+	detail := strings.TrimSpace(strings.TrimPrefix(text[idx+len(sentinel):], ":"))
+	if detail == "" {
+		return fallback
+	}
+	return detail
 }
 
 // ToolRegistry builds MCP tool definitions from an integration registry and

--- a/internal/services/mcp/tools_test.go
+++ b/internal/services/mcp/tools_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -516,19 +517,19 @@ type unauthorizedTaskManager struct{ name string }
 
 func (u *unauthorizedTaskManager) Name() string { return u.name }
 func (u *unauthorizedTaskManager) ListTasks(_ context.Context, _ integration.TaskFilter) ([]integration.TaskSummary, error) {
-	return nil, integration.ErrLinearUnauthorized
+	return nil, fmt.Errorf("%w: Authentication required, not authenticated", integration.ErrLinearUnauthorized)
 }
 func (u *unauthorizedTaskManager) GetTask(_ context.Context, _ string) (*integration.TaskDetail, error) {
-	return nil, integration.ErrLinearUnauthorized
+	return nil, fmt.Errorf("%w: Authentication required, not authenticated", integration.ErrLinearUnauthorized)
 }
 func (u *unauthorizedTaskManager) FindRelated(_ context.Context, _ string) ([]integration.TaskSummary, error) {
-	return nil, integration.ErrLinearUnauthorized
+	return nil, fmt.Errorf("%w: Authentication required, not authenticated", integration.ErrLinearUnauthorized)
 }
 func (u *unauthorizedTaskManager) UpdateTask(_ context.Context, _ string, _ integration.TaskUpdate) error {
-	return integration.ErrLinearUnauthorized
+	return fmt.Errorf("%w: Authentication required, not authenticated", integration.ErrLinearUnauthorized)
 }
 func (u *unauthorizedTaskManager) CreateTask(_ context.Context, _ integration.TaskCreateSpec) (*integration.TaskSummary, error) {
-	return nil, integration.ErrLinearUnauthorized
+	return nil, fmt.Errorf("%w: Authentication required, not authenticated", integration.ErrLinearUnauthorized)
 }
 
 func TestCallToolTaskManager_UnauthorizedSurfacesReconnectMessage(t *testing.T) {
@@ -563,6 +564,8 @@ func TestCallToolTaskManager_UnauthorizedSurfacesReconnectMessage(t *testing.T) 
 				"unauthorized errors should use the reserved 'linear unauthorized:' prefix so log queries can pick them out")
 			require.Contains(t, text, "reconnect linear",
 				"unauthorized error should explicitly tell the agent to ask the user to reconnect Linear")
+			require.Contains(t, text, "Authentication required, not authenticated",
+				"unauthorized error should preserve Linear's auth detail for sandbox CLI output")
 		})
 	}
 }

--- a/internal/services/mcp/tools_test.go
+++ b/internal/services/mcp/tools_test.go
@@ -507,6 +507,66 @@ func TestCallToolTaskManagerUnknownMethod(t *testing.T) {
 	}
 }
 
+// unauthorizedTaskManager always returns ErrLinearUnauthorized to exercise the
+// dedicated reconnect-Linear path in taskManagerError. We use a fresh mock
+// rather than threading an error knob through mockTaskManager — the existing
+// mock's "always succeed" contract is what most tests rely on, and the
+// auth-error case is narrow enough that a separate mock keeps both readable.
+type unauthorizedTaskManager struct{ name string }
+
+func (u *unauthorizedTaskManager) Name() string { return u.name }
+func (u *unauthorizedTaskManager) ListTasks(_ context.Context, _ integration.TaskFilter) ([]integration.TaskSummary, error) {
+	return nil, integration.ErrLinearUnauthorized
+}
+func (u *unauthorizedTaskManager) GetTask(_ context.Context, _ string) (*integration.TaskDetail, error) {
+	return nil, integration.ErrLinearUnauthorized
+}
+func (u *unauthorizedTaskManager) FindRelated(_ context.Context, _ string) ([]integration.TaskSummary, error) {
+	return nil, integration.ErrLinearUnauthorized
+}
+func (u *unauthorizedTaskManager) UpdateTask(_ context.Context, _ string, _ integration.TaskUpdate) error {
+	return integration.ErrLinearUnauthorized
+}
+func (u *unauthorizedTaskManager) CreateTask(_ context.Context, _ integration.TaskCreateSpec) (*integration.TaskSummary, error) {
+	return nil, integration.ErrLinearUnauthorized
+}
+
+func TestCallToolTaskManager_UnauthorizedSurfacesReconnectMessage(t *testing.T) {
+	t.Parallel()
+
+	reg := integration.NewRegistry()
+	reg.RegisterTaskManager(&unauthorizedTaskManager{name: "linear"})
+	tr := NewToolRegistry(reg)
+
+	cases := []struct {
+		tool string
+		args string
+	}{
+		{"linear_get_task", `{"task_id":"VIR-35"}`},
+		{"linear_list_tasks", `{}`},
+		{"linear_find_related_tasks", `{"task_id":"VIR-35"}`},
+		{"linear_update_task", `{"task_id":"VIR-35"}`},
+		{"linear_create_task", `{"title":"x"}`},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.tool, func(t *testing.T) {
+			t.Parallel()
+			result := tr.CallTool(context.Background(), tc.tool, json.RawMessage(tc.args))
+			require.True(t, result.IsError, "%s should return IsError when Linear is unauthorized", tc.tool)
+			require.Len(t, result.Content, 1)
+			text := result.Content[0].Text
+			// Stable, greppable prefix — workers tail sandbox stdout into
+			// VictoriaLogs, so this string is what ops will search for to
+			// find sessions blocked on a dead Linear token.
+			require.Contains(t, text, "linear unauthorized:",
+				"unauthorized errors should use the reserved 'linear unauthorized:' prefix so log queries can pick them out")
+			require.Contains(t, text, "reconnect linear",
+				"unauthorized error should explicitly tell the agent to ask the user to reconnect Linear")
+		})
+	}
+}
+
 func TestToolSchemaHasRequiredFields(t *testing.T) {
 	t.Parallel()
 	tr := NewToolRegistry(buildTestRegistry())


### PR DESCRIPTION
## Summary
- `integration/linear.go:doGraphQL` now maps 401 → `ErrLinearUnauthorized`, 429 → `LinearRateLimitError`, and reads up to 4 KiB of any other non-2xx body (preferring a parsed GraphQL `errors[].message`) so opaque "linear API returned 400" errors are now self-explaining.
- The MCP tool dispatcher (`mcp/tools.go`) detects `ErrLinearUnauthorized` and returns a greppable `"linear unauthorized: ... reconnect linear ..."` string instead of a generic failure, across `list/get/find_related/update/create`. Sandbox stdout is captured into worker logs, so ops can grep VictoriaLogs for orgs whose Linear OAuth has gone stale without needing org_id in the sandbox.
- New tests cover 401, 429 with Retry-After, 4xx body capture, 200-with-graphql-errors, oversize-message truncation, and the unauthorized→reconnect dispatcher path for all five Linear tools.

## Test plan
- [x] \`make lint\` clean (0 issues)
- [x] \`go build ./...\` clean
- [x] \`go test ./internal/services/integration/ ./internal/services/mcp/\` passes
- [ ] Reconnect Linear in production and verify a session that references a Linear identifier no longer triggers a sandbox-side \`linear_get_task\` (the inline create path will now snapshot the issue into the prompt instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)