### PR TITLE
Fix single-tab tooltip trigger scope in AgentTabStrip

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -105,6 +105,30 @@ describe("AgentTabStrip", () => {
     expect(screen.getByRole("tooltip")).toHaveTextContent("1 message queued");
   });
 
+  it("keeps the single-agent tooltip trigger scoped to the visible tab label", () => {
+    const thread = makeThread({ label: "Main" });
+
+    renderWithProviders(
+      <AgentTabStrip
+        threads={[thread]}
+        activeThreadId={thread.id}
+        viewedThreadIds={new Set([thread.id])}
+        overlapsByThreadId={new Map()}
+        statusConfig={statusConfig}
+        onActiveThreadChange={vi.fn()}
+        onAddTab={vi.fn()}
+        onRevertThread={vi.fn()}
+        onArchiveThread={vi.fn()}
+        archivePendingThreadId={null}
+      />,
+    );
+
+    const trigger = screen.getByRole("group", { name: "Codex Idle" });
+
+    expect(trigger).not.toHaveClass("flex-1");
+    expect(trigger.parentElement).toHaveClass("flex-1");
+  });
+
   it("keeps the full tab strip once a second tab exists", () => {
     const threads = [
       makeThread({ id: "thread-1", label: "Main tab" }),

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -153,81 +153,83 @@ export function AgentTabStrip({
       <TooltipProvider delayDuration={150}>
         <div className="shrink-0 border-b border-border bg-background px-3 py-2">
           <div className="flex min-w-0 items-center gap-2 min-h-9">
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div
-                  tabIndex={0}
-                  role="group"
-                  aria-label={`${agentLabel} ${statusLabel}`}
-                  className="flex min-w-0 flex-1 items-center gap-2 rounded-md px-1 py-1 outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                >
-                  {showUnreadDot ? (
-                    <span
-                      className={cn(
-                        "h-2 w-2 shrink-0 rounded-full bg-primary",
-                        activeThread.status === "running" && !isCancelling && "animate-pulse",
-                      )}
-                      aria-hidden
-                    />
-                  ) : (
-                    <span className="h-2 w-2 shrink-0" aria-hidden />
-                  )}
-                  <span className="truncate text-xs font-medium text-foreground">{activeThread.label}</span>
-                  {isCancelling && (
-                    <Loader2
-                      className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"
-                      aria-label="Cancelling"
-                    />
-                  )}
-                  {queued > 0 && (
-                    <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
-                      {queued}
-                    </Badge>
-                  )}
-                  {needsAttention && (
-                    <span
-                      className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
-                      aria-label="Needs attention"
-                    />
-                  )}
-                  {overlap.length > 0 && (
-                    <AlertTriangle
-                      className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
-                      aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
-                    />
-                  )}
-                </div>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" className="max-w-sm text-xs">
-                <div className="space-y-1">
-                  <div className="font-medium">
-                    {agentLabel}
-                    <span className="font-normal text-muted-foreground"> — {activeThread.label}</span>
-                  </div>
-                  <div className="text-muted-foreground">
-                    {statusLabel}
-                    {queued > 0 ? ` · ${queued} message${queued === 1 ? "" : "s"} queued` : ""}
-                  </div>
-                  {overlap.length > 0 && (
-                    <div className="pt-1">
-                      <div className="font-medium text-amber-700 dark:text-amber-400">
-                        Overlap with another tab:
-                      </div>
-                      <ul className="text-muted-foreground">
-                        {overlap.slice(0, 5).map((path) => (
-                          <li key={path} className="truncate">
-                            {path}
-                          </li>
-                        ))}
-                        {overlap.length > 5 && (
-                          <li className="text-muted-foreground/80">…and {overlap.length - 5} more</li>
+            <div className="flex min-w-0 flex-1 items-center">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    tabIndex={0}
+                    role="group"
+                    aria-label={`${agentLabel} ${statusLabel}`}
+                    className="inline-flex max-w-full min-w-0 items-center gap-2 rounded-md px-1 py-1 outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  >
+                    {showUnreadDot ? (
+                      <span
+                        className={cn(
+                          "h-2 w-2 shrink-0 rounded-full bg-primary",
+                          activeThread.status === "running" && !isCancelling && "animate-pulse",
                         )}
-                      </ul>
+                        aria-hidden
+                      />
+                    ) : (
+                      <span className="h-2 w-2 shrink-0" aria-hidden />
+                    )}
+                    <span className="truncate text-xs font-medium text-foreground">{activeThread.label}</span>
+                    {isCancelling && (
+                      <Loader2
+                        className="h-3.5 w-3.5 shrink-0 animate-spin text-muted-foreground"
+                        aria-label="Cancelling"
+                      />
+                    )}
+                    {queued > 0 && (
+                      <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
+                        {queued}
+                      </Badge>
+                    )}
+                    {needsAttention && (
+                      <span
+                        className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+                        aria-label="Needs attention"
+                      />
+                    )}
+                    {overlap.length > 0 && (
+                      <AlertTriangle
+                        className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
+                        aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
+                      />
+                    )}
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-sm text-xs">
+                  <div className="space-y-1">
+                    <div className="font-medium">
+                      {agentLabel}
+                      <span className="font-normal text-muted-foreground"> — {activeThread.label}</span>
                     </div>
-                  )}
-                </div>
-              </TooltipContent>
-            </Tooltip>
+                    <div className="text-muted-foreground">
+                      {statusLabel}
+                      {queued > 0 ? ` · ${queued} message${queued === 1 ? "" : "s"} queued` : ""}
+                    </div>
+                    {overlap.length > 0 && (
+                      <div className="pt-1">
+                        <div className="font-medium text-amber-700 dark:text-amber-400">
+                          Overlap with another tab:
+                        </div>
+                        <ul className="text-muted-foreground">
+                          {overlap.slice(0, 5).map((path) => (
+                            <li key={path} className="truncate">
+                              {path}
+                            </li>
+                          ))}
+                          {overlap.length > 5 && (
+                            <li className="text-muted-foreground/80">…and {overlap.length - 5} more</li>
+                          )}
+                        </ul>
+                      </div>
+                    )}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </div>
 
             <ThreadActionsMenu
               threads={tabs}


### PR DESCRIPTION
## Summary
Updated `AgentTabStrip` so the single-agent tooltip trigger is scoped to the visible tab label/status cluster rather than stretching across the entire top bar. This ensures the tooltip appears when hovering “Main”, matching the intended UI behavior and covering the regression mentioned.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx`**
  - Adjusted the `TooltipTrigger`/wrapper markup so it no longer inherits the flex growth (`flex-1`) used by the surrounding row.
  - Kept the tooltip hover target aligned to the actual tab content (label + status indicators), preventing accidental activation from the broader top-bar area.
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`**
  - Added regression test: verifies the single-agent tooltip trigger does **not** have `flex-1` (and that the parent may, but the trigger itself remains scoped).

## Test plan
- `npx vitest run src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 7b889ee0](https://143.dev/sessions/7b889ee0-4e88-4aa8-b8e2-a622c7bfc5a1)