### PR TITLE
Align left resize handle behavior with right bar and hide grip until hover/drag

### DIFF
--- a/frontend/src/components/resize-handle.test.tsx
+++ b/frontend/src/components/resize-handle.test.tsx
@@ -9,15 +9,21 @@ describe("ResizeHandle", () => {
     expect(container.firstChild).toBeTruthy();
   });
 
-  it("renders a visible desktop rail with a wider hit target", () => {
+  it("renders a full-height desktop rail with a wider hit target", () => {
     const onResize = vi.fn();
     const { container } = render(<ResizeHandle onResize={onResize} />);
     const handle = container.firstChild as HTMLElement;
+    const grip = handle.querySelector("[data-testid='resize-handle-grip']");
 
     expect(handle.className).toContain("w-3");
+    expect(handle.className).toContain("h-full");
     expect(handle.className).toContain("cursor-col-resize");
     expect(handle.querySelector("[data-testid='resize-handle-rail']")).toBeTruthy();
-    expect(handle.querySelector("[data-testid='resize-handle-grip']")).toBeTruthy();
+    expect(grip).toBeTruthy();
+    expect(grip?.className).toContain("opacity-0");
+    expect(grip?.className).toContain("group-hover:opacity-100");
+    expect(grip?.className).toContain("group-focus-visible:opacity-100");
+    expect(grip?.className).toContain("group-data-[dragging=true]:opacity-100");
   });
 
   it("calls onResize with delta during drag", () => {

--- a/frontend/src/components/resize-handle.tsx
+++ b/frontend/src/components/resize-handle.tsx
@@ -82,7 +82,7 @@ export function ResizeHandle({ direction = "horizontal", onResize, className, te
       data-testid={testId}
       data-dragging={isDragging ? "true" : "false"}
       className={cn(
-        "group relative z-10 shrink-0 touch-none select-none",
+        "group relative z-10 h-full shrink-0 touch-none select-none",
         direction === "horizontal" && "-mx-1.5 w-3 cursor-col-resize",
         className,
       )}
@@ -90,12 +90,12 @@ export function ResizeHandle({ direction = "horizontal", onResize, className, te
       <div
         data-testid="resize-handle-rail"
         aria-hidden="true"
-        className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/80 transition-colors duration-150 group-hover:bg-border group-data-[dragging=true]:bg-primary/50"
+        className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-border/45 transition-colors duration-150 group-hover:bg-border/80 group-data-[dragging=true]:bg-primary/50"
       />
       <div
         data-testid="resize-handle-grip"
         aria-hidden="true"
-        className="absolute left-1/2 top-1/2 h-14 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/90 shadow-sm transition-colors duration-150 group-hover:bg-muted-foreground/80 group-data-[dragging=true]:bg-primary"
+        className="absolute left-1/2 top-1/2 h-14 w-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-border/90 opacity-0 shadow-sm transition-[background-color,opacity] duration-150 group-hover:opacity-100 group-focus-visible:opacity-100 group-data-[dragging=true]:bg-primary group-data-[dragging=true]:opacity-100"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Updated `ResizeHandle` so the left-side vertical bars behave consistently with the right-side version. The handle rail now spans the full bar height for easier dragging, and the grip is hidden until hover or an active drag.

## Changes
- **frontend/src/components/resize-handle.tsx**
  - Made the outer handle container full-height (`h-full`) so drag interactions work anywhere along the bar.
  - Adjusted rail styling to use a slightly lighter border color on the full-height rail.
  - Updated the grip to start hidden (`opacity-0`) and become visible on:
    - `group-hover`
    - `group-focus-visible`
    - `group-data-[dragging=true]`
- **frontend/src/components/resize-handle.test.tsx**
  - Updated expectations to verify the rail is full height (`h-full`).
  - Added assertions that the grip exists and is initially hidden, then shown via the relevant opacity classes.

## Test plan
- `npx vitest run src/components/resize-handle.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build` (build succeeded; noted a non-blocking Next.js warning about multiple lockfiles/deprecated middleware convention)

[143.dev](https://143.dev) | [session adbd20f9](https://143.dev/sessions/adbd20f9-280c-4ab2-8ec7-5551b17fae94)