### PR TITLE
Simplify fresh-thread empty state and update tests for new session tab UI

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1535,6 +1535,11 @@ describe('SessionDetailPage', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
     });
+    expect(screen.getByText('New tab')).toBeInTheDocument();
+    expect(screen.queryByText('Fresh tab')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fresh context')).not.toBeInTheDocument();
+    expect(screen.getByText('No context in this tab yet.')).toBeInTheDocument();
+    expect(screen.getByText('Send a task or add context to get started.')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Send a message to Codex 2...')).toBeInTheDocument();
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2048,6 +2048,12 @@ function ChatPanel({
     timelineEntries.length === 0 &&
     session.status !== "pending" &&
     (!hasLoadedTimelineInputs || expectingMoreContent);
+  const showFreshThreadShell =
+    !!activeThread &&
+    activeThread.status === "idle" &&
+    activeThread.current_turn === 0 &&
+    timelineEntries.length === 0 &&
+    !showLoadingSkeleton;
 
   const persistScrollPosition = useCallback((scrollTop: number) => {
     if (typeof window === "undefined" || !viewerScope) return;
@@ -2364,15 +2370,18 @@ function ChatPanel({
         {showLoadingSkeleton ? (
           <SessionTimelineSkeleton />
         ) : (
-          <ChatTimeline
-            entries={timelineEntries}
-            isRunning={isRunning}
-            diffStats={session.diff_stats}
-            onDiffClick={onDiffClick}
-            onApprovePlan={canSendMessage ? onApprovePlan : undefined}
-            onAdjustPlan={canSendMessage ? onAdjustPlan : undefined}
-            getEntryContainerProps={getEntryContainerProps}
-          />
+          <>
+            {showFreshThreadShell ? <FreshThreadShell thread={activeThread} /> : null}
+            <ChatTimeline
+              entries={timelineEntries}
+              isRunning={isRunning}
+              diffStats={session.diff_stats}
+              onDiffClick={onDiffClick}
+              onApprovePlan={canSendMessage ? onApprovePlan : undefined}
+              onAdjustPlan={canSendMessage ? onAdjustPlan : undefined}
+              getEntryContainerProps={getEntryContainerProps}
+            />
+          </>
         )}
         {(activeThread?.status === "pending" || (!activeThread && session.status === "pending")) && (
           <div className="flex items-center justify-center py-12">
@@ -2426,6 +2435,28 @@ function areChatPanelPropsEqual(previous: ChatPanelProps, next: ChatPanelProps):
 }
 
 const MemoizedChatPanel = memo(ChatPanel, areChatPanelPropsEqual);
+
+function FreshThreadShell({ thread }: { thread: SessionThread }) {
+  return (
+    <Card className="mx-auto max-w-2xl border-border/60 bg-muted/20 shadow-none">
+      <CardContent className="flex flex-col gap-3 p-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <AgentBadge
+            agentType={thread.agent_type}
+            labelClassName="text-xs font-medium text-foreground"
+          />
+          <span className="text-sm font-medium text-foreground">New tab</span>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-foreground">No context in this tab yet.</p>
+          <p className="text-sm text-muted-foreground">
+            Send a task or add context to get started.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Main component


### PR DESCRIPTION
## Summary
Updated the newly-created coding agent tab empty state to be a copy-only “New tab” shell (removing redundant “Fresh context”/“Fresh tab” badges). Adjusted the session detail regression test to assert the new UI text and absence of the removed elements.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Added `showFreshThreadShell` logic to render an empty-state shell only when the active thread is `idle`, has `current_turn === 0`, and there are no timeline entries while not showing the loading skeleton.
  - Introduced `FreshThreadShell` component that renders the simplified copy-only UI (“New tab”, “No context in this tab yet.”, “Send a task or add context to get started.”) above `ChatTimeline`.
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Updated the regression test to expect:
    - `New tab` to be present
    - `Fresh tab` and `Fresh context` to be absent
    - the new empty-state copy to be present

## Test plan
- Ran targeted Vitest regression:
  - `npx vitest run -t "does not shimmer forever for a freshly-created idle thread" "src/app/(dashboard)/sessions/[id]/page.test.tsx" --reporter=dot`
- Verified build health:
  - `npm run typecheck`
  - `npm run lint`
  - `npm run build` (completed successfully; existing workspace-root/deprecated middleware warnings still appear)

[143.dev](https://143.dev) | [session d5f21f74](https://143.dev/sessions/d5f21f74-bdea-4c06-acdd-7815e8e26744)