### PR TITLE
Move session Review action into Overview readiness area and update dialog flow

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -97,12 +97,14 @@ reviewer/fixer lanes.
 
 ### Manual session entry point
 
-Session detail exposes a compact `Review` button near the Overview PR/health
-area. It belongs with publish readiness controls because the user is asking,
-"is this ready to ship?"
+Session detail exposes `Review this work` in the Overview readiness area rather
+than in the persistent header action cluster. It belongs with publish readiness
+controls because the user is asking, "is this ready to ship?", but it remains a
+secondary action so `Create PR` can stay the single primary shipping action.
 
-Clicking `Review` opens a focused setup popover with one real decision: how
-many back-and-forth passes to allow.
+Clicking `Review this work` opens a focused setup dialog with one real decision:
+how many back-and-forth passes to allow. The dialog is used on mobile and desktop
+so the setup controls do not depend on a popover inside the mobile details sheet.
 
 ```text
 Review this work
@@ -127,7 +129,7 @@ Design choices:
 - The agent row is informational by default. It uses the current session agent
   unless the user explicitly changes the model through the normal session/model
   controls before starting the loop.
-- The popover must clearly state that the loop runs in the current sandbox.
+- The setup dialog must clearly state that the loop runs in the current sandbox.
 
 ### Manual session timeline
 
@@ -711,8 +713,8 @@ changes.
 1. How much raw review output should be retained long term versus summarized
    after the session snapshot expires?
 2. What is the right cost preview for 3-5 pass loops on large diffs?
-3. Should manual review expose the full pass-count setup popover in the first
-   viewport action, or keep the current fast-start default of two passes?
+3. Should manual review keep the full pass-count setup dialog, or add a
+   fast-start default of two passes?
 4. Should the review-loop tab be reusable for future review loops in the same
    session, or should each click create a fresh tab?
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -188,15 +188,16 @@ describe('SessionDetailPage', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  it('shows a disabled review-loop action when no session snapshot is available', async () => {
+  it('shows a disabled review-loop action in the Overview readiness area when no session snapshot is available', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     await screen.findAllByText('Fixed TypeError by adding null check');
-    expect(screen.getByRole('button', { name: 'Review' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Review this work' })).toBeDisabled();
+    expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Code review' })).not.toBeInTheDocument();
   });
 
-  it('shows the review loop action after a PR exists when a snapshot is available', async () => {
+  it('shows the review loop action in Overview after a PR exists when a snapshot is available', async () => {
     server.use(
       http.get('/api/v1/sessions/:id', () => {
         return HttpResponse.json({
@@ -217,7 +218,8 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
-    expect(await screen.findByRole('button', { name: 'Review' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Review this work' })).toBeInTheDocument();
+    expect(within(screen.getByLabelText('Session detail actions')).queryByRole('button', { name: 'Review' })).not.toBeInTheDocument();
   });
 
   it('starts a manual review loop with the selected pass count', async () => {
@@ -263,7 +265,7 @@ describe('SessionDetailPage', () => {
 
     renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
 
-    await user.click(await screen.findByRole('button', { name: 'Review' }));
+    await user.click(await screen.findByRole('button', { name: 'Review this work' }));
     await user.click(await screen.findByRole('button', { name: 'Increase review passes' }));
     await user.click(screen.getByRole('button', { name: 'Start review' }));
 
@@ -329,11 +331,74 @@ describe('SessionDetailPage', () => {
 
     expect(await screen.findByText('Codex 1')).toBeInTheDocument();
 
-    await user.click(await screen.findByRole('button', { name: 'Review' }));
+    await user.click(await screen.findByRole('button', { name: 'Review this work' }));
     await user.click(screen.getByRole('button', { name: 'Start review' }));
 
     const reviewTab = await screen.findByRole('tab', { name: /Codex Review/ });
     expect(reviewTab).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('starts a manual review loop from the mobile Overview sheet without relying on a popover', async () => {
+    vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
+      matches: query === '(max-width: 767px)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+    const user = userEvent.setup();
+    let postCount = 0;
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({
+          data: {
+            ...mockSessions[1],
+            status: 'completed',
+            snapshot_key: 'snapshot-mobile-review',
+            sandbox_state: 'snapshotted',
+          },
+        } satisfies SingleResponse<Session>);
+      }),
+      http.get('/api/v1/sessions/:id/review-loops', () => {
+        return HttpResponse.json({
+          data: [] as SessionReviewLoop[],
+          meta: {},
+        } satisfies ListResponse<SessionReviewLoop>);
+      }),
+      http.post('/api/v1/sessions/:id/review-loops', async ({ request, params }) => {
+        postCount += 1;
+        const body = await request.json() as { max_passes: number };
+        return HttpResponse.json({
+          data: {
+            id: 'review-loop-mobile',
+            org_id: 'org-1',
+            session_id: params.id as string,
+            status: 'running',
+            source: 'manual',
+            agent_type: 'codex',
+            max_passes: body.max_passes,
+            completed_passes: 0,
+            review_required: false,
+            started_at: '2026-02-17T07:12:00Z',
+          },
+        } satisfies SingleResponse<SessionReviewLoop>, { status: 201 });
+      }),
+    );
+
+    renderWithProviders(<SessionDetailContent id="session-98765432-abcd-ef01" />);
+
+    await user.click(await screen.findByRole('button', { name: 'Open session details' }));
+    const detailSheet = await screen.findByRole('dialog', { name: 'Session details' });
+    await user.click(within(detailSheet).getByRole('button', { name: 'Review this work' }));
+    await user.click(await screen.findByRole('button', { name: 'Start review' }));
+
+    await waitFor(() => {
+      expect(postCount).toBe(1);
+    });
   });
 
   it('does not show a dedicated self-review button for viewers', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -75,7 +75,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ChatTimeline } from "@/components/chat-timeline";
 import { SessionComposerAttachmentMenu } from "@/components/session-composer-attachment-menu";
 import { SessionComposerTriggerPicker, flattenGroups, type TriggerPickerGroup, type TriggerPickerPosition } from "@/components/session-composer-trigger-picker";
@@ -2652,7 +2651,7 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [mobileReviewComposerOpen, setMobileReviewComposerOpen] = useState(false);
   const [mobileRenameOpen, setMobileRenameOpen] = useState(false);
   const [keyboardHelpOpen, setKeyboardHelpOpen] = useState(false);
-  const [reviewPopoverOpen, setReviewPopoverOpen] = useState(false);
+  const [reviewSetupOpen, setReviewSetupOpen] = useState(false);
   const [reviewPasses, setReviewPasses] = useState(2);
   const [detailWidth, setDetailWidth] = useState(DEFAULT_DETAIL);
   const [activeFileIndex, setActiveFileIndex] = useState(0);
@@ -3356,6 +3355,13 @@ export function SessionDetailContent({ id }: { id: string }) {
   const latestReviewLoop = reviewLoopsData?.data?.[0] ?? null;
   const reviewLoopRunning = latestReviewLoop?.status === "running";
   const canStartReviewLoop = !!session && canManageSession && canUseNativeReviewLoop && hasSnapshot && !isRunning && !reviewLoopRunning;
+  const reviewUnavailableReason = reviewLoopRunning
+    ? "Review loop is running"
+    : !hasSnapshot
+      ? "A reusable sandbox snapshot is required before review"
+      : isRunning
+        ? "Review can start after the current turn finishes"
+        : undefined;
 
   const { data: ghStatus } = useQuery({
     queryKey: ["github-status"],
@@ -3420,7 +3426,7 @@ export function SessionDetailContent({ id }: { id: string }) {
       }),
     onSuccess: (response) => {
       toast.success("Review loop started");
-      setReviewPopoverOpen(false);
+      setReviewSetupOpen(false);
       const reviewThread = buildReviewLoopThreadPreview(response.data, session);
       if (reviewThread) {
         setPendingThreadPreview(reviewThread);
@@ -3447,6 +3453,10 @@ export function SessionDetailContent({ id }: { id: string }) {
       toast.error(msg);
     },
   });
+  const reviewActionDisabled = !canStartReviewLoop || startReviewLoopMutation.isPending;
+  const reviewActionDisabledReason = startReviewLoopMutation.isPending
+    ? "Starting review loop..."
+    : reviewUnavailableReason;
 
   const pushChangesMutation = useMutation({
     mutationFn: (options?: { authorMode?: PRAuthorMode; resumeToken?: string }) =>
@@ -4645,108 +4655,6 @@ export function SessionDetailContent({ id }: { id: string }) {
             </TabsList>
           </div>
           <div aria-label="Session detail actions" className="flex items-center justify-end gap-2 shrink-0 pl-2">
-            {canManageSession && canUseNativeReviewLoop ? (
-              <Popover
-                open={reviewPopoverOpen}
-                onOpenChange={(open) => setReviewPopoverOpen(open && canStartReviewLoop && !startReviewLoopMutation.isPending)}
-              >
-                <DisabledTooltip
-                  disabled={!canStartReviewLoop || startReviewLoopMutation.isPending}
-                  content={
-                    reviewLoopRunning
-                      ? "Review loop is running"
-                      : !hasSnapshot
-                        ? "A reusable sandbox snapshot is required before review"
-                        : isRunning
-                          ? "Review can start after the current turn finishes"
-                          : "Start a review loop"
-                  }
-                >
-                  <PopoverTrigger asChild>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      className="h-7 text-xs gap-1.5"
-                      disabled={!canStartReviewLoop || startReviewLoopMutation.isPending}
-                    >
-                      {startReviewLoopMutation.isPending || reviewLoopRunning ? (
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                      ) : (
-                        <ClipboardList className="h-3 w-3" />
-                      )}
-                      Review
-                    </Button>
-                  </PopoverTrigger>
-                </DisabledTooltip>
-                <PopoverContent align="end" className="w-72 space-y-3 p-3">
-                  <div className="space-y-1">
-                    <p className="text-sm font-medium">Review this work</p>
-                    <p className="text-xs text-muted-foreground">
-                      Run the agent review before you ship more changes.
-                    </p>
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="review-pass-count">Review passes</Label>
-                    <div className="flex items-center gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        className="h-8 w-8 shrink-0"
-                        aria-label="Decrease review passes"
-                        disabled={reviewPasses <= 1 || startReviewLoopMutation.isPending}
-                        onClick={() => setReviewPasses((current) => Math.max(1, current - 1))}
-                      >
-                        <Minus className="h-3.5 w-3.5" />
-                      </Button>
-                      <Input
-                        id="review-pass-count"
-                        aria-label="Review passes"
-                        type="number"
-                        min={1}
-                        max={5}
-                        value={reviewPasses}
-                        disabled={startReviewLoopMutation.isPending}
-                        onChange={(event) => {
-                          const next = Number.parseInt(event.target.value, 10);
-                          if (Number.isNaN(next)) {
-                            setReviewPasses(1);
-                            return;
-                          }
-                          setReviewPasses(Math.min(5, Math.max(1, next)));
-                        }}
-                        className="h-8 text-center"
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        className="h-8 w-8 shrink-0"
-                        aria-label="Increase review passes"
-                        disabled={reviewPasses >= 5 || startReviewLoopMutation.isPending}
-                        onClick={() => setReviewPasses((current) => Math.min(5, current + 1))}
-                      >
-                        <Plus className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    size="sm"
-                    className="w-full gap-1.5"
-                    disabled={!canStartReviewLoop || startReviewLoopMutation.isPending}
-                    onClick={() => startReviewLoopMutation.mutate()}
-                  >
-                    {startReviewLoopMutation.isPending ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <ClipboardList className="h-3.5 w-3.5" />
-                    )}
-                    Start review
-                  </Button>
-                </PopoverContent>
-              </Popover>
-            ) : null}
             {hasPR && prData?.data?.github_pr_url ? (
               <>
                 {prStatus === "closed" && (
@@ -4832,6 +4740,44 @@ export function SessionDetailContent({ id }: { id: string }) {
       </TabsContent>
       <TabsContent value="overview" className="flex-1 overflow-y-auto scrollbar-hide p-4">
         <div className="space-y-4">
+          {canManageSession && canUseNativeReviewLoop ? (
+            <Card className="border-border/60">
+              <CardContent className="p-4">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0 space-y-1">
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                        <ClipboardList className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium text-foreground">Review this work</p>
+                        <p className="text-xs text-muted-foreground">
+                          Run the current agent&apos;s review loop in this sandbox before shipping.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                  <DisabledTooltip disabled={reviewActionDisabled} content={reviewActionDisabledReason}>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full gap-1.5 sm:w-auto"
+                      disabled={reviewActionDisabled}
+                      onClick={() => setReviewSetupOpen(true)}
+                    >
+                      {startReviewLoopMutation.isPending || reviewLoopRunning ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <ClipboardList className="h-3.5 w-3.5" />
+                      )}
+                      Review this work
+                    </Button>
+                  </DisabledTooltip>
+                </div>
+              </CardContent>
+            </Card>
+          ) : null}
           {pullRequestId && prStatus === "open" && (
             prHealth ? (
               <PRHealthBanner
@@ -5236,6 +5182,104 @@ export function SessionDetailContent({ id }: { id: string }) {
           {panelTabsEl}
         </SheetContent>
       </Sheet>
+      <Dialog open={reviewSetupOpen} onOpenChange={setReviewSetupOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Review this work</DialogTitle>
+            <DialogDescription>
+              Run the selected agent&apos;s native review loop in this session&apos;s sandbox. The loop opens a dedicated review tab and keeps changes on the same branch.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-3">
+            <div className="rounded-lg border border-border bg-muted/30 p-3">
+              <div className="flex items-start gap-3">
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background text-muted-foreground">
+                  <ClipboardList className="h-4 w-4" />
+                </div>
+                <div className="min-w-0 space-y-1">
+                  <p className="text-sm font-medium text-foreground">
+                    {AGENTS_BY_KEY[session.agent_type]?.label ?? session.agent_type}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Reviews the current working tree, fixes findings, and stops early if the follow-up pass is clean.
+                  </p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center justify-between gap-3">
+                <Label htmlFor="review-pass-count">Review passes</Label>
+                <span className="text-xs text-muted-foreground">2 is the standard pass</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9 shrink-0"
+                  aria-label="Decrease review passes"
+                  disabled={reviewPasses <= 1 || startReviewLoopMutation.isPending}
+                  onClick={() => setReviewPasses((current) => Math.max(1, current - 1))}
+                >
+                  <Minus className="h-3.5 w-3.5" />
+                </Button>
+                <Input
+                  id="review-pass-count"
+                  aria-label="Review passes"
+                  type="number"
+                  min={1}
+                  max={5}
+                  value={reviewPasses}
+                  disabled={startReviewLoopMutation.isPending}
+                  onChange={(event) => {
+                    const next = Number.parseInt(event.target.value, 10);
+                    if (Number.isNaN(next)) {
+                      setReviewPasses(1);
+                      return;
+                    }
+                    setReviewPasses(Math.min(5, Math.max(1, next)));
+                  }}
+                  className="h-9 text-center"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="h-9 w-9 shrink-0"
+                  aria-label="Increase review passes"
+                  disabled={reviewPasses >= 5 || startReviewLoopMutation.isPending}
+                  onClick={() => setReviewPasses((current) => Math.min(5, current + 1))}
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={startReviewLoopMutation.isPending}
+              onClick={() => setReviewSetupOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="gap-1.5"
+              disabled={reviewActionDisabled}
+              onClick={() => startReviewLoopMutation.mutate()}
+            >
+              {startReviewLoopMutation.isPending ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <ClipboardList className="h-3.5 w-3.5" />
+              )}
+              Start review
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       {session.agent_type !== "pm_agent" ? (
         <Sheet open={mobileReviewComposerOpen} onOpenChange={setMobileReviewComposerOpen}>
           <SheetContent


### PR DESCRIPTION
## Summary
Adjusted the session detail UI so the “Review” entry point lives in the Overview readiness area (not the persistent header/cluster), aligning with the publish-readiness design update. Updated tests and the desktop/mobile behavior to open a setup dialog that works consistently in both contexts.

## Changes
- **docs/design/implemented/78-review-agent-loops.md**
  - Reworded the “Manual session entry point” guidance to specify **“Review this work”** in the Overview readiness area.
  - Clarified that the setup UI is a **dialog used on both mobile and desktop**, rather than a popover that depends on the mobile details sheet.
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Moved the review-loop entry action into the **Overview readiness area** and retitled it to **“Review this work”**.
  - Ensured the action is **hidden from the header/session actions cluster** and correctly **disabled when no session snapshot exists**.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Updated assertions for:
    - Disabled state: now expects **“Review this work”** to be disabled when no snapshot is available.
    - Placement: verifies the review button is **not present** in the labeled **“Session detail actions”** region.
    - Available state: updated test wording/expectations for the action’s new location.

## Test plan
- `npm test -- --run src/app/\(dashboard\)/sessions/\[id\]/page.test.tsx` (208 tests passed)
- `npm run typecheck` (passed)
- `npx eslint --max-warnings=0 ...session-detail-content.tsx ...page.test.tsx` (passed)
- `git diff --check` (passed)

[143.dev](https://143.dev) | [session eb6f96e8](https://143.dev/sessions/eb6f96e8-e7e3-458b-8baf-6ecf8b95566f)