### PR TITLE
Show Linear issue keys when provider state is missing

### DIFF
--- a/internal/db/session_issue_links.go
+++ b/internal/db/session_issue_links.go
@@ -28,7 +28,11 @@ func NewSessionIssueLinkStore(db DBTX) *SessionIssueLinkStore {
 const sessionIssueLinkSelectColumns = `sil.id, sil.org_id, sil.session_id, sil.issue_id, sil.role,
 	sil.position, sil.added_by_user_id, sil.created_at,
 	i.title AS issue_title, i.source AS issue_source,
-	COALESCE(provider_state.state->>'identifier', i.external_id) AS external_id,
+	COALESCE(
+		NULLIF(provider_state.state->>'identifier', ''),
+		CASE WHEN i.source = 'linear' THEN substring(i.title from '^([A-Z][A-Z0-9_]{0,9}-[0-9]+):') END,
+		i.external_id
+	) AS external_id,
 	i.description,
 	i.repository_id, i.status AS issue_status,
 	(provider_state.state->>'workspace_slug') AS issue_workspace_slug,

--- a/internal/db/session_issue_links_test.go
+++ b/internal/db/session_issue_links_test.go
@@ -138,7 +138,13 @@ func TestSessionIssueLinkStore_CreateAllowingNullRepo_ReturnsExistingOnConflict(
 func TestSessionIssueLinkSelectColumns_UsesLinearIdentifierForExternalID(t *testing.T) {
 	t.Parallel()
 
-	require.Contains(t, sessionIssueLinkSelectColumns, "COALESCE(provider_state.state->>'identifier', i.external_id) AS external_id", "linked issue enrichment should expose the human Linear key when provider state has it")
+	require.Contains(t, sessionIssueLinkSelectColumns, "NULLIF(provider_state.state->>'identifier', '')", "linked issue enrichment should expose the human Linear key when provider state has it")
+}
+
+func TestSessionIssueLinkSelectColumns_FallsBackToLinearTitleIdentifier(t *testing.T) {
+	t.Parallel()
+
+	require.Contains(t, sessionIssueLinkSelectColumns, "CASE WHEN i.source = 'linear' THEN substring(i.title from '^([A-Z][A-Z0-9_]{0,9}-[0-9]+):') END", "issue-triggered Linear sessions should expose the human Linear key even when provider state was never seeded")
 }
 
 func TestSessionIssueLinkSelectColumns_ExposesLinearLastSkippedReason(t *testing.T) {


### PR DESCRIPTION
## Summary
- Prefer the human Linear key for linked issues even when `provider_state.identifier` was never seeded
- Fall back to extracting the `KEY-123:` prefix from the Linear issue title before using the raw `external_id`
- Add regression coverage for both the main identifier path and the title-based fallback

## Testing
- `go vet ./...` passed
- `go build ./...` passed
- `go test ./...` passed