### PR TITLE
Speed up frontend CI by removing coverage from main PR runs and moving it to scheduled/manual

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   push:
     branches: [main]
+  schedule:
+    - cron: "17 10 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
@@ -175,7 +178,7 @@ jobs:
   frontend-test:
     name: Frontend Test
     needs: changes
-    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'push'
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.ci == 'true' || github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -206,13 +209,18 @@ jobs:
         timeout-minutes: 10
         run: npx vitest run --changed=pr-base --passWithNoTests
 
-      - name: Run full tests with coverage (main only)
+      - name: Run full tests (main)
         if: github.event_name == 'push'
         timeout-minutes: 10
+        run: npx vitest run --reporter=dot
+
+      - name: Run full tests with coverage (scheduled/manual)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        timeout-minutes: 20
         run: npx vitest run --coverage --coverage.reporter=text --coverage.reporter=json-summary --coverage.reporter=lcov
 
-      - name: Check frontend coverage floor (main only)
-        if: github.event_name == 'push'
+      - name: Check frontend coverage floor (scheduled/manual)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           COVERAGE=$(cat coverage/coverage-summary.json | node -e "
             const data = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
@@ -228,7 +236,7 @@ jobs:
           fi
 
       - name: Upload coverage artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -385,7 +385,7 @@ Build the skeleton that everything else plugs into, including GitHub authenticat
 5. **Repository management** (13) — ✅ Full CRUD store, UpsertFromGitHub for idempotent webhook sync, DisconnectByInstallationID for cleanup, installation token management
 6. **Frontend scaffold** (03) — ✅ Next.js 16 + App Router + shadcn/ui + TanStack Query. Pages: Overview, Issues, Runs, Settings, Analytics (placeholder), Costs (placeholder). Vitest test suite with MSW mocks.
 7. **Docker Compose + Makefile** (10) — ✅ Postgres 17 + Go server (air hot reload) + Next.js frontend. Makefile with dev, test, migrate, build, lint targets.
-8. **Success metrics instrumentation** — ✅ Prometheus metrics middleware (http_requests_total, http_request_duration_seconds, http_requests_in_flight). `/metrics` endpoint. CI/CD via GitHub Actions with coverage gates (70% backend, 80% frontend).
+8. **Success metrics instrumentation** — ✅ Prometheus metrics middleware (http_requests_total, http_request_duration_seconds, http_requests_in_flight). `/metrics` endpoint. CI/CD via GitHub Actions with coverage gates (70% backend, 80% frontend); frontend coverage runs on scheduled/manual CI while hot-path PR/main runs prioritize fast failure detection.
 
 **Milestone**: ✅ You can start the app, sign in with GitHub, connect repositories, and see connected repos in the dashboard. Core metrics are being captured from the first run.
 

--- a/frontend/src/ci-guardrails.test.ts
+++ b/frontend/src/ci-guardrails.test.ts
@@ -35,7 +35,7 @@ describe("frontend CI guardrails", () => {
     expect(frontendTestJob).toContain("npx vitest run");
   });
 
-  it("keeps PR frontend tests fast and reserves coverage for main", () => {
+  it("keeps hot-path frontend tests fast and reserves coverage for scheduled/manual runs", () => {
     const workflow = fs.readFileSync(
       path.join(repoRoot, ".github", "workflows", "ci.yml"),
       "utf8"
@@ -52,8 +52,11 @@ describe("frontend CI guardrails", () => {
     const affectedTestsStep = frontendTestJob.match(
       /      - name: Run affected tests \(PR\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
     )?.[0];
+    const fullMainStep = frontendTestJob.match(
+      /      - name: Run full tests \(main\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
+    )?.[0];
     const fullCoverageStep = frontendTestJob.match(
-      /      - name: Run full tests with coverage \(main only\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
+      /      - name: Run full tests with coverage \(scheduled\/manual\)\n[\s\S]*?(?=\n      - name:|\n  [a-z0-9-]+:|\n$)/
     )?.[0];
 
     expect(affectedTestsStep).toBeDefined();
@@ -61,8 +64,13 @@ describe("frontend CI guardrails", () => {
     expect(affectedTestsStep).not.toContain("--coverage");
     expect(frontendTestJob).not.toContain("diff-cover");
 
+    expect(fullMainStep).toBeDefined();
+    expect(fullMainStep).toContain("if: github.event_name == 'push'");
+    expect(fullMainStep).not.toContain("--coverage");
+
     expect(fullCoverageStep).toBeDefined();
-    expect(fullCoverageStep).toContain("if: github.event_name == 'push'");
+    expect(fullCoverageStep).toContain("github.event_name == 'schedule'");
+    expect(fullCoverageStep).toContain("github.event_name == 'workflow_dispatch'");
     expect(fullCoverageStep).toContain("--coverage");
   });
 


### PR DESCRIPTION
## Summary
This updates the GitHub Actions CI strategy to make PR/main feedback faster by running full frontend tests without coverage on push events. Coverage gating is moved to scheduled and manually-triggered runs to catch regressions without slowing every merge.

## Changes
- **.github/workflows/ci.yml**
  - Added **scheduled** (`cron`) and **workflow_dispatch** triggers.
  - Updated `frontend-test` job condition to run on **push, schedule, and workflow_dispatch** (when frontend/ci changes apply).
  - Replaced the **main-only** “full tests with coverage” step with a **main push** “full tests (dot reporter)” step to prioritize fast failure.
  - Added **scheduled/manual** step to run **full tests with coverage** (and increased timeout to 20 minutes).
  - Moved the **frontend coverage floor check** and **coverage artifact upload** to **scheduled/manual** runs.
- **docs/design/overall.md**
  - Documented the revised CI/CD coverage strategy: coverage gates run on scheduled/manual while hot-path PR/main runs prioritize speed.
- **frontend/src/ci-guardrails.test.ts**
  - Updated CI guardrails to align with the new “coverage runs only on scheduled/manual” approach.

## Test plan
- Verified CI guardrail test behavior updated to red-first, then passed.
- Ran locally: `npm run typecheck`, `npm run lint`, and `npm run build`.
- Confirmed the test suite timing locally (~4m56s for the full frontend suite) and that coverage is no longer executed on push/main.

[143.dev](https://143.dev) | [session abd5c6c2](https://143.dev/sessions/abd5c6c2-ad98-4892-87bd-6ee191820704)