### PR TITLE
Fix manual session title truncation for UTF-8 input

### DIFF
--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/api/sse"
@@ -2751,7 +2752,7 @@ func buildManualSessionDescription(message string, images []string) string {
 const defaultManualSessionTitle = "Manual Session"
 
 func manualSessionTitle(message string) string {
-	trimmed := strings.TrimSpace(message)
+	trimmed := strings.TrimSpace(strings.ToValidUTF8(message, ""))
 	if trimmed == "" {
 		return defaultManualSessionTitle
 	}
@@ -2760,11 +2761,18 @@ func manualSessionTitle(message string) string {
 		trimmed = trimmed[:idx]
 	}
 
-	if len(trimmed) <= 120 {
-		return trimmed
-	}
+	return truncateUTF8Title(trimmed, 120)
+}
 
-	return strings.TrimSpace(trimmed[:120]) + "..."
+func truncateUTF8Title(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	truncated := value[:maxBytes]
+	for len(truncated) > 0 && !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return strings.TrimSpace(truncated) + "..."
 }
 
 // shouldOverrideTitleWithLinearIssue reports whether a Linear primary

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/assembledhq/143/internal/api/middleware"
@@ -4193,13 +4194,19 @@ func TestManualSessionTitle(t *testing.T) {
 			message:  strings.Repeat("a", 200),
 			expected: strings.Repeat("a", 120) + "...",
 		},
+		{
+			name:     "long message truncates at utf8 boundary",
+			message:  strings.Repeat("a", 119) + "…" + strings.Repeat("b", 20),
+			expected: strings.Repeat("a", 119) + "...",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := manualSessionTitle(tt.message)
-			require.Equal(t, tt.expected, result)
+			require.True(t, utf8.ValidString(result), "manualSessionTitle should always return valid UTF-8")
+			require.Equal(t, tt.expected, result, "manualSessionTitle should derive the expected display title")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Sanitize manual session titles before persistence so invalid UTF-8 cannot reach Postgres.
- Truncate titles at a valid UTF-8 boundary instead of slicing raw bytes, which caused `CREATE_FAILED` on mobile inputs containing multibyte characters.
- Add a regression test covering the boundary case that reproduced the production failure.

## Testing
- Added a unit test for UTF-8-safe manual session title truncation.
- `go test ./internal/api/handlers -run TestManualSessionTitle -count=1`
- `go test ./internal/api/handlers -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...` partially passed; one unrelated existing deploy test fails because `docs/design/47-logging-victorialogs.md` is missing in this worktree.