### PR TITLE
Fix usage breakdown model queries to use session model override

### DIFF
--- a/docs/design/implemented/66-usage-breakdown-by-agent-model-reasoning.md
+++ b/docs/design/implemented/66-usage-breakdown-by-agent-model-reasoning.md
@@ -63,9 +63,9 @@ Relevant session fields now used by the rollup include:
 - `sessions.agent_type`
 - `sessions.reasoning_effort`
 - `sessions.token_usage`
-- `sessions.model_used`
+- `sessions.model_override`
 
-Model breakdown now uses persisted effective-model data instead of `model_override`.
+Model breakdown persists normalized model buckets in `usage_hourly_execution.model_used`. The rollup derives that bucket from provider-reported `sessions.token_usage.native_usage.model` when available, falling back to `sessions.model_override` and then `unknown`.
 
 ## Design principles
 
@@ -218,10 +218,10 @@ Reasoning needs explicit bucket semantics:
 
 #### `model`
 
-- Source: persisted effective runtime model
+- Source: normalized model bucket stored on `usage_hourly_execution.model_used`
 - Purpose: cost-driver analysis
 
-This dimension requires a new persisted field such as `sessions.model_used`.
+The rollup source is provider-reported token metadata when present, then the session's configured `model_override`, then `unknown`.
 
 #### `capacity`
 
@@ -230,7 +230,7 @@ This dimension requires a new persisted field such as `sessions.model_used`.
 
 ### Model fidelity requirement
 
-Model breakdown should not launch until the system persists the effective runtime model used by the session.
+Model breakdown should use a persisted rollup bucket rather than deriving rows from request-time session scans.
 
 Reasons:
 
@@ -239,7 +239,7 @@ Reasons:
 - Amp and Pi express model selection differently than Codex/Claude/Gemini
 - finance-oriented comparisons must reflect actual runtime choice
 
-The shipped UI uses persisted `model_used`; it does not derive model analytics from `model_override`.
+The shipped UI reads persisted `usage_hourly_execution.model_used`. The hourly rollup may use `model_override` only as a fallback when provider token metadata does not report the runtime model.
 
 ### User drilldowns
 
@@ -429,7 +429,7 @@ Reasoning:
 
 1. Added `usage_hourly_execution` and backfilled `agent`, `reasoning`, `model`, and `capacity` rollups through the existing hourly reroll path.
 2. Shipped `Agent` and `Reasoning` breakdowns plus execution filters.
-3. Persisted effective runtime model as `model_used`.
+3. Persisted normalized model buckets as `usage_hourly_execution.model_used`.
 4. Enabled `Model` breakdown, `Model` filter, and stacked token-by-model charts.
 
 Still explicitly not part of this implementation:
@@ -595,7 +595,7 @@ Implemented.
 
 Ship:
 
-- persisted `model_used`
+- persisted `usage_hourly_execution.model_used`
 - `Model` breakdown
 - `Model` filter
 - stacked `total tokens by model` chart
@@ -633,7 +633,7 @@ Users may assume the model view is authoritative before it is.
 
 Mitigation:
 
-- do not expose `Model` until `model_used` exists
+- do not expose `Model` until `usage_hourly_execution.model_used` is populated by the hourly rollup
 
 ### Risk: filter complexity overwhelms casual users
 

--- a/internal/db/usage_rollup_store.go
+++ b/internal/db/usage_rollup_store.go
@@ -105,7 +105,7 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 			e.session_id,
 			COALESCE(s.triggered_by_user_id, '00000000-0000-0000-0000-000000000000'::uuid) AS user_id,
 			s.agent_type,
-			s.model_used,
+			s.model_override AS model_used,
 			s.reasoning_effort,
 			s.token_usage,
 			e.cpu_limit,
@@ -254,7 +254,7 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 		SELECT
 			COALESCE(s.triggered_by_user_id, '00000000-0000-0000-0000-000000000000'::uuid) AS user_id,
 			s.agent_type,
