### PR TITLE
Restore Claude config across snapshot resumes

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -3006,6 +3006,9 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 			}
 			authBillingMode = mode
 		case models.AgentTypeClaudeCode:
+			if err := o.restoreClaudeCodeConfigFromBackup(ctx, sandbox); err != nil {
+				log.Warn().Err(err).Msg("failed to restore Claude Code config from backup; continuing with existing sandbox state")
+			}
 			mode, err := o.ensureClaudeCodeAuth(ctx, session, sandbox, sandboxCfg.Env)
 			if err != nil {
 				return err
@@ -4558,6 +4561,33 @@ func (o *Orchestrator) removeClaudeCodeCredentialsFile(ctx context.Context, sand
 	}
 	if exitCode != 0 {
 		return fmt.Errorf("remove stale claude credentials: exited with code %d: %s", exitCode, stderr.String())
+	}
+	return nil
+}
+
+func (o *Orchestrator) restoreClaudeCodeConfigFromBackup(ctx context.Context, sandbox *Sandbox) error {
+	if sandbox == nil || sandbox.HomeDir == "" {
+		return nil
+	}
+
+	configPath := path.Join(sandbox.HomeDir, ".claude.json")
+	backupDir := path.Join(sandbox.HomeDir, ".claude", "backups")
+	cmd := fmt.Sprintf(
+		"if [ ! -f '%s' ] && [ -d '%s' ]; then latest=$(ls -t '%s'/.claude.json.backup.* 2>/dev/null | head -n 1); if [ -n \"$latest\" ]; then cp \"$latest\" '%s' && chmod 600 '%s'; fi; fi",
+		shellEscapeSingleQuote(configPath),
+		shellEscapeSingleQuote(backupDir),
+		shellEscapeSingleQuote(backupDir),
+		shellEscapeSingleQuote(configPath),
+		shellEscapeSingleQuote(configPath),
+	)
+
+	var stdout, stderr bytes.Buffer
+	exitCode, err := o.provider.Exec(ctx, sandbox, cmd, &stdout, &stderr)
+	if err != nil {
+		return fmt.Errorf("restore claude config backup: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("restore claude config backup: exited with code %d: %s", exitCode, stderr.String())
 	}
 	return nil
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -4842,6 +4842,67 @@ func TestContinueSession_ClaudeTokenFailureRemovesStaleCredentialsBeforeAPIKeyFa
 	require.Len(t, d.sessions.getFailureUpdates(), 0, "successful fallback should not record a Claude auth failure")
 }
 
+func TestContinueSession_ClaudeSnapshotRestoresTopLevelConfigFromBackup(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	issue.Source = models.IssueSourceManual
+	session := testRun(orgID, issue.ID)
+	session.Origin = models.SessionOriginManual
+	session.InteractionMode = models.SessionInteractionModeInteractive
+	session.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
+	session.Status = string(models.SessionStatusIdle)
+	session.CurrentTurn = 1
+	session.SnapshotKey = strPtr("snapshots/test/session-with-claude-backup.tar")
+	session.AgentSessionID = strPtr("claude-session-abc")
+
+	d := defaultDeps()
+	d.issues.issue = issue
+	d.messages.messages = []models.SessionMessage{
+		{
+			ID:         1,
+			SessionID:  session.ID,
+			OrgID:      orgID,
+			TurnNumber: 2,
+			Role:       models.MessageRoleUser,
+			Content:    "Keep going.",
+		},
+	}
+	d.provider.RestoreFn = func(ctx context.Context, sb *agent.Sandbox, reader io.Reader) error {
+		_, err := io.ReadAll(reader)
+		return err
+	}
+	d.provider.SnapshotFn = func(ctx context.Context, sb *agent.Sandbox) (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader([]byte("next-snapshot"))), nil
+	}
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		require.True(t, prompt.Continuation, "snapshot-backed Claude resume should use continuation mode when an agent session id exists")
+		return &agent.AgentResult{
+			Summary:         "continued",
+			ConfidenceScore: 0.82,
+			ExitCode:        0,
+		}, nil
+	}
+	d.snapshots.data = map[string][]byte{
+		*session.SnapshotKey: []byte("restored-snapshot"),
+	}
+
+	orch := buildOrchestrator(d)
+	err := orch.ContinueSession(context.Background(), session, nil)
+	require.NoError(t, err, "snapshot resume should succeed after restoring Claude config from backup")
+
+	var restoreCmd string
+	for _, cmd := range d.provider.ExecCalls {
+		if strings.Contains(cmd, ".claude.json.backup.*") {
+			restoreCmd = cmd
+			break
+		}
+	}
+	require.NotEmpty(t, restoreCmd, "snapshot-backed Claude resume should attempt to restore ~/.claude.json from the newest backup")
+	require.Contains(t, restoreCmd, "cp \"$latest\" '/home/sandbox/.claude.json'", "restore command should copy Claude's newest backup to the top-level config path")
+}
+
 // errForcedCreateFailure is used by tests that short-circuit provider.Create so
 // the test can inspect the SandboxConfig without running the full sandbox
 // lifecycle. Named so grep picks it up and future refactors don't silently

