### PR TITLE
Fix session details 503s by hardening Caddy rollout gating and thread row loading

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -376,6 +376,32 @@ func TestDNSProbeVectorAlertFieldNamesAlign(t *testing.T) {
 	}
 }
 
+func TestRollingDeployAllowsCaddyToDiscoverNewUpstreamBeforeDrainingOld(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+
+	require.Contains(t, deployText, `CADDY_UPSTREAM_DISCOVERY_ATTEMPTS:-10`, "rolling deploy should use a bounded readiness loop instead of a single blind sleep")
+	require.Contains(t, deployText, `for i in $(seq 1 "$attempts")`, "rolling deploy should retry Caddy reachability checks before old containers drain")
+	require.Contains(t, deployText, `docker exec "$caddy_id" sh -c`, "rolling deploy should probe from inside the Caddy container network namespace")
+	require.Contains(t, deployText, `resolve_caddy_service_ips "$caddy_id" "$service"`, "rolling deploy should verify Caddy's service-name DNS path includes the new upstream")
+	require.Contains(t, deployText, `grep -Fxq "$new_ip"`, "rolling deploy should wait until Docker DNS resolves the service name to the new container IP")
+	require.Contains(t, deployText, `CADDY_DYNAMIC_REFRESH_SECONDS:-2`, "rolling deploy should give Caddy one dynamic upstream refresh after DNS includes the new container")
+	require.Contains(t, deployText, `read -r first second third _`, "rolling deploy should parse BusyBox nslookup Address N rows by field position")
+	require.Contains(t, deployText, `Address)`, "rolling deploy should handle BusyBox nslookup rows like `Address 1: 172.20.0.5 api`")
+	require.NotContains(t, deployText, `ip="${line##* }"`, "rolling deploy must not parse nslookup answers from the trailing token because BusyBox may append the hostname after the IP")
+	require.Contains(t, deployText, `http://$new_ip:$port/healthz`, "rolling deploy should probe the new container's health endpoint directly")
+	require.Contains(t, deployText, `wait_caddy_upstream_discovery "$service" "$new_container"`, "rolling deploy should wait for Caddy to discover the new upstream before old containers drain")
+
+	waitIndex := strings.Index(deployText, `wait_caddy_upstream_discovery "$service" "$new_container"`)
+	drainIndex := strings.Index(deployText, `echo "Draining $old_count old $service container(s)`)
+	require.NotEqual(t, -1, waitIndex, "wait call should be present in deploy script")
+	require.NotEqual(t, -1, drainIndex, "old-container drain should be present in deploy script")
+	require.Less(t, waitIndex, drainIndex, "Caddy upstream discovery wait should happen before draining old containers")
+}
+
 func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -467,6 +467,101 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     return 1
   }
 
