### PR TITLE
Fix sandbox GC to reclaim legacy unlabeled worker containers

### DIFF
--- a/docs/design/implemented/76-sandbox-disk-guardrails.md
+++ b/docs/design/implemented/76-sandbox-disk-guardrails.md
@@ -38,7 +38,7 @@ It also carries provider-owned labels used by host-local GC:
 - `com.assembledhq.143.purpose`
 - `com.assembledhq.143.created_at`
 
-The worker-local GC accepts both label schemes and also treats legacy unlabeled containers whose image name contains `143-sandbox` as managed sandboxes, excluding the `143-sandbox-dns` sidecar. The image fallback is intentionally backward-compatible with older production sandboxes that predate ownership labels; new cleanup logic should prefer labels for safety, but must keep this fallback until those hosts no longer carry legacy containers.
+The worker-local GC accepts both label schemes and also treats legacy unlabeled containers whose image name contains `143-sandbox` as managed sandboxes when they are attached to the configured sandbox network, excluding the `143-sandbox-dns` sidecar. The image fallback is intentionally backward-compatible with older production sandboxes that predate ownership labels; new cleanup logic should prefer labels for safety, but must keep this fallback until those hosts no longer carry legacy containers.
 
 ## Worker-Local Sandbox GC
 

--- a/docs/design/implemented/76-sandbox-disk-guardrails.md
+++ b/docs/design/implemented/76-sandbox-disk-guardrails.md
@@ -38,7 +38,7 @@ It also carries provider-owned labels used by host-local GC:
 - `com.assembledhq.143.purpose`
 - `com.assembledhq.143.created_at`
 
-The worker-local GC accepts both label schemes and filters in-process rather than relying on repository image names. This keeps cleanup independent of image tags, deploy tags, and sandbox image rotations while remaining compatible with the live-capacity checks on `origin/main`.
+The worker-local GC accepts both label schemes and also treats legacy unlabeled containers whose image name contains `143-sandbox` as managed sandboxes, excluding the `143-sandbox-dns` sidecar. The image fallback is intentionally backward-compatible with older production sandboxes that predate ownership labels; new cleanup logic should prefer labels for safety, but must keep this fallback until those hosts no longer carry legacy containers.
 
 ## Worker-Local Sandbox GC
 

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -572,6 +572,10 @@ func isLiveSandboxContainer(summary container.Summary) bool {
 	if summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels)) {
 		return true
 	}
+	return isLegacySandboxImage(summary)
+}
+
+func isLegacySandboxImage(summary container.Summary) bool {
 	image := strings.ToLower(summary.Image)
 	return strings.Contains(image, "143-sandbox") && !strings.Contains(image, "143-sandbox-dns")
 }
