### PR TITLE
Bind dogfood preview frontend to 0.0.0.0

### DIFF
--- a/.143/preview-frontend.sh
+++ b/.143/preview-frontend.sh
@@ -25,4 +25,7 @@ if [ ! -d node_modules ]; then
 fi
 
 echo '[143-preview] starting next dev server...'
-exec npm run dev
+# Next defaults can be localhost-only depending on version/config. The preview
+# worker proxies to the sandbox container IP, so the dev server must bind all
+# interfaces, not just loopback.
+exec npm run dev -- --hostname 0.0.0.0

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -786,3 +786,25 @@ func TestParseConfig_CommittedDogfoodConfig(t *testing.T) {
 		dir = parent
 	}
 }
+
+func TestCommittedDogfoodFrontendScriptBindsExternally(t *testing.T) {
+	t.Parallel()
+
+	// Walk up from the package dir to the repo root (where `.143/` lives).
+	dir, err := os.Getwd()
+	require.NoError(t, err, "test should resolve the package working directory")
+	for {
+		candidate := filepath.Join(dir, ".143", "preview-frontend.sh")
+		if _, err := os.Stat(candidate); err == nil {
+			raw, err := os.ReadFile(candidate)
+			require.NoError(t, err, "test should read committed dogfood frontend preview script")
+			require.Contains(t, string(raw), "--hostname 0.0.0.0", "dogfood Next preview must bind externally so the worker proxy can dial the sandbox IP")
+			return
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Skip("repo root .143/preview-frontend.sh not found from test working directory")
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary
- Update the committed dogfood preview frontend entrypoint to start Next with `--hostname 0.0.0.0` so the worker proxy can reach the sandbox container IP.
- Add a regression test that asserts the repo-owned preview script keeps the external bind in place.

## Testing
- `go test ./internal/services/preview -run 'TestCommittedDogfoodFrontendScriptBindsExternally|TestParseConfig_CommittedDogfoodConfig' -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`