### PR TITLE
Simplify PeopleFilter trigger summary and remove user badge rendering

### DIFF
--- a/frontend/src/components/people-filter.test.tsx
+++ b/frontend/src/components/people-filter.test.tsx
@@ -28,4 +28,59 @@ describe("PeopleFilter", () => {
     expect(trigger).toHaveAttribute("data-size", "default");
     expect(trigger).toHaveClass("text-xs", "font-medium", "h-8");
   });
+
+  it("summarizes selected people in the trigger without rendering user badges", () => {
+    const members: User[] = [
+      {
+        id: "user-1",
+        org_id: "org-1",
+        name: "Jane Doe",
+        email: "jane@example.com",
+        role: "member",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "user-2",
+        org_id: "org-1",
+        name: "Grace Hopper",
+        email: "grace@example.com",
+        role: "member",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "user-3",
+        org_id: "org-1",
+        name: "Margaret Hamilton",
+        email: "margaret@example.com",
+        role: "member",
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ];
+
+    const { rerender, container } = renderWithProviders(
+      <PeopleFilter
+        mode="custom"
+        selectedUserIDs={["user-2"]}
+        members={members}
+        currentUser={members[0]}
+        onFilterChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Grace Hopper/ })).toBeInTheDocument();
+    expect(container.querySelector("[data-slot='badge']")).not.toBeInTheDocument();
+
+    rerender(
+      <PeopleFilter
+        mode="custom"
+        selectedUserIDs={["user-2", "user-3"]}
+        members={members}
+        currentUser={members[0]}
+        onFilterChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Grace Hopper \+1 other/ })).toBeInTheDocument();
+    expect(container.querySelector("[data-slot='badge']")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/people-filter.tsx
+++ b/frontend/src/components/people-filter.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { ChevronDown, Users } from "lucide-react";
-import { useMemo, useState } from "react";
-import { Badge } from "@/components/ui/badge";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
@@ -35,14 +34,6 @@ function serializeSelection(selectedUserIDs: string[], currentUser: User | null)
   return selectedUserIDs.join(",");
 }
 
-function filterChips(selectedUserIDs: string[], members: User[], currentUser: User | null) {
-  return selectedUserIDs.map((id) => {
-    if (id === currentUser?.id) return { id, label: "You" };
-    const member = members.find((item) => item.id === id);
-    return { id, label: member?.name.split(" ")[0] ?? "User" };
-  });
-}
-
 export function PeopleFilter({
   mode,
   selectedUserIDs,
@@ -54,7 +45,6 @@ export function PeopleFilter({
 }: PeopleFilterProps) {
   const [open, setOpen] = useState(false);
   const label = peopleFilterLabel(mode, selectedUserIDs, members, currentUser);
-  const chips = useMemo(() => filterChips(selectedUserIDs, members, currentUser), [currentUser, members, selectedUserIDs]);
 
   function setMine() {
     onFilterChange(null);
@@ -123,15 +113,6 @@ export function PeopleFilter({
                 Everyone
               </Button>
             </div>
-            {mode === "custom" && chips.length > 0 && (
-              <div className="mt-3 flex flex-wrap gap-1.5">
-                {chips.map((chip) => (
-                  <Badge key={chip.id} variant="secondary" className="text-xs">
-                    {chip.label}
-                  </Badge>
-                ))}
-              </div>
-            )}
           </div>
 
           <Command shouldFilter>
@@ -168,21 +149,6 @@ export function PeopleFilter({
           </Command>
         </PopoverContent>
       </Popover>
-
-      {mode === "custom" && chips.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1.5">
-          {chips.slice(0, 2).map((chip) => (
-            <Badge key={chip.id} variant="outline" className="text-xs">
-              {chip.label}
-            </Badge>
-          ))}
-          {chips.length > 2 && (
-            <Badge variant="outline" className="text-xs">
-              +{chips.length - 2}
-            </Badge>
-          )}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/hooks/use-people-filter.test.ts
+++ b/frontend/src/hooks/use-people-filter.test.ts
@@ -61,7 +61,7 @@ describe("usePeopleFilter helpers", () => {
   it("builds compact labels for custom selections", () => {
     expect(peopleFilterLabel("mine", ["user-1"], members, currentUser)).toBe("Mine");
     expect(peopleFilterLabel("all", [], members, currentUser)).toBe("Everyone");
-    expect(peopleFilterLabel("custom", ["user-2"], members, currentUser)).toBe("Grace");
-    expect(peopleFilterLabel("custom", ["user-2", "user-3"], members, currentUser)).toBe("Grace +1");
+    expect(peopleFilterLabel("custom", ["user-2"], members, currentUser)).toBe("Grace Hopper");
+    expect(peopleFilterLabel("custom", ["user-2", "user-3"], members, currentUser)).toBe("Grace Hopper +1 other");
   });
 });

--- a/frontend/src/hooks/use-people-filter.ts
+++ b/frontend/src/hooks/use-people-filter.ts
@@ -69,14 +69,14 @@ export function peopleFilterLabel(
   if (mode === "all") return "Everyone";
 
   const names = selectedUserIDs.map((id) => {
-    if (id === currentUser?.id) return "You";
+    if (id === currentUser?.id) return currentUser.name;
     const member = members.find((item) => item.id === id);
-    return member?.name.split(" ")[0] ?? "User";
+    return member?.name ?? "User";
   });
 
   if (names.length === 0) return "People";
   if (names.length === 1) return names[0];
-  return `${names[0]} +${names.length - 1}`;
+  return `${names[0]} +${names.length - 1} ${names.length === 2 ? "other" : "others"}`;
 }
 
 export function useFilterSuffix(


### PR DESCRIPTION
## Summary
Update the PeopleFilter “custom” UI to simplify how selected users are displayed in the dropdown trigger: the trigger now summarizes the lead selected user (e.g., “Grace Hopper +1 other”) while keeping the lead user included. User badges are no longer rendered to match the simplified design.

## Changes
- **frontend/src/components/people-filter.tsx**
  - Removed the custom-mode user badge/chip rendering (no more `<Badge />` elements for selected users).
  - Ensured the trigger title summarizes selected users without dropping the “lead” selected user.
- **frontend/src/hooks/use-people-filter.ts**
  - Adjusted the people filter logic that drives the trigger summary/counting so it stays consistent with the expected lead+others wording.
- **Tests**
  - **frontend/src/components/people-filter.test.tsx**: Added coverage asserting the trigger shows “Grace Hopper” / “Grace Hopper +1 other” and that no badge elements render.
  - **frontend/src/hooks/use-people-filter.test.ts**: Updated/validated behavior for lead-user retention in trigger summary.

## Test plan
- `npx vitest --run src/hooks/use-people-filter.test.ts src/components/people-filter.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 851c0023](https://143.dev/sessions/851c0023-46f2-4791-b1e0-98e91b3a5760)