### PR TITLE
Fix preview loading and preserve sandbox auth cookies

### DIFF
--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -122,7 +122,7 @@ describe('LoginPage', () => {
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
-  it('disables email submit until csrf warmup finishes', () => {
+  it('shows an email auth skeleton until csrf warmup finishes', () => {
     document.cookie = 'csrf_token=; Max-Age=0; path=/';
     useAuthProvidersMock.mockReturnValue({
       providers: { github: true, google: true, email: true },
@@ -131,7 +131,8 @@ describe('LoginPage', () => {
 
     renderWithProviders(<LoginPage />);
 
-    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
+    expect(screen.getByTestId('email-auth-skeleton')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument();
   });
 
   it('shows GitHub button', () => {

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -83,6 +83,9 @@ describe('LoginPage', () => {
       isLoading: false,
     });
 
+    document.cookie = 'csrf_token=; Max-Age=0; path=/';
+    document.cookie = 'csrf_token=test-csrf; path=/';
+
     Object.defineProperty(window, 'location', {
       value: createLocationMock(),
       writable: true,
@@ -117,6 +120,18 @@ describe('LoginPage', () => {
 
     expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('disables email submit until csrf warmup finishes', () => {
+    document.cookie = 'csrf_token=; Max-Age=0; path=/';
+    useAuthProvidersMock.mockReturnValue({
+      providers: { github: true, google: true, email: true },
+      isLoading: true,
+    });
+
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeDisabled();
   });
 
   it('shows GitHub button', () => {

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -105,6 +105,20 @@ describe('LoginPage', () => {
     expect(screen.getByRole('tab', { name: 'Sign up' })).toBeInTheDocument();
   });
 
+  it('keeps the login form visible while auth status is still loading', () => {
+    useAuthMock.mockReturnValue({
+      user: null,
+      isLoading: true,
+      isAuthenticated: false,
+      logout: vi.fn(),
+    });
+
+    renderWithProviders(<LoginPage />);
+
+    expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
   it('shows GitHub button', () => {
     renderWithProviders(<LoginPage />);
 

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { Suspense, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -12,7 +12,11 @@ import { Label } from "@/components/ui/label";
 import { api } from "@/lib/api";
 import { captureError } from "@/lib/errors";
 import { useAuth, useAuthProviders } from "@/hooks/use-auth";
-import { useEffect } from "react";
+
+function hasCSRFCookie(): boolean {
+  if (typeof document === "undefined") return false;
+  return document.cookie.split("; ").some((cookie) => cookie.startsWith("csrf_token="));
+}
 
 export default function LoginPage() {
   return (
@@ -26,7 +30,7 @@ function LoginPageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
-  const { providers } = useAuthProviders();
+  const { providers, isLoading: providersLoading } = useAuthProviders();
 
   const invitation = searchParams.get("invitation") ?? undefined;
   const invitedEmail = searchParams.get("email") ?? "";
@@ -54,6 +58,8 @@ function LoginPageContent() {
   const [signUpName, setSignUpName] = useState("");
   const [signUpEmail, setSignUpEmail] = useState(identityEmail);
   const [signUpPassword, setSignUpPassword] = useState("");
+  const emailAuthReady = hasCSRFCookie();
+  const emailAuthPending = !emailAuthReady && (authLoading || providersLoading);
 
   useEffect(() => {
     if (!isSwitchAccount && !authLoading && isAuthenticated) {
@@ -71,6 +77,10 @@ function LoginPageContent() {
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (!emailAuthReady) {
+      setError("Secure email sign-in is still initializing. Try again in a moment.");
+      return;
+    }
     setLoading(true);
     try {
       await api.auth.loginEmail(signInEmail, signInPassword);
@@ -87,6 +97,10 @@ function LoginPageContent() {
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
+    if (!emailAuthReady) {
+      setError("Secure email sign-up is still initializing. Try again in a moment.");
+      return;
+    }
     setLoading(true);
     try {
       await api.auth.register(signUpEmail, signUpPassword, signUpName, invitation);
@@ -222,6 +236,14 @@ function LoginPageContent() {
             </div>
           )}
 
+          {!emailAuthReady && (
+            <CardDescription className="text-center text-xs">
+              {emailAuthPending
+                ? "Preparing secure email authentication..."
+                : "Secure email authentication could not be initialized. Refresh and try again."}
+            </CardDescription>
+          )}
+
           <Tabs value={tab} onValueChange={setTab}>
             <TabsList className="w-full">
               <TabsTrigger value="signin" className="flex-1">Sign in</TabsTrigger>
@@ -252,7 +274,12 @@ function LoginPageContent() {
                     required
                   />
                 </div>
-                <Button type="submit" className="w-full" loading={loading}>
+                <Button
+                  type="submit"
+                  className="w-full"
+                  loading={loading}
+                  disabled={loading || !emailAuthReady}
+                >
                   Sign in
                 </Button>
               </form>
@@ -295,7 +322,12 @@ function LoginPageContent() {
                     minLength={8}
                   />
                 </div>
-                <Button type="submit" className="w-full" loading={loading}>
+                <Button
+                  type="submit"
+                  className="w-full"
+                  loading={loading}
+                  disabled={loading || !emailAuthReady}
+                >
                   Create account
                 </Button>
               </form>

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -100,7 +100,7 @@ function LoginPageContent() {
     }
   };
 
-  if (authLoading || (!isSwitchAccount && isAuthenticated)) {
+  if (!isSwitchAccount && isAuthenticated) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background px-4">
         <div className="w-full max-w-sm rounded-lg border border-border bg-card p-6 space-y-4">

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -18,6 +18,23 @@ function hasCSRFCookie(): boolean {
   return document.cookie.split("; ").some((cookie) => cookie.startsWith("csrf_token="));
 }
 
+function EmailAuthSkeleton() {
+  return (
+    <div data-testid="email-auth-skeleton" className="space-y-3 pt-1" aria-hidden="true">
+      <div className="h-9 w-full rounded-md bg-muted animate-pulse" />
+      <div className="space-y-2 pt-2">
+        <div className="h-4 w-12 rounded bg-muted animate-pulse" />
+        <div className="h-9 w-full rounded-md bg-muted animate-pulse" />
+      </div>
+      <div className="space-y-2">
+        <div className="h-4 w-16 rounded bg-muted animate-pulse" />
+        <div className="h-9 w-full rounded-md bg-muted animate-pulse" />
+      </div>
+      <div className="h-9 w-full rounded-md bg-muted animate-pulse" />
+    </div>
+  );
+}
+
 export default function LoginPage() {
   return (
     <Suspense>
@@ -236,103 +253,105 @@ function LoginPageContent() {
             </div>
           )}
 
-          {!emailAuthReady && (
+          {!emailAuthReady && !emailAuthPending && (
             <CardDescription className="text-center text-xs">
-              {emailAuthPending
-                ? "Preparing secure email authentication..."
-                : "Secure email authentication could not be initialized. Refresh and try again."}
+              Secure email authentication could not be initialized. Refresh and try again.
             </CardDescription>
           )}
 
-          <Tabs value={tab} onValueChange={setTab}>
-            <TabsList className="w-full">
-              <TabsTrigger value="signin" className="flex-1">Sign in</TabsTrigger>
-              <TabsTrigger value="signup" className="flex-1">Sign up</TabsTrigger>
-            </TabsList>
+          {emailAuthPending ? (
+            <EmailAuthSkeleton />
+          ) : (
+            <Tabs value={tab} onValueChange={setTab}>
+              <TabsList className="w-full">
+                <TabsTrigger value="signin" className="flex-1">Sign in</TabsTrigger>
+                <TabsTrigger value="signup" className="flex-1">Sign up</TabsTrigger>
+              </TabsList>
 
-            <TabsContent value="signin">
-              <form onSubmit={handleSignIn} className="space-y-3 pt-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="signin-email">Email</Label>
-                  <Input
-                    id="signin-email"
-                    type="email"
-                    placeholder="you@example.com"
-                    value={signInEmail}
-                    onChange={(e) => setSignInEmail(e.target.value)}
-                    readOnly={Boolean(invitation && identityEmail)}
-                    required
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="signin-password">Password</Label>
-                  <Input
-                    id="signin-password"
-                    type="password"
-                    value={signInPassword}
-                    onChange={(e) => setSignInPassword(e.target.value)}
-                    required
-                  />
-                </div>
-                <Button
-                  type="submit"
-                  className="w-full"
-                  loading={loading}
-                  disabled={loading || !emailAuthReady}
-                >
-                  Sign in
-                </Button>
-              </form>
-            </TabsContent>
+              <TabsContent value="signin">
+                <form onSubmit={handleSignIn} className="space-y-3 pt-2">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="signin-email">Email</Label>
+                    <Input
+                      id="signin-email"
+                      type="email"
+                      placeholder="you@example.com"
+                      value={signInEmail}
+                      onChange={(e) => setSignInEmail(e.target.value)}
+                      readOnly={Boolean(invitation && identityEmail)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="signin-password">Password</Label>
+                    <Input
+                      id="signin-password"
+                      type="password"
+                      value={signInPassword}
+                      onChange={(e) => setSignInPassword(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    className="w-full"
+                    loading={loading}
+                    disabled={loading || !emailAuthReady}
+                  >
+                    Sign in
+                  </Button>
+                </form>
+              </TabsContent>
 
-            <TabsContent value="signup">
-              <form onSubmit={handleSignUp} className="space-y-3 pt-2">
-                <div className="space-y-1.5">
-                  <Label htmlFor="signup-name">Name</Label>
-                  <Input
-                    id="signup-name"
-                    type="text"
-                    placeholder="Your name"
-                    value={signUpName}
-                    onChange={(e) => setSignUpName(e.target.value)}
-                    required
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="signup-email">Email</Label>
-                  <Input
-                    id="signup-email"
-                    type="email"
-                    placeholder="you@example.com"
-                    value={signUpEmail}
-                    onChange={(e) => setSignUpEmail(e.target.value)}
-                    readOnly={Boolean(invitation && identityEmail)}
-                    required
-                  />
-                </div>
-                <div className="space-y-1.5">
-                  <Label htmlFor="signup-password">Password</Label>
-                  <Input
-                    id="signup-password"
-                    type="password"
-                    placeholder="At least 8 characters"
-                    value={signUpPassword}
-                    onChange={(e) => setSignUpPassword(e.target.value)}
-                    required
-                    minLength={8}
-                  />
-                </div>
-                <Button
-                  type="submit"
-                  className="w-full"
-                  loading={loading}
-                  disabled={loading || !emailAuthReady}
-                >
-                  Create account
-                </Button>
-              </form>
-            </TabsContent>
-          </Tabs>
+              <TabsContent value="signup">
+                <form onSubmit={handleSignUp} className="space-y-3 pt-2">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="signup-name">Name</Label>
+                    <Input
+                      id="signup-name"
+                      type="text"
+                      placeholder="Your name"
+                      value={signUpName}
+                      onChange={(e) => setSignUpName(e.target.value)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="signup-email">Email</Label>
+                    <Input
+                      id="signup-email"
+                      type="email"
+                      placeholder="you@example.com"
+                      value={signUpEmail}
+                      onChange={(e) => setSignUpEmail(e.target.value)}
+                      readOnly={Boolean(invitation && identityEmail)}
+                      required
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="signup-password">Password</Label>
+                    <Input
+                      id="signup-password"
+                      type="password"
+                      placeholder="At least 8 characters"
+                      value={signUpPassword}
+                      onChange={(e) => setSignUpPassword(e.target.value)}
+                      required
+                      minLength={8}
+                    />
+                  </div>
+                  <Button
+                    type="submit"
+                    className="w-full"
+                    loading={loading}
+                    disabled={loading || !emailAuthReady}
+                  >
+                    Create account
+                  </Button>
+                </form>
+              </TabsContent>
+            </Tabs>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/hooks/use-in-view.test.tsx
+++ b/frontend/src/hooks/use-in-view.test.tsx
@@ -5,24 +5,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useInView } from "./use-in-view";
 
 function HookProbe() {
-  const { inView } = useInView();
-  return <div data-testid="hook-probe" data-in-view={String(inView)} />;
+  const { ref, inView } = useInView();
+  return <div ref={ref} data-testid="hook-probe" data-in-view={String(inView)} />;
 }
 
 describe("useInView", () => {
   const originalIntersectionObserver = globalThis.IntersectionObserver;
   const originalMatchMedia = window.matchMedia;
+  const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
 
   beforeEach(() => {
-    globalThis.IntersectionObserver = vi.fn(() => ({
-      observe: vi.fn(),
-      disconnect: vi.fn(),
-      unobserve: vi.fn(),
-      takeRecords: vi.fn(() => []),
-      root: null,
-      rootMargin: "",
-      thresholds: [],
-    })) as unknown as typeof IntersectionObserver;
+    class MockIntersectionObserver implements IntersectionObserver {
+      readonly root = null;
+      readonly rootMargin = "";
+      readonly thresholds = [];
+      disconnect = vi.fn();
+      observe = vi.fn();
+      takeRecords = vi.fn(() => []);
+      unobserve = vi.fn();
+    }
+
+    globalThis.IntersectionObserver = MockIntersectionObserver as unknown as typeof IntersectionObserver;
     window.matchMedia = vi.fn().mockReturnValue({
       matches: false,
       media: "(prefers-reduced-motion: reduce)",
@@ -38,6 +41,7 @@ describe("useInView", () => {
   afterEach(() => {
     globalThis.IntersectionObserver = originalIntersectionObserver;
     window.matchMedia = originalMatchMedia;
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 
   it("renders visible content on the server before hydration", () => {
@@ -56,5 +60,23 @@ describe("useInView", () => {
     render(<HookProbe />);
 
     expect(screen.getByTestId("hook-probe")).toHaveAttribute("data-in-view", "true");
+  });
+
+  it("marks below-the-fold content as not in view after layout measurement", () => {
+    HTMLElement.prototype.getBoundingClientRect = vi.fn(() => ({
+      x: 0,
+      y: 900,
+      top: 900,
+      left: 0,
+      bottom: 1100,
+      right: 200,
+      width: 200,
+      height: 200,
+      toJSON: () => ({}),
+    }));
+
+    render(<HookProbe />);
+
+    expect(screen.getByTestId("hook-probe")).toHaveAttribute("data-in-view", "false");
   });
 });

--- a/frontend/src/hooks/use-in-view.test.tsx
+++ b/frontend/src/hooks/use-in-view.test.tsx
@@ -1,0 +1,23 @@
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { useInView } from "./use-in-view";
+
+function HookProbe() {
+  const { inView } = useInView();
+  return <div data-in-view={String(inView)} />;
+}
+
+describe("useInView", () => {
+  it("renders visible content on the server before hydration", () => {
+    const originalWindow = globalThis.window;
+
+    // Match the hook's server-render branch even though the test suite runs in
+    // jsdom by default.
+    Reflect.deleteProperty(globalThis, "window");
+    const html = renderToString(<HookProbe />);
+    globalThis.window = originalWindow;
+
+    expect(html).toContain('data-in-view="true"');
+  });
+});

--- a/frontend/src/hooks/use-in-view.test.tsx
+++ b/frontend/src/hooks/use-in-view.test.tsx
@@ -1,14 +1,45 @@
+import { render, screen } from "@testing-library/react";
 import { renderToString } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useInView } from "./use-in-view";
 
 function HookProbe() {
   const { inView } = useInView();
-  return <div data-in-view={String(inView)} />;
+  return <div data-testid="hook-probe" data-in-view={String(inView)} />;
 }
 
 describe("useInView", () => {
+  const originalIntersectionObserver = globalThis.IntersectionObserver;
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    globalThis.IntersectionObserver = vi.fn(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+      unobserve: vi.fn(),
+      takeRecords: vi.fn(() => []),
+      root: null,
+      rootMargin: "",
+      thresholds: [],
+    })) as unknown as typeof IntersectionObserver;
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      media: "(prefers-reduced-motion: reduce)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    globalThis.IntersectionObserver = originalIntersectionObserver;
+    window.matchMedia = originalMatchMedia;
+  });
+
   it("renders visible content on the server before hydration", () => {
     const originalWindow = globalThis.window;
 
@@ -19,5 +50,11 @@ describe("useInView", () => {
     globalThis.window = originalWindow;
 
     expect(html).toContain('data-in-view="true"');
+  });
+
+  it("renders the same visible state on the first client paint", () => {
+    render(<HookProbe />);
+
+    expect(screen.getByTestId("hook-probe")).toHaveAttribute("data-in-view", "true");
   });
 });

--- a/frontend/src/hooks/use-in-view.ts
+++ b/frontend/src/hooks/use-in-view.ts
@@ -15,7 +15,7 @@ export function useInView<T extends HTMLElement = HTMLDivElement>(
   const reducedMotion =
     typeof window !== "undefined" &&
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  const [inView, setInView] = useState(reducedMotion);
+  const [inView, setInView] = useState(reducedMotion || typeof window === "undefined");
 
   useEffect(() => {
     if (reducedMotion) return;

--- a/frontend/src/hooks/use-in-view.ts
+++ b/frontend/src/hooks/use-in-view.ts
@@ -14,11 +14,13 @@ export function useInView<T extends HTMLElement = HTMLDivElement>(
   const ref = useRef<T | null>(null);
   const reducedMotion =
     typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-  const [inView, setInView] = useState(reducedMotion || typeof window === "undefined");
+  const [inView, setInView] = useState(true);
 
   useEffect(() => {
     if (reducedMotion) return;
+    if (typeof IntersectionObserver === "undefined") return;
 
     const el = ref.current;
     if (!el) return;

--- a/frontend/src/hooks/use-in-view.ts
+++ b/frontend/src/hooks/use-in-view.ts
@@ -1,10 +1,19 @@
-import { useRef, useState, useEffect } from "react";
+import { useRef, useState, useEffect, useLayoutEffect } from "react";
 
 interface InViewOptions {
   /** Fraction from top of viewport where element triggers. Default 0.85. */
   threshold?: number;
   /** Stay true once triggered. Default true. */
   once?: boolean;
+}
+
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function isElementInView(el: HTMLElement, threshold: number): boolean {
+  const rect = el.getBoundingClientRect();
+  const triggerLine = window.innerHeight * threshold;
+  return rect.top <= triggerLine && rect.bottom >= 0;
 }
 
 export function useInView<T extends HTMLElement = HTMLDivElement>(
@@ -17,6 +26,15 @@ export function useInView<T extends HTMLElement = HTMLDivElement>(
     typeof window.matchMedia === "function" &&
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const [inView, setInView] = useState(true);
+
+  useIsomorphicLayoutEffect(() => {
+    if (reducedMotion || typeof IntersectionObserver === "undefined") return;
+
+    const el = ref.current;
+    if (!el) return;
+
+    setInView(isElementInView(el, threshold));
+  }, [threshold, reducedMotion]);
 
   useEffect(() => {
     if (reducedMotion) return;

--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -674,9 +674,33 @@ func (g *Gateway) injectSecurityHeaders(h http.Header) {
 }
 
 func stripSensitiveResponseHeaders(h http.Header) {
-	// Remove Set-Cookie from sandbox responses. Our own session cookie is
-	// set directly in the exchange handler, not via proxy responses.
+	// Let sandbox apps manage their own preview-domain auth state (for example
+	// session_token and csrf_token) while protecting the gateway-owned preview
+	// access cookie from being replaced by the sandbox response.
+	setCookies := h.Values("Set-Cookie")
+	if len(setCookies) == 0 {
+		return
+	}
+
 	h.Del("Set-Cookie")
+	for _, raw := range setCookies {
+		switch setCookieName(raw) {
+		case "__Host-preview_session", "preview_session":
+			continue
+		default:
+			h.Add("Set-Cookie", raw)
+		}
+	}
+}
+
+func setCookieName(raw string) string {
+	parts := strings.SplitN(raw, ";", 2)
+	first := strings.TrimSpace(parts[0])
+	kv := strings.SplitN(first, "=", 2)
+	if len(kv) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(kv[0])
 }
 
 func stripPreviewCookie(req *http.Request) {

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -195,12 +195,17 @@ func TestStripSensitiveResponseHeaders(t *testing.T) {
 	t.Parallel()
 
 	h := make(http.Header)
-	h.Set("Set-Cookie", "session=abc123")
+	h.Add("Set-Cookie", "__Host-preview_session=preview-secret; Path=/; Secure; HttpOnly")
+	h.Add("Set-Cookie", "session_token=app-session; Path=/; HttpOnly")
+	h.Add("Set-Cookie", "csrf_token=csrf-token; Path=/")
 	h.Set("Content-Type", "text/html")
 
 	stripSensitiveResponseHeaders(h)
 
-	require.Empty(t, h.Get("Set-Cookie"))
+	require.Equal(t, []string{
+		"session_token=app-session; Path=/; HttpOnly",
+		"csrf_token=csrf-token; Path=/",
+	}, h.Values("Set-Cookie"))
 	require.Equal(t, "text/html", h.Get("Content-Type"))
 }
 


### PR DESCRIPTION
## Summary
- Keep the login form visible while auth state is still loading, and add coverage for that behavior.
- Treat `useInView` as visible during server render so preview content does not disappear before hydration.
- Preserve sandbox-managed preview auth cookies while still stripping the gateway-owned preview session cookie.
- Add tests covering the new hook behavior and cookie filtering.

## Testing
- Added unit coverage for login loading behavior, server-side `useInView` rendering, and preview response header filtering.
- Existing frontend and gateway test suites were updated to validate the new behavior.