### PR TITLE
Fix preview failure notifications and improve expandable error log truncation

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -584,6 +584,9 @@ describe("PreviewPanel component", () => {
 
     const startupLogRegion = screen.getByLabelText("Preview startup error logs");
     expect(startupLogRegion).toHaveTextContent(summary);
+    expect(startupLogRegion).toHaveClass("line-clamp-6");
+    expect(startupLogRegion).toHaveClass("overflow-y-hidden");
+    expect(startupLogRegion).not.toHaveClass("overflow-auto");
 
     await user.click(screen.getByRole("button", { name: "Show full error logs" }));
 
@@ -592,11 +595,15 @@ describe("PreviewPanel component", () => {
         /duplicate migration file: 000125_github_installation_repo_claims\.down\.sql/,
       );
     });
+    expect(startupLogRegion).not.toHaveClass("line-clamp-6");
+    expect(startupLogRegion).toHaveClass("sm:max-h-[min(56vh,28rem)]");
+    expect(startupLogRegion).toHaveClass("overflow-y-hidden");
+    expect(startupLogRegion).not.toHaveClass("overflow-auto");
     expect(screen.getByRole("button", { name: "Show summary" })).toBeInTheDocument();
     expect(mockLogs).toHaveBeenCalledWith("sess-1");
   });
 
-  it("shows Failed badge when phase is failed", async () => {
+  it("does not show a standalone Failed badge when failure diagnostics are visible", async () => {
     mockGet.mockResolvedValue(
       makePreviewStatus({ status: "failed", error: "err" }),
     );
@@ -604,8 +611,9 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed")).toBeInTheDocument();
+      expect(screen.getByText("Preview failed to start")).toBeInTheDocument();
     });
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
   });
 
   /* ---------- Query error state ---------- */
@@ -713,7 +721,7 @@ describe("PreviewPanel component", () => {
     expect(badge.className).toContain("text-emerald-600");
   });
 
-  it("applies destructive color class for failed phase badge", async () => {
+  it("applies destructive color class to failed diagnostics", async () => {
     mockGet.mockResolvedValue(
       makePreviewStatus({ status: "failed", error: "err" }),
     );
@@ -721,11 +729,11 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("Failed")).toBeInTheDocument();
+      expect(screen.getByText("Preview failed to start")).toBeInTheDocument();
     });
 
-    const badge = screen.getByText("Failed").closest("[class]")!;
-    expect(badge.className).toContain("text-destructive");
+    const heading = screen.getByText("Preview failed to start").closest("[class]")!;
+    expect(heading.className).toContain("text-destructive");
   });
 
   it("uses one primary starting label in the startup canvas", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -727,10 +727,10 @@ export function PreviewPanel({
         </div>
 
         {/* Status badge */}
-        {status && (
+        {status && status !== "failed" && (
           <Badge variant="secondary" className={cn(statusColor(status))}>
             {status === "ready" && <CheckCircle2 className="size-3" />}
-            {(status === "failed" || status === "unhealthy") && <AlertTriangle className="size-3" />}
+            {status === "unhealthy" && <AlertTriangle className="size-3" />}
             {STATUS_LABELS[status]}
           </Badge>
         )}
@@ -1017,8 +1017,10 @@ export function PreviewPanel({
               id={startupErrorLogsId}
               aria-label="Preview startup error logs"
               className={cn(
-                "max-h-28 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/50 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground",
-                showFullStartupLogs && "max-h-80 text-foreground",
+                "overflow-y-hidden whitespace-pre-wrap break-words rounded-md bg-background/50 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground",
+                showFullStartupLogs
+                  ? "sm:max-h-[min(56vh,28rem)] text-foreground"
+                  : "line-clamp-6",
                 previewLogsQuery.isError && showFullStartupLogs && "text-muted-foreground",
               )}
             >


### PR DESCRIPTION
## Summary
Updated the preview panel failure UI to avoid showing a redundant standalone “Failed” badge when detailed failure diagnostics are present. Also changed the error log presentation to use clipped wrapping when collapsed and a responsive max-height when expanded, with mobile uncapped for better readability.

## Changes
- **`frontend/src/components/preview/preview-panel.tsx`**
  - Removed the standalone failed-state badge when `status === "failed"`; the failure card/heading is now the only failed-state indicator.
  - Adjusted badge icon/label rendering so warning styling (`unhealthy`) remains, while `failed` relies on diagnostics content.
  - Reworked error log truncation/expansion behavior:
    - Collapsed state uses `line-clamp-6` with `overflow-y-hidden`.
    - Expanded state grows, with desktop/tablet capped at `min(56vh, 28rem)` via `sm:max-h-[min(56vh,28rem)]`.
    - Mobile expanded logs are not capped by that max-height.
- **`frontend/src/components/preview/preview-panel.test.tsx`**
  - Updated tests to assert collapsed/expanded log container classes (`line-clamp-6`, `overflow-y-hidden`, `sm:max-h-[min(56vh,28rem)]`).
  - Updated failed-state assertions to confirm the standalone “Failed” text is not rendered and that the failure heading (“Preview failed to start”) is shown instead.
  - Renamed/re-scoped tests to reflect the new failed diagnostics behavior.

## Test plan
- `npm test -- preview-panel.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 0fa900a3](https://143.dev/sessions/0fa900a3-c6f8-4045-84fd-daf04bdb409d)