### PR TITLE
Fix GitHub workspace repository selection

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { renderWithProviders, screen, waitFor, userEvent } from "@/test/test-utils";
+import { renderWithProviders, screen, waitFor, within, userEvent } from "@/test/test-utils";
 import IntegrationsPage from "./page";
 
 const {
@@ -123,5 +123,16 @@ describe("IntegrationsPage", () => {
 
     await user.click(screen.getByRole("button", { name: "Connect GitHub account" }));
     expect(githubConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders repository claiming controls inside the GitHub integration card", async () => {
+    renderWithProviders(<IntegrationsPage />);
+
+    await screen.findByText("acme/api");
+
+    const githubCard = screen.getByText("GitHub").closest("[data-testid='integration-card']");
+    expect(githubCard).not.toBeNull();
+    expect(within(githubCard as HTMLElement).getByText("acme/api")).toBeInTheDocument();
+    expect(screen.queryByText("GitHub repositories")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -88,75 +88,73 @@ function GitHubRepositoryClaims({
 
   return (
     <>
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm">GitHub repositories</CardTitle>
-          <CardDescription>
+      <div className="mt-3 border-t border-border pt-3">
+        <div className="mb-2">
+          <p className="text-xs font-medium text-foreground">Repository access</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
             Choose which repositories this 143 organization owns from the connected GitHub installation.
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {isLoading ? (
-            <p className="text-sm text-muted-foreground">Loading repositories...</p>
-          ) : error ? (
-            <p className="text-sm text-destructive">
-              {error instanceof Error ? error.message : "Failed to load GitHub repositories."}
-            </p>
-          ) : repos.length === 0 ? (
-            <p className="text-sm text-muted-foreground">No repositories are available to this GitHub App installation.</p>
-          ) : (
-            <div className="space-y-2">
-              {repos.map((repo) => {
-                const transfer = repo.status === "owned_by_other_org";
-                const canClaim = repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (transfer && repo.can_transfer);
-                const pending = claimMutation.isPending && claimMutation.variables?.githubId === repo.github_id;
-                return (
-                  <div key={repo.github_id} className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
-                    <div className="min-w-0">
-                      <div className="truncate text-sm font-medium">{repo.full_name}</div>
-                      <div className="mt-1 flex items-center gap-2">
-                        <Badge variant={repo.status === "owned_by_current_org" ? "secondary" : "outline"} className="text-xs">
-                          {claimStatusLabel(repo)}
-                        </Badge>
-                        {repo.private && <span className="text-xs text-muted-foreground">Private</span>}
-                      </div>
+          </p>
+        </div>
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading repositories...</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">
+            {error instanceof Error ? error.message : "Failed to load GitHub repositories."}
+          </p>
+        ) : repos.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No repositories are available to this GitHub App installation.</p>
+        ) : (
+          <div className="space-y-2">
+            {repos.map((repo) => {
+              const transfer = repo.status === "owned_by_other_org";
+              const canClaim = repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (transfer && repo.can_transfer);
+              const pending = claimMutation.isPending && claimMutation.variables?.githubId === repo.github_id;
+              return (
+                <div key={repo.github_id} className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium">{repo.full_name}</div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <Badge variant={repo.status === "owned_by_current_org" ? "secondary" : "outline"} className="text-xs">
+                        {claimStatusLabel(repo)}
+                      </Badge>
+                      {repo.private && <span className="text-xs text-muted-foreground">Private</span>}
                     </div>
-                    {canClaim ? (
-                      <Button
-                        size="sm"
-                        variant={transfer ? "outline" : "default"}
-                        loading={pending}
-                        disabled={pending}
-                        onClick={() => {
-                          if (transfer) setTransferRepo(repo);
-                          else claimMutation.mutate({ githubId: repo.github_id, allowTransfer: false });
-                        }}
-                      >
-                        {transfer ? "Transfer" : "Claim"}
-                      </Button>
-                    ) : null}
                   </div>
-                );
-              })}
-              {claimMutation.isError && (
-                <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
-                  <p className="text-sm text-destructive">
-                    {claimError instanceof Error ? claimError.message : "Failed to claim repository."}
-                  </p>
-                  {needsGitHubUserAuth && (
-                    <Button size="sm" variant="outline" onClick={() => api.githubStatus.connect()}>
-                      Connect GitHub account
+                  {canClaim ? (
+                    <Button
+                      size="sm"
+                      variant={transfer ? "outline" : "default"}
+                      loading={pending}
+                      disabled={pending}
+                      onClick={() => {
+                        if (transfer) setTransferRepo(repo);
+                        else claimMutation.mutate({ githubId: repo.github_id, allowTransfer: false });
+                      }}
+                    >
+                      {transfer ? "Transfer" : "Claim"}
                     </Button>
-                  )}
+                  ) : null}
                 </div>
-              )}
-              {actionable.length === 0 && (
-                <p className="text-xs text-muted-foreground">All available repositories are already accounted for.</p>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+              );
+            })}
+            {claimMutation.isError && (
+              <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
+                <p className="text-sm text-destructive">
+                  {claimError instanceof Error ? claimError.message : "Failed to claim repository."}
+                </p>
+                {needsGitHubUserAuth && (
+                  <Button size="sm" variant="outline" onClick={() => api.githubStatus.connect()}>
+                    Connect GitHub account
+                  </Button>
+                )}
+              </div>
+            )}
+            {actionable.length === 0 && (
+              <p className="text-xs text-muted-foreground">All available repositories are already accounted for.</p>
+            )}
+          </div>
+        )}
+      </div>
       <AlertDialog open={!!transferRepo} onOpenChange={(open) => !open && setTransferRepo(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
@@ -437,6 +435,14 @@ export default function IntegrationsPage() {
         onDisconnectRepo={(id) => disconnectRepoMutation.mutate(id)}
         onReconnectRepo={undefined}
         pendingRepoID={pendingRepoID}
+        githubExtra={
+          isAdmin && githubConnected ? (
+            <GitHubRepositoryClaims
+              installationId={githubIntegration?.github_installation_id}
+              enabled={githubConnected}
+            />
+          ) : undefined
+        }
         sentryConnected={Boolean(sentryIntegration)}
         linearConnected={Boolean(linearIntegration)}
         linearLoading={false}
@@ -464,12 +470,6 @@ export default function IntegrationsPage() {
         disconnectError={disconnectMutation.isError ? "Failed to disconnect." : null}
         readOnly={!isAdmin}
       />
-      {isAdmin && githubConnected && (
-        <GitHubRepositoryClaims
-          installationId={githubIntegration?.github_installation_id}
-          enabled={githubConnected}
-        />
-      )}
       {slackIntegration && isAdmin && <SlackChannelPicker />}
       </div>
 

--- a/frontend/src/components/integration-connection-cards.tsx
+++ b/frontend/src/components/integration-connection-cards.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { RefreshCw, X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
@@ -38,6 +38,7 @@ type RepoCallbacks = {
 type SourceControlIntegrationCardProps = IntegrationCallbacks & RepoCallbacks & {
   githubConnected: boolean;
   githubRepos?: GithubRepoChip[];
+  githubExtra?: ReactNode;
   onConnectGitHub: () => void;
   onSyncRepos?: () => void;
   isSyncing?: boolean;
@@ -407,6 +408,7 @@ export function SourceControlIntegrationCard({
   onDisconnectRepo,
   onReconnectRepo,
   pendingRepoID,
+  githubExtra,
 }: SourceControlIntegrationCardProps) {
   const github = getIntegrationByKey("github");
 
@@ -420,12 +422,15 @@ export function SourceControlIntegrationCard({
           logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
           badge: <Badge variant="outline" className="text-xs">Required</Badge>,
           extra: githubConnected ? (
-            <ConnectedReposList
-              repos={githubRepos}
-              onDisconnectRepo={onDisconnectRepo}
-              onReconnectRepo={onReconnectRepo}
-              pendingRepoID={pendingRepoID}
-            />
+            <>
+              <ConnectedReposList
+                repos={githubRepos}
+                onDisconnectRepo={onDisconnectRepo}
+                onReconnectRepo={onReconnectRepo}
+                pendingRepoID={pendingRepoID}
+              />
+              {githubExtra}
+            </>
           ) : undefined,
           action: (
             <div className="flex items-center gap-1.5">
@@ -527,12 +532,15 @@ export function AllIntegrationCards(props: AllIntegrationCardsProps) {
     logo: <IntegrationLogo name={github.name} src={github.logoSrc} />,
     badge: <Badge variant="outline" className="text-xs">Required</Badge>,
     extra: props.githubConnected ? (
-      <ConnectedReposList
-        repos={props.githubRepos ?? []}
-        onDisconnectRepo={props.readOnly ? undefined : props.onDisconnectRepo}
-        onReconnectRepo={props.readOnly ? undefined : props.onReconnectRepo}
-        pendingRepoID={props.pendingRepoID}
-      />
+      <>
+        <ConnectedReposList
+          repos={props.githubRepos ?? []}
+          onDisconnectRepo={props.readOnly ? undefined : props.onDisconnectRepo}
+          onReconnectRepo={props.readOnly ? undefined : props.onReconnectRepo}
+          pendingRepoID={props.pendingRepoID}
+        />
+        {props.githubExtra}
+      </>
     ) : undefined,
     action: (
       <IntegrationAction

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -1335,6 +1335,9 @@ func (h *IntegrationHandler) githubInstallationLink(ctx context.Context, orgID u
 		if installationID > 0 && cfg.InstallationID != installationID {
 			continue
 		}
+		if !h.githubInstallationAllowsConfigFallback(ctx, cfg.InstallationID) {
+			continue
+		}
 		if cfg.AccountLogin == "" {
 			cfg.AccountLogin = "unknown"
 		}
@@ -1362,6 +1365,20 @@ func (h *IntegrationHandler) githubInstallationLink(ctx context.Context, orgID u
 	}
 
 	return models.GitHubInstallationOrgLink{}, false
+}
+
+func (h *IntegrationHandler) githubInstallationAllowsConfigFallback(ctx context.Context, installationID int64) bool {
+	if h.githubInstallations == nil || installationID == 0 {
+		return true
+	}
+	installation, err := h.githubInstallations.GetByInstallationID(ctx, installationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return true
+	}
+	if err != nil {
+		return false
+	}
+	return installation.Status == "" || installation.Status == "active"
 }
 
 func (h *IntegrationHandler) userIsAdminInOrg(ctx context.Context, userID, orgID uuid.UUID) bool {

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -1319,30 +1319,48 @@ func (h *IntegrationHandler) githubInstallationLink(ctx context.Context, orgID u
 			return link, true
 		}
 	}
-	if installationID == 0 {
-		integrations, err := h.integrationStore.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
-		if err != nil || len(integrations) == 0 {
-			return models.GitHubInstallationOrgLink{}, false
-		}
+
+	integrations, err := h.integrationStore.ListByOrgAndProvider(ctx, orgID, string(models.IntegrationProviderGitHub))
+	if err != nil || len(integrations) == 0 {
+		return models.GitHubInstallationOrgLink{}, false
+	}
+	for _, integration := range integrations {
 		var cfg struct {
 			InstallationID int64  `json:"installation_id"`
 			AccountLogin   string `json:"account_login"`
 		}
-		if integrations[0].Config == nil || json.Unmarshal(integrations[0].Config, &cfg) != nil || cfg.InstallationID == 0 {
-			return models.GitHubInstallationOrgLink{}, false
+		if integration.Config == nil || json.Unmarshal(integration.Config, &cfg) != nil || cfg.InstallationID == 0 {
+			continue
 		}
-		installationID = cfg.InstallationID
+		if installationID > 0 && cfg.InstallationID != installationID {
+			continue
+		}
 		if cfg.AccountLogin == "" {
 			cfg.AccountLogin = "unknown"
 		}
 		return models.GitHubInstallationOrgLink{
 			OrgID:          orgID,
-			IntegrationID:  &integrations[0].ID,
-			InstallationID: installationID,
+			IntegrationID:  &integration.ID,
+			InstallationID: cfg.InstallationID,
 			AccountLogin:   cfg.AccountLogin,
 			Status:         "active",
 		}, true
 	}
+
+	if h.repoStore != nil {
+		repoInstallationID, repoErr := h.repoStore.GetAnyInstallationIDByOrg(ctx, orgID)
+		if repoErr == nil && repoInstallationID > 0 && (installationID == 0 || repoInstallationID == installationID) {
+			accountLogin := "unknown"
+			return models.GitHubInstallationOrgLink{
+				OrgID:          orgID,
+				IntegrationID:  &integrations[0].ID,
+				InstallationID: repoInstallationID,
+				AccountLogin:   accountLogin,
+				Status:         "active",
+			}, true
+		}
+	}
+
 	return models.GitHubInstallationOrgLink{}, false
 }
 

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -1913,6 +1913,45 @@ func TestIntegrationHandler_GitHubInstallationLink_FallsBackToRepoInstallationFo
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestIntegrationHandler_GitHubInstallationLink_DoesNotFallBackToDeletedInstallationConfig(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	handler := NewIntegrationHandler(
+		db.NewIntegrationStore(mock),
+		nil,
+		"",
+		"",
+		"http://localhost:8080",
+		"http://localhost:3000",
+	)
+	handler.githubInstallations = db.NewGitHubInstallationStore(mock)
+
+	mock.ExpectQuery("SELECT l.id, l.org_id, l.integration_id, l.installation_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "integration_id", "installation_id", "account_login", "linked_by_user_id", "status", "created_at", "updated_at"}))
+	mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE org_id = @org_id AND provider = @provider AND status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+			AddRow(integrationID, orgID, "github", json.RawMessage(`{"installation_id":12345,"account_login":"acme"}`), "active", nil, now))
+	mock.ExpectQuery("SELECT installation_id, account_id, account_login, account_type, repository_selection, status, created_at, updated_at").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"installation_id", "account_id", "account_login", "account_type", "repository_selection", "status", "created_at", "updated_at"}).
+			AddRow(int64(12345), int64(987), "acme", nil, nil, "deleted", now, now))
+
+	link, ok := handler.githubInstallationLink(context.Background(), orgID, 12345)
+
+	require.False(t, ok, "githubInstallationLink should not synthesize a link for a deleted GitHub installation")
+	require.Equal(t, models.GitHubInstallationOrgLink{}, link, "deleted installation fallback should return an empty link")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestIntegrationHandler_ClaimGitHubInstallationRepositories_MapsUniqueOwnershipRaceToConflict(t *testing.T) {
 	t.Parallel()
 

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -1870,6 +1870,49 @@ func TestIntegrationHandler_ClaimGitHubInstallationRepositories_RequiresUserAuth
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestIntegrationHandler_GitHubInstallationLink_FallsBackToRepoInstallationForExplicitID(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgxmock pool should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	handler := NewIntegrationHandler(
+		db.NewIntegrationStore(mock),
+		nil,
+		"",
+		"",
+		"http://localhost:8080",
+		"http://localhost:3000",
+	)
+	handler.githubInstallations = db.NewGitHubInstallationStore(mock)
+	handler.repoStore = db.NewRepositoryStore(mock)
+
+	mock.ExpectQuery("SELECT l.id, l.org_id, l.integration_id, l.installation_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "integration_id", "installation_id", "account_login", "linked_by_user_id", "status", "created_at", "updated_at"}))
+	mock.ExpectQuery("SELECT id, org_id, provider, config, status, last_synced_at, created_at FROM integrations WHERE org_id = @org_id AND provider = @provider AND status = 'active'").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}).
+			AddRow(integrationID, orgID, "github", json.RawMessage(`{}`), "active", nil, now))
+	mock.ExpectQuery("SELECT installation_id FROM repositories").
+		WithArgs(pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"installation_id"}).AddRow(int64(12345)))
+
+	link, ok := handler.githubInstallationLink(context.Background(), orgID, 12345)
+
+	require.True(t, ok, "githubInstallationLink should synthesize a link from legacy repository installation data")
+	require.Equal(t, orgID, link.OrgID, "fallback link should remain scoped to the requesting org")
+	require.NotNil(t, link.IntegrationID, "fallback link should preserve the active integration id for claims")
+	require.Equal(t, integrationID, *link.IntegrationID, "fallback link should use the active GitHub integration")
+	require.Equal(t, int64(12345), link.InstallationID, "fallback link should use the requested installation id")
+	require.Equal(t, "unknown", link.AccountLogin, "fallback link should have a stable account label when config is missing it")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestIntegrationHandler_ClaimGitHubInstallationRepositories_MapsUniqueOwnershipRaceToConflict(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fix the GitHub repository selection flow for legacy orgs whose active repositories still carry the GitHub installation ID, but whose newer `github_installation_org_links` row/config is missing.
- Keep the fallback scoped: stale integration config is not accepted when the global GitHub installation is known to be deleted.
- Move the repository claim/transfer controls into the existing top GitHub integration card and remove the duplicate standalone GitHub repositories card.

## Why
The integrations page could show GitHub as connected in the top card while the repository selector below failed with `github installation is not linked to this organization`. That happened because the top card inferred installation state from active repo rows, while the selector required a newer installation-org link row.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- `npm test -- --run 'src/app/(dashboard)/settings/integrations/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`