### PR TITLE
Investigate and harden worker disk space exhaustion handling

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -232,7 +233,12 @@ func main() {
 
 			// Build sandbox+preview provider so worker-capable modes can start,
 			// stop, and hydrate previews locally.
-			sandboxExec := providers.NewDockerProvider(apiDockerCli, logger, providers.WithResolvConf(cfg.SandboxResolvConf))
+			sandboxExec := providers.NewDockerProvider(
+				apiDockerCli,
+				logger,
+				providers.WithResolvConf(cfg.SandboxResolvConf),
+				providers.WithRequireDiskQuota(cfg.SandboxRequireDiskQuota),
+			)
 			dockerPreviewProvider := previewproviders.NewDockerPreviewProvider(apiDockerCli, sandboxExec, logger)
 			pvProvider = dockerPreviewProvider
 			snapshotExec = sandboxExec
@@ -531,6 +537,9 @@ func main() {
 		// the provider doesn't expose stats.
 		if workerServices != nil && workerServices.RuntimeSampler != nil {
 			go workerServices.RuntimeSampler.Run(ctx)
+		}
+		if workerServices != nil && workerServices.SandboxGC != nil {
+			go workerServices.SandboxGC.Run(ctx)
 		}
 
 		// Upload reaper: clean up old uploaded files (local mode only; use S3 lifecycle rules for S3).
@@ -896,7 +905,13 @@ func buildServices(
 		logger.Error().Err(err).Msg("Docker not available — all Phase 3+ services disabled")
 		return nil
 	}
-	sandboxProvider := providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime(cfg.SandboxRuntime), providers.WithResolvConf(cfg.SandboxResolvConf))
+	sandboxProvider := providers.NewDockerProvider(
+		dockerCli,
+		logger,
+		providers.WithRuntime(cfg.SandboxRuntime),
+		providers.WithResolvConf(cfg.SandboxResolvConf),
+		providers.WithRequireDiskQuota(cfg.SandboxRequireDiskQuota),
+	)
 
 	// Startup health check: verify Docker daemon connectivity and, for gVisor,
 	// that the runsc runtime is functional. Retry a few times because Docker and
@@ -917,9 +932,26 @@ func buildServices(
 			}
 		}
 		if healthErr != nil {
+			if errors.Is(healthErr, providers.ErrDiskQuotaUnsupported) {
+				logger.Error().Err(healthErr).Msg("sandbox disk quota is required but Docker storage cannot enforce it — all Phase 3+ services disabled")
+				return nil
+			}
 			if cfg.SandboxRuntime == "runsc" && !cfg.SandboxRequireGVisor {
 				logger.Warn().Err(healthErr).Msg("gVisor not available, falling back to runc — NOT RECOMMENDED FOR PRODUCTION")
-				sandboxProvider = providers.NewDockerProvider(dockerCli, logger, providers.WithRuntime("runc"), providers.WithResolvConf(cfg.SandboxResolvConf))
+				sandboxProvider = providers.NewDockerProvider(
+					dockerCli,
+					logger,
+					providers.WithRuntime("runc"),
+					providers.WithResolvConf(cfg.SandboxResolvConf),
+					providers.WithRequireDiskQuota(cfg.SandboxRequireDiskQuota),
+				)
+				healthCtx, healthCancel := context.WithTimeout(context.Background(), 30*time.Second)
+				fallbackErr := sandboxProvider.HealthCheck(healthCtx)
+				healthCancel()
+				if fallbackErr != nil {
+					logger.Error().Err(fallbackErr).Msg("fallback runc sandbox health check failed — Phase 3+ services disabled")
+					return nil
+				}
 			} else {
 				logger.Error().Err(healthErr).Msg("sandbox health check failed — Phase 3+ services disabled")
 				return nil
@@ -1144,6 +1176,19 @@ func buildServices(
 		}
 	}
 
+	var sandboxGC *agent.SandboxGC
+	if cfg.SandboxGCInterval > 0 {
+		if gcProvider, ok := any(sandboxProvider).(agent.SandboxGCProvider); ok {
+			sandboxGC = agent.NewSandboxGC(gcProvider, sessionStore, containerUsageStore, agent.SandboxGCConfig{
+				Interval:                cfg.SandboxGCInterval,
+				UnreferencedGracePeriod: cfg.SandboxGCGrace,
+				HardMaxAge:              cfg.SandboxGCHardMax,
+			}, logger)
+		} else {
+			logger.Info().Msg("sandbox provider does not support managed-container listing; sandbox GC disabled")
+		}
+	}
+
 	svc := &worker.Services{
 		Orchestrator:    orchestrator,
 		PR:              prService,
@@ -1157,6 +1202,7 @@ func buildServices(
 		TitleService:    titleService,
 		Linear:          linearService,
 		RuntimeSampler:  runtimeSampler,
+		SandboxGC:       sandboxGC,
 	}
 	if sandboxAuthServer != nil {
 		// Capture by value: the closure outlives buildServices, but the

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -121,6 +121,10 @@ write_files:
       GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID}
       GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}
       CHROME_WS_URL=${CHROME_WS_URL}
+      SANDBOX_REQUIRE_DISK_QUOTA=true
+      SANDBOX_GC_INTERVAL=5m
+      SANDBOX_GC_GRACE=30m
+      SANDBOX_GC_HARD_MAX=24h
 
   # Per-host identity. Stays put across deploys — deploy.sh only rewrites
   # /opt/143/.env, then re-appends this file. If you re-IP the host or

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -31,6 +31,8 @@ func TestWorkerProvisioningIncludesGitHubAppUserAuthSecrets(t *testing.T) {
 	require.Contains(t, string(cloudInit), "SOPS_AGE_KEY=${SOPS_AGE_KEY}", "worker cloud-init should provide SOPS_AGE_KEY so the container can decrypt .env.production.enc at boot")
 	require.Contains(t, string(cloudInit), "GITHUB_APP_CLIENT_ID=${GITHUB_APP_CLIENT_ID}", "worker cloud-init should provide the GitHub App user auth client ID")
 	require.Contains(t, string(cloudInit), "GITHUB_APP_CLIENT_SECRET=${GITHUB_APP_CLIENT_SECRET}", "worker cloud-init should provide the GitHub App user auth client secret")
+	require.Contains(t, string(cloudInit), "SANDBOX_REQUIRE_DISK_QUOTA=true", "worker cloud-init should require Docker disk quota support by default")
+	require.Contains(t, string(cloudInit), "SANDBOX_GC_INTERVAL=5m", "worker cloud-init should enable worker-local sandbox GC")
 	require.Contains(t, string(cloudInit), "- path: /opt/143/.env.production.enc", "worker cloud-init should stage the encrypted production env file before docker compose starts")
 	require.Contains(t, string(cloudInit), "ENV_PRODUCTION_ENC_B64", "worker cloud-init should carry the encrypted production env payload as base64 input")
 
@@ -40,6 +42,8 @@ func TestWorkerProvisioningIncludesGitHubAppUserAuthSecrets(t *testing.T) {
 	require.Contains(t, string(provisionScript), "GITHUB_APP_CLIENT_ID=%s", "worker reprovision path should write the GitHub App user auth client ID into .env")
 	require.Contains(t, string(provisionScript), "GITHUB_APP_CLIENT_SECRET=%s", "worker reprovision path should write the GitHub App user auth client secret into .env")
 	require.Contains(t, string(provisionScript), "WORKER_MAX_ACTIVE_SANDBOXES=%s", "worker reprovision path should write the per-machine live sandbox capacity cap into .env")
+	require.Contains(t, string(provisionScript), "SANDBOX_REQUIRE_DISK_QUOTA=%s", "worker reprovision path should write the disk-quota requirement into .env")
+	require.Contains(t, string(provisionScript), "SANDBOX_GC_INTERVAL=%s", "worker reprovision path should write the sandbox GC interval into .env")
 	require.Contains(t, string(provisionScript), `scp "${SCP_OPTS[@]}" "$ENC_FILE" root@"$HOST":/opt/143/`, "worker reprovision path should copy .env.production.enc to the host before starting docker compose so bind-mount source creation cannot turn it into a directory")
 }
 
@@ -253,6 +257,28 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	makefile, err := os.ReadFile("../Makefile")
 	require.NoError(t, err, "test should read Makefile")
 	require.Contains(t, string(makefile), "repair-deploy-sudoers:", "Makefile should expose the no-teardown sudoers repair as an operator target")
+}
+
+func TestDeployPrunesDockerArtifactsAfterSuccessfulRollout(t *testing.T) {
+	t.Parallel()
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy script")
+	deployText := string(deployScript)
+
+	require.Contains(t, deployText, "prune_docker_deploy_artifacts()", "deploy.sh should define one prune helper so app, worker, and detached worker paths stay aligned")
+	require.Contains(t, deployText, `docker container prune -f --filter "until=$prune_until"`, "deploy prune should remove stopped containers after a successful rollout")
+	require.Contains(t, deployText, `docker image prune -af --filter "until=$prune_until"`, "deploy prune should remove old unused SHA-tagged images after a successful rollout")
+	require.Contains(t, deployText, `docker builder prune -af --filter "until=$prune_until"`, "deploy prune should remove unused build cache after a successful rollout")
+	require.Contains(t, deployText, `"DEPLOY_DOCKER_PRUNE=${DEPLOY_DOCKER_PRUNE:-1}"`, "deploy should pass the prune enable/disable knob through SSH to the remote host")
+	require.Contains(t, deployText, `"DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-24h}"`, "deploy should pass the prune age window through SSH to the remote host")
+	require.Contains(t, deployText, `docker image inspect "$sandbox_image"`, "worker prune should verify the sandbox image survived image pruning")
+	require.Contains(t, deployText, `docker pull "$sandbox_image"`, "worker prune should re-pull the sandbox image when image pruning removes it")
+	require.Contains(t, deployText, `$(declare -f drain_worker_service wait_container_healthy dump_diagnostics prune_docker_deploy_artifacts)`, "detached worker rollovers should embed the prune helper in the host-side script")
+	require.Contains(t, deployText, `IMAGE_TAG='$IMAGE_TAG'`, "detached worker rollovers should bake IMAGE_TAG so the prune helper can protect the sandbox image")
+	require.Contains(t, deployText, `prune_docker_deploy_artifacts worker`, "detached worker rollovers should prune only after the new worker is healthy")
+	require.Contains(t, deployText, `prune_docker_deploy_artifacts "$ROLE"`, "synchronous deploy paths should prune after the rollout and health checks succeed")
+	require.Contains(t, deployText, `DEPLOY_DOCKER_PRUNE=0`, "operators should have an explicit escape hatch for incident response or rollback-cache preservation")
 }
 
 // Pin the multi-resolver Docker DNS wiring so a future refactor doesn't

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -134,6 +134,10 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${DB_PASSWORD:?DB_PASSWORD is required for worker role (set it or add to .env.production.enc)}"
     : "${DB_HOST:?DB_HOST is required for worker role (set it or add to .env.production.enc)}"
     : "${VICTORIALOGS_HOST:?VICTORIALOGS_HOST is required for worker role (set it or add to .env.production.enc)}"
+    : "${SANDBOX_REQUIRE_DISK_QUOTA:=true}"
+    : "${SANDBOX_GC_INTERVAL:=5m}"
+    : "${SANDBOX_GC_GRACE:=30m}"
+    : "${SANDBOX_GC_HARD_MAX:=24h}"
     # Refresh the shared secrets in /opt/143/.env, then re-append the per-host
     # identity from /opt/143/.env.local (NODE_ID, WORKER_PRIVATE_IP,
     # PREVIEW_INTERNAL_BASE_URL) so docker compose can still interpolate them
@@ -141,9 +145,10 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     # and we abort if it's missing instead of silently coming up with an
     # empty NODE_ID and WORKER_PRIVATE_IP=0.0.0.0 (would expose worker to
     # the public internet).
-    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nWORKER_PROCESS_COUNT=%s\nWORKER_MAX_ACTIVE_SANDBOXES=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\n' \
+    printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nWORKER_PROCESS_COUNT=%s\nWORKER_MAX_ACTIVE_SANDBOXES=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\nSANDBOX_REQUIRE_DISK_QUOTA=%s\nSANDBOX_GC_INTERVAL=%s\nSANDBOX_GC_GRACE=%s\nSANDBOX_GC_HARD_MAX=%s\n' \
       "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       "${WORKER_PROCESS_COUNT:-}" "${WORKER_MAX_ACTIVE_SANDBOXES:-}" "${SANDBOX_CPU_LIMIT:-}" "${SANDBOX_MEMORY_LIMIT_MB:-}" "${SANDBOX_DISK_LIMIT_GB:-}" \
+      "$SANDBOX_REQUIRE_DISK_QUOTA" "$SANDBOX_GC_INTERVAL" "$SANDBOX_GC_GRACE" "$SANDBOX_GC_HARD_MAX" \
       | ssh "${SSH_OPTS[@]}" deploy@"$HOST" '
           set -euo pipefail
           cat > /opt/143/.env
@@ -416,6 +421,9 @@ fi
 ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
   "COMPOSE_FILE=$COMPOSE_FILE" "HEALTH_SERVICE=$HEALTH_SERVICE" "ROLE=$ROLE" "IMAGE_TAG=$TAG" \
   "WORKER_DEPLOY_DETACH=${WORKER_DEPLOY_DETACH:-}" \
+  "DEPLOY_DOCKER_PRUNE=${DEPLOY_DOCKER_PRUNE:-1}" \
+  "DOCKER_PRUNE_UNTIL=${DOCKER_PRUNE_UNTIL:-24h}" \
+  "DEPLOY_DOCKER_VOLUME_PRUNE=${DEPLOY_DOCKER_VOLUME_PRUNE:-0}" \
   bash << 'REMOTE'
   set -euo pipefail
   cd /opt/143
@@ -689,6 +697,43 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     fi
   }
 
