### PR TITLE
Fix tab underline clipping by moving overflow/padding to scroll wrapper

### DIFF
--- a/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.test.tsx
@@ -309,10 +309,12 @@ describe('ProjectSidebar', () => {
 
     const tabList = screen.getByRole('tablist');
     expect(tabList).toHaveAttribute('data-variant', 'line');
-    expect(tabList.className).toContain('pb-1');
     expect(tabList.className).toContain('justify-start');
-    expect(tabList.className).toContain('overflow-x-auto');
-    expect(tabList.className).toContain('overflow-y-visible');
+
+    const scrollWrapper = tabList.parentElement;
+    expect(scrollWrapper?.className).toContain('overflow-x-auto');
+    expect(scrollWrapper?.className).toContain('overflow-y-hidden');
+    expect(scrollWrapper?.className).toContain('pb-1');
   });
 
   it('has search input', () => {

--- a/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/projects/project-sidebar.tsx
@@ -184,21 +184,23 @@ export function ProjectSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList variant="line" size="sm" className="overflow-x-auto overflow-y-visible pb-1">
-            {filterTabs.map((tab) => {
-              const count = tab.value === "active" ? activeCount : 0;
-              return (
-                <TabsTrigger key={tab.value} value={tab.value}>
-                  {tab.label}
-                  {count > 0 && (
-                    <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 bg-primary">
-                      {count}
-                    </span>
-                  )}
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
+          <div className="overflow-x-auto overflow-y-hidden pb-1">
+            <TabsList variant="line" size="sm">
+              {filterTabs.map((tab) => {
+                const count = tab.value === "active" ? activeCount : 0;
+                return (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                    {count > 0 && (
+                      <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 bg-primary">
+                        {count}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+          </div>
         </Tabs>
       </div>
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -132,8 +132,13 @@ describe("AgentTabStrip", () => {
     expect(tabList).toBeInTheDocument();
     expect(tabList).toHaveAttribute("data-variant", "line");
     expect(tabList).not.toHaveClass("bg-muted/60");
-    expect(tabList).toHaveClass("overflow-y-visible");
-    expect(tabList).toHaveClass("pb-1");
+
+    // The scroll/clip wrapper lives on the parent div so the active-tab
+    // underline (positioned just below the trigger) isn't clipped.
+    const scrollWrapper = tabList.parentElement;
+    expect(scrollWrapper).toHaveClass("overflow-x-auto");
+    expect(scrollWrapper).toHaveClass("overflow-y-hidden");
+    expect(scrollWrapper).toHaveClass("pb-1");
     expect(activeTab).toHaveTextContent(/Main tab/i);
     expect(activeTab).not.toHaveTextContent(/Idle/i);
     expect(activeTab).toHaveClass("data-[state=active]:text-primary");
@@ -141,6 +146,77 @@ describe("AgentTabStrip", () => {
     expect(screen.getByRole("tab", { name: /review/i })).not.toHaveTextContent(/Completed/i);
     expect(screen.getByRole("button", { name: "Close Main tab" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close Review tab" })).toBeInTheDocument();
+  });
+
+  it("keeps the bar at the same height in single-tab and multi-tab modes", () => {
+    // Regression guard: the bar's vertical sizing comes from `py-2` on the outer
+    // wrapper and `min-h-9` on the inner flex. Both modes must apply the same
+    // height-determining classes; otherwise the bar visibly jumps when a second
+    // tab appears (which is what happened before #893/#910 — the active-tab
+    // underline needed bottom padding that only existed in multi-tab mode).
+    const baseProps = {
+      viewedThreadIds: new Set<string>(),
+      overlapsByThreadId: new Map<string, string[]>(),
+      statusConfig,
+      onActiveThreadChange: vi.fn(),
+      onAddTab: vi.fn(),
+      onRevertThread: vi.fn(),
+      onArchiveThread: vi.fn(),
+      archivePendingThreadId: null,
+    };
+
+    const heightOnlyClasses = (el: HTMLElement) =>
+      el.className
+        .split(/\s+/)
+        .filter((cls) => /^(h-|min-h-|max-h-|py-|pt-|pb-)\S/.test(cls))
+        .sort()
+        .join(" ");
+
+    const captureBarShell = () => {
+      const addBtn = screen.getByRole("button", { name: "Add agent tab" });
+      const innerFlex = addBtn.parentElement;
+      const outerWrapper = innerFlex?.parentElement;
+      if (!innerFlex || !outerWrapper) {
+        throw new Error("Could not locate bar shell from add-tab button");
+      }
+      return {
+        outer: heightOnlyClasses(outerWrapper),
+        inner: heightOnlyClasses(innerFlex),
+      };
+    };
+
+    const single = renderWithProviders(
+      <AgentTabStrip
+        threads={[makeThread({ id: "thread-1", label: "Solo tab" })]}
+        activeThreadId="thread-1"
+        {...baseProps}
+      />,
+    );
+    const singleShell = captureBarShell();
+    single.unmount();
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={[
+          makeThread({ id: "thread-1", label: "Main tab" }),
+          makeThread({ id: "thread-2", label: "Review", agent_type: "claude_code" }),
+        ]}
+        activeThreadId="thread-1"
+        {...baseProps}
+      />,
+    );
+    const multiShell = captureBarShell();
+
+    // Height-determining classes must agree across modes — that's what keeps
+    // the bar from jumping. The specific value isn't sacred; the equality is.
+    expect(multiShell.outer).toBe(singleShell.outer);
+    expect(multiShell.inner).toBe(singleShell.inner);
+
+    // The inner flex must keep *some* explicit height affordance — without
+    // one, single-tab collapses to the icon-button intrinsic height (32px)
+    // while multi-tab grows to fit the underline (36px).
+    expect(singleShell.inner).not.toBe("");
+    expect(multiShell.inner).not.toBe("");
   });
 
   it("shows only the revert action in the desktop tab actions menu", async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -152,7 +152,7 @@ export function AgentTabStrip({
     return (
       <TooltipProvider delayDuration={150}>
         <div className="shrink-0 border-b border-border bg-background px-3 py-2">
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2 min-h-9">
             <Tooltip>
               <TooltipTrigger asChild>
                 <div
@@ -255,116 +255,118 @@ export function AgentTabStrip({
   return (
     <TooltipProvider delayDuration={150}>
       <div className="border-b border-border bg-background px-3 py-2 shrink-0">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-2 min-w-0 min-h-9">
           <Tabs value={activeThreadId} onValueChange={onActiveThreadChange} className="min-w-0 flex-1">
-            <TabsList
-              variant="line"
-              size="sm"
-              aria-label="Agent tabs"
-              className={cn(
-                "h-auto max-w-full justify-start gap-1 overflow-x-auto overflow-y-visible border-b-0 bg-transparent p-0 pb-1",
-              )}
-            >
-              {tabs.map((thread) => {
-                const agent = AGENTS_BY_KEY[thread.agent_type];
-                const agentLabel = agent?.label ?? thread.agent_type;
-                const statusLabel = threadStatusLabel(thread.status, statusConfig);
-                const needsAttention = thread.status === "awaiting_input" || thread.status === "failed";
-                const overlap = overlapsByThreadId.get(thread.id) ?? [];
-                const isCancelling = thread.cancel_requested_at != null && isActiveStatus(thread.status);
-                const queued = thread.pending_message_count ?? 0;
-                const showUnreadDot = shouldShowUnreadDot(thread, viewedThreadIds);
-                const showArchiveButton = canArchiveThread(thread, tabs.length);
-                const isNonInteractive = nonInteractiveThreadIds?.has(thread.id) ?? false;
-                const closeLabel = `Close ${thread.label}${thread.label.toLowerCase().endsWith(" tab") ? "" : " tab"}`;
+            <div className="overflow-x-auto overflow-y-hidden pb-1 min-w-0">
+              <TabsList
+                variant="line"
+                size="sm"
+                aria-label="Agent tabs"
+                className={cn(
+                  "h-auto max-w-full justify-start gap-1 border-b-0 bg-transparent px-0",
+                )}
+              >
+                {tabs.map((thread) => {
+                  const agent = AGENTS_BY_KEY[thread.agent_type];
+                  const agentLabel = agent?.label ?? thread.agent_type;
+                  const statusLabel = threadStatusLabel(thread.status, statusConfig);
+                  const needsAttention = thread.status === "awaiting_input" || thread.status === "failed";
+                  const overlap = overlapsByThreadId.get(thread.id) ?? [];
+                  const isCancelling = thread.cancel_requested_at != null && isActiveStatus(thread.status);
+                  const queued = thread.pending_message_count ?? 0;
+                  const showUnreadDot = shouldShowUnreadDot(thread, viewedThreadIds);
+                  const showArchiveButton = canArchiveThread(thread, tabs.length);
+                  const isNonInteractive = nonInteractiveThreadIds?.has(thread.id) ?? false;
+                  const closeLabel = `Close ${thread.label}${thread.label.toLowerCase().endsWith(" tab") ? "" : " tab"}`;
 
-                return (
-                  <div key={thread.id} className="group relative flex shrink-0 items-center">
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <TabsTrigger
-                          value={thread.id}
-                          disabled={isNonInteractive}
-                          className={cn(
-                            "h-8 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
-                            "after:bg-primary after:bg-none data-[state=active]:after:opacity-100",
-                            showArchiveButton && "pr-8",
-                            tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
-                            isNonInteractive && "cursor-default opacity-60",
-                          )}
-                        >
-                          {showUnreadDot ? (
-                            <span
-                              className={cn(
-                                "h-2 w-2 shrink-0 rounded-full bg-primary",
-                                thread.status === "running" && !isCancelling && "animate-pulse",
-                              )}
-                              aria-hidden
-                            />
-                          ) : (
-                            <span className="h-2 w-2 shrink-0" aria-hidden />
-                          )}
-                          <span className="truncate">{thread.label}</span>
-                          {isCancelling && (
-                            <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-label="Cancelling" />
-                          )}
-                          {queued > 0 && (
-                            <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
-                              {queued}
-                            </Badge>
-                          )}
-                          {needsAttention && (
-                            <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-label="Needs attention" />
-                          )}
-                          {overlap.length > 0 && (
-                            <AlertTriangle
-                              className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
-                              aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
-                            />
-                          )}
-                        </TabsTrigger>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom" className="max-w-sm text-xs">
-                        <div className="space-y-1">
-                          <div className="font-medium">{thread.label} <span className="font-normal text-muted-foreground">- {agentLabel}</span></div>
-                          <div className="text-muted-foreground">{statusLabel}{queued > 0 ? ` · ${queued} message${queued === 1 ? "" : "s"} queued` : ""}</div>
-                          {overlap.length > 0 && (
-                            <div className="pt-1">
-                              <div className="font-medium text-amber-700 dark:text-amber-400">Overlap with another tab:</div>
-                              <ul className="text-muted-foreground">
-                                {overlap.slice(0, 5).map((p) => (
-                                  <li key={p} className="truncate">{p}</li>
-                                ))}
-                                {overlap.length > 5 && (
-                                  <li className="text-muted-foreground/80">…and {overlap.length - 5} more</li>
+                  return (
+                    <div key={thread.id} className="group relative flex shrink-0 items-center">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <TabsTrigger
+                            value={thread.id}
+                            disabled={isNonInteractive}
+                            className={cn(
+                              "h-7 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
+                              "after:bg-primary after:bg-none data-[state=active]:after:opacity-100",
+                              showArchiveButton && "pr-8",
+                              tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
+                              isNonInteractive && "cursor-default opacity-60",
+                            )}
+                          >
+                            {showUnreadDot ? (
+                              <span
+                                className={cn(
+                                  "h-2 w-2 shrink-0 rounded-full bg-primary",
+                                  thread.status === "running" && !isCancelling && "animate-pulse",
                                 )}
-                              </ul>
-                            </div>
-                          )}
-                        </div>
-                      </TooltipContent>
-                    </Tooltip>
-                    {showArchiveButton ? (
-                      <Button
-                        type="button"
-                        size="icon"
-                        variant="ghost"
-                        className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-sm opacity-70 hover:opacity-100 focus-visible:opacity-100"
-                        aria-label={closeLabel}
-                        title={closeLabel}
-                        disabled={archivePendingThreadId === thread.id}
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          onArchiveThread(thread.id);
-                        }}
-                      >
-                        {archivePendingThreadId === thread.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}
-                      </Button>
-                    ) : null}
-                  </div>
-                );
-              })}
-            </TabsList>
+                                aria-hidden
+                              />
+                            ) : (
+                              <span className="h-2 w-2 shrink-0" aria-hidden />
+                            )}
+                            <span className="truncate">{thread.label}</span>
+                            {isCancelling && (
+                              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-label="Cancelling" />
+                            )}
+                            {queued > 0 && (
+                              <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
+                                {queued}
+                              </Badge>
+                            )}
+                            {needsAttention && (
+                              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-label="Needs attention" />
+                            )}
+                            {overlap.length > 0 && (
+                              <AlertTriangle
+                                className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
+                                aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
+                              />
+                            )}
+                          </TabsTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" className="max-w-sm text-xs">
+                          <div className="space-y-1">
+                            <div className="font-medium">{thread.label} <span className="font-normal text-muted-foreground">- {agentLabel}</span></div>
+                            <div className="text-muted-foreground">{statusLabel}{queued > 0 ? ` · ${queued} message${queued === 1 ? "" : "s"} queued` : ""}</div>
+                            {overlap.length > 0 && (
+                              <div className="pt-1">
+                                <div className="font-medium text-amber-700 dark:text-amber-400">Overlap with another tab:</div>
+                                <ul className="text-muted-foreground">
+                                  {overlap.slice(0, 5).map((p) => (
+                                    <li key={p} className="truncate">{p}</li>
+                                  ))}
+                                  {overlap.length > 5 && (
+                                    <li className="text-muted-foreground/80">…and {overlap.length - 5} more</li>
+                                  )}
+                                </ul>
+                              </div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                      {showArchiveButton ? (
+                        <Button
+                          type="button"
+                          size="icon"
+                          variant="ghost"
+                          className="absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-sm opacity-70 hover:opacity-100 focus-visible:opacity-100"
+                          aria-label={closeLabel}
+                          title={closeLabel}
+                          disabled={archivePendingThreadId === thread.id}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            onArchiveThread(thread.id);
+                          }}
+                        >
+                          {archivePendingThreadId === thread.id ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <X className="h-3.5 w-3.5" />}
+                        </Button>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </TabsList>
+            </div>
           </Tabs>
 
           <ThreadActionsMenu

--- a/frontend/src/app/(dashboard)/sessions/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/page.test.tsx
@@ -80,10 +80,12 @@ describe('SessionSidebar', () => {
 
     const tabList = screen.getByRole('tablist');
     expect(tabList).toHaveAttribute('data-variant', 'line');
-    expect(tabList.className).toContain('pb-1');
     expect(tabList.className).toContain('justify-start');
-    expect(tabList.className).toContain('overflow-x-auto');
-    expect(tabList.className).toContain('overflow-y-visible');
+
+    const scrollWrapper = tabList.parentElement;
+    expect(scrollWrapper?.className).toContain('overflow-x-auto');
+    expect(scrollWrapper?.className).toContain('overflow-y-hidden');
+    expect(scrollWrapper?.className).toContain('pb-1');
   });
 
   it('shows status indicators for sessions', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -255,10 +255,14 @@ describe('SessionSidebar', () => {
 
     const tabList = screen.getByRole('tablist');
     expect(tabList).toHaveAttribute('data-variant', 'line');
-    expect(tabList.className).toContain('pb-1');
     expect(tabList.className).toContain('justify-start');
-    expect(tabList.className).toContain('overflow-x-auto');
-    expect(tabList.className).toContain('overflow-y-visible');
+
+    // The scroll/clip wrapper lives on the parent div so the active-tab
+    // underline (positioned just below the trigger) isn't clipped.
+    const scrollWrapper = tabList.parentElement;
+    expect(scrollWrapper?.className).toContain('overflow-x-auto');
+    expect(scrollWrapper?.className).toContain('overflow-y-hidden');
+    expect(scrollWrapper?.className).toContain('pb-1');
   });
 
   it('navigates when the selected row shell is tapped', async () => {

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -568,28 +568,30 @@ export function SessionSidebar() {
           onValueChange={(v) => setActiveFilter(v === "all" ? null : v)}
           className="gap-0"
         >
-          <TabsList variant="line" size="sm" className="overflow-x-auto overflow-y-visible pb-1">
-            {filterTabs.map((tab) => {
-              const count = getCountForTab(tab.value, counts);
-              const label = renderCount(count, counts);
-              // Active uses the existing attention-grabbing pill; All/Archived get a
-              // muted inline number so totals are visible without being loud.
-              // Zero buckets render nothing — a "0" badge is noise.
-              const isActivePill = tab.value === "active" && count !== undefined && count > 0;
-              const isMutedNumber = !isActivePill && label !== undefined && count !== undefined && count > 0;
-              return (
-                <TabsTrigger key={tab.value} value={tab.value}>
-                  {tab.label}
-                  {isActivePill && (
-                    <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 bg-primary">{label}</span>
-                  )}
-                  {isMutedNumber && (
-                    <span className="text-xs leading-none text-muted-foreground/60 tabular-nums">{label}</span>
-                  )}
-                </TabsTrigger>
-              );
-            })}
-          </TabsList>
+          <div className="overflow-x-auto overflow-y-hidden pb-1">
+            <TabsList variant="line" size="sm">
+              {filterTabs.map((tab) => {
+                const count = getCountForTab(tab.value, counts);
+                const label = renderCount(count, counts);
+                // Active uses the existing attention-grabbing pill; All/Archived get a
+                // muted inline number so totals are visible without being loud.
+                // Zero buckets render nothing — a "0" badge is noise.
+                const isActivePill = tab.value === "active" && count !== undefined && count > 0;
+                const isMutedNumber = !isActivePill && label !== undefined && count !== undefined && count > 0;
+                return (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                    {isActivePill && (
+                      <span className="rounded-full text-white text-xs leading-none px-1.5 py-0.5 bg-primary">{label}</span>
+                    )}
+                    {isMutedNumber && (
+                      <span className="text-xs leading-none text-muted-foreground/60 tabular-nums">{label}</span>
+                    )}
+                  </TabsTrigger>
+                );
+              })}
+            </TabsList>
+          </div>
         </Tabs>
       </div>
 


### PR DESCRIPTION
## Summary

No findings.

I reviewed the changed frontend components/tests and didn’t see a behavioral regression in the tab/sidebar layout changes. The overflow wrapper plus bottom padding looks consistent with the underline positioning in `TabsTrigger`, and the tab strip height guard is scoped to the regression being fixed.

I attempted to run the targeted frontend tests, but the workspace is missing `frontend/node_modules`, so `npm test` failed immediately with `sh: 1: eslint: not found`. Residual risk is mainly visual: I could not verify the layout in a browser or run the required frontend checks without installing dependencies.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session c407c32a](https://143.dev/sessions/c407c32a-593a-41f8-8cd6-f1404d5f09e5)