### PR TITLE
Fix mobile swipe archive to keep row displaced until backend confirms removal

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx
@@ -193,10 +193,21 @@ describe('SessionSidebar', () => {
 
   it('archives a session from the swipe action', async () => {
     let archiveCalls = 0;
-    serveSessions([
-      makeSession({ id: 's1', result_summary: 'Swipe me' }),
-    ]);
+    let resolveArchiveRefetch: (() => void) | undefined;
     server.use(
+      http.get('/api/v1/sessions', () => {
+        if (archiveCalls === 0) {
+          return HttpResponse.json({
+            data: [makeSession({ id: 's1', result_summary: 'Swipe me' })],
+            meta: {},
+          });
+        }
+        return new Promise((resolve) => {
+          resolveArchiveRefetch = () => {
+            resolve(HttpResponse.json({ data: [], meta: {} }));
+          };
+        });
+      }),
       http.post('/api/v1/sessions/s1/archive', () => {
         archiveCalls += 1;
         return HttpResponse.json({ status: 'archived' });
@@ -216,6 +227,62 @@ describe('SessionSidebar', () => {
 
     await waitFor(() => {
       expect(archiveCalls).toBe(1);
+    });
+    expect(screen.queryByText('Swipe me')).not.toBeInTheDocument();
+    resolveArchiveRefetch?.();
+  });
+
+  it('keeps a committed mobile archive row displaced until the backend removes it', async () => {
+    let archiveCalls = 0;
+    let archiveSettled = false;
+    let resolveArchive: (() => void) | undefined;
+    server.use(
+      http.get('/api/v1/sessions', () => {
+        if (archiveSettled) {
+          return HttpResponse.json({ data: [], meta: {} });
+        }
+        return HttpResponse.json({
+          data: [makeSession({ id: 's1', result_summary: 'Swipe pending' })],
+          meta: {},
+        });
+      }),
+      http.post('/api/v1/sessions/s1/archive', () => {
+        archiveCalls += 1;
+        return new Promise((resolve) => {
+          resolveArchive = () => {
+            archiveSettled = true;
+            resolve(HttpResponse.json({ status: 'archived' }));
+          };
+        });
+      }),
+    );
+
+    renderWithProviders(<SessionSidebar />);
+    const row = await screen.findByText('Swipe pending');
+    const surface = row.closest('[data-swipe-surface="true"]') as HTMLElement | null;
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+    Object.defineProperty(container!, 'offsetWidth', {
+      configurable: true,
+      value: 390,
+    });
+
+    fireEvent.touchStart(surface!, { touches: [{ clientX: 320, clientY: 24 }] });
+    fireEvent.touchMove(surface!, { touches: [{ clientX: 170, clientY: 26 }] });
+    fireEvent.touchEnd(surface!);
+
+    await waitFor(() => {
+      expect(archiveCalls).toBe(1);
+    });
+    expect(screen.getByText('Swipe pending')).toBeInTheDocument();
+    expect(container).toHaveAttribute('data-swipe-state', 'committed');
+    expect(surface!.style.transform).toBe('translateX(-390px)');
+
+    resolveArchive?.();
+
+    await waitFor(() => {
+      expect(screen.queryByText('Swipe pending')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
+++ b/frontend/src/app/(dashboard)/sessions/session-sidebar.tsx
@@ -21,7 +21,7 @@ import { queryKeys } from "@/lib/query-keys";
 import { useOptimisticSessions, type OptimisticSession } from "@/contexts/optimistic-sessions";
 import { DiffStatsBadge } from "@/components/code-review/diff-stats-badge";
 import { NoReposWarning } from "@/components/no-repos-warning";
-import type { SessionListItem, User } from "@/lib/types";
+import type { ListResponse, SessionListItem, User } from "@/lib/types";
 import { prMergedAccent } from "@/lib/pr-status-styles";
 import { hasSessionKeyboardTransientSurface, isSessionKeyboardTextEntryTarget } from "@/hooks/use-session-keyboard-shortcuts";
 import {
@@ -318,9 +318,28 @@ export function SessionSidebar() {
     queryClient.invalidateQueries({ queryKey: queryKeys.sessions.all });
   };
 
+  const removeSessionFromCachedLists = (sessionId: string) => {
+    queryClient.setQueriesData<ListResponse<SessionListItem>>(
+      { queryKey: queryKeys.sessions.all },
+      (current) => {
+        if (!current || !Array.isArray(current.data)) {
+          return current;
+        }
+        const nextData = current.data.filter((session) => session.id !== sessionId);
+        if (nextData.length === current.data.length) {
+          return current;
+        }
+        return { ...current, data: nextData };
+      },
+    );
+  };
+
   const archiveMutation = useMutation({
     mutationFn: (sessionId: string) => api.sessions.archive(sessionId),
-    onSuccess: invalidateSessions,
+    onSuccess: (_response, sessionId) => {
+      removeSessionFromCachedLists(sessionId);
+      invalidateSessions();
+    },
     onError: () => {
       toast.error("Failed to archive session");
     },
@@ -328,7 +347,10 @@ export function SessionSidebar() {
 
   const unarchiveMutation = useMutation({
     mutationFn: (sessionId: string) => api.sessions.unarchive(sessionId),
-    onSuccess: invalidateSessions,
+    onSuccess: (_response, sessionId) => {
+      removeSessionFromCachedLists(sessionId);
+      invalidateSessions();
+    },
     onError: () => {
       toast.error("Failed to unarchive session");
     },

--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -334,6 +334,64 @@ describe('SwipeActionRow', () => {
     }
   });
 
+  it('keeps a revealed row slid left after tapping the action until the action settles', async () => {
+    vi.useFakeTimers();
+    const action = deferred<void>();
+    const onAction = vi.fn(() => action.promise);
+
+    try {
+      renderWithProviders(
+        <SwipeActionRow
+          actionLabel="Archive item"
+          actionText="Archive"
+          onAction={onAction}
+        >
+          <div>Row content</div>
+        </SwipeActionRow>,
+      );
+
+      const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]') as HTMLElement | null;
+      expect(surface).not.toBeNull();
+      const container = surface!.parentElement;
+      expect(container).not.toBeNull();
+      Object.defineProperty(container!, 'offsetWidth', {
+        configurable: true,
+        value: 390,
+      });
+
+      fireEvent.touchStart(surface!, {
+        touches: [{ clientX: 220, clientY: 20 }],
+      });
+      fireEvent.touchMove(surface!, {
+        touches: [{ clientX: 120, clientY: 24 }],
+      });
+      fireEvent.touchEnd(surface!);
+
+      expect(container).toHaveAttribute('data-swipe-state', 'open');
+
+      fireEvent.click(screen.getAllByRole('button', { name: 'Archive item' })[0]);
+
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(container).toHaveAttribute('data-swipe-state', 'committed');
+      expect(surface!.style.transform).toBe('translateX(-390px)');
+
+      await act(async () => {
+        action.resolve();
+        await action.promise;
+      });
+
+      expect(surface!.style.transform).toBe('translateX(-390px)');
+
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+
+      expect(surface!.style.transform).toBe('translateX(-0px)');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('swallows rejected promises from the revealed action button path', async () => {
     const action = deferred<void>();
     const onUnhandledRejection = vi.fn();

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -366,13 +366,10 @@ export function SwipeActionRow({
             aria-hidden={trailingActionHidden}
             tabIndex={trailingActionHidden ? -1 : 0}
             className="relative h-full w-full rounded-none rounded-r-lg bg-transparent px-0 text-white shadow-none hover:bg-transparent hover:text-white active:bg-transparent"
-            onClick={() => {
-              close();
-              try {
-                handleActionPromise(onAction());
-              } catch (error) {
-                throw error;
-              }
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              commitAction(containerRef.current?.offsetWidth || gestureWidth);
             }}
           >
             <span className="relative flex h-full w-full flex-col items-center justify-center gap-0.5 px-4 text-center">


### PR DESCRIPTION
## Summary
This fixes mobile session archiving so a swipe action in an “archived” row no longer snaps back/disappears prematurely while the archive request is still pending. The change ensures the revealed swipe path uses the same commit behavior as the release-to-archive flow, then waits for the backend to remove the session.

## Changes
- **frontend/src/components/swipe-action-row.tsx**
  - Updated the mobile swipe “revealed action” commit/reveal behavior to route through the same committed path as release-to-archive, preventing the row from closing before the async archive settles.
- **frontend/src/components/swipe-action-row.test.tsx**
  - Added/adjusted interaction tests to validate the committed/displaced UI state during pending async work and correct cleanup after completion.
- **frontend/src/app/(dashboard)/sessions/session-sidebar.tsx**
  - Ensured the sessions sidebar archive UI works with the updated swipe commit behavior so the row remains displaced while the backend call is in-flight.
- **frontend/src/app/(dashboard)/sessions/session-sidebar.test.tsx**
  - Added tests covering:
    - The shared swipe component behavior for pending archive requests.
    - The real sessions sidebar flow where the row stays displaced until the backend removes it, and only then disappears from the list.

## Test plan
- `npm run test -- --run 'src/app/(dashboard)/sessions/session-sidebar.test.tsx' src/components/swipe-action-row.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 93bf6707](https://143.dev/sessions/93bf6707-f732-492c-9ce1-c3457a16e691)