### PR TITLE
Use review-loop-specific continuation dedupe keys

### DIFF
--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -211,7 +211,7 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 	summary := strings.TrimSpace(assistantSummary)
 	switch pass.Status {
 	case models.ReviewLoopPassStatusReviewing:
-		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopDecisionPrompt(), nil)
+		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopDecisionPrompt(), nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, pass.ID, "decision")))
 		if err != nil {
 			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to request review decision: %s", err))
 			return err
@@ -241,7 +241,7 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 			}
 			return nil
 		}
-		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopFixPrompt(), nil)
+		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopFixPrompt(), nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, pass.ID, "fix")))
 		if err != nil {
 			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start fix pass: %s", err))
 			return err
@@ -261,7 +261,7 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 		if err := s.store.CreatePass(ctx, next); err != nil {
 			return err
 		}
-		msg, err := s.sendReview(ctx, &loop, next, nil)
+		msg, err := s.sendReview(ctx, &loop, next, nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, next.ID, "review")))
 		if err != nil {
 			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start confirmation review: %s", err))
 			return err
@@ -290,7 +290,19 @@ func automationOpenPRDedupeKey(sessionID uuid.UUID) string {
 	return "open_pr:review_loop:" + sessionID.String()
 }
 
-func (s *Service) sendReview(ctx context.Context, loop *models.SessionReviewLoop, pass *models.SessionReviewLoopPass, userID *uuid.UUID) (*models.SessionMessage, error) {
+type sendOption func(*threadsvc.SendMessageInput)
+
+func withContinuationDedupeKey(key string) sendOption {
+	return func(input *threadsvc.SendMessageInput) {
+		input.ContinuationDedupeKeyOverride = &key
+	}
+}
+
+func reviewLoopContinuationDedupeKey(loopID, passID uuid.UUID, phase string) string {
+	return fmt.Sprintf("continue_session_review_loop:%s:%s:%s", loopID.String(), passID.String(), phase)
+}
+
+func (s *Service) sendReview(ctx context.Context, loop *models.SessionReviewLoop, pass *models.SessionReviewLoopPass, userID *uuid.UUID, opts ...sendOption) (*models.SessionMessage, error) {
 	arguments := strings.TrimPrefix(prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{AgentType: loop.AgentType}), "/review")
 	arguments = strings.TrimSpace(arguments)
 	command := models.SessionInputCommand{
@@ -302,21 +314,30 @@ func (s *Service) sendReview(ctx context.Context, loop *models.SessionReviewLoop
 		Arguments: arguments,
 		Source:    models.SessionInputCommandSourceBuiltin,
 	}
-	return s.sendPlain(ctx, *loop, prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{AgentType: loop.AgentType}), userID, command)
+	return s.sendPlain(ctx, *loop, prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{AgentType: loop.AgentType}), userID, append(opts, withCommands(command))...)
 }
 
-func (s *Service) sendPlain(ctx context.Context, loop models.SessionReviewLoop, message string, userID *uuid.UUID, commands ...models.SessionInputCommand) (*models.SessionMessage, error) {
+func withCommands(commands ...models.SessionInputCommand) sendOption {
+	return func(input *threadsvc.SendMessageInput) {
+		input.Commands = commands
+	}
+}
+
+func (s *Service) sendPlain(ctx context.Context, loop models.SessionReviewLoop, message string, userID *uuid.UUID, opts ...sendOption) (*models.SessionMessage, error) {
 	if loop.ThreadID == nil {
 		return nil, fmt.Errorf("review loop has no thread")
 	}
-	result, err := s.runtime.SendMessage(ctx, threadsvc.SendMessageInput{
+	input := threadsvc.SendMessageInput{
 		SessionID: loop.SessionID,
 		OrgID:     loop.OrgID,
 		ThreadID:  *loop.ThreadID,
 		UserID:    userID,
 		Message:   message,
-		Commands:  commands,
-	})
+	}
+	for _, opt := range opts {
+		opt(&input)
+	}
+	result, err := s.runtime.SendMessage(ctx, input)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -160,12 +160,16 @@ func TestService_OnThreadTurnCompleteDirtyThenClean(t *testing.T) {
 	require.NoError(t, err, "review completion should enqueue decision")
 	require.Equal(t, "Found a missing regression test", store.markedReviewOutput, "review output should be stored natively")
 	require.Contains(t, threads.sent[0].Message, "REVIEW_CLEAN", "decision prompt should ask for the clean sentinel")
+	require.NotNil(t, threads.sent[0].ContinuationDedupeKeyOverride, "review decision prompt should use a dedicated continuation dedupe key")
+	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, passID, "decision"), *threads.sent[0].ContinuationDedupeKeyOverride, "review decision prompt should not collide with the currently running review job")
 
 	store.latestPass.Status = models.ReviewLoopPassStatusDeciding
 	err = svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "NEEDS_FIX_PASS")
 	require.NoError(t, err, "dirty decision should enqueue a fix pass")
 	require.Equal(t, models.ReviewLoopDecisionNeedsFix, store.fixDecision, "dirty decision should be persisted")
 	require.Contains(t, threads.sent[1].Message, "Fix the issues you identified", "fix prompt should reference the previous review")
