### PR TITLE
Scope Claude stale-resume fallback to the active thread

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -966,6 +966,10 @@ func latestDurableCheckpoint(session *models.Session) (DurableCheckpoint, bool) 
 	return checkpoint, true
 }
 
+const retryableSnapshotSaveMaxAttempts = 3
+
+var retryableSnapshotSaveBackoff = 50 * time.Millisecond
+
 func latestUserMessage(messages []models.SessionMessage) *models.SessionMessage {
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == models.MessageRoleUser {
@@ -973,6 +977,49 @@ func latestUserMessage(messages []models.SessionMessage) *models.SessionMessage 
 		}
 	}
 	return nil
+}
+
+func shouldRetryClaudeResumeFromSnapshot(session *models.Session, prompt *AgentPrompt, result *AgentResult) bool {
+	if session == nil || session.AgentType != models.AgentTypeClaudeCode {
+		return false
+	}
+	if prompt == nil || !prompt.Continuation || prompt.ResumeSessionID == "" {
+		return false
+	}
+	if result == nil {
+		return false
+	}
+	if result.ExitCode != 1 {
+		return false
+	}
+	if strings.TrimSpace(result.Summary) != "" {
+		return false
+	}
+	if result.AgentSessionID != "" {
+		return false
+	}
+	return true
+}
+
+func isRetryableSnapshotSaveError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, ".git/objects/pack/") &&
+		strings.Contains(msg, "File removed before we read it")
+}
+
+func waitForRetryableSnapshotSave(ctx context.Context, attempt int) error {
+	backoff := time.Duration(attempt) * retryableSnapshotSaveBackoff
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // latestUserMessageInScope returns the most recent user message bound to the
@@ -1004,6 +1051,23 @@ func latestUserMessageInScope(messages []models.SessionMessage, threadID *uuid.U
 		return &messages[i]
 	}
 	return nil
+}
+
+func messagesInScope(messages []models.SessionMessage, threadID *uuid.UUID) []models.SessionMessage {
+	scoped := make([]models.SessionMessage, 0, len(messages))
+	for _, message := range messages {
+		if threadID == nil {
+			if message.ThreadID != nil {
+				continue
+			}
+		} else {
+			if message.ThreadID == nil || *message.ThreadID != *threadID {
+				continue
+			}
+		}
+		scoped = append(scoped, message)
+	}
+	return scoped
 }
 
 // unprocessedUserMessages returns the consecutive trailing user messages for
@@ -2316,6 +2380,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		return fmt.Errorf("no user message found")
 	}
 	threadID := latestMsg.ThreadID
+	scopedMessages := messagesInScope(messages, threadID)
 	// Bundle every trailing user message in scope into the prompt seed so
 	// rapid mid-turn sends are all delivered to the agent. The latest
 	// message remains the "carrier" for thread_id, references, and
@@ -2926,6 +2991,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	//   - Fresh: no snapshot; clone repo fresh and build a reconstructed
 	//     prompt from the conversation history + stored diff.
 	var prompt *AgentPrompt
+	var restoredWorkspaceFallbackPrompt func() (*AgentPrompt, error)
 	authBillingMode := TokenBillingModeUnknown
 	if reusedExisting || hasSnapshot {
 		// Re-inject agent auth (Codex auth.json or Claude Code credentials.json).
@@ -3013,7 +3079,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			// prior context when running a fresh exec. The snapshot already
 			// restored the workspace, so do not ask the agent to re-apply the
 			// stored diff.
-			basePrompt.UserPrompt = o.buildRestoredWorkspaceResumeContext(session, promptIssue, messages, userMessage)
+			basePrompt.UserPrompt = o.buildRestoredWorkspaceResumeContext(session, promptIssue, scopedMessages, userMessage)
 			basePrompt.Continuation = false
 			basePrompt.RevisionContext = revisionContext
 			prompt = basePrompt
@@ -3040,6 +3106,18 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 					return *session.ReasoningEffort
 				}(),
 				RevisionContext: revisionContext,
