### PR TITLE
Document event-driven PR repair in-progress UX for suppressed actions (VIR-84)

### DIFF
--- a/docs/design/future/74-pr-repair-in-progress-ux.md
+++ b/docs/design/future/74-pr-repair-in-progress-ux.md
@@ -1,0 +1,341 @@
+# 74 - PR Repair In-Progress UX
+
+> **Status:** Proposed | **Last reviewed:** 2026-05-07
+
+## Goal
+
+When an operator clicks `Fix tests` or `Resolve conflicts`, the PR health row should stop presenting that same action as available while the repair session for the current PR state is still running.
+
+This is not just a button-loading problem. The product needs a durable PR-level notion of "a repair action is already in progress for this exact snapshot" so the UI remains correct after:
+
+- the initial mutation completes
+- a page refresh
+- navigation into or out of the repair session
+- a second viewer opening the same PR
+
+## Problem
+
+Today the UI only holds a short-lived `pendingAction` value in local mutation state. That covers the round-trip while the repair API call is in flight, but not the steady state afterward.
+
+The backend already persists repair runs in `pull_request_repair_runs` and already dedupes repeated launches through `reused_in_flight`. The gap is that `GET /api/v1/pull-requests/:id/health` does not expose that durable in-progress state back to the client.
+
+Result: the UI briefly shows `Opening repair session…`, then returns to a clickable `Fix tests` or `Resolve conflicts` button even though a repair session is already running.
+
+## Product behavior
+
+### Core rule
+
+For the PR's current `health_version`, if there is a non-terminal active repair run for an action, that action must not render as clickable in the PR health row.
+
+### Desired steady-state UX
+
+If a `fix_tests` repair run is active for the current `health_version`:
+
+- do not render the `Fix tests` button
+- render a non-clickable status surface: `Fix tests running`
+- if the active session is not the session currently being viewed, render `Open repair session`
+
+If a `resolve_conflicts` repair run is active for the current `health_version`:
+
+- do not render `Resolve conflicts`
+- do not render `Fix tests`
+- render a non-clickable status surface: `Resolve conflicts running`
+- if the active session is not the session currently being viewed, render `Open repair session`
+
+If there are no active repair runs for the current `health_version`:
+
+- render the normal eligible actions based on PR health (`can_fix_tests`, `can_resolve_conflicts`, `can_merge`)
+
+If the PR advances to a newer `health_version`:
+
+- older active repair runs no longer suppress current actions
+- the existing stale-context signal (`newer repair context available`) remains responsible for telling the user an older repair session exists against outdated PR state
+
+### Why `resolve_conflicts` suppresses both repair CTAs
+
+Conflict resolution is the more fundamental repair action. The existing PR-health design already prioritizes `Resolve conflicts` over `Fix tests`, because resolving conflicts can invalidate the prior CI result. Once a conflict-repair session is running, keeping `Fix tests` visible for the same PR state creates misleading parallelism.
+
+### Merge behavior
+
+While any repair run is active for the current `health_version`, the PR health row should not offer `Merge`.
+
+The goal is to keep the row internally consistent: a PR should not simultaneously present "repair is already running for this state" and "merge now" as peer actions.
+
+## State model
+
+The source of truth should stay on the PR-health API response.
+
+Suggested response shape:
+
+```json
+{
+  "pull_request_id": "uuid",
+  "health_version": 12,
+  "active_repairs": [
+    {
+      "action_type": "fix_tests",
+      "session_id": "uuid",
+      "session_status": "running",
+      "health_version": 12
+    }
+  ]
+}
+```
+
+Suggested server model:
+
+```go
+type PullRequestActiveRepair struct {
+    ActionType    PullRequestRepairActionType `json:"action_type"`
+    SessionID     uuid.UUID                   `json:"session_id"`
+    SessionStatus string                      `json:"session_status"`
+    HealthVersion int64                       `json:"health_version"`
+}
+```
+
+Suggested response field:
+
+```go
+ActiveRepairs []PullRequestActiveRepair `json:"active_repairs,omitempty"`
+```
+
+## Request and render flow
+
+```text
+User clicks Fix tests
+        |
+        v
+POST /pull-requests/:id/repair/fix-tests
+        |
+        +--> backend reuses existing active run OR creates a new one
+        |
+        v
+frontend shows optimistic "Opening repair session…"
+        |
+        v
+frontend refetches GET /pull-requests/:id/health
+        |
+        v
+response includes active_repairs for current health_version
+        |
+        v
+banner replaces CTA with "Fix tests running" + optional "Open repair session"
+```
+
+This is the key handoff:
+
+- mutation-local loading handles the click itself
+- API-backed `active_repairs` handles the steady state afterward
+
+## How the UI leaves the in-progress state
+
+The preferred path is event-driven, not client polling.
+
+When the repair session pushes code and CI reruns, the PR health row should update through the existing GitHub-sync pipeline:
+
+```text
+repair session pushes changes to PR branch
+        |
+        v
+GitHub emits pull_request.synchronize and later check_run / check_suite events
+        |
+        v
+143 enqueues sync_pull_request_state for that PR
+        |
+        v
+backend writes the new health snapshot and recomputes active_repairs
+        |
+        v
+backend publishes pull_request.updated over the org-scoped SSE stream
+        |
+        v
+open clients invalidate/refetch that PR health query
+        |
+        v
+banner exits "Fix tests running" when the current health response no longer has
+the matching active repair or no longer needs repair for that health_version
+```
+
+This keeps the steady-state client cheap:
+
+- no tight polling loop from the browser
+- no repeated DB reads just to discover nothing changed
+- updates arrive when GitHub tells us the PR actually changed
+
+We should still keep the existing backend reconciliation job for missed webhooks or delivery gaps, but that is a low-frequency safety net, not the primary UX path.
+
+## Backend specification
+
+### Data source
+
+Use `pull_request_repair_runs` as the durable record of launched PR repair work.
+
+The backend should treat a repair run as active for banner purposes only when all of the following are true:
+
+1. `pull_request_id` matches the current PR
+2. `health_version` matches the current PR health response
+3. `active = true`
+4. the linked session is non-terminal
+
+Terminal session statuses should not suppress the CTA. The banner should return to normal eligibility as soon as the repair session is no longer running.
+
+### Query shape
+
+Add a store method that lists active repair runs for a PR and health version. The method should be org-scoped and return all active rows, not just one action type.
+
+Suggested shape:
+
+```go
+func (s *PullRequestStore) ListActiveRepairRuns(
+    ctx context.Context,
+    orgID uuid.UUID,
+    pullRequestID uuid.UUID,
+    healthVersion int64,
+) ([]models.PullRequestRepairRun, error)
+```
+
+`buildPullRequestHealthResponse` should then:
+
+1. build the normal PR health response
+2. load active repair runs for `pr.ID` and the response `HealthVersion`
+3. load each linked session status
+4. discard runs whose sessions are terminal
+5. populate `ActiveRepairs`
+6. derive `CanMerge` after active repairs are known, so merge is suppressed when needed
+
+### Event-driven refresh after CI changes
+
+We should not add a new frontend polling loop just to clear `Fix tests running`.
+
+Instead, after a repair session changes the PR branch:
+
+1. GitHub webhook events (`pull_request.synchronize`, `check_run`, and `check_suite`) enqueue the normal PR-health sync job
+2. the sync job writes the latest health snapshot and recomputes `ActiveRepairs`
+3. the backend emits the normalized `pull_request.updated` event on the existing org-scoped SSE channel
+4. subscribed clients refetch only the affected PR health query
+
+That means the "tests finished" transition is driven by the same event pipeline that already updates mergeability, failing checks, and repair eligibility.
+
+`ActiveRepairs` should be recomputed from the latest DB state on every PR-health sync write. In practice this means:
+
+- when the linked session becomes terminal, the next health response drops the active repair
+- when a new push creates a newer `health_version`, older repair runs stop suppressing current actions
+- when checks turn green, the banner naturally falls back from `Fix tests running` to the next healthy or mergeable state
+
+### Session terminality
+
+Use the same terminal-session rules already relied on by repair-launch dedupe logic. This should not invent a second definition of "in progress."
+
+### Obsolete runs
+
+Keep `ObsoleteActiveRepairSessions` separate from `ActiveRepairs`.
+
+They answer different questions:
+
+- `ActiveRepairs`: is a repair currently running for this exact PR state?
+- `ObsoleteActiveRepairSessions`: is there an older repair session that no longer matches the current PR state?
+
+## Frontend specification
+
+### API types
+
+Add `active_repairs` to `PullRequestHealthResponse` in `frontend/src/lib/types.ts`.
+
+### Banner rendering
+
+`PRHealthBanner` should derive display state in this order:
+
+1. transient mutation state (`pendingAction`)
+2. durable API state (`active_repairs`)
+3. base eligibility (`can_fix_tests`, `can_resolve_conflicts`, `can_merge`)
+
+That ordering prevents flicker:
+
+- the click immediately shows progress
+- the subsequent health refetch preserves the non-clickable state
+- the CTA only returns if the repair truly ended or the PR state changed
+
+### Transport
+
+The session detail page should stay subscribed to the existing org-scoped SSE stream for PR updates.
+
+On a matching `pull_request.updated` event for the currently displayed PR:
+
+- invalidate/refetch `["pull-request", pullRequestId, "health"]`
+- do not start a dedicated timer-based polling loop for this feature
+
+This keeps the browser work proportional to actual PR events rather than wall-clock time.
+
+### UI structure
+
+Recommended action-row rendering:
+
+```text
+[Fix tests running] [Open repair session]
+```
+
+or
+
+```text
+[Resolve conflicts running] [Open repair session]
+```
+
+The first element is status, not a button. It can be a muted badge-like surface or disabled button styling, but it must not be clickable and must read as "work already started."
+
+### Same-session behavior
+
+If the active repair session matches the currently viewed session:
+
+- do not render `Open repair session`
+- keep the in-progress status text only
+
+If the active repair session differs:
+
+- render `Open repair session`
+- route to `/sessions/:id`
+
+## Copy
+
+Preferred visible labels:
+
+- `Fix tests running`
+- `Resolve conflicts running`
+- `Open repair session`
+
+Optional supporting copy when space permits:
+
+- `A Fix tests session is already running for this PR state.`
+- `A Resolve conflicts session is already running for this PR state.`
+
+## Testing
+
+### Backend
+
+Add table-driven tests for:
+
+- current-version active `fix_tests` run is returned in `active_repairs`
+- current-version active `resolve_conflicts` run is returned in `active_repairs`
+- terminal linked sessions are excluded
+- active runs for older health versions are excluded
+- merge is suppressed when `active_repairs` is non-empty
+- webhook-driven health recomputation clears `active_repairs` after the linked session is terminal or the PR advances to a newer health version
+
+### Frontend
+
+Add tests for:
+
+- `Fix tests` button is replaced by `Fix tests running`
+- `Resolve conflicts` active state suppresses both repair CTAs
+- matching `pull_request.updated` SSE events trigger the PR health refetch instead of relying on timer polling
+- `Open repair session` appears only when the active session differs from the current session
+- optimistic `Opening repair session…` transitions to durable in-progress state after the health refetch
+
+## Rollout
+
+This should ship as a focused PR-health enhancement:
+
+- no new page
+- no new operator workflow
+- no client-only persistence layer
+
+The implementation is complete when the PR health row reflects the same in-progress truth the backend already uses to dedupe repair launches.

