### PR TITLE
Fix /sessions/new flash warnings by deferring banners until setup/integrations load

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx
@@ -5,6 +5,14 @@ import { ManualSessionCreatePageContent } from "./manual-session-create-page-con
 
 const DRAFT_STORAGE_KEY = "143:new-session-draft";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
 const mocks = vi.hoisted(() => ({
   settingsGetMock: vi.fn().mockResolvedValue({
     data: {
@@ -248,6 +256,53 @@ describe("ManualSessionCreatePageContent", () => {
 
     expect(await screen.findByTestId("no-repos-warning")).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: /Model override/i })).toBeInTheDocument();
+  });
+
+  it("does not show repository setup warning before the repository fetch resolves", async () => {
+    const repos = deferred<{ data: never[] }>();
+    mocks.repositoriesListMock.mockImplementationOnce(() => repos.promise);
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    expect(await screen.findByRole("textbox", { name: "Manual session prompt" })).toBeInTheDocument();
+    expect(screen.queryByTestId("no-repos-warning")).not.toBeInTheDocument();
+
+    repos.resolve({ data: [] });
+
+    expect(await screen.findByTestId("no-repos-warning")).toBeInTheDocument();
+  });
+
+  it("does not show the agent configuration warning before setup queries resolve", async () => {
+    const settings = deferred<Awaited<ReturnType<typeof mocks.settingsGetMock>>>();
+    mocks.settingsGetMock.mockImplementationOnce(() => settings.promise);
+    mocks.resolvedCredsMock.mockResolvedValueOnce({
+      data: [
+        { provider: "openai", source: "none" },
+        { provider: "anthropic", source: "none" },
+        { provider: "gemini", source: "none" },
+        { provider: "amp", source: "none" },
+        { provider: "pi", source: "none" },
+      ],
+    });
+    mocks.codexAuthStatusMock.mockResolvedValueOnce({ data: { status: "none" } });
+    mocks.codingAuthsListMock.mockResolvedValueOnce({ data: [] });
+
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    expect(await screen.findByRole("textbox", { name: "Manual session prompt" })).toBeInTheDocument();
+    expect(screen.queryByText(/No API key configured/)).not.toBeInTheDocument();
+
+    settings.resolve({
+      data: {
+        name: "Test Org",
+        settings: {
+          default_agent_type: "codex",
+          default_llm_model: "gpt-5.4-mini",
+        },
+      },
+    });
+
+    expect(await screen.findByText(/No API key configured for Codex/)).toBeInTheDocument();
   });
 
   it("uses a mobile settings sheet instead of inline repo and model controls on small screens", async () => {
@@ -497,12 +552,35 @@ describe("ManualSessionCreatePageContent", () => {
     expect(screen.getByRole("menuitem", { name: "Add linear issue" })).toBeInTheDocument();
   });
 
-  it("shows the linear issue action even when Linear is not configured", async () => {
+  it("hides the linear issue action when Linear is not configured", async () => {
     const user = userEvent.setup();
     mocks.integrationsListMock.mockResolvedValueOnce({ data: [] });
     renderWithProviders(<ManualSessionCreatePageContent />);
 
     await user.click(await screen.findByRole("button", { name: "Add files or photos" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Add linear issue" })).not.toBeInTheDocument();
+  });
+
+  it("hides the linear issue action until the integrations fetch confirms active Linear", async () => {
+    const user = userEvent.setup();
+    const integrations = deferred<Awaited<ReturnType<typeof mocks.integrationsListMock>>>();
+    mocks.integrationsListMock.mockImplementationOnce(() => integrations.promise);
+    renderWithProviders(<ManualSessionCreatePageContent />);
+
+    await user.click(await screen.findByRole("button", { name: "Add files or photos" }));
+
+    expect(screen.queryByRole("menuitem", { name: "Add linear issue" })).not.toBeInTheDocument();
+
+    integrations.resolve({
+      data: [
+        {
+          id: "integration-linear",
+          provider: "linear",
+          status: "active",
+        },
+      ],
+    });
 
     expect(await screen.findByRole("menuitem", { name: "Add linear issue" })).toBeInTheDocument();
   });

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -89,6 +89,7 @@ import {
 } from "@/lib/coding-agent-reasoning";
 import type {
   CodingAuth,
+  Integration,
   OrgSettings,
   Organization,
   Repository,
@@ -495,7 +496,7 @@ export function ManualSessionComposer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { data: settingsResponse } = useQuery<SingleResponse<Organization>>({
+  const { data: settingsResponse, isSuccess: settingsLoaded } = useQuery<SingleResponse<Organization>>({
     queryKey: queryKeys.settings.all,
     queryFn: () => api.settings.get(),
   });
@@ -503,7 +504,7 @@ export function ManualSessionComposer({
   const settings = settingsResponse?.data?.settings as OrgSettings | undefined;
   const defaultAgentType = settings?.default_agent_type ?? "codex";
 
-  const { data: reposResponse } = useQuery<ListResponse<Repository>>({
+  const { data: reposResponse, isSuccess: reposLoaded } = useQuery<ListResponse<Repository>>({
     queryKey: queryKeys.repositories.all,
     queryFn: () => api.repositories.list(),
   });
@@ -523,19 +524,23 @@ export function ManualSessionComposer({
     }
   }, [userSelectedRepoId, reposResponse, repositories]);
 
-  const { data: resolvedCredsResponse } = useQuery<ListResponse<ResolvedCredential>>({
+  const { data: resolvedCredsResponse, isSuccess: resolvedCredsLoaded } = useQuery<ListResponse<ResolvedCredential>>({
     queryKey: queryKeys.credentials.resolved,
     queryFn: () => api.userCredentials.listResolved(),
   });
   const resolvedCredentials = useMemo(() => resolvedCredsResponse?.data ?? [], [resolvedCredsResponse]);
 
-  const { data: codexAuthResponse } = useQuery({
+  const { data: codexAuthResponse, isSuccess: codexAuthLoaded } = useQuery({
     queryKey: queryKeys.codexAuth.status,
     queryFn: () => api.codexAuth.status(),
   });
-  const { data: codingAuthsResponse } = useQuery<ListResponse<CodingAuth>>({
+  const { data: codingAuthsResponse, isSuccess: codingAuthsLoaded } = useQuery<ListResponse<CodingAuth>>({
     queryKey: ["coding-auths"],
     queryFn: () => api.codingAuths.list(),
+  });
+  const { data: integrationsResponse, isSuccess: integrationsLoaded } = useQuery<ListResponse<Integration>>({
+    queryKey: queryKeys.integrations.all,
+    queryFn: () => api.integrations.list(),
   });
 
   // Auto-select: user's choice > last used repo > first repo.
@@ -616,6 +621,11 @@ export function ManualSessionComposer({
     [effectiveAgentType],
   );
   const hasAgentCredentials = isAgentAvailable(effectiveAgentType, resolvedCredentials, codexAuthStatus, codingAuths);
+  const agentCredentialStateLoaded = settingsLoaded && resolvedCredsLoaded && codexAuthLoaded && codingAuthsLoaded;
+  const shouldShowAgentKeyRequiredBanner = agentCredentialStateLoaded && !hasAgentCredentials;
+  const linearConnected = integrationsLoaded && (integrationsResponse?.data ?? []).some(
+    (integration) => integration.provider === "linear" && integration.status === "active",
+  );
 
   const handleRepoChange = useCallback((id: string) => {
     setUserSelectedRepoId(id);
@@ -1223,7 +1233,7 @@ export function ManualSessionComposer({
 
       {heroSlot}
 
-      {repositories.length === 0 && (
+      {reposLoaded && repositories.length === 0 && (
         <div className="shrink-0 px-0">
           <div className={cn("w-full mx-auto", innerClassName)}>
             <NoReposWarning />
@@ -1231,7 +1241,7 @@ export function ManualSessionComposer({
         </div>
       )}
 
-      {!hasAgentCredentials && (
+      {shouldShowAgentKeyRequiredBanner && (
         <div className="shrink-0 px-0">
           <div className={cn("w-full mx-auto", innerClassName)}>
             <AgentKeyRequiredBanner agentType={effectiveAgentType} />
@@ -1463,6 +1473,7 @@ export function ManualSessionComposer({
                         onUploadFiles={() => uploadInputRef.current?.click()}
                         onAddImageURL={() => setShowImageInput(true)}
                         onAddLinearIssue={() => setShowLinearInput(true)}
+                        showLinearIssue={linearConnected}
                       />
                       <Button
                         type="button"
@@ -1508,6 +1519,7 @@ export function ManualSessionComposer({
                       onUploadFiles={() => uploadInputRef.current?.click()}
                       onAddImageURL={() => setShowImageInput(true)}
                       onAddLinearIssue={() => setShowLinearInput(true)}
+                      showLinearIssue={linearConnected}
                     />
 
                     <ComposerSettingsControls

--- a/frontend/src/components/session-composer-attachment-menu.tsx
+++ b/frontend/src/components/session-composer-attachment-menu.tsx
@@ -16,6 +16,7 @@ type SessionComposerAttachmentMenuProps = {
   onUploadFiles: () => void;
   onAddImageURL: () => void;
   onAddLinearIssue: () => void;
+  showLinearIssue?: boolean;
   buttonAriaLabel: string;
   buttonTitle?: string;
   buttonClassName?: string;
@@ -27,6 +28,7 @@ export function SessionComposerAttachmentMenu({
   onUploadFiles,
   onAddImageURL,
   onAddLinearIssue,
+  showLinearIssue = true,
   buttonAriaLabel,
   buttonTitle,
   buttonClassName,
@@ -55,10 +57,12 @@ export function SessionComposerAttachmentMenu({
           <LinkIcon data-testid="add-image-url-link-icon" className="mr-2 h-4 w-4" />
           Add image URL
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={onAddLinearIssue}>
-          <LinearIcon className="mr-2 h-4 w-4" />
-          Add linear issue
-        </DropdownMenuItem>
+        {showLinearIssue ? (
+          <DropdownMenuItem onClick={onAddLinearIssue}>
+            <LinearIcon className="mr-2 h-4 w-4" />
+            Add linear issue
+          </DropdownMenuItem>
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
## Summary
This fixes the `/sessions/new` UI “flash” where configuration and repository warnings briefly appear before the required backend setup calls finish. It also gates the Linear action so it only enables once active Linear is confirmed, avoiding incorrect availability.

## Changes
- **frontend/src/components/manual-session-composer.tsx**
  - Delay showing the **missing agent credentials** (amber) banner until backend setup queries resolve.
  - Delay showing the **no repositories** warning until the repositories fetch completes.
  - Fetch integrations and only enable **“Add linear issue”** after active Linear is confirmed.
- **frontend/src/components/session-composer-attachment-menu.tsx**
  - Add a `showLinearIssue` gate so the Linear menu item is hidden/disabled until the parent confirms Linear is active.
- **frontend/src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx**
  - Add regression tests asserting warnings are not rendered before their corresponding fetch promises resolve.
  - Update/extend Linear gating coverage to ensure the menu action is hidden when Linear isn’t configured/confirmed active.

## Test plan
- `npm run test:ci -- src/app/(dashboard)/sessions/new/manual-session-create-page-content.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 392d9eb3](https://143.dev/sessions/392d9eb3-3161-4828-b18f-420900d9b177)