### PR TITLE
Fix health-based drain during app deploys

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -50,7 +50,11 @@ import (
 	"github.com/assembledhq/143/internal/worker"
 )
 
-const nodeDrainMarkTimeout = 5 * time.Second
+const (
+	nodeDrainMarkTimeout      = 5 * time.Second
+	httpDrainPropagationDelay = 7 * time.Second
+	httpShutdownTimeout       = 100 * time.Second
+)
 
 func main() {
 	cfg := config.Load()
@@ -554,9 +558,10 @@ func main() {
 	//     mid-execution produces orphaned thread rows when partial DB state
 	//     lands during the orchestrator's cleanup defers. The matching outer
 	//     bound is docker-compose.worker.yml stop_grace_period.
-	//   - HTTP API drain:      110s. Bounded by docker-compose.app.yml
-	//     stop_grace_period=120s with a 10s SIGKILL safety margin. Only
-	//     load-bearing on api/all modes.
+	//   - HTTP API drain:      100s. Bounded by docker-compose.app.yml
+	//     stop_grace_period=120s with room for node drain + Caddy health
+	//     propagation before Docker's SIGKILL deadline. Only load-bearing
+	//     on api/all modes.
 	//   - Preview gateway:     60s, in parallel with HTTP drain.
 	// On worker-only nodes the HTTP drain is a no-op (no traffic) so the
 	// long worker budget is the only thing the deploy actually waits on.
@@ -574,6 +579,14 @@ func main() {
 			logger.Warn().Err(err).Msg("failed to mark node draining")
 		}
 		nodeDrainCancel()
+
+		// Mark /healthz unhealthy before closing the listener. Caddy probes
+		// every 2s with a 2s timeout and refreshes dynamic upstream DNS every
+		// 2s, so this propagation window covers a full missed-probe cycle
+		// plus scheduling slack before Docker stops the old container.
+		close(shutdownCh)
+		time.Sleep(httpDrainPropagationDelay)
+
 		drainCtx, drainCancel := context.WithTimeout(context.Background(), cfg.WorkerDrainTimeout)
 		for {
 			activeJobs := 0
@@ -607,12 +620,6 @@ func main() {
 	drained:
 		drainCancel()
 
-		// Signal long-lived SSE handlers to return before calling Shutdown.
-		// Without this, Shutdown blocks on each open SSE connection until its
-		// deadline expires; the client then sees an abrupt reset rather than
-		// a clean EOF (which EventSource retries from on its own).
-		close(shutdownCh)
-
 		cancel() // stop worker
 		if recycleWorker != nil {
 			recycleWorker.Stop()
@@ -639,9 +646,9 @@ func main() {
 			}
 		}()
 
-		// Drain the main API server. 110s leaves ~10s of headroom before
+		// Drain the main API server. The timeout leaves headroom before
 		// Docker SIGKILLs the container at stop_grace_period=120s.
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 110*time.Second)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), httpShutdownTimeout)
 		defer shutdownCancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {
 			logger.Error().Err(err).Msg("server shutdown failed")

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -208,22 +208,34 @@ func TestGracefulShutdownUsesShortNodeDrainContext(t *testing.T) {
 	require.NoError(t, err, "main.go should be readable for shutdown ordering regression test")
 
 	body := string(src)
-	require.Contains(t, body, "const nodeDrainMarkTimeout = 5 * time.Second",
+	require.Contains(t, body, "nodeDrainMarkTimeout      = 5 * time.Second",
 		"node drain DB marking should use a short bounded timeout")
+	require.Contains(t, body, "httpDrainPropagationDelay = 7 * time.Second",
+		"HTTP drain propagation should cover Caddy's 2s health interval, 2s timeout, and DNS refresh slack")
+	require.Contains(t, body, "httpShutdownTimeout       = 100 * time.Second",
+		"HTTP shutdown should leave headroom inside docker-compose.app.yml stop_grace_period after drain propagation")
 	require.Contains(t, body, "nodeDrainCtx, nodeDrainCancel := context.WithTimeout(context.Background(), nodeDrainMarkTimeout)",
 		"node drain DB marking should not consume the worker job drain context")
 	require.Contains(t, body, "nodeManager.RequestDrain(nodeDrainCtx, time.Now())",
 		"node drain DB marking should use the short node-drain context")
 	require.Contains(t, body, "drainCtx, drainCancel := context.WithTimeout(context.Background(), cfg.WorkerDrainTimeout)",
 		"worker jobs should keep the full configured drain timeout")
+	require.Contains(t, body, "shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), httpShutdownTimeout)",
+		"HTTP shutdown should use the bounded timeout constant")
 
 	nodeDrain := strings.Index(body, "nodeManager.RequestDrain(nodeDrainCtx, time.Now())")
+	httpDrainSignal := strings.Index(body, "close(shutdownCh)")
+	httpDrainDelay := strings.Index(body, "time.Sleep(httpDrainPropagationDelay)")
 	workerDrain := strings.Index(body, "drainCtx, drainCancel := context.WithTimeout(context.Background(), cfg.WorkerDrainTimeout)")
 	activeJobLoop := strings.Index(body, "activeJobs := 0")
 	require.NotEqual(t, -1, nodeDrain, "shutdown should mark the node draining")
+	require.NotEqual(t, -1, httpDrainSignal, "shutdown should mark HTTP health as draining")
+	require.NotEqual(t, -1, httpDrainDelay, "shutdown should wait for proxy health propagation")
 	require.NotEqual(t, -1, workerDrain, "shutdown should create the worker drain context")
 	require.NotEqual(t, -1, activeJobLoop, "shutdown should wait for active jobs")
-	require.Less(t, nodeDrain, workerDrain, "node drain DB marking should happen before the worker drain budget starts")
+	require.Less(t, nodeDrain, httpDrainSignal, "node drain DB marking should happen before HTTP health drain begins")
+	require.Less(t, httpDrainSignal, httpDrainDelay, "HTTP health should be marked draining before waiting for proxy propagation")
+	require.Less(t, httpDrainDelay, workerDrain, "proxy propagation should finish before the worker drain budget starts")
 	require.Less(t, workerDrain, activeJobLoop, "the worker drain budget should be reserved for the active-job wait")
 }
 

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -173,7 +173,7 @@ func TestProductionAlertsUseValidLogsQLRangeFilters(t *testing.T) {
 func TestLoggingDesignDocsTrackProvisionedDashboardsAndAlerts(t *testing.T) {
 	t.Parallel()
 
-	design, err := os.ReadFile("../docs/design/47-logging-victorialogs.md")
+	design, err := os.ReadFile("../docs/design/implemented/47-logging-victorialogs.md")
 	require.NoError(t, err, "test should read the VictoriaLogs design doc")
 
 	designText := string(design)

--- a/internal/api/handlers/health.go
+++ b/internal/api/handlers/health.go
@@ -14,6 +14,7 @@ import (
 type HealthHandler struct {
 	pool        *pgxpool.Pool
 	redisHealth func(context.Context) bool
+	draining    <-chan struct{}
 }
 
 func NewHealthHandler(pool *pgxpool.Pool) *HealthHandler {
@@ -24,8 +25,17 @@ func (h *HealthHandler) SetRedisHealthCheck(check func(context.Context) bool) {
 	h.redisHealth = check
 }
 
+func (h *HealthHandler) SetDrainingSignal(draining <-chan struct{}) {
+	h.draining = draining
+}
+
 func (h *HealthHandler) Healthz(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
+	if h.isDraining() {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"status":"draining"}`))
+		return
+	}
 	redisStatus := "unavailable"
 	if h.redisHealth != nil {
 		ctx, cancel := context.WithTimeout(r.Context(), time.Second)
@@ -35,6 +45,18 @@ func (h *HealthHandler) Healthz(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	_, _ = w.Write([]byte(`{"status":"ok","redis":"` + redisStatus + `"}`))
+}
+
+func (h *HealthHandler) isDraining() bool {
+	if h.draining == nil {
+		return false
+	}
+	select {
+	case <-h.draining:
+		return true
+	default:
+		return false
+	}
 }
 
 // Version returns the server deploy SHA and build metadata.

--- a/internal/api/handlers/health_test.go
+++ b/internal/api/handlers/health_test.go
@@ -46,6 +46,24 @@ func TestHealthz_WithRedisHealthy(t *testing.T) {
 	require.Contains(t, w.Body.String(), `"redis":"ok"`, "health response should report healthy Redis")
 }
 
+func TestHealthz_WhenDraining(t *testing.T) {
+	t.Parallel()
+
+	draining := make(chan struct{})
+	h := &HealthHandler{}
+	h.SetDrainingSignal(draining)
+	close(draining)
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+
+	h.Healthz(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code, "health check should fail while the process is draining")
+	require.Contains(t, w.Body.String(), `"status":"draining"`, "health response should report draining status")
+	require.Equal(t, "application/json", w.Header().Get("Content-Type"), "draining health response should set JSON content type")
+}
+
 func TestVersion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -147,6 +147,7 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 
 	// Create handlers
 	healthHandler := handlers.NewHealthHandler(pool)
+	healthHandler.SetDrainingSignal(shutdownCh)
 	if redisClient != nil {
 		healthHandler.SetRedisHealthCheck(redisClient.Healthy)
 	}


### PR DESCRIPTION
## Summary
- Make `/healthz` flip to `503` as soon as shutdown starts so Caddy stops routing new traffic to a draining API container.
- Add a short health-propagation window before HTTP shutdown, and trim the HTTP shutdown deadline so the full drain still fits inside Docker’s `stop_grace_period`.
- Update regression coverage for shutdown ordering and the new draining health response.
- Fix a stale design-doc path in a deploy test so the full Go suite passes.

## Testing
- Added unit coverage for draining `/healthz` behavior.
- Added shutdown-order regression coverage in `cmd/server`.
- Verified `go vet ./...`, `go build ./...`, and `go test ./...` pass.