### PR TITLE
[codex] fix worker preview sandbox routing

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestFrontendContainerBindsAllInterfaces(t *testing.T) {
@@ -631,4 +632,23 @@ func TestSandboxDNSConfigAlignment(t *testing.T) {
 	dockerfileText := string(dockerfile)
 	require.Contains(t, dockerfileText, "--server=127.0.0.11", "dnsmasq must forward to Docker's embedded resolver — that's the only place preview-infra container names are registered")
 	require.Contains(t, dockerfileText, "--no-resolv", "dnsmasq must ignore its own /etc/resolv.conf (which itself points at 127.0.0.11) to avoid a forwarding loop")
+}
+
+func TestWorkerCanReachSandboxBridge(t *testing.T) {
+	t.Parallel()
+
+	compose, err := os.ReadFile("../docker-compose.worker.yml")
+	require.NoError(t, err, "test should read the worker compose file")
+
+	var parsed struct {
+		Services map[string]struct {
+			Networks map[string]any `yaml:"networks"`
+		} `yaml:"services"`
+	}
+	require.NoError(t, yaml.Unmarshal(compose, &parsed), "worker compose should be valid YAML")
+
+	worker, ok := parsed.Services["worker"]
+	require.True(t, ok, "worker compose should define the worker service")
+	require.Contains(t, worker.Networks, "default", "worker must stay on the default compose network so it can reach chrome and other local services")
+	require.Contains(t, worker.Networks, "sandbox", "worker must join 143-sandbox so preview proxy dials can reach sandbox container IPs")
 }

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -123,6 +123,9 @@ services:
     # expose 8080 on the public IP for monitoring.
     ports:
       - "${WORKER_PRIVATE_IP:?missing in /opt/143/.env.local}:8080:8080"
+    networks:
+      default: {}
+      sandbox: {}
     group_add:
       - ${DOCKER_GID:-988}
     volumes:


### PR DESCRIPTION
## Summary

- Attach the worker service to both the default compose network and the external `143-sandbox` bridge.
- Add a deploy regression test that parses `docker-compose.worker.yml` and verifies the worker keeps default-network access while joining the sandbox bridge.

## Root Cause

Preview services were healthy inside the sandbox, but the worker process could not dial sandbox container IPs such as `172.30.0.3:3000`. The worker container was only on the default compose network, while sandboxes and `sandbox-dns` live on the external `143-sandbox` bridge.

## Impact

After workers are recreated with this compose change, preview proxy and reachability checks can route from the worker container to sandbox preview ports.

## Validation

- `go test ./deploy -count=1`
- `go vet ./deploy`
- `git diff --check`