### PR TITLE
Unify session tab/thread strip styling and fix active tab visual state

### DIFF
--- a/docs/design/implemented/68-sandbox-agent-tabs-and-threads.md
+++ b/docs/design/implemented/68-sandbox-agent-tabs-and-threads.md
@@ -207,6 +207,12 @@ transcript and composer fill the area below:
 The side details panel can summarize active tabs, but it should not be the
 primary navigation surface for switching between them.
 
+The multi-tab strip should visually match the rest of the session chrome
+instead of introducing a separate tray treatment. Use the shared line-tab
+pattern already used by adjacent session sub-navigation: transparent strip
+background, a clear active state, and the product's primary underline/accent
+language rather than a detached gray pill bar.
+
 ### Add Tab
 
 The v1 `+` action should be deliberately small. A new tab starts as an empty

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -120,8 +120,14 @@ describe("AgentTabStrip", () => {
       />,
     );
 
-    expect(screen.getByRole("tablist", { name: "Agent tabs" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: /main tab/i })).toBeInTheDocument();
+    const tabList = screen.getByRole("tablist", { name: "Agent tabs" });
+    const activeTab = screen.getByRole("tab", { selected: true });
+
+    expect(tabList).toBeInTheDocument();
+    expect(tabList).toHaveAttribute("data-variant", "line");
+    expect(tabList).not.toHaveClass("bg-muted/60");
+    expect(activeTab).toHaveTextContent("Main tab");
+    expect(activeTab).toHaveClass("data-[state=active]:text-primary");
     expect(screen.getByRole("tab", { name: /review/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -255,12 +255,11 @@ export function AgentTabStrip({
         <div className="flex items-center gap-2 min-w-0">
           <Tabs value={activeThreadId} onValueChange={onActiveThreadChange} className="min-w-0 flex-1">
             <TabsList
-              variant={tabs.length > 1 ? "default" : "line"}
+              variant="line"
               size="sm"
               aria-label="Agent tabs"
               className={cn(
-                "h-auto max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden",
-                tabs.length === 1 ? "border-b-0 bg-transparent p-0" : "bg-muted/60 p-1",
+                "h-auto max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden border-b-0 bg-transparent p-0",
               )}
             >
               {tabs.map((thread) => {
@@ -278,7 +277,7 @@ export function AgentTabStrip({
                       <TabsTrigger
                         value={thread.id}
                         className={cn(
-                          "h-8 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs",
+                          "h-8 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:text-primary",
                           tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
                         )}
                       >


### PR DESCRIPTION
## Summary

Updated the session thread strip to use the same line-tab treatment as the surrounding session navigation, so the gray tray is gone and the active tab now reads more clearly through the shared underline/accent pattern plus stronger active text color. The change is in [agent-tab-strip.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx), with a regression test in [agent-tab-strip.test.tsx](/home/sandbox/143/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx). I also added the intent to the design doc at [68-sandbox-agent-tabs-and-threads.md](/home/sandbox/143/docs/design/implemented/68-sandbox-agent-tabs-and-threads.md).

Verification passed:
- `npx vitest run src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

`npm run build` still prints the existing Next.js workspace-root warning about multiple `package-lock.json` files, but the build completed successfully.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 0a59290d](https://143.dev/sessions/0a59290d-c70c-466f-8448-c2547bbba761)