### PR TITLE
Keep “Main” tab label text size consistent with other agent tabs

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -56,13 +56,16 @@ describe("AgentTabStrip", () => {
 
     const idleDot = container.querySelector(".bg-primary");
     const addButton = screen.getByRole("button", { name: "Add agent tab" });
+    const label = screen.getByText("Main tab");
 
     expect(idleDot).not.toBeNull();
     expect(screen.queryByRole("tablist", { name: "Agent tabs" })).not.toBeInTheDocument();
-    expect(screen.getByText("Main tab")).toBeInTheDocument();
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveClass("text-xs");
+    expect(label).not.toHaveClass("text-sm");
     expect(screen.getByRole("group", { name: "Codex Idle" })).toBeInTheDocument();
 
-    await user.hover(screen.getByText("Main tab"));
+    await user.hover(label);
 
     expect(await screen.findByRole("tooltip")).toHaveTextContent("Idle");
     expect(screen.getByRole("tooltip")).toHaveTextContent("2 messages queued");

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -174,7 +174,7 @@ export function AgentTabStrip({
                     )}
                     aria-hidden
                   />
-                  <span className="truncate text-sm font-medium text-foreground">{activeThread.label}</span>
+                  <span className="truncate text-xs font-medium text-foreground">{activeThread.label}</span>
                   {isCancelling && (
                     <Loader2
                       className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"


### PR DESCRIPTION
## Summary
Updated the single “Main” tab header to use the same compact `text-xs` label styling as the multi-tab agent strip. Added a regression assertion to prevent the label from drifting back to `text-sm`.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx**
  - Changed the single-tab label styling from `truncate text-sm ...` to `truncate text-xs ...`.
- **frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx**
  - Added assertions that the “Main tab” label:
    - is present
    - has class `text-xs`
    - does **not** have class `text-sm`
  - Updated hover target to reuse the located label element.

## Test plan
- Attempted to run:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build`
  - targeted `vitest`
- Verification is blocked in this checkout because frontend dependencies/tools (`tsc`, `eslint`, `next`, `vitest`) are not installed, so the commands could not complete.

[143.dev](https://143.dev) | [session 368c3e58](https://143.dev/sessions/368c3e58-792f-4e99-8d7d-5e32d8c43ef8)