### PR TITLE
Fix session detail right panel layering and remove validation tab from keyboard shortcuts

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -288,6 +288,17 @@ describe('SessionDetailPage', () => {
     expect(screen.getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
   });
 
+  it('renders the desktop detail panel as an opaque surface above neighboring content', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const detailPanel = screen.getByTestId('session-detail-panel');
+
+    expect(detailPanel).toHaveClass('relative');
+    expect(detailPanel).toHaveClass('z-10');
+    expect(detailPanel).toHaveClass('bg-background');
+  });
+
   it('shows detail panel tabs for Overview and Changes', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -3757,9 +3757,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       open: isMobileReviewViewport ? mobileDetailOpen : showDetailPanel,
       required: centerMode === "review" && showDetailPanel,
       activeTab: detailTab,
-      availableTabs: showValidationTab
-        ? (["overview", "changes", "validation", "preview"] as const)
-        : (["overview", "changes", "preview"] as const),
+      availableTabs: ["overview", "changes", "preview"] as const,
       onToggle: toggleDetailsFromKeyboard,
       onClose: closeDetailsFromKeyboard,
       onTabChange: handleDetailTabClick,
@@ -4387,8 +4385,9 @@ export function SessionDetailContent({ id }: { id: string }) {
         <div className="hidden md:flex">
           <ResizeHandle onResize={handleDetailResize} />
           <div
+            data-testid="session-detail-panel"
             style={{ width: detailWidth }}
-            className="border-l border-border bg-muted/20 flex flex-col shrink-0 overflow-hidden"
+            className="relative z-10 border-l border-border bg-background flex flex-col shrink-0 overflow-hidden"
           >
             {panelTabsEl}
           </div>

--- a/frontend/src/hooks/use-session-keyboard-shortcuts.test.ts
+++ b/frontend/src/hooks/use-session-keyboard-shortcuts.test.ts
@@ -25,7 +25,7 @@ function makeOptions(overrides = {}) {
       open: true,
       required: false,
       activeTab: "overview" as const,
-      availableTabs: ["overview", "changes", "validation", "preview"] as const,
+      availableTabs: ["overview", "changes", "preview"] as const,
       onToggle: vi.fn(),
       onClose: vi.fn(),
       onTabChange: vi.fn(),

--- a/frontend/src/hooks/use-session-keyboard-shortcuts.ts
+++ b/frontend/src/hooks/use-session-keyboard-shortcuts.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-export type SessionDetailTab = "overview" | "changes" | "validation" | "preview";
+export type SessionDetailTab = "overview" | "changes" | "preview";
 
 type TranscriptControls = {
   focus: () => void;


### PR DESCRIPTION
## Summary
This change fixes the session details right panel being visually overlapped by nearby header/content by ensuring the desktop panel renders as an opaque, higher z-index surface. It also removes the unused `validation` tab from the session detail keyboard shortcut/tab contract to match the current UI.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`**
  - Add `data-testid="session-detail-panel"` to the desktop detail panel container.
  - Update desktop panel styling to include `relative z-10` and switch to `bg-background` so it layers above neighboring content.
  - Remove conditional `availableTabs` logic that included `"validation"`; desktop now uses a fixed `["overview", "changes", "preview"]`.
- **`frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`**
  - Add a test asserting the desktop detail panel has `relative`, `z-10`, and `bg-background` classes to prevent future overlap regressions.
- **`frontend/src/hooks/use-session-keyboard-shortcuts.ts`**
  - Remove `"validation"` from the `SessionDetailTab` type.
- **`frontend/src/hooks/use-session-keyboard-shortcuts.test.ts`**
  - Update expectations to reflect the updated tab list (no `"validation"`).

## Test plan
- Run `typecheck`, `lint`, and `build`.
- Run the updated unit tests for:
  - `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - `frontend/src/hooks/use-session-keyboard-shortcuts.test.ts`

[143.dev](https://143.dev) | [session 09c0690e](https://143.dev/sessions/09c0690e-e992-43c1-9e3e-1d120a3c0361)