### PR TITLE
[codex] Refresh worker sandbox DNS config

### DIFF
--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -62,6 +62,7 @@ runcmd:
   # Clone repo to get compose files
   - su - deploy -c 'git clone --depth 1 ${REPO_URL} /tmp/143-repo'
   - su - deploy -c 'cp /tmp/143-repo/docker-compose.worker.yml /opt/143/'
+  - su - deploy -c 'cp /tmp/143-repo/Dockerfile.dnsmasq /opt/143/'
   - su - deploy -c 'cp -r /tmp/143-repo/deploy /opt/143/deploy'
   - rm -rf /tmp/143-repo
 
@@ -70,15 +71,20 @@ runcmd:
   - su - deploy -c 'docker pull ghcr.io/assembledhq/143-sandbox:latest'
   - su - deploy -c 'docker pull chromedp/headless-shell:latest'
 
-  # Create the shared sandbox egress network (idempotent). The worker also
-  # self-heals this at startup, but pre-creating it on bootstrap means the
-  # first health check never has to. enable_icc=false blocks one sandbox
-  # from TCP-connecting to another on the same bridge.
-  - su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
+  # Create the shared sandbox egress network with the same pinned subnet used
+  # by provision.sh and deploy.sh. The subnet lets sandbox-dns claim the static
+  # 172.30.0.2 IP that /etc/143/sandbox-resolv.conf points at. enable_icc=false
+  # blocks one sandbox from TCP-connecting to another on the same bridge.
+  - su - deploy -c 'docker network inspect 143-sandbox >/dev/null 2>&1 || docker network create --driver bridge --subnet 172.30.0.0/24 --opt com.docker.network.bridge.enable_icc=false --label managed-by=143 143-sandbox'
 
   # Apply host-level egress rules: block sandbox traffic to cloud metadata
   # and RFC1918. Must run AFTER the network exists (reads its subnet).
   - /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
