### PR TITLE
[VIR-86] Add Builder role to RBAC and hide restricted dashboard actions

### DIFF
--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -13,6 +13,7 @@ The system aggregates issues from support, Sentry, and Linear, prioritizes them 
 ## Identity and organization context
 
 - The current product is single-organization per user, but the intended long-term identity model is **one user identity, many organization memberships**. A user represents the human account (email, GitHub ID, Google ID); membership represents access to an organization and carries the user's role for that org.
+- Organization memberships now support a fourth assignable role, `builder`, alongside `admin`, `member`, and `viewer`. `Builder` is more constrained than `member`: it can use build/session workflows and personal coding-agent setup, but it does not inherit the broader member repo/settings/evals/project/PR-shipping surface until explicit builder guardrails exist.
 - All product data remains scoped to exactly one `org_id`. Multi-organization support should change how the active org is resolved for a request, not introduce cross-org views by default.
 - The detailed future design lives in [future/50-multi-organization-membership.md](future/50-multi-organization-membership.md). The key product guardrail is that single-org users should see no new UI or onboarding complexity.
 - Invitation acceptance is **token-driven and immediate**. Opening an invite while already signed in should claim it right away and switch the tab's active org to the invited org; unauthenticated invite flows should carry a prominent "invitation pending" callout with org and target identity so the auth screen never looks like a generic login.

--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -30,6 +30,10 @@ vi.mock("@/hooks/use-auth", () => ({
   }),
 }));
 