+	require.NotNil(t, threads.sent[1].ContinuationDedupeKeyOverride, "review fix prompt should use a dedicated continuation dedupe key")
+	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, passID, "fix"), *threads.sent[1].ContinuationDedupeKeyOverride, "review fix prompt should not collide with the decision job")
 
 	store.latestPass.Status = models.ReviewLoopPassStatusFixing
 	err = svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "Added the regression test")
@@ -174,6 +178,8 @@ func TestService_OnThreadTurnCompleteDirtyThenClean(t *testing.T) {
 	require.Len(t, store.createdPasses, 1, "fix completion should create the confirmation pass")
 	require.Equal(t, 2, store.createdPasses[0].PassIndex, "confirmation pass should increment pass_index")
 	require.Contains(t, threads.sent[2].Message, "/review", "confirmation pass should run /review again")
+	require.NotNil(t, threads.sent[2].ContinuationDedupeKeyOverride, "confirmation review prompt should use a dedicated continuation dedupe key")
+	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, store.createdPasses[0].ID, "review"), *threads.sent[2].ContinuationDedupeKeyOverride, "confirmation review prompt should not collide with the fix job")
 
 	store.latestPass = store.createdPasses[0]
 	store.latestPass.Status = models.ReviewLoopPassStatusDeciding

--- a/internal/services/thread/service.go
+++ b/internal/services/thread/service.go
@@ -172,6 +172,11 @@ type SendMessageInput struct {
 	Commands                models.SessionInputCommands
 	PlanMode                bool
 	ResolveReviewCommentIDs []uuid.UUID
+	// ContinuationDedupeKeyOverride is for system-generated follow-up turns
+	// created while the current same-thread worker job is still marked running.
+	// User sends should leave it nil so rapid-fire messages keep normal thread
+	// dedupe behavior.
+	ContinuationDedupeKeyOverride *string
 }
 
 // SendMessageResult carries everything callers need to finish handling a
@@ -623,6 +628,9 @@ func (s *Service) SendMessage(ctx context.Context, input SendMessageInput) (*Sen
 	// this tab collapse, while sibling sends that arrive during another tab's
 	// turn are queued without enqueueing a second shared-sandbox job.
 	dedupeKey := db.ContinueSessionDedupeKey(thread.ID)
+	if input.ContinuationDedupeKeyOverride != nil && *input.ContinuationDedupeKeyOverride != "" {
+		dedupeKey = *input.ContinuationDedupeKeyOverride
+	}
 	payload := map[string]string{
 		"session_id": thread.SessionID.String(),
 		"thread_id":  input.ThreadID.String(),

--- a/internal/services/thread/service_test.go
+++ b/internal/services/thread/service_test.go
@@ -1128,6 +1128,39 @@ func TestService_SendMessage(t *testing.T) {
 			},
 		},
 		{
+			name: "success with continuation dedupe override",
+			input: SendMessageInput{
+				SessionID: sessionID,
+				OrgID:     orgID,
+				ThreadID:  threadID,
+				UserID:    &userID,
+				Message:   "internal follow-up",
+				ContinuationDedupeKeyOverride: func() *string {
+					key := "continue_session_review_loop:loop:pass:decision"
+					return &key
+				}(),
+			},
+			setupDeps: func(deps *testDeps) {
+				deps.threadStore.claimIdleFn = func(_ context.Context, _, _, _ uuid.UUID) (models.SessionThread, error) {
+					return models.SessionThread{ID: threadID, SessionID: sessionID, OrgID: orgID, CurrentTurn: 1, Status: models.ThreadStatusRunning}, nil
+				}
+				deps.messageStore.createFn = func(_ context.Context, msg *models.SessionMessage) error {
+					msg.ID = 43
+					msg.CreatedAt = time.Now()
+					return nil
+				}
+				deps.jobStore.enqueueFn = func(_ context.Context, _ uuid.UUID, queue, jobType string, payload any, _ int, dedupeKey *string) (uuid.UUID, error) {
+					require.Equal(t, "agent", queue, "thread messages should use the agent queue")
+					require.Equal(t, "continue_session", jobType, "thread messages should reuse the continue-session worker")
+					require.IsType(t, map[string]string{}, payload, "thread message payload should be string keyed")
+					require.Equal(t, threadID.String(), payload.(map[string]string)["thread_id"], "thread id should still be included for worker attribution")
+					require.NotNil(t, dedupeKey, "override enqueue should carry a dedupe key")
+					require.Equal(t, "continue_session_review_loop:loop:pass:decision", *dedupeKey, "internal follow-up should use the caller-provided dedupe key")
+					return uuid.New(), nil
+				}
+			},
+		},
+		{
 			name: "claims parent session before creating thread message",
 			input: SendMessageInput{
 				SessionID: sessionID,


### PR DESCRIPTION
## Summary
- Add a continuation dedupe override for system-generated thread follow-ups.
- Use phase-specific dedupe keys for review-loop decision, fix, and re-review turns so they are not swallowed by the still-running parent job.
- Add tests covering both the review-loop path and the thread-service override behavior.

## Testing
- `go test ./internal/services/reviewloop ./internal/services/thread`
- `go vet ./...`
- `go build ./...`
- `go test ./...`