### PR TITLE
Fix usage breakdown percentages and cost math; add session metrics to table

### DIFF
--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -607,7 +607,8 @@ describe('UsageBreakdownTable', () => {
               total_output_tokens: 2000,
               total_tokens: 7000,
               total_llm_cost_usd: 0.5,
-              percentage: 100.0,
+              percentage: 60.0,
+              share_of_tokens: 87.5,
             },
           ],
           meta: {},
@@ -625,8 +626,13 @@ describe('UsageBreakdownTable', () => {
       expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     });
     expect(screen.getByText('1.0h')).toBeInTheDocument();
+    expect(screen.getByText('20.0m')).toBeInTheDocument();
     expect(screen.getByText('7.0K')).toBeInTheDocument();
+    expect(screen.getByText('2.3K')).toBeInTheDocument();
     expect(screen.getByText('Share of Tokens')).toBeInTheDocument();
+    expect(screen.getByText('Minutes / Session')).toBeInTheDocument();
+    expect(screen.getByText('Tokens / Session')).toBeInTheDocument();
+    expect(screen.getByText('87.5%')).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
@@ -93,28 +93,38 @@ export function UsageBreakdownTable({ start, end, dimension, filters, onRowClick
                   <TableHead className="pl-4 text-xs">{leadingLabel(dimension)}</TableHead>
                   <TableHead className="text-right text-xs">Sessions</TableHead>
                   <TableHead className="text-right text-xs">Container Minutes</TableHead>
+                  <TableHead className="text-right text-xs">Minutes / Session</TableHead>
                   <TableHead className="text-right text-xs">Total Tokens</TableHead>
+                  <TableHead className="text-right text-xs">Tokens / Session</TableHead>
                   <TableHead className="text-right text-xs">Est. Cost</TableHead>
                   <TableHead className="pr-4 text-right text-xs">Share of Tokens</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {rows.map((row) => (
-                  <TableRow
-                    key={row.key}
-                    className={cn(onRowClick && "cursor-pointer hover:bg-muted/50", selectedKey === row.key && "bg-muted/50")}
-                    onClick={() => onRowClick?.({ dimension, key: row.key })}
-                  >
-                    <TableCell className="pl-4 text-[13px] font-medium">{row.label}</TableCell>
-                    <TableCell className="text-right text-[13px] tabular-nums">{formatNumber(row.total_sessions)}</TableCell>
-                    <TableCell className="text-right text-[13px] tabular-nums">{formatMinutes(row.total_container_minutes)}</TableCell>
-                    <TableCell className="text-right text-[13px] tabular-nums">{formatTokenCount(row.total_tokens)}</TableCell>
-                    <TableCell className="text-right text-[13px] tabular-nums">{formatCost(row.total_llm_cost_usd)}</TableCell>
-                    <TableCell className="pr-4 text-right text-[13px] tabular-nums">
-                      {(row.share_of_tokens ?? row.percentage).toFixed(1)}%
-                    </TableCell>
-                  </TableRow>
-                ))}
+                {rows.map((row) => {
+                  const minutesPerSession = row.total_sessions > 0 ? row.total_container_minutes / row.total_sessions : 0;
+                  const tokensPerSession = row.total_sessions > 0 ? row.total_tokens / row.total_sessions : 0;
+                  const shareOfTokens = row.share_of_tokens ?? row.percentage ?? 0;
+
+                  return (
+                    <TableRow
+                      key={row.key}
+                      className={cn(onRowClick && "cursor-pointer hover:bg-muted/50", selectedKey === row.key && "bg-muted/50")}
+                      onClick={() => onRowClick?.({ dimension, key: row.key })}
+                    >
+                      <TableCell className="pl-4 text-[13px] font-medium">{row.label}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatNumber(row.total_sessions)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatMinutes(row.total_container_minutes)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatMinutes(minutesPerSession)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatTokenCount(row.total_tokens)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatTokenCount(tokensPerSession)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatCost(row.total_llm_cost_usd)}</TableCell>
+                      <TableCell className="pr-4 text-right text-[13px] tabular-nums">
+                        {shareOfTokens.toFixed(1)}%
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
               </TableBody>
             </Table>
           </div>

--- a/internal/db/usage_rollup_store.go
+++ b/internal/db/usage_rollup_store.go
@@ -92,6 +92,21 @@ func normalizeUsageModel(modelUsed *string, tokenUsageRaw []byte) string {
 	return "unknown"
 }
 
+func usageTokenCostSQL(alias string) string {
+	return `COALESCE(
+				NULLIF(` + alias + `.token_usage->>'total_cost_usd', '')::double precision,
+				CASE
+					WHEN lower(` + alias + `.token_usage->'cost'->>'unit') = 'usd'
+					THEN NULLIF(` + alias + `.token_usage->'cost'->>'amount', '')::double precision
+				END,
+				CASE
+					WHEN lower(` + alias + `.token_usage->'native_cost'->>'unit') = 'usd'
+					THEN NULLIF(` + alias + `.token_usage->'native_cost'->>'amount', '')::double precision
+				END,
+				0
+			)`
+}
+
 // RollupHour computes and upserts hourly aggregates for a single org and hour.
 // It writes rows at multiple dimensional levels: org-total, per-user, per-tier.
 func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour time.Time) error {
@@ -272,7 +287,7 @@ func (s *UsageRollupStore) RollupHour(ctx context.Context, orgID uuid.UUID, hour
 			), @unknown_capacity) AS capacity_key,
 			COALESCE((s.token_usage->>'input_tokens')::bigint, 0) AS input_tokens,
 			COALESCE((s.token_usage->>'output_tokens')::bigint, 0) AS output_tokens,
-			COALESCE((s.token_usage->>'total_cost_usd')::double precision, 0) AS cost_usd
+			`+usageTokenCostSQL("s")+` AS cost_usd
 		FROM sessions s
 		WHERE s.org_id = @org_id
 		  AND s.token_usage IS NOT NULL
@@ -940,12 +955,15 @@ func (s *UsageRollupStore) GetBreakdown(ctx context.Context, orgID uuid.UUID, st
 	}
 
 	if dimension == "user" {
-		var grandTotalMinutes float64
+		var grandTotalMinutes, grandTotalTokens, grandTotalCost float64
 		if err := s.db.QueryRow(ctx, `
-			SELECT COALESCE(SUM(uh.total_container_minutes), 0)
+			SELECT
+				COALESCE(SUM(uh.total_container_minutes), 0),
+				COALESCE(SUM(uh.total_input_tokens + uh.total_output_tokens), 0),
+				COALESCE(SUM(uh.total_llm_cost_usd), 0)
 			FROM usage_hourly uh
 			WHERE uh.org_id = @org_id AND uh.hour_utc >= @start AND uh.hour_utc < @end
-			  AND uh.user_id IS NOT NULL AND uh.capacity_tier IS NULL`, args).Scan(&grandTotalMinutes); err != nil {
+			  AND uh.user_id IS NOT NULL AND uh.capacity_tier IS NULL`, args).Scan(&grandTotalMinutes, &grandTotalTokens, &grandTotalCost); err != nil {
 			return nil, fmt.Errorf("query breakdown grand total: %w", err)
 		}
 		query := fmt.Sprintf(`
@@ -987,7 +1005,7 @@ func (s *UsageRollupStore) GetBreakdown(ctx context.Context, orgID uuid.UUID, st
 			return nil, fmt.Errorf("query breakdown: %w", err)
 		}
 		defer rows.Close()
-		return scanUsageBreakdownRows(rows, grandTotalMinutes, 0, 0)
+		return scanUsageBreakdownRows(rows, grandTotalMinutes, grandTotalTokens, grandTotalCost)
 	}
 
 	keyExpr := "uhe.capacity_key"

--- a/internal/db/usage_rollup_store_test.go
+++ b/internal/db/usage_rollup_store_test.go
@@ -981,7 +981,7 @@ func TestGetBreakdown_UserDimension(t *testing.T) {
 	// Grand total query
 	mock.ExpectQuery("SELECT COALESCE\\(SUM").
 		WithArgs(args).
-		WillReturnRows(pgxmock.NewRows([]string{"total"}).AddRow(100.0))
+		WillReturnRows(pgxmock.NewRows([]string{"total_minutes", "total_tokens", "total_cost"}).AddRow(100.0, 2700.0, 0.80))
 
 	cols := []string{
 		"key", "label",
@@ -999,8 +999,24 @@ func TestGetBreakdown_UserDimension(t *testing.T) {
 	require.Len(t, rows, 2)
 	require.Equal(t, "alice@test.com", rows[0].Label)
 	require.Equal(t, 60.0, rows[0].Percentage) // 60/100 * 100 = 60.0%
+	require.Equal(t, 55.6, rows[0].ShareOfTokens)
+	require.Equal(t, 62.5, rows[0].ShareOfTokenCost)
 	require.Equal(t, 40.0, rows[1].Percentage) // 40/100 * 100 = 40.0%
+	require.Equal(t, 44.4, rows[1].ShareOfTokens)
+	require.Equal(t, 37.5, rows[1].ShareOfTokenCost)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestUsageTokenCostSQL_UsesUSDObjectFallbacks(t *testing.T) {
+	t.Parallel()
+
+	sql := usageTokenCostSQL("s")
+
+	require.Contains(t, sql, "s.token_usage->>'total_cost_usd'", "cost extraction should keep the canonical total_cost_usd field")
+	require.Contains(t, sql, "s.token_usage->'cost'->>'amount'", "cost extraction should support persisted USD cost objects")
+	require.Contains(t, sql, "s.token_usage->'native_cost'->>'amount'", "cost extraction should support persisted native USD cost objects")
+	require.Contains(t, sql, "lower(s.token_usage->'cost'->>'unit') = 'usd'", "cost object fallback should only use USD costs")
+	require.Contains(t, sql, "lower(s.token_usage->'native_cost'->>'unit') = 'usd'", "native cost object fallback should only use USD costs")
 }
 
 func TestGetBreakdown_CapacityDimension(t *testing.T) {
@@ -1160,7 +1176,7 @@ func TestGetBreakdown_QueryError(t *testing.T) {
 	// Grand total query succeeds
 	mock.ExpectQuery("SELECT COALESCE\\(SUM").
 		WithArgs(args).
-		WillReturnRows(pgxmock.NewRows([]string{"total"}).AddRow(100.0))
+		WillReturnRows(pgxmock.NewRows([]string{"total_minutes", "total_tokens", "total_cost"}).AddRow(100.0, 0.0, 0.0))
 
 	// Main breakdown query fails
 	mock.ExpectQuery("SELECT\\s+uh.user_id::text AS key").
@@ -1278,7 +1294,7 @@ func TestGetBreakdown_EmptyResult(t *testing.T) {
 	// Grand total query
 	mock.ExpectQuery("SELECT COALESCE\\(SUM").
 		WithArgs(args).
-		WillReturnRows(pgxmock.NewRows([]string{"total"}).AddRow(0.0))
+		WillReturnRows(pgxmock.NewRows([]string{"total_minutes", "total_tokens", "total_cost"}).AddRow(0.0, 0.0, 0.0))
 
 	cols := []string{
 		"key", "label",


### PR DESCRIPTION
## Summary
Corrected the Usage Breakdown table’s percentage/share calculations and aligned token/cost math with the underlying rollup results. Added per-session metrics (minutes/session and tokens/session) to make the breakdown more interpretable.

## Changes
- `frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx`
  - Fixed how row “percentage” and “Share of Tokens” are derived/represented (now uses `share_of_tokens` when available).
  - Added new columns:
    - **Minutes / Session** (`total_container_minutes / total_sessions`)
    - **Tokens / Session** (`total_tokens / total_sessions`)
  - Avoid divide-by-zero by returning `0` when `total_sessions === 0`.
- `internal/db/usage_rollup_store.go`
  - Updated usage rollup computations to resolve cost/percentage inconsistencies (ensuring `percentage` and `share_of_tokens` are calculated from the correct totals).
- `frontend/src/app/(dashboard)/settings/usage/page.test.tsx`
  - Updated/extended tests to assert the corrected percentage/share values and the presence of the new session metric columns/values.
- `internal/db/usage_rollup_store_test.go`
  - Adjusted expectations to match the corrected rollup math and added coverage for the new/changed computed fields.

## Test plan
- Ran frontend unit tests for the usage breakdown page (`page.test.tsx`).
- Ran backend usage rollup store tests (`usage_rollup_store_test.go`).
- Verified rendered values for **Share of Tokens**, **Minutes / Session**, and **Tokens / Session** using the updated test fixtures.

[143.dev](https://143.dev) | [session a3ed10a2](https://143.dev/sessions/a3ed10a2-fc0d-4ee2-8ffc-3dc19cf1e65b)