+vi.mock("./automation-stats-card", () => ({
+  AutomationStatsCard: () => <div data-testid="automation-stats-card" />,
+}));
+
 describe("AutomationDetailPage", () => {
   beforeEach(() => {
     currentUserRole.value = "member";

--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { fireEvent, renderWithProviders, screen, userEvent, waitFor } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import { http, HttpResponse } from "msw";
@@ -6,6 +6,7 @@ import AutomationDetailPage from "./page";
 import { AUTOMATION_GOAL_MAX_LENGTH } from "@/lib/automation-validation";
 
 const pushMock = vi.fn();
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
 
 vi.mock("next/link", () => ({
   default: ({ children, href, ...props }: React.ComponentProps<"a"> & { href: string }) => (
@@ -22,7 +23,19 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => new URLSearchParams("tab=paused"),
 }));
 
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
+}));
+
 describe("AutomationDetailPage", () => {
+  beforeEach(() => {
+    currentUserRole.value = "member";
+    pushMock.mockReset();
+  });
+
   it("matches the schedule controls and labels to the app input sizing", async () => {
     server.use(
       http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
@@ -91,6 +104,63 @@ describe("AutomationDetailPage", () => {
     expect(runEveryText).toHaveClass("text-xs", "font-medium", "leading-none", "text-muted-foreground");
     expect(atText).toHaveClass("text-xs", "font-medium", "leading-none", "text-muted-foreground");
     expect(screen.queryByText(/Run time is in/i)).not.toBeInTheDocument();
+  });
+
+  it("hides member-only automation actions from builders", async () => {
+    currentUserRole.value = "builder";
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole("button", { name: "Pause" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Run now" })).not.toBeInTheDocument();
+
+    await userEvent.setup().click(screen.getByRole("tab", { name: "Settings" }));
+    expect(screen.queryByRole("button", { name: "Save changes" })).not.toBeInTheDocument();
   });
 
   it("renders a back button to the automations list preserving query params", async () => {

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -25,6 +25,7 @@ import { AutomationModelSelect } from "@/components/automation-model-select";
 import { api } from "@/lib/api";
 import { agentTypeForModel } from "@/lib/agents";
 import { AUTOMATION_GOAL_MAX_LENGTH, automationGoalLengthState } from "@/lib/automation-validation";
+import { useAuth } from "@/hooks/use-auth";
 import type { Automation } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import {
@@ -60,7 +61,7 @@ type IntervalUnit = (typeof INTERVAL_UNITS)[number];
 const toIntervalUnit = (v: string, fallback: IntervalUnit): IntervalUnit =>
   (INTERVAL_UNITS as readonly string[]).includes(v) ? (v as IntervalUnit) : fallback;
 
-function SettingsTab({ automation }: { automation: Automation }) {
+function SettingsTab({ automation, canManage }: { automation: Automation; canManage: boolean }) {
   const queryClient = useQueryClient();
   const [name, setName] = useState(automation.name);
   const [goal, setGoal] = useState(automation.goal);
@@ -287,21 +288,23 @@ function SettingsTab({ automation }: { automation: Automation }) {
           contentClassName="w-[var(--radix-popover-trigger-width)]"
         />
       </div>
-      <div className="flex items-center gap-3 pt-2">
-        <Button
-          onClick={() => updateMutation.mutate()}
-          disabled={updateMutation.isPending || goalLength.isTooLong}
-        >
-          {updateMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-          Save changes
-        </Button>
-        {updateMutation.isError && (
-          <p className="text-xs text-destructive">Failed to save changes.</p>
-        )}
-        {updateMutation.isSuccess && !updateMutation.isPending && (
-          <p className="text-xs text-muted-foreground">Saved.</p>
-        )}
-      </div>
+      {canManage && (
+        <div className="flex items-center gap-3 pt-2">
+          <Button
+            onClick={() => updateMutation.mutate()}
+            disabled={updateMutation.isPending || goalLength.isTooLong}
+          >
+            {updateMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Save changes
+          </Button>
+          {updateMutation.isError && (
+            <p className="text-xs text-destructive">Failed to save changes.</p>
+          )}
+          {updateMutation.isSuccess && !updateMutation.isPending && (
+            <p className="text-xs text-muted-foreground">Saved.</p>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -310,7 +313,9 @@ export default function AutomationDetailPage() {
   const params = useParams();
   const router = useRouter();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
   const automationId = params?.id as string;
+  const canManage = user?.role === "admin" || user?.role === "member";
 
   const { data, isLoading } = useQuery({
     queryKey: ["automation", automationId],
@@ -410,7 +415,7 @@ export default function AutomationDetailPage() {
         <PageHeader
           title={automation.name}
           description={headerDescription}
-          action={
+          action={canManage ? (
             <div className="flex items-center gap-2">
               {automation.enabled ? (
                 <Button
@@ -454,7 +459,7 @@ export default function AutomationDetailPage() {
                 Run now
               </Button>
             </div>
-          }
+          ) : undefined}
         />
 
         {headerError && (
@@ -478,7 +483,7 @@ export default function AutomationDetailPage() {
                 edit remounts SettingsTab, reseeding its useState-from-props
                 form fields. Without this, the visible values would drift
                 from the server until the user manually reopens the tab. */}
-            <SettingsTab key={automation.updated_at} automation={automation} />
+            <SettingsTab key={automation.updated_at} automation={automation} canManage={canManage} />
           </TabsContent>
         </Tabs>
       </div>

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -6,19 +6,30 @@ import NewAutomationPage from "./page";
 import { AUTOMATION_GOAL_MAX_LENGTH } from "@/lib/automation-validation";
 
 const pushMock = vi.fn();
+const replaceMock = vi.fn();
 const searchParams = new URLSearchParams("template=security-sweep");
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
-    replace: vi.fn(),
+    replace: replaceMock,
   }),
   useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
 }));
 
 describe("NewAutomationPage", () => {
   beforeEach(() => {
     pushMock.mockReset();
+    replaceMock.mockReset();
+    currentUserRole.value = "member";
   });
 
   it("allows the timezone selector to wrap cleanly on mobile layouts", async () => {
@@ -222,6 +233,16 @@ describe("NewAutomationPage", () => {
     await user.click(await screen.findByRole("button", { name: /\/review/i }));
 
     expect(goalInput).toHaveValue("/review ");
+  });
+
+  it("redirects builders away from the new automation form", async () => {
+    currentUserRole.value = "builder";
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/automations");
+    });
   });
 
   it("submits the selected base branch from the branch picker", async () => {

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ChevronDown, Loader2 } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -24,6 +24,7 @@ import {
 import { api } from "@/lib/api";
 import { agentTypeForModel } from "@/lib/agents";
 import { AUTOMATION_GOAL_MAX_LENGTH, automationGoalLengthState } from "@/lib/automation-validation";
+import { useAuth } from "@/hooks/use-auth";
 import { BranchPicker } from "@/components/branch-picker";
 import { AutomationGoalEditor } from "@/components/automation-goal-editor";
 import { AutomationModelSelect } from "@/components/automation-model-select";
@@ -52,7 +53,15 @@ import { TimezonePicker } from "../timezone-picker";
 export default function NewAutomationPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { user, isLoading } = useAuth();
+  const canManage = user?.role === "admin" || user?.role === "member";
   const initialTemplate = getAutomationTemplate(searchParams.get("template") ?? "");
+
+  useEffect(() => {
+    if (!isLoading && !canManage) {
+      router.replace("/automations");
+    }
+  }, [canManage, isLoading, router]);
 
   // Form state
   const [name, setName] = useState(initialTemplate?.name ?? "");
@@ -133,6 +142,10 @@ export default function NewAutomationPage() {
       router.push(`/automations/${res.data.id}`);
     },
   });
+
+  if (!isLoading && !canManage) {
+    return null;
+  }
 
   if (repos.length === 0 && reposData) {
     return (

--- a/frontend/src/app/(dashboard)/automations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.test.tsx
@@ -1,11 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { renderWithProviders, screen } from "@/test/test-utils";
 import { server } from "@/test/mocks/server";
 import AutomationsPage from "./page";
 
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
+}));
+
 describe("AutomationsPage", () => {
   it("renders automation cards with mobile-friendly stacked details", async () => {
+    currentUserRole.value = "member";
     server.use(
       http.get("*/api/v1/automations", () => HttpResponse.json({
         data: [
@@ -71,5 +81,40 @@ describe("AutomationsPage", () => {
       name: "More options for Weekly release hardening sweep for mobile checkout reliability",
     });
     expect(menuButton).toHaveClass("self-start", "shrink-0");
+  });
+
+  it("hides member-only create and mutation controls from builders", async () => {
+    currentUserRole.value = "builder";
+    server.use(
+      http.get("*/api/v1/automations", () => HttpResponse.json({
+        data: [
+          {
+            id: "auto-enabled",
+            org_id: "org-1",
+            repository_id: "repo-1",
+            name: "Weekly sweep",
+            goal: "Keep things healthy",
+            scope: "",
+            execution_mode: "async",
+            max_concurrent: 1,
+            base_branch: "main",
+            schedule_type: "interval",
+            interval_value: 1,
+            interval_unit: "weeks",
+            enabled: true,
+            priority: 50,
+            created_at: "2026-04-01T00:00:00Z",
+            updated_at: "2026-04-01T00:00:00Z",
+          },
+        ],
+        meta: {},
+      })),
+    );
+
+    renderWithProviders(<AutomationsPage />);
+
+    await screen.findByText("Weekly sweep");
+    expect(screen.queryByRole("link", { name: /new/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /more options for weekly sweep/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/automations/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { useAuth } from "@/hooks/use-auth";
 
 function formatSchedule(a: Automation): string {
   const tz = a.timezone || "UTC";
@@ -32,7 +33,7 @@ function formatSchedule(a: Automation): string {
   return `${intervalText} at ${formatRunAtWithTimezone(a.interval_run_at, tz)}`;
 }
 
-function AutomationCard({ automation }: { automation: Automation }) {
+function AutomationCard({ automation, canManage }: { automation: Automation; canManage: boolean }) {
   const queryClient = useQueryClient();
 
   const pauseMutation = useMutation({
@@ -105,45 +106,47 @@ function AutomationCard({ automation }: { automation: Automation }) {
           </div>
         </Link>
 
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8 self-start shrink-0"
-              aria-label={`More options for ${automation.name}`}
-            >
-              <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {automation.enabled ? (
-              <DropdownMenuItem
-                onClick={() => pauseMutation.mutate()}
-                disabled={pauseMutation.isPending}
+        {canManage && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 self-start shrink-0"
+                aria-label={`More options for ${automation.name}`}
               >
-                <Pause className="h-3.5 w-3.5 mr-2" />
-                Pause
-              </DropdownMenuItem>
-            ) : (
+                <MoreHorizontal className="h-4 w-4 text-muted-foreground" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {automation.enabled ? (
+                <DropdownMenuItem
+                  onClick={() => pauseMutation.mutate()}
+                  disabled={pauseMutation.isPending}
+                >
+                  <Pause className="h-3.5 w-3.5 mr-2" />
+                  Pause
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  onClick={() => resumeMutation.mutate()}
+                  disabled={resumeMutation.isPending}
+                >
+                  <Play className="h-3.5 w-3.5 mr-2" />
+                  Resume
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
-                onClick={() => resumeMutation.mutate()}
-                disabled={resumeMutation.isPending}
+                onClick={handleDelete}
+                disabled={deleteMutation.isPending}
+                className="text-destructive focus:text-destructive"
               >
-                <Play className="h-3.5 w-3.5 mr-2" />
-                Resume
+                <Trash2 className="h-3.5 w-3.5 mr-2" />
+                Delete
               </DropdownMenuItem>
-            )}
-            <DropdownMenuItem
-              onClick={handleDelete}
-              disabled={deleteMutation.isPending}
-              className="text-destructive focus:text-destructive"
-            >
-              <Trash2 className="h-3.5 w-3.5 mr-2" />
-              Delete
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
       {mutationError && (
         <p className="px-4 pb-3 text-xs text-destructive" role="alert">
@@ -155,6 +158,8 @@ function AutomationCard({ automation }: { automation: Automation }) {
 }
 
 export default function AutomationsPage() {
+  const { user } = useAuth();
+  const canManage = user?.role === "admin" || user?.role === "member";
   const { data, isLoading } = useQuery({
     queryKey: ["automations"],
     queryFn: () => api.automations.list(),
@@ -171,14 +176,14 @@ export default function AutomationsPage() {
         <PageHeader
           title="Automations"
           description="Recurring agents that run on a schedule for your team."
-          action={
+          action={canManage ? (
             <Button asChild size="sm">
               <Link href="/automations/new">
                 <Plus className="h-4 w-4 mr-1.5" />
                 New
               </Link>
             </Button>
-          }
+          ) : undefined}
         />
 
         {isLoading && (
@@ -191,12 +196,12 @@ export default function AutomationsPage() {
           <div className="text-center py-16 space-y-3">
             <RefreshCw className="h-8 w-8 mx-auto text-muted-foreground/40" />
             <p className="text-sm text-muted-foreground">No automations yet</p>
-            <Button asChild variant="outline" size="sm">
+            {canManage && <Button asChild variant="outline" size="sm">
               <Link href="/automations/new">
                 <Plus className="h-4 w-4 mr-1.5" />
                 Create your first automation
               </Link>
-            </Button>
+            </Button>}
           </div>
         )}
 
@@ -207,7 +212,7 @@ export default function AutomationsPage() {
             </h2>
             <div className="space-y-2">
               {enabled.map((a) => (
-                <AutomationCard key={a.id} automation={a} />
+                <AutomationCard key={a.id} automation={a} canManage={canManage} />
               ))}
             </div>
           </section>
@@ -220,7 +225,7 @@ export default function AutomationsPage() {
             </h2>
             <div className="space-y-2">
               {paused.map((a) => (
-                <AutomationCard key={a.id} automation={a} />
+                <AutomationCard key={a.id} automation={a} canManage={canManage} />
               ))}
             </div>
           </section>

--- a/frontend/src/app/(dashboard)/automations/templates/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/templates/page.test.tsx
@@ -1,6 +1,15 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import AutomationTemplatesPage from "./page";
+
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
+}));
 
 describe("AutomationTemplatesPage", () => {
   it("renders a deeper template library with category browsing", () => {
@@ -11,5 +20,14 @@ describe("AutomationTemplatesPage", () => {
     expect(screen.getByText("Find flaky tests")).toBeInTheDocument();
     expect(screen.getAllByRole("link", { name: /Use template/i }).length).toBeGreaterThan(0);
     expect(screen.getByText(/Browse examples and richer prompts/i)).toBeInTheDocument();
+  });
+
+  it("hides create links for builders", () => {
+    currentUserRole.value = "builder";
+
+    render(<AutomationTemplatesPage />);
+
+    expect(screen.queryByRole("link", { name: "New automation" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Use template/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/automations/templates/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/templates/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { ArrowRight } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { useAuth } from "@/hooks/use-auth";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,19 +15,22 @@ import {
 } from "@/lib/automation-templates";
 
 export default function AutomationTemplatesPage() {
+  const { user } = useAuth();
+  const canManage = user?.role === "admin" || user?.role === "member";
+
   return (
     <PageContainer size="default">
       <div className="space-y-6">
         <PageHeader
           title="Automation templates"
           description="Browse examples and richer prompts for recurring agent work. These templates favor clear scope, concrete outputs, and explicit verification."
-          action={
+          action={canManage ? (
             <Button asChild size="sm">
               <Link href="/automations/new">
                 New automation
               </Link>
             </Button>
-          }
+          ) : undefined}
         />
 
         <Card className="border-dashed">
@@ -112,12 +116,14 @@ export default function AutomationTemplatesPage() {
                             </div>
                           </div>
 
-                          <Button asChild variant="outline" size="sm">
-                            <Link href={`/automations/new?template=${template.id}`}>
-                              Use template
-                              <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
-                            </Link>
-                          </Button>
+                          {canManage ? (
+                            <Button asChild variant="outline" size="sm">
+                              <Link href={`/automations/new?template=${template.id}`}>
+                                Use template
+                                <ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+                              </Link>
+                            </Button>
+                          ) : null}
                         </CardContent>
                       </Card>
                     );

--- a/frontend/src/app/(dashboard)/projects/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/new/page.test.tsx
@@ -5,17 +5,27 @@ import { http, HttpResponse } from "msw";
 import NewProjectPage from "./page";
 
 const pushMock = vi.fn();
+const replaceMock = vi.fn();
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: pushMock,
-    replace: vi.fn(),
+    replace: replaceMock,
   }),
   useSearchParams: () => new URLSearchParams(),
 }));
 
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
+}));
+
 describe("NewProjectPage", () => {
   it("submits the selected base branch from the branch picker", async () => {
+    currentUserRole.value = "member";
     const user = userEvent.setup();
     let requestBody: Record<string, unknown> | null = null;
 
@@ -73,6 +83,16 @@ describe("NewProjectPage", () => {
         repository_id: "repo-1",
         base_branch: "release/2026.04",
       });
+    });
+  });
+
+  it("redirects builders away from the new project form", async () => {
+    currentUserRole.value = "builder";
+
+    renderWithProviders(<NewProjectPage />);
+
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/projects");
     });
   });
 });

--- a/frontend/src/app/(dashboard)/projects/new/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/new/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import {
   Sparkles,
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/collapsible";
 import { api } from "@/lib/api";
 import { AGENTS } from "@/lib/agents";
+import { useAuth } from "@/hooks/use-auth";
 import { BranchPicker } from "@/components/branch-picker";
 import { NoReposWarning } from "@/components/no-repos-warning";
 import { MobileBackButton } from "@/components/mobile-back-button";
@@ -48,6 +49,14 @@ function priorityLevelToNumeric(level: PriorityLevel): number {
 
 export default function NewProjectPage() {
   const router = useRouter();
+  const { user, isLoading } = useAuth();
+  const canManage = user?.role === "admin" || user?.role === "member";
+
+  useEffect(() => {
+    if (!isLoading && !canManage) {
+      router.replace("/projects");
+    }
+  }, [canManage, isLoading, router]);
 
   // AI description
   const [description, setDescription] = useState("");
@@ -149,6 +158,10 @@ export default function NewProjectPage() {
         generateMutation.mutate();
       }
     }
+  }
+
+  if (!isLoading && !canManage) {
+    return null;
   }
 
   const canSubmit =

--- a/frontend/src/app/(dashboard)/projects/page.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/page.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen } from "@/test/test-utils";
+import ProjectsPage from "./page";
+
+const currentUserRole = vi.hoisted(() => ({ value: "member" }));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({
+    user: { role: currentUserRole.value },
+    isLoading: false,
+  }),
+}));
+
+describe("ProjectsPage", () => {
+  it("shows the new-project action for members", () => {
+    currentUserRole.value = "member";
+
+    renderWithProviders(<ProjectsPage />);
+
+    expect(screen.getByRole("link", { name: /new project/i })).toHaveAttribute("href", "/projects/new");
+  });
+
+  it("hides the new-project action from builders", () => {
+    currentUserRole.value = "builder";
+
+    renderWithProviders(<ProjectsPage />);
+
+    expect(screen.queryByRole("link", { name: /new project/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(dashboard)/projects/page.tsx
+++ b/frontend/src/app/(dashboard)/projects/page.tsx
@@ -1,8 +1,14 @@
+"use client";
+
 import Link from "next/link";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
 
 export default function ProjectsPage() {
+  const { user } = useAuth();
+  const canManage = user?.role === "admin" || user?.role === "member";
+
   return (
     <div className="hidden md:flex h-full items-center justify-center p-8">
       <div className="max-w-md text-center space-y-4">
@@ -10,12 +16,12 @@ export default function ProjectsPage() {
         <p className="text-sm text-muted-foreground">
           Start a new project, or open one from the list to continue.
         </p>
-        <Button asChild>
+        {canManage && <Button asChild>
           <Link href="/projects/new">
             <Plus className="h-4 w-4" />
             New project
           </Link>
-        </Button>
+        </Button>}
       </div>
     </div>
   );

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -20,12 +20,12 @@ let mockPathname = '/projects';
 let mockSelectedSegment: string | null = null;
 const mockAuthState: {
   isAuthenticated: boolean;
-  user: { id: string } | null;
+  user: { id: string; role: string } | null;
   isLoading: boolean;
   logout: ReturnType<typeof vi.fn>;
 } = {
   isAuthenticated: true,
-  user: { id: 'user-1' },
+  user: { id: 'user-1', role: 'member' },
   isLoading: false,
   logout: vi.fn(),
 };
@@ -52,7 +52,7 @@ describe('ProjectSidebar', () => {
     mockPathname = '/projects';
     mockSelectedSegment = null;
     mockAuthState.isAuthenticated = true;
-    mockAuthState.user = { id: 'user-1' };
+    mockAuthState.user = { id: 'user-1', role: 'member' };
     mockAuthState.isLoading = false;
     mockAuthState.logout = vi.fn();
     notifyError.mockReset();
@@ -133,6 +133,32 @@ describe('ProjectSidebar', () => {
     renderWithProviders(<ProjectSidebar />);
     const link = screen.getByRole('link', { name: /New project/ });
     expect(link).toHaveAttribute('href', '/projects/new');
+  });
+
+  it('hides the New project entry for builders', async () => {
+    mockAuthState.user = { id: 'user-1', role: 'builder' };
+
+    renderWithProviders(<ProjectSidebar />);
+    await screen.findByText('Test Project');
+
+    expect(screen.queryByRole('link', { name: /New project/ })).not.toBeInTheDocument();
+  });
+
+  it('does not request the team roster for builders', async () => {
+    mockAuthState.user = { id: 'user-1', role: 'builder' };
+    let teamRequestCount = 0;
+
+    server.use(
+      http.get('*/api/v1/team/members', () => {
+        teamRequestCount += 1;
+        return HttpResponse.json({ error: { code: 'FORBIDDEN', message: 'insufficient permissions' } }, { status: 403 });
+      }),
+    );
+
+    renderWithProviders(<ProjectSidebar />);
+    await screen.findByText('Test Project');
+
+    expect(teamRequestCount).toBe(0);
   });
 
   it('shows empty state when API returns no projects', async () => {
@@ -325,6 +351,17 @@ describe('ProjectSidebar', () => {
     const newProjectTexts = screen.getAllByText('New project');
     // At least 2: the top "+ New project" link + the ghost entry
     expect(newProjectTexts.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('hides the ghost New project entry for builders', async () => {
+    mockAuthState.user = { id: 'user-1', role: 'builder' };
+    mockPathname = '/projects/new';
+    mockSelectedSegment = 'new';
+
+    renderWithProviders(<ProjectSidebar />);
+    await screen.findByText('Test Project');
+
+    expect(screen.queryByText('New project')).not.toBeInTheDocument();
   });
 
   it('highlights the selected project from the active layout segment', async () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -68,9 +68,11 @@ export function ProjectSidebar() {
     void setSearchParam(search || null);
   }, [search, searchParam, setSearchParam]);
 
+  const canListTeamMembers = currentUser?.role === "admin" || currentUser?.role === "member";
   const { data: membersData } = useQuery({
     queryKey: ["team", "members"],
     queryFn: () => api.team.listMembers(),
+    enabled: canListTeamMembers,
   });
 
   const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);
@@ -140,6 +142,7 @@ export function ProjectSidebar() {
     currentFilter === "all" &&
     !search.trim() &&
     displayedProjects.length === 0;
+  const canManage = canListTeamMembers;
 
   return (
     <div className="w-full h-full border-r border-border bg-muted/30 flex flex-col">
@@ -166,12 +169,14 @@ export function ProjectSidebar() {
         </div>
 
         {/* New project button */}
-        <Button asChild variant="outline" className="w-full gap-2 bg-background text-xs shadow-sm">
-          <Link href="/projects/new">
-            <Plus className="h-4 w-4" />
-            New project
-          </Link>
-        </Button>
+        {canManage && (
+          <Button asChild variant="outline" className="w-full gap-2 bg-background text-xs shadow-sm">
+            <Link href="/projects/new">
+              <Plus className="h-4 w-4" />
+              New project
+            </Link>
+          </Button>
+        )}
 
         {/* Filter tabs */}
         <Tabs
@@ -200,7 +205,7 @@ export function ProjectSidebar() {
       {/* Project list */}
       <div className="flex-1 overflow-y-auto px-2 pb-2">
         {/* Ghost "New project" entry when creating */}
-        {isNewProject && (
+        {canManage && isNewProject && (
           <Link
             href="/projects/new"
             className="block rounded-lg px-3 py-2.5 mb-0.5 bg-background shadow-sm border border-border/50"

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2886,6 +2886,49 @@ describe('SessionDetailPage', () => {
     expect(screen.getByRole('button', { name: /Create PR/ })).not.toBeDisabled();
   });
 
+  it('hides PR mutation controls and skips the team roster lookup for builders', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      status: 'completed',
+      diff: '--- a/file.ts\n+++ b/file.ts\n@@ -1 +1 @@\n-old\n+new',
+      diff_stats: { added: 1, removed: 1, files_changed: 1 },
+      snapshot_key: 'snap-abc',
+    };
+    let teamRequestCount = 0;
+
+    server.use(
+      http.get('/api/v1/auth/me', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockMembers[0],
+            role: 'builder',
+          },
+        } satisfies SingleResponse<User>);
+      }),
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithDiff } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/pr', () => {
+        return HttpResponse.json(
+          { error: { code: 'NOT_FOUND', message: 'pull request not found' } },
+          { status: 404 },
+        );
+      }),
+      http.get('/api/v1/team/members', () => {
+        teamRequestCount += 1;
+        return HttpResponse.json({ error: { code: 'FORBIDDEN', message: 'insufficient permissions' } }, { status: 403 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    await screen.findAllByText('Fixed TypeError by adding null check');
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /Create PR/ })).not.toBeInTheDocument();
+    });
+    expect(teamRequestCount).toBe(0);
+  });
+
   it('does not show Create PR button when PR already exists', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2441,6 +2441,8 @@ const TRANSCRIPT_PAGE_VIEWPORT_RATIO = 0.85;
 export function SessionDetailContent({ id }: { id: string }) {
   const router = useRouter();
   const { user, isLoading: isAuthLoading } = useAuth();
+  const canListTeamMembers = user?.role === "admin" || user?.role === "member";
+  const canShipPR = canListTeamMembers;
   const terminalStatuses = new Set(["completed", "pr_created", "failed", "cancelled", "skipped"]);
   const [reviewParam, setReviewParam] = useQueryState("review");
   const [previewParam, setPreviewParam] = useQueryState("preview");
@@ -2591,6 +2593,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const { data: membersData } = useQuery({
     queryKey: ["team", "members"],
     queryFn: () => api.team.listMembers(),
+    enabled: canListTeamMembers,
   });
 
   const viewerScope = useMemo<SessionScrollViewerScope | null>(
@@ -3062,7 +3065,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const hasPR = !!prData?.data;
   const hasSnapshot = !!session?.snapshot_key;
   const hasSessionChanges = !!session?.diff || !!session?.diff_stats;
-  const canCreatePR = hasSnapshot && !hasPR && !isRunning;
+  const canCreatePR = canShipPR && hasSnapshot && !hasPR && !isRunning;
   const isTerminalSession = terminalSessionStatuses.has(session?.status ?? "");
   const showExpiredPRAction = hasSessionChanges && !hasSnapshot && !hasPR && isTerminalSession;
   const needsGitHubStatus = canCreatePR || (hasPR && prData?.data?.status === "open");
@@ -4054,10 +4057,10 @@ export function SessionDetailContent({ id }: { id: string }) {
     pr: {
       canCreate: canCreatePR && localPRState === "idle" && !createPRMutation.isPending,
       canView: !!prData?.data?.github_pr_url,
-      canPush: hasPR && prStatus === "open" && !!session?.has_unpushed_changes && hasSnapshot && !isRunning && localPushState === "idle" && !pushChangesMutation.isPending,
-      canFixTests: !!prHealth?.can_fix_tests && pendingPRAction === null,
-      canResolveConflicts: !!prHealth?.can_resolve_conflicts && pendingPRAction === null,
-      canMerge: prHealthAllowsMerge(prHealth) && pendingPRAction === null,
+      canPush: canShipPR && hasPR && prStatus === "open" && !!session?.has_unpushed_changes && hasSnapshot && !isRunning && localPushState === "idle" && !pushChangesMutation.isPending,
+      canFixTests: canShipPR && !!prHealth?.can_fix_tests && pendingPRAction === null,
+      canResolveConflicts: canShipPR && !!prHealth?.can_resolve_conflicts && pendingPRAction === null,
+      canMerge: canShipPR && prHealthAllowsMerge(prHealth) && pendingPRAction === null,
       onCreate: createPRFromKeyboard,
       onView: viewPRFromKeyboard,
       onPush: pushChangesFromKeyboard,
@@ -4111,13 +4114,15 @@ export function SessionDetailContent({ id }: { id: string }) {
       (snapshotUnavailable ? snapshotMessage : null) ||
       (prState === "failed" ? session.pr_creation_error || PR_ERROR_TOAST_MESSAGE : null);
   const showPRAction =
-    canCreatePR ||
-    showExpiredPRAction ||
-    queueingPR ||
-    creatingPR ||
-    finalizingPR ||
-    prState === "failed" ||
-    Boolean(prActionError);
+    canShipPR && (
+      canCreatePR ||
+      showExpiredPRAction ||
+      queueingPR ||
+      creatingPR ||
+      finalizingPR ||
+      prState === "failed" ||
+      Boolean(prActionError)
+    );
 
   let prActionLabel = "Create PR";
   let prActionSpinning = false;
@@ -4165,8 +4170,8 @@ export function SessionDetailContent({ id }: { id: string }) {
     (localPushState === "queued" && pushState !== "failed" && pushState !== "succeeded") ||
     pushState === "queued" ||
     pushState === "pushing";
-  const canPushChanges = pushAvailable && hasSnapshot && !isRunning;
-  const showPushAction = pushAvailable && (canPushChanges || queueingPush || pushingChanges || pushState === "failed" || localPushActionError);
+  const canPushChanges = canShipPR && pushAvailable && hasSnapshot && !isRunning;
+  const showPushAction = canShipPR && pushAvailable && (canPushChanges || queueingPush || pushingChanges || pushState === "failed" || localPushActionError);
   let pushActionLabel = "Push changes";
   let pushActionSpinning = false;
   let pushActionDisabled = false;
@@ -4950,6 +4955,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       <SessionKeyboardHelpOverlay
         open={keyboardHelpOpen}
         onOpenChange={setKeyboardHelpOpen}
+        canShipPR={canShipPR}
       />
       <AlertDialog
         open={!!prAuthPrompt}

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -185,6 +185,7 @@ export function SessionSidebar() {
     isResolved,
     setPeopleFilter,
   } = usePeopleFilter();
+  const canListTeamMembers = currentUser?.role === "admin" || currentUser?.role === "member";
   const selectedId = selectedSegment && selectedSegment !== "new" ? selectedSegment : undefined;
   const [searchParam, setSearchParam] = useQueryState("search", parseAsString);
   const [search, setSearch] = useState(searchParam ?? "");
@@ -237,6 +238,7 @@ export function SessionSidebar() {
   const { data: membersData } = useQuery({
     queryKey: ["team", "members"],
     queryFn: () => api.team.listMembers(),
+    enabled: canListTeamMembers,
   });
   const members = useMemo<User[]>(() => membersData?.data ?? [], [membersData?.data]);
 

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.test.tsx
@@ -6,12 +6,12 @@ import { SessionsPageContent } from './sessions-page-content';
 
 const mockAuthState: {
   isAuthenticated: boolean;
-  user: { id: string } | null;
+  user: { id: string; role: string } | null;
   isLoading: boolean;
   logout: ReturnType<typeof vi.fn>;
 } = {
   isAuthenticated: true,
-  user: { id: 'user-1' },
+  user: { id: 'user-1', role: 'member' },
   isLoading: false,
   logout: vi.fn(),
 };
@@ -30,7 +30,7 @@ vi.mock('@/hooks/use-auth', () => ({
 describe('SessionsPageContent', () => {
   beforeEach(() => {
     mockAuthState.isAuthenticated = true;
-    mockAuthState.user = { id: 'user-1' };
+    mockAuthState.user = { id: 'user-1', role: 'member' };
     mockAuthState.isLoading = false;
     mockAuthState.logout = vi.fn();
   });
@@ -57,5 +57,22 @@ describe('SessionsPageContent', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(requestCount).toBe(0);
     expect(screen.getByText('Loading sessions...')).toBeInTheDocument();
+  });
+
+  it('does not request the team roster for builders', async () => {
+    mockAuthState.user = { id: 'user-1', role: 'builder' };
+    let teamRequestCount = 0;
+
+    server.use(
+      http.get('/api/v1/team/members', () => {
+        teamRequestCount += 1;
+        return HttpResponse.json({ error: { code: 'FORBIDDEN', message: 'insufficient permissions' } }, { status: 403 });
+      }),
+    );
+
+    renderWithProviders(<SessionsPageContent />);
+
+    expect(await screen.findByText(/Fixed TypeError by adding null check/)).toBeInTheDocument();
+    expect(teamRequestCount).toBe(0);
   });
 });

--- a/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/sessions-page-content.tsx
@@ -211,6 +211,7 @@ export function SessionsPageContent() {
     isResolved,
     setPeopleFilter,
   } = usePeopleFilter();
+  const canListTeamMembers = currentUser?.role === "admin" || currentUser?.role === "member";
   const [activeFilter, setActiveFilter] = useQueryState("status", parseAsString);
   const [repo] = useQueryState("repo");
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -281,6 +282,7 @@ export function SessionsPageContent() {
   const { data: membersData } = useQuery({
     queryKey: ["team", "members"],
     queryFn: () => api.team.listMembers(),
+    enabled: canListTeamMembers,
   });
 
   const members = useMemo(() => membersData?.data ?? [], [membersData?.data]);

--- a/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/agent/page.test.tsx
@@ -300,7 +300,7 @@ describe("Agent settings page", () => {
     await user.hover(within(dialog).getByRole("button", { name: "Where to get a Pi API key" }));
     const piLinks = await screen.findAllByRole("link", { name: "Pi dashboard" });
     expect(piLinks[0]).toHaveAttribute("href", "https://pi.dev/");
-  });
+  }, 10000);
 
   it("does not render the agent-specific access card", async () => {
     installHandlers();

--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -180,6 +180,33 @@ describe('SettingsLayout', () => {
     expect(replaceMock).not.toHaveBeenCalled();
   });
 
+  it('redirects builders away from /settings/team', async () => {
+    useAuthMock.mockReturnValue({ user: { role: 'builder' }, isLoading: false });
+    pathnameMock.value = '/settings/team';
+
+    renderWithProviders(
+      <SettingsLayout>
+        <div>team roster</div>
+      </SettingsLayout>
+    );
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/settings/account'));
+  });
+
+  it('lets builders through to /settings/agent', () => {
+    useAuthMock.mockReturnValue({ user: { role: 'builder' }, isLoading: false });
+    pathnameMock.value = '/settings/agent';
+
+    renderWithProviders(
+      <SettingsLayout>
+        <div>agent settings</div>
+      </SettingsLayout>
+    );
+
+    expect(screen.getByText('agent settings')).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+  });
+
   it('does not mount children for access-controlled pages while auth is still loading', () => {
     useAuthMock.mockReturnValue({ user: null, isLoading: true });
     pathnameMock.value = '/settings/team';

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -24,6 +24,14 @@ const VIEWER_BLOCKED_PATHS = new Set([
   "/settings/evals",
 ]);
 
+// Builders can access personal coding-agent setup, but they do not inherit the
+// broader member settings surface for team/evals/integrations management.
+const BUILDER_BLOCKED_PATHS = new Set([
+  "/settings/team",
+  "/settings/integrations",
+  "/settings/evals",
+]);
+
 function isAdminOnlyPath(pathname: string): boolean {
   if (ADMIN_ONLY_PATHS.has(pathname)) return true;
   for (const base of ADMIN_ONLY_PATHS) {
@@ -40,6 +48,14 @@ function isViewerBlockedPath(pathname: string): boolean {
   return false;
 }
 
+function isBuilderBlockedPath(pathname: string): boolean {
+  if (BUILDER_BLOCKED_PATHS.has(pathname)) return true;
+  for (const base of BUILDER_BLOCKED_PATHS) {
+    if (pathname.startsWith(base + "/")) return true;
+  }
+  return false;
+}
+
 export default function SettingsLayout({
   children,
 }: {
@@ -49,13 +65,15 @@ export default function SettingsLayout({
   const pathname = usePathname();
   const { user, isLoading } = useAuth();
 
-  const roleGuardedPath = isAdminOnlyPath(pathname) || isViewerBlockedPath(pathname);
+  const roleGuardedPath = isAdminOnlyPath(pathname) || isViewerBlockedPath(pathname) || isBuilderBlockedPath(pathname);
   const role = user?.role;
   let restricted = false;
   if (!isLoading && role !== undefined) {
     if (role !== "admin" && isAdminOnlyPath(pathname)) {
       restricted = true;
     } else if (role === "viewer" && isViewerBlockedPath(pathname)) {
+      restricted = true;
+    } else if (role === "builder" && isBuilderBlockedPath(pathname)) {
       restricted = true;
     }
   }

--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -230,6 +230,25 @@ describe('TeamSettingsPage', () => {
     });
   });
 
+  it('offers builder as an invite role option', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamSettingsPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'Invite' }));
+    await user.click(await screen.findByLabelText('Role'));
+
+    expect(await screen.findByRole('option', { name: 'Builder' })).toBeInTheDocument();
+  });
+
+  it('offers builder in the member role selector for admins', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamSettingsPage />);
+
+    await user.click(await screen.findByLabelText('Role for Member User'));
+
+    expect(await screen.findByRole('option', { name: 'Builder' })).toBeInTheDocument();
+  });
+
   it('shows informative self action text instead of a dash placeholder', async () => {
     renderWithProviders(<TeamSettingsPage />);
 

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -246,6 +246,7 @@ export default function TeamSettingsPage() {
     switch (role) {
       case "admin":
         return "default" as const;
+      case "builder":
       case "member":
         return "secondary" as const;
       default:
@@ -386,6 +387,7 @@ export default function TeamSettingsPage() {
                             <SelectContent>
                               <SelectItem value="admin">Admin</SelectItem>
                               <SelectItem value="member">Member</SelectItem>
+                              <SelectItem value="builder">Builder</SelectItem>
                               <SelectItem value="viewer">Viewer</SelectItem>
                             </SelectContent>
                             </Select>
@@ -736,6 +738,7 @@ export default function TeamSettingsPage() {
                   <SelectContent>
                     <SelectItem value="admin">Admin</SelectItem>
                     <SelectItem value="member">Member</SelectItem>
+                    <SelectItem value="builder">Builder</SelectItem>
                     <SelectItem value="viewer">Viewer</SelectItem>
                   </SelectContent>
                 </Select>

--- a/frontend/src/components/command-palette/command-palette-actions.test.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.test.ts
@@ -17,6 +17,16 @@ describe("command-palette-actions", () => {
     expect(actions.find((a) => a.id === "settings-audit-log")).toBeUndefined();
   });
 
+  it("hides member-only settings and eval actions for builders", () => {
+    const actions = getFilteredActions("builder");
+    expect(actions.find((a) => a.id === "settings-integrations")).toBeUndefined();
+    expect(actions.find((a) => a.id === "settings-evals")).toBeUndefined();
+    expect(actions.find((a) => a.id === "settings-team")).toBeUndefined();
+    expect(actions.find((a) => a.id === "action-new-project")).toBeUndefined();
+    expect(actions.find((a) => a.id === "action-new-eval")).toBeUndefined();
+    expect(actions.find((a) => a.id === "settings-agents")).toBeDefined();
+  });
+
   it("all static actions have unique ids", () => {
     const ids = staticActions.map((a) => a.id);
     expect(new Set(ids).size).toBe(ids.length);

--- a/frontend/src/components/command-palette/command-palette-actions.ts
+++ b/frontend/src/components/command-palette/command-palette-actions.ts
@@ -26,6 +26,8 @@ export interface PaletteAction {
   preserveRepo?: boolean;
   /** If set, only users with this role see the action. */
   requiredRole?: string;
+  /** If set, users with any of these roles do not see the action. */
+  hiddenRoles?: string[];
   group: "navigation" | "settings" | "quick-actions";
   /** If set, show this keyboard shortcut hint on the right. */
   shortcut?: string;
@@ -40,24 +42,26 @@ export const staticActions: PaletteAction[] = [
 
   // Settings & admin
   { id: "settings-account", label: "Account", icon: CircleUser, href: "/settings/account", group: "settings" },
-  { id: "settings-general", label: "General", icon: Settings, href: "/settings", group: "settings" },
-  { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/settings/integrations", group: "settings" },
-  { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", requiredRole: "admin", group: "settings" },
-  { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/settings/llm", group: "settings" },
+  { id: "settings-general", label: "General", icon: Settings, href: "/settings", requiredRole: "admin", group: "settings" },
+  { id: "settings-integrations", label: "Integrations", icon: Plug, href: "/settings/integrations", hiddenRoles: ["viewer", "builder"], group: "settings" },
+  { id: "settings-agents", label: "Coding agents", icon: Bot, href: "/settings/agent", hiddenRoles: ["viewer"], group: "settings" },
+  { id: "settings-llm", label: "LLM", icon: Sparkles, href: "/settings/llm", requiredRole: "admin", group: "settings" },
   { id: "settings-autopilot", label: "Autopilot", icon: Target, href: "/settings/autopilot", requiredRole: "admin", group: "settings" },
-  { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", group: "settings" },
-  { id: "settings-team", label: "Team", icon: Users, href: "/settings/team", group: "settings" },
+  { id: "settings-evals", label: "Evals", icon: FlaskConical, href: "/settings/evals", hiddenRoles: ["viewer", "builder"], group: "settings" },
+  { id: "settings-team", label: "Team", icon: Users, href: "/settings/team", hiddenRoles: ["viewer", "builder"], group: "settings" },
   { id: "settings-audit-log", label: "Audit log", icon: ScrollText, href: "/settings/audit-log", requiredRole: "admin", group: "settings" },
 
   // Quick actions
   { id: "action-new-session", label: "New session", icon: Plus, href: "/sessions/new", preserveRepo: true, group: "quick-actions" },
-  { id: "action-new-project", label: "New project", icon: Plus, href: "/projects/new", preserveRepo: true, group: "quick-actions" },
-  { id: "action-new-eval", label: "Create eval task", icon: Plus, href: "/settings/evals/new", group: "quick-actions" },
+  { id: "action-new-project", label: "New project", icon: Plus, href: "/projects/new", preserveRepo: true, hiddenRoles: ["builder"], group: "quick-actions" },
+  { id: "action-new-eval", label: "Create eval task", icon: Plus, href: "/settings/evals/new", hiddenRoles: ["viewer", "builder"], group: "quick-actions" },
   { id: "action-logout", label: "Log out", icon: LogOut, group: "quick-actions" },
 ];
 
 export function getFilteredActions(userRole: string): PaletteAction[] {
   return staticActions.filter(
-    (action) => !action.requiredRole || action.requiredRole === userRole
+    (action) =>
+      (!action.requiredRole || action.requiredRole === userRole) &&
+      !action.hiddenRoles?.includes(userRole)
   );
 }

--- a/frontend/src/components/command-palette/command-palette.test.tsx
+++ b/frontend/src/components/command-palette/command-palette.test.tsx
@@ -63,7 +63,8 @@ describe("CommandPalette", () => {
 
   it("excludes admin-only items for non-admin users", async () => {
     renderPalette({ userRole: "member" });
-    await screen.findByText("General");
+    await screen.findByText("Account");
+    expect(screen.queryByText("General")).not.toBeInTheDocument();
     expect(screen.queryByText("Audit log")).not.toBeInTheDocument();
     expect(screen.getAllByText("Autopilot")).toHaveLength(1);
   });

--- a/frontend/src/components/session-keyboard-help-overlay.test.tsx
+++ b/frontend/src/components/session-keyboard-help-overlay.test.tsx
@@ -22,4 +22,13 @@ describe("SessionKeyboardHelpOverlay", () => {
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
+
+  it("hides PR shortcuts when the viewer cannot ship PRs", () => {
+    renderWithProviders(
+      <SessionKeyboardHelpOverlay open onOpenChange={vi.fn()} canShipPR={false} />,
+    );
+
+    expect(screen.queryByText("Ship PR")).not.toBeInTheDocument();
+    expect(screen.queryByText("p c")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/session-keyboard-help-overlay.tsx
+++ b/frontend/src/components/session-keyboard-help-overlay.tsx
@@ -11,6 +11,7 @@ import {
 type SessionKeyboardHelpOverlayProps = {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  canShipPR?: boolean;
 };
 
 const shortcutGroups = [
@@ -58,7 +59,15 @@ const shortcutGroups = [
   },
 ];
 
-export function SessionKeyboardHelpOverlay({ open, onOpenChange }: SessionKeyboardHelpOverlayProps) {
+export function SessionKeyboardHelpOverlay({
+  open,
+  onOpenChange,
+  canShipPR = true,
+}: SessionKeyboardHelpOverlayProps) {
+  const visibleShortcutGroups = canShipPR
+    ? shortcutGroups
+    : shortcutGroups.filter((group) => group.title !== "Ship PR");
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -72,7 +81,7 @@ export function SessionKeyboardHelpOverlay({ open, onOpenChange }: SessionKeyboa
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 overflow-y-auto p-5 sm:grid-cols-2">
-          {shortcutGroups.map((group) => (
+          {visibleShortcutGroups.map((group) => (
             <section key={group.title} className="space-y-2">
               <h3 className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                 {group.title}

--- a/frontend/src/components/sidebar-settings-section.test.tsx
+++ b/frontend/src/components/sidebar-settings-section.test.tsx
@@ -79,4 +79,30 @@ describe('SidebarSettingsSection', () => {
       expect(screen.queryByText(hidden)).not.toBeInTheDocument();
     }
   });
+
+  it('shows only builder-safe settings entries for builders', () => {
+    renderWithProviders(
+      <SidebarSettingsSection pathname="/settings/account" userRole="builder" />
+    );
+
+    for (const visible of [
+      'Account',
+      'Coding agents',
+    ]) {
+      expect(screen.getByText(visible)).toBeInTheDocument();
+    }
+
+    for (const hidden of [
+      'Integrations',
+      'Evals',
+      'Team',
+      'LLM',
+      'Autopilot',
+      'General',
+      'Usage',
+      'Audit log',
+    ]) {
+      expect(screen.queryByText(hidden)).not.toBeInTheDocument();
+    }
+  });
 });

--- a/frontend/src/components/sidebar-settings-section.tsx
+++ b/frontend/src/components/sidebar-settings-section.tsx
@@ -28,9 +28,9 @@ interface SettingsItem {
   icon: LucideIcon;
   href: string;
   adminOnly?: boolean;
-  // Hides the entry from viewers. Backend rejects the underlying reads, so
-  // showing the link would land them on an empty/failed page.
-  hideForViewers?: boolean;
+  // Hides the entry from selected roles. Backend rejects the underlying reads,
+  // so showing the link would land them on an empty/failed page.
+  hideForRoles?: string[];
 }
 
 interface SettingsGroup {
@@ -48,18 +48,18 @@ const settingsGroups: SettingsGroup[] = [
   {
     label: "PLATFORM",
     items: [
-      { label: "Integrations", icon: Plug, href: "/settings/integrations", hideForViewers: true },
-      { label: "Coding agents", icon: Bot, href: "/settings/agent", hideForViewers: true },
+      { label: "Integrations", icon: Plug, href: "/settings/integrations", hideForRoles: ["viewer", "builder"] },
+      { label: "Coding agents", icon: Bot, href: "/settings/agent", hideForRoles: ["viewer"] },
       { label: "LLM", icon: Sparkles, href: "/settings/llm", adminOnly: true },
       { label: "Autopilot", icon: Target, href: "/settings/autopilot", adminOnly: true },
-      { label: "Evals", icon: FlaskConical, href: "/settings/evals", hideForViewers: true },
+      { label: "Evals", icon: FlaskConical, href: "/settings/evals", hideForRoles: ["viewer", "builder"] },
     ],
   },
   {
     label: "ORGANIZATION",
     items: [
       { label: "General", icon: Settings, href: "/settings", adminOnly: true },
-      { label: "Team", icon: Users, href: "/settings/team", hideForViewers: true },
+      { label: "Team", icon: Users, href: "/settings/team", hideForRoles: ["viewer", "builder"] },
       { label: "Usage", icon: BarChart3, href: "/settings/usage", adminOnly: true },
       { label: "Audit log", icon: ScrollText, href: "/settings/audit-log", adminOnly: true },
     ],
@@ -156,7 +156,7 @@ export function SidebarSettingsSection({
             {settingsGroups.map((group, groupIndex) => {
               const visibleItems = group.items.filter((item) => {
                 if (item.adminOnly && userRole !== "admin") return false;
-                if (item.hideForViewers && userRole === "viewer") return false;
+                if (item.hideForRoles?.includes(userRole ?? "")) return false;
                 return true;
               });
               if (visibleItems.length === 0) return null;

--- a/internal/api/handlers/team.go
+++ b/internal/api/handlers/team.go
@@ -218,7 +218,7 @@ func (h *TeamHandler) ChangeRole(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !models.IsValidRole(body.Role) {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, builder, member, or viewer")
 		return
 	}
 
@@ -389,7 +389,7 @@ func (h *TeamHandler) CreateInvitation(w http.ResponseWriter, r *http.Request) {
 		body.Role = models.RoleMember
 	}
 	if !models.IsValidRole(body.Role) {
-		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, member, or viewer")
+		writeError(w, r, http.StatusBadRequest, "VALIDATION_ERROR", "invalid role: must be admin, builder, member, or viewer")
 		return
 	}
 

--- a/internal/api/handlers/team_test.go
+++ b/internal/api/handlers/team_test.go
@@ -501,6 +501,24 @@ func TestTeamHandler_ChangeRole(t *testing.T) {
 			},
 			expectedCode: http.StatusOK,
 		},
+		{
+			name:        "successfully changes role to builder",
+			memberID:    memberID.String(),
+			body:        map[string]string{"role": "builder"},
+			currentUser: adminUser,
+			users: &mockTeamUserStore{
+				getByIDGlobalFn: func(_ context.Context, _ uuid.UUID) (models.User, error) {
+					return models.User{ID: memberID, Email: "b@c.com", Name: "Bob"}, nil
+				},
+			},
+			memberships: &mockTeamMembershipStore{
+				updateRoleGuardedFn: func(_ context.Context, _, _ uuid.UUID, role string) (string, error) {
+					require.Equal(t, "builder", role, "ChangeRole should pass the builder role through to the membership store")
+					return "member", nil
+				},
+			},
+			expectedCode: http.StatusOK,
+		},
 	}
 
 	for _, tt := range tests {
@@ -679,6 +697,34 @@ func TestTeamHandler_ChangeRole_PostUpdateLookupFails(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Equal(t, memberID, resp.Data.ID)
 	require.Equal(t, "viewer", resp.Data.Role)
+}
+
+func TestTeamHandler_CreateInvitation_AcceptsBuilderRole(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	adminUser := &models.User{ID: uuid.New(), OrgID: orgID, Role: "admin", Name: "Admin User"}
+	createdRoles := make([]string, 0, 1)
+
+	h := newTeamHandler(nil, &mockTeamMembershipStore{}, nil, &mockTeamInvitationStore{
+		createFn: func(_ context.Context, inv *models.Invitation) error {
+			createdRoles = append(createdRoles, inv.Role)
+			inv.ID = uuid.New()
+			inv.Status = "pending"
+			inv.CreatedAt = time.Now()
+			return nil
+		},
+	}, nil)
+
+	body, _ := json.Marshal(map[string]string{"email": "builder@example.com", "role": "builder"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/team/invitations", bytes.NewReader(body))
+	req = req.WithContext(teamCtx(orgID, adminUser))
+	w := httptest.NewRecorder()
+
+	h.CreateInvitation(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code, "CreateInvitation should accept builder as a valid membership role")
+	require.Equal(t, []string{"builder"}, createdRoles, "CreateInvitation should persist the requested builder role")
 }
 
 // RemoveMember succeeds even when CountForUser fails afterward — the removal

--- a/internal/api/middleware/rbac_test.go
+++ b/internal/api/middleware/rbac_test.go
@@ -40,13 +40,24 @@ func TestRequireRole(t *testing.T) {
 		},
 		{
 			name:         "allows request when user role matches one of the allowed roles",
-			allowedRoles: []string{"admin", "member"},
+			allowedRoles: []string{"admin", "builder", "member"},
 			user: &models.User{
 				ID:    uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000001"),
 				OrgID: uuid.MustParse("bbbbbbbb-0000-0000-0000-000000000002"),
 				Role:  "member",
 			},
 			requestMethod: http.MethodGet,
+			expectedCode:  http.StatusOK,
+		},
+		{
+			name:         "allows builder to access member-grade route",
+			allowedRoles: []string{"admin", "builder", "member"},
+			user: &models.User{
+				ID:    uuid.MustParse("bcbcbcbc-0000-0000-0000-000000000001"),
+				OrgID: uuid.MustParse("bcbcbcbc-0000-0000-0000-000000000002"),
+				Role:  "builder",
+			},
+			requestMethod: http.MethodPost,
 			expectedCode:  http.StatusOK,
 		},
 		{
@@ -62,7 +73,7 @@ func TestRequireRole(t *testing.T) {
 		},
 		{
 			name:         "returns 403 when viewer tries to access write-only route",
-			allowedRoles: []string{"admin", "member"},
+			allowedRoles: []string{"admin", "builder", "member"},
 			user: &models.User{
 				ID:    uuid.MustParse("dddddddd-0000-0000-0000-000000000001"),
 				OrgID: uuid.MustParse("dddddddd-0000-0000-0000-000000000002"),

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -695,10 +695,10 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 			// process; context.Background() is the right lifetime here.
 			r.With(middleware.CreateOrgRateLimit(context.Background(), 5)).Post("/api/v1/organizations", organizationsHandler.Create)
 
-			// Read-only routes (all roles: admin, member, viewer)
+			// Read-only routes (all roles: admin, builder, member, viewer)
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.OrgContext)
-				r.Use(middleware.RequireRole("admin", "member", "viewer"))
+				r.Use(middleware.RequireRole("admin", "builder", "member", "viewer"))
 
 				r.Get("/api/v1/version", healthHandler.Version)
 
@@ -793,31 +793,27 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 
 			})
 
-			// Write routes (admin and member only)
+			// Builder workflow routes. Builders can create and iterate on work,
+			// plus manage their personal coding-agent/auth setup, but they do not
+			// inherit the broader member settings/repo/project mutation surface.
 			r.Group(func(r chi.Router) {
 				r.Use(middleware.OrgContext)
-				r.Use(middleware.RequireRole("admin", "member"))
+				r.Use(middleware.RequireRole("admin", "builder", "member"))
 
-				r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
-				r.Post("/api/v1/repositories/{id}/disconnect", repoHandler.Disconnect)
-				r.Post("/api/v1/repositories/{id}/reconnect", repoHandler.Reconnect)
-
-				// Team roster read — sits in the admin+member group (not the
-				// all-roles read group) so viewers cannot enumerate org members.
-				r.Get("/api/v1/team/members", teamHandler.ListMembers)
-
-				// Coding-agents config reads. Members can view what's configured
-				// (so /settings/agent renders read-only); mutations stay admin-only.
+				// Coding-agents config reads. Builders and members can view what's
+				// configured (so /settings/agent renders read-only when needed);
+				// org-scope mutations stay admin-only.
 				r.Get("/api/v1/settings/coding-auths", codingAuthHandler.List)
 				r.Get("/api/v1/settings/codex-auth/subscriptions", codexAuthHandler.List)
 				r.Get("/api/v1/settings/claude-code-auth/subscriptions", claudeCodeAuthHandler.List)
 
 				// Codex / Claude OAuth subscription flows. Org-scope writes are
 				// admin-gated inside each handler (see resolveOAuthScope);
-				// personal-scope writes are available to any member because they
-				// target the caller's own credential rows. Routing both into the
-				// admin+member group lets a single endpoint serve both cases —
-				// the handler decides based on the request's scope param.
+				// personal-scope writes are available to builders and members
+				// because they target the caller's own credential rows. Routing
+				// both into the builder workflow group lets a single endpoint
+				// serve both cases — the handler decides based on the request's
+				// scope param.
 				r.Post("/api/v1/settings/codex-auth/initiate", codexAuthHandler.Initiate)
 				r.Get("/api/v1/settings/codex-auth/status", codexAuthHandler.Status)
 				r.Post("/api/v1/settings/codex-auth/disconnect", codexAuthHandler.DisconnectAll) // legacy compat
@@ -828,31 +824,19 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/settings/claude-code-auth/disconnect", claudeCodeAuthHandler.DisconnectAll) // legacy compat
 				r.Delete("/api/v1/settings/claude-code-auth/subscriptions/{id}", claudeCodeAuthHandler.DisconnectByPath)
 
-				// Unified coding-credentials writes. Personal-scope mutations live in
-				// this group because they target the requester's own credentials and
-				// do not require admin privileges for members. The handler enforces
-				// "admin only when scope=org" via resolveScopeFromBody; per-row Move
-				// and bulk Reorder both rely on that gate, so both can sit here
-				// without allowing members to reorder the org stack.
+				// Unified coding-credentials writes. Personal-scope mutations live
+				// in this group because they target the requester's own credentials
+				// and do not require admin privileges for builders or members. The
+				// handler enforces "admin only when scope=org" via
+				// resolveScopeFromBody; per-row Move and bulk Reorder both rely on
+				// that gate, so both can sit here without allowing non-admins to
+				// reorder the org stack.
 				// See docs/design/future/65-unified-coding-credentials.md.
 				r.Post("/api/v1/coding-credentials", codingCredentialHandler.Create)
 				r.Patch("/api/v1/coding-credentials/{id}", codingCredentialHandler.Update)
 				r.Delete("/api/v1/coding-credentials/{id}", codingCredentialHandler.Delete)
 				r.Patch("/api/v1/coding-credentials/{id}/move", codingCredentialHandler.Move)
 				r.Patch("/api/v1/coding-credentials/reorder", codingCredentialHandler.Reorder)
-
-				// Eval reads — admin+member only so viewers cannot enumerate eval
-				// tasks or runs. Eval writes are gated even more tightly (admin-only)
-				// further down.
-				r.Get("/api/v1/evals/tasks", evalHandler.ListTasks)
-				r.Get("/api/v1/evals/tasks/{id}", evalHandler.GetTask)
-				r.Get("/api/v1/evals/tasks/{id}/runs", evalHandler.ListRuns)
-				r.Get("/api/v1/evals/runs/{runId}", evalHandler.GetRun)
-				r.Get("/api/v1/evals/batch", evalHandler.ListBatches)
-				r.Get("/api/v1/evals/batch/{batchId}", evalHandler.GetBatch)
-				r.Get("/api/v1/evals/batch/{batchId}/stream", evalHandler.StreamBatchUpdates)
-				r.Get("/api/v1/evals/bootstrap/candidates", evalHandler.GetBootstrapCandidates)
-				r.Get("/api/v1/evals/bootstrap/{runId}/stream", evalHandler.StreamBootstrapUpdates)
 
 				// Personal credential management
 				r.Put("/api/v1/settings/credentials/personal/{provider}", userCredentialHandler.UpsertPersonal)
@@ -876,11 +860,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/sessions/{id}/cancel", sessionHandler.CancelSession)
 				r.Post("/api/v1/sessions/{id}/archive", sessionHandler.ArchiveSession)
 				r.Post("/api/v1/sessions/{id}/unarchive", sessionHandler.UnarchiveSession)
-				r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
-				r.Post("/api/v1/sessions/{id}/pr/push", sessionHandler.PushChangesToPR)
-				r.Post("/api/v1/pull-requests/{id}/repair/fix-tests", pullRequestHandler.FixTests)
-				r.Post("/api/v1/pull-requests/{id}/repair/resolve-conflicts", pullRequestHandler.ResolveConflicts)
-				r.Post("/api/v1/pull-requests/{id}/merge", pullRequestHandler.Merge)
 				r.Post("/api/v1/sessions/{id}/threads", sessionThreadHandler.CreateThread)
 				r.Patch("/api/v1/sessions/{id}/threads/{tid}", sessionThreadHandler.UpdateThread)
 				r.Post("/api/v1/sessions/{id}/threads/{tid}/archive", sessionThreadHandler.ArchiveThread)
@@ -905,6 +884,44 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/sessions/{id}/review-comments/send", sessionReviewCommentHandler.SendToAgent)
 				r.Patch("/api/v1/sessions/{id}/review-comments/{commentId}", sessionReviewCommentHandler.Update)
 				r.Delete("/api/v1/sessions/{id}/review-comments/{commentId}", sessionReviewCommentHandler.Delete)
+
+			})
+
+			// Member settings / operations routes. Builders do not inherit this
+			// broader org-management and PR-shipping surface until dedicated
+			// guardrails are in place.
+			r.Group(func(r chi.Router) {
+				r.Use(middleware.OrgContext)
+				r.Use(middleware.RequireRole("admin", "member"))
+
+				r.Patch("/api/v1/repositories/{id}", repoHandler.Update)
+				r.Post("/api/v1/repositories/{id}/disconnect", repoHandler.Disconnect)
+				r.Post("/api/v1/repositories/{id}/reconnect", repoHandler.Reconnect)
+
+				// Team roster read — sits in the admin+member group (not the
+				// all-roles read group) so viewers and builders cannot enumerate
+				// org members.
+				r.Get("/api/v1/team/members", teamHandler.ListMembers)
+
+				// Eval reads — admin+member only so viewers/builders cannot
+				// enumerate eval tasks or runs. Eval writes are gated even more
+				// tightly (admin-only) further down.
+				r.Get("/api/v1/evals/tasks", evalHandler.ListTasks)
+				r.Get("/api/v1/evals/tasks/{id}", evalHandler.GetTask)
+				r.Get("/api/v1/evals/tasks/{id}/runs", evalHandler.ListRuns)
+				r.Get("/api/v1/evals/runs/{runId}", evalHandler.GetRun)
+				r.Get("/api/v1/evals/batch", evalHandler.ListBatches)
+				r.Get("/api/v1/evals/batch/{batchId}", evalHandler.GetBatch)
+				r.Get("/api/v1/evals/batch/{batchId}/stream", evalHandler.StreamBatchUpdates)
+				r.Get("/api/v1/evals/bootstrap/candidates", evalHandler.GetBootstrapCandidates)
+				r.Get("/api/v1/evals/bootstrap/{runId}/stream", evalHandler.StreamBootstrapUpdates)
+
+				r.Post("/api/v1/sessions/{id}/pr", sessionHandler.CreatePR)
+				r.Post("/api/v1/sessions/{id}/pr/push", sessionHandler.PushChangesToPR)
+				r.Post("/api/v1/pull-requests/{id}/repair/fix-tests", pullRequestHandler.FixTests)
+				r.Post("/api/v1/pull-requests/{id}/repair/resolve-conflicts", pullRequestHandler.ResolveConflicts)
+				r.Post("/api/v1/pull-requests/{id}/merge", pullRequestHandler.Merge)
+
 				// Automations (write)
 				r.Post("/api/v1/automations", automationHandler.Create)
 				r.Patch("/api/v1/automations/{id}", automationHandler.Update)
@@ -940,7 +957,6 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 				r.Post("/api/v1/pm/documents/{docId}/sync", pmDocumentHandler.SyncFromNotion)
 				r.Post("/api/v1/pm/documents/{docId}/restore", pmDocumentHandler.RestoreVersion)
 				r.Post("/api/v1/pm/document-set-pins", pmDocumentHandler.CreateDocumentSetPin)
-
 			})
 
 			// Admin-only routes

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -62,21 +62,24 @@ func TestNewRouter_EncryptionKeyValidation(t *testing.T) {
 	}
 }
 
-func TestSessionThreadPatchRouteIsWriteOnly(t *testing.T) {
+func TestSessionThreadPatchRouteIsBuilderWorkflowOnly(t *testing.T) {
 	t.Parallel()
 
 	source, err := os.ReadFile("router.go")
 	require.NoError(t, err, "router.go should be readable for route grouping regression test")
 
-	readGroupStart := strings.Index(string(source), `RequireRole("admin", "member", "viewer")`)
-	writeGroupStart := strings.Index(string(source), `RequireRole("admin", "member")`)
+	readGroupStart := strings.Index(string(source), `RequireRole("admin", "builder", "member", "viewer")`)
+	builderGroupStart := strings.Index(string(source), `RequireRole("admin", "builder", "member")`)
+	memberWriteGroupStart := strings.Index(string(source), `RequireRole("admin", "member")`)
 	patchRoute := strings.Index(string(source), `r.Patch("/api/v1/sessions/{id}/threads/{tid}", sessionThreadHandler.UpdateThread)`)
 
-	require.NotEqual(t, -1, readGroupStart, "router should still define a viewer-readable route group")
-	require.NotEqual(t, -1, writeGroupStart, "router should still define an admin/member write route group")
+	require.NotEqual(t, -1, readGroupStart, "router should still define an all-roles readable route group")
+	require.NotEqual(t, -1, builderGroupStart, "router should still define a builder workflow route group")
+	require.NotEqual(t, -1, memberWriteGroupStart, "router should still define an admin/member-only route group")
 	require.NotEqual(t, -1, patchRoute, "thread update PATCH route should be registered")
-	require.Greater(t, patchRoute, writeGroupStart, "thread update PATCH route should live in the admin/member write group")
-	require.Greater(t, writeGroupStart, readGroupStart, "write route group should follow the viewer-readable group")
+	require.Greater(t, patchRoute, builderGroupStart, "thread update PATCH route should live in the builder workflow group")
+	require.Less(t, patchRoute, memberWriteGroupStart, "thread update PATCH route should not be widened into the admin/member-only settings group")
+	require.Greater(t, builderGroupStart, readGroupStart, "builder workflow route group should follow the all-roles readable group")
 }
 
 func testRouterPrivateKeyPEM(t *testing.T) string {

--- a/internal/db/organization_memberships.go
+++ b/internal/db/organization_memberships.go
@@ -136,8 +136,8 @@ func (s *OrganizationMembershipStore) Insert(ctx context.Context, userID, orgID 
 // re-accept (e.g. a double-clicked link) must not downgrade an admin back to
 // the invite's original role, but a pending invite that legitimately upgrades
 // an existing member should apply. Privilege ordering is admin > member >
-// viewer; a request for a lower-or-equal role is a no-op at the DB level but
-// the returned role reflects the row that now exists.
+// builder > viewer; a request for a lower-or-equal role is a no-op at the DB
+// level but the returned role reflects the row that now exists.
 //
 // Use UpdateRole / UpdateRoleGuarded for explicit role changes (including
 // demotions) — those paths enforce the last-admin invariant, GrantAtLeast
@@ -152,7 +152,8 @@ func (s *OrganizationMembershipStore) GrantAtLeast(ctx context.Context, userID, 
 		ON CONFLICT (user_id, org_id) DO UPDATE
 		SET role = CASE
 			WHEN EXCLUDED.role = 'admin' THEN 'admin'
-			WHEN EXCLUDED.role = 'member' AND organization_memberships.role = 'viewer' THEN 'member'
+			WHEN EXCLUDED.role = 'member' AND organization_memberships.role IN ('builder', 'viewer') THEN 'member'
+			WHEN EXCLUDED.role = 'builder' AND organization_memberships.role = 'viewer' THEN 'builder'
 			ELSE organization_memberships.role
 		END
 		RETURNING role`

--- a/internal/db/organization_memberships_test.go
+++ b/internal/db/organization_memberships_test.go
@@ -116,6 +116,7 @@ func TestOrganizationMembershipStore_GrantAtLeast(t *testing.T) {
 	}{
 		{"admin role", "admin"},
 		{"member role", "member"},
+		{"builder role", "builder"},
 		{"viewer role", "viewer"},
 	}
 
@@ -139,6 +140,25 @@ func TestOrganizationMembershipStore_GrantAtLeast(t *testing.T) {
 			require.NoError(t, mock.ExpectationsWereMet())
 		})
 	}
+}
+
+func TestOrganizationMembershipStore_GrantAtLeast_SQLSupportsBuilderUpgrade(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	store := NewOrganizationMembershipStore(mock)
+
+	mock.ExpectQuery(`(?s)INSERT INTO organization_memberships.+WHEN EXCLUDED\.role = 'builder' AND organization_memberships\.role = 'viewer' THEN 'builder'.+RETURNING role`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"role"}).AddRow("builder"))
+
+	effective, err := store.GrantAtLeast(context.Background(), uuid.New(), uuid.New(), "builder")
+	require.NoError(t, err)
+	require.Equal(t, "builder", effective)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestOrganizationMembershipStore_Insert(t *testing.T) {

--- a/internal/models/membership.go
+++ b/internal/models/membership.go
@@ -6,21 +6,23 @@ import (
 	"github.com/google/uuid"
 )
 
-// Role constants for organization_memberships.role. These mirror the legacy
-// users.role values so behavior is identical during the compatibility window.
+// Role constants for organization_memberships.role. Admin/member/viewer mirror
+// the legacy users.role values; builder is the new assignable non-admin role
+// that sits between member and viewer in the permission lattice.
 const (
-	RoleAdmin  = "admin"
-	RoleMember = "member"
-	RoleViewer = "viewer"
+	RoleAdmin   = "admin"
+	RoleMember  = "member"
+	RoleBuilder = "builder"
+	RoleViewer  = "viewer"
 )
 
 // ValidRoles lists every legal membership role, in order of decreasing privilege.
-var ValidRoles = []string{RoleAdmin, RoleMember, RoleViewer}
+var ValidRoles = []string{RoleAdmin, RoleMember, RoleBuilder, RoleViewer}
 
 // IsValidRole reports whether r is one of the known membership roles.
 func IsValidRole(r string) bool {
 	switch r {
-	case RoleAdmin, RoleMember, RoleViewer:
+	case RoleAdmin, RoleMember, RoleBuilder, RoleViewer:
 		return true
 	}
 	return false

--- a/internal/models/membership_test.go
+++ b/internal/models/membership_test.go
@@ -15,6 +15,7 @@ func TestIsValidRole(t *testing.T) {
 		valid bool
 	}{
 		{name: "admin", role: RoleAdmin, valid: true},
+		{name: "builder", role: RoleBuilder, valid: true},
 		{name: "member", role: RoleMember, valid: true},
 		{name: "viewer", role: RoleViewer, valid: true},
 		{name: "empty", role: "", valid: false},
@@ -32,5 +33,5 @@ func TestIsValidRole(t *testing.T) {
 
 func TestValidRoles_OrderedByPrivilege(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, []string{RoleAdmin, RoleMember, RoleViewer}, ValidRoles)
+	require.Equal(t, []string{RoleAdmin, RoleMember, RoleBuilder, RoleViewer}, ValidRoles)
 }


### PR DESCRIPTION
## Summary
Implements the new `builder` organization role (VIR-86) in both the RBAC layer and the dashboard. To keep the UI consistent with permissions, builder users now have restricted workflow/actions hidden rather than merely disabled.

## Changes
- **RBAC / backend**
  - Updated role model and membership handling to support a new `builder` role.
  - Adjusted RBAC middleware and handler logic to enforce the builder permission surface on the server.
  - Touched team/membership API paths to ensure role checks align with the new builder semantics.
  - Files:  
    - `internal/api/handlers/team.go`, `internal/api/handlers/team_test.go`  
    - `internal/api/middleware/rbac_test.go`  
    - `internal/api/router.go`, `internal/api/router_test.go`  
    - `internal/db/organization_memberships.go`, `internal/db/organization_memberships_test.go`  
    - `internal/models/membership.go`, `internal/models/membership_test.go`
- **Frontend permissions / UI**
  - Added role-aware hiding of restricted UI actions for `builder` users across multiple dashboard areas (automations, projects, sessions, templates, settings, and sidebar areas).
  - Updated command palette actions to avoid exposing builder-inappropriate commands.
  - Files (highlights):
    - `frontend/src/app/(dashboard)/automations/*/page.tsx`, related tests
    - `frontend/src/app/(dashboard)/projects/*/page.tsx`, `project-sidebar.tsx`, related tests
    - `frontend/src/app/(dashboard)/sessions/*`, related tests
    - `frontend/src/app/(dashboard)/settings/layout.tsx`, `settings/team/page.tsx`, related tests
    - `frontend/src/components/command-palette/command-palette-actions.ts`, `*.test.ts`
    - `frontend/src/components/sidebar-settings-section.tsx`, `*.test.tsx`
- **Docs**
  - Documented the new `builder` role and its intended constrained surface area.
  - File: `docs/design/overall.md`
- **Tests**
  - Added/updated UI tests to validate that builder users do not see restricted actions.
  - Added auth-role mocking in relevant page tests.
  - Files: multiple `*.test.tsx`/`*.test.ts` across affected dashboard routes and components.

## Test plan
- Ran frontend test suite (Vitest/React Testing Library) and updated role-specific expectations for builder visibility.
- Ran backend RBAC/middleware tests and membership/team handler tests to confirm server-side enforcement for the new `builder` role.

[143.dev](https://143.dev) | [session dbde0f80](https://143.dev/sessions/dbde0f80-6a3a-4d53-99d3-b52ab1d04f11)