### PR TITLE
Align desktop session header heights between conversation and details sidebar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -334,6 +334,14 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByRole('tab', { name: 'Validation' })).not.toBeInTheDocument();
   });
 
+  it('uses the same desktop header height for the conversation and detail panels', async () => {
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    expect(screen.getByTestId('session-main-header')).toHaveClass('min-h-14');
+    expect(screen.getByTestId('session-detail-header')).toHaveClass('min-h-14');
+  });
+
   it('uses a dedicated mobile close button that does not compete with PR actions', async () => {
     vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
       matches: query === '(max-width: 767px)',

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2435,6 +2435,7 @@ const MIN_DETAIL = 280;
 const MAX_DETAIL = 600;
 const DEFAULT_DETAIL = 384;
 const MOBILE_REVIEW_MEDIA_QUERY = "(max-width: 767px)";
+const SESSION_HEADER_HEIGHT_CLASSNAME = "min-h-14";
 // Transcript keyboard scroll tuning. Step matches a comfortable line-pair
 // jump; page distance follows browser conventions (~85% viewport with a
 // floor for very short panels).
@@ -4281,7 +4282,10 @@ export function SessionDetailContent({ id }: { id: string }) {
       onValueChange={(v) => handleDetailTabClick(v as DetailTab)}
       className="flex flex-col flex-1 min-h-0 gap-0"
     >
-      <div className="border-b border-border px-2 py-2 shrink-0">
+      <div
+        data-testid="session-detail-header"
+        className={cn("border-b border-border px-2 py-2 shrink-0", SESSION_HEADER_HEIGHT_CLASSNAME)}
+      >
         <div className="flex items-center gap-2 min-w-0">
           <div
             ref={detailTabsRef}
@@ -4496,7 +4500,13 @@ export function SessionDetailContent({ id }: { id: string }) {
               archivePendingThreadId={archiveThreadMutation.isPending ? archiveThreadMutation.variables ?? null : null}
             />
 
-            <div className="hidden md:flex border-b border-border px-4 py-3 bg-background items-center justify-between shrink-0">
+            <div
+              data-testid="session-main-header"
+              className={cn(
+                "hidden border-b border-border bg-background px-4 py-3 md:flex items-center justify-between shrink-0",
+                SESSION_HEADER_HEIGHT_CLASSNAME,
+              )}
+            >
               <div className="min-w-0 flex-1 flex items-center gap-2">
                 {isEditingTitle ? (
                   <div className="min-w-0 flex-1 flex items-center gap-2">


### PR DESCRIPTION
## Summary
This change aligns the desktop header heights for the session conversation area and the right-side details sidebar to prevent vertical misalignment. It introduces a shared explicit header height class contract and adds a regression test to enforce it.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Added `SESSION_HEADER_HEIGHT_CLASSNAME = "min-h-14"` to define the shared desktop header height.
  - Applied `min-h-14` to:
    - The **conversation/detail main header** (`data-testid="session-main-header"`)
    - The **details panel header** (`data-testid="session-detail-header"`)
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added test **“uses the same desktop header height for the conversation and detail panels”** asserting both headers have the `min-h-14` class.

## Test plan
- `npx vitest --run src/app/(dashboard)/sessions/[id]/page.test.tsx -t "uses the same desktop header height for the conversation and detail panels"`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 92469346](https://143.dev/sessions/92469346-ec32-4fe6-bcc7-8d7a433de580)