### PR TITLE
Relocate PR commit message files out of /tmp in sandbox pushes

### DIFF
--- a/internal/services/agent/providers/docker.go
+++ b/internal/services/agent/providers/docker.go
@@ -952,6 +952,9 @@ func writeFileTarTarget(sb *agent.Sandbox, cleanPath, fallbackRelPath string) (s
 		}
 	}
 	if bestRoot == "" {
+		if strings.HasPrefix(cleanPath, "/") {
+			return path.Dir(cleanPath), path.Base(cleanPath)
+		}
 		return "/", fallbackRelPath
 	}
 	return bestRoot, strings.TrimPrefix(cleanPath, bestRoot+"/")

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -2435,6 +2435,51 @@ func TestDockerProvider_ShellInjection(t *testing.T) {
 		}
 		require.True(t, foundFile, "tar payload should preserve the literal destination path")
 	})
+
+	t.Run("WriteFile to tmp does not rewrite tmp directory metadata", func(t *testing.T) {
+		t.Parallel()
+
+		var capturedCmd []string
+		conn := newCapturingConn()
+
+		mock := &mockDockerClient{}
+		mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+			capturedCmd = config.Cmd
+			return container.ExecCreateResponse{ID: "exec-tmp-write"}, nil
+		}
+		mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+			return types.HijackedResponse{Conn: conn, Reader: bufio.NewReader(conn)}, nil
+		}
+		mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+			return container.ExecInspect{ExitCode: 0}, nil
+		}
+		p := NewDockerProvider(mock, newTestLogger())
+		sb := &agent.Sandbox{ID: "test-container", Provider: "docker", WorkDir: "/workspace", HomeDir: "/home/sandbox"}
+
+		err := p.WriteFile(context.Background(), sb, "/tmp/143-pr-commit-msg", []byte("commit message"))
+		require.NoError(t, err, "WriteFile should support existing absolute directories such as /tmp")
+		require.Equal(t, []string{"tar", "xf", "-", "-C", "/tmp"}, capturedCmd, "WriteFile should extract directly into /tmp instead of rewriting /tmp metadata")
+
+		tr := tar.NewReader(bytes.NewReader(conn.Captured()))
+		var foundFile bool
+		for {
+			hdr, readErr := tr.Next()
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			require.NoError(t, readErr, "tar payload should be readable")
+			require.NotEqual(t, "tmp/", hdr.Name, "tar payload must not include the existing /tmp directory")
+			require.NotEqual(t, "tmp/143-pr-commit-msg", hdr.Name, "tar payload must be relative to /tmp, not rooted at /")
+			if hdr.Name != "143-pr-commit-msg" {
+				continue
+			}
+			foundFile = true
+			body, readErr := io.ReadAll(tr)
+			require.NoError(t, readErr, "tar file body should be readable")
+			require.Equal(t, []byte("commit message"), body, "tar payload should contain the requested file bytes")
+		}
+		require.True(t, foundFile, "tar payload should contain the tmp target file")
+	})
 }
 
 func TestDockerProvider_CloneRepo(t *testing.T) {

--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1068,15 +1068,16 @@ func (s *PRService) pushSessionBranch(
 		}
 	}()
 
+	commitMsgPath := pushCommitMsgPath(sandbox.HomeDir)
 	// Commit message goes to a file so multi-line / hostile content can't
 	// leak through argv. Token goes via the helper socket — no token files,
 	// no askpass shell stub.
