### PR TITLE
Fix active agent tab gradient underline in session tab strip

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -143,6 +143,8 @@ describe("AgentTabStrip", () => {
     expect(activeTab).not.toHaveTextContent(/Idle/i);
     expect(activeTab).toHaveClass("data-[state=active]:text-primary");
     expect(activeTab).toHaveClass("data-[state=active]:bg-transparent");
+    expect(activeTab).toHaveClass("after:bg-[image:var(--gradient-primary)]");
+    expect(activeTab).not.toHaveClass("after:bg-none");
     expect(screen.getByRole("tab", { name: /review/i })).not.toHaveTextContent(/Completed/i);
     expect(screen.getByRole("button", { name: "Close Main tab" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Close Review tab" })).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -288,7 +288,7 @@ export function AgentTabStrip({
                             disabled={isNonInteractive}
                             className={cn(
                               "h-7 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
-                              "after:bg-primary after:bg-none data-[state=active]:after:opacity-100",
+                              "after:bg-[image:var(--gradient-primary)] data-[state=active]:after:opacity-100",
                               showArchiveButton && "pr-8",
                               tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
                               isNonInteractive && "cursor-default opacity-60",


### PR DESCRIPTION
## Summary
Fixed the missing purple/gradient underline on the active agent tab in the session tab strip. The active-tab styles were overriding the shared underline by setting `after:bg-none`, which cleared the gradient image; the active state now preserves the gradient background.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx`**
  - Updated the active tab `after` background styling to use `after:bg-[image:var(--gradient-primary)]` instead of `after:bg-primary after:bg-none`, preventing the underline gradient from being removed.
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`**
  - Added a regression assertion to ensure the active tab keeps `after:bg-[image:var(--gradient-primary)]` and does **not** include `after:bg-none`.

## Test plan
- `npx vitest run 'src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

*(Note: the first test attempt was blocked due to missing local deps like `eslint`; ran `npm ci` before re-running.)*

[143.dev](https://143.dev) | [session ac31e080](https://143.dev/sessions/ac31e080-ab9c-4df5-afac-b7b31068d99f)