@@ -621,7 +625,8 @@ func (d *DockerProvider) ListManagedSandboxes(ctx context.Context) ([]agent.Mana
 }
 
 func isManagedSandboxSummary(summary container.Summary) bool {
-	return summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels))
+	return summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels)) ||
+		isLegacySandboxImage(summary)
 }
 
 func isManagedSandboxLabels(labels map[string]string) bool {

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -604,7 +604,7 @@ func (d *DockerProvider) ListManagedSandboxes(ctx context.Context) ([]agent.Mana
 
 	out := make([]agent.ManagedSandboxContainer, 0, len(containers))
 	for _, c := range containers {
-		if !isManagedSandboxSummary(c) {
+		if !isManagedSandboxSummary(c, d.network) {
 			continue
 		}
 		createdAt := time.Unix(c.Created, 0).UTC()
@@ -624,13 +624,21 @@ func (d *DockerProvider) ListManagedSandboxes(ctx context.Context) ([]agent.Mana
 	return out, nil
 }
 
-func isManagedSandboxSummary(summary container.Summary) bool {
+func isManagedSandboxSummary(summary container.Summary, sandboxNetwork string) bool {
 	return summary.Labels != nil && (summary.Labels[sandboxLabelLegacySandbox] == "true" || isManagedSandboxLabels(summary.Labels)) ||
-		isLegacySandboxImage(summary)
+		(isLegacySandboxImage(summary) && isContainerAttachedToNetwork(summary, sandboxNetwork))
 }
 
 func isManagedSandboxLabels(labels map[string]string) bool {
 	return labels[SandboxLabelManaged] == "true" && labels[SandboxLabelType] == "sandbox"
+}
+
+func isContainerAttachedToNetwork(summary container.Summary, networkName string) bool {
+	if networkName == "" || summary.NetworkSettings == nil {
+		return false
+	}
+	_, ok := summary.NetworkSettings.Networks[networkName]
+	return ok
 }
 
 func firstLabelValue(labels map[string]string, keys ...string) string {

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -440,12 +440,33 @@ func TestDockerProvider_ListManagedSandboxes(t *testing.T) {
 					Created: createdAt.Add(-3 * time.Hour).Unix(),
 					Image:   "ghcr.io/assembledhq/143-sandbox:legacy",
 					Labels:  map[string]string{},
+					NetworkSettings: &container.NetworkSettingsSummary{
+						Networks: map[string]*network.EndpointSettings{
+							"143-sandbox": {},
+						},
+					},
 				},
 				{
 					ID:      "container-4",
 					Created: createdAt.Add(-4 * time.Hour).Unix(),
 					Image:   "143-sandbox-dns:local",
 					Labels:  map[string]string{},
+					NetworkSettings: &container.NetworkSettingsSummary{
+						Networks: map[string]*network.EndpointSettings{
+							"143-sandbox": {},
+						},
+					},
+				},
+				{
+					ID:      "container-5",
+					Created: createdAt.Add(-5 * time.Hour).Unix(),
+					Image:   "ghcr.io/assembledhq/143-sandbox:legacy",
+					Labels:  map[string]string{},
+					NetworkSettings: &container.NetworkSettingsSummary{
+						Networks: map[string]*network.EndpointSettings{
+							"other-network": {},
+						},
+					},
 				},
 			}, nil
 		},
@@ -478,7 +499,7 @@ func TestDockerProvider_ListManagedSandboxes(t *testing.T) {
 			Purpose:   "",
 			CreatedAt: createdAt.Add(-3 * time.Hour),
 		},
-	}, containers, "ListManagedSandboxes should map Docker summaries into GC metadata, include legacy image-based sandboxes, skip DNS sidecars, and fall back to Docker creation time")
+	}, containers, "ListManagedSandboxes should map Docker summaries into GC metadata, include legacy image-based sandboxes only on the sandbox network, skip DNS sidecars, and fall back to Docker creation time")
 }
 
 func TestDockerProvider_EnsureNetwork(t *testing.T) {

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -438,6 +438,13 @@ func TestDockerProvider_ListManagedSandboxes(t *testing.T) {
 				{
 					ID:      "container-3",
 					Created: createdAt.Add(-3 * time.Hour).Unix(),
+					Image:   "ghcr.io/assembledhq/143-sandbox:legacy",
+					Labels:  map[string]string{},
+				},
+				{
+					ID:      "container-4",
+					Created: createdAt.Add(-4 * time.Hour).Unix(),
+					Image:   "143-sandbox-dns:local",
 					Labels:  map[string]string{},
 				},
 			}, nil
@@ -464,7 +471,14 @@ func TestDockerProvider_ListManagedSandboxes(t *testing.T) {
 			Purpose:   "preview",
 			CreatedAt: createdAt.Add(-2 * time.Hour),
 		},
-	}, containers, "ListManagedSandboxes should map Docker summaries into GC metadata and fall back to Docker creation time")
+		{
+			ID:        "container-3",
+			SessionID: "",
+			OrgID:     "",
+			Purpose:   "",
+			CreatedAt: createdAt.Add(-3 * time.Hour),
+		},
+	}, containers, "ListManagedSandboxes should map Docker summaries into GC metadata, include legacy image-based sandboxes, skip DNS sidecars, and fall back to Docker creation time")
 }
 
 func TestDockerProvider_EnsureNetwork(t *testing.T) {


### PR DESCRIPTION
## Summary
- Teach worker sandbox GC to treat legacy `143-sandbox` image containers as managed, while still excluding the `143-sandbox-dns` sidecar
- Add regression coverage for `ListManagedSandboxes` so legacy image-based sandboxes are included and DNS sidecars are skipped
- Update the sandbox disk guardrails design note to document the backward-compatible fallback

## Testing
- `go vet ./...` passed
- `go build ./...` passed
- `go test ./...` passed