--- a/docs/design/implemented/74-pr-repair-in-progress-ux.md
+++ b/docs/design/implemented/74-pr-repair-in-progress-ux.md
@@ -1,6 +1,6 @@
 # 74 - PR Repair In-Progress UX
 
-> **Status:** Proposed | **Last reviewed:** 2026-05-07
+> **Status:** Implemented | **Last reviewed:** 2026-05-07
 
 ## Goal
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -1,6 +1,6 @@
 # Design: 143.dev
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-05-06
+> **Status:** Partially Implemented | **Last reviewed:** 2026-05-07
 
 [143.dev](http://143.dev) is an open-source platform that turns customer pain and production errors into safe, validated code fixes that ship automatically.
 
@@ -27,6 +27,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 - Manual session creation should accept attachments-only starts. If the user uploads screenshots, photos, or files without typing prompt text, the create action stays enabled, the initial turn persists those attachments, and the session can begin with a placeholder title until the agent or user adds more text.
 - Settings pages should not rely on desktop-only table layouts on phones. Shared headers should give actions a full-width mobile lane, and dense settings lists should collapse into stacked rows/cards with inline labels instead of forcing horizontal scanning.
 - Automation run history should use a clear execution-row layout: strong status-first rows, a consistent metadata rail, room for result or failure snippets, and collapsible quiet-run groupings for low-signal streaks. Scope this to `/automations/:id` first and leave `/sessions` unchanged while the pattern is validated. Wireframes: [future/72-execution-list-wireframes.md](future/72-execution-list-wireframes.md).
+- PR health repair actions should expose durable in-progress state from the server rather than relying on mutation-local button spinners. For the current PR `health_version`, the health response carries `active_repairs`, the session detail banner suppresses conflicting repair/merge CTAs, and operators can jump into the active repair session after refreshes, navigation, or multi-viewer handoff. Detailed design: [implemented/74-pr-repair-in-progress-ux.md](implemented/74-pr-repair-in-progress-ux.md).
 
 ## Autopilot workspace UX
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2222,6 +2222,109 @@ describe('SessionDetailPage', () => {
     });
   });
 
