### PR TITLE
Fix clipped active tab underline by overriding ::after bottom offset

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -168,6 +168,7 @@ describe("AgentTabStrip", () => {
     expect(activeTab).toHaveClass("data-[state=active]:text-primary");
     expect(activeTab).toHaveClass("data-[state=active]:bg-transparent");
     expect(activeTab).toHaveClass("after:bg-[image:var(--gradient-primary)]");
+    expect(activeTab).toHaveClass("after:!bottom-[-3px]");
     expect(activeTab).not.toHaveClass("after:bg-none");
     expect(screen.getByRole("tab", { name: /review/i })).not.toHaveTextContent(/Completed/i);
     expect(screen.getByRole("button", { name: "Close Main tab" })).toBeInTheDocument();

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -290,7 +290,7 @@ export function AgentTabStrip({
                             disabled={isNonInteractive}
                             className={cn(
                               "h-7 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
-                              "after:bg-[image:var(--gradient-primary)] data-[state=active]:after:opacity-100",
+                              "after:!bottom-[-3px] after:bg-[image:var(--gradient-primary)] data-[state=active]:after:opacity-100",
                               showArchiveButton && "pr-8",
                               tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
                               isNonInteractive && "cursor-default opacity-60",


### PR DESCRIPTION
## Summary
The active agent tab underline was getting clipped inside a scroll wrapper (`overflow-y-hidden`). Updated the tab strip styling to override the `::after` underline offset so it remains visible without changing layout height.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx`**
  - Adjusted active tab `::after` styling by forcing `after:!bottom-[-3px]` to counter the scroll wrapper padding/clip behavior.
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`**
  - Added a regression assertion that the active tab includes `after:!bottom-[-3px]`.

## Test plan
- Ran: `npm test -- --run 'src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx'`
- Ran: `npm run typecheck`
- Ran: `npm run lint`
- Ran: `npm run build` (completed successfully; existing Next.js warnings only)

[143.dev](https://143.dev) | [session 639cb6fe](https://143.dev/sessions/639cb6fe-46b8-4e7d-b2b0-ea123f07d198)