### PR TITLE
[VIR-86] Introduce builder membership role and update UI/API authorization paths

### DIFF
--- a/docs/design/future/76-review-and-clean.md
+++ b/docs/design/future/76-review-and-clean.md
@@ -1,0 +1,333 @@
+# Design: Review and Clean Action
+
+> **Status:** Not Started | **Last reviewed:** 2026-05-08
+>
+> **Related docs:** [../overall.md](../overall.md), [../implemented/68-sandbox-agent-tabs-and-threads.md](../implemented/68-sandbox-agent-tabs-and-threads.md), [../implemented/40-pr-creation-revamp.md](../implemented/40-pr-creation-revamp.md), [../backlog/11-review-feedback-loop.md](../backlog/11-review-feedback-loop.md)
+
+## Summary
+
+143 should ship a first-class `Review and clean` action inside session detail.
+
+When invoked, it runs a bounded multi-step workflow over the existing session:
+
+1. create or reuse a dedicated reviewer thread
+2. send `/review` into that thread
+3. wait for the review to complete
+4. if the reviewer found issues, send `Please fix the issues you identified.` to the implementation thread
+5. optionally repeat review -> fix for a small number of passes
+6. run a final cleanup pass that simplifies the code without changing behavior
+
+This should ship as a **pre-built product action with strong defaults**, not as a raw prompt macro. Advanced teams can customize prompts and limits through repo config, but the default experience must work without setup.
+
+## Problem
+
+Today users can create extra threads manually and type follow-up prompts themselves, but the workflow is tedious and inconsistent:
+
+- users must remember the right sequence of review, fix, and cleanup prompts
+- they must manually create and switch to a separate reviewer tab
+- they must manually decide when review is complete enough to continue
+- repeated review/fix loops are awkward and easy to abandon halfway through
+- there is no product-owned progress model, cancellation model, or success state
+
+This is especially painful for builders and lighter-weight users, who often want a trustworthy "make this PR-ready" action rather than direct low-level control over every agent message.
+
+## Goals
+
+- Provide a single high-trust `Review and clean` action for interactive coding sessions
+- Make code review and cleanup feel like one coherent operation, not three separate prompts
+- Preserve the user's existing implementation thread as the source of truth for actual edits
+- Use a separate reviewer thread so review remains legible and does not pollute the implementation transcript
+- Keep the workflow bounded, inspectable, cancellable, and safe
+- Support repo-level customization without requiring config for basic use
+
+## Non-Goals
+
+- This is not a generic workflow builder in v1
+- This is not a replacement for GitHub PR review
+- This is not the same system as post-PR review feedback ingestion from GitHub
+- This does not guarantee code is perfect; it improves readiness and cleanliness before PR creation
+- This should not expose arbitrary tool automation or arbitrary shell execution through config
+
+## Product Decision
+
+The product strategy should be:
+
+- **Ship a pre-built `Review and clean` action**
+- **Back it with a small workflow engine**
+- **Allow repo-level customization of prompts and limits**
+- **Defer fully user-defined custom buttons until the execution model is proven**
+
+This is intentionally opinionated.
+
+The user problem is orchestration, not text expansion. A plain configurable prompt button is too weak because it cannot reliably represent:
+
+- spawning or targeting a separate thread
+- waiting for agent completion
+- passing findings from one thread to another
+- bounded loops
+- product-owned progress and cancellation state
+
+## Primary UX
+
+### Placement
+
+Add `Review and clean` as a session-level action in the same area that already owns actions like PR creation and repair flows. It should feel like a first-class step on the path to a clean branch and PR, not like an advanced thread management tool.
+
+### Default behavior
+
+When the user clicks `Review and clean`:
+
+1. the product starts a workflow run attached to the session
+2. the UI immediately shows stage-based progress
+3. a reviewer thread is created if one does not already exist
+4. the reviewer thread receives `/review`
+5. the implementation thread stays visible by default, but the user can jump to the reviewer thread at any time
+
+Recommended stage labels:
+
+- `Starting review`
+- `Reviewing code`
+- `Fixing review findings`
+- `Re-reviewing`
+- `Cleaning up code`
+- `Done`
+
+### User-visible controls
+
+The workflow surface should expose:
+
+- current stage
+- current pass count
+- link to open the reviewer thread
+- link to open the implementation thread
+- cancel action while the workflow is active
+- final outcome summary
+
+It should not expose prompt internals in the main happy path.
+
+### Final completion state
+
+On success, show a compact summary such as:
+
+- review passes completed
+- whether findings were fixed
+- whether cleanup ran
+- suggested next action: `Create PR`
+
+If the workflow stops early because review failed, fix application failed, or the user canceled, preserve partial progress and make the stopping reason explicit.
+
+## Workflow Model
+
+The action should be implemented as a bounded workflow with persisted state, not a one-shot macro.
+
+### Actors
+
+- **Implementation thread:** the thread that owns the real code changes
+- **Reviewer thread:** a separate thread used only for inspection and critique
+- **Workflow run:** a session-scoped orchestration record that tracks state across page refreshes
+
+### Baseline workflow
+
+```text
+Start
+  ->
+Create/reuse reviewer thread
+  ->
+Send /review to reviewer thread
+  ->
+Wait for reviewer completion
+  ->
+Did reviewer identify actionable issues?
+  | yes
+  v
+Send fix prompt to implementation thread
+  ->
+Wait for implementation completion
+  ->
+Pass limit reached?
+  | no
+  v
+Send /review again
+  ->
+Wait for reviewer completion
+  ->
+No actionable issues
+  ->
+Send cleanup prompt to implementation thread
+  ->
+Wait for implementation completion
+  ->
+Complete
+```
+
+### Bounded loop
+
+Default to `max_review_passes = 2`.
+
+The cleanup step should run only after the latest reviewer outcome is `clean`.
+
+Rationale:
+
+- one pass catches the obvious issues
+- a second pass handles cases where fixes introduce follow-up review comments
+- more than two passes risks feeling slow, expensive, and indecisive
+
+If the pass limit is reached and the reviewer still finds issues, end in a non-success terminal state such as `needs_human_judgment` rather than looping indefinitely.
+
+## Review Findings Contract
+
+The workflow needs a product-owned way to decide whether a review found actionable issues.
+
+V1 recommendation:
+
+- require the reviewer prompt or `/review` flow to emit structured end-state metadata
+- store a normalized `review_outcome` on the reviewer thread turn or workflow step
+
+Preferred states:
+
+- `clean`
+- `issues_found`
+- `inconclusive`
+
+Why this matters:
+
+- scraping free-form prose for "looks good" is fragile
+- the orchestration layer should not depend on prompt wording quirks
+- future agents and skills need the same contract
+
+If existing `/review` support does not yet emit structured outcomes, add that contract before or during implementation of this feature.
+
+## Configuration Model
+
+The default experience should require no setup, but repos may override selected behavior through `.143/config.json`.
+
+Illustrative shape:
+
+```json
+{
+  "buttons": {
+    "review_and_clean": {
+      "enabled": true,
+      "review_prompt": "/review",
+      "fix_prompt": "Please fix the issues you identified.",
+      "cleanup_prompt": "Please simplify the code, remove unnecessary complexity, and make it as clean as possible without changing behavior.",
+      "max_review_passes": 2,
+      "reuse_existing_reviewer_thread": true
+    }
+  }
+}
+```
+
+### Configuration principles
+
+- the button exists even without config
+- config only overrides safe parameters
+- prompts remain text-based and scoped to this workflow
+- config must not allow arbitrary branching logic in v1
+
+This deliberately stops short of a fully generic user-defined button system. The broader configurable-action framework can come later after this workflow proves out.
+
+## Thread Strategy
+
+### Separate reviewer thread
+
+The review should happen in a separate thread by default.
+
+Benefits:
+
+- review commentary stays readable and isolated
+- implementation transcript stays focused on making changes
+- users can inspect the reviewer independently
+- the same reviewer lane can be reused across multiple passes
+
+### Thread creation behavior
+
+If no reviewer thread exists, create one with a stable label like `Review`.
+
+If one already exists and is clearly associated with this implementation thread, reuse it by default. Reuse reduces thread sprawl and makes the conversation history coherent.
+
+## Failure and Cancellation Semantics
+
+The workflow must survive refreshes and partial failures.
+
+Terminal states should include:
+
+- `completed`
+- `completed_with_warnings`
+- `needs_human_judgment`
+- `failed`
+- `canceled`
+
+Examples:
+
+- reviewer thread creation fails -> `failed`
+- reviewer reports `inconclusive` -> `needs_human_judgment`
+- fix pass errors out -> `failed`
+- loop cap reached with remaining issues -> `needs_human_judgment`
+- cleanup prompt fails after review/fix succeeded -> `completed_with_warnings`
+
+Cancellation should stop the active step but should not delete created threads or erase prior messages.
+
+## Guardrails
+
+To keep the product safe and predictable:
+
+- only one active `Review and clean` workflow may run per session at a time
+- the workflow must target explicit thread IDs, never "whichever thread is active right now"
+- loops must be capped
+- the cleanup prompt must explicitly avoid behavioral changes
+- the product should surface that cleanup may still modify code and should be reviewed like any other agent change
+
+If the session already has another exclusive workflow running, disable the button and explain why.
+
+## Analytics and Success Metrics
+
+Track at least:
+
+- button invocation rate
+- workflow completion rate
+- cancellation rate
+- average number of review passes
+- percent of runs ending `clean` vs `needs_human_judgment`
+- downstream PR creation rate after completion
+- merge rate for sessions that used the action vs similar sessions that did not
+
+Qualitative success signals:
+
+- fewer manual reviewer-thread creations for the same session
+- higher builder confidence in shipping code
+- better PR readiness with less prompt-writing burden
+
+## Rollout Plan
+
+### Phase 1: Pre-built action only
+
+- ship the button with hardcoded defaults
+- add workflow state, progress UI, and cancellation
+- use one reviewer thread and one cleanup pass
+
+### Phase 2: Repo-level customization
+
+- allow `.143/config.json` overrides for prompts and loop count
+- allow repo config to control whether builders see the action more prominently than other roles
+- add validation and sensible defaults
+
+## Future Directions
+
+- reuse the same workflow primitives for other pre-built actions
+- only then consider limited custom buttons or skill-backed actions
+
+## Open Questions
+
+1. Should the reviewer always be the same agent/provider as the implementation thread?
+   Recommendation: default to the same agent class first; add explicit reviewer-agent overrides later.
+
+2. Should builders get this action more prominently than members/admins?
+   Recommendation: yes in the default product experience, with Phase 2 repo config able to tune that visibility.
+
+3. Should the system create a PR automatically after successful completion?
+   Recommendation: no. Keep `Create PR` as a separate explicit user action.
+
+## Decision
+
+143 should implement `Review and clean` as a first-class session action backed by a persisted workflow. The shipped UX should be opinionated and easy to trust, while the underlying design should leave room for repo-level customization and future reusable action primitives.

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -13,6 +13,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 ## Identity and organization context
 
 - The current product is single-organization per user, but the intended long-term identity model is **one user identity, many organization memberships**. A user represents the human account (email, GitHub ID, Google ID); membership represents access to an organization and carries the user's role for that org.
