### PR TITLE
Fix preview 404 handling and isolate preview crashes

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -132,6 +132,7 @@ import { AgentBadge } from "@/components/agent-badge";
 import { PendingAttachmentStrip } from "@/components/pending-attachment-strip";
 import { PRHealthBanner, prHealthAllowsMerge } from "@/components/pr-health-banner";
 import { SessionKeyboardHelpOverlay } from "@/components/session-keyboard-help-overlay";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { useAuth } from "@/hooks/use-auth";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useDocumentVisible } from "@/hooks/use-document-visible";
@@ -169,6 +170,24 @@ const PreviewPanel = dynamic(
 const PREVIEW_ORIGIN_TEMPLATE =
   process.env.NEXT_PUBLIC_PREVIEW_ORIGIN_TEMPLATE ||
   "http://{id}.preview.localhost:9090";
+
+function PreviewTabErrorFallback() {
+  return (
+    <Card className="border-destructive/20 bg-destructive/5">
+      <CardContent className="flex items-start gap-3 p-4">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+        <div className="min-w-0 space-y-1">
+          <p className="text-sm font-medium text-destructive">
+            Preview panel could not be rendered
+          </p>
+          <p className="text-xs text-muted-foreground">
+            The rest of the session is still available. Refresh the page to try the preview again.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 const FAILURE_CATEGORY_CODEX_AUTH = "codex_auth_expired";
 const PR_ERROR_TOAST_DURATION_MS = 10_000;
@@ -4392,10 +4411,12 @@ export function SessionDetailContent({ id }: { id: string }) {
         </div>
       </TabsContent>
       <TabsContent value="preview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
-        <PreviewPanel
-          sessionId={id}
-          previewOriginTemplate={PREVIEW_ORIGIN_TEMPLATE}
-        />
+        <ErrorBoundary fallback={<PreviewTabErrorFallback />}>
+          <PreviewPanel
+            sessionId={id}
+            previewOriginTemplate={PREVIEW_ORIGIN_TEMPLATE}
+          />
+        </ErrorBoundary>
       </TabsContent>
     </Tabs>
   );

--- a/frontend/src/components/preview/console-badge.test.tsx
+++ b/frontend/src/components/preview/console-badge.test.tsx
@@ -35,6 +35,18 @@ describe("ConsoleBadge", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("treats a null console payload as no messages", async () => {
+    consoleGetMock.mockResolvedValue(null);
+    const { container } = renderWithProviders(
+      <ConsoleBadge sessionId="sess-1" />
+    );
+
+    await waitFor(() => {
+      expect(consoleGetMock).toHaveBeenCalledWith("sess-1");
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
   it("shows error badge when errors are present", async () => {
     consoleGetMock.mockResolvedValue([
       { level: "error", text: "TypeError: x is not a function", source: "app.js", line: 42, timestamp: new Date().toISOString() },

--- a/frontend/src/components/preview/console-badge.tsx
+++ b/frontend/src/components/preview/console-badge.tsx
@@ -55,11 +55,15 @@ export function ConsoleBadge({ sessionId }: ConsoleBadgeProps) {
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [expanded]);
 
-  const { data: messages = [] } = useQuery({
+  const { data: rawMessages } = useQuery({
     queryKey: ["preview-console", sessionId],
     queryFn: () => api.sessions.preview.console(sessionId),
     refetchInterval: 10000,
   });
+  const messages = useMemo(
+    () => (Array.isArray(rawMessages) ? rawMessages : []),
+    [rawMessages],
+  );
 
   const { errorCount, warnCount } = useMemo(() => {
     let errors = 0;

--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -17,6 +17,7 @@ const mockStart = vi.hoisted(() => vi.fn());
 const mockStop = vi.hoisted(() => vi.fn());
 const mockRestart = vi.hoisted(() => vi.fn());
 const mockBootstrap = vi.hoisted(() => vi.fn());
+const mockConsoleBadgeState = vi.hoisted(() => ({ shouldThrow: false }));
 
 vi.mock("@/lib/api", () => ({
   api: {
@@ -33,9 +34,12 @@ vi.mock("@/lib/api", () => ({
 }));
 
 vi.mock("./console-badge", () => ({
-  ConsoleBadge: ({ sessionId }: { sessionId: string }) => (
-    <div data-testid="console-badge">ConsoleBadge:{sessionId}</div>
-  ),
+  ConsoleBadge: ({ sessionId }: { sessionId: string }) => {
+    if (mockConsoleBadgeState.shouldThrow) {
+      throw new Error("console badge exploded");
+    }
+    return <div data-testid="console-badge">ConsoleBadge:{sessionId}</div>;
+  },
 }));
 
 vi.mock("./design-mode-overlay", () => ({
@@ -132,6 +136,7 @@ describe("PreviewPanel component", () => {
     mockStop.mockResolvedValue({});
     mockRestart.mockResolvedValue({});
     mockBootstrap.mockResolvedValue({ token: "tok-1" });
+    mockConsoleBadgeState.shouldThrow = false;
 
     class MockResizeObserver {
       constructor(callback: ResizeObserverCallback) {
@@ -380,6 +385,25 @@ describe("PreviewPanel component", () => {
     await waitFor(() => {
       expect(screen.getByTestId("console-badge")).toBeInTheDocument();
     });
+  });
+
+  it("keeps the preview panel usable if the console badge crashes", async () => {
+    const originalError = console.error;
+    console.error = vi.fn();
+    mockConsoleBadgeState.shouldThrow = true;
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "ready" }));
+
+    try {
+      renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Ready")).toBeInTheDocument();
+      });
+      expect(screen.getByTitle("Preview")).toBeInTheDocument();
+      expect(screen.queryByTestId("console-badge")).not.toBeInTheDocument();
+    } finally {
+      console.error = originalError;
+    }
   });
 
   it("renders TTLWarning when expires_at is set and preview is active", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -355,13 +355,15 @@ export function PreviewPanel({
   });
 
   const instance = previewStatus?.instance;
+  const rawServices = previewStatus?.services;
+  const rawInfrastructure = previewStatus?.infrastructure;
   const services = useMemo(
-    () => previewStatus?.services ?? [],
-    [previewStatus?.services],
+    () => (Array.isArray(rawServices) ? rawServices : []),
+    [rawServices],
   );
   const infrastructure = useMemo(
-    () => previewStatus?.infrastructure ?? [],
-    [previewStatus?.infrastructure],
+    () => (Array.isArray(rawInfrastructure) ? rawInfrastructure : []),
+    [rawInfrastructure],
   );
   const status = instance?.status;
   const isActive =
@@ -706,7 +708,11 @@ export function PreviewPanel({
         )}
 
         {/* Console errors badge */}
-        {isReady && <ConsoleBadge sessionId={sessionId} />}
+        {isReady && (
+          <ErrorBoundary fallback={null}>
+            <ConsoleBadge sessionId={sessionId} />
+          </ErrorBoundary>
+        )}
 
         {/* TTL Warning */}
         {instance?.expires_at && isReady && (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -451,10 +451,10 @@ export const api = {
       extend: (sessionId: string) => post(`/api/v1/sessions/${sessionId}/preview/extend`),
       services: (sessionId: string) =>
         get<import('./types').ListResponse<import('./preview-types').PreviewService>>(`/api/v1/sessions/${sessionId}/preview/services`)
-          .then(r => r.data),
+          .then(r => r.data ?? []),
       console: (sessionId: string) =>
         get<import('./types').ListResponse<import('./preview-types').ConsoleMessage>>(`/api/v1/sessions/${sessionId}/preview/console`)
-          .then(r => r.data),
+          .then(r => r.data ?? []),
       inspect: (sessionId: string, x: number, y: number) =>
         post<import('./types').SingleResponse<import('./preview-types').ElementInfo>>(`/api/v1/sessions/${sessionId}/preview/inspect`, { x, y })
           .then(r => r.data),

--- a/internal/models/responses.go
+++ b/internal/models/responses.go
@@ -1,9 +1,19 @@
 package models
 
+import "encoding/json"
+
 // ListResponse is the standard envelope for list endpoints.
 type ListResponse[T any] struct {
 	Data []T            `json:"data"`
 	Meta PaginationMeta `json:"meta"`
+}
+
+func (r ListResponse[T]) MarshalJSON() ([]byte, error) {
+	type listResponse ListResponse[T]
+	if r.Data == nil {
+		r.Data = []T{}
+	}
+	return json.Marshal(listResponse(r))
 }
 
 // SingleResponse is the standard envelope for single-item endpoints.

--- a/internal/models/responses_test.go
+++ b/internal/models/responses_test.go
@@ -1,0 +1,22 @@
+package models_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/assembledhq/143/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListResponseMarshalJSONEncodesNilDataAsEmptyArray(t *testing.T) {
+	t.Parallel()
+
+	body, err := json.Marshal(models.ListResponse[string]{})
+	require.NoError(t, err, "ListResponse should marshal successfully")
+	require.JSONEq(
+		t,
+		`{"data":[],"meta":{}}`,
+		string(body),
+		"ListResponse should encode nil data as an empty array",
+	)
+}


### PR DESCRIPTION
## Summary
- Treat empty preview console/status payloads as empty lists instead of crashing on `null` or missing data.
- Add error boundaries around the preview tab and console badge so a preview widget failure does not take down the full session page.
- Normalize list responses to serialize nil slices as `[]` and add a regression test for that API contract.

## Testing
- Added unit coverage for the nil list-response JSON shape.
- Added frontend regression tests for null preview console payloads and a crashing preview badge.
- Verified the change with frontend typecheck, lint, build, and Go test/vet/build.