### PR TITLE
Fix preview readiness probe to use /readyz

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -24,7 +24,7 @@
           "DEMO_MODE": "true"
         },
         "ready": {
-          "http_path": "/api/v1/health",
+          "http_path": "/readyz",
           "timeout_seconds": 240
         }
       }

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/assembledhq/143/internal/models"
@@ -155,6 +156,23 @@ func TestParseConfig_FromRepoConfigPreviewSection(t *testing.T) {
 	require.NoError(t, err, "ParseConfig should accept nested preview config inside .143/config.json")
 	require.Equal(t, "web", cfg.Primary, "ParseConfig should parse the nested preview section")
 	require.Contains(t, cfg.Services, "web", "ParseConfig should preserve services from the nested preview section")
+}
+
+func TestDogfoodPreviewConfig_ServerUsesRegisteredReadinessPath(t *testing.T) {
+	t.Parallel()
+
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok, "test should resolve its source file path")
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", "..", ".."))
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot, ".143", "config.json"))
+	require.NoError(t, err, "dogfood preview config should be readable")
+
+	cfg, err := ParseConfig(raw)
+	require.NoError(t, err, "dogfood preview config should parse")
+	server, ok := cfg.Services["server"]
+	require.True(t, ok, "dogfood preview config should define the server service")
+	require.Equal(t, "/readyz", server.Ready.HTTPPath, "server readiness probe should hit the registered public readiness endpoint")
 }
 
 func TestParseConfig_RepoConfigWithoutPreviewSection(t *testing.T) {


### PR DESCRIPTION
## Summary
- Update the dogfood preview config to probe the server on `/readyz` instead of `/api/v1/health`
- Add a regression test to keep the preview config aligned with the router’s registered readiness endpoint

## Testing
- Added a unit test covering the dogfood preview config readiness path
- Verified the change with Go test, vet, and build checks; the full Go test suite also ran, with one unrelated pre-existing docs-path failure in `deploy`