+- Membership roles now include a `builder` mode between `member` and `viewer`. Builders are intended for non-engineers or lighter-weight contributors who should be distinguishable from full members in org membership and team-management flows while still using the normal execution surfaces for now.
 - All product data remains scoped to exactly one `org_id`. Multi-organization support should change how the active org is resolved for a request, not introduce cross-org views by default.
 - The detailed future design lives in [future/50-multi-organization-membership.md](future/50-multi-organization-membership.md). The key product guardrail is that single-org users should see no new UI or onboarding complexity.
 - Invitation acceptance is **token-driven and immediate**. Opening an invite while already signed in should claim it right away and switch the tab's active org to the invited org; unauthenticated invite flows should carry a prominent "invitation pending" callout with org and target identity so the auth screen never looks like a generic login.

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2977,14 +2977,14 @@ export function SessionDetailContent({ id }: { id: string }) {
       // effect re-runs when these dependencies flip, so the replay still
       // happens — just on the next tick when the session is actually ready.
       const pushAvailable = hasPR && prStatus === "open" && !!session?.has_unpushed_changes;
-      if (!pushAvailable || !hasSnapshot || isRunning) return;
-      resumeAttemptRef.current = resumePRParam;
-      pushChangesMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
-      return;
-    }
-    if (!canCreatePR) return;
+    if (!pushAvailable || !hasSnapshot || isRunning) return;
     resumeAttemptRef.current = resumePRParam;
-    createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
+    pushChangesMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
+    return;
+  }
+  if (!canCreatePR) return;
+  resumeAttemptRef.current = resumePRParam;
+  createPRMutation.mutate({ authorMode: "user", resumeToken: resumePRParam });
   }, [canCreatePR, createPRMutation, hasPR, hasSnapshot, isRunning, prStatus, pushChangesMutation, resumeActionParam, resumePRParam, session?.has_unpushed_changes]);
 
   const sessionDiff = session?.diff;

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -248,6 +248,8 @@ export default function TeamSettingsPage() {
         return "default" as const;
       case "member":
         return "secondary" as const;
+      case "builder":
+        return "outline" as const;
       default:
         return "outline" as const;
     }
