### PR TITLE
Align session header and detail panel heights with fixed h-14

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -334,12 +334,12 @@ describe('SessionDetailPage', () => {
     expect(screen.queryByRole('tab', { name: 'Validation' })).not.toBeInTheDocument();
   });
 
-  it('uses the same desktop header height for the conversation and detail panels', async () => {
+  it('uses the same desktop header bar height for the conversation and detail panels', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
 
-    expect(screen.getByTestId('session-main-header')).toHaveClass('min-h-14');
-    expect(screen.getByTestId('session-detail-header')).toHaveClass('min-h-14');
+    expect(screen.getByTestId('session-main-header')).toHaveClass('h-14');
+    expect(screen.getByTestId('session-detail-header-bar')).toHaveClass('h-14');
   });
 
   it('uses a dedicated mobile close button that does not compete with PR actions', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2464,7 +2464,7 @@ const MIN_DETAIL = 280;
 const MAX_DETAIL = 600;
 const DEFAULT_DETAIL = 384;
 const MOBILE_REVIEW_MEDIA_QUERY = "(max-width: 767px)";
-const SESSION_HEADER_HEIGHT_CLASSNAME = "min-h-14";
+const SESSION_HEADER_HEIGHT_CLASSNAME = "h-14";
 // Transcript keyboard scroll tuning. Step matches a comfortable line-pair
 // jump; page distance follows browser conventions (~85% viewport with a
 // floor for very short panels).
@@ -4312,9 +4312,12 @@ export function SessionDetailContent({ id }: { id: string }) {
     >
       <div
         data-testid="session-detail-header"
-        className={cn("border-b border-border px-2 py-2 shrink-0", SESSION_HEADER_HEIGHT_CLASSNAME)}
+        className="border-b border-border shrink-0"
       >
-        <div className="flex items-center gap-2 min-w-0">
+        <div
+          data-testid="session-detail-header-bar"
+          className={cn("flex items-center gap-2 min-w-0 px-2", SESSION_HEADER_HEIGHT_CLASSNAME)}
+        >
           <div
             ref={detailTabsRef}
             aria-label="Session detail tabs"


### PR DESCRIPTION
## Summary
This fixes a desktop layout mismatch between the session conversation header and the detail panel header by using the same fixed `h-14` height on both. The detail panel’s header bar was split out so PR error notices can render below without affecting normal header alignment.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Switch `SESSION_HEADER_HEIGHT_CLASSNAME` from `min-h-14` to `h-14`.
  - Remove the height class from the outer `session-detail-header` container.
  - Add `data-testid="session-detail-header-bar"` and apply `h-14` (via `SESSION_HEADER_HEIGHT_CLASSNAME`) to the inner header bar element.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Update the regression test to assert:
    - `session-main-header` has class `h-14`
    - `session-detail-header-bar` has class `h-14`
  - Adjust test description wording to match the new “header bar” terminology.

## Test plan
- `npx vitest run src/app/(dashboard)/sessions/[id]/page.test.tsx -t "same desktop header bar height"`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Note: ran `npm ci` first because `frontend/node_modules` was missing.

[143.dev](https://143.dev) | [session 29e87ece](https://143.dev/sessions/29e87ece-81a4-4727-9fc6-facf89cd13df)