+  it('keeps the repair CTA suppressed while navigating to a different repair session', async () => {
+    server.use(
+      http.get('/api/v1/pull-requests/:id/health', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockPRHealth,
+            failing_test_count: 1,
+            can_fix_tests: true,
+            needs_agent_action: true,
+            summary: 'PR #42 has 1 failing test job.',
+            active_repairs: [],
+          },
+        } satisfies SingleResponse<typeof mockPRHealth>);
+      }),
+      http.post('/api/v1/pull-requests/:id/repair/fix-tests', () => {
+        return HttpResponse.json({
+          data: {
+            session_id: 'session-revision-123',
+            mode: 'revision',
+            reused_in_flight: false,
+            head_sha: 'head-sha',
+            base_sha: 'base-sha',
+            health_version: 1,
+            repair_action_type: 'fix_tests',
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Fix tests' }));
+
+    await waitFor(() => {
+      expect(routerPush).toHaveBeenCalledWith('/sessions/session-revision-123');
+    });
+    expect(screen.getByRole('button', { name: 'Opening repair session…' })).toBeDisabled();
+    expect(screen.queryByRole('button', { name: 'Fix tests' })).not.toBeInTheDocument();
+  });
+
+  it('replaces Fix tests with a durable running state after the repair launch succeeds', async () => {
+    let healthRequestCount = 0;
+    server.use(
+      http.get('/api/v1/pull-requests/:id/health', () => {
+        healthRequestCount += 1;
+        if (healthRequestCount === 1) {
+          return HttpResponse.json({
+            data: {
+              ...mockPRHealth,
+              failing_test_count: 1,
+              can_fix_tests: true,
+              needs_agent_action: true,
+              summary: 'PR #42 has 1 failing test job.',
+              active_repairs: [],
+            },
+          } satisfies SingleResponse<typeof mockPRHealth>);
+        }
+
+        return HttpResponse.json({
+          data: {
+            ...mockPRHealth,
+            failing_test_count: 1,
+            can_fix_tests: false,
+            can_merge: false,
+            needs_agent_action: true,
+            summary: 'PR #42 has 1 failing test job.',
+            active_repairs: [{
+              action_type: 'fix_tests' as const,
+              session_id: 'session-repair-123',
+              session_status: 'running',
+              health_version: 1,
+            }],
+          },
+        } satisfies SingleResponse<typeof mockPRHealth>);
+      }),
+      http.post('/api/v1/pull-requests/:id/repair/fix-tests', () => {
+        return HttpResponse.json({
+          data: {
+            session_id: 'session-abcdef12-3456-7890',
+            mode: 'existing',
+            reused_in_flight: false,
+            head_sha: 'head-sha',
+            base_sha: 'base-sha',
+            health_version: 1,
+            repair_action_type: 'fix_tests',
+          },
+        });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Fix tests' }));
+
+    expect(await screen.findByText('Fix tests running')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Fix tests' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: 'Open repair session' })).toBeInTheDocument();
+  });
+
   it('shows failure next steps and retry button', async () => {
     const failedSession: Session = {
       ...mockSessions[1],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2715,9 +2715,8 @@ export function SessionDetailContent({ id }: { id: string }) {
       setRepairActionError(null);
       setPendingPRAction(action);
     },
-    onSuccess: (response) => {
-      setPendingPRAction(null);
-      void queryClient.invalidateQueries({ queryKey: ["pull-request", pullRequestId, "health"] });
+    onSuccess: async (response) => {
+      const repairHealthQueryKey = ["pull-request", pullRequestId, "health"];
       void queryClient.invalidateQueries({ queryKey: ["session", id] });
       void queryClient.invalidateQueries({ queryKey: ["session", id, "timeline"] });
       void queryClient.invalidateQueries({ queryKey: ["session", id, "pr"] });
@@ -2725,6 +2724,11 @@ export function SessionDetailContent({ id }: { id: string }) {
       if (response.data.session_id !== id) {
         router.push(`/sessions/${response.data.session_id}`);
         return;
+      }
+      try {
+        await queryClient.refetchQueries({ queryKey: repairHealthQueryKey, type: "active" });
+      } finally {
+        setPendingPRAction(null);
       }
       // Same-session response: without explicit feedback the click looks
       // dead. Reused-in-flight is the common case (repair already running on
@@ -3974,12 +3978,14 @@ export function SessionDetailContent({ id }: { id: string }) {
             prHealth ? (
               <PRHealthBanner
                 health={prHealth}
+                currentSessionId={id}
                 pendingAction={pendingPRAction}
                 repairError={repairActionError}
                 mergeAuthRequired={ghBlocked}
                 onFixTests={() => startRepairMutation.mutate("fix_tests")}
                 onResolveConflicts={() => startRepairMutation.mutate("resolve_conflicts")}
                 onMerge={handleMergeAction}
+                onOpenRepairSession={(sessionId) => router.push(`/sessions/${sessionId}`)}
                 pushChanges={showPushAction ? {
                   label: pushActionLabel,
                   disabled: pushActionDisabled,

--- a/frontend/src/components/pr-health-banner-sync-copy.test.tsx
+++ b/frontend/src/components/pr-health-banner-sync-copy.test.tsx
@@ -31,6 +31,7 @@ const health: PullRequestHealthResponse = {
   conflict_detail_available: false,
   failing_test_detail_available: false,
   obsolete_active_repair_sessions: false,
+  active_repairs: [],
 };
 
 describe("PRHealthBanner sync copy", () => {

--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -31,6 +31,7 @@ const baseHealth: PullRequestHealthResponse = {
   conflict_detail_available: false,
   failing_test_detail_available: false,
   obsolete_active_repair_sessions: false,
+  active_repairs: [],
 };
 
 describe("PRHealthBanner", () => {
@@ -394,5 +395,100 @@ describe("PRHealthBanner", () => {
     const button = screen.getByRole("button", { name: /Pushing/ });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute("title", "Pushing changes to the PR branch");
+  });
+
+  it("replaces Fix tests with a running state and open-session action for an active fix-tests repair on another session", () => {
+    const onOpenRepairSession = vi.fn();
+
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          can_fix_tests: true,
+          can_merge: true,
+          active_repairs: [{
+            action_type: "fix_tests",
+            session_id: "session-repair-123",
+            session_status: "running",
+            health_version: 2,
+          }],
+        }}
+        currentSessionId="session-current"
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onOpenRepairSession={onOpenRepairSession}
+      />,
+    );
+
+    expect(screen.getByText("Fix tests running")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Fix tests" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Merge$/ })).toBeNull();
+    expect(screen.getByRole("button", { name: "Open repair session" })).toBeInTheDocument();
+  });
+
+  it("suppresses both repair CTAs when resolve conflicts is already running for the current PR state", () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          can_resolve_conflicts: true,
+          can_fix_tests: true,
+          active_repairs: [{
+            action_type: "resolve_conflicts",
+            session_id: "session-current",
+            session_status: "running",
+            health_version: 2,
+          }],
+        }}
+        currentSessionId="session-current"
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onOpenRepairSession={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Resolve conflicts running")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Resolve conflicts" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Fix tests" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Merge$/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Open repair session" })).toBeNull();
+    expect(screen.queryByText("Resolve conflicts first. CI may need to rerun afterward.")).toBeNull();
+  });
+
+  it("treats an active repair as non-healthy even when the repair action booleans are suppressed", () => {
+    const { container } = renderWithProviders(
+      <PRHealthBanner
+        health={{
+          ...baseHealth,
+          needs_agent_action: true,
+          summary: "PR #42 has an active repair session.",
+          active_repairs: [{
+            action_type: "fix_tests",
+            session_id: "session-current",
+            session_status: "running",
+            health_version: 2,
+          }],
+        }}
+        currentSessionId="session-current"
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        onOpenRepairSession={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector("svg.lucide-git-pull-request")).toBeInTheDocument();
+    expect(container.querySelector("svg.lucide-check-circle-2")).toBeNull();
   });
 });

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -32,32 +32,45 @@ export type PushChangesAction = {
 
 type PRHealthBannerProps = {
   health: PullRequestHealthResponse;
+  currentSessionId?: string;
   pendingAction: PRBannerAction;
   repairError?: string | null;
   mergeAuthRequired?: boolean;
   onFixTests: () => void;
   onResolveConflicts: () => void;
   onMerge: () => void;
+  onOpenRepairSession?: (sessionId: string) => void;
   pushChanges?: PushChangesAction;
 };
 
 export function PRHealthBanner({
   health,
+  currentSessionId,
   pendingAction,
   repairError,
   mergeAuthRequired = false,
   onFixTests,
   onResolveConflicts,
   onMerge,
+  onOpenRepairSession,
   pushChanges,
 }: PRHealthBannerProps) {
-  const isHealthy = !health.can_fix_tests && !health.can_resolve_conflicts;
+  const activeRepairState = deriveActiveRepairState(health.active_repairs, currentSessionId);
+  const isHealthy = activeRepairState.label === null && !health.can_fix_tests && !health.can_resolve_conflicts;
   const orderedChecks = [...(health.checks ?? [])]
     .map((check) => ({ ...check, status: normalizeCheckStatus(check.status) }))
     .sort((a, b) => statusRank(a.status) - statusRank(b.status) || a.name.localeCompare(b.name));
-  const canShowMergeButton = health.can_merge && checksAllowMerge(health.checks_confirmed, orderedChecks);
+  const canShowResolveConflictsButton = health.can_resolve_conflicts && !activeRepairState.suppressResolveConflicts;
+  const canShowFixTestsButton = health.can_fix_tests && !activeRepairState.suppressFixTests;
+  const canShowMergeButton =
+    !activeRepairState.suppressMerge && health.can_merge && checksAllowMerge(health.checks_confirmed, orderedChecks);
   const hasActionableButton =
-    health.can_resolve_conflicts || health.can_fix_tests || canShowMergeButton || !!pushChanges;
+    !!activeRepairState.label ||
+    canShowResolveConflictsButton ||
+    canShowFixTestsButton ||
+    canShowMergeButton ||
+    !!pushChanges ||
+    !!activeRepairState.openSessionID;
   const failedChecks = orderedChecks.filter((check) => check.status === "failed").length;
   const failedSummaryLabel = orderedChecks.length > 0
     ? `${failedChecks}/${orderedChecks.length} failed`
@@ -151,8 +164,24 @@ export function PRHealthBanner({
 
             {hasActionableButton && (
               <div className="space-y-2">
+                {activeRepairState.label && pendingAction === null && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Badge variant="secondary" className="text-xs">
+                      {activeRepairState.label}
+                    </Badge>
+                    {activeRepairState.openSessionID && onOpenRepairSession && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onOpenRepairSession(activeRepairState.openSessionID!)}
+                      >
+                        Open repair session
+                      </Button>
+                    )}
+                  </div>
+                )}
                 <div className="flex flex-wrap gap-2">
-                  {health.can_resolve_conflicts && (
+                  {canShowResolveConflictsButton && (
                     <Button
                       size="sm"
                       variant="outline"
@@ -167,7 +196,7 @@ export function PRHealthBanner({
                       {pendingAction === "resolve_conflicts" ? "Opening repair session…" : "Resolve conflicts"}
                     </Button>
                   )}
-                  {health.can_fix_tests && (
+                  {canShowFixTestsButton && (
                     <Button
                       size="sm"
                       variant="outline"
@@ -216,7 +245,7 @@ export function PRHealthBanner({
                     </Button>
                   )}
                 </div>
-                {health.can_resolve_conflicts && health.can_fix_tests && (
+                {canShowResolveConflictsButton && canShowFixTestsButton && (
                   <p className="text-xs text-muted-foreground">
                     Resolve conflicts first. CI may need to rerun afterward.
                   </p>
@@ -233,6 +262,34 @@ export function PRHealthBanner({
       </CardContent>
     </Card>
   );
+}
+
+function deriveActiveRepairState(
+  activeRepairs: PullRequestHealthResponse["active_repairs"],
+  currentSessionId?: string,
+): {
+  label: string | null;
+  openSessionID: string | null;
+  suppressFixTests: boolean;
+  suppressResolveConflicts: boolean;
+  suppressMerge: boolean;
+} {
+  const repairs = activeRepairs ?? [];
+  const resolveConflicts = repairs.find((repair) => repair.action_type === "resolve_conflicts");
+  const fixTests = repairs.find((repair) => repair.action_type === "fix_tests");
+  const dominantRepair = resolveConflicts ?? fixTests ?? null;
+
+  return {
+    label: dominantRepair
+      ? dominantRepair.action_type === "resolve_conflicts"
+        ? "Resolve conflicts running"
+        : "Fix tests running"
+      : null,
+    openSessionID: dominantRepair && dominantRepair.session_id !== currentSessionId ? dominantRepair.session_id : null,
+    suppressFixTests: !!fixTests || !!resolveConflicts,
+    suppressResolveConflicts: !!resolveConflicts,
+    suppressMerge: repairs.length > 0,
+  };
 }
 
 function statusRank(status: PullRequestCheckStatus) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -411,6 +411,13 @@ export interface PullRequestCheckSummary {
   summary?: string;
 }
 
+export interface PullRequestActiveRepair {
+  action_type: "fix_tests" | "resolve_conflicts";
+  session_id: string;
+  session_status: string;
+  health_version: number;
+}
+
 export interface PullRequestHealthResponse {
   pull_request_id: string;
   pull_request_number: number;
@@ -431,6 +438,7 @@ export interface PullRequestHealthResponse {
   can_resolve_conflicts: boolean;
   can_fix_tests: boolean;
   can_merge: boolean;
+  active_repairs?: PullRequestActiveRepair[];
   enrichment_status: "not_requested" | "pending" | "ready" | "failed" | "stale";
   enrichment_requested: boolean;
   enrichment_ready: boolean;

--- a/frontend/src/test/mocks/handlers.ts
+++ b/frontend/src/test/mocks/handlers.ts
@@ -139,6 +139,7 @@ export const mockPRHealth: PullRequestHealthResponse = {
   can_resolve_conflicts: false,
   can_fix_tests: false,
   can_merge: false,
+  active_repairs: [],
   enrichment_status: 'ready',
   enrichment_requested: false,
   enrichment_ready: true,

--- a/internal/db/pull_request_health.go
+++ b/internal/db/pull_request_health.go
@@ -324,6 +324,27 @@ func (s *PullRequestStore) GetActiveRepairRun(ctx context.Context, orgID, pullRe
 	return pgx.CollectOneRow(rows, pgx.RowToStructByName[models.PullRequestRepairRun])
 }
 
+func (s *PullRequestStore) ListActiveRepairRuns(ctx context.Context, orgID, pullRequestID uuid.UUID, healthVersion int64) ([]models.PullRequestRepairRun, error) {
+	query := `
+		SELECT ` + prRepairRunSelectColumns + `
+		FROM pull_request_repair_runs
+		WHERE org_id = @org_id
+		  AND pull_request_id = @pull_request_id
+		  AND health_version = @health_version
+		  AND active = true
+		ORDER BY created_at DESC`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"org_id":          orgID,
+		"pull_request_id": pullRequestID,
+		"health_version":  healthVersion,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list active pull request repair runs: %w", err)
+	}
+	return pgx.CollectRows(rows, pgx.RowToStructByName[models.PullRequestRepairRun])
+}
+
 func (s *PullRequestStore) CreateRepairRun(ctx context.Context, run *models.PullRequestRepairRun) error {
 	query := `
 		INSERT INTO pull_request_repair_runs (

--- a/internal/db/pull_request_health_test.go
+++ b/internal/db/pull_request_health_test.go
@@ -297,6 +297,38 @@ func TestPullRequestStore_UpdateHealthEnrichmentAndRepairRuns(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all enrichment and repair run expectations should be met")
 }
 
+func TestPullRequestStore_ListActiveRepairRuns(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewPullRequestStore(mock)
+	orgID := uuid.New()
+	prID := uuid.New()
+	sessionA := uuid.New()
+	sessionB := uuid.New()
+	now := time.Now().UTC()
+
+	mock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":          orgID,
+			"pull_request_id": prID,
+			"health_version":  int64(9),
+		}).
+		WillReturnRows(pgxmock.NewRows(prRepairRunColumns).
+			AddRow(uuid.New(), orgID, prID, sessionA, models.PullRequestRepairActionTypeFixTests, int64(9), true, nil, now, now).
+			AddRow(uuid.New(), orgID, prID, sessionB, models.PullRequestRepairActionTypeResolveConflicts, int64(9), true, nil, now, now))
+
+	runs, err := store.ListActiveRepairRuns(context.Background(), orgID, prID, 9)
+	require.NoError(t, err, "ListActiveRepairRuns should return active repair runs for the current health version")
+	require.Len(t, runs, 2, "ListActiveRepairRuns should return every active repair run for the pull request health version")
+	require.Equal(t, sessionA, runs[0].SessionID, "ListActiveRepairRuns should decode the first repair session")
+	require.Equal(t, sessionB, runs[1].SessionID, "ListActiveRepairRuns should decode the second repair session")
+	require.NoError(t, mock.ExpectationsWereMet(), "all active repair run expectations should be met")
+}
+
 func TestPullRequestStore_beginTxRequiresTxStarter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/models/pr_health.go
+++ b/internal/models/pr_health.go
@@ -180,12 +180,20 @@ type PullRequestHealthResponse struct {
 	CanResolveConflicts          bool                              `json:"can_resolve_conflicts"`
 	CanFixTests                  bool                              `json:"can_fix_tests"`
 	CanMerge                     bool                              `json:"can_merge"`
+	ActiveRepairs                []PullRequestActiveRepair         `json:"active_repairs,omitempty"`
 	EnrichmentStatus             PullRequestHealthEnrichmentStatus `json:"enrichment_status"`
 	EnrichmentRequested          bool                              `json:"enrichment_requested"`
 	EnrichmentReady              bool                              `json:"enrichment_ready"`
 	ConflictDetailAvailable      bool                              `json:"conflict_detail_available"`
 	FailingTestDetailAvailable   bool                              `json:"failing_test_detail_available"`
 	ObsoleteActiveRepairSessions bool                              `json:"obsolete_active_repair_sessions,omitempty"`
+}
+
+type PullRequestActiveRepair struct {
+	ActionType    PullRequestRepairActionType `json:"action_type"`
+	SessionID     uuid.UUID                   `json:"session_id"`
+	SessionStatus string                      `json:"session_status"`
+	HealthVersion int64                       `json:"health_version"`
 }
 
 type PullRequestRepairResponse struct {

--- a/internal/services/github/pr_health_service.go
+++ b/internal/services/github/pr_health_service.go
@@ -188,8 +188,64 @@ func (s *PRService) buildPullRequestHealthResponse(ctx context.Context, pr model
 		return nil, err
 	}
 
+	if err := s.populateActiveRepairs(ctx, pr, resp); err != nil {
+		return nil, err
+	}
 	resp.Summary = buildPRHealthSummaryText(*resp)
 	return resp, nil
+}
+
+func (s *PRService) populateActiveRepairs(ctx context.Context, pr models.PullRequest, resp *models.PullRequestHealthResponse) error {
+	if resp.HealthVersion == 0 || s.sessions == nil {
+		return nil
+	}
+
+	runs, err := s.pullRequests.ListActiveRepairRuns(ctx, pr.OrgID, pr.ID, resp.HealthVersion)
+	if err != nil {
+		return err
+	}
+	if len(runs) == 0 {
+		return nil
+	}
+
+	sessionIDs := make([]uuid.UUID, 0, len(runs))
+	seenSessionIDs := make(map[uuid.UUID]struct{}, len(runs))
+	for _, run := range runs {
+		if _, ok := seenSessionIDs[run.SessionID]; ok {
+			continue
+		}
+		seenSessionIDs[run.SessionID] = struct{}{}
+		sessionIDs = append(sessionIDs, run.SessionID)
+	}
+
+	sessions, err := s.sessions.ListByIDs(ctx, pr.OrgID, sessionIDs)
+	if err != nil {
+		return fmt.Errorf("list repair sessions for pull request health: %w", err)
+	}
+	sessionsByID := make(map[uuid.UUID]models.Session, len(sessions))
+	for _, session := range sessions {
+		sessionsByID[session.ID] = session
+	}
+
+	activeRepairs := make([]models.PullRequestActiveRepair, 0, len(runs))
+	for _, run := range runs {
+		session, ok := sessionsByID[run.SessionID]
+		if !ok || isSessionTerminalStatus(session.Status) {
+			continue
+		}
+		activeRepairs = append(activeRepairs, models.PullRequestActiveRepair{
+			ActionType:    run.ActionType,
+			SessionID:     run.SessionID,
+			SessionStatus: session.Status,
+			HealthVersion: run.HealthVersion,
+		})
+	}
+
+	if len(activeRepairs) > 0 {
+		resp.ActiveRepairs = activeRepairs
+		resp.CanMerge = false
+	}
+	return nil
 }
 
 func derivePullRequestRepairActions(resp *models.PullRequestHealthResponse) {

--- a/internal/services/github/pr_health_service_test.go
+++ b/internal/services/github/pr_health_service_test.go
@@ -138,6 +138,116 @@ func TestPRServiceBuildRepairRevisionContextUsesCurrentHealthSummary(t *testing.
 	require.Equal(t, "base-new", revisionContext.RepairContext.BaseSHA, "repair context should preserve the selected base SHA")
 }
 
+func TestPRServiceBuildPullRequestHealthResponseIncludesActiveRepairs(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgx mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	pullRequestID := uuid.New()
+	sessionID := uuid.New()
+	terminalSessionID := uuid.New()
+	now := time.Now().UTC()
+	summary := models.PullRequestHealthSummary{
+		MergeState:       models.PullRequestMergeStateClean,
+		HasConflicts:     false,
+		FailingTestCount: 1,
+		NeedsAgentAction: true,
+		ChecksConfirmed:  true,
+		Checks: []models.PullRequestCheckSummary{
+			{Name: "unit tests", Category: models.PullRequestCheckCategoryTest, Status: models.PullRequestCheckStatusFailed},
+		},
+	}
+	summaryJSON, err := json.Marshal(summary)
+	require.NoError(t, err, "should marshal current health summary")
+
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_current WHERE org_id = .+ AND pull_request_id = .+").
+		WithArgs(pgx.NamedArgs{
+			"org_id":          orgID,
+			"pull_request_id": pullRequestID,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"pull_request_id",
+			"org_id",
+			"version",
+			"head_sha",
+			"base_sha",
+			"summary_json",
+			"summary_preview_json",
+			"enrichment_status",
+			"enriched_at",
+			"created_at",
+			"updated_at",
+		}).AddRow(
+			pullRequestID,
+			orgID,
+			int64(7),
+			"head-new",
+			"base-new",
+			summaryJSON,
+			summaryJSON,
+			models.PullRequestHealthEnrichmentStatusReady,
+			nil,
+			now,
+			now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_health_snapshots WHERE org_id = .+ AND pull_request_id = .+ AND version = .+").
+		WithArgs(pgx.NamedArgs{
+			"org_id":          orgID,
+			"pull_request_id": pullRequestID,
+			"version":         int64(7),
+		}).
+		WillReturnRows(pgxmock.NewRows(prHealthSnapshotTestColumns).AddRow(
+			pullRequestID, orgID, int64(7), "head-new", "base-new", summaryJSON, nil, []byte(`{"checks":[{"name":"unit tests"}]}`), 24, models.PullRequestHealthEnrichmentStatusReady, &now, now,
+		))
+	mock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{
+			"org_id":          orgID,
+			"pull_request_id": pullRequestID,
+			"health_version":  int64(7),
+		}).
+		WillReturnRows(pgxmock.NewRows(prRepairRunTestColumns).
+			AddRow(uuid.New(), orgID, pullRequestID, sessionID, models.PullRequestRepairActionTypeFixTests, int64(7), true, nil, now, now).
+			AddRow(uuid.New(), orgID, pullRequestID, terminalSessionID, models.PullRequestRepairActionTypeResolveConflicts, int64(7), true, nil, now, now))
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE org_id = .+ AND id = ANY\\(@ids\\) AND deleted_at IS NULL").
+		WithArgs(pgx.NamedArgs{
+			"org_id": orgID,
+			"ids":    []uuid.UUID{sessionID, terminalSessionID},
+		}).
+		WillReturnRows(pgxmock.NewRows(prHealthSessionColumns).
+			AddRow(newPRHealthSessionRow(sessionID, orgID, now, "running")...).
+			AddRow(newPRHealthSessionRow(terminalSessionID, orgID, now, string(models.SessionStatusCompleted))...))
+
+	service := &PRService{
+		pullRequests: db.NewPullRequestStore(mock),
+		sessions:     db.NewSessionStore(mock),
+		logger:       zerolog.New(io.Discard),
+	}
+
+	resp, err := service.buildPullRequestHealthResponse(context.Background(), models.PullRequest{
+		ID:               pullRequestID,
+		OrgID:            orgID,
+		GitHubPRNumber:   42,
+		GitHubRepo:       "assembledhq/143",
+		GitHubPRURL:      "https://github.com/assembledhq/143/pull/42",
+		Status:           "open",
+		MergeState:       models.PullRequestMergeStateClean,
+		HasConflicts:     false,
+		FailingTestCount: 0,
+		NeedsAgentAction: false,
+		HealthVersion:    7,
+	})
+	require.NoError(t, err, "buildPullRequestHealthResponse should succeed")
+	require.Len(t, resp.ActiveRepairs, 1, "buildPullRequestHealthResponse should only include active repairs whose linked sessions are still non-terminal")
+	require.Equal(t, models.PullRequestRepairActionTypeFixTests, resp.ActiveRepairs[0].ActionType, "buildPullRequestHealthResponse should surface the running repair action")
+	require.Equal(t, sessionID, resp.ActiveRepairs[0].SessionID, "buildPullRequestHealthResponse should surface the running repair session")
+	require.Equal(t, "running", resp.ActiveRepairs[0].SessionStatus, "buildPullRequestHealthResponse should surface the linked session status")
+	require.False(t, resp.CanMerge, "buildPullRequestHealthResponse should suppress merge while a repair is active for the current health version")
+	require.NoError(t, mock.ExpectationsWereMet(), "all active repair health queries should be executed")
+}
+
 func TestPRServiceBuildPullRequestHealthResponseLoadsSnapshotDetails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/github/pr_merge_test.go
+++ b/internal/services/github/pr_merge_test.go
@@ -393,6 +393,9 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
 			prID, orgID, int64(1), "head-merge", "base-merge", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusNotRequested, (*time.Time)(nil), now, now,
 		))
+	prMock.ExpectQuery("SELECT .+ FROM pull_request_repair_runs").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID, "health_version": int64(1)}).
+		WillReturnRows(pgxmock.NewRows(prRepairRunTestColumns))
 	repoMock.ExpectQuery("SELECT .+ FROM repositories WHERE org_id = .+ AND full_name = .+ AND status = 'active'").
 		WithArgs(pgx.NamedArgs{"org_id": orgID, "full_name": "assembledhq/143"}).
 		WillReturnRows(pgxmock.NewRows(prTestRepoColumns).AddRow(
@@ -401,11 +404,6 @@ func TestPRServiceMergePullRequestRunsMergedFollowUps(t *testing.T) {
 	prMock.ExpectExec("UPDATE pull_requests SET status = @status, merged_at = now\\(\\), updated_at = now\\(\\) WHERE id = @id AND org_id = @org_id").
 		WithArgs(pgx.NamedArgs{"id": prID, "org_id": orgID, "status": "merged"}).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
-	prMock.ExpectQuery("SELECT .+ FROM pull_request_health_current").
-		WithArgs(pgx.NamedArgs{"org_id": orgID, "pull_request_id": prID}).
-		WillReturnRows(pgxmock.NewRows(prHealthCurrentTestColumns).AddRow(
-			prID, orgID, int64(1), "head-merge", "base-merge", summaryJSON, summaryJSON, models.PullRequestHealthEnrichmentStatusNotRequested, (*time.Time)(nil), now, now,
-		))
 
 	sessionRow := newPRHealthSessionRow(sessionID, orgID, now, string(models.SessionStatusCompleted))
 	setPRHealthSessionRowValue(sessionRow, "primary_issue_id", &issueID)


### PR DESCRIPTION
## Summary
Updated the PR repair in-progress UX design doc to clarify how the PR health row should leave the “in progress” state after tests finish. It also aligns the flow with an event-driven approach so the UI doesn’t rely on ephemeral client state, addressing VIR-84.

## Changes
- Updated `docs/design/future/74-pr-repair-in-progress-ux.md` to:
  - Define the core rule: for the PR’s current `health_version`, active non-terminal repair runs suppress the corresponding clickable actions.
  - Specify steady-state rendering:
    - Hide `Fix tests` / `Resolve conflicts` when their respective repair run is active.
    - Show non-clickable “<action> running” status, and “Open repair session” when viewing a different session.
    - Suppress `Merge` while any repair run is active for the current `health_version`.
  - Prefer an event-driven path:
    - `pull_request.synchronize`, `check_run`, and `check_suite` webhooks enqueue normal PR-health sync
    - backend recomputes `active_repairs`
    - backend emits `pull_request.updated` on the existing org-scoped SSE stream
    - clients refetch only the affected PR health query
  - Add an explicit flow diagram and state that we should not introduce a dedicated frontend polling loop.
  - Keep only the existing low-frequency backend reconciliation job as a safety net for missed webhooks.

## Test plan
- Validated by reviewing the updated doc’s state/UX rules against the desired end-to-end behavior (refresh, multiple viewers, and transitioning out of “in progress” after test completion) and ensuring the described backend signals support durable UI correctness.

[143.dev](https://143.dev) | [session caf0b50b](https://143.dev/sessions/caf0b50b-2573-4394-a501-fa79623cca51)