### PR TITLE
Fix Fresh Tab header spacing and remove Agent badge in session detail

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -1543,7 +1543,10 @@ describe('SessionDetailPage', () => {
     await waitFor(() => {
       expect(screen.queryByTestId('session-timeline-skeleton')).not.toBeInTheDocument();
     });
-    expect(screen.getByText('New tab')).toBeInTheDocument();
+    const freshTabCard = screen.getByText('No context in this tab yet.').closest('[data-slot="card"]');
+    expect(freshTabCard).not.toBeNull();
+    expect(within(freshTabCard as HTMLElement).getByText('New tab')).toBeInTheDocument();
+    expect(within(freshTabCard as HTMLElement).queryByText(/^Codex$/)).not.toBeInTheDocument();
     expect(screen.queryByText('Fresh tab')).not.toBeInTheDocument();
     expect(screen.queryByText('Fresh context')).not.toBeInTheDocument();
     expect(screen.getByText('No context in this tab yet.')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2371,7 +2371,7 @@ function ChatPanel({
           <SessionTimelineSkeleton />
         ) : (
           <>
-            {showFreshThreadShell ? <FreshThreadShell thread={activeThread} /> : null}
+            {showFreshThreadShell ? <FreshThreadShell /> : null}
             <ChatTimeline
               entries={timelineEntries}
               isRunning={isRunning}
@@ -2436,17 +2436,11 @@ function areChatPanelPropsEqual(previous: ChatPanelProps, next: ChatPanelProps):
 
 const MemoizedChatPanel = memo(ChatPanel, areChatPanelPropsEqual);
 
-function FreshThreadShell({ thread }: { thread: SessionThread }) {
+function FreshThreadShell() {
   return (
-    <Card className="mx-auto max-w-2xl border-border/60 bg-muted/20 shadow-none">
+    <Card className="w-full max-w-[92%] border-border/60 bg-muted/20 shadow-none">
       <CardContent className="flex flex-col gap-3 p-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <AgentBadge
-            agentType={thread.agent_type}
-            labelClassName="text-xs font-medium text-foreground"
-          />
-          <span className="text-sm font-medium text-foreground">New tab</span>
-        </div>
+        <span className="text-sm font-medium text-foreground">New tab</span>
         <div className="space-y-1">
           <p className="text-sm text-foreground">No context in this tab yet.</p>
           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
Updated the “Fresh tab” shell to remove the Agent badge (so it only displays a simple “New tab” label) and adjusted the card sizing/alignment to match the transcript bubble width. Tightened the session detail page test to assert both the presence of “New tab” and the absence of the “Codex” label in that card.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Simplified `FreshThreadShell` to render `<FreshThreadShell />` without passing a thread prop.
  - Updated `FreshThreadShell` UI:
    - Removed `AgentBadge` rendering.
    - Changed card classes from `mx-auto max-w-2xl` to `w-full max-w-[92%]` to resolve margin/alignment mismatch with the `Files changed` row and transcript bubble sizing.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Strengthened assertions for the fresh-tab card:
    - Verify the card containing “No context in this tab yet.” includes **“New tab”**.
    - Verify **no** `Codex` label is rendered within that same card.

## Test plan
- Ran: `npx vitest run 'src/app/(dashboard)/sessions/[id]/page.test.tsx' --reporter=dot`
- Ran: `npm run typecheck`
- Ran: `npm run lint`
- Ran: `npm run build`

[143.dev](https://143.dev) | [session 414cc09b](https://143.dev/sessions/414cc09b-c69a-4829-9764-0e0681bae874)