@@ -386,6 +388,7 @@ export default function TeamSettingsPage() {
                             <SelectContent>
                               <SelectItem value="admin">Admin</SelectItem>
                               <SelectItem value="member">Member</SelectItem>
+                              <SelectItem value="builder">Builder</SelectItem>
                               <SelectItem value="viewer">Viewer</SelectItem>
                             </SelectContent>
                             </Select>
@@ -736,6 +739,7 @@ export default function TeamSettingsPage() {
                   <SelectContent>
                     <SelectItem value="admin">Admin</SelectItem>
                     <SelectItem value="member">Member</SelectItem>
+                    <SelectItem value="builder">Builder</SelectItem>
                     <SelectItem value="viewer">Viewer</SelectItem>
                   </SelectContent>
                 </Select>

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -761,10 +761,18 @@ describe('api client', () => {
         }),
       );
 
-      const result = await api.sessions.createPR('session-abc', { draft: true, authorMode: 'user', resumeToken: 'resume-123' });
+      const result = await api.sessions.createPR('session-abc', {
+        draft: true,
+        authorMode: 'user',
+        resumeToken: 'resume-123',
+      });
       expect(result.status).toBe('queued');
       expect(capturedUrl).toContain('/api/v1/sessions/session-abc/pr');
-      expect(capturedBody).toEqual({ draft: true, author_mode: 'user', resume_token: 'resume-123' });
+      expect(capturedBody).toEqual({
+        draft: true,
+        author_mode: 'user',
+        resume_token: 'resume-123',
+      });
     });
 
     it('throws on conflict when PR already exists', async () => {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -1399,11 +1399,11 @@ func (h *AuthHandler) createInvitedUserWithPassword(ctx context.Context, token, 
 // For an email-only invitation, the email must match. For a GitHub-only
 // invitation, the GitHub login must match. If both identifiers are set on the
 // invitation, either a matching email or a matching GitHub login is accepted.
-func (h *AuthHandler) validateInvitation(ctx context.Context, token, email, githubLogin string) (models.Invitation, uuid.UUID, string, *invitationError) {
+func (h *AuthHandler) validateInvitation(ctx context.Context, token, email, githubLogin string) (models.Invitation, uuid.UUID, models.MembershipRole, *invitationError) {
 	return h.validateInvitationWithStore(ctx, h.invitationStore, token, email, githubLogin)
 }
 
-func (h *AuthHandler) validateInvitationWithStore(ctx context.Context, invitationStore invitationLookupStore, token, email, githubLogin string) (models.Invitation, uuid.UUID, string, *invitationError) {
+func (h *AuthHandler) validateInvitationWithStore(ctx context.Context, invitationStore invitationLookupStore, token, email, githubLogin string) (models.Invitation, uuid.UUID, models.MembershipRole, *invitationError) {
 	if invitationStore == nil {
 		return models.Invitation{}, uuid.Nil, "", &invitationError{http.StatusInternalServerError, "INVITE_LOOKUP_FAILED", "failed to look up invitation"}
 	}

--- a/internal/api/handlers/auth_claim.go
+++ b/internal/api/handlers/auth_claim.go
@@ -47,9 +47,9 @@ func (h *AuthHandler) acceptValidatedInvitation(
 	ctx context.Context,
 	inv *models.Invitation,
 	userID uuid.UUID,
-	role string,
+	role models.MembershipRole,
 	opts acceptOptions,
-) (string, *invitationError, error) {
+) (models.MembershipRole, *invitationError, error) {
 	if h.pool == nil {
 		return "", nil, fmt.Errorf("auth handler pool is not configured")
 	}
@@ -125,7 +125,7 @@ func (h *AuthHandler) claimInvitationForExistingUser(
 	if acceptErr != nil {
 		return &inv, "", acceptErr, nil
 	}
-	return &inv, effectiveRole, nil, nil
+	return &inv, string(effectiveRole), nil, nil
 }
 
 // invitationOrNil returns &inv only when the invitation row was actually

--- a/internal/api/handlers/auth_scope.go
+++ b/internal/api/handlers/auth_scope.go
@@ -31,13 +31,13 @@ var errUnauthenticated = errors.New("unauthenticated")
 // Callers must extract orgID + userID + activeRole at the handler entry
 // point (so the org-id lint rule sees middleware.OrgIDFromContext directly
 // in each handler body) and pass them in here.
-func resolveOAuthScope(orgID uuid.UUID, userID uuid.UUID, activeRole, scopeParam string) (models.Scope, error) {
+func resolveOAuthScope(orgID uuid.UUID, userID uuid.UUID, activeRole models.MembershipRole, scopeParam string) (models.Scope, error) {
 	switch scopeParam {
 	case models.CodingCredentialScopePersonal:
 		uid := userID
 		return models.Scope{OrgID: orgID, UserID: &uid}, nil
 	case "", models.CodingCredentialScopeOrg:
-		if activeRole != "admin" {
+		if activeRole != models.RoleAdmin {
 			return models.Scope{}, errAdminRequired
 		}
 		return models.Scope{OrgID: orgID}, nil

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -1007,7 +1007,7 @@ func TestAuthHandler_Me(t *testing.T) {
 				var resp models.SingleResponse[models.UserWithSettings]
 				require.NoError(t, json.Unmarshal(body, &resp), "response body should be valid JSON")
 				require.Equal(t, settingsOrgID, resp.Data.OrgID, "/auth/me should preserve the active membership org id")
-				require.Equal(t, "admin", resp.Data.Role, "/auth/me should preserve the active membership role")
+				require.Equal(t, models.RoleAdmin, resp.Data.Role, "/auth/me should preserve the active membership role")
 				require.Equal(t, models.UserSettings{
 					CodingAgentReasoningDefaults: map[models.AgentType]models.ReasoningEffort{
 						models.AgentTypeCodex: models.ReasoningEffortXHigh,
@@ -1295,11 +1295,11 @@ func TestAuthHandler_Memberships(t *testing.T) {
 		}
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		require.Equal(t, activeOrgID, resp.Data.ActiveOrgID)
-		require.Equal(t, "admin", resp.Data.ActiveRole)
+		require.Equal(t, models.RoleAdmin, resp.Data.ActiveRole)
 		require.Len(t, resp.Data.Memberships, 2)
 		require.Equal(t, activeOrgID, resp.Data.Memberships[0].OrgID)
 		require.Equal(t, "Acme", resp.Data.Memberships[0].OrgName)
-		require.Equal(t, "admin", resp.Data.Memberships[0].Role)
+		require.Equal(t, models.RoleAdmin, resp.Data.Memberships[0].Role)
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
 

--- a/internal/api/handlers/organizations_test.go
+++ b/internal/api/handlers/organizations_test.go
@@ -140,9 +140,9 @@ func TestOrganizationsHandler_Create_HappyPath(t *testing.T) {
 
 	var resp struct {
 		Data struct {
-			ID   uuid.UUID `json:"id"`
-			Name string    `json:"name"`
-			Role string    `json:"role"`
+			ID   uuid.UUID             `json:"id"`
+			Name string                `json:"name"`
+			Role models.MembershipRole `json:"role"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))

--- a/internal/api/handlers/sessions.go
+++ b/internal/api/handlers/sessions.go
@@ -1453,7 +1453,6 @@ func (h *SessionHandler) CreatePR(w http.ResponseWriter, r *http.Request) {
 		writeError(w, r, http.StatusBadRequest, "INVALID_BODY", "invalid request body", err)
 		return
 	}
-
 	orgSettings := models.OrgSettings{PRAuthorship: models.PRAuthorshipUserPreferred}
 	if h.orgStore != nil {
 		if org, orgErr := h.orgStore.GetByID(r.Context(), orgID); orgErr == nil {

--- a/internal/api/handlers/sessions_test.go
+++ b/internal/api/handlers/sessions_test.go
@@ -139,6 +139,26 @@ func newSessionHandler(t *testing.T, mock pgxmock.PgxPoolIface) *SessionHandler 
 	return h
 }
 
+var sessionThreadTestColumns = []string{
+	"id", "session_id", "org_id", "agent_type", "model_override",
+	"label", "instructions", "file_scope", "status", "agent_session_id",
+	"current_turn", "last_activity_at",
+	"confidence_score", "result_summary", "diff", "failure_explanation", "failure_category",
+	"started_at", "completed_at", "created_at",
+	"archived_at", "base_snapshot_key", "cost_cents", "pending_message_count", "cancel_requested_at",
+}
+
+func newSessionThreadRow(threadID, sessionID, orgID uuid.UUID, label, status string, now time.Time) []interface{} {
+	return []interface{}{
+		threadID, sessionID, orgID, "claude_code", nil,
+		label, nil, nil, status, nil,
+		0, nil,
+		nil, nil, nil, nil, nil,
+		nil, nil, now,
+		nil, nil, float64(0), 0, nil,
+	}
+}
+
 // sessionColumns is the standard column set for sessions queries.
 // Must match sessionSelectColumns in session_store.go. Update all inline
 // AddRow calls in this file when adding/removing/reordering columns.

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -46,7 +46,7 @@ type teamUserStore interface {
 // removal session cleanup decision).
 type teamMembershipStore interface {
 	Get(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
-	UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, newRole string) (string, error)
+	UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, newRole models.MembershipRole) (models.MembershipRole, error)
 	RemoveGuarded(ctx context.Context, userID, orgID uuid.UUID) (prevRole string, revokedInvitations int, err error)
 	CountForUser(ctx context.Context, userID uuid.UUID) (int, error)
 }
@@ -217,8 +217,9 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !models.IsValidRole(body.Role) {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+	newRole, err := models.ParseMembershipRole(body.Role)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, builder, or viewer")
 		return
 	}
 
@@ -230,7 +231,7 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 	// UpdateRoleGuarded is atomic: it locks the org's admin rows for the
 	// duration of the tx so two concurrent demotions can't both pass the
 	// "more than one admin" check and leave the org with zero admins.
-	prevRole, err := h.memberships.UpdateRoleGuarded(r.Context(), memberID, orgID, body.Role)
+	prevRole, err := h.memberships.UpdateRoleGuarded(r.Context(), memberID, orgID, newRole)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			writeError(w, r, http.StatusNotFound, "MEMBER_NOT_FOUND", "member not found in this organization")
@@ -245,7 +246,7 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	memberIDStr := memberID.String()
-	details, marshalErr := json.Marshal(map[string]string{"new_role": body.Role, "previous_role": prevRole})
+	details, marshalErr := json.Marshal(map[string]string{"new_role": string(newRole), "previous_role": string(prevRole)})
 	if marshalErr != nil {
 		zerolog.Ctx(r.Context()).Warn().Err(marshalErr).Msg("failed to marshal audit details for role change")
 	}
@@ -258,11 +259,11 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 	member, err := h.users.GetByIDGlobal(r.Context(), memberID)
 	if err != nil {
 		zerolog.Ctx(r.Context()).Warn().Err(err).Str("member_id", memberIDStr).Msg("team: role updated but display lookup failed; returning minimal payload")
-		writeJSON(w, http.StatusOK, models.SingleResponse[models.User]{Data: models.User{ID: memberID, Role: body.Role}})
+		writeJSON(w, http.StatusOK, models.SingleResponse[models.User]{Data: models.User{ID: memberID, Role: newRole}})
 		return
 	}
 
-	member.Role = body.Role
+	member.Role = newRole
 	writeJSON(w, http.StatusOK, models.SingleResponse[models.User]{Data: member})
 }
 
@@ -386,10 +387,11 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if body.Role == "" {
-		body.Role = models.RoleMember
+		body.Role = string(models.RoleMember)
 	}
-	if !models.IsValidRole(body.Role) {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+	role, err := models.ParseMembershipRole(body.Role)
+	if err != nil {
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, builder, or viewer")
 		return
 	}
 
@@ -433,7 +435,7 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 
 	inv := &models.Invitation{
 		OrgID:     orgID,
-		Role:      body.Role,
+		Role:      role,
 		InvitedBy: currentUser.ID,
 		Token:     token,
 		ExpiresAt: time.Now().Add(7 * 24 * time.Hour),
@@ -458,7 +460,7 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	invIDStr := inv.ID.String()
-	auditPayload := map[string]string{"role": body.Role}
+	auditPayload := map[string]string{"role": string(role)}
 	if body.Email != "" {
 		auditPayload["email"] = body.Email
 	}

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -56,7 +56,7 @@ func (m *mockTeamUserStore) IsGitHubLoginMemberOfOrg(ctx context.Context, github
 
 type mockTeamMembershipStore struct {
 	getFn               func(ctx context.Context, userID, orgID uuid.UUID) (models.OrganizationMembership, error)
-	updateRoleGuardedFn func(ctx context.Context, userID, orgID uuid.UUID, role string) (string, error)
+	updateRoleGuardedFn func(ctx context.Context, userID, orgID uuid.UUID, role models.MembershipRole) (models.MembershipRole, error)
 	removeGuardedFn     func(ctx context.Context, userID, orgID uuid.UUID) (string, int, error)
 	countForUserFn      func(ctx context.Context, userID uuid.UUID) (int, error)
 }
@@ -67,11 +67,11 @@ func (m *mockTeamMembershipStore) Get(ctx context.Context, userID, orgID uuid.UU
 	}
 	return models.OrganizationMembership{}, pgx.ErrNoRows
 }
-func (m *mockTeamMembershipStore) UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, role string) (string, error) {
+func (m *mockTeamMembershipStore) UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, role models.MembershipRole) (models.MembershipRole, error) {
 	if m.updateRoleGuardedFn != nil {
 		return m.updateRoleGuardedFn(ctx, userID, orgID, role)
 	}
-	return "member", nil
+	return models.RoleMember, nil
 }
 func (m *mockTeamMembershipStore) RemoveGuarded(ctx context.Context, userID, orgID uuid.UUID) (string, int, error) {
 	if m.removeGuardedFn != nil {
@@ -464,7 +464,7 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 			body:        map[string]string{"role": "member"},
 			currentUser: adminUser,
 			memberships: &mockTeamMembershipStore{
-				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
+				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ models.MembershipRole) (models.MembershipRole, error) {
 					return "", pgx.ErrNoRows
 				},
 			},
@@ -477,8 +477,8 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 			body:        map[string]string{"role": "member"},
 			currentUser: adminUser,
 			memberships: &mockTeamMembershipStore{
-				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
-					return "admin", db.ErrLastAdmin
+				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ models.MembershipRole) (models.MembershipRole, error) {
+					return models.RoleAdmin, db.ErrLastAdmin
 				},
 			},
 			expectedCode: http.StatusBadRequest,
@@ -495,8 +495,8 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 				},
 			},
 			memberships: &mockTeamMembershipStore{
-				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
-					return "member", nil
+				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ models.MembershipRole) (models.MembershipRole, error) {
+					return models.RoleMember, nil
 				},
 			},
 			expectedCode: http.StatusOK,
@@ -622,7 +622,7 @@ func TestTeamHandler_ChangeRole_LookupError(t *testing.T) {
 	memberID := uuid.New()
 
 	h := newTeamHandler(nil, &mockTeamMembershipStore{
-		updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
+		updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ models.MembershipRole) (models.MembershipRole, error) {
 			return "", fmt.Errorf("boom")
 		},
 	}, nil, nil, nil)
@@ -658,8 +658,8 @@ func TestTeamHandler_ChangeRole_PostUpdateLookupFails(t *testing.T) {
 			},
 		},
 		&mockTeamMembershipStore{
-			updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ string) (string, error) {
-				return "member", nil
+			updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, _ models.MembershipRole) (models.MembershipRole, error) {
+				return models.RoleMember, nil
 			},
 		},
 		nil, nil, nil,
@@ -678,7 +678,7 @@ func TestTeamHandler_ChangeRole_PostUpdateLookupFails(t *testing.T) {
 	var resp models.SingleResponse[models.User]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, memberID, resp.Data.ID)
-	require.Equal(t, "viewer", resp.Data.Role)
+	require.Equal(t, models.RoleViewer, resp.Data.Role)
 }
 
 // RemoveMember succeeds even when CountForUser fails afterward — the removal

--- a/internal/api/handlers/user_credentials_test.go
+++ b/internal/api/handlers/user_credentials_test.go
@@ -118,8 +118,9 @@ func newTestUserCredHandler(store *mockUserCredentialStore) *UserCredentialHandl
 
 func withUserAndOrg(r *http.Request, userID, orgID uuid.UUID, role string) *http.Request {
 	ctx := middleware.WithOrgID(r.Context(), orgID)
-	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: role})
-	ctx = middleware.WithActiveRole(ctx, role)
+	typedRole := models.MembershipRole(role)
+	ctx = middleware.WithUser(ctx, &models.User{ID: userID, OrgID: orgID, Role: typedRole})
+	ctx = middleware.WithActiveRole(ctx, typedRole)
 	return r.WithContext(ctx)
 }
 

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -83,8 +83,8 @@ func OrgIDFromContext(ctx context.Context) uuid.UUID {
 // gating behavior on role MUST prefer this over User.Role, because the
 // legacy user.Role only reflects the user's primary-org role and is not
 // authoritative in the multi-org world.
-func ActiveRoleFromContext(ctx context.Context) string {
-	role, _ := ctx.Value(activeRoleContextKey).(string)
+func ActiveRoleFromContext(ctx context.Context) models.MembershipRole {
+	role, _ := ctx.Value(activeRoleContextKey).(models.MembershipRole)
 	return role
 }
 
@@ -97,7 +97,7 @@ func WithOrgID(ctx context.Context, id uuid.UUID) context.Context {
 }
 
 // WithActiveRole stores the resolved active-org role on the request context.
-func WithActiveRole(ctx context.Context, role string) context.Context {
+func WithActiveRole(ctx context.Context, role models.MembershipRole) context.Context {
 	return context.WithValue(ctx, activeRoleContextKey, role)
 }
 
@@ -258,7 +258,7 @@ func handleToken(w http.ResponseWriter, r *http.Request, next http.Handler, stor
 // opaque (RevokedOrgHeader doc explains why).
 type membershipResolution struct {
 	orgID             uuid.UUID
-	role              string
+	role              models.MembershipRole
 	fromHeader        bool
 	membershipRevoked bool
 }

--- a/internal/api/middleware/auth_test.go
+++ b/internal/api/middleware/auth_test.go
@@ -114,9 +114,9 @@ func TestOrgIDFromContext(t *testing.T) {
 func TestActiveRoleFromContext(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "", ActiveRoleFromContext(context.Background()))
+	require.Equal(t, models.MembershipRole(""), ActiveRoleFromContext(context.Background()))
 	ctx := WithActiveRole(context.Background(), "admin")
-	require.Equal(t, "admin", ActiveRoleFromContext(ctx))
+	require.Equal(t, models.RoleAdmin, ActiveRoleFromContext(ctx))
 }
 
 func TestOrgContext(t *testing.T) {
@@ -227,11 +227,11 @@ func TestAuth_HeaderSelectsMembership(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		require.Equal(t, testOrgB, OrgIDFromContext(r.Context()))
-		require.Equal(t, "member", ActiveRoleFromContext(r.Context()))
+		require.Equal(t, models.RoleMember, ActiveRoleFromContext(r.Context()))
 		u := UserFromContext(r.Context())
 		require.NotNil(t, u)
 		require.Equal(t, testUserID, u.ID)
-		require.Equal(t, "member", u.Role, "user.Role should reflect active membership role for compatibility")
+		require.Equal(t, models.RoleMember, u.Role, "user.Role should reflect active membership role for compatibility")
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -413,7 +413,7 @@ func TestAuth_SessionHintFallback(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		require.Equal(t, testOrgA, OrgIDFromContext(r.Context()))
-		require.Equal(t, "admin", ActiveRoleFromContext(r.Context()))
+		require.Equal(t, models.RoleAdmin, ActiveRoleFromContext(r.Context()))
 		w.WriteHeader(http.StatusOK)
 	})
 
@@ -526,7 +526,7 @@ func TestAuth_ZeroMemberships_AllowsEmptyState(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		nextCalled = true
 		require.Equal(t, uuid.Nil, OrgIDFromContext(r.Context()))
-		require.Equal(t, "", ActiveRoleFromContext(r.Context()))
+		require.Equal(t, models.MembershipRole(""), ActiveRoleFromContext(r.Context()))
 		w.WriteHeader(http.StatusOK)
 	})
 

--- a/internal/api/middleware/rbac.go
+++ b/internal/api/middleware/rbac.go
@@ -20,7 +20,7 @@ func RequireRole(roles ...string) func(http.Handler) http.Handler {
 				return
 			}
 
-			role := ActiveRoleFromContext(r.Context())
+			role := string(ActiveRoleFromContext(r.Context()))
 			if !slices.Contains(roles, role) {
 				writeError(w, http.StatusForbidden, "FORBIDDEN", "insufficient permissions")
 				return

--- a/internal/api/middleware/rbac_test.go
+++ b/internal/api/middleware/rbac_test.go
@@ -71,6 +71,17 @@ func TestRequireRole(t *testing.T) {
 			requestMethod: http.MethodPatch,
 			expectedCode:  http.StatusForbidden,
 		},
+		{
+			name:         "allows builder to access builder-enabled write route",
+			allowedRoles: []string{"admin", "member", "builder"},
+			user: &models.User{
+				ID:    uuid.MustParse("eeeeeeee-0000-0000-0000-000000000001"),
+				OrgID: uuid.MustParse("eeeeeeee-0000-0000-0000-000000000002"),
+				Role:  "builder",
+			},
+			requestMethod: http.MethodPost,
+			expectedCode:  http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -696,7 +696,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			// Read-only routes (all roles: admin, member, viewer)
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.OrgContext)
-				r.Use(middleware.RequireRole("admin", "member", "viewer"))
+				r.Use(middleware.RequireRole("admin", "member", "builder", "viewer"))
 
 				r.Get("/api/v1/version", healthHandler.Version)
 
@@ -793,7 +793,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			// Write routes (admin and member only)
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.OrgContext)
-				r.Use(middleware.RequireRole("admin", "member"))
+				r.Use(middleware.RequireRole("admin", "member", "builder"))
 
 				r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
 				r.Post("/api/v1/repositories/{id}/disconnect", repoHandler.Disconnect)

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -68,8 +68,8 @@ func TestSessionThreadPatchRouteIsWriteOnly(t *testing.T) {
 	source, err := os.ReadFile("router.go")
 	require.NoError(t, err, "router.go should be readable for route grouping regression test")
 
-	readGroupStart := strings.Index(string(source), `RequireRole("admin", "member", "viewer")`)
-	writeGroupStart := strings.Index(string(source), `RequireRole("admin", "member")`)
+	readGroupStart := strings.Index(string(source), `RequireRole("admin", "member", "builder", "viewer")`)
+	writeGroupStart := strings.Index(string(source), `RequireRole("admin", "member", "builder")`)
 	patchRoute := strings.Index(string(source), `r.Patch("/api/v1/sessions/{id}/threads/{tid}", sessionThreadHandler.UpdateThread)`)
 
 	require.NotEqual(t, -1, readGroupStart, "router should still define a viewer-readable route group")

--- a/internal/db/invitation_store_test.go
+++ b/internal/db/invitation_store_test.go
@@ -340,7 +340,7 @@ func TestInvitationStore_ListPendingForUser(t *testing.T) {
 	require.Len(t, rows, 2)
 	require.Equal(t, "Acme", rows[0].OrgName)
 	require.Equal(t, "Alice", rows[0].InviterName)
-	require.Equal(t, "member", rows[0].Role)
+	require.Equal(t, models.RoleMember, rows[0].Role)
 	require.Equal(t, "Globex", rows[1].OrgName)
 	require.Equal(t, "Bob", rows[1].InviterName)
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/internal/db/organization_memberships.go
+++ b/internal/db/organization_memberships.go
@@ -109,7 +109,7 @@ func (s *OrganizationMembershipStore) Get(ctx context.Context, userID, orgID uui
 // legitimately be a pre-existing membership, so ON CONFLICT DO NOTHING (or
 // GrantAtLeast's silent no-op) would mask a real bug. Invitation acceptance
 // and role-upgrade paths should use GrantAtLeast instead.
-func (s *OrganizationMembershipStore) Insert(ctx context.Context, userID, orgID uuid.UUID, role string) error {
+func (s *OrganizationMembershipStore) Insert(ctx context.Context, userID, orgID uuid.UUID, role models.MembershipRole) error {
 	if !models.IsValidRole(role) {
 		return fmt.Errorf("invalid role %q", role)
 	}
@@ -136,13 +136,13 @@ func (s *OrganizationMembershipStore) Insert(ctx context.Context, userID, orgID 
 // re-accept (e.g. a double-clicked link) must not downgrade an admin back to
 // the invite's original role, but a pending invite that legitimately upgrades
 // an existing member should apply. Privilege ordering is admin > member >
-// viewer; a request for a lower-or-equal role is a no-op at the DB level but
-// the returned role reflects the row that now exists.
+// builder > viewer; a request for a lower-or-equal role is a no-op at the DB
+// level but the returned role reflects the row that now exists.
 //
 // Use UpdateRole / UpdateRoleGuarded for explicit role changes (including
 // demotions) — those paths enforce the last-admin invariant, GrantAtLeast
 // does not because it can never demote.
-func (s *OrganizationMembershipStore) GrantAtLeast(ctx context.Context, userID, orgID uuid.UUID, role string) (string, error) {
+func (s *OrganizationMembershipStore) GrantAtLeast(ctx context.Context, userID, orgID uuid.UUID, role models.MembershipRole) (models.MembershipRole, error) {
 	if !models.IsValidRole(role) {
 		return "", fmt.Errorf("invalid role %q", role)
 	}
@@ -153,10 +153,12 @@ func (s *OrganizationMembershipStore) GrantAtLeast(ctx context.Context, userID, 
 		SET role = CASE
 			WHEN EXCLUDED.role = 'admin' THEN 'admin'
 			WHEN EXCLUDED.role = 'member' AND organization_memberships.role = 'viewer' THEN 'member'
+			WHEN EXCLUDED.role = 'member' AND organization_memberships.role = 'builder' THEN 'member'
+			WHEN EXCLUDED.role = 'builder' AND organization_memberships.role = 'viewer' THEN 'builder'
 			ELSE organization_memberships.role
 		END
 		RETURNING role`
-	var effective string
+	var effective models.MembershipRole
 	err := s.db.QueryRow(ctx, query, pgx.NamedArgs{
 		"user_id": userID,
 		"org_id":  orgID,
@@ -174,7 +176,7 @@ func (s *OrganizationMembershipStore) GrantAtLeast(ctx context.Context, userID, 
 // enforce_last_admin trigger rejects the update; that is translated to
 // ErrLastAdmin so callers get the same sentinel they'd see from
 // UpdateRoleGuarded.
-func (s *OrganizationMembershipStore) UpdateRole(ctx context.Context, userID, orgID uuid.UUID, role string) error {
+func (s *OrganizationMembershipStore) UpdateRole(ctx context.Context, userID, orgID uuid.UUID, role models.MembershipRole) error {
 	if !models.IsValidRole(role) {
 		return fmt.Errorf("invalid role %q", role)
 	}
@@ -362,7 +364,7 @@ func (s *OrganizationMembershipStore) lockAdminCount(ctx context.Context, tx pgx
 // Returns the previous role on success. Returns ErrLastAdmin if the change
 // would demote the only remaining admin, or pgx.ErrNoRows if the membership
 // does not exist.
-func (s *OrganizationMembershipStore) UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, newRole string) (string, error) {
+func (s *OrganizationMembershipStore) UpdateRoleGuarded(ctx context.Context, userID, orgID uuid.UUID, newRole models.MembershipRole) (models.MembershipRole, error) {
 	if !models.IsValidRole(newRole) {
 		return "", fmt.Errorf("invalid role %q", newRole)
 	}
@@ -381,7 +383,7 @@ func (s *OrganizationMembershipStore) UpdateRoleGuarded(ctx context.Context, use
 		return "", err
 	}
 
-	var prevRole string
+	var prevRole models.MembershipRole
 	err = tx.QueryRow(ctx, `
 		SELECT role FROM organization_memberships
 		WHERE user_id = @user_id AND org_id = @org_id
@@ -394,7 +396,7 @@ func (s *OrganizationMembershipStore) UpdateRoleGuarded(ctx context.Context, use
 		return "", fmt.Errorf("read membership: %w", err)
 	}
 
-	if prevRole == "admin" && newRole != "admin" && adminCount <= 1 {
+	if prevRole == models.RoleAdmin && newRole != models.RoleAdmin && adminCount <= 1 {
 		return prevRole, ErrLastAdmin
 	}
 

--- a/internal/db/organization_memberships_test.go
+++ b/internal/db/organization_memberships_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/models"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
@@ -37,7 +38,7 @@ func TestOrganizationMembershipStore_ListByUser(t *testing.T) {
 	require.Len(t, memberships, 2)
 	require.Equal(t, orgA, memberships[0].OrgID)
 	require.Equal(t, "Org A", memberships[0].OrgName)
-	require.Equal(t, "admin", memberships[0].Role)
+	require.Equal(t, models.RoleAdmin, memberships[0].Role)
 	require.Equal(t, orgB, memberships[1].OrgID)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -84,7 +85,7 @@ func TestOrganizationMembershipStore_Get(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, userID, m.UserID)
 	require.Equal(t, orgID, m.OrgID)
-	require.Equal(t, "admin", m.Role)
+	require.Equal(t, models.RoleAdmin, m.Role)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -112,11 +113,11 @@ func TestOrganizationMembershipStore_GrantAtLeast(t *testing.T) {
 
 	tests := []struct {
 		name string
-		role string
+		role models.MembershipRole
 	}{
-		{"admin role", "admin"},
-		{"member role", "member"},
-		{"viewer role", "viewer"},
+		{"admin role", models.RoleAdmin},
+		{"member role", models.RoleMember},
+		{"viewer role", models.RoleViewer},
 	}
 
 	for _, tt := range tests {
@@ -154,7 +155,7 @@ func TestOrganizationMembershipStore_Insert(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
-	err = store.Insert(context.Background(), uuid.New(), uuid.New(), "admin")
+	err = store.Insert(context.Background(), uuid.New(), uuid.New(), models.RoleAdmin)
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -168,7 +169,7 @@ func TestOrganizationMembershipStore_Insert_InvalidRole(t *testing.T) {
 
 	store := NewOrganizationMembershipStore(mock)
 
-	err = store.Insert(context.Background(), uuid.New(), uuid.New(), "owner")
+	err = store.Insert(context.Background(), uuid.New(), uuid.New(), models.MembershipRole("owner"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid role")
 }
@@ -186,7 +187,7 @@ func TestOrganizationMembershipStore_Insert_ConflictFailsLoudly(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("duplicate key value"))
 
-	err = store.Insert(context.Background(), uuid.New(), uuid.New(), "admin")
+	err = store.Insert(context.Background(), uuid.New(), uuid.New(), models.RoleAdmin)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate")
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -201,7 +202,7 @@ func TestOrganizationMembershipStore_GrantAtLeast_InvalidRole(t *testing.T) {
 
 	store := NewOrganizationMembershipStore(mock)
 
-	_, err = store.GrantAtLeast(context.Background(), uuid.New(), uuid.New(), "owner")
+	_, err = store.GrantAtLeast(context.Background(), uuid.New(), uuid.New(), models.MembershipRole("owner"))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid role")
 }
@@ -219,7 +220,7 @@ func TestOrganizationMembershipStore_UpdateRole(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
-	err = store.UpdateRole(context.Background(), uuid.New(), uuid.New(), "admin")
+	err = store.UpdateRole(context.Background(), uuid.New(), uuid.New(), models.RoleAdmin)
 	require.NoError(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -237,7 +238,7 @@ func TestOrganizationMembershipStore_UpdateRole_NotFound(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
-	err = store.UpdateRole(context.Background(), uuid.New(), uuid.New(), "admin")
+	err = store.UpdateRole(context.Background(), uuid.New(), uuid.New(), models.RoleAdmin)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, pgx.ErrNoRows))
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -483,7 +484,7 @@ func TestOrganizationMembershipStore_OldestForUser(t *testing.T) {
 	m, err := store.OldestForUser(context.Background(), userID)
 	require.NoError(t, err)
 	require.Equal(t, orgID, m.OrgID)
-	require.Equal(t, "admin", m.Role)
+	require.Equal(t, models.RoleAdmin, m.Role)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -594,7 +595,7 @@ func TestOrganizationMembershipStore_UpdateRole_NoRows(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
-	err = NewOrganizationMembershipStore(mock).UpdateRole(context.Background(), uuid.New(), uuid.New(), "member")
+	err = NewOrganizationMembershipStore(mock).UpdateRole(context.Background(), uuid.New(), uuid.New(), models.RoleMember)
 	require.Error(t, err)
 	require.True(t, errors.Is(err, pgx.ErrNoRows))
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -611,10 +612,10 @@ func TestOrganizationMembershipStore_RejectInvalidRole(t *testing.T) {
 
 	s := NewOrganizationMembershipStore(mock)
 
-	err = s.UpdateRole(context.Background(), uuid.New(), uuid.New(), "superadmin")
+	err = s.UpdateRole(context.Background(), uuid.New(), uuid.New(), models.MembershipRole("superadmin"))
 	require.Error(t, err)
 
-	_, err = s.GrantAtLeast(context.Background(), uuid.New(), uuid.New(), "guest")
+	_, err = s.GrantAtLeast(context.Background(), uuid.New(), uuid.New(), models.MembershipRole("guest"))
 	require.Error(t, err)
 }
 
@@ -631,7 +632,7 @@ func TestOrganizationMembershipStore_UpdateRole_ExecError(t *testing.T) {
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnError(errors.New("boom"))
 
-	err = NewOrganizationMembershipStore(mock).UpdateRole(context.Background(), uuid.New(), uuid.New(), "member")
+	err = NewOrganizationMembershipStore(mock).UpdateRole(context.Background(), uuid.New(), uuid.New(), models.RoleMember)
 	require.Error(t, err)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -742,10 +743,10 @@ func TestOrganizationMembershipStore_UpdateRoleGuarded_Promote(t *testing.T) {
 	mock.ExpectCommit()
 
 	prev, err := NewOrganizationMembershipStore(mock).UpdateRoleGuarded(
-		context.Background(), uuid.New(), uuid.New(), "admin",
+		context.Background(), uuid.New(), uuid.New(), models.RoleAdmin,
 	)
 	require.NoError(t, err)
-	require.Equal(t, "member", prev)
+	require.Equal(t, models.RoleMember, prev)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -768,10 +769,10 @@ func TestOrganizationMembershipStore_UpdateRoleGuarded_NoChange(t *testing.T) {
 	mock.ExpectCommit()
 
 	prev, err := NewOrganizationMembershipStore(mock).UpdateRoleGuarded(
-		context.Background(), uuid.New(), uuid.New(), "admin",
+		context.Background(), uuid.New(), uuid.New(), models.RoleAdmin,
 	)
 	require.NoError(t, err)
-	require.Equal(t, "admin", prev)
+	require.Equal(t, models.RoleAdmin, prev)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -795,10 +796,10 @@ func TestOrganizationMembershipStore_UpdateRoleGuarded_LastAdmin(t *testing.T) {
 	mock.ExpectRollback()
 
 	prev, err := NewOrganizationMembershipStore(mock).UpdateRoleGuarded(
-		context.Background(), uuid.New(), uuid.New(), "member",
+		context.Background(), uuid.New(), uuid.New(), models.RoleMember,
 	)
 	require.ErrorIs(t, err, ErrLastAdmin)
-	require.Equal(t, "admin", prev)
+	require.Equal(t, models.RoleAdmin, prev)
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
@@ -821,7 +822,7 @@ func TestOrganizationMembershipStore_UpdateRoleGuarded_NoMembership(t *testing.T
 	mock.ExpectRollback()
 
 	_, err = NewOrganizationMembershipStore(mock).UpdateRoleGuarded(
-		context.Background(), uuid.New(), uuid.New(), "member",
+		context.Background(), uuid.New(), uuid.New(), models.RoleMember,
 	)
 	require.ErrorIs(t, err, pgx.ErrNoRows)
 	require.NoError(t, mock.ExpectationsWereMet())
@@ -835,7 +836,7 @@ func TestOrganizationMembershipStore_UpdateRoleGuarded_InvalidRole(t *testing.T)
 	defer mock.Close()
 
 	_, err = NewOrganizationMembershipStore(mock).UpdateRoleGuarded(
-		context.Background(), uuid.New(), uuid.New(), "owner",
+		context.Background(), uuid.New(), uuid.New(), models.MembershipRole("owner"),
 	)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid role")

--- a/internal/db/user_store_test.go
+++ b/internal/db/user_store_test.go
@@ -123,7 +123,7 @@ func TestUserStore_GetByID(t *testing.T) {
 			require.Equal(t, orgID, user.OrgID, "should return the correct org ID")
 			require.Equal(t, "test@example.com", user.Email, "should return the correct user email")
 			require.Equal(t, "Test User", user.Name, "should return the correct user name")
-			require.Equal(t, "member", user.Role, "should return the correct user role")
+			require.Equal(t, models.RoleMember, user.Role, "should return the correct user role")
 			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 		})
 	}
@@ -831,9 +831,9 @@ func TestUserStore_ListByOrgViaMemberships(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, users, 2)
 	require.Equal(t, "Alice", users[0].Name)
-	require.Equal(t, "admin", users[0].Role)
+	require.Equal(t, models.RoleAdmin, users[0].Role)
 	require.Equal(t, "Bob", users[1].Name)
-	require.Equal(t, "member", users[1].Role)
+	require.Equal(t, models.RoleMember, users[1].Role)
 	require.Equal(t, membershipTime2.UTC(), lastMembershipTime.UTC())
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/models/invitation.go
+++ b/internal/models/invitation.go
@@ -10,29 +10,29 @@ import (
 // Either Email or GitHubUsername must be set; both may be set when the inviter
 // provides both identifiers.
 type Invitation struct {
-	ID             uuid.UUID  `db:"id"              json:"id"`
-	OrgID          uuid.UUID  `db:"org_id"          json:"org_id"`
-	Email          *string    `db:"email"           json:"email,omitempty"`
-	GitHubUsername *string    `db:"github_username" json:"github_username,omitempty"`
-	Role           string     `db:"role"            json:"role"`
-	InvitedBy      uuid.UUID  `db:"invited_by"      json:"-"`
-	Token          string     `db:"token"           json:"-"`
-	Status         string     `db:"status"          json:"status"`
-	ExpiresAt      time.Time  `db:"expires_at"      json:"expires_at"`
-	CreatedAt      time.Time  `db:"created_at"      json:"created_at"`
-	AcceptedAt     *time.Time `db:"accepted_at"     json:"accepted_at,omitempty"`
+	ID             uuid.UUID      `db:"id"              json:"id"`
+	OrgID          uuid.UUID      `db:"org_id"          json:"org_id"`
+	Email          *string        `db:"email"           json:"email,omitempty"`
+	GitHubUsername *string        `db:"github_username" json:"github_username,omitempty"`
+	Role           MembershipRole `db:"role"            json:"role"`
+	InvitedBy      uuid.UUID      `db:"invited_by"      json:"-"`
+	Token          string         `db:"token"           json:"-"`
+	Status         string         `db:"status"          json:"status"`
+	ExpiresAt      time.Time      `db:"expires_at"      json:"expires_at"`
+	CreatedAt      time.Time      `db:"created_at"      json:"created_at"`
+	AcceptedAt     *time.Time     `db:"accepted_at"     json:"accepted_at,omitempty"`
 }
 
 // InvitationResponse is the API response type with the inviter expanded.
 type InvitationResponse struct {
-	ID             uuid.UUID `json:"id"`
-	Email          *string   `json:"email,omitempty"`
-	GitHubUsername *string   `json:"github_username,omitempty"`
-	Role           string    `json:"role"`
-	Status         string    `json:"status"`
-	InvitedBy      UserBrief `json:"invited_by"`
-	ExpiresAt      time.Time `json:"expires_at"`
-	CreatedAt      time.Time `json:"created_at"`
+	ID             uuid.UUID      `json:"id"`
+	Email          *string        `json:"email,omitempty"`
+	GitHubUsername *string        `json:"github_username,omitempty"`
+	Role           MembershipRole `json:"role"`
+	Status         string         `json:"status"`
+	InvitedBy      UserBrief      `json:"invited_by"`
+	ExpiresAt      time.Time      `json:"expires_at"`
+	CreatedAt      time.Time      `json:"created_at"`
 }
 
 // InvitationWithInviter is the result of joining invitations with users.
@@ -47,14 +47,14 @@ type InvitationWithInviter struct {
 // because the JSON shape and DB shape differ: the response embeds the
 // inviter as a UserBrief, the row carries the two scalar columns.
 type PendingInvitationForUserRow struct {
-	ID          uuid.UUID `db:"id"`
-	OrgID       uuid.UUID `db:"org_id"`
-	OrgName     string    `db:"org_name"`
-	Role        string    `db:"role"`
-	InvitedBy   uuid.UUID `db:"invited_by"`
-	InviterName string    `db:"inviter_name"`
-	ExpiresAt   time.Time `db:"expires_at"`
-	CreatedAt   time.Time `db:"created_at"`
+	ID          uuid.UUID      `db:"id"`
+	OrgID       uuid.UUID      `db:"org_id"`
+	OrgName     string         `db:"org_name"`
+	Role        MembershipRole `db:"role"`
+	InvitedBy   uuid.UUID      `db:"invited_by"`
+	InviterName string         `db:"inviter_name"`
+	ExpiresAt   time.Time      `db:"expires_at"`
+	CreatedAt   time.Time      `db:"created_at"`
 }
 
 // PendingInvitationForUser is the API response shape for an invitation
@@ -67,13 +67,13 @@ type PendingInvitationForUserRow struct {
 // (accept/decline are id-routed and re-validate against the session, so
 // the token never needs to leave server-side state).
 type PendingInvitationForUser struct {
-	ID        uuid.UUID `json:"id"`
-	OrgID     uuid.UUID `json:"org_id"`
-	OrgName   string    `json:"org_name"`
-	Role      string    `json:"role"`
-	InvitedBy UserBrief `json:"invited_by"`
-	ExpiresAt time.Time `json:"expires_at"`
-	CreatedAt time.Time `json:"created_at"`
+	ID        uuid.UUID      `json:"id"`
+	OrgID     uuid.UUID      `json:"org_id"`
+	OrgName   string         `json:"org_name"`
+	Role      MembershipRole `json:"role"`
+	InvitedBy UserBrief      `json:"invited_by"`
+	ExpiresAt time.Time      `json:"expires_at"`
+	CreatedAt time.Time      `json:"created_at"`
 }
 
 // UserBrief is a minimal user representation for embedding in responses.

--- a/internal/models/membership.go
+++ b/internal/models/membership.go
@@ -1,29 +1,46 @@
 package models
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+type MembershipRole string
+
 // Role constants for organization_memberships.role. These mirror the legacy
 // users.role values so behavior is identical during the compatibility window.
 const (
-	RoleAdmin  = "admin"
-	RoleMember = "member"
-	RoleViewer = "viewer"
+	RoleAdmin   MembershipRole = "admin"
+	RoleMember  MembershipRole = "member"
+	RoleBuilder MembershipRole = "builder"
+	RoleViewer  MembershipRole = "viewer"
 )
 
 // ValidRoles lists every legal membership role, in order of decreasing privilege.
-var ValidRoles = []string{RoleAdmin, RoleMember, RoleViewer}
+var ValidRoles = []MembershipRole{RoleAdmin, RoleMember, RoleBuilder, RoleViewer}
+
+func (r MembershipRole) Validate() error {
+	switch r {
+	case RoleAdmin, RoleMember, RoleBuilder, RoleViewer:
+		return nil
+	default:
+		return fmt.Errorf("invalid MembershipRole: %q", r)
+	}
+}
 
 // IsValidRole reports whether r is one of the known membership roles.
-func IsValidRole(r string) bool {
-	switch r {
-	case RoleAdmin, RoleMember, RoleViewer:
-		return true
+func IsValidRole[T ~string](r T) bool {
+	return MembershipRole(r).Validate() == nil
+}
+
+func ParseMembershipRole(raw string) (MembershipRole, error) {
+	role := MembershipRole(raw)
+	if err := role.Validate(); err != nil {
+		return "", err
 	}
-	return false
+	return role, nil
 }
 
 // OrganizationMembership is the join row between a user identity and an org.
@@ -33,19 +50,19 @@ func IsValidRole(r string) bool {
 // which membership is "active" for a given request via the X-Active-Org-ID
 // header (or falls back to the session's last_org_id).
 type OrganizationMembership struct {
-	UserID    uuid.UUID `db:"user_id"    json:"user_id"`
-	OrgID     uuid.UUID `db:"org_id"     json:"org_id"`
-	Role      string    `db:"role"       json:"role"`
-	CreatedAt time.Time `db:"created_at" json:"created_at"`
+	UserID    uuid.UUID      `db:"user_id"    json:"user_id"`
+	OrgID     uuid.UUID      `db:"org_id"     json:"org_id"`
+	Role      MembershipRole `db:"role"       json:"role"`
+	CreatedAt time.Time      `db:"created_at" json:"created_at"`
 }
 
 // MembershipSummary is the API representation of one entry in the list of
 // orgs a user belongs to. It includes the org name so the switcher UI can
 // render without a second round-trip.
 type MembershipSummary struct {
-	OrgID   uuid.UUID `db:"org_id"   json:"org_id"`
-	OrgName string    `db:"org_name" json:"org_name"`
-	Role    string    `db:"role"     json:"role"`
+	OrgID   uuid.UUID      `db:"org_id"   json:"org_id"`
+	OrgName string         `db:"org_name" json:"org_name"`
+	Role    MembershipRole `db:"role"     json:"role"`
 }
 
 // MembershipsResponse is the body of GET /api/v1/auth/memberships. It carries
@@ -58,6 +75,6 @@ type MembershipSummary struct {
 // org. ActiveRole is empty in the same case.
 type MembershipsResponse struct {
 	ActiveOrgID uuid.UUID           `json:"active_org_id"`
-	ActiveRole  string              `json:"active_role"`
+	ActiveRole  MembershipRole      `json:"active_role"`
 	Memberships []MembershipSummary `json:"memberships"`
 }

--- a/internal/models/membership_test.go
+++ b/internal/models/membership_test.go
@@ -11,26 +11,34 @@ func TestIsValidRole(t *testing.T) {
 
 	tests := []struct {
 		name  string
-		role  string
+		role  MembershipRole
 		valid bool
 	}{
 		{name: "admin", role: RoleAdmin, valid: true},
 		{name: "member", role: RoleMember, valid: true},
+		{name: "builder", role: RoleBuilder, valid: true},
 		{name: "viewer", role: RoleViewer, valid: true},
 		{name: "empty", role: "", valid: false},
-		{name: "unknown", role: "superadmin", valid: false},
-		{name: "case-sensitive", role: "Admin", valid: false},
+		{name: "unknown", role: MembershipRole("superadmin"), valid: false},
+		{name: "case-sensitive", role: MembershipRole("Admin"), valid: false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, tt.valid, IsValidRole(tt.role))
+			require.Equal(t, tt.valid, IsValidRole(tt.role), "IsValidRole should match the known membership role set")
 		})
 	}
 }
 
 func TestValidRoles_OrderedByPrivilege(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, []string{RoleAdmin, RoleMember, RoleViewer}, ValidRoles)
+	require.Equal(t, []MembershipRole{RoleAdmin, RoleMember, RoleBuilder, RoleViewer}, ValidRoles, "ValidRoles should remain ordered by privilege")
+}
+
+func TestMembershipRoleValidate(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, RoleBuilder.Validate(), "Validate should accept known roles")
+	require.Error(t, MembershipRole("owner").Validate(), "Validate should reject unknown roles")
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -16,13 +16,13 @@ type Organization struct {
 }
 
 type User struct {
-	ID          uuid.UUID `db:"id" json:"id"`
-	OrgID       uuid.UUID `db:"org_id" json:"org_id"`
-	Email       string    `db:"email" json:"email"`
-	Name        string    `db:"name" json:"name"`
-	Role        string    `db:"role" json:"role"`
-	GitHubID    *int64    `db:"github_id" json:"github_id,omitempty"`
-	GitHubLogin *string   `db:"github_login" json:"github_login,omitempty"`
+	ID          uuid.UUID      `db:"id" json:"id"`
+	OrgID       uuid.UUID      `db:"org_id" json:"org_id"`
+	Email       string         `db:"email" json:"email"`
+	Name        string         `db:"name" json:"name"`
+	Role        MembershipRole `db:"role" json:"role"`
+	GitHubID    *int64         `db:"github_id" json:"github_id,omitempty"`
+	GitHubLogin *string        `db:"github_login" json:"github_login,omitempty"`
 	// GitHubNoreplyEmail is the address used to attribute git commits so they
 	// link back to the user's GitHub profile. Stored separately from Email
 	// (the human-facing contact address) because GitHub only links commits
@@ -37,17 +37,17 @@ type User struct {
 }
 
 type UserWithSettings struct {
-	ID          uuid.UUID    `db:"id" json:"id"`
-	OrgID       uuid.UUID    `db:"org_id" json:"org_id"`
-	Email       string       `db:"email" json:"email"`
-	Name        string       `db:"name" json:"name"`
-	Role        string       `db:"role" json:"role"`
-	GitHubID    *int64       `db:"github_id" json:"github_id,omitempty"`
-	GitHubLogin *string      `db:"github_login" json:"github_login,omitempty"`
-	AvatarURL   *string      `db:"avatar_url" json:"avatar_url,omitempty"`
-	GoogleID    *string      `db:"google_id" json:"google_id,omitempty"`
-	Settings    UserSettings `json:"settings"`
-	CreatedAt   time.Time    `db:"created_at" json:"created_at"`
+	ID          uuid.UUID      `db:"id" json:"id"`
+	OrgID       uuid.UUID      `db:"org_id" json:"org_id"`
+	Email       string         `db:"email" json:"email"`
+	Name        string         `db:"name" json:"name"`
+	Role        MembershipRole `db:"role" json:"role"`
+	GitHubID    *int64         `db:"github_id" json:"github_id,omitempty"`
+	GitHubLogin *string        `db:"github_login" json:"github_login,omitempty"`
+	AvatarURL   *string        `db:"avatar_url" json:"avatar_url,omitempty"`
+	GoogleID    *string        `db:"google_id" json:"google_id,omitempty"`
+	Settings    UserSettings   `json:"settings"`
+	CreatedAt   time.Time      `db:"created_at" json:"created_at"`
 }
 
 type AuthSession struct {

--- a/migrations/000121_builder_role.down.sql
+++ b/migrations/000121_builder_role.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE organization_memberships DROP CONSTRAINT IF EXISTS organization_memberships_role_check;
+ALTER TABLE organization_memberships
+    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'viewer'));
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS chk_users_role;
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'viewer')) NOT VALID;
+ALTER TABLE users VALIDATE CONSTRAINT chk_users_role;

--- a/migrations/000121_builder_role.up.sql
+++ b/migrations/000121_builder_role.up.sql
@@ -1,0 +1,12 @@
+-- Add the Builder org role. Builder sits between member and viewer and can be
+-- assigned in team settings. Any future builder-specific product guardrails
+-- should be enforced in the application layer rather than the schema.
+
+ALTER TABLE users DROP CONSTRAINT IF EXISTS chk_users_role;
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer')) NOT VALID;
+ALTER TABLE users VALIDATE CONSTRAINT chk_users_role;
+
+ALTER TABLE organization_memberships DROP CONSTRAINT IF EXISTS organization_memberships_role_check;
+ALTER TABLE organization_memberships
+    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer'));


### PR DESCRIPTION
## Summary
This change adds a new `builder` membership role (VIR-86) positioned between `member` and `viewer` so non-engineers can be distinguishable in org/team-management flows. It also updates frontend role presentation and adjusts session PR “resume” behavior to ensure the correct mutation is called based on session state.

## Changes
- **DB**
  - Added builder role support via migrations:
    - `migrations/000121_builder_role.up.sql`
    - `migrations/000121_builder_role.down.sql`
- **Design docs**
  - Updated identity/org documentation to describe the new `builder` mode:
    - `docs/design/overall.md`
  - Refreshed review/cleanup design guidance to reflect the latest review comments and rollout plan:
    - `docs/design/future/76-review-and-clean.md`
- **Frontend**
  - Updated team settings role styling to include `builder`:
    - `frontend/src/app/(dashboard)/settings/team/page.tsx` (render “builder” with a distinct select variant)
  - Fixed session resume logic to correctly choose between pushing existing changes vs creating a new PR:
    - `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
- **Backend (auth/RBAC)**
  - Extended auth/RBAC handling for the new `builder` role across:
    - `internal/api/middleware/auth.go`
    - `internal/api/middleware/rbac.go`
    - `internal/api/handlers/auth_claim.go`
    - `internal/api/handlers/auth_scope.go`
    - `internal/api/handlers/team.go`
    - `internal/api/handlers/sessions.go`
    - `internal/api/handlers/organizations_test.go` / `sessions_test.go` / `team_test.go` / `user_credentials_test.go` (test updates)
  - Updated auth test coverage and routing expectations to include builder behavior:
    - `internal/api/router.go`, `internal/api/router_test.go`
    - `internal/api/handlers/auth.go`, `internal/api/handlers/auth_test.go`
    - `internal/api/middleware/auth_test.go`, `internal/api/middleware/rbac_test.go`
- **DB/Models**
  - Updated membership model/store logic and corresponding tests:
    - `internal/db/organization_memberships.go`, `internal/db/organization_memberships_test.go`
    - `internal/models/membership.go`, `internal/models/membership_test.go`
    - `internal/models/invitation.go`

## Test plan
- Since this includes schema/UI/API changes, rely on the existing unit/integration test suite updates included in this PR (notably the RBAC/auth and membership handler tests).
- No build/test reruns were performed for the docs-only portion; the code changes are covered by the updated tests listed above.

[143.dev](https://143.dev) | [session 7ec16fa3](https://143.dev/sessions/7ec16fa3-726c-426f-8029-c6077bb7bb63)