### PR TITLE
Fix settings “Updated at” header and scoped autosave status to prevent duplicate green checks

### DIFF
--- a/frontend/src/app/(dashboard)/settings/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.test.tsx
@@ -5,20 +5,30 @@ import SettingsPage from './page';
 const {
   settingsGetMock,
   settingsUpdateMock,
+  auditLogsListMock,
+  teamListMembersMock,
   useAuthMock,
 } = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
+      id: 'org-1',
       name: 'Test Org',
       settings: {},
+      created_at: '2026-05-01T12:00:00Z',
+      updated_at: '2026-05-01T12:00:00Z',
     },
   }),
   settingsUpdateMock: vi.fn().mockResolvedValue({
     data: {
+      id: 'org-1',
       name: 'Updated Org',
       settings: {},
+      created_at: '2026-05-01T12:00:00Z',
+      updated_at: '2026-05-06T15:30:00Z',
     },
   }),
+  auditLogsListMock: vi.fn().mockResolvedValue({ data: [] }),
+  teamListMembersMock: vi.fn().mockResolvedValue({ data: [] }),
   useAuthMock: vi.fn(() => ({
     user: { role: 'admin' },
   })),
@@ -29,6 +39,12 @@ vi.mock('@/lib/api', () => ({
     settings: {
       get: settingsGetMock,
       update: settingsUpdateMock,
+    },
+    auditLogs: {
+      list: auditLogsListMock,
+    },
+    team: {
+      listMembers: teamListMembersMock,
     },
   },
 }));
@@ -47,10 +63,15 @@ describe('SettingsPage', () => {
     });
     settingsGetMock.mockResolvedValue({
       data: {
+        id: 'org-1',
         name: 'Test Org',
         settings: {},
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-01T12:00:00Z',
       },
     });