+  resolve_caddy_service_ips() {
+    local caddy_id="$1" service="$2"
+    docker exec "$caddy_id" sh -c '
+      service="$1"
+      if command -v getent >/dev/null 2>&1; then
+        getent hosts "$service" | while read -r ip _; do
+          case "$ip" in
+            *:*) ;;
+            *) echo "$ip" ;;
+          esac
+        done
+      elif command -v nslookup >/dev/null 2>&1; then
+        nslookup "$service" | while read -r first second third _; do
+          case "$first" in
+            Address:)
+              ip="$second"
+              ;;
+            Address)
+              case "$second" in
+                *:) ip="$third" ;;
+                *) continue ;;
+              esac
+              ;;
+            *)
+              continue
+              ;;
+          esac
+          case "$ip" in
+            ""|*:*) ;;
+            *) echo "$ip" ;;
+          esac
+        done
+      else
+        exit 127
+      fi
+    ' sh "$service" | sort -u
+  }
+
+  # wait_caddy_upstream_discovery SERVICE CONTAINER_ID - Docker health means the
+  # container is ready, but Caddy still needs to be able to reach it from the
+  # proxy container's network namespace. Keep the old app/frontend container
+  # serving until the same service-name DNS path Caddy uses includes the new
+  # upstream and Caddy can probe it directly.
+  wait_caddy_upstream_discovery() {
+    local service="$1" new_container="$2" port
+    case "$service" in
+      api) port="8080" ;;
+      frontend) port="3000" ;;
+      *) return 0 ;;
+    esac
+
+    local caddy_id
+    caddy_id="$(docker compose -f "$COMPOSE_FILE" ps -q caddy | head -1 || true)"
+    if [ -z "$caddy_id" ]; then
+      echo "ERROR: caddy container not found; refusing to drain old $service containers"
+      return 1
+    fi
+
+    local new_ip
+    new_ip="$(docker inspect --format '{{range .NetworkSettings.Networks}}{{if .IPAddress}}{{println .IPAddress}}{{end}}{{end}}' "$new_container" | head -1)"
+    if [ -z "$new_ip" ]; then
+      echo "ERROR: could not determine IP for new $service container ${new_container:0:12}"
+      return 1
+    fi
+
+    local attempts="${CADDY_UPSTREAM_DISCOVERY_ATTEMPTS:-10}"
+    local interval="${CADDY_UPSTREAM_DISCOVERY_INTERVAL_SECONDS:-1}"
+    local dynamic_refresh="${CADDY_DYNAMIC_REFRESH_SECONDS:-2}"
+    local url="http://$new_ip:$port/healthz"
+    local dns_seen=0
+
+    echo "Waiting for Caddy to reach healthy $service upstream at $new_ip:$port..."
+    for i in $(seq 1 "$attempts"); do
+      local service_ips
+      service_ips="$(resolve_caddy_service_ips "$caddy_id" "$service" || true)"
+      if printf '%s\n' "$service_ips" | grep -Fxq "$new_ip"; then
+        if [ "$dns_seen" -eq 0 ]; then
+          echo "Caddy service DNS resolves $service to new upstream $new_ip; waiting ${dynamic_refresh}s for dynamic upstream refresh..."
+          sleep "$dynamic_refresh"
+          dns_seen=1
+        fi
+        if docker exec "$caddy_id" sh -c 'if command -v wget >/dev/null 2>&1; then wget -qO- -T 2 "$1" >/dev/null; elif command -v curl >/dev/null 2>&1; then curl -fsS --max-time 2 "$1" >/dev/null; else exit 127; fi' sh "$url"; then
+          echo "Caddy discovered and reached new $service upstream on attempt $i."
+          return 0
+        fi
+      fi
+      if [ "$i" -lt "$attempts" ]; then
+        sleep "$interval"
+      fi
+    done
+
+    echo "ERROR: Caddy could not reach new $service upstream at $new_ip:$port after $attempts attempt(s)"
+    return 1
+  }
+
   # rolling_deploy_service SERVICE — roll a single service with zero-downtime:
   #   1. scale up by 1 alongside the existing container(s)
   #   2. wait for the new container's health check
@@ -537,6 +632,7 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
 
     if [ -n "$old_containers" ]; then
+      wait_caddy_upstream_discovery "$service" "$new_container"
       # Stop each old container with a long timeout so in-flight requests and
       # SSE streams have time to drain. Docker sends SIGTERM and only falls
       # back to SIGKILL once stop_grace_period (compose) / -t (CLI) expires.

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -34,7 +34,7 @@ const sessionThreadListColumns = `id, session_id, org_id, agent_type, model_over
 	confidence_score, result_summary,
 	CASE WHEN diff IS NULL THEN NULL ELSE '__diff_present__' END AS diff,
 	failure_explanation, failure_category,
-	started_at, completed_at, created_at,
+	started_at, completed_at, created_at, archived_at,
 	base_snapshot_key, cost_cents, pending_message_count, cancel_requested_at`
 
 // ErrThreadLimitReached is returned when the maximum number of threads per session

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -230,6 +230,27 @@ func TestSessionThreadStore_ListBySession_OmitsRawDiffPayloads(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionThreadStore_ListBySession_SelectsArchivedAt(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionThreadStore(mock)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery(`(?s)SELECT .+created_at,\s+archived_at,\s+base_snapshot_key.+FROM session_threads`).
+		WithArgs(anyArgs(2)...).
+		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns))
+
+	threads, err := store.ListBySession(context.Background(), orgID, sessionID)
+	require.NoError(t, err, "ListBySession should select every SessionThread field required for row decoding")
+	require.Empty(t, threads, "ListBySession should return no rows from the empty result set")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionThreadStore_ListStuckRunningThreads(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fixes the session details failure by selecting `archived_at` in `ListBySession`, which restores row decoding for session thread lists.
- Replaces the previous blind Caddy sleep with a bounded readiness loop that waits for the new upstream to appear in Caddy’s service DNS path before draining old containers.
- Hardens the DNS fallback parser so BusyBox `nslookup` output is parsed by field position instead of accidentally treating the trailing hostname as the IP.
- Adds regression coverage for both the DB column projection and the deploy-script readiness behavior.

## Testing
- Added focused unit tests for `SessionThreadStore.ListBySession` and the deploy script expectations.
- Validated the deploy script syntax and ran the Go verification suite (`go vet`, `go build`, `go test`).