--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -944,9 +944,10 @@ func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.Re
 		Str("container_id", sb.ID).
 		Msg("snapshotting sandbox")
 
-	// Tar workspace + agent state dirs. --ignore-failed-read handles missing dirs gracefully.
-	// Agent state dirs (.claude/, .codex/, .gemini/) live under HomeDir, not WorkDir —
-	// HOME is set to the sandbox user's home so CLI configs resolve there.
+	// Tar workspace + agent state. --ignore-failed-read handles missing paths gracefully.
+	// Agent state dirs (.claude/, .codex/, .gemini/) and Claude Code's top-level
+	// .claude.json live under HomeDir, not WorkDir; HOME is set to the sandbox
+	// user's home so CLI configs resolve there.
 	//
 	// Stderr is intentionally NOT redirected to /dev/null inside the shell so
 	// diagnostic messages from a failing tar reach our caller via the docker
@@ -954,8 +955,8 @@ func (d *DockerProvider) Snapshot(ctx context.Context, sb *agent.Sandbox) (io.Re
 	workDirRel := strings.TrimPrefix(sb.WorkDir, "/")
 	homeDirRel := strings.TrimPrefix(sb.HomeDir, "/")
 	cmd := fmt.Sprintf(
-		"tar czf - --ignore-failed-read -C / '%s' '%s/.claude' '%s/.codex' '%s/.gemini'",
-		workDirRel, homeDirRel, homeDirRel, homeDirRel,
+		"tar czf - --ignore-failed-read -C / '%s' '%s/.claude' '%s/.claude.json' '%s/.codex' '%s/.gemini'",
+		workDirRel, homeDirRel, homeDirRel, homeDirRel, homeDirRel,
 	)
 
 	execCfg := container.ExecOptions{

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -1307,6 +1307,7 @@ func TestDockerProvider_Snapshot(t *testing.T) {
 		tarCmd := gotCmd[2]
 		require.Contains(t, tarCmd, "'home/sandbox/backend'", "tar should include the WorkDir relative path")
 		require.Contains(t, tarCmd, "'home/sandbox/.claude'", "tar should include the .claude dir under HomeDir")
+		require.Contains(t, tarCmd, "'home/sandbox/.claude.json'", "tar should include Claude Code's top-level config file under HomeDir")
 		require.Contains(t, tarCmd, "'home/sandbox/.codex'", "tar should include the .codex dir under HomeDir")
 		require.Contains(t, tarCmd, "'home/sandbox/.gemini'", "tar should include the .gemini dir under HomeDir")
 		require.NotContains(t, tarCmd, "2>/dev/null", "tar stderr must not be silenced — we capture it for diagnostics")


### PR DESCRIPTION
## Summary
- Include `/home/sandbox/.claude.json` in sandbox snapshots so Claude Code resumes retain the top-level config file alongside `.claude/` state.
- Add a resume-time repair step for Claude Code sessions that restores `.claude.json` from the newest backup when replaying an existing snapshot.
- Add regression coverage for both the snapshot tar contents and the Claude snapshot-resume path.

## Testing
- Added unit tests covering snapshot tar contents and snapshot-backed Claude resume behavior.
- Verified the Go change set with `go vet ./...`, `go build ./...`, and `go test ./...`.