### PR TITLE
[VIR-92] Run auth redirect middleware on / and /login so authenticated users land on /sessions

### DIFF
--- a/frontend/src/middleware.test.ts
+++ b/frontend/src/middleware.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { config, middleware } from "./middleware";
+
+function requestFor(path: string, cookie?: string) {
+  return new NextRequest(`https://143.dev${path}`, {
+    headers: cookie ? { cookie } : undefined,
+  });
+}
+
+describe("middleware", () => {
+  it("runs on the website homepage so authenticated sessions land in the app", () => {
+    expect(config.matcher).toContain("/");
+  });
+
+  it("redirects authenticated homepage requests to sessions", () => {
+    const response = middleware(requestFor("/", "session_token=token-123"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://143.dev/sessions");
+  });
+
+  it("allows unauthenticated homepage requests through", () => {
+    const response = middleware(requestFor("/"));
+
+    expect(response.headers.get("location")).toBeNull();
+  });
+});

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -15,5 +15,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/login"],
+  matcher: ["/", "/login"],
 };


### PR DESCRIPTION
## Summary

Implemented VIR-92.

Changed [frontend/src/middleware.ts](/home/sandbox/143/frontend/src/middleware.ts:18) so the auth-cookie redirect middleware runs on both `/` and `/login`. Authenticated visits to the website homepage now redirect to `/sessions`.

Added regression coverage in [frontend/src/middleware.test.ts](/home/sandbox/143/frontend/src/middleware.test.ts:11) for:
- matcher includes `/`
- authenticated `/` redirects to `/sessions`
- unauthenticated `/` continues normally

Verification passed:
- `npm exec vitest run src/middleware.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

Build emitted only existing Next.js warnings about multiple lockfiles and the deprecated `middleware` filename convention.

**Issue**: linear — VIR-92: Authenticated sessions should send you to the authenticated page (instead of the website homepage) (medium)

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 5c549a47](https://143.dev/sessions/5c549a47-74ef-4de3-98ef-34d648f43827)