+			}
+			if !reusedExisting && session.AgentType == models.AgentTypeClaudeCode && resumeSessionID != "" {
+				restoredWorkspaceFallbackPrompt = func() (*AgentPrompt, error) {
+					basePrompt, err := adapter.PreparePrompt(ctx, buildSnapshotContinueInput())
+					if err != nil {
+						return nil, fmt.Errorf("prepare prompt for restored-workspace fallback: %w", err)
+					}
+					basePrompt.UserPrompt = o.buildRestoredWorkspaceResumeContext(session, promptIssue, scopedMessages, userMessage)
+					basePrompt.Continuation = false
+					basePrompt.RevisionContext = revisionContext
+					return basePrompt, nil
+				}
 			}
 		}
 
@@ -3139,6 +3217,33 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 		execCtx = WithInteractiveHandleAttacher(execCtx, o.cancels.HandleAttacher(session.ID))
 	}
 	result, err := adapter.Execute(execCtx, sandbox, prompt, logCh)
+	if err == nil && restoredWorkspaceFallbackPrompt != nil && shouldRetryClaudeResumeFromSnapshot(session, prompt, result) {
+		log.Warn().
+			Str("resume_session_id", prompt.ResumeSessionID).
+			Int("exit_code", result.ExitCode).
+			Msg("claude resume failed against restored snapshot; retrying with reconstructed context")
+		fallbackPrompt, fallbackErr := restoredWorkspaceFallbackPrompt()
+		if fallbackErr != nil {
+			err = fallbackErr
+		} else {
+			fallbackResult, fallbackExecErr := adapter.Execute(execCtx, sandbox, fallbackPrompt, logCh)
+			if fallbackExecErr != nil {
+				err = fmt.Errorf("execute restored-workspace fallback after stale Claude resume: %w", fallbackExecErr)
+			} else if fallbackResult == nil {
+				err = errors.New("restored-workspace fallback after stale Claude resume returned no result")
+			} else if fallbackResult.ExitCode != 0 {
+				msg := strings.TrimSpace(fallbackResult.Error)
+				if msg == "" {
+					msg = fmt.Sprintf("claude fallback exited with code %d", fallbackResult.ExitCode)
+				}
+				err = fmt.Errorf("restored-workspace fallback after stale Claude resume failed: %s", msg)
+				result = fallbackResult
+			} else {
+				prompt = fallbackPrompt
+				result = fallbackResult
+			}
+		}
+	}
 	close(logCh)
 	logWg.Wait()
 
