### PR TITLE
Guard production env commits and document the read-only prod workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,10 +17,12 @@ fi
 has_go=0
 has_migration=0
 has_store=0
+has_prod_env=0
 
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
   case "$f" in
+    .env.production.enc)         has_prod_env=1 ;;
     *.go)                        has_go=1 ;;
   esac
   case "$f" in
@@ -82,6 +84,19 @@ run_check() {
     fail=1
   fi
 }
+
+case "${COMMIT_PROD_ENV:-}" in
+  1|true|TRUE|True) commit_prod_env=1 ;;
+  *)                commit_prod_env=0 ;;
+esac
+
+if [[ $has_prod_env -eq 1 && "$commit_prod_env" != "1" ]]; then
+  echo "  [pre-commit] production env guard ... FAIL"
+  echo "    .env.production.enc is staged." >&2
+  echo "    This file is protected production configuration and is often dirtied accidentally by stale worktrees or secret rotation." >&2
+  echo "    If this is intentional, re-run commit with: COMMIT_PROD_ENV=true git commit ..." >&2
+  fail=1
+fi
 
 if [[ $has_migration -eq 1 ]]; then
   if ensure_tool lint-schema; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,10 +4,6 @@ Use docs/design/overall.md as the overall design of the system, think of it as a
 
 When investigating bugs or unexpected behavior, three Make targets give read-only access to prod. All require `SSH_KEY` (defaults to `~/.ssh/143-deploy`) and resolve hosts/credentials from `.env.production.enc` via sops.
 
-### Production secrets guardrail
-
-Treat `.env.production.enc` as protected production configuration. Do not edit, regenerate, stage, or commit it unless the user explicitly asks for a production secret/config change. Read-only decrypts through the Make targets below are fine. Before finishing any work that involved prod debugging, check `git status --short -- .env.production.enc` and leave it clean unless the requested task was specifically to update production env.
-
 ### Querying the database
 
 - **`make db-query Q='SELECT ...'`** — runs a one-shot SQL query against the prod Postgres as the `readonly` role. SELECT-only, every connection is a read-only txn, bounded by a 30s `statement_timeout`. Use single quotes around `Q` and escape literal `$` as `$$` (Make eats single `$`). For an interactive session, use `make db-psql`.
@@ -370,3 +366,7 @@ Do **NOT** use for operational/lifecycle entities, external entity mirrors, comp
 ## Database Triggers
 
 The `trg_project_task_counts_update` trigger (migration 000047) fires on ALL column updates to `project_tasks`, not just status changes. This is because PostgreSQL does not allow `REFERENCING` transition tables with column-list triggers (`AFTER UPDATE OF status`). The recount logic is idempotent so correctness is unaffected, but be aware that updating non-status columns (e.g. `branch_name`, `pr_url`) will also trigger a recount of `total_tasks`, `completed_tasks`, and `failed_tasks` on the parent project.
+
+## Production Secrets Guardrail
+
+Treat `.env.production.enc` as protected production configuration. Do not edit, regenerate, stage, or commit it unless the user explicitly asks for a production secret/config change. Read-only decrypts through the Make targets above are fine. Before finishing any work that involved prod debugging, check `git status --short -- .env.production.enc` and leave it clean unless the requested task was specifically to update production env.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@ Use docs/design/overall.md as the overall design of the system, think of it as a
 
 When investigating bugs or unexpected behavior, three Make targets give read-only access to prod. All require `SSH_KEY` (defaults to `~/.ssh/143-deploy`) and resolve hosts/credentials from `.env.production.enc` via sops.
 
+### Production secrets guardrail
+
+Treat `.env.production.enc` as protected production configuration. Do not edit, regenerate, stage, or commit it unless the user explicitly asks for a production secret/config change. Read-only decrypts through the Make targets below are fine. Before finishing any work that involved prod debugging, check `git status --short -- .env.production.enc` and leave it clean unless the requested task was specifically to update production env.
+
 ### Querying the database
 
 - **`make db-query Q='SELECT ...'`** — runs a one-shot SQL query against the prod Postgres as the `readonly` role. SELECT-only, every connection is a read-only txn, bounded by a 30s `statement_timeout`. Use single quotes around `Q` and escape literal `$` as `$$` (Make eats single `$`). For an interactive session, use `make db-psql`.


### PR DESCRIPTION
## Summary
- Added a pre-commit guard that blocks staged `.env.production.enc` changes unless explicitly allowed via `COMMIT_PROD_ENV=true`.
- Accepted `1`, `true`, `TRUE`, and `True` for the override to keep the escape hatch simple.
- Added an AGENTS.md note telling Codex to avoid editing or staging production env secrets during read-only prod debugging.

## Testing
- Verified the hook blocks staged `.env.production.enc` by default.
- Verified the override accepts the supported truthy values.
- Confirmed the rest of the worktree remains unaffected.