### PR TITLE
Suppress benign Codex stdin diagnostics in session timelines

### DIFF
--- a/frontend/src/lib/timeline.test.ts
+++ b/frontend/src/lib/timeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildTimeline } from "./timeline";
+import { buildTimeline, buildTimelineFromResponse } from "./timeline";
 import type { SessionMessage, SessionLog } from "./types";
 
 function makeMessage(overrides: Partial<SessionMessage> & { id: number; created_at: string }): SessionMessage {
@@ -84,6 +84,28 @@ describe("buildTimeline", () => {
     const result = buildTimeline([], logs);
     expect(result).toHaveLength(1);
     expect(result[0].kind).toBe("error");
+  });
+
+  it("classifies the benign Codex stdin diagnostic as a hidden log", () => {
+    const logs = [
+      makeLog({ id: 1, created_at: "2026-01-01T00:00:01Z", level: "error", message: "Reading additional input from stdin..." }),
+    ];
+    const result = buildTimeline([], logs);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("log");
+  });
+
+  it("normalizes benign Codex stdin diagnostics from timeline responses", () => {
+    const log = makeLog({ id: 1, created_at: "2026-01-01T00:00:01Z", level: "error", message: "Reading additional input from stdin..." });
+    const result = buildTimelineFromResponse([
+      {
+        kind: "error",
+        created_at: "2026-01-01T00:00:01Z",
+        log,
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].kind).toBe("log");
   });
 
   it("shows streamed assistant output logs as assistant_output when no persisted message exists", () => {

--- a/frontend/src/lib/timeline.ts
+++ b/frontend/src/lib/timeline.ts
@@ -31,6 +31,10 @@ function isVisibleAssistantOutput(log: SessionLog): boolean {
   return log.level === "output" && (!log.metadata || !log.metadata.type || isAssistantFinalMetadata(log.metadata));
 }
 
+function isBenignCodexDiagnostic(log: SessionLog): boolean {
+  return log.level === "error" && log.message.trim() === "Reading additional input from stdin...";
+}
+
 function metadataString(metadata: SessionLog["metadata"] | null | undefined, key: string): string | undefined {
   const value = metadata?.[key];
   return typeof value === "string" ? value : undefined;
@@ -171,7 +175,7 @@ export function buildTimeline(
       continue;
     }
 
-    if (log.level === "error") {
+    if (log.level === "error" && !isBenignCodexDiagnostic(log)) {
       entries.push({ kind: "error", data: log });
       i++;
       continue;
@@ -207,6 +211,9 @@ export function timelineEntryFromResponse(entry: SessionTimelineResponseEntry): 
     case "tool_group":
       return { kind: "tool_group", toolUse: entry.tool_use!, toolResult: entry.tool_result };
     case "error":
+      if (entry.log && isBenignCodexDiagnostic(entry.log)) {
+        return { kind: "log", data: entry.log };
+      }
       return { kind: "error", data: entry.log! };
     case "log":
       return { kind: "log", data: entry.log! };

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -98,12 +98,15 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 		// event. We avoid `codex exec resume --last` because `--last` reads
 		// whichever rollout file is newest in ~/.codex/sessions, which is
 		// non-deterministic when stale entries are present.
-		msg := shellEscapeDouble(prompt.UserMessage)
+		promptPath := fmt.Sprintf("%s/.143-followup-prompt.md", sandbox.HomeDir)
+		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(prompt.UserMessage)); err != nil {
+			return nil, fmt.Errorf("write follow-up prompt file: %w", err)
+		}
 		cmd = fmt.Sprintf(
-			"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s %s \"%s\"",
+			"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s '%s' - < '%s'",
 			reasoningArg,
 			shellEscapeCodex(prompt.ResumeSessionID),
-			msg,
+			shellEscapeCodex(promptPath),
 		)
 	} else {
 		// Fresh exec — used for first turns and as the fallback for
@@ -116,7 +119,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s \"$(cat '%s')\"",
+			"codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s - < '%s'",
 			reasoningArg,
 			shellEscapeCodex(promptPath),
 		)
@@ -157,7 +160,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	// Filter refresh-token errors once and reuse the result.
 	var filteredStderr string
 	if len(stderr) > 0 {
-		filteredStderr = filterRefreshTokenLines(string(stderr))
+		filteredStderr = filterCodexStderrLines(string(stderr))
 		if filteredStderr != "" {
 			logCh <- agent.LogEntry{
 				Timestamp: time.Now(),
@@ -614,26 +617,38 @@ func isRefreshTokenError(msg string) bool {
 		strings.Contains(msg, "invalid_grant")
 }
 
-// filterRefreshTokenLines removes refresh-token error lines from stderr
-// output. Splits by newline and removes only lines matching refresh-token
-// errors, preserving any real error lines mixed in.
+// filterRefreshTokenLines preserves the previous helper name for tests and
+// callers that only care about refresh-token suppression.
 func filterRefreshTokenLines(stderr string) string {
+	return filterCodexStderrLines(stderr)
+}
+
+// filterCodexStderrLines removes known benign Codex CLI diagnostics from
+// stderr while preserving real failures. Codex prints the stdin notice when a
+// prompt argument is provided under non-TTY stdin; it is informational and the
+// CLI can still exit 0 after a successful turn.
+func filterCodexStderrLines(stderr string) string {
 	lines := strings.Split(stderr, "\n")
 	var kept []string
 	for _, line := range lines {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		if !isRefreshTokenError(line) {
-			kept = append(kept, line)
+		if isBenignCodexDiagnostic(line) || isRefreshTokenError(line) {
+			continue
 		}
+		kept = append(kept, line)
 	}
 	return strings.Join(kept, "\n")
 }
 
-// shellEscapeCodex escapes single quotes in a path for use inside a
-// single-quoted shell string. It is only used on internally-generated
-// file paths (e.g. promptPath), never on user-supplied input.
+func isBenignCodexDiagnostic(msg string) bool {
+	return strings.TrimSpace(msg) == "Reading additional input from stdin..."
+}
+
+// shellEscapeCodex escapes single quotes for use inside a single-quoted shell
+// string. It is only used on internally-generated values such as prompt paths
+// and Codex session IDs, never on user-supplied prompt text.
 func shellEscapeCodex(s string) string {
 	return strings.ReplaceAll(s, "'", "'\\''")
 }

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -681,6 +681,8 @@ func TestCodexAdapter_Execute(t *testing.T) {
 			promptData, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 			require.True(t, exists, "prompt file should have been written")
 			require.Contains(t, string(promptData), "Fix the bug.")
+			require.Contains(t, provider.ExecCalls[0], " - < '/home/sandbox/.143-prompt.md'", "codex should read the initial prompt from stdin to avoid appending Docker exec stdin")
+			require.NotContains(t, provider.ExecCalls[0], "\"$(cat '/home/sandbox/.143-prompt.md')\"", "codex should not pass the initial prompt as an argv argument")
 			require.NotContains(t, provider.ExecCalls[0], ".143-agent.pid", "codex adapter must not embed pidfile scaffolding (provider internal)")
 			require.NotContains(t, provider.ExecCalls[0], "& pid=$!", "codex adapter must not embed shell-shim wrapping (provider internal)")
 		})
@@ -782,6 +784,7 @@ func TestCodexAdapter_Execute_ContinuationWithoutSessionIDFallsBackToFreshExec(t
 	require.NotContains(t, provider.ExecCalls[0], "codex exec resume", "continuation without a session ID must not use the non-deterministic resume path")
 	require.NotContains(t, provider.ExecCalls[0], "--last", "the --last fallback must not be used")
 	require.Contains(t, provider.ExecCalls[0], "codex exec --dangerously-bypass-approvals-and-sandbox", "continuation without a session ID should run a fresh codex exec")
+	require.Contains(t, provider.ExecCalls[0], " - < '/home/sandbox/.143-prompt.md'", "fresh fallback should feed the embedded-history prompt over stdin")
 	contents, exists := provider.Files["/home/sandbox/.143-prompt.md"]
 	require.True(t, exists, "fresh exec must write the system+user prompt to a file")
 	require.Contains(t, string(contents), "history-embedded user prompt", "prompt file should carry the orchestrator-provided history-embedded user prompt")
@@ -888,8 +891,12 @@ func TestCodexAdapter_Execute_ContinuationWithResumeSessionIDIncludesReasoningEf
 	require.NotNil(t, result, "continuation should return a result")
 	require.Contains(t, provider.ExecCalls[0], `codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json`, "continuation should use explicit resume mode")
 	require.Contains(t, provider.ExecCalls[0], "session-123", "continuation should target the provided Codex session ID")
+	require.Contains(t, provider.ExecCalls[0], " - < '/home/sandbox/.143-followup-prompt.md'", "continuation should feed the follow-up prompt over stdin")
 	require.Contains(t, provider.ExecCalls[0], "model_reasoning_effort", "continuation should include the reasoning override config")
 	require.Contains(t, provider.ExecCalls[0], "xhigh", "continuation should include the requested reasoning effort")
+	contents, exists := provider.Files["/home/sandbox/.143-followup-prompt.md"]
+	require.True(t, exists, "continuation should write the follow-up prompt file")
+	require.Equal(t, "Please continue.", string(contents), "follow-up prompt file should contain the user message exactly")
 }
 
 func TestIsDuplicateOutput(t *testing.T) {
@@ -1095,6 +1102,44 @@ func TestFilterRefreshTokenLines(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, tt.expect, filterRefreshTokenLines(tt.input))
+		})
+	}
+}
+
+func TestFilterCodexStderrLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		expect string
+	}{
+		{
+			name:   "removes benign stdin diagnostic",
+			input:  "Reading additional input from stdin...",
+			expect: "",
+		},
+		{
+			name:   "removes benign stdin diagnostic while preserving real stderr",
+			input:  "Reading additional input from stdin...\nreal error line",
+			expect: "real error line",
+		},
+		{
+			name:   "keeps other stdin errors",
+			input:  "failed reading from stdin: permission denied",
+			expect: "failed reading from stdin: permission denied",
+		},
+		{
+			name:   "still removes refresh token errors",
+			input:  "Reading additional input from stdin...\nERROR codex_core::auth: Failed to refresh token: refresh_token_reused",
+			expect: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.expect, filterCodexStderrLines(tt.input), "codex stderr filtering should only remove known benign diagnostics")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Feed Codex prompts through stdin-backed prompt files so non-TTY execs stop emitting the noisy `Reading additional input from stdin...` diagnostic.
- Treat that exact Codex message as a benign runtime notice instead of a red error in both live timeline composition and persisted timeline responses.
- Add coverage for the Codex adapter path and the timeline classification logic.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Added targeted unit tests for the Codex adapter and frontend timeline behavior.