@@ -4593,22 +4698,42 @@ func (o *Orchestrator) snapshotSession(ctx context.Context, session *models.Sess
 
 	snapshotKey := fmt.Sprintf("snapshots/%s/%s/workspace.tar.zst", session.OrgID, session.ID)
 
-	reader, err := o.provider.Snapshot(ctx, sandbox)
-	if err != nil {
-		return "", 0, fmt.Errorf("snapshot sandbox: %w", err)
+	for attempt := 1; attempt <= retryableSnapshotSaveMaxAttempts; attempt++ {
+		reader, err := o.provider.Snapshot(ctx, sandbox)
+		if err != nil {
+			return "", 0, fmt.Errorf("snapshot sandbox: %w", err)
+		}
+
+		countingReader := &countingReadCloser{ReadCloser: reader}
+		saveErr := o.snapshots.Save(ctx, snapshotKey, countingReader)
+		closeErr := reader.Close()
+		if saveErr == nil && closeErr == nil {
+			// Store the snapshot key on the session for subsequent use.
+			session.SnapshotKey = &snapshotKey
+			return snapshotKey, countingReader.n, nil
+		}
+
+		if saveErr == nil {
+			saveErr = closeErr
+		}
+		if closeErr != nil && saveErr != closeErr {
+			o.logger.Warn().Err(closeErr).Int("attempt", attempt).Msg("snapshot reader close returned an additional error after save failure")
+		}
+		if !isRetryableSnapshotSaveError(saveErr) || attempt == retryableSnapshotSaveMaxAttempts {
+			return "", 0, fmt.Errorf("save snapshot to storage: %w", saveErr)
+		}
+		o.logger.Warn().
+			Err(saveErr).
+			Int("attempt", attempt).
+			Int("max_attempts", retryableSnapshotSaveMaxAttempts).
+			Str("snapshot_key", snapshotKey).
+			Msg("retrying snapshot after transient git pack churn")
+		if waitErr := waitForRetryableSnapshotSave(ctx, attempt); waitErr != nil {
+			return "", 0, fmt.Errorf("save snapshot to storage: %w", waitErr)
+		}
 	}
-	defer reader.Close()
 
-	countingReader := &countingReadCloser{ReadCloser: reader}
-
-	if err := o.snapshots.Save(ctx, snapshotKey, countingReader); err != nil {
-		return "", 0, fmt.Errorf("save snapshot to storage: %w", err)
-	}
-
-	// Store the snapshot key on the session for subsequent use.
-	session.SnapshotKey = &snapshotKey
-
-	return snapshotKey, countingReader.n, nil
+	return "", 0, fmt.Errorf("save snapshot to storage: retry loop exhausted for %s", snapshotKey)
 }
 
 type countingReadCloser struct {

--- a/internal/services/agent/orchestrator_helpers_internal_test.go
+++ b/internal/services/agent/orchestrator_helpers_internal_test.go
@@ -700,10 +700,16 @@ func (s *snapshotSessionStubProvider) ExecStream(context.Context, *Sandbox, stri
 // snapshotSessionRecordingStore is a SnapshotStore that records every
 // Save call so tests can assert that we did NOT save a corrupt archive.
 type snapshotSessionRecordingStore struct {
-	saves []string
+	saves     []string
+	saveCalls int
+	saveFn    func(ctx context.Context, key string, reader io.Reader) error
 }
 
 func (s *snapshotSessionRecordingStore) Save(ctx context.Context, key string, reader io.Reader) error {
+	s.saveCalls++
+	if s.saveFn != nil {
+		return s.saveFn(ctx, key, reader)
+	}
 	if _, err := io.Copy(io.Discard, reader); err != nil {
 		return err
 	}
@@ -768,6 +774,52 @@ func TestSnapshotSessionOnTurnSuccess_SnapshotsWhenAgentExitedClean(t *testing.T
 	require.NotNil(t, session.SnapshotKey)
 	require.Equal(t, key, *session.SnapshotKey)
 	require.Equal(t, int64(len("archive-bytes")), size)
+}
+
+func TestSnapshotSessionOnTurnSuccess_RetriesGitPackChurnSnapshotFailures(t *testing.T) {
+	t.Parallel()
+
+	provider := &snapshotSessionStubProvider{
+		snapshotFn: func(ctx context.Context, sb *Sandbox) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader([]byte("archive-bytes"))), nil
+		},
+	}
+	attempts := 0
+	var store *snapshotSessionRecordingStore
+	store = &snapshotSessionRecordingStore{
+		saveFn: func(ctx context.Context, key string, reader io.Reader) error {
+			if _, err := io.Copy(io.Discard, reader); err != nil {
+				return err
+			}
+			attempts++
+			if attempts < 3 {
+				return errors.New(
+					"buffer snapshot snapshots/org/session/workspace.tar.zst: snapshot tar exited with code 1: " +
+						"tar: home/sandbox/143/.git/objects/pack/pack-123.pack: File removed before we read it",
+				)
+			}
+			store.saves = append(store.saves, key)
+			return nil
+		},
+	}
+	o := &Orchestrator{
+		provider:  provider,
+		snapshots: store,
+		logger:    zerolog.Nop(),
+	}
+
+	session := &models.Session{ID: uuid.New(), OrgID: uuid.New()}
+	sandbox := &Sandbox{ID: "sandbox-1"}
+	result := &AgentResult{ExitCode: 0}
+
+	key, size, err := o.snapshotSessionOnTurnSuccess(context.Background(), session, sandbox, result, zerolog.Nop())
+	require.NoError(t, err, "retryable git pack churn should not abort the turn snapshot")
+	require.Equal(t, 3, provider.calls(), "each retry should rebuild the snapshot from a fresh provider stream")
+	require.Equal(t, 3, store.saveCalls, "storage save should be retried for the recognized tar churn signature")
+	require.Equal(t, []string{key}, store.saves, "the snapshot should eventually persist after the retryable churn clears")
+	require.NotNil(t, session.SnapshotKey, "successful retry should still advance the session snapshot key")
+	require.Equal(t, key, *session.SnapshotKey)
+	require.Equal(t, int64(len("archive-bytes")), size, "successful attempt should report the final archive size")
 }
 
 func TestSnapshotSessionOnTurnSuccess_PassesNilResultThrough(t *testing.T) {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -3161,6 +3161,177 @@ func TestContinueSession_EmbedsHistoryWhenResumeBySessionIDAdapterHasNoCapturedS
 	require.NotContains(t, promptSeen.UserPrompt, priorDiff, "snapshot fallback must not include the prior diff as work to re-apply")
 }
 
+func TestContinueSession_FallsBackToFreshClaudeExecWhenSnapshotResumeStateIsStale(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.AgentType = models.AgentTypeClaudeCode
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	snapshotKey := "existing-snapshot"
+	session.SnapshotKey = &snapshotKey
+	session.AgentSessionID = strPtr("stale-claude-session")
+
+	d := defaultDeps()
+	d.adapter = &mockAgentAdapter{
+		name:       models.AgentTypeClaudeCode,
+		resumeMode: agent.ResumeBySessionID,
+	}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 1,
+			Role:       models.MessageRoleUser,
+			Content:    "Please review my changes.",
+		},
+		{
+			ID:         2,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 1,
+			Role:       models.MessageRoleAssistant,
+			Content:    "I found two issues: a missing nil check and an unbounded loop.",
+		},
+		{
+			ID:         3,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "please fix both of these issues",
+		},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.snapshots.data = map[string][]byte{snapshotKey: []byte("restored-snapshot")}
+
+	var prompts []*agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		prompts = append(prompts, prompt)
+		if len(prompts) == 1 {
+			return &agent.AgentResult{
+				ExitCode: 1,
+				Error:    "claude CLI exited with code 1",
+			}, nil
+		}
+		return &agent.AgentResult{
+			Summary:         "fixed",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+			AgentSessionID:  "fresh-claude-session",
+		}, nil
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, nil)
+	require.NoError(t, err, "ContinueSession should recover from a stale Claude resume id by retrying with reconstructed context")
+	require.Len(t, prompts, 2, "the Claude adapter should be executed once for the stale resume and once for the fresh-exec fallback")
+	require.True(t, prompts[0].Continuation, "the first attempt should use deterministic Claude resume")
+	require.Equal(t, "stale-claude-session", prompts[0].ResumeSessionID, "the first attempt should use the persisted Claude session id")
+	require.False(t, prompts[1].Continuation, "the fallback should run a fresh exec against the restored workspace")
+	require.Empty(t, prompts[1].ResumeSessionID, "the fallback must not retry the same stale Claude session id")
+	require.Contains(t, prompts[1].UserPrompt, "Previous conversation history", "the fallback should reconstruct prior conversation context")
+	require.Contains(t, prompts[1].UserPrompt, "Please review my changes.", "the fallback should include the earlier user turn")
+	require.Contains(t, prompts[1].UserPrompt, "missing nil check", "the fallback should include the earlier assistant summary")
+	require.Contains(t, prompts[1].UserPrompt, "please fix both of these issues", "the fallback should end with the new user message")
+
+	updates := d.sessions.getTurnUpdates()
+	require.Len(t, updates, 1, "ContinueSession should still persist a single completed turn")
+	require.Equal(t, "fresh-claude-session", updates[0].agentSessionID, "successful fallback should advance the stored Claude session id")
+	require.NotEmpty(t, updates[0].snapshotKey, "successful fallback should refresh the snapshot")
+
+	messages := d.messages.getMessages()
+	var assistantMessages []models.SessionMessage
+	for _, msg := range messages {
+		if msg.Role == models.MessageRoleAssistant {
+			assistantMessages = append(assistantMessages, msg)
+		}
+	}
+	require.Len(t, assistantMessages, 2, "only the original assistant message and the successful fallback reply should exist")
+	require.Equal(t, "fixed", assistantMessages[len(assistantMessages)-1].Content, "the session timeline should record only the successful fallback output")
+}
+
+func TestContinueSession_FallsBackToFreshClaudeExecWhenSnapshotResumeStateIsStale_ScopesHistoryToRequestedThread(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	mainThreadID := uuid.New()
+	codexThreadID := uuid.New()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.AgentType = models.AgentTypeClaudeCode
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 2
+	snapshotKey := "existing-snapshot"
+	session.SnapshotKey = &snapshotKey
+	session.AgentSessionID = strPtr("stale-claude-session")
+
+	d := defaultDeps()
+	d.adapter = &mockAgentAdapter{
+		name:       models.AgentTypeClaudeCode,
+		resumeMode: agent.ResumeBySessionID,
+	}
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{ID: 10, SessionID: session.ID, OrgID: orgID, ThreadID: &mainThreadID, TurnNumber: 1, Role: models.MessageRoleUser, Content: "main tab question"},
+		{ID: 11, SessionID: session.ID, OrgID: orgID, ThreadID: &mainThreadID, TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "main tab answer"},
+		{ID: 20, SessionID: session.ID, OrgID: orgID, ThreadID: &codexThreadID, TurnNumber: 1, Role: models.MessageRoleUser, Content: "codex tab prior question"},
+		{ID: 21, SessionID: session.ID, OrgID: orgID, ThreadID: &codexThreadID, TurnNumber: 1, Role: models.MessageRoleAssistant, Content: "codex tab prior answer"},
+		{ID: 22, SessionID: session.ID, OrgID: orgID, ThreadID: &codexThreadID, TurnNumber: 2, Role: models.MessageRoleUser, Content: "please fix the failing test"},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.snapshots.data = map[string][]byte{snapshotKey: []byte("restored-snapshot")}
+
+	var prompts []*agent.AgentPrompt
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		prompts = append(prompts, prompt)
+		if len(prompts) == 1 {
+			return &agent.AgentResult{
+				ExitCode: 1,
+				Error:    "claude CLI exited with code 1",
+			}, nil
+		}
+		return &agent.AgentResult{
+			Summary:         "fixed",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+			AgentSessionID:  "fresh-claude-session",
+		}, nil
+	}
+
+	err := buildOrchestrator(d).ContinueSession(context.Background(), session, &agent.ContinueSessionOptions{ThreadID: &codexThreadID})
+	require.NoError(t, err, "ContinueSession should recover from a stale Claude resume id on the requested thread")
+	require.Len(t, prompts, 2, "the Claude adapter should be executed once for the stale resume and once for the fresh-exec fallback")
+	require.Contains(t, prompts[1].UserPrompt, "codex tab prior question", "the fallback should include earlier history from the requested thread")
+	require.Contains(t, prompts[1].UserPrompt, "codex tab prior answer", "the fallback should include the requested thread's assistant history")
+	require.Contains(t, prompts[1].UserPrompt, "please fix the failing test", "the fallback should end with the new message from the requested thread")
+	require.NotContains(t, prompts[1].UserPrompt, "main tab question", "the fallback should not include sibling-thread user history")
+	require.NotContains(t, prompts[1].UserPrompt, "main tab answer", "the fallback should not include sibling-thread assistant history")
+}
+
 func TestContinueSession_UsesThreadExecutionOptions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Scope reconstructed conversation history to the active thread before building restored-workspace fallback prompts.
- Apply the same scoped history to both the legacy missing-session-id resume path and the new stale Claude resume retry path.
- Add a regression test that reproduces a multi-tab session and verifies sibling-thread messages are excluded from the fallback prompt.

## Testing
- Added targeted unit coverage for the stale-resume fallback thread-scope regression.
- Verified the agent package and full repository with `go test ./internal/services/agent`, `go vet ./...`, `go build ./...`, and `go test ./...`.