### PR TITLE
Default Usage page breakdown to user totals and add regression test coverage

### DIFF
--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -347,7 +347,35 @@ describe('UsagePage', () => {
     expect(screen.getByText('Last 30d')).toBeInTheDocument();
     expect(screen.getByText('This month')).toBeInTheDocument();
     expect(screen.getByText('Breakdown')).toBeInTheDocument();
-    expect(screen.getAllByText('By Model')).toHaveLength(2);
+    expect(screen.getAllByText('By User')).toHaveLength(2);
+  });
+
+  it('defaults the breakdown request to user totals', async () => {
+    const breakdownDimensions: Array<string | null> = [];
+    const timeseriesStackBy: Array<string | null> = [];
+    server.use(
+      http.get('*/api/v1/usage/timeseries', ({ request }) => {
+        timeseriesStackBy.push(new URL(request.url).searchParams.get('stack_by'));
+        return HttpResponse.json({
+          data: {
+            buckets: [],
+            period_start: '2026-03-13T00:00:00Z',
+            period_end: '2026-04-12T00:00:00Z',
+          },
+        });
+      }),
+      http.get('*/api/v1/usage/breakdown', ({ request }) => {
+        breakdownDimensions.push(new URL(request.url).searchParams.get('dimension'));
+        return HttpResponse.json({ data: [], meta: {} });
+      })
+    );
+
+    renderWithProviders(<UsagePage />);
+
+    await waitFor(() => {
+      expect(breakdownDimensions).toContain('user');
+    });
+    expect(timeseriesStackBy).toContain(null);
   });
 
   it('offers user breakdown and does not expose capacity breakdown', async () => {
@@ -360,8 +388,7 @@ describe('UsagePage', () => {
     expect(screen.queryByText('By Capacity')).not.toBeInTheDocument();
   });
 
-  it('keeps the chart request valid when switching to user breakdown', async () => {
-    const user = userEvent.setup();
+  it('keeps the chart request valid for the default user breakdown', async () => {
     server.use(
       http.get('*/api/v1/usage/timeseries', ({ request }) => {
         const stackBy = new URL(request.url).searchParams.get('stack_by');
@@ -403,9 +430,6 @@ describe('UsagePage', () => {
     );
 
     renderWithProviders(<UsagePage />);
-
-    await user.click(screen.getByLabelText('Break down by'));
-    await user.click(screen.getByText('By User'));
 
     await waitFor(() => {
       expect(screen.getByText('alice@example.com')).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/settings/usage/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.tsx
@@ -27,8 +27,8 @@ const UsageTimeseriesChart = dynamic(
 export default function UsagePage() {
   const [preset, setPreset] = useState<DatePreset>("30d");
   const [metric, setMetric] = useState<MetricKey>("total_tokens");
-  const [dimension, setDimension] = useState<UsageBreakdownDimension>("model");
-  const [chartMode, setChartMode] = useState<"totals" | "stacked">("stacked");
+  const [dimension, setDimension] = useState<UsageBreakdownDimension>("user");
+  const [chartMode, setChartMode] = useState<"totals" | "stacked">("totals");
   const [selectedAgent, setSelectedAgent] = useQueryState("agent", parseAsString);
   const [selectedModel, setSelectedModel] = useQueryState("model", parseAsString);
   const [selectedReasoning, setSelectedReasoning] = useQueryState("reasoning", parseAsString);


### PR DESCRIPTION
## Summary
Change the default breakdown on the Usage settings page from **By Model** to **By User** so the initial API requests match the expected user-focused view. Updated the chart mode accordingly and added a regression test to prevent `dimension=model`/`stack_by` from being sent on first load.

## Changes
- **frontend/src/app/(dashboard)/settings/usage/page.tsx**
  - Default `dimension` state changed from `"model"` to `"user"`.
  - Default `chartMode` changed from `"stacked"` to `"totals"` to align with the new user breakdown.
- **frontend/src/app/(dashboard)/settings/usage/page.test.tsx**
  - Updated UI assertions to expect **By User** selected by default.
  - Added `defaults the breakdown request to user totals` test verifying:
    - initial `/api/v1/usage/breakdown` request includes `dimension=user`
    - initial `/api/v1/usage/timeseries` request does **not** include `stack_by` (remains `null`)
  - Adjusted/streamlined the default-breakdown chart request test (no longer clicks to switch breakdown).

## Test plan
- `npx vitest run 'src/app/(dashboard)/settings/usage/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 74e9dba4](https://143.dev/sessions/74e9dba4-75dd-4120-9c0f-79e351a74cb7)