### PR TITLE
Keep preview routing on owning workers during cold-start gaps

### DIFF
--- a/docs/design/implemented/48-worker-owned-preview-routing.md
+++ b/docs/design/implemented/48-worker-owned-preview-routing.md
@@ -85,6 +85,8 @@ Preview-capable workers publish the following metadata through `nodes.metadata`:
 
 Workers only advertise `preview_capable = true` after boot-time local recovery work is complete and the HTTP listener is bound. This prevents app nodes from routing preview lifecycle calls to a worker that is registered in the cluster but not yet accepting internal preview RPC.
 
+`preview_capable` gates cold-start worker selection. Existing previews and live session sandboxes remain pinned by `worker_node_id`; app nodes may resolve that owner with `preview_internal_base_url` even during the short interval before the worker re-advertises cold-start capability, so deployment readiness races do not orphan already-created preview rows.
+
 Startup recovery is worker-scoped. A worker only rehydrates sandbox-auth sockets for preview-held sessions whose active `preview_instances.worker_node_id` matches its own `NODE_ID`; it must not scan or rebind sockets for containers owned by peer workers.
 
 ## Deployment Contract

--- a/internal/services/preview/worker_routing.go
+++ b/internal/services/preview/worker_routing.go
@@ -68,11 +68,31 @@ func parseWorkerNode(node models.Node) (WorkerNode, error) {
 	}, nil
 }
 
+func parseRoutableWorkerNode(node models.Node) (WorkerNode, error) {
+	var metadata WorkerNodeMetadata
+	if len(node.Metadata) > 0 {
+		if err := json.Unmarshal(node.Metadata, &metadata); err != nil {
+			return WorkerNode{}, fmt.Errorf("parse node metadata: %w", err)
+		}
+	}
+	baseURL := strings.TrimRight(metadata.PreviewInternalBaseURL, "/")
+	if baseURL == "" {
+		return WorkerNode{}, fmt.Errorf("node %s has no preview internal base url", node.ID)
+	}
+	return WorkerNode{
+		ID:      node.ID,
+		Mode:    node.Mode,
+		BaseURL: baseURL,
+	}, nil
+}
+
 func isResolvableNodeStatus(status string) bool {
 	return status == "active" || status == "draining"
 }
 
-// ResolveNode returns a preview-capable worker by ID.
+// ResolveNode returns a routable worker by ID. Existing previews and live
+// sandboxes stay pinned to their owning worker, so routing only requires the
+// internal base URL; cold-start selection still requires preview_capable.
 func (s *WorkerSelector) ResolveNode(ctx context.Context, nodeID string) (WorkerNode, error) {
 	node, err := s.nodes.GetByID(ctx, nodeID)
 	if err != nil {
@@ -81,7 +101,7 @@ func (s *WorkerSelector) ResolveNode(ctx context.Context, nodeID string) (Worker
 	if !isResolvableNodeStatus(node.Status) {
 		return WorkerNode{}, fmt.Errorf("node %s is not routable", nodeID)
 	}
-	return parseWorkerNode(*node)
+	return parseRoutableWorkerNode(*node)
 }
 
 // SelectStartNode picks the worker that should handle Start Preview for the session.

--- a/internal/services/preview/worker_routing_test.go
+++ b/internal/services/preview/worker_routing_test.go
@@ -47,6 +47,34 @@ func TestWorkerSelector_ResolveNode_AllowsDrainingWorker(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestWorkerSelector_ResolveNode_AllowsTemporarilyNonCapableOwner(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create pgxmock pool")
+	defer mock.Close()
+
+	now := time.Now()
+	metadata, err := json.Marshal(WorkerNodeMetadata{
+		PreviewInternalBaseURL: "http://worker-1.internal:8080",
+	})
+	require.NoError(t, err, "should marshal worker metadata")
+
+	mock.ExpectQuery("SELECT .+ FROM nodes WHERE id = @id").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerNodeTestCols).
+				AddRow("worker-1", "worker", "worker-1.internal", "active", metadata, now, now),
+		)
+
+	selector := NewWorkerSelector(db.NewNodeStore(mock), db.NewPreviewStore(mock))
+	worker, err := selector.ResolveNode(context.Background(), "worker-1")
+	require.NoError(t, err, "ResolveNode should route existing previews when the worker has an internal base URL")
+	require.Equal(t, "worker-1", worker.ID, "ResolveNode should return the owning worker")
+	require.Equal(t, "http://worker-1.internal:8080", worker.BaseURL, "ResolveNode should preserve the worker base URL")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestParseWorkerNode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Allow `ResolveNode` to route by a worker’s internal preview base URL even when `preview_capable` is temporarily false
- Keep existing previews and live sandbox sessions pinned to their owning `worker_node_id` during worker redeploy and re-advertisement windows
- Document the routing contract in the implemented design doc
- Add coverage for resolving a temporarily non-capable but still routable worker

## Testing
- Added a unit test for resolving an owning worker while it is not yet preview-capable
- Existing preview routing tests continue to cover active and draining worker behavior