### PR TITLE
Pin worker default route to the compose bridge

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -642,7 +642,9 @@ func TestWorkerCanReachSandboxBridge(t *testing.T) {
 
 	var parsed struct {
 		Services map[string]struct {
-			Networks map[string]any `yaml:"networks"`
+			Networks map[string]struct {
+				GatewayPriority int `yaml:"gw_priority"`
+			} `yaml:"networks"`
 		} `yaml:"services"`
 	}
 	require.NoError(t, yaml.Unmarshal(compose, &parsed), "worker compose should be valid YAML")
@@ -651,4 +653,5 @@ func TestWorkerCanReachSandboxBridge(t *testing.T) {
 	require.True(t, ok, "worker compose should define the worker service")
 	require.Contains(t, worker.Networks, "default", "worker must stay on the default compose network so it can reach chrome and other local services")
 	require.Contains(t, worker.Networks, "sandbox", "worker must join 143-sandbox so preview proxy dials can reach sandbox container IPs")
+	require.Greater(t, worker.Networks["default"].GatewayPriority, worker.Networks["sandbox"].GatewayPriority, "worker default gateway must stay on the compose default network so DB/private-fleet traffic does not route through the sandbox bridge")
 }

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -124,8 +124,14 @@ services:
     ports:
       - "${WORKER_PRIVATE_IP:?missing in /opt/143/.env.local}:8080:8080"
     networks:
-      default: {}
-      sandbox: {}
+      # The worker must join 143-sandbox to dial preview/sandbox container IPs,
+      # but DB/private-fleet traffic must keep using the normal compose bridge
+      # default gateway. If Docker picks 143-sandbox as the default route,
+      # startup DB pings go through the sandbox egress path and time out.
+      default:
+        gw_priority: 1
+      sandbox:
+        gw_priority: 0
     group_add:
       - ${DOCKER_GID:-988}
     volumes:


### PR DESCRIPTION
## Summary
- Set the worker container’s compose `default` network to a higher `gw_priority` than `143-sandbox` so Postgres and private-fleet traffic keep using the normal bridge route.
- Keep the worker attached to `143-sandbox` for preview/sandbox IP reachability, but prevent Docker from choosing it as the default gateway.
- Add a regression test that verifies the worker joins both networks and that `default` has higher gateway priority than `sandbox`.

## Testing
- Added a deploy config test covering the worker network priorities.
- `go vet ./...` passed.
- `go build ./...` passed.
- `go test ./...` passed.
- Verified on a worker host with a temporary container that the default route stays on `172.18.0.1` and TCP to `10.0.0.3:5432` succeeds.