### PR TITLE
Fix GitHub installation claims migration to deduplicate by installation_id before upsert

### DIFF
--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -141,3 +141,22 @@ func TestAutomationsGoalLengthExpandMigrationRaisesConstraint(t *testing.T) {
 	require.Contains(t, upSQL, "char_length(goal) BETWEEN 1 AND 64000",
 		"up migration should raise the automation goal cap to 64000 characters")
 }
+
+func TestGitHubInstallationClaimsMigrationDeduplicatesInstallationsBeforeUpsert(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("../../migrations/000126_github_installation_repo_claims.up.sql")
+	require.NoError(t, err, "test should read the GitHub installation claims migration")
+
+	sql := string(body)
+	require.Contains(t, sql, "WITH installation_candidates AS",
+		"migration should stage installation candidates before the upsert")
+	require.Contains(t, sql, "ROW_NUMBER() OVER",
+		"migration should rank candidates so each installation_id is upserted once")
+	require.Contains(t, sql, "PARTITION BY installation_id",
+		"migration should deduplicate by installation_id before ON CONFLICT DO UPDATE")
+	require.Contains(t, sql, "MIN(created_at) OVER (PARTITION BY installation_id) AS first_seen_created_at",
+		"migration should preserve the earliest integration timestamp for installation created_at")
+	require.Contains(t, sql, "WHERE candidate_rank = 1",
+		"migration should only upsert the selected candidate per installation")
+}

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -159,4 +160,19 @@ func TestGitHubInstallationClaimsMigrationDeduplicatesInstallationsBeforeUpsert(
 		"migration should preserve the earliest integration timestamp for installation created_at")
 	require.Contains(t, sql, "WHERE candidate_rank = 1",
 		"migration should only upsert the selected candidate per installation")
+}
+
+func TestGitHubInstallationClaimsDownMigrationDropsChildLinksFirst(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("../../migrations/000126_github_installation_repo_claims.down.sql")
+	require.NoError(t, err, "test should read the GitHub installation claims down migration")
+
+	sql := string(body)
+	linkDrop := strings.Index(sql, "DROP TABLE IF EXISTS github_installation_org_links")
+	installationDrop := strings.Index(sql, "DROP TABLE IF EXISTS github_installations")
+	require.NotEqual(t, -1, linkDrop, "down migration should drop github_installation_org_links")
+	require.NotEqual(t, -1, installationDrop, "down migration should drop github_installations")
+	require.Less(t, linkDrop, installationDrop,
+		"down migration should drop child org-link table before parent installations table")
 }

--- a/migrations/000126_github_installation_repo_claims.up.sql
+++ b/migrations/000126_github_installation_repo_claims.up.sql
@@ -34,23 +34,50 @@ CREATE INDEX idx_github_installation_org_links_org
 CREATE INDEX idx_github_installation_org_links_installation
     ON github_installation_org_links (installation_id, status);
 
+WITH installation_candidates AS (
+    SELECT
+        (i.config->>'installation_id')::bigint AS installation_id,
+        COALESCE(NULLIF(i.config->>'account_id', '')::bigint, 0) AS account_id,
+        COALESCE(NULLIF(i.config->>'account_login', ''), split_part(r.full_name, '/', 1), 'unknown') AS account_login,
+        NULLIF(i.config->>'account_id', '') IS NULL AS missing_account_id,
+        NULLIF(i.config->>'account_login', '') IS NULL AS missing_account_login,
+        i.created_at,
+        i.id AS integration_id,
+        r.full_name
+    FROM integrations i
+    LEFT JOIN repositories r
+      ON r.integration_id = i.id
+    WHERE i.provider = 'github'
+      AND i.config ? 'installation_id'
+      AND NULLIF(i.config->>'installation_id', '') IS NOT NULL
+),
+ranked_installation_candidates AS (
+    SELECT
+        installation_id,
+        account_id,
+        account_login,
+        MIN(created_at) OVER (PARTITION BY installation_id) AS first_seen_created_at,
+        ROW_NUMBER() OVER (
+            PARTITION BY installation_id
+            ORDER BY
+                missing_account_id,
+                missing_account_login,
+                created_at ASC,
+                integration_id ASC,
+                full_name ASC NULLS LAST
+        ) AS candidate_rank
+    FROM installation_candidates
+)
 INSERT INTO github_installations (installation_id, account_id, account_login, status, created_at, updated_at)
-SELECT DISTINCT
-    (i.config->>'installation_id')::bigint AS installation_id,
-    COALESCE(NULLIF(i.config->>'account_id', '')::bigint, 0) AS account_id,
-    COALESCE(NULLIF(i.config->>'account_login', ''), split_part(r.full_name, '/', 1), 'unknown') AS account_login,
+SELECT
+    installation_id,
+    account_id,
+    account_login,
     'active',
-    min(i.created_at),
+    first_seen_created_at,
     now()
-FROM integrations i
-LEFT JOIN repositories r
-  ON r.integration_id = i.id
-WHERE i.provider = 'github'
-  AND i.config ? 'installation_id'
-  AND NULLIF(i.config->>'installation_id', '') IS NOT NULL
-GROUP BY (i.config->>'installation_id')::bigint,
-         COALESCE(NULLIF(i.config->>'account_id', '')::bigint, 0),
-         COALESCE(NULLIF(i.config->>'account_login', ''), split_part(r.full_name, '/', 1), 'unknown')
+FROM ranked_installation_candidates
+WHERE candidate_rank = 1
 ON CONFLICT (installation_id) DO UPDATE
 SET account_id = EXCLUDED.account_id,
     account_login = EXCLUDED.account_login,


### PR DESCRIPTION
## Summary
Updated the `000126_github_installation_repo_claims` migration to ensure only one row per `installation_id` is upserted. This deduplicates staged candidates before `ON CONFLICT DO UPDATE` and preserves the earliest `created_at` as `github_installations.created_at`.

## Changes
- **migrations/000126_github_installation_repo_claims.up.sql**
  - Refactored the insert to stage candidates in CTEs (`installation_candidates`, `ranked_installation_candidates`).
  - Added `ROW_NUMBER() OVER (PARTITION BY installation_id ...)` to rank candidates and select a single winner per `installation_id`.
  - Kept a separate `MIN(created_at) OVER (PARTITION BY installation_id) AS first_seen_created_at` and used it to populate `github_installations.created_at`.
  - Limited the upsert source rows with `WHERE candidate_rank = 1` to prevent multi-row conflicts.
- **internal/db/migrations_test.go**
  - Added `TestGitHubInstallationClaimsMigrationDeduplicatesInstallationsBeforeUpsert` to assert the migration contains the expected deduplication and “first seen” timestamp logic.

## Test plan
- `make lint-schema`
- `go test ./internal/db -run TestGitHubInstallationClaimsMigrationDeduplicatesInstallationsBeforeUpsert -count=1`
- `go vet -p=1 ./...`
- `go build -p=1 ./...`
- `go test -p=1 ./...`

[143.dev](https://143.dev) | [session 7ec371c2](https://143.dev/sessions/7ec371c2-4e4c-4e13-9a49-603c5187fcdc)