### PR TITLE
Adjust preview startup phase rail layout for narrow panels and improve readability

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import {
   buildPreviewIframeSrc,
   PREVIEW_BOOTSTRAP_READY_EVENT,
@@ -123,12 +123,32 @@ describe("PreviewPanel bootstrap helpers", () => {
 /* ------------------------------------------------------------------ */
 
 describe("PreviewPanel component", () => {
+  let resizeObserverCallback: ResizeObserverCallback | null = null;
+  const originalResizeObserver = window.ResizeObserver;
+
   beforeEach(() => {
     vi.resetAllMocks();
     mockStart.mockResolvedValue({});
     mockStop.mockResolvedValue({});
     mockRestart.mockResolvedValue({});
     mockBootstrap.mockResolvedValue({ token: "tok-1" });
+
+    class MockResizeObserver {
+      constructor(callback: ResizeObserverCallback) {
+        resizeObserverCallback = callback;
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+
+    window.ResizeObserver = MockResizeObserver as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    resizeObserverCallback = null;
+    window.ResizeObserver = originalResizeObserver;
   });
 
   /* ---------- Loading state ---------- */
@@ -208,6 +228,60 @@ describe("PreviewPanel component", () => {
     expect(screen.getByRole("button", { name: "Stop preview" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restart preview" })).toBeInTheDocument();
     expect(screen.queryByText("Start Preview")).not.toBeInTheDocument();
+  });
+
+  it("stacks startup phase tiles when the panel becomes narrow", async () => {
+    mockGet.mockResolvedValue(
+      makePreviewStatus(
+        { status: "starting" },
+        [],
+        [
+          {
+            id: "infra-1",
+            preview_instance_id: "prev-1",
+            infra_name: "postgres",
+            template: "postgres",
+            container_id: "ctr-1",
+            status: "provisioning",
+            host: "postgres",
+            port: 5432,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+      ),
+    );
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Preparing preview")).toBeInTheDocument();
+    });
+
+    const phaseRail = screen.getByTestId("preview-startup-phase-rail");
+
+    resizeObserverCallback?.(
+      [
+        {
+          target: phaseRail,
+          contentRect: {
+            width: 220,
+            height: 0,
+            x: 0,
+            y: 0,
+            top: 0,
+            right: 220,
+            bottom: 0,
+            left: 0,
+            toJSON: () => ({}),
+          },
+        } as unknown as ResizeObserverEntry,
+      ],
+      {} as ResizeObserver,
+    );
+
+    await waitFor(() => {
+      expect(phaseRail).toHaveAttribute("data-layout", "stacked");
+    });
   });
 
   it("hides the Provisioning rail tile when the preview has no infrastructure", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -76,6 +76,26 @@ const STATUS_LABELS: Record<PreviewStatus, string> = {
 };
 
 const STARTUP_PHASES = ["Provisioning", "Starting", "Opening"] as const;
+const STARTUP_PHASE_RAIL_STACK_WIDTH = 300;
+const STARTUP_PHASE_RAIL_COMPACT_WIDTH = 420;
+
+type StartupPhaseRailLayout = "default" | "compact" | "stacked";
+
+function getStartupPhaseRailLayout(
+  width: number,
+  phaseCount: number,
+): StartupPhaseRailLayout {
+  if (phaseCount <= 1) {
+    return "default";
+  }
+  if (width < STARTUP_PHASE_RAIL_STACK_WIDTH) {
+    return "stacked";
+  }
+  if (phaseCount >= 3 && width < STARTUP_PHASE_RAIL_COMPACT_WIDTH) {
+    return "compact";
+  }
+  return "default";
+}
 
 function statusColor(status: PreviewStatus): string {
   switch (status) {
@@ -301,10 +321,12 @@ export function PreviewPanel({
 }: PreviewPanelProps) {
   const queryClient = useQueryClient();
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const startupPhaseRailRef = useRef<HTMLDivElement | null>(null);
   const [selectedWidth, setSelectedWidth] = useState<number>(0); // 0 = full
   const [designMode, setDesignMode] = useState(false);
   const [bootstrapComplete, setBootstrapComplete] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [startupPhaseRailLayout, setStartupPhaseRailLayout] = useState<StartupPhaseRailLayout>("default");
 
   // Poll preview status every 3s when active
   const {
@@ -601,6 +623,35 @@ export function PreviewPanel({
     (phase) => phase !== "Provisioning" || infrastructure.length > 0,
   );
 
+  useEffect(() => {
+    const rail = startupPhaseRailRef.current;
+    if (!rail) {
+      return;
+    }
+
+    const updateLayout = (width: number) => {
+      setStartupPhaseRailLayout(
+        getStartupPhaseRailLayout(width, visibleStartupPhases.length),
+      );
+    };
+
+    updateLayout(rail.getBoundingClientRect().width);
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) {
+        return;
+      }
+      updateLayout(entry.contentRect.width);
+    });
+    observer.observe(rail);
+    return () => observer.disconnect();
+  }, [visibleStartupPhases.length]);
+
   if (statusLoading) {
     return (
       <div className="flex flex-col gap-3">
@@ -846,9 +897,18 @@ export function PreviewPanel({
                 <p className="text-sm text-muted-foreground">{startupSubtitle}</p>
               </div>
               <div
+                ref={startupPhaseRailRef}
+                data-testid="preview-startup-phase-rail"
+                data-layout={startupPhaseRailLayout}
                 className={cn(
                   "mt-8 grid w-full max-w-md gap-3",
-                  visibleStartupPhases.length === 3 ? "grid-cols-3" : "grid-cols-2",
+                  startupPhaseRailLayout === "stacked"
+                    ? "grid-cols-1"
+                    : startupPhaseRailLayout === "compact"
+                      ? "grid-cols-2"
+                      : visibleStartupPhases.length === 3
+                        ? "grid-cols-3"
+                        : "grid-cols-2",
                 )}
               >
                 {visibleStartupPhases.map((phase) => {
@@ -857,7 +917,7 @@ export function PreviewPanel({
                     <div
                       key={phase}
                       className={cn(
-                        "flex flex-col items-center gap-2 rounded-lg border bg-card/70 px-3 py-2.5 text-xs text-muted-foreground",
+                        "flex flex-col items-center gap-2 rounded-lg border bg-card/70 px-3.5 py-3 text-center text-xs leading-tight text-muted-foreground",
                         phaseState === "active" && "border-primary/30 text-foreground shadow-sm",
                         phaseState === "complete" && "text-emerald-600 dark:text-emerald-400",
                       )}
@@ -869,7 +929,7 @@ export function PreviewPanel({
                       ) : (
                         <Circle className="size-3.5" />
                       )}
-                      <span className={phaseState === "active" ? "font-medium" : undefined}>
+                      <span className={cn("text-balance", phaseState === "active" ? "font-medium" : undefined)}>
                         {phase}
                       </span>
                     </div>


### PR DESCRIPTION
## Summary
Update the PreviewPanel startup phase rail to be width-aware so the right sidebar remains readable on narrow panels. Added a regression test that simulates `ResizeObserver` width changes and verifies the rail switches to the stacked layout when the panel becomes narrow (fixing the UI break reported in the related small-panel scenario).

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Added width/phase-count based layout logic via `getStartupPhaseRailLayout(...)`.
  - Introduced layout states (`default`, `compact`, `stacked`) with explicit width thresholds to keep phase tiles usable at smaller widths.
  - Extended the component to react to `ResizeObserver` measurements and apply the appropriate `data-layout` to the startup phase rail.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Added a `ResizeObserver` mock and lifecycle cleanup to safely drive layout changes in tests.
  - Added test **"stacks startup phase tiles when the panel becomes narrow"** that:
    - renders the component with provisioning tiles,
    - triggers a `ResizeObserver` callback with a narrow width,
    - asserts `data-layout="stacked"` on the rail.

## Test plan
- Ran the updated Vitest suite for `preview-panel` and confirmed the new narrow-panel regression test passes with the mocked `ResizeObserver`.

[143.dev](https://143.dev) | [session 949de02e](https://143.dev/sessions/949de02e-bb74-4e50-bb0e-3f2c3e9ebc99)