-			s.model_used,
+			s.model_override AS model_used,
 			s.reasoning_effort,
 			s.token_usage,
 			COALESCE((
@@ -1534,7 +1534,7 @@ func computeDurationStats(durations []float64) (avg, p95 float64) {
 }
 
 func normalizedSessionModelSQL(alias string) string {
-	return fmt.Sprintf("COALESCE(NULLIF(%s.model_used, ''), COALESCE(%s.token_usage->'native_usage'->>'model', 'unknown'))", alias, alias)
+	return fmt.Sprintf("COALESCE(NULLIF(%s.model_override, ''), COALESCE(%s.token_usage->'native_usage'->>'model', 'unknown'))", alias, alias)
 }
 
 func normalizedSessionReasoningSQL(alias string) string {

--- a/internal/db/usage_rollup_store_test.go
+++ b/internal/db/usage_rollup_store_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/models"
 )
 
 func TestComputePeakConcurrent_Empty(t *testing.T) {
@@ -559,6 +561,38 @@ func TestRollupHour_NoEvents(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestRollupHour_UsesSessionModelOverrideColumn(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "mock pool should be created")
+	defer mock.Close()
+
+	store := NewUsageRollupStore(mock)
+	orgID := uuid.New()
+	hour := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+
+	eventCols := []string{"id", "session_id", "user_id", "agent_type", "model_used", "reasoning_effort", "token_usage", "cpu_limit", "memory_limit_mb", "started_at", "stopped_at", "container_minutes", "duration_ms"}
+	mock.ExpectQuery("s\\.model_override").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "hour_start": hour, "hour_end": hour.Add(time.Hour), "now": pgxmock.AnyArg()}).
+		WillReturnRows(pgxmock.NewRows(eventCols))
+
+	tokenCols := []string{"user_id", "agent_type", "model_used", "reasoning_effort", "token_usage", "capacity_key", "input_tokens", "output_tokens", "cost_usd"}
+	mock.ExpectQuery("s\\.model_override").
+		WithArgs(pgx.NamedArgs{"org_id": orgID, "hour": hour, "hour_start": hour, "hour_end": hour.Add(time.Hour), "now": pgxmock.AnyArg(), "unknown_capacity": usageUnknownCapacityKey}).
+		WillReturnRows(pgxmock.NewRows(tokenCols))
+
+	mock.ExpectBegin()
+	eb := mock.ExpectBatch()
+	eb.ExpectExec("INSERT INTO usage_hourly").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectCommit()
+
+	err = store.RollupHour(context.Background(), orgID, hour)
+	require.NoError(t, err, "RollupHour should query the real sessions model column")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestRollupHour_TokenQueryError(t *testing.T) {
 	t.Parallel()
 	mock, err := pgxmock.NewPool()
@@ -1034,6 +1068,63 @@ func TestGetBreakdown_AgentDimension_UsesAllCapacityRollups(t *testing.T) {
 	require.Len(t, rows, 1)
 	require.Equal(t, 2, rows[0].TotalSessions)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBreakdown_ModelDimension_UsesSessionModelOverrideColumn(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "mock pool should be created")
+	defer mock.Close()
+
+	store := NewUsageRollupStore(mock)
+	orgID := uuid.New()
+	start := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	mock.ExpectQuery("SELECT\\s+COALESCE\\(SUM\\(uhe.total_container_minutes\\), 0\\),").
+		WithArgs(pgx.NamedArgs{
+			"org_id":       orgID,
+			"start":        start,
+			"end":          end,
+			"limit":        10,
+			"all_capacity": usageAllCapacityKey,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{"total_minutes", "total_tokens", "total_cost"}).AddRow(100.0, 3000.0, 1.0))
+
+	mock.ExpectQuery("NULLIF\\(s\\.model_override").
+		WithArgs(pgx.NamedArgs{
+			"org_id":       orgID,
+			"start":        start,
+			"end":          end,
+			"limit":        10,
+			"all_capacity": usageAllCapacityKey,
+		}).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"key", "label",
+			"total_container_minutes", "total_sessions", "total_container_starts",
+			"peak_concurrent", "total_input_tokens", "total_output_tokens", "total_tokens", "total_llm_cost_usd",
+		}).AddRow("gpt-5.4", "gpt-5.4", 100.0, 2, 3, 2, int64(2000), int64(1000), int64(3000), 1.0))
+
+	rows, err := store.GetBreakdown(context.Background(), orgID, start, end, "model", "tokens_desc", 10, UsageExecutionFilters{})
+	require.NoError(t, err, "model breakdown should query the real sessions model column")
+	require.Equal(t, []models.UsageBreakdownRow{
+		{
+			Key:                   "gpt-5.4",
+			Label:                 "gpt-5.4",
+			TotalContainerMinutes: 100,
+			TotalSessions:         2,
+			TotalContainerStarts:  3,
+			PeakConcurrent:        2,
+			TotalInputTokens:      2000,
+			TotalOutputTokens:     1000,
+			TotalTokens:           3000,
+			TotalLLMCostUSD:       1,
+			Percentage:            100,
+			ShareOfTokenCost:      100,
+			ShareOfTokens:         100,
+		},
+	}, rows, "model breakdown should return normalized model rows")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestGetBreakdown_QueryError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace the broken `sessions.model_used` reference with `sessions.model_override` in the usage rollup path
- Keep the persisted `usage_hourly_execution.model_used` bucket as the API source for model breakdowns
- Add regression coverage for rollup and model-breakdown queries that would otherwise 500 in production
- Update the implemented design doc to match the actual model source

## Testing
- Added targeted unit tests for the rollup and model breakdown query paths
- `go test ./internal/db`
- `go vet ./...`
- `go build ./...`
- `go test ./...`