### PR TITLE
Fix session “Add agent tab” accessibility and focus for both strip and header actions

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -507,7 +507,9 @@ describe('SessionDetailPage', () => {
     await user.click(screen.getByRole('tab', { name: /Claude review/ }));
     expect(await screen.findByText('Claude found a missing pagination cap.')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Add agent tab' }));
+    const addTabButtons = screen.getAllByRole('button', { name: 'Add agent tab' });
+    const stripAddButton = addTabButtons[addTabButtons.length - 1] as HTMLButtonElement;
+    await user.click(stripAddButton);
 
     await waitFor(() => {
       expect(createdThread).toBe(true);
@@ -607,7 +609,9 @@ describe('SessionDetailPage', () => {
 
     expect(await screen.findByPlaceholderText('Send a message to Claude Code...')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Add agent tab' }));
+    const addTabButtons = screen.getAllByRole('button', { name: 'Add agent tab' });
+    const stripAddButton = addTabButtons[addTabButtons.length - 1] as HTMLButtonElement;
+    await user.click(stripAddButton);
     expect(await screen.findByPlaceholderText('Send a message to Claude Code 2...')).toBeInTheDocument();
 
     await user.click(screen.getByLabelText('Agent'));
@@ -618,6 +622,81 @@ describe('SessionDetailPage', () => {
     });
     expect(screen.getByRole('tab', { name: /Codex 2/ })).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Send a message to Codex 2...')).toBeInTheDocument();
+  });
+
+  it('shows a desktop header add-tab action that creates a tab directly', async () => {
+    const sessionId = 'session-header-new-tab';
+    const threads: SessionThread[] = [
+      {
+        id: 'thread-main',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'codex',
+        label: 'Codex',
+        status: 'idle',
+        current_turn: 1,
+        created_at: '2026-02-17T07:00:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    ];
+    let createdThread = false;
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            id: sessionId,
+            status: 'idle',
+            agent_type: 'codex',
+            sandbox_state: 'ready',
+            threads,
+          },
+        } satisfies SingleResponse<Session & { threads: SessionThread[] }>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/messages', () => {
+        return HttpResponse.json({ data: [] as SessionMessage[], meta: {} } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/logs', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.get('/api/v1/sessions/:id/thread-file-events', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.post('/api/v1/sessions/:id/threads', async ({ request, params }) => {
+        const body = await request.json() as { label: string; agent_type: string };
+        createdThread = true;
+        const thread: SessionThread = {
+          id: 'thread-new',
+          session_id: params.id as string,
+          org_id: 'org-1',
+          agent_type: body.agent_type as SessionThread['agent_type'],
+          label: body.label,
+          status: 'idle',
+          current_turn: 0,
+          created_at: '2026-02-17T07:04:00Z',
+          cost_cents: 0,
+          pending_message_count: 0,
+        };
+        threads.push(thread);
+        return HttpResponse.json({ data: thread } satisfies SingleResponse<SessionThread>, { status: 201 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    await screen.findByPlaceholderText('Send a message to Codex...');
+
+    const headerActions = screen.getByTestId('session-header-actions');
+    const newTabButton = within(headerActions).getByRole('button', { name: 'Add agent tab' });
+    await user.click(newTabButton);
+
+    await waitFor(() => {
+      expect(createdThread).toBe(true);
+    });
+    expect(await screen.findByRole('tab', { name: /Codex 2/ })).toBeInTheDocument();
   });
 
   it('persists the selected model on a blank tab before the first thread send', async () => {
@@ -720,7 +799,9 @@ describe('SessionDetailPage', () => {
 
     expect(await screen.findByPlaceholderText('Send a message to Codex...')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: 'Add agent tab' }));
+    const addTabButtons = screen.getAllByRole('button', { name: 'Add agent tab' });
+    const stripAddButton = addTabButtons[addTabButtons.length - 1] as HTMLButtonElement;
+    await user.click(stripAddButton);
     expect(await screen.findByPlaceholderText('Send a message to Codex 2...')).toBeInTheDocument();
 
     await user.click(screen.getByLabelText('Model override'));
@@ -6447,8 +6528,9 @@ describe('SessionDetailPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<SessionDetailContent id={sessionId} />);
 
-    await screen.findByRole('button', { name: 'Add agent tab' });
-    await user.click(screen.getByRole('button', { name: 'Add agent tab' }));
+    const addTabButtons = await screen.findAllByRole('button', { name: 'Add agent tab' });
+    const stripAddButton = addTabButtons[addTabButtons.length - 1] as HTMLButtonElement;
+    await user.click(stripAddButton);
 
     const textarea = await screen.findByPlaceholderText('Send a message to Codex 2...');
 
@@ -6514,11 +6596,78 @@ describe('SessionDetailPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<SessionDetailContent id={sessionId} />);
 
-    await screen.findByRole('button', { name: 'Add agent tab' });
-    await user.click(screen.getByRole('button', { name: 'Add agent tab' }));
+    const addTabButtons = await screen.findAllByRole('button', { name: 'Add agent tab' });
+    const stripAddButton = addTabButtons[addTabButtons.length - 1] as HTMLButtonElement;
+    await user.click(stripAddButton);
 
     await waitFor(() => {
-      expect(document.activeElement).toHaveAttribute('aria-label', 'Add agent tab');
+      expect(stripAddButton).toHaveFocus();
+    });
+  });
+
+  it('returns focus to the desktop header add-tab trigger when a new tab has no composer', async () => {
+    const sessionId = 'session-header-create-tab-no-composer';
+    const threads: SessionThread[] = [
+      {
+        id: 'thread-main',
+        session_id: sessionId,
+        org_id: 'org-1',
+        agent_type: 'pm_agent',
+        label: 'Planner',
+        status: 'idle',
+        current_turn: 1,
+        created_at: '2026-02-17T07:00:00Z',
+        cost_cents: 0,
+        pending_message_count: 0,
+      },
+    ];
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[0],
+            id: sessionId,
+            agent_type: 'pm_agent',
+            status: 'idle',
+            sandbox_state: 'snapshotted',
+            threads,
+          },
+        } satisfies SingleResponse<Session & { threads: SessionThread[] }>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/messages', () => {
+        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<SessionMessage>);
+      }),
+      http.get('/api/v1/sessions/:id/threads/:threadId/logs', () => {
+        return HttpResponse.json({ data: [], meta: {} });
+      }),
+      http.post('/api/v1/sessions/:id/threads', async () => {
+        const thread: SessionThread = {
+          id: 'thread-new',
+          session_id: sessionId,
+          org_id: 'org-1',
+          agent_type: 'codex',
+          label: 'Codex 2',
+          status: 'idle',
+          current_turn: 0,
+          created_at: '2026-02-17T07:04:00Z',
+          cost_cents: 0,
+          pending_message_count: 0,
+        };
+        threads.push(thread);
+        return HttpResponse.json({ data: thread } satisfies SingleResponse<SessionThread>, { status: 201 });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<SessionDetailContent id={sessionId} />);
+
+    const headerActions = await screen.findByTestId('session-header-actions');
+    const headerAddButton = within(headerActions).getByRole('button', { name: 'Add agent tab' });
+    await user.click(headerAddButton);
+
+    await waitFor(() => {
+      expect(headerAddButton).toHaveFocus();
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -20,6 +20,7 @@ import {
   Check,
   XCircle,
   X,
+  Plus,
   Square,
   PanelRightOpen,
   PanelRightClose,
@@ -341,6 +342,8 @@ type PRActionErrorState = {
   code?: string;
   message: string;
 };
+
+type AddTabTriggerSource = "strip" | "header";
 
 const terminalSessionStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
 const SNAPSHOT_EXPIRED_PR_MESSAGE =
@@ -3281,6 +3284,8 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [newThreadLabel, setNewThreadLabel] = useState("");
   const focusComposerAfterThreadCreateRef = useRef(false);
   const addTabButtonRef = useRef<HTMLButtonElement>(null);
+  const headerAddTabButtonRef = useRef<HTMLButtonElement>(null);
+  const lastAddTabTriggerSourceRef = useRef<AddTabTriggerSource>("strip");
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null);
   const composerUploadInputRef = useRef<HTMLInputElement>(null);
   // Tracks an in-flight agent-switch PATCH so the send-time PATCH can wait
@@ -3785,11 +3790,21 @@ export function SessionDetailContent({ id }: { id: string }) {
         return;
       }
 
+      if (lastAddTabTriggerSourceRef.current === "header") {
+        headerAddTabButtonRef.current?.focus();
+        return;
+      }
+
       addTabButtonRef.current?.focus();
     });
 
     return () => window.cancelAnimationFrame(rafID);
   }, [activeThread?.id, composerCanSendMessage, session?.agent_type]);
+
+  const handleCreateThreadFrom = useCallback((source: AddTabTriggerSource) => {
+    lastAddTabTriggerSourceRef.current = source;
+    createThreadMutation.mutate(buildDefaultThreadRequest());
+  }, [buildDefaultThreadRequest, createThreadMutation]);
 
   useEffect(() => {
     setNewThreadModel("");
@@ -4494,19 +4509,38 @@ export function SessionDetailContent({ id }: { id: string }) {
                 )}
                 <LinkedIssueChips session={session} />
               </div>
-              <DisabledTooltip disabled={centerMode === "review" && showDetailPanel} content={detailToggleTitle}>
+              <div className="flex items-center gap-2" data-testid="session-header-actions">
                 <Button
-                  variant="ghost"
+                  ref={headerAddTabButtonRef}
+                  type="button"
+                  variant="outline"
                   size="icon"
-                  className={cn(centerMode === "review" && showDetailPanel && "opacity-30 cursor-not-allowed", "h-8 w-8 shrink-0")}
-                  disabled={centerMode === "review" && showDetailPanel}
-                  onClick={() => setShowDetailPanel(!showDetailPanel)}
-                  title={detailToggleTitle}
-                  aria-keyshortcuts="d"
+                  className="h-8 w-8 shrink-0"
+                  aria-label="Add agent tab"
+                  title="Add agent tab"
+                  onClick={() => handleCreateThreadFrom("header")}
+                  disabled={createThreadMutation.isPending}
                 >
-                  {showDetailPanel ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+                  {createThreadMutation.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Plus className="h-4 w-4" />
+                  )}
                 </Button>
-              </DisabledTooltip>
+                <DisabledTooltip disabled={centerMode === "review" && showDetailPanel} content={detailToggleTitle}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className={cn(centerMode === "review" && showDetailPanel && "opacity-30 cursor-not-allowed", "h-8 w-8 shrink-0")}
+                    disabled={centerMode === "review" && showDetailPanel}
+                    onClick={() => setShowDetailPanel(!showDetailPanel)}
+                    title={detailToggleTitle}
+                    aria-keyshortcuts="d"
+                  >
+                    {showDetailPanel ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+                  </Button>
+                </DisabledTooltip>
+              </div>
             </div>
           </>
         ) : null}
@@ -4520,7 +4554,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             overlapsByThreadId={overlapsByThreadId}
             statusConfig={statusConfig}
             onActiveThreadChange={setActiveThreadId}
-            onAddTab={() => createThreadMutation.mutate(buildDefaultThreadRequest())}
+            onAddTab={() => handleCreateThreadFrom("strip")}
             addTabPending={createThreadMutation.isPending}
             onCancelThread={(tid) => cancelThreadMutation.mutate(tid)}
             onForkThread={(tid) => forkThreadMutation.mutate(tid)}


### PR DESCRIPTION
## Summary
This restores the missing “new thread” behavior for desktop header users and fixes two accessibility regressions: the header “+” action now matches the accessible name used by the strip control, and focus correctly returns to the trigger the user clicked (strip or header). This resolves the session-tab creation findings and makes keyboard/screen-reader interactions consistent.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Set the desktop header **“+”** action to use the same accessible name as the strip control (**“Add agent tab”**), improving assistive technology discoverability.
  - Scoped/targeted the header “add tab” test behavior via the existing **`session-header-actions`** container instead of relying on a special screen-reader label.
  - Fixed focus regression after tab creation so focus returns to the actual trigger element the user used (strip `+` or header `+`).
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Updated existing tab-creation tests to reliably click the strip “Add agent tab” button when multiple “Add agent tab” buttons exist.
  - Added/updated coverage for the desktop header add-tab action to ensure it creates a tab directly and doesn’t regress focus/labels.

## Test plan
- Ran the updated unit/integration tests in **`frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`** covering both strip and header add-tab flows and the focus return behavior.
- Noted: could not run the full frontend verification suite in this environment due to missing frontend dependencies (`eslint: not found`).

[143.dev](https://143.dev) | [session 8ebd3db8](https://143.dev/sessions/8ebd3db8-a7cf-4f3e-891a-aa6433959610)