+
+  # Write the resolv.conf that sandboxes bind-mount at /etc/resolv.conf.
+  # This must stay aligned with the sandbox-dns static IP in the worker compose
+  # file, so use the same shared writer as provision.sh and deploy.sh.
+  - /opt/143/deploy/scripts/sandbox-resolv-conf.sh
 
   # Apply kernel tuning
   - sysctl -p /etc/sysctl.d/99-worker.conf

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -305,7 +305,22 @@ func TestSandboxDNSConfigAlignment(t *testing.T) {
 	provisionText := string(provisionScript)
 	require.Contains(t, provisionText, "--subnet "+sandboxSubnet, "provision.sh should create 143-sandbox with the pinned subnet so sandbox-dns gets a predictable static IP")
 	require.Contains(t, provisionText, `"$EXISTING_SANDBOX_SUBNET" != "`+sandboxSubnet+`"`, "provision.sh should fail loudly when an existing 143-sandbox network has a different subnet — silent reuse breaks the static-IP mapping")
-	require.Contains(t, provisionText, "nameserver "+sandboxDNSIP, "provision.sh should write sandbox-dns's IP into /etc/143/sandbox-resolv.conf")
+
+	// The sandbox resolv.conf writer is the single source of truth for the
+	// nameserver line. provision.sh and deploy.sh both call it so a content
+	// change rolls out via routine deploys instead of requiring a fleet-wide
+	// reprovision maintenance window.
+	resolvScript, err := os.ReadFile("../deploy/scripts/sandbox-resolv-conf.sh")
+	require.NoError(t, err, "test should read the sandbox resolv.conf writer")
+	require.Contains(t, string(resolvScript), "nameserver "+sandboxDNSIP, "sandbox-resolv-conf.sh should write sandbox-dns's IP into /etc/143/sandbox-resolv.conf")
+	require.Contains(t, provisionText, "/opt/143/deploy/scripts/sandbox-resolv-conf.sh", "provision.sh should delegate to the shared writer instead of inlining the file content — keeps provision and deploy byte-aligned")
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read the deploy script")
+	deployText := string(deployScript)
+	require.Contains(t, deployText, "/opt/143/deploy/scripts/sandbox-resolv-conf.sh", "deploy.sh should refresh /etc/143/sandbox-resolv.conf on every worker deploy so a content change doesn't strand existing workers on stale DNS")
+	require.Contains(t, deployText, "run_sandbox_resolv_conf", "deploy.sh should wrap sandbox-resolv-conf.sh in a retryable helper so legacy workers missing the new sudoers grant self-repair")
+	require.Contains(t, deployText, "Retrying sandbox resolv.conf refresh after sudoers repair", "deploy.sh should retry sandbox-resolv-conf.sh after repairing sudoers so the first deploy that introduces the helper succeeds on legacy workers")
+	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/sandbox-resolv-conf.sh", "deploy.sh should invoke sandbox-resolv-conf.sh with sudo -n so missing sudoers fails fast instead of hanging in CI")
 
 	compose, err := os.ReadFile("../docker-compose.worker.yml")
 	require.NoError(t, err, "test should read the worker compose file")
@@ -313,6 +328,14 @@ func TestSandboxDNSConfigAlignment(t *testing.T) {
 	require.Contains(t, composeText, "ipv4_address: "+sandboxDNSIP, "worker compose should pin sandbox-dns to the same static IP that sandbox-resolv.conf points at")
 	require.Contains(t, composeText, "name: 143-sandbox", "worker compose should attach sandbox-dns to the externally-managed 143-sandbox bridge, not a compose-private network")
 	require.Contains(t, composeText, "external: true", "worker compose should declare the sandbox network as external — the bridge is created by provision.sh, not compose")
+
+	cloudInit, err := os.ReadFile("../deploy/cloud-init/worker.yml")
+	require.NoError(t, err, "test should read the worker cloud-init template")
+	cloudInitText := string(cloudInit)
+	require.Contains(t, cloudInitText, "--subnet "+sandboxSubnet, "worker cloud-init should create 143-sandbox with the same pinned subnet as provision.sh so sandbox-dns can claim its static IP")
+	require.Contains(t, cloudInitText, "/opt/143/deploy/scripts/sandbox-resolv-conf.sh", "worker cloud-init should write /etc/143/sandbox-resolv.conf through the shared writer before starting the worker")
+	require.Contains(t, cloudInitText, "cp /tmp/143-repo/Dockerfile.dnsmasq /opt/143/", "worker cloud-init should stage Dockerfile.dnsmasq before docker compose starts so sandbox-dns can build on first boot")
+	require.Contains(t, provisionText, `"$PROJECT_DIR/Dockerfile.dnsmasq" root@"$HOST":/opt/143/`, "provision.sh should stage Dockerfile.dnsmasq before docker compose starts so sandbox-dns can build on fresh worker provisioning")
 
 	dockerfile, err := os.ReadFile("../Dockerfile.dnsmasq")
 	require.NoError(t, err, "test should read the dnsmasq Dockerfile")

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -41,6 +41,7 @@ Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/systemctl restart docker, \
     /usr/bin/apt-get install -y --no-install-recommends iptables-persistent, \
     /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox, \
+    /opt/143/deploy/scripts/sandbox-resolv-conf.sh, \
     /opt/143/deploy/scripts/install-log-rotation.sh *
 
 deploy ALL=(root) NOPASSWD: DEPLOY_CMDS

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -65,6 +65,11 @@ warn_log_rotation_skipped() {
   echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
 }
 
+run_sandbox_resolv_conf() {
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n /opt/143/deploy/scripts/sandbox-resolv-conf.sh"
+}
+
 # --- Refresh secrets from .env.production.enc ---
 if [ -z "${SOPS_AGE_KEY:-}" ]; then
   AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
@@ -213,6 +218,39 @@ if [ "$ROLE" = "worker" ]; then
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "mv /opt/143/deploy/scripts/sandbox-firewall.sh.new /opt/143/deploy/scripts/sandbox-firewall.sh \
      || { rm -f /opt/143/deploy/scripts/sandbox-firewall.sh.new; exit 1; }"
+
+  # Sync the sandbox-resolv.conf writer. This is the single source of truth
+  # for /etc/143/sandbox-resolv.conf, which gets bind-mounted into every
+  # sandbox at /etc/resolv.conf. The earlier chown above normalized
+  # ownership for the whole /opt/143/deploy/scripts dir, so re-using it
+  # here without another chown is fine. Atomic-rename via .new for the
+  # same ETXTBSY-class reasons noted on sandbox-firewall.sh above.
+  scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/sandbox-resolv-conf.sh" \
+    deploy@"$HOST":/opt/143/deploy/scripts/sandbox-resolv-conf.sh.new
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "mv /opt/143/deploy/scripts/sandbox-resolv-conf.sh.new /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
+     && chmod +x /opt/143/deploy/scripts/sandbox-resolv-conf.sh \
+     || { rm -f /opt/143/deploy/scripts/sandbox-resolv-conf.sh.new; exit 1; }"
+
+  # Refresh /etc/143/sandbox-resolv.conf to match the version of the writer
+  # script in this deploy. This is required config, not optional hardening:
+  # stale DNS strands all new sandboxes on preview-infra lookups. Run it from
+  # the local deploy flow so legacy workers missing the new sudoers grant can
+  # use the same no-teardown repair path as other deploy-time sudo helpers.
+  echo "Refreshing sandbox resolv.conf..."
+  if ! run_sandbox_resolv_conf; then
+    echo "sandbox-resolv-conf.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+    if repair_deploy_sudoers; then
+      echo "Retrying sandbox resolv.conf refresh after sudoers repair..."
+      run_sandbox_resolv_conf
+    else
+      echo "ERROR: sandbox-resolv-conf.sh failed and sudoers repair via root SSH did not complete."
+      echo "  Run once from a machine with root SSH access:"
+      echo "    make repair-deploy-sudoers ROLE=$ROLE HOST=$HOST SSH_KEY=$SSH_KEY"
+      echo "  Then re-run the deploy."
+      exit 1
+    fi
+  fi
 
   # Sync Dockerfile.dnsmasq alongside the worker compose file. The
   # sandbox-dns service is built locally on each worker (see

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -288,6 +288,12 @@ if [ "$ROLE" = "app" ] || [ "$ROLE" = "worker" ] || [ "$ROLE" = "logging" ]; the
   # Vector collector is included from the main compose file
   scp "${SCP_OPTS[@]}" "$PROJECT_DIR/docker-compose.vector.yml" root@"$HOST":/opt/143/
 fi
+if [ "$ROLE" = "worker" ]; then
+  # sandbox-dns is built locally from docker-compose.worker.yml on first
+  # `docker compose up`, so fresh worker provisioning must stage its Dockerfile
+  # before Step 5 starts services. Routine deploys refresh this separately.
+  scp "${SCP_OPTS[@]}" "$PROJECT_DIR/Dockerfile.dnsmasq" root@"$HOST":/opt/143/
+fi
 scp "${SCP_OPTS[@]}" -r "$PROJECT_DIR/deploy" root@"$HOST":/opt/143/
 ssh "${SSH_OPTS[@]}" root@"$HOST" "chown -R deploy:deploy /opt/143 && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh"
 
@@ -426,26 +432,12 @@ PULL_APP
       if [ -x /opt/143/deploy/scripts/sandbox-firewall.sh ]; then
         /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox
       fi
-      # Provision /etc/143/sandbox-resolv.conf for sandboxes to bind-mount at
-      # /etc/resolv.conf. Required because user-defined Docker networks inject
-      # 127.0.0.11 (Docker's embedded DNS) into resolv.conf, and gVisor's
-      # netstack can't reach it. HostConfig.DNS doesn't help — it only changes
-      # the upstream the embedded resolver forwards to.
-      #
-      # Points at the sandbox-dns container's static IP (172.30.0.2 on the
-      # 143-sandbox bridge). sandbox-dns is a non-gVisor container that CAN
-      # reach 127.0.0.11 normally and forwards every query there, so preview-
-      # infrastructure container names (preview-db-<handle>, etc.) resolve
-      # via Docker's embedded resolver while public lookups continue to work
-      # through the daemon's upstream forwarders. Bringing up sandbox-dns is
-      # gated by docker-compose.worker.yml depends_on, so by the time the
-      # worker is taking traffic this address is answering.
-      mkdir -p /etc/143
-      cat > /etc/143/sandbox-resolv.conf <<RESOLV
-nameserver 172.30.0.2
-options edns0 trust-ad ndots:0
-RESOLV
-      chmod 644 /etc/143/sandbox-resolv.conf
+      # Provision /etc/143/sandbox-resolv.conf via the shared writer so the
+      # provisioning path and routine deploys agree byte-for-byte on its
+      # contents. See deploy/scripts/sandbox-resolv-conf.sh for the full
+      # rationale (gVisor + Docker embedded DNS + sandbox-dns sidecar). The
+      # file was scp'd to /opt/143 in Step 2 and runs as root here.
+      /opt/143/deploy/scripts/sandbox-resolv-conf.sh
       # Provision /var/run/143/sandbox-auth/ for the per-session GitHub
       # credential sockets. The worker container bind-mounts this path
       # in (see docker-compose.worker.yml); the orchestrator running as

--- a/deploy/scripts/repair-deploy-sudoers.sh
+++ b/deploy/scripts/repair-deploy-sudoers.sh
@@ -45,6 +45,7 @@ Cmnd_Alias DEPLOY_CMDS = \
     /usr/bin/systemctl restart docker, \
     /usr/bin/apt-get install -y --no-install-recommends iptables-persistent, \
     /opt/143/deploy/scripts/sandbox-firewall.sh 143-sandbox, \
+    /opt/143/deploy/scripts/sandbox-resolv-conf.sh, \
     /opt/143/deploy/scripts/install-log-rotation.sh *
 
 deploy ALL=(root) NOPASSWD: DEPLOY_CMDS

--- a/deploy/scripts/sandbox-resolv-conf.sh
+++ b/deploy/scripts/sandbox-resolv-conf.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single source of truth for /etc/143/sandbox-resolv.conf — the resolv.conf
+# bind-mounted into every sandbox at /etc/resolv.conf.
+#
+# Why a sandbox-specific resolv.conf at all: gVisor's netstack can't reach
+# Docker's embedded resolver at 127.0.0.11, so the auto-injected nameserver
+# on user-defined networks doesn't resolve from inside a runsc sandbox. The
+# sandbox-dns sidecar (a non-gVisor container at the static IP below) sits
+# on the same bridge, forwards queries to 127.0.0.11 from a namespace where
+# it's reachable, and answers preview-infrastructure container names like
+# preview-db-<handle> — public DNS continues to flow through dnsmasq's
+# upstream forwarders.
+#
+# Why this lives in its own script: provision.sh runs once per host, but the
+# file's content can change in a routine PR (e.g. PR #815 swapped 1.1.1.1 →
+# 172.30.0.2). If the only writer is provision.sh, every content change
+# requires the operator to schedule a fleet-wide reprovision maintenance
+# window — and a deploy that lands the new code without that step leaves
+# every worker silently misconfigured (sandboxes resolve preview-db names
+# against 1.1.1.1, get NXDOMAIN, and previews fail at the migrator). Both
+# provision.sh and deploy.sh call this script so the file stays current via
+# normal deploys; existing sandboxes pick up the change on their next
+# create because the bind-mount reads the host file at lookup time.
+#
+# Usage: sudo /opt/143/deploy/scripts/sandbox-resolv-conf.sh
+#
+# Atomic write: tee to a sibling .tmp and rename(2). An in-place truncate-
+# then-write would expose sandboxes to an empty resolv.conf for the few
+# microseconds between the truncate and the close — under preview churn
+# during a deploy, that window is enough to fail a sandbox's first DNS
+# lookup. rename(2) swaps the inode atomically.
+#
+# IP must agree with:
+#   - docker-compose.worker.yml      (sandbox-dns ipv4_address)
+#   - deploy/scripts/provision.sh    (subnet --subnet 172.30.0.0/24)
+# TestSandboxDNSConfigAlignment in deploy/deploy_config_test.go locks the
+# alignment in CI; update all three together.
+
+DEST=/etc/143/sandbox-resolv.conf
+TMP="${DEST}.tmp"
+
+mkdir -p "$(dirname "$DEST")"
+
+cat > "$TMP" <<RESOLV
+nameserver 172.30.0.2
+options edns0 trust-ad ndots:0
+RESOLV
+
+chmod 644 "$TMP"
+mv -f "$TMP" "$DEST"


### PR DESCRIPTION
This moves the worker sandbox resolv.conf content into a shared `sandbox-resolv-conf.sh` writer used by provisioning, cloud-init, and routine worker deploys. Worker deploys now sync and run that helper with sudo repair fallback, so existing workers pick up DNS changes without reprovisioning. Fresh worker provisioning/cloud-init also stage `Dockerfile.dnsmasq` and create the pinned sandbox subnet before starting compose. The alignment test now locks the helper, deploy/provision/cloud-init paths, Dockerfile staging, and sandbox DNS IP/subnet together.

Validation: `go test ./deploy`; `bash -n deploy/scripts/deploy.sh deploy/scripts/provision.sh deploy/scripts/bootstrap.sh deploy/scripts/repair-deploy-sudoers.sh deploy/scripts/sandbox-resolv-conf.sh`; `git diff --check`.