### PR TITLE
[codex] Fix Linear workflow state lookup

### DIFF
--- a/internal/services/linear/client.go
+++ b/internal/services/linear/client.go
@@ -343,7 +343,7 @@ func (c *graphQLClient) WorkflowStateForType(ctx context.Context, teamID string,
 	if teamID == "" || stateType == "" {
 		return nil, errors.New("teamID and stateType are required")
 	}
-	query := `query($teamID: String!) {
+	query := `query($teamID: ID!) {
 		workflowStates(filter: { team: { id: { eq: $teamID } } }, first: 50) {
 			nodes { id name type position }
 		}

--- a/internal/services/linear/client_test.go
+++ b/internal/services/linear/client_test.go
@@ -347,6 +347,7 @@ func TestGraphQLClientWorkflowStateForType(t *testing.T) {
 
 	client := newGraphQLClientForTest(t, func(t *testing.T, req linearGraphQLRequest, w http.ResponseWriter) {
 		require.Contains(t, req.Query, "workflowStates", "WorkflowStateForType should query team workflow states")
+		require.Contains(t, req.Query, "$teamID: ID!", "WorkflowStateForType should declare teamID with Linear's ID scalar")
 		require.Contains(t, string(req.Variables), `"teamID":"team-1"`, "WorkflowStateForType should pass the team id")
 		writeGraphQLResponse(t, w, `{
 			"data": {"workflowStates": {"nodes": [


### PR DESCRIPTION
Fixes Linear workflow-state lookup by declaring the team ID variable as GraphQL `ID!` instead of `String!`. Linear rejects the old query before resolving target states, which kept `linear_milestone:started` jobs retrying and left linked issues in Backlog. Adds a regression assertion that `WorkflowStateForType` uses Linear's expected ID scalar.

Validation: `go test ./internal/services/linear -run TestGraphQLClientWorkflowStateForType -count=1`, `go vet ./...`, `go build ./...`, and `go test ./...`.