### PR TITLE
Refine preview path tracking to preserve navigation restores

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -342,7 +342,7 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 
 	// Intercept heartbeat pings before recording activity so the heartbeat
 	// URL does not overwrite last_path (which is used for navigation restore).
-	if r.URL.Path == "/__143_heartbeat" {
+	if r.URL.Path == previewHeartbeatPath {
 		// Still record access for idle timeout tracking.
 		if err := g.manager.RecordAccess(r.Context(), orgID, previewID); err != nil {
 			g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to record access")
@@ -355,13 +355,50 @@ func (g *Gateway) handleProxy(w http.ResponseWriter, r *http.Request, previewID 
 	if err := g.manager.RecordAccess(r.Context(), orgID, previewID); err != nil {
 		g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to record access")
 	}
-	if r.URL.Path != "" && r.URL.Path != "/" && !strings.HasPrefix(r.URL.Path, "/__143_") {
+	if shouldRecordPreviewLastPath(r) {
 		if err := g.manager.RecordLastPath(r.Context(), orgID, previewID, r.URL.Path); err != nil {
 			g.logger.Warn().Err(err).Str("preview_id", previewID.String()).Msg("failed to record last path")
 		}
 	}
 
 	g.proxyToWorker(w, r, orgID, previewID)
+}
+
+const (
+	previewPlatformPathPrefix = "/__143_"
+	previewHeartbeatPath      = previewPlatformPathPrefix + "heartbeat"
+)
+
+func shouldRecordPreviewLastPath(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+
+	requestPath := r.URL.Path
+	if requestPath == "" || requestPath == "/" {
+		return false
+	}
+	if strings.HasPrefix(requestPath, previewPlatformPathPrefix) {
+		return false
+	}
+
+	// Browser navigations advertise Sec-Fetch-Dest: document. Framework
+	// internals, assets, EventSource/HMR, and fetch/XHR requests do not.
+	if fetchDest := r.Header.Get("Sec-Fetch-Dest"); fetchDest != "" {
+		return fetchDest == "document"
+	}
+
+	return acceptsHTMLDocument(r.Header.Get("Accept"))
+}
+
+func acceptsHTMLDocument(accept string) bool {
+	for _, rawPart := range strings.Split(accept, ",") {
+		mediaType := strings.ToLower(strings.TrimSpace(strings.SplitN(rawPart, ";", 2)[0]))
+		if mediaType == "text/html" || mediaType == "application/xhtml+xml" {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *Gateway) proxyToWorker(w http.ResponseWriter, r *http.Request, orgID, previewID uuid.UUID) {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -67,6 +67,111 @@ func TestExtractPreviewID(t *testing.T) {
 	}
 }
 
+func TestShouldRecordPreviewLastPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		headers map[string]string
+		want    bool
+	}{
+		{
+			name:   "records document navigation from fetch metadata",
+			method: http.MethodGet,
+			path:   "/login",
+			headers: map[string]string{
+				"Sec-Fetch-Dest": "document",
+			},
+			want: true,
+		},
+		{
+			name:   "records document navigation from accept header",
+			method: http.MethodGet,
+			path:   "/sessions/abc",
+			headers: map[string]string{
+				"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+			},
+			want: true,
+		},
+		{
+			name:   "skips root",
+			method: http.MethodGet,
+			path:   "/",
+			headers: map[string]string{
+				"Sec-Fetch-Dest": "document",
+			},
+			want: false,
+		},
+		{
+			name:   "skips platform heartbeat",
+			method: http.MethodGet,
+			path:   "/__143_heartbeat",
+			headers: map[string]string{
+				"Sec-Fetch-Dest": "empty",
+			},
+			want: false,
+		},
+		{
+			name:   "skips framework event stream",
+			method: http.MethodGet,
+			path:   "/framework-hmr",
+			headers: map[string]string{
+				"Accept": "text/event-stream",
+			},
+			want: false,
+		},
+		{
+			name:   "skips script asset",
+			method: http.MethodGet,
+			path:   "/assets/app.js",
+			headers: map[string]string{
+				"Sec-Fetch-Dest": "script",
+			},
+			want: false,
+		},
+		{
+			name:   "skips json fetch",
+			method: http.MethodGet,
+			path:   "/rpc/auth/me",
+			headers: map[string]string{
+				"Accept": "application/json",
+			},
+			want: false,
+		},
+		{
+			name:   "skips image asset",
+			method: http.MethodGet,
+			path:   "/favicon.ico",
+			headers: map[string]string{
+				"Sec-Fetch-Dest": "image",
+			},
+			want: false,
+		},
+		{
+			name:   "skips non-get request",
+			method: http.MethodPost,
+			path:   "/login",
+			headers: map[string]string{
+				"Accept": "text/html",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			for key, value := range tt.headers {
+				req.Header.Set(key, value)
+			}
+			require.Equal(t, tt.want, shouldRecordPreviewLastPath(req), "gateway should only preserve user navigation paths for preview restore")
+		})
+	}
+}
+
 func TestEncodeDecode_CookieValue(t *testing.T) {
 	t.Parallel()
 	secret := []byte("test-secret-key-for-hmac")


### PR DESCRIPTION
## Summary
- Update preview gateway path tracking to distinguish real document navigations from framework internals, assets, and non-navigation requests.
- Reuse shared preview path constants for heartbeat handling.
- Add table-driven coverage for the new last-path recording rules.

## Testing
- Added unit tests for `shouldRecordPreviewLastPath` covering document navigations, platform paths, assets, fetch/XHR requests, and non-GET methods.
- Not run (not requested).