### PR TITLE
Fix stale session diff loading for the Files changed button

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -4342,6 +4342,45 @@ describe('SessionDetailPage', () => {
     expect((await screen.findAllByText('src/app.ts')).length).toBeGreaterThan(0);
   });
 
+  it('refetches stale empty diff data when the conversation files-changed button opens review', async () => {
+    const sessionWithDiff: Session = {
+      ...mockSessions[0],
+      diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);',
+      diff_stats: { added: 1, removed: 0, files_changed: 1 },
+    };
+    let diffRequestCount = 0;
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: sessionWithoutRawDiff(sessionWithDiff) } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/diff', () => {
+        diffRequestCount += 1;
+        return HttpResponse.json({
+          data: {
+            session_id: sessionWithDiff.id,
+            diff: diffRequestCount === 1 ? '' : sessionWithDiff.diff,
+            diff_stats: sessionWithDiff.diff_stats,
+            diff_history: [],
+            diff_truncated: false,
+            diff_history_truncated: false,
+          },
+        } satisfies SingleResponse<SessionDiff>);
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    await screen.findAllByText('Fixed TypeError by adding null check');
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByText('1 file changed'));
+
+    expect((await screen.findAllByText('src/app.ts')).length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(diffRequestCount).toBe(2);
+    });
+  });
+
   it('shows contextual empty state for completed session with no changes', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -2773,6 +2773,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const {
     data: diffData,
     isLoading: isDiffLoading,
+    isFetching: isDiffFetching,
     isError: isDiffError,
     error: diffError,
     refetch: refetchDiff,
@@ -3379,6 +3380,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       filesChanged: stats.files_changed,
     };
   }, [session?.diff_stats, sessionDiffPayload?.diff_stats]);
+  const diffStatsFileCount = diffStats?.filesChanged ?? 0;
   const diffLoadErrorText = isDiffError
     ? diffError instanceof ApiError
       ? diffError.message
@@ -3415,6 +3417,41 @@ export function SessionDetailContent({ id }: { id: string }) {
     diffSearchQuery,
     setDiffSearchQuery,
   } = diffViewState;
+  const emptyDiffRecoveryKeyRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      !shouldLoadDiff ||
+      !sessionDiffPayload ||
+      isDiffLoading ||
+      isDiffFetching ||
+      isDiffError ||
+      diffStatsFileCount === 0 ||
+      diffFiles.length > 0 ||
+      !diffRevisionKey
+    ) {
+      return;
+    }
+
+    if (emptyDiffRecoveryKeyRef.current === diffRevisionKey) {
+      return;
+    }
+
+    emptyDiffRecoveryKeyRef.current = diffRevisionKey;
+    void refetchDiff();
+  }, [
+    diffFiles.length,
+    diffRevisionKey,
+    diffStatsFileCount,
+    isDiffError,
+    isDiffFetching,
+    isDiffLoading,
+    refetchDiff,
+    sessionDiffPayload,
+    shouldLoadDiff,
+  ]);
+  const isDiffDisplayLoading =
+    isDiffLoading ||
+    (isDiffFetching && diffStatsFileCount > 0 && diffFiles.length === 0);
 
   const {
     comments,
@@ -4526,7 +4563,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           passRange={passRange}
           onPassRangeChange={setPassRange}
           emptyStatusText={
-            isDiffLoading
+            isDiffDisplayLoading
               ? "Loading changes..."
               : session.status === "running" || session.status === "pending"
               ? "Changes will appear here as the agent modifies files."
@@ -4808,7 +4845,7 @@ export function SessionDetailContent({ id }: { id: string }) {
           {centerMode === "review" && (
             <div className="h-full animate-in fade-in duration-150 flex flex-col">
               <div className="flex-1 min-h-0">
-                {isDiffLoading ? (
+                {isDiffDisplayLoading ? (
                   <div className="h-full w-full bg-muted/20 animate-pulse rounded-lg" />
                 ) : diffLoadErrorText ? (
                   <div className="flex h-full items-center justify-center p-6">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -95,8 +95,8 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return parseSuccessBody<T>(res);
 }
 
-function get<T>(path: string): Promise<T> {
-  return request<T>(path);
+function get<T>(path: string, options?: RequestInit): Promise<T> {
+  return request<T>(path, options);
 }
 
 function post<T>(path: string, body?: unknown): Promise<T> {
@@ -339,7 +339,10 @@ export const api = {
     },
     recordView: (sessionId: string) => post<{ status: string }>(`/api/v1/sessions/${sessionId}/view`, {}),
     get: (id: string) => get<import('./types').SingleResponse<import('./types').SessionDetail>>(`/api/v1/sessions/${id}`),
-    getDiff: (id: string) => get<import('./types').SingleResponse<import('./types').SessionDiff>>(`/api/v1/sessions/${id}/diff`),
+    getDiff: (id: string) => get<import('./types').SingleResponse<import('./types').SessionDiff>>(
+      `/api/v1/sessions/${id}/diff`,
+      { cache: 'no-store' },
+    ),
     update: (id: string, body: { title: string }) =>
       patch<import('./types').SingleResponse<import('./types').Session>>(`/api/v1/sessions/${id}`, body),
     getLogs: (sessionId: string) => get<import('./types').ListResponse<import('./types').SessionLog>>(`/api/v1/sessions/${sessionId}/logs`),


### PR DESCRIPTION
## Summary
- Fixed the session conversation `Files changed` path so it no longer gets stuck on an empty/stale diff payload when the session metadata already reports changed files.
- Forced the lazy session diff request to bypass browser cache with `cache: 'no-store'`.
- Added a recovery refetch in the review surface when `diff_stats` says files changed but the parsed diff is empty.
- Added a regression test covering the stale-empty first response case.

## Testing
- `npm test -- --run src/app/(dashboard)/sessions/[id]/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`