### PR TITLE
Share capitalizeWords utility and use it in agent/team settings UI

### DIFF
--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -83,6 +83,42 @@ describe("Agent settings page", () => {
     });
   });
 
+  it("capitalizes status and usage note in the details sheet", async () => {
+    const user = userEvent.setup();
+    installHandlers();
+    server.use(
+      http.get("/api/v1/settings/coding-auths", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "auth-1",
+              org_id: "org-1",
+              priority: 1,
+              agent: "codex",
+              auth_type: "subscription",
+              label: "Team seat A",
+              scope: "organization",
+              provider: "openai_chatgpt",
+              status: "needs_reauth",
+              is_default: true,
+              usage_note: "chatgpt plus",
+              created_at: "2026-04-22T10:00:00Z",
+              updated_at: "2026-04-22T10:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<AgentPage />);
+
+    await user.click((await screen.findAllByRole("button", { name: "Team seat A" }))[0]);
+
+    expect(screen.getByText("Needs Reauth")).toBeInTheDocument();
+    expect(screen.getByText("Chatgpt Plus")).toBeInTheDocument();
+  });
+
   it("shows expanded provider choices in the add auth modal", async () => {
     const user = userEvent.setup();
     installHandlers();

--- a/frontend/src/app/(dashboard)/settings/agent/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.tsx
@@ -31,6 +31,7 @@ import { ClaudeCodeAuthModal } from "@/components/claude-code-auth-modal";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useAutosaveNumericField } from "@/hooks/useAutosaveNumericField";
 import { applyOrgSettingsPatch, coalesceSettingsPatch, type SettingsPatch } from "@/lib/settings-autosave";
+import { capitalizeWords } from "@/lib/utils";
 import {
   MAX_CONCURRENT_RUNS,
   MAX_SESSION_DURATION_MINUTES,
@@ -119,11 +120,6 @@ function defaultLabel(provider: ModalProvider, authType: AddFlowAuthType) {
     default:
       return "Coding auth";
   }
-}
-
-function capitalizeWord(value: string) {
-  if (!value) return value;
-  return value[0].toUpperCase() + value.slice(1);
 }
 
 export default function AgentPage() {
@@ -348,7 +344,7 @@ export default function AgentPage() {
                         </div>
                         <div>
                           <Badge variant="outline" className="text-xs">
-                            {capitalizeWord(row.status.replace(/_/g, " "))}
+                            {capitalizeWords(row.status)}
                           </Badge>
                         </div>
                       </div>
@@ -490,7 +486,7 @@ export default function AgentPage() {
                   <div className="grid gap-3 text-sm">
                     <div className="flex items-center justify-between">
                       <span className="text-muted-foreground">Status</span>
-                      <span className={authStatusTone(selected.status)}>{selected.status.replaceAll("_", " ")}</span>
+                      <span className={authStatusTone(selected.status)}>{capitalizeWords(selected.status)}</span>
                     </div>
                     <div className="flex items-center justify-between">
                       <span className="text-muted-foreground">Priority</span>
@@ -502,7 +498,7 @@ export default function AgentPage() {
                     </div>
                     <div className="flex items-center justify-between gap-4">
                       <span className="text-muted-foreground">Usage note</span>
-                      <span className="text-right">{selected.usage_note ?? "Unavailable"}</span>
+                      <span className="text-right">{selected.usage_note ? capitalizeWords(selected.usage_note) : "Unavailable"}</span>
                     </div>
                   </div>
 
@@ -620,7 +616,7 @@ export default function AgentPage() {
                       </SelectTrigger>
                       <SelectContent>
                         {AVAILABLE_AMP_MODES.map((mode) => (
-                          <SelectItem key={mode} value={mode}>{capitalizeWord(mode)}</SelectItem>
+                          <SelectItem key={mode} value={mode}>{capitalizeWords(mode)}</SelectItem>
                         ))}
                       </SelectContent>
                     </Select>

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -40,6 +40,7 @@ import { PageHeader } from "@/components/page-header";
 import { PageContainer } from "@/components/page-container";
 import { useAuth } from "@/hooks/use-auth";
 import { AuditLogTrigger } from "@/components/audit/audit-log-trigger";
+import { capitalizeWords } from "@/lib/utils";
 import type {
   User,
   InvitationResponse,
@@ -232,7 +233,6 @@ export default function TeamSettingsPage() {
     });
   }
 
-  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
   const inviteDraftLabel = inviteDraft
     ? inviteDraft.mode === "github"
       ? `@${inviteDraft.value}`
@@ -364,7 +364,7 @@ export default function TeamSettingsPage() {
                         <div className="flex items-center">
                         {isSelf || !canManageTeam ? (
                           <Badge variant={roleBadgeVariant(member.role)}>
-                            {capitalize(member.role)}
+                            {capitalizeWords(member.role)}
                           </Badge>
                         ) : (
                           <Select
@@ -380,7 +380,7 @@ export default function TeamSettingsPage() {
                               aria-label={`Role for ${member.name}`}
                             >
                               <SelectValue>
-                                {capitalize(member.role)}
+                                {capitalizeWords(member.role)}
                               </SelectValue>
                             </SelectTrigger>
                             <SelectContent>
@@ -455,7 +455,7 @@ export default function TeamSettingsPage() {
                         )}
                         Invited by {inv.invited_by.name} as{" "}
                         <Badge variant="outline" className="ml-0.5">
-                          {capitalize(inv.role)}
+                          {capitalizeWords(inv.role)}
                         </Badge>
                       </div>
                     </div>
@@ -731,7 +731,7 @@ export default function TeamSettingsPage() {
                 <Label htmlFor="invite-role">Role</Label>
                 <Select value={inviteRole} onValueChange={setInviteRole}>
                   <SelectTrigger id="invite-role" className="h-9 w-full">
-                    <SelectValue>{capitalize(inviteRole)}</SelectValue>
+                    <SelectValue>{capitalizeWords(inviteRole)}</SelectValue>
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="admin">Admin</SelectItem>
@@ -774,11 +774,11 @@ export default function TeamSettingsPage() {
                 <>
                   You&apos;re about to change your own role from{" "}
                   <span className="font-medium">
-                    {capitalize(pendingRoleChange?.member.role ?? "")}
+                    {capitalizeWords(pendingRoleChange?.member.role ?? "")}
                   </span>{" "}
                   to{" "}
                   <span className="font-medium">
-                    {capitalize(pendingRoleChange?.newRole ?? "")}
+                    {capitalizeWords(pendingRoleChange?.newRole ?? "")}
                   </span>
                   . You may lose access to admin features and won&apos;t be able to undo this
                   yourself.
@@ -787,11 +787,11 @@ export default function TeamSettingsPage() {
                 <>
                   Change {pendingRoleChange?.member.name}&apos;s role from{" "}
                   <span className="font-medium">
-                    {capitalize(pendingRoleChange?.member.role ?? "")}
+                    {capitalizeWords(pendingRoleChange?.member.role ?? "")}
                   </span>{" "}
                   to{" "}
                   <span className="font-medium">
-                    {capitalize(pendingRoleChange?.newRole ?? "")}
+                    {capitalizeWords(pendingRoleChange?.newRole ?? "")}
                   </span>
                   ? Their permissions will update immediately.
                 </>

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { formatTimeAgo, isImageURL, fileNameFromURL } from "./utils";
+import { capitalizeWords, formatTimeAgo, isImageURL, fileNameFromURL } from "./utils";
+
+describe("capitalizeWords", () => {
+  it("capitalizes each word in a space-delimited string", () => {
+    expect(capitalizeWords("chatgpt plus")).toBe("Chatgpt Plus");
+  });
+
+  it("replaces underscores with spaces before capitalizing", () => {
+    expect(capitalizeWords("needs_reauth")).toBe("Needs Reauth");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(capitalizeWords("")).toBe("");
+  });
+});
 
 describe("formatTimeAgo", () => {
   it("returns 'just now' for dates less than a minute ago", () => {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -6,6 +6,12 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function capitalizeWords(value: string): string {
+  return value
+    .replaceAll("_", " ")
+    .replace(/\b\w/g, (match) => match.toUpperCase())
+}
+
 export function sessionTitle(session: Session): string {
   if (session.title) return session.title;
   if (session.pm_approach) return session.pm_approach;


### PR DESCRIPTION
## Summary
Moved the word-capitalization logic into a shared frontend utility so it’s reused consistently across settings pages. Updated the Coding Agent details sheet (status and usage note display) and the team settings page to use the shared helper.

## Changes
- **Added shared utility:** `frontend/src/lib/utils.ts`
  - Introduced/relocated `capitalizeWords` for consistent capitalization (e.g., transforming snake_case like `needs_reauth` to `Needs Reauth`).
- **Added tests for utility + UI:**
  - `frontend/src/lib/utils.test.ts`: added/updated coverage for `capitalizeWords`.
  - `frontend/src/app/(dashboard)/settings/agent/page.test.tsx`: added a test asserting the details sheet capitalizes **Status** and **usage note**.
- **Updated agent settings UI:**
  - `frontend/src/app/(dashboard)/settings/agent/page.tsx`
    - Removed the local inline `capitalizeWord` helper.
    - Imported and used `capitalizeWords` for displayed status/usage-related text in the details sheet.
- **De-duplicated team settings rendering:**
  - `frontend/src/app/(dashboard)/settings/team/page.tsx`
    - Replaced the duplicate inline role-capitalization helper with `capitalizeWords`.

## Test plan
- `vitest src/lib/utils.test.ts`
- `vitest src/app/(dashboard)/settings/agent/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session c9eb6653](https://143.dev/sessions/c9eb6653-e391-40b1-8ce6-ceb396f6abc5)