-	if err := s.sandboxProvider.WriteFile(ctx, sandbox, pushCommitMsgPath, []byte(commitMsg)); err != nil {
+	if err := s.sandboxProvider.WriteFile(ctx, sandbox, commitMsgPath, []byte(commitMsg)); err != nil {
 		return nil, fmt.Errorf("write commit message to sandbox: %w", err)
 	}
 
 	pushURL := fmt.Sprintf("https://github.com/%s.git", repo.FullName)
-	script := buildPushScript(sandbox.WorkDir, authorName, authorEmail, branchName, pushURL)
+	script := buildPushScript(sandbox.WorkDir, commitMsgPath, authorName, authorEmail, branchName, pushURL)
 
 	var stdout, stderr bytes.Buffer
 	exitCode, execErr := s.sandboxProvider.Exec(ctx, sandbox, script, &stdout, &stderr)
@@ -1206,10 +1207,19 @@ func (s *PRService) captureSandboxSnapshot(ctx context.Context, sandbox *agent.S
 	return path, size, nil
 }
 
-// pushCommitMsgPath is the in-sandbox file the script reads `git commit -F`
-// from. Under /tmp so it's auto-cleaned on sandbox destroy; the trap inside
-// the script also removes it explicitly on exit for defense in depth.
-const pushCommitMsgPath = "/tmp/143-pr-commit-msg"
+// pushCommitMsgFilename is the in-sandbox file the script reads with
+// `git commit -F`. Keep it under HomeDir rather than /tmp: /tmp is a hardened
+// tmpfs in runsc sandboxes, and tar-based file injection must not rely on
+// mutating /tmp metadata.
+const pushCommitMsgFilename = ".143-pr-commit-msg"
+
+func pushCommitMsgPath(homeDir string) string {
+	root := strings.TrimRight(strings.TrimSpace(homeDir), "/")
+	if root == "" {
+		root = "/home/sandbox"
+	}
+	return root + "/" + pushCommitMsgFilename
+}
 
 // pushExitNoChanges is the sentinel exit code the push script uses when the
 // restored working tree has no uncommitted changes AND no commits ahead of
@@ -1273,10 +1283,10 @@ echo "%[8]s$(git rev-parse HEAD)"
 // Every %s interpolation is passed through shellQuote, which correctly
 // handles embedded single quotes (via the `'\”` trick) — so any UTF-8
 // string is safe to interpolate.
-func buildPushScript(workDir, authorName, authorEmail, branchName, pushURL string) string {
+func buildPushScript(workDir, commitMsgPath, authorName, authorEmail, branchName, pushURL string) string {
 	return fmt.Sprintf(
 		pushScriptTemplate,
-		shellQuote(pushCommitMsgPath),
+		shellQuote(commitMsgPath),
 		shellQuote(workDir),
 		shellQuote(authorName),
 		shellQuote(authorEmail),

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3713,6 +3713,7 @@ func TestBuildPushScript_Structure(t *testing.T) {
 
 	script := buildPushScript(
 		"/home/user/repo",
+		"/home/user/.143-pr-commit-msg",
 		"Test User",
 		"test@example.com",
 		"143/abc123/fix-typo",
@@ -3721,7 +3722,7 @@ func TestBuildPushScript_Structure(t *testing.T) {
 
 	// Only the commit-msg file is created by the script; auth comes from
 	// the per-push credential socket, so there's nothing else to clean up.
-	require.Contains(t, script, "cleanup() { rm -f '/tmp/143-pr-commit-msg'; }")
+	require.Contains(t, script, "cleanup() { rm -f '/home/user/.143-pr-commit-msg'; }")
 	require.Contains(t, script, "trap cleanup EXIT")
 
 	// Author identity is set via git config with quoted values.
@@ -3732,7 +3733,7 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	require.Contains(t, script, "cd '/home/user/repo'")
 
 	// Commit message is read from file (not argv).
-	require.Contains(t, script, "git commit -F '/tmp/143-pr-commit-msg'")
+	require.Contains(t, script, "git commit -F '/home/user/.143-pr-commit-msg'")
 
 	// Push uses --force-with-lease keyed on the remote SHA we just observed
 	// via ls-remote. Auth flows through credential.helper=!143-tools
@@ -3758,6 +3759,7 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 	// shellQuote's '\'' trick must keep the script well-formed.
 	script := buildPushScript(
 		"/home/user/repo",
+		"/home/user/.143-pr-commit-msg",
 		"Bot",
 		"bot@example.com",
 		"143/abc/it's-fine",
@@ -3946,6 +3948,7 @@ func TestPushSessionBranch(t *testing.T) {
 
 	const fakeHeadSHA = "abc1234567890abcdef1234567890abcdef12345"
 	successStdout := pushHeadSHASentinel + fakeHeadSHA + "\n"
+	commitMsgPath := pushCommitMsgPath(agent.DefaultSandboxConfig().HomeDir)
 
 	tests := []struct {
 		name                 string
@@ -3968,7 +3971,7 @@ func TestPushSessionBranch(t *testing.T) {
 		{
 			name:           "write commit message failure returns error",
 			snapshots:      &prTestSnapshotStore{payload: []byte("snapshot")},
-			provider:       &prTestSandboxProvider{writeErrs: map[string]error{pushCommitMsgPath: errors.New("disk full")}},
+			provider:       &prTestSandboxProvider{writeErrs: map[string]error{commitMsgPath: errors.New("disk full")}},
 			wantErrSubstr:  "write commit message to sandbox",
 			wantDestroyCnt: 1,
 		},
@@ -4071,7 +4074,7 @@ func TestPushSessionBranch(t *testing.T) {
 			} else {
 				require.NoError(t, err, "pushSessionBranch should succeed")
 				require.NotNil(t, result, "pushSessionBranch should return a non-nil result on success")
-				require.Equal(t, []byte("commit message"), tt.provider.writes[pushCommitMsgPath], "pushSessionBranch should write the commit message file")
+				require.Equal(t, []byte("commit message"), tt.provider.writes[commitMsgPath], "pushSessionBranch should write the commit message file under the sandbox home directory")
 				require.NotContains(t, tt.provider.lastExecCmd, "GIT_ASKPASS", "pushSessionBranch should auth via the credential socket, not askpass")
 				require.NotContains(t, tt.provider.lastExecCmd, "x-access-token", "pushSessionBranch should not embed credentials in the push URL")
 				require.Equal(t, tt.wantHeadSHA, result.HeadSHA, "pushSessionBranch should return the parsed HEAD SHA")
@@ -4758,7 +4761,7 @@ func TestCreatePR_SuccessPushesSnapshotBranchAndStoresPR(t *testing.T) {
 	require.Equal(t, "owner/repo", pr.GitHubRepo, "CreatePR should store the repository name")
 	require.Equal(t, 1, labelCalls, "CreatePR should add labels to the created PR")
 	require.Equal(t, true, createPRPayload["draft"], "CreatePR should honor the org default draft setting")
-	require.Contains(t, string(provider.writes[pushCommitMsgPath]), "Co-authored-by: Alice <alice@example.com>", "CreatePR should include a co-author trailer when using the app token for a user-triggered run")
+	require.Contains(t, string(provider.writes[pushCommitMsgPath(agent.DefaultSandboxConfig().HomeDir)]), "Co-authored-by: Alice <alice@example.com>", "CreatePR should include a co-author trailer when using the app token for a user-triggered run")
 	require.Contains(t, provider.lastExecCmd, "HEAD:refs/heads/", "CreatePR should push the restored branch before opening the PR")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 	_ = body


### PR DESCRIPTION
## Summary
- Move the temporary PR commit-message file from `/tmp` into the sandbox home directory so tar-based writes do not mutate hardened `/tmp` metadata in runsc sandboxes.
- Update the Docker provider’s tar target logic to write directly into absolute directories like `/tmp` without rewriting parent directory entries.
- Add regression coverage for both the Docker write path and push-script rendering.

## Testing
- Added/updated unit tests covering the `/tmp` write regression and push script path rendering.
- Verified the change with the existing Go test suite, including the new regression coverage.