### PR TITLE
Seed preview users with role-specific demo accounts

### DIFF
--- a/.143/seed.sql
+++ b/.143/seed.sql
@@ -1,5 +1,5 @@
 -- Seed data for preview dogfooding.
--- Creates a default organization and admin user so the preview is
+-- Creates a default organization and four users so the preview is
 -- immediately usable without requiring the registration flow, plus a
 -- placeholder integration and a couple of repositories/projects so the
 -- logged-in UI shows populated screens instead of empty states.
@@ -10,13 +10,14 @@
 -- them into the sign-in form. If you change either side, regenerate the
 -- bcrypt hash below (cost 10) and update the config defaults in lockstep.
 --
--- Password: "preview-dogfood" (bcrypt hash below).
+-- Password for all preview users: "preview" (bcrypt hash below).
 --
--- All rows use fixed UUIDs + ON CONFLICT DO NOTHING so the seed is
--- safely re-runnable. Tables with secondary unique indexes (e.g.
+-- All rows use fixed UUIDs and conflict handlers so the seed is safely
+-- re-runnable. Tables with secondary unique indexes (e.g.
 -- repositories.idx_repositories_org_github) use the unqualified
 -- ON CONFLICT DO NOTHING form so any unique violation — not just on id —
--- no-ops rather than aborting the transaction.
+-- no-ops rather than aborting the transaction; identity rows use DO UPDATE
+-- so old dogfood credentials converge to the current preview credentials.
 
 INSERT INTO organizations (id, name, settings, created_at, updated_at)
 VALUES (
@@ -29,17 +30,82 @@ VALUES (
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO users (id, org_id, email, name, role, password_hash, created_at)
-VALUES (
-  '00000000-0000-4000-a000-000000000002'::uuid,
-  '00000000-0000-4000-a000-000000000001'::uuid,
-  'dogfood@143.dev',
-  'Preview Admin',
-  'admin',
-  -- bcrypt hash of "preview-dogfood" (cost 10)
-  '$2a$10$yq0Z0nFAzgJa1IuC.zbMh.RmEdX2dAJk8XQwELbmOA1AztcbCUyVi',
-  now()
-)
-ON CONFLICT (email) DO NOTHING;
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'preview-admin@143.dev',
+    'Preview Admin',
+    'admin',
+    -- bcrypt hash of "preview" (cost 10)
+    '$2y$10$MtyCwm3KVYgmLvAinVwMHO3c65omeHXqqyIqwlz9JXJ30.5V2fyAe',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000003'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'preview-member@143.dev',
+    'Preview Member',
+    'member',
+    -- bcrypt hash of "preview" (cost 10)
+    '$2y$10$MtyCwm3KVYgmLvAinVwMHO3c65omeHXqqyIqwlz9JXJ30.5V2fyAe',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000004'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'preview-builder@143.dev',
+    'Preview Builder',
+    'builder',
+    -- bcrypt hash of "preview" (cost 10)
+    '$2y$10$MtyCwm3KVYgmLvAinVwMHO3c65omeHXqqyIqwlz9JXJ30.5V2fyAe',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000005'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'preview-viewer@143.dev',
+    'Preview Viewer',
+    'viewer',
+    -- bcrypt hash of "preview" (cost 10)
+    '$2y$10$MtyCwm3KVYgmLvAinVwMHO3c65omeHXqqyIqwlz9JXJ30.5V2fyAe',
+    now()
+  )
+ON CONFLICT (id) DO UPDATE
+SET org_id = EXCLUDED.org_id,
+    email = EXCLUDED.email,
+    name = EXCLUDED.name,
+    role = EXCLUDED.role,
+    password_hash = EXCLUDED.password_hash;
+
+INSERT INTO organization_memberships (user_id, org_id, role, created_at)
+VALUES
+  (
+    '00000000-0000-4000-a000-000000000002'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'admin',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000003'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'member',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000004'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'builder',
+    now()
+  ),
+  (
+    '00000000-0000-4000-a000-000000000005'::uuid,
+    '00000000-0000-4000-a000-000000000001'::uuid,
+    'viewer',
+    now()
+  )
+ON CONFLICT (user_id, org_id) DO UPDATE
+SET role = EXCLUDED.role;
 
 -- Placeholder GitHub integration so repositories have a valid FK target.
 -- The preview does not actually talk to GitHub, so the config is empty.

--- a/docs/guides/previews.md
+++ b/docs/guides/previews.md
@@ -16,10 +16,18 @@ This guide covers how to add preview support to a repo. For the underlying archi
 2. Open a session against the 143 repo (or anything on `main`).
 3. Click **Start Preview**.
 
-**Demo credentials** (shown on the login page when `DEMO_MODE=true`):
+**Demo credentials** (the admin login is shown on the login page when `DEMO_MODE=true`):
 
-- Email: `dogfood@143.dev`
-- Password: `preview-dogfood`
+- Email: `preview-admin@143.dev`
+- Password: `preview`
+
+Additional seeded users use the same password:
+
+| Email | Role |
+|---|---|
+| `preview-member@143.dev` | `member` |
+| `preview-builder@143.dev` | `builder` |
+| `preview-viewer@143.dev` | `viewer` |
 
 The banner renders whatever `DEMO_EMAIL` / `DEMO_PASSWORD` the server was started with (defaults match the values above and the seeded admin in `.143/seed.sql`). If you override those env vars, regenerate the bcrypt hash in `seed.sql` in lockstep or the banner will point at credentials that don't log in.
 

--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -135,8 +135,8 @@ describe('LoginPage', () => {
         google: false,
         email: true,
         demo: true,
-        demo_email: 'dogfood@143.dev',
-        demo_password: 'preview-dogfood',
+        demo_email: 'preview-admin@143.dev',
+        demo_password: 'preview',
       },
       isLoading: false,
     });
@@ -145,8 +145,8 @@ describe('LoginPage', () => {
 
     const banner = screen.getByTestId('demo-banner');
     expect(banner).toHaveTextContent('Demo environment');
-    expect(banner).toHaveTextContent('dogfood@143.dev');
-    expect(banner).toHaveTextContent('preview-dogfood');
+    expect(banner).toHaveTextContent('preview-admin@143.dev');
+    expect(banner).toHaveTextContent('preview');
   });
 
   it('renders banner text returned by /providers verbatim (server is source of truth)', () => {
@@ -167,7 +167,7 @@ describe('LoginPage', () => {
     const banner = screen.getByTestId('demo-banner');
     expect(banner).toHaveTextContent('override@example.com');
     expect(banner).toHaveTextContent('override-pw');
-    expect(banner).not.toHaveTextContent('dogfood@143.dev');
+    expect(banner).not.toHaveTextContent('preview-admin@143.dev');
   });
 
   it('hides demo banner when demo mode is off', () => {

--- a/internal/api/handlers/auth_test.go
+++ b/internal/api/handlers/auth_test.go
@@ -885,16 +885,16 @@ func TestAuthHandler_Providers(t *testing.T) {
 			cfg: &config.Config{
 				GitHubOAuthClientID: "gh-id",
 				DemoMode:            true,
-				DemoEmail:           "dogfood@143.dev",
-				DemoPassword:        "preview-dogfood",
+				DemoEmail:           "preview-admin@143.dev",
+				DemoPassword:        "preview",
 			},
 			expected: map[string]any{
 				"github":        false,
 				"google":        false,
 				"email":         true,
 				"demo":          true,
-				"demo_email":    "dogfood@143.dev",
-				"demo_password": "preview-dogfood",
+				"demo_email":    "preview-admin@143.dev",
+				"demo_password": "preview",
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,8 @@ import (
 // login-page banner that advertises credentials that won't actually sign in
 // — LogStatus warns about this at boot.
 const (
-	defaultDemoEmail    = "dogfood@143.dev"
-	defaultDemoPassword = "preview-dogfood"
+	defaultDemoEmail    = "preview-admin@143.dev"
+	defaultDemoPassword = "preview"
 )
 
 type Config struct {
@@ -47,8 +47,8 @@ type Config struct {
 	// login-page banner when DemoMode is on. Defaults must match the seeded
 	// admin in .143/seed.sql and the constants below — override via env
 	// only if you also regenerate the bcrypt hash in the seed.
-	DemoEmail    string `env:"DEMO_EMAIL"    envDefault:"dogfood@143.dev"`
-	DemoPassword string `env:"DEMO_PASSWORD" envDefault:"preview-dogfood"`
+	DemoEmail    string `env:"DEMO_EMAIL"    envDefault:"preview-admin@143.dev"`
+	DemoPassword string `env:"DEMO_PASSWORD" envDefault:"preview"`
 	// WorkerProcessCount controls how many worker loops run inside a single
 	// server process when MODE is "worker" or "all". Increase this on larger
 	// hosts to process more jobs/sandboxes in parallel.

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -51,10 +51,14 @@ func TestMigrationsAllowBuilderRole(t *testing.T) {
 	require.NoError(t, err, "test should read builder role migration")
 
 	sql := string(body)
-	require.Contains(t, sql, "chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'))",
+	require.Contains(t, sql, "chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer')) NOT VALID",
 		"users role constraint should allow seeded builder users")
-	require.Contains(t, sql, "organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer'))",
+	require.Contains(t, sql, "VALIDATE CONSTRAINT chk_users_role",
+		"users role constraint should validate separately to reduce lock pressure")
+	require.Contains(t, sql, "organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer')) NOT VALID",
 		"membership role constraint should allow seeded builder memberships")
+	require.Contains(t, sql, "VALIDATE CONSTRAINT organization_memberships_role_check",
+		"membership role constraint should validate separately to reduce lock pressure")
 }
 
 // TestCopyCodingCredentialsMigrationStampsTeamDefaultMarker locks the

--- a/internal/db/migrations_test.go
+++ b/internal/db/migrations_test.go
@@ -44,6 +44,19 @@ func TestMigrationsDeclareSessionsModelUsedColumn(t *testing.T) {
 	require.Fail(t, "schema must add sessions.model_used because SessionStore.UpdateResult writes it")
 }
 
+func TestMigrationsAllowBuilderRole(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("../../migrations/000130_builder_role_constraints.up.sql")
+	require.NoError(t, err, "test should read builder role migration")
+
+	sql := string(body)
+	require.Contains(t, sql, "chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'))",
+		"users role constraint should allow seeded builder users")
+	require.Contains(t, sql, "organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer'))",
+		"membership role constraint should allow seeded builder memberships")
+}
+
 // TestCopyCodingCredentialsMigrationStampsTeamDefaultMarker locks the
 // step-3 INSERT to write `team_default_origin_user_id = uc.user_id`. The
 // down migration's orphan check and the dual-write mirror's cleanup both

--- a/internal/db/preview_seed_test.go
+++ b/internal/db/preview_seed_test.go
@@ -1,0 +1,48 @@
+package db
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestPreviewSeedUsers(t *testing.T) {
+	t.Parallel()
+
+	body, err := os.ReadFile("../../.143/seed.sql")
+	require.NoError(t, err, "test should read preview seed SQL")
+	sql := string(body)
+
+	tests := []struct {
+		name        string
+		id          string
+		email       string
+		displayName string
+		role        string
+	}{
+		{name: "admin", id: "00000000-0000-4000-a000-000000000002", email: "preview-admin@143.dev", displayName: "Preview Admin", role: "admin"},
+		{name: "member", id: "00000000-0000-4000-a000-000000000003", email: "preview-member@143.dev", displayName: "Preview Member", role: "member"},
+		{name: "builder", id: "00000000-0000-4000-a000-000000000004", email: "preview-builder@143.dev", displayName: "Preview Builder", role: "builder"},
+		{name: "viewer", id: "00000000-0000-4000-a000-000000000005", email: "preview-viewer@143.dev", displayName: "Preview Viewer", role: "viewer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Contains(t, sql, "'"+tt.email+"'", "preview seed should include the expected login email")
+			userPattern := regexp.MustCompile(`(?s)'` + regexp.QuoteMeta(tt.email) + `'.*'` + regexp.QuoteMeta(tt.displayName) + `'.*'` + regexp.QuoteMeta(tt.role) + `'`)
+			require.True(t, userPattern.MatchString(sql), "preview seed should assign the expected legacy role")
+			require.Contains(t, sql, "'"+tt.id+"'::uuid,\n    '00000000-0000-4000-a000-000000000001'::uuid,\n    '"+tt.role+"'", "preview seed should assign the expected membership role")
+		})
+	}
+
+	hashes := regexp.MustCompile(`\$2[ayb]\$10\$[A-Za-z0-9./]{53}`).FindAllString(sql, -1)
+	require.NotEmpty(t, hashes, "preview seed should include bcrypt password hashes")
+	for _, hash := range hashes {
+		require.NoError(t, bcrypt.CompareHashAndPassword([]byte(hash), []byte("preview")), "every preview seed password hash should match the shared preview password")
+	}
+}

--- a/migrations/000130_builder_role_constraints.down.sql
+++ b/migrations/000130_builder_role_constraints.down.sql
@@ -1,0 +1,19 @@
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS chk_users_role;
+
+UPDATE users
+SET role = 'member'
+WHERE role = 'builder';
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'viewer'));
+
+ALTER TABLE organization_memberships
+    DROP CONSTRAINT IF EXISTS organization_memberships_role_check;
+
+UPDATE organization_memberships
+SET role = 'member'
+WHERE role = 'builder';
+
+ALTER TABLE organization_memberships
+    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'viewer'));

--- a/migrations/000130_builder_role_constraints.up.sql
+++ b/migrations/000130_builder_role_constraints.up.sql
@@ -2,10 +2,16 @@ ALTER TABLE users
     DROP CONSTRAINT IF EXISTS chk_users_role;
 
 ALTER TABLE users
-    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'));
+    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer')) NOT VALID;
+
+ALTER TABLE users
+    VALIDATE CONSTRAINT chk_users_role;
 
 ALTER TABLE organization_memberships
     DROP CONSTRAINT IF EXISTS organization_memberships_role_check;
 
 ALTER TABLE organization_memberships
-    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer'));
+    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer')) NOT VALID;
+
+ALTER TABLE organization_memberships
+    VALIDATE CONSTRAINT organization_memberships_role_check;

--- a/migrations/000130_builder_role_constraints.up.sql
+++ b/migrations/000130_builder_role_constraints.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS chk_users_role;
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role CHECK (role IN ('admin', 'member', 'builder', 'viewer'));
+
+ALTER TABLE organization_memberships
+    DROP CONSTRAINT IF EXISTS organization_memberships_role_check;
+
+ALTER TABLE organization_memberships
+    ADD CONSTRAINT organization_memberships_role_check CHECK (role IN ('admin', 'member', 'builder', 'viewer'));


### PR DESCRIPTION
## Summary
- Replace the single dogfood login with four preview accounts: admin, member, builder, and viewer
- Use `preview` as the shared password for all seeded preview users and keep the login banner/docs in sync
- Add the missing `builder` role migration so the database constraints accept the seeded data, with low-lock `NOT VALID` validation
- Add regression tests for the preview seed and the new role constraint migration

## Testing
- `go test ./internal/db -count=1`
- `go vet ./...`
- `go build ./...`
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test -- --run src/app/\(auth\)/login/page.test.tsx`