### PR TITLE
Strip stale auth_error markers from duplicate Linear integration rows

### DIFF
--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -455,6 +455,9 @@ func (h *IntegrationHandler) StartLinearOAuth(w http.ResponseWriter, r *http.Req
 }
 
 func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r *http.Request) {
+	logger := zerolog.Ctx(r.Context())
+	logger.Info().Msg("linear oauth callback received")
+
 	code, ok := validateOAuthCallback(w, r, linearIntegrationOAuthStateCookie)
 	if !ok {
 		return
@@ -500,6 +503,11 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 		return
 	}
 
+	logger.Info().
+		Str("org_id", orgID.String()).
+		Str("workspace_id", workspaceID).
+		Msg("linear oauth callback completed; credentials stored and integration active")
+
 	// Trigger an initial team-key refresh so detection's bare-identifier
 	// branch works on the very next session. Three-tier strategy:
 	//  1. Detached-context background refresh kicked off here so the OAuth
@@ -514,7 +522,6 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 	//     is the last line of defense after that.
 	// All paths are nil-safe so test harnesses without these hooks still
 	// complete the OAuth flow normally.
-	logger := zerolog.Ctx(r.Context())
 	if h.linearTeamKeyRefresher != nil {
 		// context.WithoutCancel: a cancelled request context (the user
 		// closing the browser tab post-redirect) must not abort the
@@ -1226,7 +1233,6 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 	}
 
 	if len(reusableIntegrations) > 0 {
-		integration := reusableIntegrations[0]
 		// A reconnect flow lands here: if the row is errored (most often
 		// from a prior 401 the worker stamped) restore it to active and
 		// strip the auth-error markers so the settings UI's Reconnect CTA
@@ -1237,21 +1243,27 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 		// When both fields need to change we write atomically so the row
 		// can never be observed as "active with stale auth_error markers"
 		// (which would render no Reconnect CTA but also no Connect CTA).
-		clearedConfig, configChanged := stripAuthErrorMarkers(integration.Config)
-		statusErrored := integration.Status == models.IntegrationStatusError
-		switch {
-		case configChanged && statusErrored:
-			if err := h.integrationStore.UpdateStatusAndConfig(ctx, orgID, integration.ID, string(models.IntegrationStatusActive), clearedConfig); err == nil {
-				integration.Config = clearedConfig
-				integration.Status = models.IntegrationStatusActive
-			}
-		case configChanged:
-			if err := h.integrationStore.UpdateConfig(ctx, orgID, integration.ID, clearedConfig); err == nil {
-				integration.Config = clearedConfig
-			}
-		case statusErrored:
-			if err := h.integrationStore.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err == nil {
-				integration.Status = models.IntegrationStatusActive
+		integration, err := h.convergeReusableRow(ctx, orgID, reusableIntegrations[0])
+		if err != nil {
+			return models.Integration{}, false, err
+		}
+		// Historical duplicates: rows created before ensureIntegration was
+		// the only write path can leave an orphan errored row alongside
+		// the canonical one. The integrations list endpoint surfaces
+		// auth_error from any row (so a worker-flipped active→error row
+		// keeps the Reconnect CTA visible), which means a stale errored
+		// duplicate continues to render the banner even after a clean
+		// reconnect against the canonical row. Converge them all so the
+		// next /api/v1/integrations response can't pull auth_error from a
+		// row we're not using. We only need the DB side effect here —
+		// callers see the canonical row, not the duplicates — so the
+		// returned converged value is discarded, but errors still
+		// propagate so a partial cleanup surfaces as 500 and the user
+		// retries instead of seeing a "successful" reconnect that left
+		// the orphan banner in place.
+		for i := 1; i < len(reusableIntegrations); i++ {
+			if _, err := h.convergeReusableRow(ctx, orgID, reusableIntegrations[i]); err != nil {
+				return models.Integration{}, false, err
 			}
 		}
 		return integration, false, nil
@@ -1270,6 +1282,39 @@ func (h *IntegrationHandler) ensureIntegration(ctx context.Context, orgID uuid.U
 	h.maybeEnqueuePMContext(ctx, orgID)
 
 	return *integration, true, nil
+}
+
+// convergeReusableRow flips an errored reusable row back to active and
+// strips any auth-error markers it carries, returning a new Integration
+// reflecting the post-converge state. Idempotent: if the row is already
+// active with no auth-error markers, no DB write fires and the returned
+// value equals the input. DB errors are surfaced to the caller —
+// swallowing them is what produced the stale-duplicate-row bug this
+// helper exists to fix; if the UPDATE fails, the OAuth flow should fail
+// loud (500) so the user retries instead of seeing a "successful"
+// reconnect that left the DB in an inconsistent state.
+func (h *IntegrationHandler) convergeReusableRow(ctx context.Context, orgID uuid.UUID, integration models.Integration) (models.Integration, error) {
+	clearedConfig, configChanged := stripAuthErrorMarkers(integration.Config)
+	statusErrored := integration.Status == models.IntegrationStatusError
+	switch {
+	case configChanged && statusErrored:
+		if err := h.integrationStore.UpdateStatusAndConfig(ctx, orgID, integration.ID, string(models.IntegrationStatusActive), clearedConfig); err != nil {
+			return integration, fmt.Errorf("converge integration %s: update status and config: %w", integration.ID, err)
+		}
+		integration.Config = clearedConfig
+		integration.Status = models.IntegrationStatusActive
+	case configChanged:
+		if err := h.integrationStore.UpdateConfig(ctx, orgID, integration.ID, clearedConfig); err != nil {
+			return integration, fmt.Errorf("converge integration %s: update config: %w", integration.ID, err)
+		}
+		integration.Config = clearedConfig
+	case statusErrored:
+		if err := h.integrationStore.UpdateStatus(ctx, orgID, integration.ID, string(models.IntegrationStatusActive)); err != nil {
+			return integration, fmt.Errorf("converge integration %s: update status: %w", integration.ID, err)
+		}
+		integration.Status = models.IntegrationStatusActive
+	}
+	return integration, nil
 }
 
 // stripAuthErrorMarkers removes the auth-error keys the linear service

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -799,6 +799,104 @@ func TestIntegrationHandler_ConnectLinear_ReactivatesErroredIntegration(t *testi
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+// TestIntegrationHandler_ConnectLinear_ConvergesDuplicateErroredRow pins
+// the duplicate-row cleanup. When ListReusableForReconnect returns the
+// canonical active row plus a stale errored duplicate (historical state
+// from before ensureIntegration was the only write path), the duplicate
+// must also have its auth_error markers stripped and status flipped to
+// active. Otherwise /api/v1/integrations would surface auth_error from
+// the orphan row and keep the Reconnect CTA visible after a healthy
+// reconnect against the canonical row.
+func TestIntegrationHandler_ConnectLinear_ConvergesDuplicateErroredRow(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	canonicalID := uuid.New()
+	duplicateID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	// Active row first (per the SQL ORDER BY), then the errored duplicate.
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+				AddRow(canonicalID, orgID, "linear", json.RawMessage(`{}`), "active", nil, now).
+				AddRow(duplicateID, orgID, "linear", json.RawMessage(`{"last_auth_error":"prior","last_auth_error_at":"2026-05-05T22:49:11Z"}`), "error", nil, now),
+		)
+
+	// Canonical row is already active+empty: no UPDATE for it. The
+	// duplicate is errored with auth-error markers, so a single atomic
+	// flip should fire for that one ID.
+	mock.ExpectExec("UPDATE integrations SET status = @status, config = @config").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "ConnectLinear should reuse the canonical active row")
+	var resp models.SingleResponse[models.Integration]
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp), "ConnectLinear response should be valid JSON")
+	require.Equal(t, canonicalID, resp.Data.ID, "ConnectLinear should return the canonical (active) integration ID, not the duplicate")
+	require.NoError(t, mock.ExpectationsWereMet(), "duplicate row must also be flipped to active+stripped")
+}
+
+// TestIntegrationHandler_ConnectLinear_PropagatesDuplicateConvergeFailure
+// pins that DB errors during duplicate-row convergence surface as 500
+// rather than getting swallowed. Silent failure here is what produced
+// the stale-duplicate-row bug to begin with — a "successful" reconnect
+// that quietly left an orphan errored row visible to the integrations
+// list, keeping the Reconnect CTA pinned on after the canonical row was
+// healthy.
+func TestIntegrationHandler_ConnectLinear_PropagatesDuplicateConvergeFailure(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	canonicalID := uuid.New()
+	duplicateID := uuid.New()
+	now := time.Now()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	handler := NewIntegrationHandler(store, nil, "", "", "http://localhost:8080", "http://localhost:3000")
+
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+				AddRow(canonicalID, orgID, "linear", json.RawMessage(`{}`), "active", nil, now).
+				AddRow(duplicateID, orgID, "linear", json.RawMessage(`{"last_auth_error":"prior","last_auth_error_at":"2026-05-05T22:49:11Z"}`), "error", nil, now),
+		)
+	// Duplicate-row UPDATE blows up — the OAuth flow must surface this
+	// as 500, not return 200 with a half-converged DB.
+	mock.ExpectExec("UPDATE integrations SET status = @status, config = @config").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnError(errors.New("update failed"))
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/integrations/linear/connect", nil)
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.ConnectLinear(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code, "ConnectLinear must return 500 when duplicate-row converge fails")
+	require.Contains(t, w.Body.String(), "CONNECT_LINEAR_FAILED")
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestIntegrationHandler_ConnectLinear_ReturnsInternalErrorWhenLookupFails(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- A historical second `integrations` row with `status=error` and `last_auth_error*` markers kept the Reconnect Linear banner pinned in the UI even after a clean OAuth reconnect against the canonical active row, because the integrations list endpoint surfaces `auth_error` from any row, not just the active one.
- `ensureIntegration` now converges every reusable row (active + errored duplicates), not just the first; the convergence helper is idempotent and returns `(Integration, error)` so a half-completed cleanup fails the OAuth flow as 500 instead of silently leaving the banner.
- Adds info logging at start and end of `HandleLinearOAuthCallback` so the flow can be grepped end-to-end instead of inferred from redirect status.
- Tests pin both the duplicate-row converge path and the error-propagation path.

## Test plan
- [x] `make lint` clean
- [x] `go test ./internal/api/handlers/` passes
- [ ] After deploy, verify the affected org's Reconnect banner clears on next reconnect (or one-shot `UPDATE` of the orphan row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
