### PR TITLE
Fix mobile Settings tab padding/typography to match other sidebar nav items

### DIFF
--- a/frontend/src/components/authenticated-layout.tsx
+++ b/frontend/src/components/authenticated-layout.tsx
@@ -248,6 +248,7 @@ function SidebarBody({
           pathname={pathname}
           userRole={user?.role}
           onNavigate={onNavigate}
+          variant={variant}
         />
       </nav>
 

--- a/frontend/src/components/sidebar-settings-section.test.tsx
+++ b/frontend/src/components/sidebar-settings-section.test.tsx
@@ -3,6 +3,14 @@ import { renderWithProviders, screen } from '@/test/test-utils';
 import { SidebarSettingsSection } from './sidebar-settings-section';
 
 describe('SidebarSettingsSection', () => {
+  it('uses the same touch target sizing as other mobile nav tabs', () => {
+    renderWithProviders(
+      <SidebarSettingsSection pathname="/sessions" userRole="admin" variant="mobile" />
+    );
+
+    expect(screen.getByRole('button', { name: /Settings/ })).toHaveClass('px-2.5', 'py-3', 'text-sm');
+  });
+
   it('shows admin-only entries when role is admin', () => {
     renderWithProviders(
       <SidebarSettingsSection pathname="/settings" userRole="admin" />

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -83,12 +83,15 @@ export function SidebarSettingsSection({
   pathname,
   userRole,
   onNavigate,
+  variant = "desktop",
 }: {
   pathname: string;
   userRole: string | undefined;
   onNavigate?: () => void;
+  variant?: "desktop" | "mobile";
 }) {
   const onSettingsPage = isSettingsPath(pathname);
+  const isMobile = variant === "mobile";
 
   // Default to expanded if on a settings page to avoid flicker; otherwise
   // start collapsed and let the mount effect restore the persisted value.
@@ -126,7 +129,8 @@ export function SidebarSettingsSection({
         <button
           type="button"
           className={cn(
-            "flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors duration-150",
+            "flex w-full items-center rounded-md px-2.5 font-medium transition-colors duration-150",
+            isMobile ? "gap-2.5 py-3 text-sm" : "gap-2 py-1.5 text-xs",
             onSettingsPage
               ? "bg-sidebar-accent text-sidebar-accent-foreground"
               : "text-muted-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
@@ -136,7 +140,8 @@ export function SidebarSettingsSection({
           <span className="flex-1 text-left">Settings</span>
           <ChevronRight
             className={cn(
-              "h-3.5 w-3.5 shrink-0 opacity-50 transition-transform duration-200",
+              "shrink-0 opacity-50 transition-transform duration-200",
+              isMobile ? "h-4 w-4" : "h-3.5 w-3.5",
               isOpen && "rotate-90"
             )}
           />


### PR DESCRIPTION
## Summary
`SidebarSettingsSection` was still rendering the desktop-sized “Settings” trigger on mobile, causing a touch-target size mismatch versus the other sidebar navigation tabs. This change wires the sidebar variant through to `SidebarSettingsSection` and updates the button classes for mobile to match.

## Changes
- **frontend/src/components/authenticated-layout.tsx**
  - Passes the current `variant` prop into `SidebarBody` so nested sidebar components can size themselves correctly.
- **frontend/src/components/sidebar-settings-section.tsx**
  - Adds a `variant?: "desktop" | "mobile"` prop (defaulting to `"desktop"`).
  - Applies mobile-specific sizing classes (`px-2.5 py-3 text-sm`, plus adjusted gaps/icon sizing) to the **Settings** button when `variant === "mobile"`.
- **frontend/src/components/sidebar-settings-section.test.tsx**
  - Adds a regression test asserting the **Settings** button has the expected mobile touch-target classes.

## Test plan
- `npx vitest run src/components/sidebar-settings-section.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (build succeeds; existing Next.js warnings remain)

[143.dev](https://143.dev) | [session 1e2f6c4e](https://143.dev/sessions/1e2f6c4e-668b-4a43-9542-d38b072732f9)