### PR TITLE
Reorder mobile session header buttons and strengthen order assertion test

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx
@@ -75,6 +75,35 @@ describe("MobileSessionTopBar", () => {
     expect(within(actionsSheet).getByRole("button", { name: "Rename session" })).toBeInTheDocument();
   });
 
+  it("places the session actions button to the left of the session details button in the mobile header", () => {
+    const { container } = renderWithProviders(
+      <MobileSessionTopBar
+        sessionTitle="Mobile session title"
+        detailButtonLabel="Open session details"
+        backTo="/sessions"
+        threads={[makeThread({ id: "thread-1", label: "Main tab" })]}
+        activeThreadId="thread-1"
+        viewedThreadIds={new Set(["thread-1"])}
+        onOpenDetails={vi.fn()}
+        onActiveThreadChange={vi.fn()}
+        onAddThread={vi.fn()}
+        onRenameSession={vi.fn()}
+        onCancelThread={vi.fn()}
+        onForkThread={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        cancelPendingThreadId={null}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    const headerButtons = Array.from(container.querySelectorAll("div.sticky button")).map((button) =>
+      button.getAttribute("aria-label"),
+    );
+
+    expect(headerButtons).toEqual(["Open session actions", "Open session details"]);
+  });
+
   it("routes thread switching and thread actions through the session actions sheet", async () => {
     const user = userEvent.setup();
     const onActiveThreadChange = vi.fn();

--- a/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx
@@ -129,22 +129,22 @@ export function MobileSessionTopBar({
           size="icon"
           variant="ghost"
           className="h-9 w-9 shrink-0"
-          aria-label={detailButtonLabel}
-          aria-controls="session-detail-sheet"
-          onClick={onOpenDetails}
+          aria-label="Open session actions"
+          aria-expanded={actionsOpen}
+          onClick={() => setActionsOpen(true)}
         >
-          <PanelBottomOpen className="h-5 w-5" />
+          <MoreVertical className="h-5 w-5" />
         </Button>
         <Button
           type="button"
           size="icon"
           variant="ghost"
           className="h-9 w-9 shrink-0"
-          aria-label="Open session actions"
-          aria-expanded={actionsOpen}
-          onClick={() => setActionsOpen(true)}
+          aria-label={detailButtonLabel}
+          aria-controls="session-detail-sheet"
+          onClick={onOpenDetails}
         >
-          <MoreVertical className="h-5 w-5" />
+          <PanelBottomOpen className="h-5 w-5" />
         </Button>
       </div>
 


### PR DESCRIPTION
## Summary
Reordered the mobile session top bar action buttons so “Open session actions” appears to the left of “Open session details” (matching the intended UX). Updated the accompanying test to assert the exact left-to-right button order to prevent regressions.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.tsx`
  - Swapped the two header icon buttons: session actions now renders first (left), and session details now renders rightmost.
  - Kept the correct `aria-label`/`aria-controls` wiring for each button after the swap.
- `frontend/src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx`
  - Added a focused test that queries the sticky header buttons and asserts their `aria-label` order:
    - `["Open session actions", "Open session details"]`

## Test plan
- `npx vitest run 'src/app/(dashboard)/sessions/[id]/mobile-session-top-bar.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; existing deprecation warnings remain)

[143.dev](https://143.dev) | [session b2f86fe6](https://143.dev/sessions/b2f86fe6-e7f9-4d64-9514-71e83c1ccfd5)