+  # prune_docker_deploy_artifacts ROLE — reclaim Docker cache after a
+  # successful rollout. Runs only after the new service is healthy so the
+  # freshly pulled image is protected by a running container. Detached worker
+  # deploys embed and call this helper inside the detached rollover script for
+  # the same reason.
+  prune_docker_deploy_artifacts() {
+    local role="${1:-}"
+    if [ "${DEPLOY_DOCKER_PRUNE:-1}" = "0" ]; then
+      echo "Docker deploy prune skipped (DEPLOY_DOCKER_PRUNE=0)."
+      return 0
+    fi
+    case "$role" in
+      app|worker)
+        ;;
+      *)
+        echo "Docker deploy prune skipped for role=$role."
+        return 0
+        ;;
+    esac
+
+    local prune_until="${DOCKER_PRUNE_UNTIL:-24h}"
+    echo "Pruning unused Docker artifacts older than $prune_until..."
+    docker container prune -f --filter "until=$prune_until" || echo "WARNING: docker container prune failed; continuing."
+    docker image prune -af --filter "until=$prune_until" || echo "WARNING: docker image prune failed; continuing."
+    docker builder prune -af --filter "until=$prune_until" || echo "WARNING: docker builder prune failed; continuing."
+    if [ "$role" = "worker" ] && [ -n "${IMAGE_TAG:-}" ]; then
+      local sandbox_image="ghcr.io/assembledhq/143-sandbox:$IMAGE_TAG"
+      if ! docker image inspect "$sandbox_image" >/dev/null 2>&1; then
+        echo "Re-pulling required sandbox image after prune: $sandbox_image"
+        docker pull "$sandbox_image"
+      fi
+    fi
+    if [ "$role" = "worker" ] && [ "${DEPLOY_DOCKER_VOLUME_PRUNE:-0}" = "1" ]; then
+      docker volume prune -f || echo "WARNING: docker volume prune failed; continuing."
+    fi
+  }
+
   # wait_container_healthy CONTAINER_ID TIMEOUT — poll until a specific container
   # passes its health check, or fail after TIMEOUT seconds.
   wait_container_healthy() {
@@ -880,10 +925,14 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       cat > "$rollover_script" <<EOS
 #!/bin/bash
 set -euo pipefail
-$(declare -f drain_worker_service wait_container_healthy dump_diagnostics)
+$(declare -f drain_worker_service wait_container_healthy dump_diagnostics prune_docker_deploy_artifacts)
 COMPOSE_FILE='$COMPOSE_FILE'
 HEALTH_SERVICE='$HEALTH_SERVICE'
 STATUS_FILE='$status_file'
+IMAGE_TAG='$IMAGE_TAG'
+DEPLOY_DOCKER_PRUNE='${DEPLOY_DOCKER_PRUNE:-1}'
+DOCKER_PRUNE_UNTIL='${DOCKER_PRUNE_UNTIL:-24h}'
+DEPLOY_DOCKER_VOLUME_PRUNE='${DEPLOY_DOCKER_VOLUME_PRUNE:-0}'
 
 # Always write a status file so the verify step has a deterministic signal.
 # If we exit before the success line writes "ok", the trap leaves "fail".
@@ -908,6 +957,7 @@ cid="\$(docker compose -f "\$COMPOSE_FILE" ps -q "\$HEALTH_SERVICE" | head -1)"
 if [ -n "\$cid" ]; then
   wait_container_healthy "\$cid" 120 || { echo "[\$(date -u -Iseconds)] HEALTH CHECK FAILED"; exit 1; }
 fi
+prune_docker_deploy_artifacts worker
 echo "[\$(date -u -Iseconds)] rollover succeeded"
 echo "ok" > "\$STATUS_FILE"
 EOS
@@ -967,6 +1017,10 @@ EOS
       exit 1
     fi
     echo "Vector is running (status: $VECTOR_STATUS)."
+  fi
+
+  if [ "$ROLE" != "worker" ] || [ -z "${WORKER_DEPLOY_DETACH:-}" ]; then
+    prune_docker_deploy_artifacts "$ROLE"
   fi
 
   echo "Deploy complete ($ROLE)."

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -85,6 +85,12 @@ else
 fi
 
 apply_worker_bucket_overrides "$ROLE" "$HOST"
+if [ "$ROLE" = "worker" ]; then
+  : "${SANDBOX_REQUIRE_DISK_QUOTA:=true}"
+  : "${SANDBOX_GC_INTERVAL:=5m}"
+  : "${SANDBOX_GC_GRACE:=30m}"
+  : "${SANDBOX_GC_HARD_MAX:=24h}"
+fi
 
 # Validate required secrets are available (from env or .env.production.enc)
 if [ "$ROLE" != "logging" ] && [ "$ROLE" != "redis" ]; then
@@ -355,9 +361,10 @@ elif [ "$ROLE" = "worker" ]; then
   # and docker-entrypoint.sh decrypts it at boot. Provision the file before the
   # first `docker compose up` — if the source path is missing, Docker creates a
   # directory at /opt/143/.env.production.enc and later deploy-time scp fails.
-  printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nREDIS_TOPOLOGY=%s\nREDIS_PRIVATE_IP=%s\nREDIS_PASSWORD=%s\nGITHUB_APP_CLIENT_ID=%s\nGITHUB_APP_CLIENT_SECRET=%s\nWORKER_PROCESS_COUNT=%s\nWORKER_MAX_ACTIVE_SANDBOXES=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\n' \
+  printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nREDIS_TOPOLOGY=%s\nREDIS_PRIVATE_IP=%s\nREDIS_PASSWORD=%s\nGITHUB_APP_CLIENT_ID=%s\nGITHUB_APP_CLIENT_SECRET=%s\nWORKER_PROCESS_COUNT=%s\nWORKER_MAX_ACTIVE_SANDBOXES=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\nSANDBOX_REQUIRE_DISK_QUOTA=%s\nSANDBOX_GC_INTERVAL=%s\nSANDBOX_GC_GRACE=%s\nSANDBOX_GC_HARD_MAX=%s\n' \
     "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" "${REDIS_TOPOLOGY:-standalone}" "${REDIS_PRIVATE_IP:-}" "${REDIS_PASSWORD:-}" "${GITHUB_APP_CLIENT_ID:-}" "${GITHUB_APP_CLIENT_SECRET:-}" \
     "${WORKER_PROCESS_COUNT:-}" "${WORKER_MAX_ACTIVE_SANDBOXES:-}" "${SANDBOX_CPU_LIMIT:-}" "${SANDBOX_MEMORY_LIMIT_MB:-}" "${SANDBOX_DISK_LIMIT_GB:-}" \
+    "$SANDBOX_REQUIRE_DISK_QUOTA" "$SANDBOX_GC_INTERVAL" "$SANDBOX_GC_GRACE" "$SANDBOX_GC_HARD_MAX" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 
   # Per-host identity (NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL)

--- a/docs/design/implemented/76-sandbox-disk-guardrails.md
+++ b/docs/design/implemented/76-sandbox-disk-guardrails.md
@@ -1,0 +1,76 @@
+# Sandbox Disk Guardrails
+
+> **Status:** Implemented | **Last reviewed:** 2026-05-09
+
+Production workers run untrusted, write-heavy coding sandboxes on the same Docker host as the worker service. Disk exhaustion is therefore a platform availability risk, not just a per-session failure. The long-term guardrail is layered: reclaim routine deploy churn, make sandbox ownership visible to the host, reconcile leaked containers continuously, tighten lifecycle accounting, and require real Docker storage quotas in production.
+
+## Goals
+
+- Keep worker and app Docker hosts from filling with old images, stopped containers, and build cache after normal deploys.
+- Make every sandbox container discoverable without relying on image tags or DB rows that may be missing after a crash.
+- Remove leaked sandbox containers that no session owns, while avoiding destruction of preview-held or turn-held containers.
+- Keep billing and active-container accounting aligned with actual container lifetime.
+- Fail worker startup when the configured sandbox disk limit is not enforceable.
+
+## Deploy Pruning
+
+`deploy/scripts/deploy.sh` prunes unused Docker artifacts only after a successful app or worker rollout and health check. The default window is `DOCKER_PRUNE_UNTIL=24h`, so the newly pulled image remains protected by the running service container while old unused images, stopped containers, and builder cache are reclaimed. Operators can disable this with `DEPLOY_DOCKER_PRUNE=0`.
+
+Worker deploys can run detached during drain-and-rollover. In that path, the prune helper is embedded into the detached rollover script and runs after the replacement worker is healthy. The parent deploy process skips pruning for detached worker deploys so it cannot remove an image before the detached script has started the replacement container.
+
+Docker volumes are not pruned by default because they may contain stateful preview infrastructure. Worker volume pruning requires `DEPLOY_DOCKER_VOLUME_PRUNE=1`.
+
+## Sandbox Labels
+
+Every Docker sandbox created by `DockerProvider` carries the worker capacity labels used by the container setup:
+
+- `143.sandbox=true`
+- `143.session_id`
+- `143.org_id`
+- `143.purpose`
+
+It also carries provider-owned labels used by host-local GC:
+
+- `com.assembledhq.143.managed=true`
+- `com.assembledhq.143.type=sandbox`
+- `com.assembledhq.143.session_id`
+- `com.assembledhq.143.org_id`
+- `com.assembledhq.143.purpose`
+- `com.assembledhq.143.created_at`
+
+The worker-local GC accepts both label schemes and filters in-process rather than relying on repository image names. This keeps cleanup independent of image tags, deploy tags, and sandbox image rotations while remaining compatible with the live-capacity checks on `origin/main`.
+
+## Worker-Local Sandbox GC
+
+Each worker starts `SandboxGC` when `SANDBOX_GC_INTERVAL` is positive. Defaults:
+
+- `SANDBOX_GC_INTERVAL=5m`
+- `SANDBOX_GC_GRACE=30m`
+- `SANDBOX_GC_HARD_MAX=24h`
+
+The GC is host-local. It lists labeled Docker sandbox containers on the current worker and compares them to all `sessions.container_id` values in Postgres.
+
+Unreferenced containers older than the grace period are destroyed immediately. This covers the failure mode where a container was created but the DB row never recorded its ID, so startup orphan reconciliation cannot see it.
+
+Referenced containers are only hard-expired after `SANDBOX_GC_HARD_MAX`, and only through `SessionStore.FinalizeContainerDestroy(orgID, sessionID, expectedContainerID)`. That CAS requires there to be no active turn holder or preview holder before the DB reference is cleared. If the CAS loses, the GC leaves the container running.
+
+When the GC destroys a container, it closes any open `container_usage_events` rows for that Docker container ID with a GC-specific exit reason.
+
+## Lifecycle Accounting
+
+`RunAgent` records `ContainerStarted` only after `AcquireTurnHold` publishes DB ownership of the new container. This prevents crashes between Docker create and DB ownership from creating open usage rows for containers the session table does not reference. `ContinueSession` already followed this order.
+
+## Enforced Disk Quotas
+
+Production worker env files set `SANDBOX_REQUIRE_DISK_QUOTA=true`. When enabled, Docker health checks create a tiny quota probe container with `StorageOpt{"size":"1G"}`. Sandbox creation also fails instead of retrying without `StorageOpt` if Docker rejects the configured per-container disk limit.
+
+This is intentionally fail-closed. Docker only enforces `StorageOpt.size` for compatible storage setups, typically `overlay2` over XFS with project quotas. Hosts using ext4 or XFS without project quotas must be reprovisioned before this flag is enabled. Local development defaults remain permissive with `SANDBOX_REQUIRE_DISK_QUOTA=false`.
+
+## Operational Recipe
+
+1. Reprovision production workers so Docker's data root uses a storage backend that supports per-container size quotas.
+2. Confirm the worker can create a container with `--storage-opt size=1G` using the production runtime.
+3. Keep `SANDBOX_REQUIRE_DISK_QUOTA=true` on workers.
+4. Keep `SANDBOX_DISK_LIMIT_GB` sized to the host's concurrency target.
+5. Leave deploy pruning enabled with the 24 hour default. Lower `DOCKER_PRUNE_UNTIL` only if image churn again threatens host capacity.
+6. Use `DEPLOY_DOCKER_PRUNE=0` only for short-lived rollback/debug sessions.

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -1,6 +1,6 @@
 # Design: 143.dev
 
-> **Status:** Partially Implemented | **Last reviewed:** 2026-05-08
+> **Status:** Partially Implemented | **Last reviewed:** 2026-05-09
 
 [143.dev](http://143.dev) is an open-source platform that turns customer pain and production errors into safe code fixes that ship automatically.
 
@@ -93,6 +93,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
     - The `Changes` file list should keep the parsed diff's order aligned with the diff viewer. It uses a grouped tree when that tree can preserve the sequence, and falls back to a flat exact-order list when interleaved paths would otherwise force the grouped view to reorder files; see [implemented/68-consistent-review-file-ordering.md](implemented/68-consistent-review-file-ordering.md).
     - The agent runs in a sandboxed container and produces a code diff.
     - Production sandboxes share the `143-sandbox` bridge with preview infrastructure and a `sandbox-dns` sidecar at a pinned bridge IP. The bridge must leave Docker inter-container communication at its default so gVisor sandboxes can reach that DNS sidecar; host firewall rules provide the egress boundary for metadata and private-network destinations.
+    - Production workers treat sandbox disk usage as a first-class capacity boundary: deploys prune unused Docker artifacts after a healthy rollout, sandbox containers carry durable ownership labels, worker-local GC reconciles labeled host containers with DB session ownership, and worker startup fails closed when Docker cannot enforce `SANDBOX_DISK_LIMIT_GB`. Details: [implemented/76-sandbox-disk-guardrails.md](implemented/76-sandbox-disk-guardrails.md).
     - Sandbox GitHub write access uses a **per-session host credential socket plus in-sandbox `gh` wrapper**, not a long-lived token embedded in the container env. The auth path now follows sandbox lifetime: preview-held containers keep their credential socket alive across turns, while fresh/hydrated continue-session sandboxes recreate the socket and bootstrap on create.
     - Repo-backed sessions also treat the **session working branch as a guarded runtime invariant**: fresh runs create a canonical working branch, continue-session fresh clones recreate it, PR creation reuses it, and sandbox bootstrap installs a branch-specific `pre-push` hook so accidental pushes to the wrong branch fail locally before they reach GitHub. See [implemented/66-session-branch-guardrails.md](implemented/66-session-branch-guardrails.md).
     - Long-running sessions must survive routine platform deploys and worker restarts. Worker infrastructure therefore uses drain-before-deploy behavior, lease-based dead-worker recovery for in-flight jobs, and checkpoint-aware resume from the last committed turn after unplanned worker loss; see [51-worker-deploy-safety.md](backlog/51-worker-deploy-safety.md).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,6 +138,10 @@ type Config struct {
 	// Sandbox
 	SandboxRuntime       string `env:"SANDBOX_RUNTIME" envDefault:"runc"`
 	SandboxRequireGVisor bool   `env:"SANDBOX_REQUIRE_GVISOR" envDefault:"false"`
+	// SandboxRequireDiskQuota fails sandbox startup when Docker cannot enforce
+	// SANDBOX_DISK_LIMIT_GB via StorageOpt. Production worker deploys set this
+	// true by default; local dev can leave it false for ext4 Docker installs.
+	SandboxRequireDiskQuota bool `env:"SANDBOX_REQUIRE_DISK_QUOTA" envDefault:"false"`
 	// SandboxResolvConf, when set, is bind-mounted read-only at /etc/resolv.conf
 	// inside every sandbox container. Required under runsc on user-defined
 	// networks because gVisor's netstack can't reach Docker's embedded DNS at
@@ -229,6 +233,13 @@ type Config struct {
 	// histograms. Operators use these to size SANDBOX_* limits against actual
 	// consumption rather than allocation. Set to 0 to disable sampling.
 	RuntimeStatsInterval time.Duration `env:"RUNTIME_STATS_INTERVAL" envDefault:"30s"`
+	// SandboxGCInterval controls worker-local cleanup of provider-labeled
+	// sandbox containers. The GC destroys old managed containers that no
+	// session row references and hard-expires idle referenced containers only
+	// after a DB finalize CAS wins. Set to 0 to disable.
+	SandboxGCInterval time.Duration `env:"SANDBOX_GC_INTERVAL" envDefault:"5m"`
+	SandboxGCGrace    time.Duration `env:"SANDBOX_GC_GRACE"    envDefault:"30m"`
+	SandboxGCHardMax  time.Duration `env:"SANDBOX_GC_HARD_MAX" envDefault:"24h"`
 
 	// Redis (optional)
 	RedisTopology   string `env:"REDIS_TOPOLOGY" envDefault:"standalone"`

--- a/internal/db/container_usage_store.go
+++ b/internal/db/container_usage_store.go
@@ -179,6 +179,30 @@ func (s *ContainerUsageStore) CloseOrphans(ctx context.Context, startedBefore ti
 	return tag.RowsAffected(), nil
 }
 
+// CloseOpenByContainerID closes open usage events for a container destroyed
+// outside the ordinary orchestrator defer path, such as worker-local sandbox
+// GC. The container ID is globally opaque enough for this system cleanup path.
+// lint:allow-no-orgid reason="system cleanup by opaque Docker container ID across all orgs"
+func (s *ContainerUsageStore) CloseOpenByContainerID(ctx context.Context, containerID string, stoppedAt time.Time, exitReason string) (int64, error) {
+	tag, err := s.db.Exec(ctx, `
+		UPDATE container_usage_events
+		SET stopped_at = @stopped_at,
+		    duration_ms = EXTRACT(EPOCH FROM (@stopped_at::timestamptz - started_at)) * 1000,
+		    container_minutes = EXTRACT(EPOCH FROM (@stopped_at::timestamptz - started_at)) / 60.0,
+		    exit_reason = @exit_reason
+		WHERE container_id = @container_id
+		  AND stopped_at IS NULL`,
+		pgx.NamedArgs{
+			"stopped_at":   stoppedAt,
+			"exit_reason":  exitReason,
+			"container_id": containerID,
+		})
+	if err != nil {
+		return 0, fmt.Errorf("close open usage by container id: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // CountActive returns the number of container usage events that have not been
 // stopped yet. Used by the observable gauge to report the true active count.
 // lint:allow-no-orgid reason="system-wide gauge counting active containers across all orgs"

--- a/internal/db/container_usage_store_test.go
+++ b/internal/db/container_usage_store_test.go
@@ -174,6 +174,25 @@ func TestContainerUsageStore_CloseOrphans(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestContainerUsageStore_CloseOpenByContainerID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewContainerUsageStore(mock)
+	stoppedAt := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	mock.ExpectExec("UPDATE container_usage_events").
+		WithArgs(stoppedAt, "sandbox_gc_unreferenced", "container-123").
+		WillReturnResult(pgxmock.NewResult("UPDATE", 2))
+
+	closed, err := store.CloseOpenByContainerID(context.Background(), "container-123", stoppedAt, "sandbox_gc_unreferenced")
+	require.NoError(t, err, "CloseOpenByContainerID should close open usage rows for a destroyed container")
+	require.Equal(t, int64(2), closed, "CloseOpenByContainerID should return the number of rows it closed")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestContainerUsageStore_CountActive(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -2208,6 +2208,36 @@ func (s *SessionStore) ListOrphanedContainers(ctx context.Context, afterID uuid.
 	return sessions, nil
 }
 
+// ListReferencedContainerIDs returns every live container_id currently
+// referenced by a session row. It is used by worker-local Docker GC to avoid
+// deleting a container that any DB row still owns.
+// lint:allow-no-orgid reason="worker-local Docker GC reconciles host containers against all session container references"
+func (s *SessionStore) ListReferencedContainerIDs(ctx context.Context) ([]string, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT container_id
+		FROM sessions
+		WHERE container_id IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("list referenced container ids: %w", err)
+	}
+	defer rows.Close()
+
+	ids := make([]string, 0)
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("scan referenced container id: %w", err)
+		}
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate referenced container ids: %w", err)
+	}
+	return ids, nil
+}
+
 // ListContainerHoldingSessions returns sessions with a preview hold owned by
 // workerNodeID whose container_id is set. Called on startup to rehydrate
 // per-session GitHub credential socket listeners for containers that survive

--- a/internal/db/session_store_test.go
+++ b/internal/db/session_store_test.go
@@ -2287,6 +2287,43 @@ func TestSessionStore_ListOrphanedContainers_QueryError(t *testing.T) {
 	require.Contains(t, err.Error(), "list orphaned containers")
 }
 
+func TestSessionStore_ListReferencedContainerIDs(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	mock.ExpectQuery(`SELECT container_id\s+FROM sessions\s+WHERE container_id IS NOT NULL`).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"container_id"}).
+				AddRow("container-a").
+				AddRow("container-b"),
+		)
+
+	ids, err := store.ListReferencedContainerIDs(context.Background())
+	require.NoError(t, err, "ListReferencedContainerIDs should not return an error")
+	require.Equal(t, []string{"container-a", "container-b"}, ids, "ListReferencedContainerIDs should return every non-null session container id")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestSessionStore_ListReferencedContainerIDs_QueryError(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	mock.ExpectQuery(`SELECT container_id\s+FROM sessions\s+WHERE container_id IS NOT NULL`).
+		WillReturnError(errors.New("boom"))
+
+	_, err = store.ListReferencedContainerIDs(context.Background())
+	require.Error(t, err, "ListReferencedContainerIDs should surface query failures")
+	require.Contains(t, err.Error(), "list referenced container ids", "ListReferencedContainerIDs should wrap query failures with context")
+}
+
 // TestSessionStore_ListContainerHoldingSessions is the rehydrate-side
 // counterpart to ListOrphanedContainers: same paging, opposite predicate
 // (EXISTS preview hold instead of NOT EXISTS). The query must filter by

--- a/internal/db/tenancy_test.go
+++ b/internal/db/tenancy_test.go
@@ -67,6 +67,7 @@ func TestMultiTenancyAudit(t *testing.T) {
 		{"sessions", "where status = 'running'"},               // ListStaleRunningSessions: system-wide cleanup across all orgs
 		{"sessions", "where sandbox_state"},                    // ListExpiredSnapshots: system-wide snapshot cleanup across all orgs
 		{"sessions", "where pending_snapshot_key is not null"}, // ReapStrandedPendingSnapshots: system-wide cross-org sweep run by leader-elected scheduler; per-org fanout adds no security and would require listing every org each tick
+		{"sessions", "where container_id is not null"},         // ListReferencedContainerIDs: worker-local Docker GC must compare host containers against all DB-owned container references
 		{"sessions", "diff_history"},                           // UpdateResult/UpdateTurnComplete: org_id is in a concatenated string fragment
 		{"repositories", "installation_id"},
 		{"integrations", "from integrations"},

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -1735,11 +1735,6 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 		o.failRun(ctx, run, fmt.Sprintf("create sandbox: %s", err))
 		return fmt.Errorf("create sandbox: %w", err)
 	}
-	containerStartedAt := time.Now()
-	var usageEventID uuid.UUID
-	if o.usageTracker != nil {
-		usageEventID = o.usageTracker.ContainerStarted(ctx, run.OrgID, run.ID, sandbox, sandboxCfg, containerStartedAt)
-	}
 	// Record the turn hold so a concurrent StartPreview can attach to this
 	// container (same ID, same filesystem) instead of hydrating a duplicate.
 	// AcquireTurnHold uses COALESCE to publish only if no one has raced ahead;
@@ -1786,6 +1781,11 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 			}
 		}
 		return fmt.Errorf("%w: actual container %s != created %s", diagErr, actualContainerID, sandbox.ID)
+	}
+	containerStartedAt := time.Now()
+	var usageEventID uuid.UUID
+	if o.usageTracker != nil {
+		usageEventID = o.usageTracker.ContainerStarted(ctx, run.OrgID, run.ID, sandbox, sandboxCfg, containerStartedAt)
 	}
 	defer func() {
 		exitReason := containerExitReason(ctx, err)

--- a/internal/services/agent/orchestrator_internal_test.go
+++ b/internal/services/agent/orchestrator_internal_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,6 +17,27 @@ import (
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/sandboxauth"
 )
+
+func TestRunAgentRecordsUsageOnlyAfterTurnHoldIsPublished(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("orchestrator.go")
+	require.NoError(t, err, "orchestrator.go should be readable for lifecycle ordering regression test")
+
+	body := string(src)
+	runStart := strings.Index(body, "func (o *Orchestrator) RunAgent(")
+	continueStart := strings.Index(body, "func (o *Orchestrator) ContinueSession(")
+	require.NotEqual(t, -1, runStart, "RunAgent should exist")
+	require.NotEqual(t, -1, continueStart, "ContinueSession should exist")
+	require.Less(t, runStart, continueStart, "RunAgent should appear before ContinueSession in orchestrator.go")
+
+	runBody := body[runStart:continueStart]
+	hold := strings.Index(runBody, "o.sessions.AcquireTurnHold")
+	usage := strings.Index(runBody, "o.usageTracker.ContainerStarted")
+	require.NotEqual(t, -1, hold, "RunAgent should publish the turn hold")
+	require.NotEqual(t, -1, usage, "RunAgent should record container usage")
+	require.Less(t, hold, usage, "RunAgent should record usage only after the DB row owns the container so pre-hold crashes do not create open usage events for unowned containers")
+}
 
 type testInternalSessionLogStore struct {
 	logs             []models.SessionLog

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -5,6 +5,7 @@ package providers
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -28,6 +29,7 @@ import (
 // Compile-time check that DockerProvider implements agent.SandboxProvider.
 var _ agent.SandboxProvider = (*DockerProvider)(nil)
 var _ agent.InteractiveSandboxProvider = (*DockerProvider)(nil)
+var _ agent.SandboxGCProvider = (*DockerProvider)(nil)
 
 // defaultScratchDir is the exec-allowed scratch dir injected as $TMPDIR (and
 // $GOTMPDIR) for sandbox containers. /tmp is mounted noexec for defense in
@@ -37,6 +39,24 @@ var _ agent.InteractiveSandboxProvider = (*DockerProvider)(nil)
 // a separate writable+exec tmpfs so well-behaved tooling has a place to work
 // without weakening the /tmp hardening.
 const defaultScratchDir = "/var/tmp"
+
+const (
+	SandboxLabelManaged   = "com.assembledhq.143.managed"
+	SandboxLabelType      = "com.assembledhq.143.type"
+	SandboxLabelSessionID = "com.assembledhq.143.session_id"
+	SandboxLabelOrgID     = "com.assembledhq.143.org_id"
+	SandboxLabelPurpose   = "com.assembledhq.143.purpose"
+	SandboxLabelCreatedAt = "com.assembledhq.143.created_at"
+
+	sandboxLabelLegacySandbox   = "143.sandbox"
+	sandboxLabelLegacySessionID = "143.session_id"
+	sandboxLabelLegacyOrgID     = "143.org_id"
+	sandboxLabelLegacyPurpose   = "143.purpose"
+)
+
+// ErrDiskQuotaUnsupported is returned when Docker rejects the StorageOpt
+// quota needed to make SANDBOX_DISK_LIMIT_GB a real host-level limit.
+var ErrDiskQuotaUnsupported = errors.New("docker disk quota unsupported")
 
 // DockerClient defines the subset of the Docker API used by DockerProvider.
 type DockerClient interface {
@@ -58,11 +78,12 @@ type DockerClient interface {
 // DockerProvider implements SandboxProvider using Docker containers
 // with optional gVisor (runsc) runtime for enhanced isolation.
 type DockerProvider struct {
-	client     DockerClient
-	runtime    string // "runsc" (gVisor) or "runc" (standard Docker)
-	network    string // pre-created Docker network with egress restrictions
-	resolvConf string // host path bind-mounted at /etc/resolv.conf in sandboxes
-	logger     zerolog.Logger
+	client           DockerClient
+	runtime          string // "runsc" (gVisor) or "runc" (standard Docker)
+	network          string // pre-created Docker network with egress restrictions
+	resolvConf       string // host path bind-mounted at /etc/resolv.conf in sandboxes
+	requireDiskQuota bool
+	logger           zerolog.Logger
 }
 
 // DockerProviderOption configures a DockerProvider.
@@ -95,6 +116,14 @@ func WithResolvConf(path string) DockerProviderOption {
 	}
 }
 
+// WithRequireDiskQuota makes Docker StorageOpt quota support mandatory when
+// SandboxConfig.DiskLimitGB is non-zero.
+func WithRequireDiskQuota(required bool) DockerProviderOption {
+	return func(p *DockerProvider) {
+		p.requireDiskQuota = required
+	}
+}
+
 // NewDockerProvider creates a new DockerProvider with the given Docker client.
 func NewDockerProvider(cli DockerClient, logger zerolog.Logger, opts ...DockerProviderOption) *DockerProvider {
 	p := &DockerProvider{
@@ -120,6 +149,12 @@ func (d *DockerProvider) HealthCheck(ctx context.Context) error {
 
 	if err := d.ensureNetwork(ctx); err != nil {
 		return fmt.Errorf("docker health check: %w", err)
+	}
+
+	if d.requireDiskQuota {
+		if err := d.checkDiskQuotaSupport(ctx); err != nil {
+			return fmt.Errorf("docker health check: %w", err)
+		}
 	}
 
 	if d.runtime == "runc" {
@@ -178,6 +213,36 @@ func (d *DockerProvider) HealthCheck(ctx context.Context) error {
 			return nil
 		}
 	}
+}
+
+func (d *DockerProvider) checkDiskQuotaSupport(ctx context.Context) error {
+	resp, err := d.client.ContainerCreate(ctx, &container.Config{
+		Image: "busybox:latest",
+		Cmd:   []string{"true"},
+		Labels: map[string]string{
+			SandboxLabelManaged: "true",
+			SandboxLabelType:    "quota-probe",
+		},
+	}, &container.HostConfig{
+		Runtime: d.runtime,
+		StorageOpt: map[string]string{
+			"size": "1G",
+		},
+	}, nil, nil, "")
+	if err != nil {
+		if isDiskQuotaUnsupported(err) {
+			return fmt.Errorf("%w: %v", ErrDiskQuotaUnsupported, err)
+		}
+		return fmt.Errorf("quota probe create: %w", err)
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := d.client.ContainerRemove(cleanupCtx, resp.ID, container.RemoveOptions{Force: true}); err != nil && !cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("quota probe cleanup: %w", err)
+	}
+	d.logger.Info().Msg("docker disk quota health check passed")
+	return nil
 }
 
 // ensureNetwork verifies the configured sandbox network exists on the Docker
@@ -299,7 +364,7 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 		User:       "sandbox",
 		Tty:        false,
 		Env:        envSlice,
-		Labels:     sandboxContainerLabels(cfg),
+		Labels:     sandboxContainerLabels(cfg, time.Now()),
 		// Keep container running with a long sleep so we can exec into it
 		Cmd: []string{"sleep", "infinity"},
 	}
@@ -390,7 +455,10 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	if err != nil {
 		// StorageOpt requires overlay2 with XFS+pquota. Fall back gracefully
 		// on hosts that don't support it (e.g. dev machines with ext4).
-		if strings.Contains(err.Error(), "storage-opt") || strings.Contains(err.Error(), "pquota") {
+		if isDiskQuotaUnsupported(err) {
+			if d.requireDiskQuota {
+				return nil, fmt.Errorf("create container with %dGB disk quota: %w: %v", cfg.DiskLimitGB, ErrDiskQuotaUnsupported, err)
+			}
 			log.Warn().Err(err).Msg("storage quota not supported by Docker storage driver; creating container without disk limit")
 			hostCfg.StorageOpt = nil
 			resp, err = d.client.ContainerCreate(ctx, containerCfg, hostCfg, networkCfg, platform, "")
@@ -456,19 +524,25 @@ func (d *DockerProvider) Create(ctx context.Context, cfg agent.SandboxConfig) (*
 	return sb, nil
 }
 
-func sandboxContainerLabels(cfg agent.SandboxConfig) map[string]string {
+func sandboxContainerLabels(cfg agent.SandboxConfig, createdAt time.Time) map[string]string {
 	labels := map[string]string{
-		"managed-by":  "143",
-		"143.sandbox": "true",
+		"managed-by":              "143",
+		sandboxLabelLegacySandbox: "true",
+		SandboxLabelManaged:       "true",
+		SandboxLabelType:          "sandbox",
+		SandboxLabelCreatedAt:     createdAt.UTC().Format(time.RFC3339Nano),
 	}
 	if cfg.SessionID != "" {
-		labels["143.session_id"] = cfg.SessionID
+		labels[sandboxLabelLegacySessionID] = cfg.SessionID
+		labels[SandboxLabelSessionID] = cfg.SessionID
 	}
 	if cfg.OrgID != "" {
-		labels["143.org_id"] = cfg.OrgID
+		labels[sandboxLabelLegacyOrgID] = cfg.OrgID
+		labels[SandboxLabelOrgID] = cfg.OrgID
 	}
 	if cfg.Purpose != "" {
-		labels["143.purpose"] = cfg.Purpose
+		labels[sandboxLabelLegacyPurpose] = cfg.Purpose
+		labels[SandboxLabelPurpose] = cfg.Purpose
 	}
 	return labels
 }
@@ -495,11 +569,72 @@ func (d *DockerProvider) CountLiveSandboxes(ctx context.Context) (int, error) {
 }
 
 func isLiveSandboxContainer(summary container.Summary) bool {
-	if summary.Labels != nil && summary.Labels["143.sandbox"] == "true" {
+	if summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels)) {
 		return true
 	}
 	image := strings.ToLower(summary.Image)
 	return strings.Contains(image, "143-sandbox") && !strings.Contains(image, "143-sandbox-dns")
+}
+
+func isDiskQuotaUnsupported(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "storage-opt") ||
+		strings.Contains(msg, "pquota") ||
+		strings.Contains(msg, "project quota") ||
+		strings.Contains(msg, "overlay over xfs")
+}
+
+// ListManagedSandboxes returns every Docker container created by this provider
+// for sandbox execution, including stopped containers. It keys off sandbox
+// labels rather than image names so tag churn does not affect cleanup safety.
+func (d *DockerProvider) ListManagedSandboxes(ctx context.Context) ([]agent.ManagedSandboxContainer, error) {
+	containers, err := d.client.ContainerList(ctx, container.ListOptions{
+		All: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list managed sandbox containers: %w", err)
+	}
+
+	out := make([]agent.ManagedSandboxContainer, 0, len(containers))
+	for _, c := range containers {
+		if !isManagedSandboxSummary(c) {
+			continue
+		}
+		createdAt := time.Unix(c.Created, 0).UTC()
+		if raw := c.Labels[SandboxLabelCreatedAt]; raw != "" {
+			if parsed, err := time.Parse(time.RFC3339Nano, raw); err == nil {
+				createdAt = parsed.UTC()
+			}
+		}
+		out = append(out, agent.ManagedSandboxContainer{
+			ID:        c.ID,
+			SessionID: firstLabelValue(c.Labels, SandboxLabelSessionID, sandboxLabelLegacySessionID),
+			OrgID:     firstLabelValue(c.Labels, SandboxLabelOrgID, sandboxLabelLegacyOrgID),
+			Purpose:   firstLabelValue(c.Labels, SandboxLabelPurpose, sandboxLabelLegacyPurpose),
+			CreatedAt: createdAt,
+		})
+	}
+	return out, nil
+}
+
+func isManagedSandboxSummary(summary container.Summary) bool {
+	return summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels))
+}
+
+func isManagedSandboxLabels(labels map[string]string) bool {
+	return labels[SandboxLabelManaged] == "true" && labels[SandboxLabelType] == "sandbox"
+}
+
+func firstLabelValue(labels map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := labels[key]; value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // CloneRepo clones a repository into the sandbox's workspace using git.

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -30,11 +30,11 @@ import (
 // mockDockerClient implements DockerClient for testing.
 type mockDockerClient struct {
 	pingFn                 func(ctx context.Context) (types.Ping, error)
+	containerListFn        func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	containerCreateFn      func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error)
 	containerStartFn       func(ctx context.Context, containerID string, options container.StartOptions) error
 	containerStopFn        func(ctx context.Context, containerID string, options container.StopOptions) error
 	containerRemoveFn      func(ctx context.Context, containerID string, options container.RemoveOptions) error
-	containerListFn        func(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	containerInspectFn     func(ctx context.Context, containerID string) (container.InspectResponse, error)
 	containerStatsFn       func(ctx context.Context, containerID string, stream bool) (container.StatsResponseReader, error)
 	containerExecCreateFn  func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
@@ -49,6 +49,13 @@ func (m *mockDockerClient) Ping(ctx context.Context) (types.Ping, error) {
 		return m.pingFn(ctx)
 	}
 	return types.Ping{}, nil
+}
+
+func (m *mockDockerClient) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
+	if m.containerListFn != nil {
+		return m.containerListFn(ctx, options)
+	}
+	return nil, nil
 }
 
 func (m *mockDockerClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
@@ -77,13 +84,6 @@ func (m *mockDockerClient) ContainerRemove(ctx context.Context, containerID stri
 		return m.containerRemoveFn(ctx, containerID, options)
 	}
 	return nil
-}
-
-func (m *mockDockerClient) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
-	if m.containerListFn != nil {
-		return m.containerListFn(ctx, options)
-	}
-	return nil, nil
 }
 
 func (m *mockDockerClient) ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error) {
@@ -372,6 +372,99 @@ func TestDockerProvider_HealthCheck(t *testing.T) {
 		require.Contains(t, err.Error(), "failed to start test container")
 		require.True(t, removeCalled, "ContainerRemove should be called for cleanup even on start failure")
 	})
+
+	t.Run("requires disk quota support when configured", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedStorageOpt map[string]string
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			capturedStorageOpt = hostConfig.StorageOpt
+			return container.CreateResponse{ID: "quota-check"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger(), WithRuntime("runc"), WithRequireDiskQuota(true))
+
+		err := p.HealthCheck(context.Background())
+		require.NoError(t, err, "HealthCheck should pass when the quota probe container can be created")
+		require.Equal(t, "1G", capturedStorageOpt["size"], "HealthCheck should create a tiny quota probe when disk quota enforcement is required")
+	})
+
+	t.Run("fails health check when required disk quota is unsupported", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			return container.CreateResponse{}, fmt.Errorf("storage-opt is supported only for overlay over xfs with pquota")
+		}
+		p := NewDockerProvider(mock, newTestLogger(), WithRuntime("runc"), WithRequireDiskQuota(true))
+
+		err := p.HealthCheck(context.Background())
+		require.ErrorIs(t, err, ErrDiskQuotaUnsupported, "HealthCheck should fail when required disk quota support is missing")
+	})
+}
+
+func TestDockerProvider_ListManagedSandboxes(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	var capturedOptions container.ListOptions
+	mock := &mockDockerClient{
+		containerListFn: func(_ context.Context, options container.ListOptions) ([]container.Summary, error) {
+			capturedOptions = options
+			return []container.Summary{
+				{
+					ID:      "container-1",
+					Created: createdAt.Add(-time.Hour).Unix(),
+					Labels: map[string]string{
+						SandboxLabelManaged:   "true",
+						SandboxLabelType:      "sandbox",
+						SandboxLabelSessionID: "session-1",
+						SandboxLabelOrgID:     "org-1",
+						SandboxLabelPurpose:   "agent_run",
+						SandboxLabelCreatedAt: createdAt.Format(time.RFC3339Nano),
+					},
+				},
+				{
+					ID:      "container-2",
+					Created: createdAt.Add(-2 * time.Hour).Unix(),
+					Labels: map[string]string{
+						sandboxLabelLegacySandbox:   "true",
+						sandboxLabelLegacySessionID: "session-2",
+						sandboxLabelLegacyOrgID:     "org-2",
+						sandboxLabelLegacyPurpose:   "preview",
+					},
+				},
+				{
+					ID:      "container-3",
+					Created: createdAt.Add(-3 * time.Hour).Unix(),
+					Labels:  map[string]string{},
+				},
+			}, nil
+		},
+	}
+	p := NewDockerProvider(mock, newTestLogger())
+
+	containers, err := p.ListManagedSandboxes(context.Background())
+	require.NoError(t, err, "ListManagedSandboxes should return Docker-managed sandbox containers")
+	require.True(t, capturedOptions.All, "ListManagedSandboxes should include stopped containers")
+	require.Empty(t, capturedOptions.Filters.Get("label"), "ListManagedSandboxes should filter in-process so both current and legacy label schemes are eligible")
+	require.Equal(t, []agent.ManagedSandboxContainer{
+		{
+			ID:        "container-1",
+			SessionID: "session-1",
+			OrgID:     "org-1",
+			Purpose:   "agent_run",
+			CreatedAt: createdAt,
+		},
+		{
+			ID:        "container-2",
+			SessionID: "session-2",
+			OrgID:     "org-2",
+			Purpose:   "preview",
+			CreatedAt: createdAt.Add(-2 * time.Hour),
+		},
+	}, containers, "ListManagedSandboxes should map Docker summaries into GC metadata and fall back to Docker creation time")
 }
 
 func TestDockerProvider_EnsureNetwork(t *testing.T) {
@@ -591,7 +684,56 @@ func TestDockerProvider_Create(t *testing.T) {
 		require.Equal(t, "runsc", sb.Metadata["runtime"], "sandbox metadata should include runtime")
 	})
 
-	t.Run("falls back when StorageOpt unsupported", func(t *testing.T) {
+	t.Run("labels managed sandbox containers with tracing metadata", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedLabels map[string]string
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			capturedLabels = config.Labels
+			return container.CreateResponse{ID: "labeled"}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+
+		cfg := agent.DefaultSandboxConfig()
+		cfg.SessionID = "session-123"
+		cfg.OrgID = "org-456"
+		cfg.Purpose = "agent_run"
+		_, err := p.Create(context.Background(), cfg)
+		require.NoError(t, err, "Create should succeed for a labeled sandbox")
+
+		require.Equal(t, "143", capturedLabels["managed-by"], "sandbox containers should retain the legacy managed-by label")
+		require.Equal(t, "true", capturedLabels[sandboxLabelLegacySandbox], "sandbox containers should be labeled for live capacity checks")
+		require.Equal(t, "session-123", capturedLabels[sandboxLabelLegacySessionID], "legacy sandbox labels should include the session id when present")
+		require.Equal(t, "org-456", capturedLabels[sandboxLabelLegacyOrgID], "legacy sandbox labels should include the org id when present")
+		require.Equal(t, "agent_run", capturedLabels[sandboxLabelLegacyPurpose], "legacy sandbox labels should include the sandbox purpose")
+		require.Equal(t, "true", capturedLabels[SandboxLabelManaged], "sandbox containers should be labeled as 143-managed")
+		require.Equal(t, "sandbox", capturedLabels[SandboxLabelType], "sandbox containers should carry a type label for host-local GC")
+		require.Equal(t, "session-123", capturedLabels[SandboxLabelSessionID], "sandbox labels should include the session id when present")
+		require.Equal(t, "org-456", capturedLabels[SandboxLabelOrgID], "sandbox labels should include the org id when present")
+		require.Equal(t, "agent_run", capturedLabels[SandboxLabelPurpose], "sandbox labels should include the sandbox purpose")
+		require.NotEmpty(t, capturedLabels[SandboxLabelCreatedAt], "sandbox labels should include an RFC3339 creation timestamp for GC age decisions")
+	})
+
+	t.Run("returns error when required StorageOpt unsupported", func(t *testing.T) {
+		t.Parallel()
+
+		callCount := 0
+
+		mock := &mockDockerClient{}
+		mock.containerCreateFn = func(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkConfig *network.NetworkingConfig, platform *ocispec.Platform, containerName string) (container.CreateResponse, error) {
+			callCount++
+			return container.CreateResponse{}, fmt.Errorf("--storage-opt is supported only for overlay over xfs with 'pquota' mount option")
+		}
+		p := NewDockerProvider(mock, newTestLogger(), WithRequireDiskQuota(true))
+
+		_, err := p.Create(context.Background(), agent.DefaultSandboxConfig())
+		require.ErrorIs(t, err, ErrDiskQuotaUnsupported, "Create should fail closed when disk quota is required but Docker rejects StorageOpt")
+		require.Equal(t, 1, callCount, "Create should not retry without StorageOpt when disk quota is required")
+	})
+
+	t.Run("falls back when StorageOpt unsupported and quota is not required", func(t *testing.T) {
 		t.Parallel()
 
 		callCount := 0

--- a/internal/services/agent/sandbox_gc.go
+++ b/internal/services/agent/sandbox_gc.go
@@ -1,0 +1,235 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+const (
+	defaultSandboxGCGracePeriod = 30 * time.Minute
+	defaultSandboxGCHardMaxAge  = 24 * time.Hour
+)
+
+// ManagedSandboxContainer is the provider-neutral subset of Docker container
+// metadata the worker-local GC needs to reconcile host state with DB state.
+type ManagedSandboxContainer struct {
+	ID        string
+	SessionID string
+	OrgID     string
+	Purpose   string
+	CreatedAt time.Time
+}
+
+// SandboxGCProvider is implemented by providers that can enumerate their
+// managed sandbox containers on the local host.
+type SandboxGCProvider interface {
+	ListManagedSandboxes(ctx context.Context) ([]ManagedSandboxContainer, error)
+	Destroy(ctx context.Context, sb *Sandbox) error
+}
+
+// SandboxReferenceStore is the DB surface the host-local GC needs. The
+// reference list is intentionally cross-org: Docker containers are host-local
+// resources and the GC must decide whether any session row still owns a
+// container before removing it.
+type SandboxReferenceStore interface {
+	ListReferencedContainerIDs(ctx context.Context) ([]string, error)
+	FinalizeContainerDestroy(ctx context.Context, orgID, sessionID uuid.UUID, expectedContainerID string) (cleared bool, err error)
+}
+
+// SandboxUsageCloser lets the GC close billing rows for containers it destroys
+// outside the ordinary orchestrator defer path.
+type SandboxUsageCloser interface {
+	CloseOpenByContainerID(ctx context.Context, containerID string, stoppedAt time.Time, exitReason string) (int64, error)
+}
+
+type SandboxGCConfig struct {
+	Interval                time.Duration
+	UnreferencedGracePeriod time.Duration
+	HardMaxAge              time.Duration
+}
+
+type SandboxGC struct {
+	provider SandboxGCProvider
+	store    SandboxReferenceStore
+	usage    SandboxUsageCloser
+	cfg      SandboxGCConfig
+	logger   zerolog.Logger
+}
+
+func NewSandboxGC(provider SandboxGCProvider, store SandboxReferenceStore, usage SandboxUsageCloser, cfg SandboxGCConfig, logger zerolog.Logger) *SandboxGC {
+	if cfg.UnreferencedGracePeriod <= 0 {
+		cfg.UnreferencedGracePeriod = defaultSandboxGCGracePeriod
+	}
+	if cfg.HardMaxAge <= 0 {
+		cfg.HardMaxAge = defaultSandboxGCHardMaxAge
+	}
+	return &SandboxGC{
+		provider: provider,
+		store:    store,
+		usage:    usage,
+		cfg:      cfg,
+		logger:   logger,
+	}
+}
+
+func (g *SandboxGC) Run(ctx context.Context) {
+	if g == nil || g.provider == nil || g.store == nil || g.cfg.Interval <= 0 {
+		return
+	}
+
+	g.logger.Info().
+		Dur("interval", g.cfg.Interval).
+		Dur("unreferenced_grace_period", g.cfg.UnreferencedGracePeriod).
+		Dur("hard_max_age", g.cfg.HardMaxAge).
+		Msg("sandbox GC started")
+
+	g.reapAndLog(ctx, time.Now())
+	ticker := time.NewTicker(g.cfg.Interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			g.logger.Info().Msg("sandbox GC stopped")
+			return
+		case now := <-ticker.C:
+			g.reapAndLog(ctx, now)
+		}
+	}
+}
+
+func (g *SandboxGC) reapAndLog(ctx context.Context, now time.Time) {
+	if err := g.ReapOnce(ctx, now); err != nil {
+		g.logger.Warn().Err(err).Msg("sandbox GC pass failed")
+	}
+}
+
+func (g *SandboxGC) ReapOnce(ctx context.Context, now time.Time) error {
+	if g == nil || g.provider == nil || g.store == nil {
+		return nil
+	}
+
+	referenced, err := g.store.ListReferencedContainerIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list referenced container ids: %w", err)
+	}
+	refSet := make(map[string]struct{}, len(referenced))
+	for _, id := range referenced {
+		if id != "" {
+			refSet[id] = struct{}{}
+		}
+	}
+
+	containers, err := g.provider.ListManagedSandboxes(ctx)
+	if err != nil {
+		return fmt.Errorf("list managed sandbox containers: %w", err)
+	}
+
+	var destroyedUnreferenced, destroyedExpired, skippedReferenced int
+	for _, c := range containers {
+		if c.ID == "" {
+			continue
+		}
+		age := sandboxContainerAge(now, c.CreatedAt)
+		if _, ok := refSet[c.ID]; !ok {
+			if age < g.cfg.UnreferencedGracePeriod {
+				continue
+			}
+			if g.destroyContainer(ctx, c, now, "sandbox_gc_unreferenced") {
+				destroyedUnreferenced++
+			}
+			continue
+		}
+
+		if age < g.cfg.HardMaxAge {
+			skippedReferenced++
+			continue
+		}
+		orgID, sessionID, parseErr := parseManagedSandboxIDs(c)
+		if parseErr != nil {
+			g.logger.Warn().Err(parseErr).
+				Str("container_id", c.ID).
+				Msg("sandbox GC: hard-expired referenced container is missing valid ownership labels; leaving it alive")
+			continue
+		}
+		cleared, err := g.store.FinalizeContainerDestroy(ctx, orgID, sessionID, c.ID)
+		if err != nil {
+			g.logger.Warn().Err(err).
+				Str("container_id", c.ID).
+				Str("session_id", c.SessionID).
+				Msg("sandbox GC: failed to finalize hard-expired container; leaving it alive")
+			continue
+		}
+		if !cleared {
+			g.logger.Info().
+				Str("container_id", c.ID).
+				Str("session_id", c.SessionID).
+				Msg("sandbox GC: hard-expired container is still held; leaving it alive")
+			continue
+		}
+		if g.destroyContainer(ctx, c, now, "sandbox_gc_expired") {
+			destroyedExpired++
+		}
+	}
+
+	if destroyedUnreferenced > 0 || destroyedExpired > 0 {
+		g.logger.Info().
+			Int("destroyed_unreferenced", destroyedUnreferenced).
+			Int("destroyed_expired", destroyedExpired).
+			Int("skipped_referenced", skippedReferenced).
+			Msg("sandbox GC pass complete")
+	}
+	return nil
+}
+
+func sandboxContainerAge(now time.Time, createdAt time.Time) time.Duration {
+	if createdAt.IsZero() {
+		return 0
+	}
+	if now.Before(createdAt) {
+		return 0
+	}
+	return now.Sub(createdAt)
+}
+
+func parseManagedSandboxIDs(c ManagedSandboxContainer) (uuid.UUID, uuid.UUID, error) {
+	orgID, err := uuid.Parse(c.OrgID)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("parse org id: %w", err)
+	}
+	sessionID, err := uuid.Parse(c.SessionID)
+	if err != nil {
+		return uuid.Nil, uuid.Nil, fmt.Errorf("parse session id: %w", err)
+	}
+	return orgID, sessionID, nil
+}
+
+func (g *SandboxGC) destroyContainer(ctx context.Context, c ManagedSandboxContainer, now time.Time, reason string) bool {
+	if err := g.provider.Destroy(ctx, &Sandbox{
+		ID:        c.ID,
+		Provider:  "docker",
+		SessionID: c.SessionID,
+		OrgID:     c.OrgID,
+		Purpose:   c.Purpose,
+	}); err != nil {
+		g.logger.Warn().Err(err).
+			Str("container_id", c.ID).
+			Str("session_id", c.SessionID).
+			Str("reason", reason).
+			Msg("sandbox GC: failed to destroy container")
+		return false
+	}
+	if g.usage != nil {
+		if _, err := g.usage.CloseOpenByContainerID(ctx, c.ID, now, reason); err != nil {
+			g.logger.Warn().Err(err).
+				Str("container_id", c.ID).
+				Str("session_id", c.SessionID).
+				Str("reason", reason).
+				Msg("sandbox GC: failed to close open usage rows after destroy")
+		}
+	}
+	return true
+}

--- a/internal/services/agent/sandbox_gc_test.go
+++ b/internal/services/agent/sandbox_gc_test.go
@@ -1,0 +1,242 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/services/agent"
+)
+
+type fakeSandboxGCProvider struct {
+	containers []agent.ManagedSandboxContainer
+	listErr    error
+	destroyErr error
+
+	mu        sync.Mutex
+	destroyed []string
+}
+
+func (f *fakeSandboxGCProvider) ListManagedSandboxes(context.Context) ([]agent.ManagedSandboxContainer, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.containers, nil
+}
+
+func (f *fakeSandboxGCProvider) Destroy(_ context.Context, sb *agent.Sandbox) error {
+	if f.destroyErr != nil {
+		return f.destroyErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.destroyed = append(f.destroyed, sb.ID)
+	return nil
+}
+
+func (f *fakeSandboxGCProvider) destroyedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.destroyed))
+	copy(out, f.destroyed)
+	return out
+}
+
+type fakeSandboxGCStore struct {
+	references []string
+	listErr    error
+	finalize   map[string]bool
+	finalErr   error
+
+	mu         sync.Mutex
+	finalized  []string
+	finalOrgID []uuid.UUID
+}
+
+func (f *fakeSandboxGCStore) ListReferencedContainerIDs(context.Context) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	out := make([]string, len(f.references))
+	copy(out, f.references)
+	return out, nil
+}
+
+func (f *fakeSandboxGCStore) FinalizeContainerDestroy(_ context.Context, orgID, _ uuid.UUID, expectedContainerID string) (bool, error) {
+	if f.finalErr != nil {
+		return false, f.finalErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.finalized = append(f.finalized, expectedContainerID)
+	f.finalOrgID = append(f.finalOrgID, orgID)
+	return f.finalize[expectedContainerID], nil
+}
+
+func (f *fakeSandboxGCStore) finalizedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.finalized))
+	copy(out, f.finalized)
+	return out
+}
+
+type fakeSandboxGCUsageCloser struct {
+	err error
+
+	mu     sync.Mutex
+	closed []string
+}
+
+func (f *fakeSandboxGCUsageCloser) CloseOpenByContainerID(_ context.Context, containerID string, _ time.Time, _ string) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = append(f.closed, containerID)
+	return 1, nil
+}
+
+func (f *fakeSandboxGCUsageCloser) closedIDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.closed))
+	copy(out, f.closed)
+	return out
+}
+
+func TestSandboxGC_ReapOnceDestroysUnreferencedContainersAfterGrace(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	provider := &fakeSandboxGCProvider{
+		containers: []agent.ManagedSandboxContainer{
+			{ID: "young", CreatedAt: now.Add(-5 * time.Minute), Purpose: "agent_run"},
+			{ID: "old", CreatedAt: now.Add(-45 * time.Minute), Purpose: "agent_run"},
+		},
+	}
+	store := &fakeSandboxGCStore{}
+	usage := &fakeSandboxGCUsageCloser{}
+	gc := agent.NewSandboxGC(provider, store, usage, agent.SandboxGCConfig{
+		UnreferencedGracePeriod: 30 * time.Minute,
+		HardMaxAge:              24 * time.Hour,
+	}, zerolog.Nop())
+
+	err := gc.ReapOnce(context.Background(), now)
+	require.NoError(t, err, "sandbox GC should complete when destroy and usage close succeed")
+	require.Equal(t, []string{"old"}, provider.destroyedIDs(), "sandbox GC should destroy only unreferenced containers older than the grace period")
+	require.Equal(t, []string{"old"}, usage.closedIDs(), "sandbox GC should close usage rows for containers it destroys")
+}
+
+func TestSandboxGC_ReapOnceKeepsReferencedContainerUntilHardMaxAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	provider := &fakeSandboxGCProvider{
+		containers: []agent.ManagedSandboxContainer{
+			{ID: "referenced", CreatedAt: now.Add(-2 * time.Hour), Purpose: "agent_run"},
+		},
+	}
+	store := &fakeSandboxGCStore{references: []string{"referenced"}}
+	usage := &fakeSandboxGCUsageCloser{}
+	gc := agent.NewSandboxGC(provider, store, usage, agent.SandboxGCConfig{
+		UnreferencedGracePeriod: 30 * time.Minute,
+		HardMaxAge:              24 * time.Hour,
+	}, zerolog.Nop())
+
+	err := gc.ReapOnce(context.Background(), now)
+	require.NoError(t, err, "sandbox GC should complete when referenced containers are below the hard max age")
+	require.Empty(t, provider.destroyedIDs(), "sandbox GC should not destroy referenced containers below the hard max age")
+	require.Empty(t, store.finalizedIDs(), "sandbox GC should not touch DB ownership for referenced containers below the hard max age")
+}
+
+func TestSandboxGC_ReapOnceExpiresReferencedContainerOnlyAfterFinalizeCAS(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	provider := &fakeSandboxGCProvider{
+		containers: []agent.ManagedSandboxContainer{
+			{
+				ID:        "expired",
+				SessionID: sessionID.String(),
+				OrgID:     orgID.String(),
+				CreatedAt: now.Add(-25 * time.Hour),
+				Purpose:   "agent_run",
+			},
+		},
+	}
+	store := &fakeSandboxGCStore{
+		references: []string{"expired"},
+		finalize:   map[string]bool{"expired": true},
+	}
+	usage := &fakeSandboxGCUsageCloser{}
+	gc := agent.NewSandboxGC(provider, store, usage, agent.SandboxGCConfig{
+		UnreferencedGracePeriod: 30 * time.Minute,
+		HardMaxAge:              24 * time.Hour,
+	}, zerolog.Nop())
+
+	err := gc.ReapOnce(context.Background(), now)
+	require.NoError(t, err, "sandbox GC should complete when a hard-expired referenced container is finalized")
+	require.Equal(t, []string{"expired"}, store.finalizedIDs(), "sandbox GC should CAS-finalize DB ownership before destroying a referenced hard-expired container")
+	require.Equal(t, []uuid.UUID{orgID}, store.finalOrgID, "sandbox GC should parse the org label and pass it to the finalize CAS")
+	require.Equal(t, []string{"expired"}, provider.destroyedIDs(), "sandbox GC should destroy a hard-expired referenced container only after finalization succeeds")
+	require.Equal(t, []string{"expired"}, usage.closedIDs(), "sandbox GC should close usage rows for hard-expired containers it destroys")
+}
+
+func TestSandboxGC_ReapOnceSkipsReferencedContainerWhenFinalizeCASLoses(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 9, 12, 0, 0, 0, time.UTC)
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	provider := &fakeSandboxGCProvider{
+		containers: []agent.ManagedSandboxContainer{
+			{
+				ID:        "held",
+				SessionID: sessionID.String(),
+				OrgID:     orgID.String(),
+				CreatedAt: now.Add(-25 * time.Hour),
+				Purpose:   "agent_run",
+			},
+		},
+	}
+	store := &fakeSandboxGCStore{
+		references: []string{"held"},
+		finalize:   map[string]bool{"held": false},
+	}
+	usage := &fakeSandboxGCUsageCloser{}
+	gc := agent.NewSandboxGC(provider, store, usage, agent.SandboxGCConfig{
+		UnreferencedGracePeriod: 30 * time.Minute,
+		HardMaxAge:              24 * time.Hour,
+	}, zerolog.Nop())
+
+	err := gc.ReapOnce(context.Background(), now)
+	require.NoError(t, err, "sandbox GC should continue when finalization loses to an active holder")
+	require.Equal(t, []string{"held"}, store.finalizedIDs(), "sandbox GC should attempt finalization for hard-expired referenced containers")
+	require.Empty(t, provider.destroyedIDs(), "sandbox GC should not destroy a referenced container when the finalize CAS returns false")
+	require.Empty(t, usage.closedIDs(), "sandbox GC should not close usage rows for containers it leaves alive")
+}
+
+func TestSandboxGC_ReapOnceReturnsListErrors(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeSandboxGCProvider{listErr: errors.New("docker unavailable")}
+	store := &fakeSandboxGCStore{}
+	gc := agent.NewSandboxGC(provider, store, nil, agent.SandboxGCConfig{
+		UnreferencedGracePeriod: 30 * time.Minute,
+		HardMaxAge:              24 * time.Hour,
+	}, zerolog.Nop())
+
+	err := gc.ReapOnce(context.Background(), time.Now())
+	require.Error(t, err, "sandbox GC should surface provider list failures")
+	require.Contains(t, err.Error(), "list managed sandbox containers", "sandbox GC should wrap provider list failures with context")
+}

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -198,6 +198,10 @@ type Services struct {
 	// is disabled (interval <= 0 in config) or the provider can't report
 	// stats (e.g. a non-Docker provider in the future).
 	RuntimeSampler *agent.RuntimeSampler
+	// SandboxGC periodically reconciles provider-labeled local sandbox
+	// containers against DB ownership so leaked containers cannot accumulate
+	// indefinitely on worker disks. nil when disabled or unsupported.
+	SandboxGC *agent.SandboxGC
 }
 
 type orchestratorService interface {


### PR DESCRIPTION
## Summary
- Added worker-side disk guardrails for sandbox containers, including disk quota enforcement and periodic GC for leaked containers.
- Updated Docker sandbox labeling and lifecycle accounting so live container counts and GC can identify both current and legacy sandbox containers.
- Extended deploy and provisioning scripts to propagate the new worker disk settings and prune unused Docker artifacts after successful rollouts.
- Added tests and design notes covering the new lifecycle and deployment behavior.

## Testing
- `go test ./...`
- `go vet ./...`
- `go build ./...`
- `make lint-tenancy`