### PR TITLE
Show GitHub PR number in merged/closed status and toast on session detail

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1607,7 +1607,7 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect((await screen.findAllByText('PR closed')).length).toBeGreaterThanOrEqual(2);
+    expect((await screen.findAllByText('PR #42 closed')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was closed without merging.')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();
     expect(screen.queryByText('PR health')).not.toBeInTheDocument();
@@ -1652,7 +1652,7 @@ describe('SessionDetailPage', () => {
     await user.click(mergeButton);
 
     await waitFor(() => expect(mergeCalled).toBe(true));
-    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('PR merged', expect.any(Object)));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('PR #42 merged', expect.any(Object)));
   });
 
   it('renders external links for CI checks shown from the PR details hover card', async () => {
@@ -1726,8 +1726,7 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByText('PR merged')).toBeInTheDocument();
-    expect(screen.queryAllByText('PR merged')).toHaveLength(1);
+    expect((await screen.findAllByText('PR #42 merged')).length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText('PR #42 was merged successfully.')).toHaveClass('text-xs');
     expect(screen.getByText('This change has landed. Open a follow-up session if you need to make another revision.')).toHaveClass('text-xs');
     expect(screen.getByRole('link', { name: 'View PR' })).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2519,11 +2519,14 @@ export function SessionDetailContent({ id }: { id: string }) {
   });
   const prHealth = prHealthData?.data;
   const prStatus = prData?.data?.status;
-  const closedPRNumber = prData?.data?.github_pr_number;
+  const prNumber = prData?.data?.github_pr_number;
+  const closedPRNumber = prNumber;
+  const closedPRLabel = closedPRNumber ? `PR #${closedPRNumber} closed` : "PR closed";
   const closedPRSummary = closedPRNumber
     ? `PR #${closedPRNumber} was closed without merging.`
     : "This pull request was closed without merging.";
-  const mergedPRNumber = prData?.data?.github_pr_number;
+  const mergedPRNumber = prNumber;
+  const mergedPRLabel = mergedPRNumber ? `PR #${mergedPRNumber} merged` : "PR merged";
   const mergedPRSummary = mergedPRNumber
     ? `PR #${mergedPRNumber} was merged successfully.`
     : "This pull request was merged successfully.";
@@ -2657,7 +2660,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       void queryClient.invalidateQueries({ queryKey: ["session", id] });
       void queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
       void queryClient.invalidateQueries({ queryKey: ["sessions"] });
-      toast.success("PR merged", prUrl ? {
+      toast.success(mergedPRLabel, prUrl ? {
         action: { label: "View \u2197", onClick: () => window.open(prUrl, "_blank", "noopener,noreferrer") },
       } : undefined);
     },
@@ -3663,7 +3666,12 @@ export function SessionDetailContent({ id }: { id: string }) {
               <>
                 {prStatus === "closed" && (
                   <Badge variant="secondary" className="h-7 px-2 text-xs">
-                    PR closed
+                    {closedPRLabel}
+                  </Badge>
+                )}
+                {prStatus === "merged" && (
+                  <Badge variant="secondary" className="h-7 px-2 text-xs">
+                    {mergedPRLabel}
                   </Badge>
                 )}
                 <Button asChild variant="outline" size="sm" className="h-7 text-xs gap-1.5">
@@ -3775,7 +3783,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     <XCircle className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 space-y-1">
-                    <div className="text-sm font-medium text-foreground">PR closed</div>
+                    <div className="text-sm font-medium text-foreground">{closedPRLabel}</div>
                     <p className="text-xs text-foreground">{closedPRSummary}</p>
                     <p className="text-xs text-muted-foreground">
                       This pull request is no longer active. Create a follow-up revision if you want to ship a new attempt.
@@ -3793,7 +3801,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     <CheckCircle2 className="h-4 w-4" />
                   </div>
                   <div className="min-w-0 space-y-1">
-                    <div className="text-sm font-medium text-foreground">PR merged</div>
+                    <div className="text-sm font-medium text-foreground">{mergedPRLabel}</div>
                     <p className="text-xs text-foreground">{mergedPRSummary}</p>
                     <p className="text-xs text-muted-foreground">
                       This change has landed. Open a follow-up session if you need to make another revision.


### PR DESCRIPTION
## Summary
Updated the session detail PR status copy so merged/closed states include the GitHub PR number when available (instead of generic “PR merged/closed”). This improves clarity and helps users quickly correlate a session to the exact PR.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Build `mergedPRLabel` and `closedPRLabel` as `PR #<n> merged|closed` when `github_pr_number` exists (fallback remains `PR merged` / `PR closed`).
  - Update the **merge-success toast** to display the numbered merged label (e.g., `PR #42 merged`) when a PR URL/number is available.
  - Ensure the **persistent merged/closed badges/headers** use the same numbered labels for consistency (including the top-right action rail).
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Tighten assertions to expect `PR #42 merged` / `PR #42 closed` instead of unnumbered strings.
  - Verify the merge toast is called with the numbered merged label.

## Test plan
- `npx vitest run src/app/(dashboard)/sessions/[id]/page.test.tsx -t '<relevant tests>'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 3d9ddf3e](https://143.dev/sessions/3d9ddf3e-92f2-4057-b26b-428459d18a71)