+    auditLogsListMock.mockClear();
+    teamListMembersMock.mockClear();
   });
 
   afterEach(() => {
@@ -70,8 +91,11 @@ describe('SettingsPage', () => {
   it('displays the organization name from server', async () => {
     settingsGetMock.mockResolvedValue({
       data: {
+        id: 'org-1',
         name: 'My Org',
         settings: {},
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-01T12:00:00Z',
       },
     });
 
@@ -94,6 +118,58 @@ describe('SettingsPage', () => {
 
     await waitFor(() => {
       expect(settingsUpdateMock).toHaveBeenCalledWith({ name: 'Updated Org' });
+    });
+  });
+
+  it('updates the header timestamp after a successful settings save', async () => {
+    settingsGetMock.mockResolvedValue({
+      data: {
+        id: 'org-1',
+        name: 'Test Org',
+        settings: {},
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-01T12:00:00Z',
+      },
+    });
+    settingsUpdateMock.mockResolvedValue({
+      data: {
+        id: 'org-1',
+        name: 'Updated Org',
+        settings: {},
+        created_at: '2026-05-01T12:00:00Z',
+        updated_at: '2026-05-06T15:30:00Z',
+      },
+    });
+
+    renderWithProviders(<SettingsPage />);
+
+    expect(await screen.findByText(/Updated at .*May 1, 2026.*12:00 PM UTC/)).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Organization name');
+    const user = userEvent.setup();
+    await user.click(input);
+    await user.keyboard('{Control>}a{/Control}Updated Org');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledWith({ name: 'Updated Org' });
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/Updated at .*May 6, 2026.*3:30 PM UTC/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows a saved indicator only on the pull requests section after PR changes', async () => {
+    renderWithProviders(<SettingsPage />);
+
+    const user = userEvent.setup();
+    await user.click((await screen.findByText('App only')).closest('label') as HTMLElement);
+
+    await waitFor(() => {
+      expect(settingsUpdateMock).toHaveBeenCalledWith({ settings: { pr_authorship: 'app_only' } });
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('Saved')).toHaveLength(1);
     });
   });
 

--- a/frontend/src/app/(dashboard)/settings/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/page.tsx
@@ -25,6 +25,54 @@ const PR_AUTHORSHIP_OPTIONS = [
   { value: "user_required", label: "User required", description: "Require users to connect GitHub before creating PRs" },
 ] as const;
 
+const settingsTimestampFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "long",
+  timeStyle: "short",
+  timeZone: "UTC",
+});
+
+function formatUpdatedAt(updatedAt: string | undefined): string | undefined {
+  if (!updatedAt) return undefined;
+  const date = new Date(updatedAt);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return `${settingsTimestampFormatter.format(date)} UTC`;
+}
+
+function useOrgSettingsAutosave() {
+  const queryClient = useQueryClient();
+  return useAutosave<SettingsPatch>({
+    queryKey: queryKeys.settings.all,
+    mutationFn: async (payload) => {
+      const response = await api.settings.update(payload);
+      queryClient.setQueryData(queryKeys.settings.all, response);
+      if (payload.name !== undefined) {
+        queryClient.setQueryData<SingleResponse<MembershipsResponse> | undefined>(
+          queryKeys.auth.memberships,
+          (previous) => {
+            if (!previous?.data) return previous;
+            return {
+              ...previous,
+              data: {
+                ...previous.data,
+                memberships: previous.data.memberships.map((membership) =>
+                  membership.org_id === response.data.id
+                    ? { ...membership, org_name: response.data.name }
+                    : membership,
+                ),
+              },
+            };
+          },
+        );
+      }
+      void queryClient.invalidateQueries({ queryKey: ["audit-logs", "latest"] });
+      return response;
+    },
+    applyOptimistic: applyOrgSettingsPatch,
+    coalesce: coalesceSettingsPatch,
+    invalidateOnSettled: false,
+  });
+}
+
 function PRAuthorshipSettings() {
   const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
@@ -36,12 +84,7 @@ function PRAuthorshipSettings() {
   const currentDraftDefault = settings.pr_draft_default ?? false;
   const currentAutoArchive = settings.auto_archive_on_pr_close ?? false;
 
-  const { save, status } = useAutosave<SettingsPatch>({
-    queryKey: queryKeys.settings.all,
-    mutationFn: (payload) => api.settings.update(payload),
-    applyOptimistic: applyOrgSettingsPatch,
-    coalesce: coalesceSettingsPatch,
-  });
+  const { save, status } = useOrgSettingsAutosave();
 
   return (
     <section className="space-y-3">
@@ -119,39 +162,11 @@ function PRAuthorshipSettings() {
 
 export default function SettingsPage() {
   const { user } = useAuth();
-  const queryClient = useQueryClient();
   const { data: settings } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
-  const autosave = useAutosave<SettingsPatch>({
-    queryKey: queryKeys.settings.all,
-    mutationFn: async (payload) => {
-      const response = await api.settings.update(payload);
-      if (payload.name !== undefined) {
-        queryClient.setQueryData<SingleResponse<MembershipsResponse> | undefined>(
-          queryKeys.auth.memberships,
-          (previous) => {
-            if (!previous?.data) return previous;
-            return {
-              ...previous,
-              data: {
-                ...previous.data,
-                memberships: previous.data.memberships.map((membership) =>
-                  membership.org_id === response.data.id
-                    ? { ...membership, org_name: response.data.name }
-                    : membership,
-                ),
-              },
-            };
-          },
-        );
-      }
-      return response;
-    },
-    applyOptimistic: applyOrgSettingsPatch,
-    coalesce: coalesceSettingsPatch,
-  });
+  const autosave = useOrgSettingsAutosave();
 
   return (
     <PageContainer size="default">
@@ -159,6 +174,10 @@ export default function SettingsPage() {
         <PageHeader
           title="General settings"
           description="Manage your organization."
+          subtitle={(() => {
+            const formattedUpdatedAt = formatUpdatedAt(settings?.data?.updated_at);
+            return formattedUpdatedAt ? `Updated at ${formattedUpdatedAt}` : undefined;
+          })()}
         />
         <AuditLogTrigger
           filters={{ resource_type: "settings" }}

--- a/frontend/src/hooks/useAutosave.test.ts
+++ b/frontend/src/hooks/useAutosave.test.ts
@@ -426,7 +426,7 @@ describe("useAutosave", () => {
     expect(callOrder).toEqual(["A", "B"]);
   });
 
-  it("shares status transitions across two hooks on the same queryKey", async () => {
+  it("scopes status transitions to the hook that originated the save", async () => {
     let resolveMutation: (() => void) | undefined;
     const mutationFn = vi.fn().mockImplementation(
       () =>
@@ -464,9 +464,8 @@ describe("useAutosave", () => {
       resultA.current.save({ settings: { v: 1 } });
     });
 
-    // Both hooks observe the "saving" transition even though only A dispatched.
     await waitFor(() => expect(resultA.current.status).toBe("saving"));
-    expect(resultB.current.status).toBe("saving");
+    expect(resultB.current.status).toBe("idle");
 
     await act(async () => {
       resolveMutation?.();
@@ -474,7 +473,7 @@ describe("useAutosave", () => {
     });
 
     await waitFor(() => expect(resultA.current.status).toBe("saved"));
-    expect(resultB.current.status).toBe("saved");
+    expect(resultB.current.status).toBe("idle");
   });
 
   it("flushes pending debounced payload on unmount so the edit isn't dropped", async () => {

--- a/frontend/src/hooks/useAutosave.ts
+++ b/frontend/src/hooks/useAutosave.ts
@@ -19,6 +19,7 @@ export interface UseAutosaveOptions<TVars> {
   coalesce?: (queued: TVars, incoming: TVars) => TVars;
   debounceMs?: number;
   errorMessage?: string;
+  invalidateOnSettled?: boolean;
 }
 
 export interface UseAutosaveResult<TVars> {
@@ -53,16 +54,19 @@ interface QueueEntry {
   inFlight: boolean;
   pendingVars: unknown;
   hasPending: boolean;
+  pendingOwnerIds: Set<string>;
   coalesce?: (queued: unknown, incoming: unknown) => unknown;
   mutationFn?: (vars: unknown) => Promise<unknown>;
   applyOptimistic?: (previous: unknown, vars: unknown) => unknown;
   errorMessage?: string;
-  listeners: Set<(status: QueueStatus) => void>;
+  invalidateOnSettled: boolean;
+  listeners: Set<(status: QueueStatus, ownerIds: ReadonlySet<string>) => void>;
 }
 
 type QueueStatus = "idle" | "saving" | "saved" | "error";
 
 const queues = new Map<string, QueueEntry>();
+let autosaveListenerID = 0;
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -108,6 +112,8 @@ function getQueue(key: QueryKey): QueueEntry {
       inFlight: false,
       pendingVars: undefined,
       hasPending: false,
+      pendingOwnerIds: new Set(),
+      invalidateOnSettled: true,
       listeners: new Set(),
     };
     queues.set(id, entry);
@@ -127,11 +133,12 @@ function maybeEvictQueue(key: string, entry: QueueEntry): void {
  */
 export function __resetAutosaveQueuesForTests(): void {
   queues.clear();
+  autosaveListenerID = 0;
 }
 
-function emit(entry: QueueEntry, status: QueueStatus): void {
+function emit(entry: QueueEntry, status: QueueStatus, ownerIds: ReadonlySet<string>): void {
   for (const listener of entry.listeners) {
-    listener(status);
+    listener(status, ownerIds);
   }
 }
 
@@ -140,25 +147,27 @@ async function run(
   entry: QueueEntry,
   vars: unknown,
   queryKey: QueryKey,
+  ownerIds: Set<string>,
 ): Promise<void> {
   entry.inFlight = true;
-  emit(entry, "saving");
+  emit(entry, "saving", ownerIds);
 
   await queryClient.cancelQueries({ queryKey });
   const previous = queryClient.getQueryData(queryKey);
   const applyOptimistic = entry.applyOptimistic!;
   const mutationFn = entry.mutationFn!;
   const errorMessage = entry.errorMessage ?? DEFAULT_ERROR_MESSAGE;
+  const invalidateOnSettled = entry.invalidateOnSettled;
   queryClient.setQueryData(queryKey, (current: unknown) => applyOptimistic(current, vars));
 
   try {
     await mutationFn(vars);
-    emit(entry, "saved");
+    emit(entry, "saved", ownerIds);
   } catch (err) {
     captureError(err, { feature: "useAutosave" });
     queryClient.setQueryData(queryKey, previous);
     toast.error(errorMessage);
-    emit(entry, "error");
+    emit(entry, "error", ownerIds);
   } finally {
     // NOTE: `inFlight` flips to false only after `invalidateQueries` settles.
     // Any `save()` call that races in between lands in the pending slot; the
@@ -171,15 +180,19 @@ async function run(
     // the optimistic cache for the failed write, so the pending run starts
     // from the rolled-back baseline and applies only the new intent.
     entry.inFlight = false;
-    await queryClient.invalidateQueries({ queryKey });
+    if (invalidateOnSettled) {
+      await queryClient.invalidateQueries({ queryKey });
+    }
     if (entry.hasPending) {
       const next = entry.pendingVars;
+      const nextOwnerIds = new Set(entry.pendingOwnerIds);
       entry.hasPending = false;
       entry.pendingVars = undefined;
+      entry.pendingOwnerIds.clear();
       // Fire the coalesced follow-up through the entry's currently-registered
       // fns (refreshed on every dispatch), so a caller who queued mid-flight
       // with updated mutationFn/applyOptimistic drives the next run.
-      void run(queryClient, entry, next, queryKey);
+      void run(queryClient, entry, next, queryKey, nextOwnerIds);
     } else {
       maybeEvictQueue(hashKey(queryKey), entry);
     }
@@ -234,9 +247,15 @@ export function useAutosave<TVars>({
   coalesce,
   debounceMs = 0,
   errorMessage = DEFAULT_ERROR_MESSAGE,
+  invalidateOnSettled = true,
 }: UseAutosaveOptions<TVars>): UseAutosaveResult<TVars> {
   const queryClient = useQueryClient();
   const [status, setStatus] = useState<AutosaveStatus>("idle");
+  const hookIDRef = useRef<string | null>(null);
+  if (hookIDRef.current === null) {
+    autosaveListenerID += 1;
+    hookIDRef.current = `autosave-${autosaveListenerID}`;
+  }
 
   // Keep latest options in refs so the stable callbacks below don't churn
   // when callers re-render. Assignment lives in an effect — matching
@@ -249,6 +268,7 @@ export function useAutosave<TVars>({
   const coalesceRef = useRef(coalesce);
   const errorMessageRef = useRef(errorMessage);
   const debounceMsRef = useRef(debounceMs);
+  const invalidateOnSettledRef = useRef(invalidateOnSettled);
   // Intentional: NO dependency array. This effect must run after every
   // commit so the refs always mirror the freshest prop/callback values a
   // parent passed in. Adding deps (e.g. `[mutationFn, applyOptimistic, ...]`)
@@ -262,6 +282,7 @@ export function useAutosave<TVars>({
     coalesceRef.current = coalesce;
     errorMessageRef.current = errorMessage;
     debounceMsRef.current = debounceMs;
+    invalidateOnSettledRef.current = invalidateOnSettled;
   });
 
   // Debounce state is local to each hook instance — two callers of the same
@@ -279,7 +300,10 @@ export function useAutosave<TVars>({
   // queryKey see consistent saving/saved/error transitions.
   useEffect(() => {
     const entry = getQueue(queryKey);
-    const listener = (next: QueueStatus) => {
+    const listener = (next: QueueStatus, ownerIds: ReadonlySet<string>) => {
+      if (!ownerIds.has(hookIDRef.current!)) {
+        return;
+      }
       setStatus(next);
       if (lingerTimerRef.current) {
         clearTimeout(lingerTimerRef.current);
@@ -349,17 +373,21 @@ export function useAutosave<TVars>({
       entry.mutationFn = (v) => mutationFnRef.current(v as TVars);
       entry.applyOptimistic = (prev, v) => applyOptimisticRef.current(prev, v as TVars);
       entry.errorMessage = errorMessageRef.current;
+      entry.invalidateOnSettled = invalidateOnSettledRef.current;
 
       if (entry.inFlight) {
         if (entry.hasPending && entry.coalesce) {
           entry.pendingVars = entry.coalesce(entry.pendingVars, vars);
+          entry.pendingOwnerIds.add(hookIDRef.current!);
         } else {
           entry.pendingVars = vars;
+          entry.pendingOwnerIds.clear();
+          entry.pendingOwnerIds.add(hookIDRef.current!);
         }
         entry.hasPending = true;
         return;
       }
-      void run(queryClient, entry, vars, queryKey);
+      void run(queryClient, entry, vars, queryKey, new Set([hookIDRef.current!]));
     },
     // queryKey identity can change per render; serializedKey is the actual dep.
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Fixed the general settings regressions in [page.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/settings/page.tsx) and the shared autosave behavior in [useAutosave.ts](/home/sandbox/143/frontend/src/hooks/useAutosave.ts).

The page now shows a real `Updated at ...` header timestamp sourced from `Organization.updated_at`, and org settings saves write the returned organization payload back into React Query immediately instead of getting clobbered by an automatic refetch. I also kept the audit-log “latest” query invalidation so the activity row can refresh separately.

The duplicate green checkmark issue came from `useAutosave` broadcasting one status to every hook on the same `queryKey`. The queue is still shared, but status is now scoped to the section that originated the save, so changing Pull Requests only marks that card as saved.

Regression coverage was added in [page.test.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/settings/page.test.tsx) and [useAutosave.test.ts](/home/sandbox/143/frontend/src/hooks/useAutosave.test.ts).

Verification:
- `npx vitest --run 'src/hooks/useAutosave.test.ts' 'src/app/(dashboard)/settings/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

`npm run build` passed. It still prints existing Next.js warnings about multiple lockfiles and deprecated `middleware` naming, but they did not block the build.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 6f3443bc](https://143.dev/sessions/6f3443bc-3ee4-4f27-b87a-690f006a3159)