### PR TITLE
Install jq during SSH worker provisioning

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -411,6 +411,7 @@ func TestDeployPinsDockerDaemonDNSResolvers(t *testing.T) {
 
 	bootstrap, err := os.ReadFile("../deploy/scripts/bootstrap.sh")
 	require.NoError(t, err, "test should read bootstrap.sh")
+	require.Contains(t, string(bootstrap), "apt-get install -y jq", "bootstrap.sh should install jq because install-docker-dns.sh requires it during SSH provisioning")
 	require.Contains(t, string(bootstrap), "/opt/143/deploy/scripts/install-docker-dns.sh *", "bootstrap.sh sudoers Cmnd_Alias must allow install-docker-dns.sh — without it the deploy+sudo path fails on app/worker hosts")
 
 	provision, err := os.ReadFile("../deploy/scripts/provision.sh")

--- a/deploy/scripts/bootstrap.sh
+++ b/deploy/scripts/bootstrap.sh
@@ -22,6 +22,10 @@ chown deploy:deploy /var/log/143
 # Docker (idempotent)
 command -v docker &>/dev/null || (curl -fsSL https://get.docker.com | sh)
 
+# Provision-time helpers merge JSON config with jq. Cloud-init installs it
+# through package metadata, but SSH provisioning only runs this bootstrap.
+command -v jq &>/dev/null || (apt-get update && apt-get install -y jq)
+
 # Add deploy to docker group (must be after Docker install creates the group)
 usermod -aG docker deploy
 


### PR DESCRIPTION
## Summary
- Install `jq` in `deploy/scripts/bootstrap.sh` so SSH-based `provision-worker` runs can complete the Docker DNS setup helper.
- Add a regression check in `deploy/deploy_config_test.go` to keep SSH bootstrap aligned with the DNS pinning flow.

## Testing
- `go test ./deploy`