### PR TITLE
Fix automation header emoji picker to update instantly without switching tabs

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -90,7 +90,7 @@ describe("AutomationDetailPage", () => {
     await waitFor(() => {
       expect(screen.getByText("Weekly audit")).toBeInTheDocument();
     });
-    expect(screen.getByLabelText("Automation icon for Weekly audit")).toHaveTextContent("🧪");
+    expect(screen.getByRole("button", { name: "Change automation emoji" })).toHaveTextContent("🧪");
 
     await userEvent.setup().click(screen.getByRole("tab", { name: "Settings" }));
 
@@ -420,6 +420,73 @@ describe("AutomationDetailPage", () => {
     await user.click(await screen.findByRole("option", { name: /Rocket/ }));
     await user.click(screen.getByRole("button", { name: "Save changes" }));
 
+    await waitFor(() => {
+      expect(updateBody).toMatchObject({ icon_type: "emoji", icon_value: "🚀" });
+    });
+  });
+
+  it("updates the automation emoji from the header picker without changing tabs", async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          icon_type: "emoji",
+          icon_value: "🧪",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ data: { id: "auto-1", icon_type: "emoji", icon_value: "🚀" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Change automation emoji" }));
+    await user.click(await screen.findByRole("option", { name: /Rocket/ }));
+
+    expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("data-state", "active");
     await waitFor(() => {
       expect(updateBody).toMatchObject({ icon_type: "emoji", icon_value: "🚀" });
     });

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -62,7 +62,13 @@ type IntervalUnit = (typeof INTERVAL_UNITS)[number];
 const toIntervalUnit = (v: string, fallback: IntervalUnit): IntervalUnit =>
   (INTERVAL_UNITS as readonly string[]).includes(v) ? (v as IntervalUnit) : fallback;
 
-function SettingsTab({ automation, canManage }: { automation: Automation; canManage: boolean }) {
+function SettingsTab({
+  automation,
+  canManage,
+}: {
+  automation: Automation;
+  canManage: boolean;
+}) {
   const queryClient = useQueryClient();
   const [name, setName] = useState(automation.name);
   const [goal, setGoal] = useState(automation.goal);
@@ -128,7 +134,11 @@ function SettingsTab({ automation, canManage }: { automation: Automation; canMan
     <div className="space-y-4 rounded-lg border border-border bg-card p-5">
       <div className="space-y-1.5">
         <Label>Emoji</Label>
-        <AutomationEmojiPicker value={iconValue} onChange={setIconValue} className="w-full sm:w-64" />
+        <AutomationEmojiPicker
+          value={iconValue}
+          onChange={setIconValue}
+          className="w-full sm:w-64"
+        />
       </div>
       <div className="space-y-1.5">
         <Label htmlFor="name">Name</Label>
@@ -367,6 +377,41 @@ export default function AutomationDetailPage() {
     onSuccess: () => router.push("/automations"),
   });
 
+  const iconMutation = useMutation({
+    mutationFn: (iconValue: string) =>
+      api.automations.update(automationId, {
+        icon_type: "emoji",
+        icon_value: iconValue,
+      }),
+    onMutate: async (iconValue: string) => {
+      await queryClient.cancelQueries({ queryKey: ["automation", automationId] });
+      const previous = queryClient.getQueryData<typeof data>(["automation", automationId]);
+      queryClient.setQueryData<typeof data>(["automation", automationId], (current) => {
+        if (!current?.data) return current;
+        return {
+          ...current,
+          data: {
+            ...current.data,
+            icon_type: "emoji",
+            icon_value: iconValue,
+          },
+        };
+      });
+      return { previous };
+    },
+    onError: (_err, _iconValue, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["automation", automationId], context.previous);
+      }
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(["automation", automationId], updated);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["automation", automationId] });
+    },
+  });
+
   if (isLoading) {
     return (
       <PageContainer size="default">
@@ -413,6 +458,7 @@ export default function AutomationDetailPage() {
     pauseMutation.isError ? "Failed to pause automation." :
     resumeMutation.isError ? "Failed to resume automation." :
     runNowMutation.isError ? "Failed to trigger run." :
+    iconMutation.isError ? "Failed to update automation emoji." :
     deleteMutation.isError ? "Failed to delete automation." :
     null;
 
@@ -423,12 +469,22 @@ export default function AutomationDetailPage() {
         <PageHeader
           title={
             <span className="inline-flex min-w-0 items-center gap-3">
-              <span
-                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-card text-lg leading-none"
-                aria-label={`Automation icon for ${automation.name}`}
-              >
-                {automation.icon_value || "⚙️"}
-              </span>
+              {canManage ? (
+                <AutomationEmojiPicker
+                  value={automation.icon_value || "⚙️"}
+                  onChange={(iconValue) => iconMutation.mutate(iconValue)}
+                  trigger="icon"
+                  triggerLabel="Change automation emoji"
+                  disabled={iconMutation.isPending}
+                />
+              ) : (
+                <span
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-border bg-card text-lg leading-none"
+                  aria-label={`Automation icon for ${automation.name}`}
+                >
+                  {automation.icon_value || "⚙️"}
+                </span>
+              )}
               <span className="min-w-0 truncate">{automation.name}</span>
             </span>
           }

--- a/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
+++ b/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
@@ -31,32 +31,58 @@ export function AutomationEmojiPicker({
   value,
   onChange,
   className,
+  open,
+  onOpenChange,
+  trigger = "select",
+  triggerLabel = "Automation emoji",
+  disabled = false,
 }: {
   value: string;
   onChange: (value: string) => void;
   className?: string;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  trigger?: "select" | "icon";
+  triggerLabel?: string;
+  disabled?: boolean;
 }) {
-  const [open, setOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const pickerOpen = open ?? internalOpen;
+  const setPickerOpen = onOpenChange ?? setInternalOpen;
   const selected = useMemo(
     () => AUTOMATION_EMOJIS.find((item) => item.emoji === value) ?? AUTOMATION_EMOJIS[0],
     [value],
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
       <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          aria-label="Automation emoji"
-          className={cn("h-10 justify-between", className)}
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="text-lg leading-none" aria-hidden="true">{selected.emoji}</span>
-            <span className="truncate">{selected.label}</span>
-          </span>
-          <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </Button>
+        {trigger === "icon" ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-lg"
+            aria-label={triggerLabel}
+            disabled={disabled}
+            className={cn("text-lg leading-none", className)}
+          >
+            {selected.emoji}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="outline"
+            aria-label={triggerLabel}
+            disabled={disabled}
+            className={cn("h-10 justify-between", className)}
+          >
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="text-lg leading-none" aria-hidden="true">{selected.emoji}</span>
+              <span className="truncate">{selected.label}</span>
+            </span>
+            <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+          </Button>
+        )}
       </PopoverTrigger>
       <PopoverContent className="w-72 p-0" align="start">
         <Command>
@@ -71,7 +97,7 @@ export function AutomationEmojiPicker({
                   checked={item.emoji === selected.emoji}
                   onSelect={() => {
                     onChange(item.emoji);
-                    setOpen(false);
+                    setPickerOpen(false);
                   }}
                 >
                   <span className="text-lg leading-none" aria-hidden="true">{item.emoji}</span>


### PR DESCRIPTION
## Summary
Updated the automation detail header emoji picker so it opens and applies in-place on mobile/desktop without forcing a tab change. The UI now optimistically updates the header emoji and rolls back if the PATCH request fails, and the tab selection behavior from this interaction has been removed.

## Changes
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Adjusted the header emoji picker interaction to open the emoji dropdown directly in place.
  - Implemented optimistic UI update for the header emoji and added rollback on backend failure.
  - Ensured selecting an emoji does **not** select/activate the **Settings** tab.
- **frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx**
  - Updated picker behavior to support immediate dropdown interaction and correct selection flow for the header use case.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Updated an existing assertion to target the new accessible control label: **“Change automation emoji”**.
  - Added a test verifying emoji updates from the header picker without changing tabs and that the PATCH payload contains `{ icon_type: "emoji", icon_value: "..." }`.

## Test plan
- `npx vitest run 'src/app/(dashboard)/automations/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 9d2ca40d](https://143.dev/sessions/9d2ca40d-f67e-4903-9e5c-bf21c262dc2e)