### PR TITLE
Document prefer-immutable code style in backend and frontend AGENTS

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -421,6 +421,19 @@ Always include `dark:` variants for banners that use **hardcoded Tailwind color 
 - Acronyms: PM, LLM, PR, API
 - The word after an acronym stays lowercase: "PM agent", "LLM model", "PR status"
 
+## Prefer Non-Mutating Code
+
+**Default to immutability.** When transforming data, return a new object/array rather than mutating the input in place. This is required for React rendering correctness (referential equality drives re-renders) and for TanStack Query cache integrity (mutating cached data breaks query invalidation).
+
+- Use spread to copy: `{ ...obj, foo: v }`, `[...arr, x]`.
+- Use array methods that return new arrays: `map`, `filter`, `concat`, `slice`, `toSorted`, `toReversed`. Avoid in-place mutators: `push`, `pop`, `splice`, `sort`, `reverse`, direct index assignment.
+- Never mutate props, `useState` values, or data returned from `useQuery`. Inside `setState`/`queryClient.setQueryData`, return a new value instead of mutating the previous one.
+- Prefer `const` and readonly types. If a value really needs to change, replace it rather than mutate it.
+
+**Mutation is the exception, not the default.** Only reach for mutating code when there is a real, measured performance reason — e.g., a hot loop building a large array where each spread would be O(n²). When you do mutate, keep the mutation strictly local to the function and add a short comment explaining why immutability was rejected.
+
+When in doubt, write the immutable version first. It's almost always fast enough and it sidesteps a whole class of stale-render and cache-corruption bugs.
+
 ## Error Reporting (Sentry)
 
 Errors are reported to Sentry via `@sentry/nextjs`. Three layers handle this automatically:

--- a/internal/AGENTS.md
+++ b/internal/AGENTS.md
@@ -30,6 +30,19 @@ func (s *FooStore) ListByOrg(ctx context.Context, orgID uuid.UUID, f FooFilters)
 
 The existing test `internal/db/tenancy_test.go` is a third layer of defense: it reads every SQL literal and requires `org_id` in any query that touches a multi-tenant table.
 
+## Prefer Non-Mutating Code
+
+**Default to immutability.** When transforming data, return a new struct value rather than mutating the input in place.
+
+- Return a new struct (or `*T` constructed with `&T{...}`) from transformation functions instead of taking a pointer and writing through it.
+- Build new slices with `append` onto a fresh slice rather than mutating an argument; same for maps — copy then write.
+- Avoid setter methods that mutate the receiver — prefer `WithFoo(v) T` style that returns a copy.
+- Don't expose mutable references across package boundaries. If you must return a slice/map, return a copy or document that the caller must not mutate it.
+
+**Mutation is the exception, not the default.** Only reach for mutating code when there is a real, measured performance reason — e.g., a hot loop where allocations show up in a profile, or building a large structure incrementally where copying each step would be O(n²). When you do mutate, keep the mutation local and add a short comment explaining why immutability was rejected.
+
+When in doubt, write the immutable version first. It's almost always fast enough, and it eliminates an entire class of aliasing and data-race bugs (especially important for anything shared across goroutines).
+
 ## No N+1 Queries
 
 Never query the database inside a loop. Always batch using `ANY()`, JOINs, or bulk fetches. If a batch store method doesn't exist yet, create one using the `ANY()` pattern in the db package.


### PR DESCRIPTION
## Summary
- Adds a "Prefer Non-Mutating Code" section to `internal/AGENTS.md` (Go-specific: return new structs, fresh slices via `append`, no mutating setters, no exposing mutable references across packages).
- Adds a parallel section to `frontend/AGENTS.md` (TS/React-specific: spread to copy, non-mutating array methods, never mutate props/state/`useQuery` data).
- Both sections allow mutation only when there is a measured performance reason, kept local with a justifying comment.

## Test plan
- [ ] Docs-only change; no runtime impact to verify.
