### PR TITLE
Prevent unnecessary rerenders in session diff and composer views

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.performance.test.tsx
@@ -5,8 +5,10 @@ import { server } from "@/test/mocks/server";
 import { mockSessions } from "@/test/mocks/handlers";
 import type { ListResponse, Session, SessionTimelineEntry, SingleResponse } from "@/lib/types";
 
-const { chatTimelineRenderState } = vi.hoisted(() => ({
+const { chatTimelineRenderState, recordReviewDiffViewRender, recordFileTreeRender } = vi.hoisted(() => ({
   chatTimelineRenderState: { count: 0 },
+  recordReviewDiffViewRender: vi.fn(),
+  recordFileTreeRender: vi.fn(),
 }));
 
 vi.mock("@/components/chat-timeline", () => ({
@@ -15,6 +17,25 @@ vi.mock("@/components/chat-timeline", () => ({
     return <div data-testid="chat-timeline-mock">{entries.length}</div>;
   },
 }));
+
+vi.mock("@/components/code-review/review-diff-view", async () => {
+  const { memo } = await vi.importActual<typeof import("react")>("react");
+  const ReviewDiffView = memo(function MockReviewDiffView({ files }: { files: unknown[] }) {
+    recordReviewDiffViewRender(files.length);
+    return <div data-testid="review-diff-view-mock">{files.length}</div>;
+  });
+  return { ReviewDiffView };
+});
+
+vi.mock("@/components/code-review", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/components/code-review")>();
+  const { memo } = await vi.importActual<typeof import("react")>("react");
+  const FileTree = memo(function MockFileTree({ files }: { files: unknown[] }) {
+    recordFileTreeRender(files.length);
+    return <div data-testid="file-tree-mock">{files.length}</div>;
+  });
+  return { ...actual, FileTree };
+});
 
 vi.mock("@/lib/notify", () => ({
   notify: {
@@ -92,10 +113,61 @@ beforeAll(() => {
 
 beforeEach(() => {
   chatTimelineRenderState.count = 0;
+  recordReviewDiffViewRender.mockClear();
+  recordFileTreeRender.mockClear();
   MockEventSource.instances = [];
   window.localStorage.clear();
   setMobileViewport(false);
 });
+
+const reviewPerfDiff = [
+  "diff --git a/src/app.ts b/src/app.ts",
+  "--- a/src/app.ts",
+  "+++ b/src/app.ts",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "diff --git a/src/utils.ts b/src/utils.ts",
+  "--- a/src/utils.ts",
+  "+++ b/src/utils.ts",
+  "@@ -1 +1 @@",
+  "-old",
+  "+new",
+  "",
+].join("\n");
+
+function installSessionWithDiffHandlers() {
+  server.use(
+    http.get("/api/v1/sessions/:id", () => {
+      return HttpResponse.json({
+        data: {
+          ...mockSessions[0],
+          primary_issue_id: undefined,
+          sandbox_state: "ready",
+          diff: undefined,
+          diff_stats: { added: 2, removed: 2, files_changed: 2 },
+          latest_diff_snapshot_id: "snapshot-1",
+          diff_collected_at: "2026-02-17T07:05:00Z",
+        },
+      } satisfies SingleResponse<Session>);
+    }),
+    http.get("/api/v1/sessions/:id/timeline", () => {
+      return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<SessionTimelineEntry>);
+    }),
+    http.get("/api/v1/sessions/:id/diff", () => {
+      return HttpResponse.json({
+        data: {
+          session_id: "session-abcdef12-3456-7890",
+          diff: reviewPerfDiff,
+          diff_stats: { added: 2, removed: 2, files_changed: 2 },
+          diff_history: [],
+          diff_truncated: false,
+          diff_history_truncated: false,
+        },
+      });
+    }),
+  );
+}
 
 describe("SessionDetailContent performance", () => {
   it("does not rerender the transcript while typing in the follow-up composer", async () => {
@@ -145,6 +217,46 @@ describe("SessionDetailContent performance", () => {
 
     expect(textarea).toHaveValue("Lag");
     expect(chatTimelineRenderState.count).toBe(0);
+  }, 30000);
+
+  it("does not rerender the active review diff while typing in the follow-up composer", async () => {
+    const { SessionDetailContent } = await import("./session-detail-content");
+    const user = userEvent.setup();
+    installSessionWithDiffHandlers();
+
+    renderWithProviders(
+      <SessionDetailContent id="session-abcdef12-3456-7890" />,
+      { searchParams: { review: "active" } },
+    );
+
+    const textarea = await screen.findByPlaceholderText("Send a follow-up message...");
+    expect(await screen.findByTestId("review-diff-view-mock")).toBeInTheDocument();
+
+    recordReviewDiffViewRender.mockClear();
+
+    await user.type(textarea, "Lag");
+
+    expect(textarea).toHaveValue("Lag");
+    expect(recordReviewDiffViewRender).not.toHaveBeenCalled();
+  }, 30000);
+
+  it("does not rerender the changes file tree while typing in the follow-up composer", async () => {
+    const { SessionDetailContent } = await import("./session-detail-content");
+    const user = userEvent.setup();
+    installSessionWithDiffHandlers();
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+
+    const textarea = await screen.findByPlaceholderText("Send a follow-up message...");
+    await user.click(screen.getByRole("tab", { name: /Changes/i }));
+    expect(await screen.findByTestId("file-tree-mock")).toBeInTheDocument();
+
+    recordFileTreeRender.mockClear();
+
+    await user.type(textarea, "Lag");
+
+    expect(textarea).toHaveValue("Lag");
+    expect(recordFileTreeRender).not.toHaveBeenCalled();
   }, 30000);
 
   it("loads the raw diff only after the changes surface is opened", async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -695,7 +695,7 @@ function OverviewTab({ session, members, prStatus }: { session: Session; members
   );
 }
 
-function ChangesTab({
+const ChangesTab = memo(function ChangesTab({
   filteredFiles,
   activeFileIndex,
   onFileSelect,
@@ -833,7 +833,9 @@ function ChangesTab({
       )}
     </div>
   );
-}
+});
+
+ChangesTab.displayName = "ChangesTab";
 
 // ---------------------------------------------------------------------------
 // Shared session composer (used in both chat and review mode)
@@ -2569,6 +2571,9 @@ export function SessionDetailContent({ id }: { id: string }) {
     setDetailTab("changes");
     setMobileDetailOpen(true);
   }, []);
+  const openMobileReviewComposer = useCallback(() => {
+    setMobileReviewComposerOpen(true);
+  }, []);
 
   // --- Exit review mode ---
   const exitReview = useCallback(() => {
@@ -2660,6 +2665,9 @@ export function SessionDetailContent({ id }: { id: string }) {
     refetchOnWindowFocus: false,
     retry: false,
   });
+  const retryDiffLoad = useCallback(() => {
+    void refetchDiff();
+  }, [refetchDiff]);
   const sessionDiffPayload = diffData?.data;
   const threads = useMemo(() => session?.threads ?? [], [session?.threads]);
   const [pendingThreadPreview, setPendingThreadPreview] = useState<PendingThreadPreview | null>(null);
@@ -3682,6 +3690,13 @@ export function SessionDetailContent({ id }: { id: string }) {
       queryClient.invalidateQueries({ queryKey: ["session", id] });
     },
   });
+  const cancelSession = cancelMutation.mutate;
+  const handleCancelSession = useCallback(() => {
+    cancelSession();
+  }, [cancelSession]);
+  const handleComposerSend = useCallback(() => {
+    queueSend();
+  }, [queueSend]);
 
   const archiveThreadMutation = useMutation({
     mutationFn: (threadId: string) => api.sessions.archiveThread(id, threadId),
@@ -4396,7 +4411,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           onAttributionFilterChange={setAttributionFilter}
           diffLoadErrorText={diffLoadErrorText}
           diffTruncationText={diffTruncationText}
-          onRetryDiffLoad={() => { void refetchDiff(); }}
+          onRetryDiffLoad={retryDiffLoad}
         />
       </TabsContent>
       <TabsContent value="overview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
@@ -4676,7 +4691,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                         <p className="text-sm font-medium text-foreground">Couldn&apos;t load changes</p>
                         <p className="text-xs text-muted-foreground">{diffLoadErrorText}</p>
                       </div>
-                      <Button type="button" variant="outline" size="sm" onClick={() => { void refetchDiff(); }}>
+                      <Button type="button" variant="outline" size="sm" onClick={retryDiffLoad}>
                         Retry
                       </Button>
                     </div>
@@ -4691,7 +4706,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                     onBack={exitReview}
                     isMobile={isMobileReviewViewport}
                     onOpenFileList={openMobileFilesList}
-                    onOpenComposer={session.agent_type !== "pm_agent" ? () => setMobileReviewComposerOpen(true) : undefined}
+                    onOpenComposer={session.agent_type !== "pm_agent" ? openMobileReviewComposer : undefined}
                     commentsByLine={commentsByLine}
                     activeCommentLine={activeCommentLine}
                     onAddComment={handleAddComment}
@@ -4749,8 +4764,8 @@ export function SessionDetailContent({ id }: { id: string }) {
               sendError={sendMutation.error}
               cancelPending={cancelMutation.isPending}
               uploadError={composerUploadError}
-              onCancelSession={() => cancelMutation.mutate()}
-              onSend={() => queueSend()}
+              onCancelSession={handleCancelSession}
+              onSend={handleComposerSend}
               textareaRef={composerTextareaRef}
               uploadInputRef={composerUploadInputRef}
               references={composerReferences}
@@ -4853,8 +4868,8 @@ export function SessionDetailContent({ id }: { id: string }) {
               sendError={sendMutation.error}
               cancelPending={cancelMutation.isPending}
               uploadError={composerUploadError}
-              onCancelSession={() => cancelMutation.mutate()}
-              onSend={() => queueSend()}
+              onCancelSession={handleCancelSession}
+              onSend={handleComposerSend}
               textareaRef={composerTextareaRef}
               uploadInputRef={composerUploadInputRef}
               references={composerReferences}

--- a/frontend/src/components/code-review/file-tree.test.tsx
+++ b/frontend/src/components/code-review/file-tree.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Profiler } from "react";
 import { FileTree } from "./file-tree";
 import type { DiffFile } from "@/lib/diff-parser";
 
@@ -97,6 +98,27 @@ describe("FileTree", () => {
     expect(screen.getByText("app.ts")).toBeInTheDocument();
     expect(screen.getByText("helpers.ts")).toBeInTheDocument();
     expect(screen.getByText("README.md")).toBeInTheDocument();
+  });
+
+  it("does not rerender when parent props are unchanged", () => {
+    const onFileSelect = vi.fn();
+    const onRender = vi.fn();
+    const { rerender } = render(
+      <Profiler id="file-tree" onRender={onRender}>
+        <FileTree files={files} activeFileIndex={0} onFileSelect={onFileSelect} />
+      </Profiler>
+    );
+    const mountDuration = onRender.mock.calls[0]?.[2] as number;
+    onRender.mockClear();
+
+    rerender(
+      <Profiler id="file-tree" onRender={onRender}>
+        <FileTree files={files} activeFileIndex={0} onFileSelect={onFileSelect} />
+      </Profiler>
+    );
+
+    const updateDuration = onRender.mock.calls[0]?.[2] as number;
+    expect(updateDuration).toBeLessThan(Math.max(0.1, mountDuration * 0.1));
   });
 
   it('shows "N files changed" count', () => {

--- a/frontend/src/components/code-review/file-tree.tsx
+++ b/frontend/src/components/code-review/file-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useMemo, useState } from "react";
+import { memo, useCallback, useMemo, useState } from "react";
 import { ChevronDown, ChevronRight, Search, FileText } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -190,7 +190,7 @@ const TreeDirectory = memo(function TreeDirectory({
   );
 });
 
-export function FileTree({
+export const FileTree = memo(function FileTree({
   files,
   activeFileIndex,
   onFileSelect,
@@ -234,12 +234,12 @@ export function FileTree({
   const filteredActiveIndex = filteredIndexMap.get(activeFileIndex) ?? activeFileIndex;
 
   // When a file is selected in the filtered tree, convert back to original index.
-  const handleFileSelect = (filteredIdx: number) => {
+  const handleFileSelect = useCallback((filteredIdx: number) => {
     const file = filteredFiles[filteredIdx];
     if (!file) return;
     const origIdx = fileToOrigIndex.get(file) ?? -1;
     if (origIdx >= 0) onFileSelect(origIdx);
-  };
+  }, [fileToOrigIndex, filteredFiles, onFileSelect]);
 
   return (
     <div className="flex flex-col h-full">
@@ -284,4 +284,6 @@ export function FileTree({
       </div>
     </div>
   );
-}
+});
+
+FileTree.displayName = "FileTree";

--- a/frontend/src/components/code-review/review-diff-view.test.tsx
+++ b/frontend/src/components/code-review/review-diff-view.test.tsx
@@ -143,6 +143,16 @@ describe("ReviewDiffView", () => {
     expect(screen.getByTestId("keyboard-help")).toBeInTheDocument();
   });
 
+  it("does not rerender the diff pane when parent props are unchanged", () => {
+    const props = defaultProps();
+    const { rerender } = render(<ReviewDiffView {...props} />);
+    const initialRenderCount = mockDiffPaneRender.mock.calls.length;
+
+    rerender(<ReviewDiffView {...props} />);
+
+    expect(mockDiffPaneRender).toHaveBeenCalledTimes(initialRenderCount);
+  });
+
   it("passes an active file change handler to DiffPane", () => {
     const props = defaultProps();
     render(<ReviewDiffView {...props} />);

--- a/frontend/src/components/code-review/review-diff-view.tsx
+++ b/frontend/src/components/code-review/review-diff-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { FileCode2 } from "lucide-react";
 import type { DiffFile } from "@/lib/diff-parser";
 import type { SessionReviewComment } from "@/lib/types";
@@ -40,7 +40,7 @@ interface ReviewDiffViewProps {
   onDiffSearchChange: (q: string) => void;
 }
 
-export function ReviewDiffView({
+export const ReviewDiffView = memo(function ReviewDiffView({
   sessionId,
   files,
   allFiles,
@@ -372,4 +372,6 @@ export function ReviewDiffView({
       <KeyboardHelpOverlay open={showKeyboardHelp} onClose={toggleShowHelp} />
     </div>
   );
-}
+});
+
+ReviewDiffView.displayName = "ReviewDiffView";

--- a/frontend/src/hooks/use-review-comments.ts
+++ b/frontend/src/hooks/use-review-comments.ts
@@ -86,6 +86,7 @@ export function useReviewComments(sessionId: string): UseReviewCommentsResult {
     }) => api.sessions.createReviewComment(sessionId, body),
     onSuccess: invalidate,
   });
+  const { mutate: createReviewComment, isPending: isCreating } = createMutation;
 
   const updateMutation = useMutation({
     mutationFn: ({
@@ -97,12 +98,14 @@ export function useReviewComments(sessionId: string): UseReviewCommentsResult {
     }) => api.sessions.updateReviewComment(sessionId, commentId, data),
     onSuccess: invalidate,
   });
+  const { mutate: updateReviewComment } = updateMutation;
 
   const deleteMutation = useMutation({
     mutationFn: (commentId: string) =>
       api.sessions.deleteReviewComment(sessionId, commentId),
     onSuccess: invalidate,
   });
+  const { mutate: deleteReviewComment } = deleteMutation;
 
   const createComment = useCallback(
     (data: {
@@ -111,23 +114,23 @@ export function useReviewComments(sessionId: string): UseReviewCommentsResult {
       side?: DiffSide;
       body: string;
     }) => {
-      createMutation.mutate(data);
+      createReviewComment(data);
     },
-    [createMutation]
+    [createReviewComment]
   );
 
   const updateComment = useCallback(
     (commentId: string, data: { body?: string; resolved?: boolean }) => {
-      updateMutation.mutate({ commentId, data });
+      updateReviewComment({ commentId, data });
     },
-    [updateMutation]
+    [updateReviewComment]
   );
 
   const deleteComment = useCallback(
     (commentId: string) => {
-      deleteMutation.mutate(commentId);
+      deleteReviewComment(commentId);
     },
-    [deleteMutation]
+    [deleteReviewComment]
   );
 
   // Derive error from per-mutation state so concurrent mutations don't clear each other's errors.
@@ -148,6 +151,6 @@ export function useReviewComments(sessionId: string): UseReviewCommentsResult {
     createComment,
     updateComment,
     deleteComment,
-    isCreating: createMutation.isPending,
+    isCreating,
   };
 }

--- a/frontend/src/lib/session-composer-mentions.test.ts
+++ b/frontend/src/lib/session-composer-mentions.test.ts
@@ -105,6 +105,12 @@ describe("session composer mentions", () => {
   it("keeps references when the token is followed by punctuation", () => {
     expect(syncReferencesWithMessage("Inspect @internal/api/handlers/sessions.go,", [fileReference])).toEqual([fileReference]);
   });
+
+  it("keeps the same references array when no references are removed", () => {
+    const references = [fileReference];
+
+    expect(syncReferencesWithMessage("Inspect @internal/api/handlers/sessions.go now", references)).toBe(references);
+  });
 });
 
 describe("session composer slash command triggers", () => {
@@ -154,6 +160,12 @@ describe("session composer slash command triggers", () => {
 
   it("syncs commands with the message text", () => {
     expect(syncCommandsWithMessage("/review focus on auth", [reviewCommand, clearCommand])).toEqual([reviewCommand]);
+  });
+
+  it("keeps the same commands array when no commands are removed", () => {
+    const commands = [reviewCommand];
+
+    expect(syncCommandsWithMessage("/review focus on auth", commands)).toBe(commands);
   });
 
   it("drops commands that only appear mid-line", () => {

--- a/frontend/src/lib/session-composer-mentions.ts
+++ b/frontend/src/lib/session-composer-mentions.ts
@@ -148,11 +148,13 @@ function insertTokenAtCaret(text: string, mention: ActiveMention, token: string)
 }
 
 export function syncReferencesWithMessage(text: string, references: SessionInputReference[]): SessionInputReference[] {
-  return references.filter((reference) => messageContainsToken(text, tokenForReference(reference)));
+  const next = references.filter((reference) => messageContainsToken(text, tokenForReference(reference)));
+  return next.length === references.length ? references : next;
 }
 
 export function syncCommandsWithMessage(text: string, commands: SessionInputCommand[]): SessionInputCommand[] {
-  return commands.filter((command) => messageContainsCommandToken(text, tokenForCommand(command)));
+  const next = commands.filter((command) => messageContainsCommandToken(text, tokenForCommand(command)));
+  return next.length === commands.length ? commands : next;
 }
 
 export function removeMentionReference(text: string, reference: SessionInputReference): string {


### PR DESCRIPTION
## Summary
- Memoize the session changes tab, review diff view, and file tree so typing in the composer does not force expensive diff UI rerenders.
- Stabilize callback props in `SessionDetailContent` and `useReviewComments` to keep memoized children from updating unnecessarily.
- Preserve reference and command array identity when composer sync functions make no changes.
- Add performance-focused tests to guard the diff viewer and composer against regression.

## Testing
- Added/updated frontend unit and performance tests covering memoization behavior and reference identity preservation.
- Not run (not requested)