### PR TITLE
Make Linear state events idempotent without aborting transactions

### DIFF
--- a/internal/db/linear_state_events.go
+++ b/internal/db/linear_state_events.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // LinearStateEventKind names a state-sync trigger so the fire-once unique
@@ -90,7 +89,7 @@ var ErrLinearStateEventExists = errors.New("linear state event already exists")
 // Insert records a state transition or skip decision. Returns
 // ErrLinearStateEventExists when the unique constraint blocks a duplicate.
 func (s *LinearStateEventStore) Insert(ctx context.Context, orgID uuid.UUID, in LinearStateEventInput) error {
-	_, err := s.db.Exec(ctx, `
+	tag, err := s.db.Exec(ctx, `
 		INSERT INTO session_issue_link_state_events (
 			org_id, session_id, issue_id, event_kind,
 			transition_from, transition_to, skipped_reason
@@ -99,7 +98,8 @@ func (s *LinearStateEventStore) Insert(ctx context.Context, orgID uuid.UUID, in 
 			@org_id, @session_id, @issue_id, @event_kind,
 			NULLIF(@transition_from, ''), NULLIF(@transition_to, ''),
 			NULLIF(@skipped_reason, '')
-		)`,
+		)
+		ON CONFLICT (session_id, issue_id, event_kind) DO NOTHING`,
 		pgx.NamedArgs{
 			"org_id":          orgID,
 			"session_id":      in.SessionID,
@@ -110,11 +110,10 @@ func (s *LinearStateEventStore) Insert(ctx context.Context, orgID uuid.UUID, in 
 			"skipped_reason":  string(in.SkippedReason),
 		})
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
-			return ErrLinearStateEventExists
-		}
 		return fmt.Errorf("insert linear state event: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrLinearStateEventExists
 	}
 	return nil
 }

--- a/internal/db/linear_state_events_test.go
+++ b/internal/db/linear_state_events_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/stretchr/testify/require"
 )
@@ -24,24 +23,24 @@ func TestLinearStateEventStore_Insert(t *testing.T) {
 		{
 			name: "inserts event",
 			setup: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectExec("INSERT INTO session_issue_link_state_events").
+				mock.ExpectExec("INSERT INTO session_issue_link_state_events[\\s\\S]+ON CONFLICT \\(session_id, issue_id, event_kind\\) DO NOTHING").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnResult(pgxmock.NewResult("INSERT", 1))
 			},
 		},
 		{
-			name: "maps unique violation",
+			name: "maps duplicate no-op without aborting transaction",
 			setup: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectExec("INSERT INTO session_issue_link_state_events").
+				mock.ExpectExec("INSERT INTO session_issue_link_state_events[\\s\\S]+ON CONFLICT \\(session_id, issue_id, event_kind\\) DO NOTHING").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
-					WillReturnError(&pgconn.PgError{Code: "23505"})
+					WillReturnResult(pgxmock.NewResult("INSERT", 0))
 			},
 			expectedErr: ErrLinearStateEventExists,
 		},
 		{
 			name: "wraps insert errors",
 			setup: func(mock pgxmock.PgxPoolIface) {
-				mock.ExpectExec("INSERT INTO session_issue_link_state_events").
+				mock.ExpectExec("INSERT INTO session_issue_link_state_events[\\s\\S]+ON CONFLICT \\(session_id, issue_id, event_kind\\) DO NOTHING").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnError(errors.New("db unavailable"))
 			},

--- a/internal/services/linear/create_path_test.go
+++ b/internal/services/linear/create_path_test.go
@@ -1096,6 +1096,48 @@ func TestWithProviderStateLockedUsesTransaction(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestWithProviderStateLockedDuplicateStateEventStillCommits(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	issueID := uuid.New()
+	linkID := uuid.New()
+	mock.ExpectBegin()
+	mock.ExpectExec("INSERT INTO session_issue_link_provider_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 1))
+	mock.ExpectExec("SELECT 1 FROM session_issue_link_provider_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("SELECT", 1))
+	mock.ExpectQuery("SELECT state FROM session_issue_link_provider_state").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"state"}).AddRow([]byte(`{"identifier":"ACS-1"}`)))
+	mock.ExpectExec("INSERT INTO session_issue_link_state_events[\\s\\S]+ON CONFLICT \\(session_id, issue_id, event_kind\\) DO NOTHING").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("INSERT", 0))
+	mock.ExpectCommit()
+
+	svc := &Service{pool: mock, providerState: newFakeProviderStateStore(), stateEvents: newFakeStateEventStore()}
+	err = svc.withProviderStateLocked(context.Background(), orgID, linkID, func(ctx context.Context, _ providerStateStore, txEvents stateEventStore, _ db.LinearProviderState) error {
+		err := txEvents.Insert(ctx, orgID, db.LinearStateEventInput{
+			SessionID:      sessionID,
+			IssueID:        issueID,
+			EventKind:      db.LinearStateEventStarted,
+			TransitionFrom: "Backlog",
+			TransitionTo:   "In Progress",
+		})
+		require.ErrorIs(t, err, db.ErrLinearStateEventExists, "duplicate fire-once events should surface as the idempotent sentinel")
+		return nil
+	})
+	require.NoError(t, err, "duplicate state event handling should not abort the provider-state transaction")
+	require.NoError(t, mock.ExpectationsWereMet(), "duplicate event no-op must still allow the outer transaction to commit")
+}
+
 func TestServiceProviderStateSnapshotAndNotifier(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Switched `session_issue_link_state_events` inserts to `ON CONFLICT DO NOTHING` so duplicate Linear milestones no longer poison the surrounding transaction.
- Kept `ErrLinearStateEventExists` as the replay signal by checking `RowsAffected() == 0`.
- Added regression coverage for both the DB store and the `withProviderStateLocked` transaction path to ensure duplicate state events still commit cleanly.

## Testing
- `go test ./internal/db -run TestLinearStateEventStore -count=1`
- `go test ./internal/services/linear -run 'TestWithProviderStateLocked|TestHandleStateTransition_FireOnceCollapseDuplicates' -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`