### PR TITLE
[codex] Fix worker node ID routing

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -474,7 +474,7 @@ func main() {
 			ctx,
 			pool,
 			logger,
-			hostname,
+			cfg.NodeID,
 			workerCount,
 			stores,
 			services,
@@ -674,7 +674,7 @@ func startProcessWorkers(
 	ctx context.Context,
 	pool db.DBTX,
 	logger zerolog.Logger,
-	hostname string,
+	nodeID string,
 	workerCount int,
 	stores *worker.Stores,
 	services *worker.Services,
@@ -687,7 +687,7 @@ func startProcessWorkers(
 ) []*worker.Worker {
 	workers := make([]*worker.Worker, 0, workerCount)
 	for i := 0; i < workerCount; i++ {
-		w := worker.New(pool, logger, hostname)
+		w := worker.New(pool, logger, nodeID)
 		worker.RegisterHandlers(w, stores, services, retentionCfg, logger)
 		workers = append(workers, w)
 	}

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"strings"
 	"sync/atomic"
@@ -147,6 +150,38 @@ func TestMainStartupRunsRehydrateBeforeWorkers(t *testing.T) {
 	require.NotEqual(t, -1, startWorkers, "startup should still start process workers")
 	require.NotEqual(t, -1, rehydrate, "startup should still run sandbox auth rehydrate")
 	require.Less(t, rehydrate, startWorkers, "sandbox auth rehydrate/sweep must run before process workers can claim jobs")
+}
+
+func TestMainPassesConfiguredNodeIDToWorkers(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "main.go", nil, 0)
+	require.NoError(t, err, "main.go should parse for worker node ID wiring regression test")
+
+	var workerStart *ast.CallExpr
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		fn, ok := call.Fun.(*ast.Ident)
+		if ok && fn.Name == "startProcessWorkers" {
+			workerStart = call
+			return false
+		}
+		return true
+	})
+
+	require.NotNil(t, workerStart, "startup should call startProcessWorkers")
+	require.GreaterOrEqual(t, len(workerStart.Args), 4, "startProcessWorkers call should include the node ID argument")
+
+	nodeArg, ok := workerStart.Args[3].(*ast.SelectorExpr)
+	require.True(t, ok, "worker node ID argument should be a selector expression")
+	root, ok := nodeArg.X.(*ast.Ident)
+	require.True(t, ok, "worker node ID argument should be rooted at cfg")
+	require.Equal(t, "cfg", root.Name, "workers should use the configured node ID root")
+	require.Equal(t, "NodeID", nodeArg.Sel.Name, "workers should use cfg.NodeID rather than the Docker hostname")
 }
 
 func TestMainAdvertisesPreviewAfterHTTPListen(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixes worker startup so process workers use the configured `cfg.NodeID` instead of the Docker container hostname when claiming jobs. This keeps `jobs.locked_by_node_id` and `jobs.target_node_id` aligned with `sessions.worker_node_id` and `nodes.id`, so pinned sandbox-bound jobs can be claimed by their owning worker. Adds a regression test that parses server startup wiring and fails if workers stop receiving `cfg.NodeID`.

## Validation
- `go test ./cmd/server -run TestMainPassesConfiguredNodeIDToWorkers -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`