### PR TITLE
Reorder prompts when user input starts with slash command

### DIFF
--- a/internal/services/agent/adapters/claude_code.go
+++ b/internal/services/agent/adapters/claude_code.go
@@ -149,7 +149,7 @@ func (a *ClaudeCodeAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox,
 		// in that case so the agent has the full context). Write the prompt
 		// under $HOME (not WorkDir, which would pollute git status) and pipe
 		// it into claude via stdin.
-		promptContent := fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, prompt.UserPrompt)
+		promptContent := composeFreshExecPrompt(prompt.SystemPrompt, prompt.UserPrompt)
 		promptPath := fmt.Sprintf("%s/.143-prompt.md", sandbox.HomeDir)
 		if err := provider.WriteFile(ctx, sandbox, promptPath, []byte(promptContent)); err != nil {
 			return nil, fmt.Errorf("write prompt file: %w", err)

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -102,7 +102,7 @@ func buildCodexPromptContent(prompt *agent.AgentPrompt) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s\n\n---\n\n%s", prompt.SystemPrompt, userPrompt), nil
+	return composeFreshExecPrompt(prompt.SystemPrompt, userPrompt), nil
 }
 
 func appendCodexHumanInputAnswer(message string, answer *agent.HumanInputAnswer) (string, error) {

--- a/internal/services/agent/adapters/prompt_builders.go
+++ b/internal/services/agent/adapters/prompt_builders.go
@@ -17,6 +17,52 @@ func usesRawTaskPrompt(input *agent.AgentInput) bool {
 	return input != nil && (input.PromptStyle == agent.PromptStyleRawTask || input.Manual || (input.Issue != nil && input.Issue.Source == models.IssueSourceManual))
 }
 
+// composeFreshExecPrompt builds the prompt-file body for the headless
+// fresh-exec path shared by Claude Code and Codex (`claude --print < file`,
+// `codex exec - < file`).
+//
+// Default layout is `<systemPrompt>\n\n---\n\n<userPrompt>`. When the user
+// prompt opens with a slash command (e.g. `/review …`), the layout is flipped
+// to `<userPrompt>\n\n---\n\n<systemPrompt>` so the CLI sees the slash token
+// at position 0 of the input and dispatches its native handler. Both CLIs
+// only recognize slash commands when they appear at the start of the user
+// turn; burying `/review` behind a multi-line system preamble caused the
+// review-loop opener to be treated as plain text instead of invoking the
+// native review command.
+func composeFreshExecPrompt(systemPrompt, userPrompt string) string {
+	if userPromptStartsWithSlashCommand(userPrompt) {
+		if strings.TrimSpace(systemPrompt) == "" {
+			return userPrompt
+		}
+		return fmt.Sprintf("%s\n\n---\n\n%s", userPrompt, systemPrompt)
+	}
+	return fmt.Sprintf("%s\n\n---\n\n%s", systemPrompt, userPrompt)
+}
+
+// userPromptStartsWithSlashCommand reports whether the first non-whitespace
+// content of userPrompt is a slash-command token (`/<name>` followed by a
+// space, newline, or end-of-string). Mirrors the recognition rule used by
+// commandTokenPresent so this helper agrees with how the upstream CLIs
+// detect commands.
+func userPromptStartsWithSlashCommand(userPrompt string) bool {
+	trimmed := strings.TrimLeft(userPrompt, " \t\n\r")
+	if len(trimmed) < 2 || trimmed[0] != '/' {
+		return false
+	}
+	for i := 1; i < len(trimmed); i++ {
+		c := trimmed[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\n' || c == '\r':
+			return i > 1
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '-' || c == ':':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // buildSystemPrompt constructs the system prompt with instructions and context.
 func buildSystemPrompt(input *agent.AgentInput) string {
 	var b strings.Builder

--- a/internal/services/agent/adapters/prompt_builders_test.go
+++ b/internal/services/agent/adapters/prompt_builders_test.go
@@ -2,6 +2,7 @@ package adapters
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -771,6 +772,71 @@ func TestExtractStackTrace(t *testing.T) {
 			for _, s := range tt.want {
 				require.Contains(t, result, s)
 			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// composeFreshExecPrompt
+// ---------------------------------------------------------------------------
+
+func TestComposeFreshExecPrompt_PlainPromptKeepsSystemFirst(t *testing.T) {
+	t.Parallel()
+
+	got := composeFreshExecPrompt("system context", "fix the failing test")
+	require.Equal(t, "system context\n\n---\n\nfix the failing test", got)
+}
+
+func TestComposeFreshExecPrompt_SlashCommandMovesUserFirst(t *testing.T) {
+	t.Parallel()
+
+	user := "/review the current workspace diff\n\nFix nits when they are local."
+	got := composeFreshExecPrompt("system context", user)
+	require.True(t, strings.HasPrefix(got, "/review "), "slash command must be at position 0 so the CLI dispatches its native handler")
+	require.Contains(t, got, "system context", "system prompt should still reach the model")
+	require.Equal(t, user+"\n\n---\n\nsystem context", got)
+}
+
+func TestComposeFreshExecPrompt_SlashCommandWithEmptySystemPromptReturnsUserOnly(t *testing.T) {
+	t.Parallel()
+
+	got := composeFreshExecPrompt("   \n\t", "/review go")
+	require.Equal(t, "/review go", got, "empty system prompts should not leave a trailing separator")
+}
+
+func TestComposeFreshExecPrompt_LeadingWhitespaceBeforeSlashStillFlips(t *testing.T) {
+	t.Parallel()
+
+	got := composeFreshExecPrompt("system context", "   /review go")
+	require.True(t, strings.HasPrefix(got, "   /review go"), "leading whitespace should still count as a slash-command opener")
+}
+
+func TestUserPromptStartsWithSlashCommand(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"plain text", "fix the bug", false},
+		{"slash with args", "/review the diff", true},
+		{"slash with newline", "/review\nfix nits", true},
+		{"slash only", "/review", true},
+		{"slash then non-identifier", "/foo!bar", false},
+		{"slash with hyphen", "/code-review now", true},
+		{"slash with colon namespace", "/plugin:review go", true},
+		{"lone slash", "/", false},
+		{"middle of line", "see /review later", false},
+		{"empty", "", false},
+		{"only whitespace", "   \n\t", false},
+		{"leading whitespace then slash", "  \t/review go", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, userPromptStartsWithSlashCommand(tc.in))
 		})
 	}
 }


### PR DESCRIPTION
## Summary
This change ensures that slash commands in user prompts are recognized by the CLI by reordering the system and user prompts when the user input begins with a slash command token.

## Problem
The Claude Code and Codex CLIs only recognize slash commands (e.g., `/review`) when they appear at position 0 of the input. Previously, the prompt composition always placed the system prompt first, which buried slash commands behind the system preamble and caused them to be treated as plain text instead of invoking native command handlers.

## Solution
Introduced `composeFreshExecPrompt()` function that intelligently reorders prompts:
- **Default layout**: `<systemPrompt>\n\n---\n\n<userPrompt>` (system first)
- **When user prompt starts with slash command**: `<userPrompt>\n\n---\n\n<systemPrompt>` (user first, so CLI sees slash at position 0)
- **Edge case**: If system prompt is empty/whitespace-only and user starts with slash, returns user prompt only (no separator)

## Key Changes
- Added `composeFreshExecPrompt(systemPrompt, userPrompt string) string` function to handle prompt composition logic
- Added `userPromptStartsWithSlashCommand(userPrompt string) bool` helper to detect slash command tokens at the start of input (accounting for leading whitespace)
- Updated `ClaudeCodeAdapter.Execute()` to use `composeFreshExecPrompt()` instead of hardcoded format string
- Updated `buildCodexPromptContent()` to use `composeFreshExecPrompt()` instead of hardcoded format string
- Added comprehensive test coverage for both functions with edge cases (leading whitespace, empty system prompts, various slash command formats)

## Implementation Details
The slash command detection mirrors the CLI's recognition rules:
- Recognizes tokens like `/review`, `/code-review`, `/plugin:review`
- Requires the slash to be followed by valid identifier characters (alphanumeric, underscore, hyphen, colon) or whitespace/newline
- Rejects invalid patterns like `/` alone or `/foo!bar`
- Properly handles leading whitespace before the slash

https://claude.ai/code/session_01DVg64MsMkg88K5qqpB2myN