### PR TITLE
Surface live preview startup tails on readiness failures

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -173,7 +173,7 @@ func TestProductionAlertsUseValidLogsQLRangeFilters(t *testing.T) {
 func TestLoggingDesignDocsTrackProvisionedDashboardsAndAlerts(t *testing.T) {
 	t.Parallel()
 
-	design, err := os.ReadFile("../docs/design/47-logging-victorialogs.md")
+	design, err := os.ReadFile("../docs/design/implemented/47-logging-victorialogs.md")
 	require.NoError(t, err, "test should read the VictoriaLogs design doc")
 
 	designText := string(design)

--- a/docs/design/implemented/44-sandbox-preview-server.md
+++ b/docs/design/implemented/44-sandbox-preview-server.md
@@ -628,7 +628,7 @@ Service startup order:
 3. The primary service starts last
 4. The preview is `ready` only when **all** services pass their readiness probes
 
-If any service fails to become ready within its timeout, the entire preview transitions to `failed` with a diagnostic indicating which service failed and why.
+If any service fails to become ready within its timeout, the entire preview transitions to `failed` with a diagnostic indicating which service failed and why. Readiness timeouts snapshot the service's live stdout/stderr tail before teardown, even if the process has not exited, so operators can tell whether startup was still compiling, downloading dependencies, migrating, seeding data, or blocked after the app server started.
 
 Service limits:
 
@@ -1043,6 +1043,7 @@ Known failure patterns the preview manager should detect and surface:
 | `MODULE_NOT_FOUND` or `Cannot find module` | "A required dependency is missing. Ensure `npm install` or equivalent runs during the Build phase." |
 | OOM kill (exit code 137) | "The preview process exceeded its memory limit ({limit}MB). Try a lighter dev server configuration or request a higher limit." |
 | Non-zero exit within 5 seconds of start | "The dev server exited immediately. Check the process output below for configuration errors." |
+| Readiness timeout with live output tail | "The {service} service did not become ready on port {port} before the timeout. Last output: {tail}" |
 | `ECONNREFUSED` on a support service port | "The {service} service is not responding on port {port}. It may have crashed or failed to start. Check the {service} process output." |
 | Support service ready but primary fails to connect | "The frontend cannot reach the backend at localhost:{port}. Ensure the backend service is configured to bind to `0.0.0.0`." |
 | Infrastructure container fails to start | "PostgreSQL failed to start. This is likely a platform issue — try restarting the preview." |

--- a/internal/services/preview/providers/docker_preview.go
+++ b/internal/services/preview/providers/docker_preview.go
@@ -295,8 +295,10 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 				timeout = time.Duration(primaryCfg.Ready.TimeoutSeconds) * time.Second
 			}
 			if err := d.waitForReadiness(ctx, state, cfg.Primary, primaryCfg.Port, primaryCfg.Ready.HTTPPath, timeout); err != nil {
+				errMsg, tail := d.recordServiceReadinessFailure(state, cfg.Primary, err)
+				notifyServiceFailed(observer, cfg.Primary, errMsg, tail)
 				d.cleanupState(handle)
-				return nil, fmt.Errorf("%w: primary service %q (port %d): %v", preview.ErrServiceNotReady, cfg.Primary, primaryCfg.Port, err)
+				return nil, fmt.Errorf("%w: primary service %q (port %d): %s", preview.ErrServiceNotReady, cfg.Primary, primaryCfg.Port, errMsg)
 			}
 			d.mu.Lock()
 			state.services[cfg.Primary].status = models.PreviewServiceStatusReady
@@ -321,16 +323,9 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 				}
 				bgCtx, cancel := context.WithTimeout(svcCtx, timeout)
 				if err := d.waitForReadiness(bgCtx, state, name, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
-					d.logger.Warn().Err(err).Str("service", name).Msg("support service readiness failed (progressive)")
-					d.mu.Lock()
-					var tail []string
-					if ss, ok := state.services[name]; ok {
-						ss.status = models.PreviewServiceStatusFailed
-						ss.err = err.Error()
-						tail = append([]string(nil), ss.outputTail...)
-					}
-					d.mu.Unlock()
-					notifyServiceFailed(observer, name, err.Error(), tail)
+					errMsg, tail := d.recordServiceReadinessFailure(state, name, err)
+					d.logger.Warn().Err(err).Str("service", name).Strs("output_tail", tail).Msg("support service readiness failed (progressive)")
+					notifyServiceFailed(observer, name, errMsg, tail)
 				} else {
 					d.mu.Lock()
 					var pid int
@@ -353,8 +348,10 @@ func (d *DockerPreviewProvider) StartPreview(ctx context.Context, sb *agent.Sand
 				timeout = time.Duration(svcCfg.Ready.TimeoutSeconds) * time.Second
 			}
 			if err := d.waitForReadiness(ctx, state, name, svcCfg.Port, svcCfg.Ready.HTTPPath, timeout); err != nil {
+				errMsg, tail := d.recordServiceReadinessFailure(state, name, err)
+				notifyServiceFailed(observer, name, errMsg, tail)
 				d.cleanupState(handle)
-				return nil, fmt.Errorf("%w: service %q (port %d): %v", preview.ErrServiceNotReady, name, svcCfg.Port, err)
+				return nil, fmt.Errorf("%w: service %q (port %d): %s", preview.ErrServiceNotReady, name, svcCfg.Port, errMsg)
 			}
 			d.mu.Lock()
 			state.services[name].status = models.PreviewServiceStatusReady
@@ -914,6 +911,31 @@ func notifyServiceFailed(observer preview.ServiceObserver, name, errMsg string, 
 		return
 	}
 	observer.OnServiceFailed(name, errMsg, tail)
+}
+
+// recordServiceReadinessFailure snapshots the live service output before
+// cleanup cancels the process. A timeout usually means the process is still
+// running, so this is the only point where we can preserve boot progress such
+// as "building binaries", "running migrations", or dependency downloads.
+func (d *DockerPreviewProvider) recordServiceReadinessFailure(state *previewState, name string, err error) (string, []string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if ss, ok := state.services[name]; ok {
+		ss.status = models.PreviewServiceStatusFailed
+		ss.err = formatServiceReadinessError(err, ss.outputTail)
+		return ss.err, append([]string(nil), ss.outputTail...)
+	}
+	return err.Error(), nil
+}
+
+func formatServiceReadinessError(err error, outputTail []string) string {
+	base := err.Error()
+	tail := truncatedTail(outputTail, serviceExitTailLines, serviceExitTailRunes)
+	if tail == "" {
+		return base
+	}
+	return base + "; last output: " + tail
 }
 
 // formatServiceExitError builds a human-readable exit message from a service's

