### PR TITLE
Add shared bottom scroll padding to SettingsLayout page container

### DIFF
--- a/frontend/src/app/(dashboard)/settings/layout.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.test.tsx
@@ -248,4 +248,19 @@ describe('SettingsLayout', () => {
 
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
+
+  it('adds shared bottom scroll padding for settings page containers', () => {
+    useAuthMock.mockReturnValue({ user: { role: 'admin' }, isLoading: false });
+
+    const { container } = renderWithProviders(
+      <SettingsLayout>
+        <div data-slot="page-container">settings content</div>
+      </SettingsLayout>
+    );
+
+    const paddingScope = container.querySelector('[data-slot="settings-layout-padding-scope"]');
+    expect(paddingScope).not.toBeNull();
+    expect(paddingScope).toHaveClass('[&_[data-slot=page-container]]:pb-24');
+    expect(paddingScope).toHaveClass('md:[&_[data-slot=page-container]]:pb-20');
+  });
 });

--- a/frontend/src/app/(dashboard)/settings/layout.tsx
+++ b/frontend/src/app/(dashboard)/settings/layout.tsx
@@ -87,5 +87,12 @@ export default function SettingsLayout({
 
   if (waitForRole || restricted) return null;
 
-  return <>{children}</>;
+  return (
+    <div
+      data-slot="settings-layout-padding-scope"
+      className="[&_[data-slot=page-container]]:pb-24 md:[&_[data-slot=page-container]]:pb-20"
+    >
+      {children}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
Update `SettingsLayout` to apply consistent bottom padding to the settings page container so content doesn’t butt up against the viewport bottom. Added a regression test to verify the padding scope and responsive values.

## Changes
- `frontend/src/app/(dashboard)/settings/layout.tsx`
  - Wrap layout children in a `div` with `data-slot="settings-layout-padding-scope"`.
  - Apply bottom padding to nested `[data-slot="page-container"]` via Tailwind: `pb-24` and responsive `md:pb-20`.
- `frontend/src/app/(dashboard)/settings/layout.test.tsx`
  - Added test asserting the padding scope exists and targets `data-slot="page-container"` with the expected classes.

## Test plan
- Ran the existing unit test suite for the settings layout (`layout.test.tsx`) and verified the new test passes.

[143.dev](https://143.dev) | [session 78e146d9](https://143.dev/sessions/78e146d9-e5de-40b8-8814-91e641dd0712)