### PR TITLE
Make mobile drawer close “X” more compact to reduce accidental clicks

### DIFF
--- a/frontend/src/components/authenticated-layout.test.tsx
+++ b/frontend/src/components/authenticated-layout.test.tsx
@@ -430,6 +430,25 @@ describe("AuthenticatedLayout", () => {
       });
     });
 
+    it("uses a compact close control in the mobile drawer header", async () => {
+      const user = userEvent.setup();
+
+      renderWithProviders(
+        <AuthenticatedLayout>
+          <div>content</div>
+        </AuthenticatedLayout>
+      );
+
+      await user.click(screen.getByRole("button", { name: "Open navigation menu" }));
+      await screen.findByRole("dialog");
+
+      const closeButton = screen.getByRole("button", { name: "Close navigation menu" });
+      expect(closeButton).toHaveClass("h-9", "w-9");
+
+      const closeIcon = closeButton.querySelector("svg");
+      expect(closeIcon).toHaveClass("h-4", "w-4");
+    });
+
     it("does not close the drawer on modifier-clicks (cmd/ctrl/middle)", async () => {
       const user = userEvent.setup();
 

--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -167,11 +167,11 @@ function SidebarBody({
           <SheetClose asChild>
             <Button
               variant="ghost"
-              size="icon"
-              className="h-11 w-11 rounded-md text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
+              size="icon-sm"
+              className="h-9 w-9 rounded-md text-muted-foreground hover:bg-sidebar-accent hover:text-foreground"
               aria-label="Close navigation menu"
             >
-              <X className="h-5 w-5" />
+              <X className="h-4 w-4" />
             </Button>
           </SheetClose>
         ) : (


### PR DESCRIPTION
## Summary
Updated the mobile navigation drawer close control in `authenticated-layout.tsx` to be harder to hit accidentally by reducing the button and icon size. Added a regression test to lock in the new sizing and prevent future UI drift.

## Changes
- **`frontend/src/components/authenticated-layout.tsx`**
  - Changed the mobile drawer close `Button` from `h-11 w-11` with `X` at `h-5 w-5` to `h-9 w-9` with `X` at `h-4 w-4` (via `size="icon-sm"` and updated classes).
- **`frontend/src/components/authenticated-layout.test.tsx`**
  - Added `uses a compact close control in the mobile drawer header` test asserting:
    - Close button has `h-9 w-9`
    - Close icon (`svg`) has `h-4 w-4`

## Test plan
- `npx vitest run src/components/authenticated-layout.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; existing Next.js warnings unchanged)

[143.dev](https://143.dev) | [session 7855fd74](https://143.dev/sessions/7855fd74-7413-4ca4-b5bd-65af150751dd)