--- a/internal/services/preview/providers/docker_preview_test.go
+++ b/internal/services/preview/providers/docker_preview_test.go
@@ -943,6 +943,60 @@ func TestWaitForReadiness_FailsFastWhenServiceStopped(t *testing.T) {
 	require.Contains(t, err.Error(), "stopped before becoming ready")
 }
 
+// TestStartPreview_ReadinessTimeoutSurfacesLiveTail verifies that a service
+// that keeps running but never passes its readiness probe still exposes the
+// current output tail. This is the dogfood-preview failure mode where the
+// server may still be compiling or migrating when the readiness budget expires.
+func TestStartPreview_ReadinessTimeoutSurfacesLiveTail(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	exec := &fakeServiceExecutor{
+		execStreamFn: func(ctx context.Context, _ string, onLine func([]byte)) (int, error) {
+			onLine([]byte("[143-preview] building binaries..."))
+			onLine([]byte("go: downloading google.golang.org/genproto/googleapis/rpc"))
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return 0, nil
+		},
+		execFn: func(_ context.Context, _ string) (int, error) {
+			return 1, nil
+		},
+	}
+	d := NewDockerPreviewProvider(&mockDockerPreviewClient{}, exec, zerolog.Nop())
+	obs := &recordingObserver{}
+	cfg := &models.PreviewConfig{
+		Name:    "dogfood",
+		Primary: "server",
+		Services: map[string]models.ServiceConfig{
+			"server": {
+				Command: []string{"sh", ".143/preview-start.sh"},
+				Port:    8080,
+				Ready:   models.ReadinessProbe{HTTPPath: "/api/v1/health", TimeoutSeconds: 1},
+			},
+		},
+	}
+
+	_, err := d.StartPreview(context.Background(), &agent.Sandbox{ID: "sb"}, cfg, nil, obs)
+	close(release)
+
+	require.Error(t, err, "StartPreview should fail when readiness never passes")
+	require.Contains(t, err.Error(), "readiness probe timed out", "error should explain readiness timeout")
+	require.Contains(t, err.Error(), "[143-preview] building binaries...", "error should include live service output")
+	require.Contains(t, err.Error(), "go: downloading", "error should include the most recent live service output")
+
+	failed := obs.failed()
+	require.Len(t, failed, 1, "observer should persist timeout diagnostics")
+	require.Equal(t, "server", failed[0].name, "observer should identify the timed-out service")
+	require.Contains(t, failed[0].errMsg, "readiness probe timed out", "observer error should explain readiness timeout")
+	require.Equal(t, []string{
+		"[143-preview] building binaries...",
+		"go: downloading google.golang.org/genproto/googleapis/rpc",
+	}, failed[0].tail, "observer should receive the live output tail")
+}
+
 // TestStartPreview_StandardMode_NotifiesObserverPerService runs StartPreview
 // to completion in standard mode with two services, both of which become
 // ready promptly, and asserts the observer received one OnServiceReady per


### PR DESCRIPTION
## Summary
- Capture the live stdout/stderr tail when a preview service times out waiting for readiness, even if the process is still running.
- Preserve that tail in the preview failure path and include it in the returned error and observer notification.
- Document the new timeout diagnostic pattern in the preview design notes.
- Fix a stale design-doc path in a deploy test so the full Go test suite passes again.

## Testing
- Added a regression test covering the "still running but timed out" preview startup case.
- Ran `go vet ./...`, `go build ./...`, and `go test ./...` successfully.