### PR TITLE
Add purple gradient underline styling to active sidebar filter tabs

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -282,9 +282,11 @@ describe('ProjectSidebar', () => {
     await screen.findByText('Test Project');
 
     const tabList = screen.getByRole('tablist');
+    expect(tabList).toHaveAttribute('data-variant', 'line');
+    expect(tabList.className).toContain('pb-1');
     expect(tabList.className).toContain('justify-start');
     expect(tabList.className).toContain('overflow-x-auto');
-    expect(tabList.className).toContain('overflow-y-hidden');
+    expect(tabList.className).toContain('overflow-y-visible');
   });
 
   it('has search input', () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -179,7 +179,7 @@ export function ProjectSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-x-auto overflow-y-hidden">
+          <TabsList variant="line" size="sm" className="overflow-x-auto overflow-y-visible pb-1">
             {filterTabs.map((tab) => {
               const count = tab.value === "active" ? activeCount : 0;
               return (

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -79,9 +79,11 @@ describe('SessionSidebar', () => {
     await screen.findByText('Fixed TypeError by adding null check');
 
     const tabList = screen.getByRole('tablist');
+    expect(tabList).toHaveAttribute('data-variant', 'line');
+    expect(tabList.className).toContain('pb-1');
     expect(tabList.className).toContain('justify-start');
     expect(tabList.className).toContain('overflow-x-auto');
-    expect(tabList.className).toContain('overflow-y-hidden');
+    expect(tabList.className).toContain('overflow-y-visible');
   });
 
   it('shows status indicators for sessions', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -245,6 +245,22 @@ describe('SessionSidebar', () => {
     expect(screen.queryByRole('link', { name: 'Open session details for No extra open button' })).not.toBeInTheDocument();
   });
 
+  it('uses the line tab variant for the session status filters', async () => {
+    serveSessions([
+      makeSession({ id: 's1', result_summary: 'Status filter tabs' }),
+    ]);
+
+    renderWithProviders(<SessionSidebar />);
+    await screen.findByText('Status filter tabs');
+
+    const tabList = screen.getByRole('tablist');
+    expect(tabList).toHaveAttribute('data-variant', 'line');
+    expect(tabList.className).toContain('pb-1');
+    expect(tabList.className).toContain('justify-start');
+    expect(tabList.className).toContain('overflow-x-auto');
+    expect(tabList.className).toContain('overflow-y-visible');
+  });
+
   it('navigates when the selected row shell is tapped', async () => {
     mockSelectedSegment = 's1';
     serveSessions([

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -566,7 +566,7 @@ export function SessionSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList size="sm" className="overflow-x-auto overflow-y-hidden">
+          <TabsList variant="line" size="sm" className="overflow-x-auto overflow-y-visible pb-1">
             {filterTabs.map((tab) => {
               const count = getCountForTab(tab.value, counts);
               const label = renderCount(count, counts);


### PR DESCRIPTION
## Summary
Updated the compact sidebar filter tab lists in both Sessions and Projects to use the same purple gradient underline treatment as the session detail tabs. This also reserves bottom spacing so the underline isn’t clipped, while keeping vertical overflow visible.

## Changes
- `frontend/src/app/(dashboard)/sessions/session-sidebar.tsx`
  - Set `TabsList` to `variant="line"`.
  - Changed tab list layout classes from `overflow-y-hidden` to `overflow-y-visible` and added `pb-1` to prevent underline clipping.
- `frontend/src/app/(dashboard)/projects/project-sidebar.tsx`
  - Same `TabsList` updates as sessions (`variant="line"`, `overflow-y-visible`, `pb-1`).
- `frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx`
  - Added test asserting the filter tabs render a `data-variant="line"` tablist and include `pb-1` / `overflow-y-visible`.
- `frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx`
  - Added corresponding test for project filter tabs.

## Test plan
- `npx vitest run ...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session a1640d21](https://143.dev/sessions/a1640d21-772e-4ec3-a971-33782930fcbf)