### PR TITLE
Fix active agent tab underline clipping in Session agent tab strip

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -132,6 +132,8 @@ describe("AgentTabStrip", () => {
     expect(tabList).toBeInTheDocument();
     expect(tabList).toHaveAttribute("data-variant", "line");
     expect(tabList).not.toHaveClass("bg-muted/60");
+    expect(tabList).toHaveClass("overflow-y-visible");
+    expect(tabList).toHaveClass("pb-1");
     expect(activeTab).toHaveTextContent(/Main tab/i);
     expect(activeTab).not.toHaveTextContent(/Idle/i);
     expect(activeTab).toHaveClass("data-[state=active]:text-primary");

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -262,7 +262,7 @@ export function AgentTabStrip({
               size="sm"
               aria-label="Agent tabs"
               className={cn(
-                "h-auto max-w-full justify-start gap-1 overflow-x-auto overflow-y-hidden border-b-0 bg-transparent p-0",
+                "h-auto max-w-full justify-start gap-1 overflow-x-auto overflow-y-visible border-b-0 bg-transparent p-0 pb-1",
               )}
             >
               {tabs.map((thread) => {


### PR DESCRIPTION
## Summary
The active tab underline styling existed but wasn’t visible in the multi-tab session strip due to CSS clipping. This change updates the tab list container to prevent the underline pseudo-element from being cut off and adds a regression assertion.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx`**
  - Replace `overflow-y-hidden` with `overflow-y-visible` on the tab list container.
  - Add `pb-1` to match the working tab list styling.
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`**
  - Add expectations that the tab list has `overflow-y-visible` and `pb-1` to prevent the underline from regressing.

## Test plan
- `npm test -- --run src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 2da84d4d](https://143.dev/sessions/2da84d4d-e68a-4798-92a0-4d865156e298)