### PR TITLE
Fallback to Claude Code subscription auth when Codex/agent execution is rate-limited

### DIFF
--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -92,6 +92,7 @@ type AgentEnv struct {
 	orgs              OrgStore
 	orgSettingsCache  *OrgSettingsCache
 	codexAuth         CodexAuthProvider
+	claudeCodeAuth    ClaudeCodeAuthProvider
 	// linearTokens, when set, supplies the LINEAR_ACCESS_TOKEN env var via a
 	// refresh-aware resolver. Without it, the sandbox falls back to reading
 	// the raw credential row (legacy path; the access token may have aged
@@ -178,6 +179,7 @@ type AgentEnvDeps struct {
 	Orgs              OrgStore                 // optional — enables agent_config overrides
 	OrgSettingsCache  *OrgSettingsCache        // optional — caches agent_config lookups
 	CodexAuth         CodexAuthProvider        // optional — enables ChatGPT OAuth for Codex
+	ClaudeCodeAuth    ClaudeCodeAuthProvider   // optional — enables Claude subscription OAuth for Claude Code
 	// LinearTokens optionally supplies a refresh-aware Linear access token
 	// for the sandbox env. When set, the orchestrator injects the result of
 	// GetValidAccessToken (rotating expired tokens transparently). Without
@@ -210,6 +212,7 @@ func NewAgentEnv(deps AgentEnvDeps) *AgentEnv {
 		orgs:              deps.Orgs,
 		orgSettingsCache:  deps.OrgSettingsCache,
 		codexAuth:         deps.CodexAuth,
+		claudeCodeAuth:    deps.ClaudeCodeAuth,
 		linearTokens:      deps.LinearTokens,
 		provider:          deps.Provider,
 		logger:            deps.Logger,
@@ -1360,6 +1363,163 @@ func (e *AgentEnv) writeCodexAuth(ctx context.Context, orgID uuid.UUID, sandbox 
 		Msg("injected codex auth.json and config.toml into sandbox")
 
 	return true, nil
+}
+
+// InjectClaudeCodeAuth writes ~/.claude/.credentials.json when a Claude Code
+// subscription credential is selected. API-key credentials intentionally return
+// false so callers can use ANTHROPIC_API_KEY after removing any stale file.
+func (e *AgentEnv) InjectClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, sandbox *Sandbox) (bool, error) {
+	return e.InjectClaudeCodeAuthForUser(ctx, orgID, nil, sandbox)
+}
+
+func (e *AgentEnv) InjectClaudeCodeAuthForUser(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, sandbox *Sandbox) (bool, error) {
+	if e == nil {
+		return false, nil
+	}
+	if e.codingCredentials != nil {
+		if picked, ok := e.lookupRecentCredential(orgID, userID, models.ProviderAnthropic); ok {
+			return e.injectPickedClaudeCodeAuth(ctx, orgID, sandbox, picked)
+		}
+		_, picked, handled := e.pickFromCodingProviderSet(ctx, orgID, userID, models.ProviderAnthropic, []models.ProviderName{
+			models.ProviderAnthropic,
+			models.ProviderAnthropicSubscription,
+		})
+		if handled {
+			if picked == nil {
+				return false, nil
+			}
+			return e.injectPickedClaudeCodeAuth(ctx, orgID, sandbox, *picked)
+		}
+	}
+
+	if e.claudeCodeAuth == nil {
+		return false, nil
+	}
+	sub, _, err := e.claudeCodeAuth.GetValidToken(ctx, orgID)
+	if err != nil {
+		return false, fmt.Errorf("get claude code subscription token: %w", err)
+	}
+	if sub == nil {
+		return false, nil
+	}
+	return e.writeClaudeCodeAuth(ctx, orgID, sandbox, *sub)
+}
+
+func (e *AgentEnv) injectPickedClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, sandbox *Sandbox, picked models.DecryptedCodingCredential) (bool, error) {
+	if picked.Provider != models.ProviderAnthropicSubscription {
+		return false, nil
+	}
+	cfg, ok := picked.Config.(models.AnthropicSubscriptionConfig)
+	if !ok || cfg.AccessToken == "" || cfg.RefreshToken == "" {
+		return false, nil
+	}
+	sub := models.AnthropicSubscription{
+		AccessToken:   cfg.AccessToken,
+		RefreshToken:  cfg.RefreshToken,
+		ExpiresAt:     cfg.ExpiresAt,
+		AccountType:   cfg.AccountType,
+		RateLimitTier: cfg.RateLimitTier,
+		Scopes:        cfg.Scopes,
+	}
+	if sub.NeedsRefresh(codexSubscriptionRefreshWindow) {
+		refresher, ok := e.claudeCodeAuth.(ClaudeCodeAuthRefresher)
+		if ok {
+			scope := models.Scope{OrgID: orgID, UserID: picked.UserID}
+			refreshed, err := refresher.RefreshTokenByID(ctx, scope, picked.ID)
+			if err == nil && refreshed != nil {
+				sub = *refreshed
+			} else if sub.IsExpired() {
+				if err != nil {
+					return false, fmt.Errorf("refresh unified claude subscription %s: %w", picked.ID, err)
+				}
+				return false, fmt.Errorf("refresh unified claude subscription %s returned no token", picked.ID)
+			} else if err != nil {
+				e.logger.Warn().
+					Err(err).
+					Str("cred_id", picked.ID.String()).
+					Msg("unified claude subscription refresh failed; using cached token")
+			}
+		} else if sub.IsExpired() {
+			return false, fmt.Errorf("unified claude subscription %s is expired and no refresh provider is configured", picked.ID)
+		}
+	}
+	return e.writeClaudeCodeAuth(ctx, orgID, sandbox, sub)
+}
+
+func (e *AgentEnv) writeClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, sandbox *Sandbox, sub models.AnthropicSubscription) (bool, error) {
+	oauthPayload := map[string]interface{}{
+		"accessToken":  sub.AccessToken,
+		"refreshToken": sub.RefreshToken,
+		"expiresAt":    sub.ExpiresAt.UnixMilli(),
+	}
+	if len(sub.Scopes) > 0 {
+		oauthPayload["scopes"] = sub.Scopes
+	}
+	if sub.AccountType != "" {
+		oauthPayload["subscriptionType"] = sub.AccountType
+	}
+	if sub.RateLimitTier != "" {
+		oauthPayload["rateLimitTier"] = sub.RateLimitTier
+	}
+	credsJSON, err := json.Marshal(map[string]interface{}{"claudeAiOauth": oauthPayload})
+	if err != nil {
+		return false, fmt.Errorf("marshal claude credentials: %w", err)
+	}
+
+	authDir := path.Join(sandbox.HomeDir, ".claude")
+	credsPath := authDir + "/.credentials.json"
+	prepCmd := fmt.Sprintf(
+		"mkdir -p '%s' && install -m 600 /dev/null '%s'",
+		shellEscapeSingleQuote(authDir),
+		shellEscapeSingleQuote(credsPath),
+	)
+
+	var prepOut, prepErr bytes.Buffer
+	exitCode, err := e.provider.Exec(ctx, sandbox, prepCmd, &prepOut, &prepErr)
+	if err != nil {
+		return false, fmt.Errorf("prepare claude credentials file: %w", err)
+	}
+	if exitCode != 0 {
+		return false, fmt.Errorf("prepare claude credentials file: exited with code %d: %s", exitCode, prepErr.String())
+	}
+
+	if err := e.provider.WriteFile(ctx, sandbox, credsPath, credsJSON); err != nil {
+		return false, fmt.Errorf("write claude credentials: %w", err)
+	}
+
+	e.logger.Debug().
+		Str("org_id", orgID.String()).
+		Msg("injected claude subscription credentials into sandbox")
+
+	return true, nil
+}
+
+func (e *AgentEnv) PrepareClaudeCodeAPIKeyFallback(ctx context.Context, sandbox *Sandbox, env map[string]string) error {
+	if env["ANTHROPIC_API_KEY"] == "" {
+		return errClaudeCodeFallbackUnavailable
+	}
+	return e.RemoveClaudeCodeCredentialsFile(ctx, sandbox)
+}
+
+func (e *AgentEnv) RemoveClaudeCodeCredentialsFile(ctx context.Context, sandbox *Sandbox) error {
+	credsPath := path.Join(sandbox.HomeDir, ".claude", ".credentials.json")
+	if _, err := e.provider.ReadFile(ctx, sandbox, credsPath); err != nil {
+		if isSandboxFileMissing(err) {
+			return nil
+		}
+		return fmt.Errorf("check stale claude credentials: %w", err)
+	}
+
+	cmd := fmt.Sprintf("rm -f '%s'", shellEscapeSingleQuote(credsPath))
+	var stdout, stderr bytes.Buffer
+	exitCode, err := e.provider.Exec(ctx, sandbox, cmd, &stdout, &stderr)
+	if err != nil {
+		return fmt.Errorf("remove stale claude credentials: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("remove stale claude credentials: exited with code %d: %s", exitCode, stderr.String())
+	}
+	return nil
 }
 
 func (e *AgentEnv) unifiedCodingCredentialIsAPIKey(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, provider models.ProviderName) bool {

--- a/internal/services/agent/env.go
+++ b/internal/services/agent/env.go
@@ -187,7 +187,7 @@ type AgentEnvDeps struct {
 	// tests and pre-refresh-flow installs, but those env vars can be stale
 	// for any session that starts within refreshWindow of expiry.
 	LinearTokens LinearTokenResolver
-	Provider     SandboxProvider // required for InjectCodexAuth
+	Provider     SandboxProvider // required for sandbox credential file injection
 	Logger       zerolog.Logger
 }
 
@@ -1447,6 +1447,9 @@ func (e *AgentEnv) injectPickedClaudeCodeAuth(ctx context.Context, orgID uuid.UU
 }
 
 func (e *AgentEnv) writeClaudeCodeAuth(ctx context.Context, orgID uuid.UUID, sandbox *Sandbox, sub models.AnthropicSubscription) (bool, error) {
+	if e.provider == nil {
+		return false, fmt.Errorf("sandbox provider is required to write claude credentials")
+	}
 	oauthPayload := map[string]interface{}{
 		"accessToken":  sub.AccessToken,
 		"refreshToken": sub.RefreshToken,
@@ -1502,6 +1505,9 @@ func (e *AgentEnv) PrepareClaudeCodeAPIKeyFallback(ctx context.Context, sandbox 
 }
 
 func (e *AgentEnv) RemoveClaudeCodeCredentialsFile(ctx context.Context, sandbox *Sandbox) error {
+	if e == nil || e.provider == nil {
+		return fmt.Errorf("sandbox provider is required to remove claude credentials")
+	}
 	credsPath := path.Join(sandbox.HomeDir, ".claude", ".credentials.json")
 	if _, err := e.provider.ReadFile(ctx, sandbox, credsPath); err != nil {
 		if isSandboxFileMissing(err) {

--- a/internal/services/agent/env_test.go
+++ b/internal/services/agent/env_test.go
@@ -1539,6 +1539,55 @@ func TestAgentEnvInjectCodexAuth(t *testing.T) {
 	}
 }
 
+func TestAgentEnvInjectClaudeCodeAuthRequiresSandboxProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	credID := uuid.New()
+	sandbox := &Sandbox{HomeDir: "/home/test"}
+	coding := &envCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderAnthropicSubscription: {
+				{
+					ID:       credID,
+					OrgID:    orgID,
+					Provider: models.ProviderAnthropicSubscription,
+					Status:   models.CodingCredentialStatusActive,
+					Config: models.AnthropicSubscriptionConfig{
+						AccessToken:  "claude-access",
+						RefreshToken: "claude-refresh",
+						ExpiresAt:    time.Now().Add(time.Hour),
+					},
+				},
+			},
+		},
+	}
+	env := NewAgentEnv(AgentEnvDeps{
+		CodingCredentials: coding,
+		Logger:            zerolog.Nop(),
+	})
+
+	injected, err := env.InjectClaudeCodeAuth(ctx, orgID, sandbox)
+
+	require.False(t, injected, "Claude auth injection should not report success when sandbox provider is missing")
+	require.Error(t, err, "Claude auth injection should return a configuration error instead of panicking")
+	require.Contains(t, err.Error(), "sandbox provider", "Claude auth injection error should identify the missing dependency")
+}
+
+func TestAgentEnvPrepareClaudeCodeAPIKeyFallbackRequiresSandboxProvider(t *testing.T) {
+	t.Parallel()
+
+	env := NewAgentEnv(AgentEnvDeps{Logger: zerolog.Nop()})
+
+	err := env.PrepareClaudeCodeAPIKeyFallback(context.Background(), &Sandbox{HomeDir: "/home/test"}, map[string]string{
+		"ANTHROPIC_API_KEY": "sk-ant-test",
+	})
+
+	require.Error(t, err, "Claude API-key fallback preparation should return a configuration error instead of panicking")
+	require.Contains(t, err.Error(), "sandbox provider", "Claude fallback error should identify the missing dependency")
+}
+
 // TestAgentEnvInjectCodexAuth_ErrorClassification verifies that
 // InjectCodexAuth tags genuine auth failures with ErrCodexAuthInvalid while
 // leaving sandbox/transport errors un-tagged. The orchestrator branches on

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -748,6 +748,7 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 			Orgs:              cfg.Orgs,
 			OrgSettingsCache:  cfg.OrgSettingsCache,
 			CodexAuth:         cfg.CodexAuth,
+			ClaudeCodeAuth:    cfg.ClaudeCodeAuth,
 			Provider:          cfg.Provider,
 			Logger:            cfg.Logger,
 		})
@@ -2302,7 +2303,10 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	// the (possibly retried) result indicates a credential-level failure.
 	// No-ops cleanly for agent types whose auth flows do not pass through
 	// the unified resolver (e.g. Codex subscription via codexauth.Service).
-	o.shedOnRunResult(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, result, err, log)
+	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, run, primaryThreadID, turnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, false, log)
+	if !parseCredentialFailureSignal(result, time.Now()).RateLimited {
+		o.shedOnRunResult(ctx, run.AgentType, run.OrgID, run.TriggeredByUserID, result, err, log)
+	}
 
 	// 11. Handle result.
 	stopReason := StopReasonNone
@@ -3577,19 +3581,8 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	// 6c. Shed the just-picked credential when the (post-retry) result shows
 	// rate-limit or auth-rejected signals. Same semantics as the entry-turn
 	// path above; see shedOnRunResult.
-	if parseCredentialFailureSignal(result, time.Now()).RateLimited {
-		o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
-		var retried bool
-		result, err, retried = o.retryContinueOnCredentialRateLimit(ctx, session, threadID, turnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, log)
-		if retried && parseCredentialFailureSignal(result, time.Now()).RateLimited {
-			o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
-			if authErr := o.blockedContinueAfterRateLimitExhaustion(ctx, session, threadID, sandboxCfg, log); authErr != nil {
-				err = authErr
-			}
-		} else {
-			o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
-		}
-	} else {
+	result, err, _ = o.retrySessionOnCredentialRateLimit(ctx, session, threadID, turnNumber, sandboxCfg, sandbox, adapter, execCtx, prompt, result, err, true, log)
+	if !parseCredentialFailureSignal(result, time.Now()).RateLimited {
 		o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
 	}
 
@@ -5203,6 +5196,10 @@ func (o *Orchestrator) ensureClaudeCodeAuth(ctx context.Context, run *models.Ses
 
 var errClaudeCodeFallbackUnavailable = errors.New("claude code API-key fallback unavailable")
 
+func IsClaudeCodeFallbackUnavailable(err error) bool {
+	return errors.Is(err, errClaudeCodeFallbackUnavailable)
+}
+
 func (o *Orchestrator) prepareClaudeCodeAPIKeyFallback(ctx context.Context, run *models.Session, sandbox *Sandbox, env map[string]string) error {
 	if env["ANTHROPIC_API_KEY"] == "" {
 		return errClaudeCodeFallbackUnavailable
@@ -5993,7 +5990,7 @@ func (o *Orchestrator) retryOnTokenExpired(
 	return result, err
 }
 
-func (o *Orchestrator) retryContinueOnCredentialRateLimit(
+func (o *Orchestrator) retrySessionOnCredentialRateLimit(
 	ctx context.Context,
 	session *models.Session,
 	threadID *uuid.UUID,
@@ -6005,6 +6002,7 @@ func (o *Orchestrator) retryContinueOnCredentialRateLimit(
 	prompt *AgentPrompt,
 	result *AgentResult,
 	err error,
+	createBlockedMessage bool,
 	log zerolog.Logger,
 ) (*AgentResult, error, bool) {
 	signal := parseCredentialFailureSignal(result, time.Now())
@@ -6012,10 +6010,14 @@ func (o *Orchestrator) retryContinueOnCredentialRateLimit(
 		return result, err, false
 	}
 
-	refreshedEnv := o.resolveContinueCredentialEnv(ctx, session, sandboxCfg)
+	o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, result, err, log)
+
+	refreshedEnv := o.resolveSessionCredentialEnv(ctx, session, sandboxCfg)
 	if authErr := o.env.CheckAuth(session.AgentType, refreshedEnv); authErr != nil {
-		logCredentialRateLimitBlockedContinue(log, session, authErr)
-		o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
+		logCredentialRateLimitBlocked(log, session, authErr)
+		if createBlockedMessage {
+			o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
+		}
 		return result, authErr, false
 	}
 
@@ -6028,7 +6030,7 @@ func (o *Orchestrator) retryContinueOnCredentialRateLimit(
 	log.Info().
 		Str("session_id", session.ID.String()).
 		Str("agent_type", string(session.AgentType)).
-		Msg("retrying continue_session with fallback credential after rate-limit signal")
+		Msg("retrying agent session with fallback credential after rate-limit signal")
 
 	retryLogCh := make(chan LogEntry, 100)
 	var retryLogWg sync.WaitGroup
@@ -6042,21 +6044,32 @@ func (o *Orchestrator) retryContinueOnCredentialRateLimit(
 	retryLogWg.Wait()
 
 	retryResult, retryErr = o.retryOnTokenExpired(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, session.ID, threadID, turnNumber, sandbox, adapter, execCtx, prompt, retryResult, retryErr, log)
+	if parseCredentialFailureSignal(retryResult, time.Now()).RateLimited {
+		o.shedOnRunResult(ctx, session.AgentType, session.OrgID, session.TriggeredByUserID, retryResult, retryErr, log)
+		refreshedEnv = o.resolveSessionCredentialEnv(ctx, session, sandboxCfg)
+		if authErr := o.env.CheckAuth(session.AgentType, refreshedEnv); authErr != nil {
+			logCredentialRateLimitBlocked(log, session, authErr)
+			if createBlockedMessage {
+				o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
+			}
+			return retryResult, authErr, true
+		}
+	}
 	return retryResult, retryErr, true
 }
 
 func (o *Orchestrator) blockedContinueAfterRateLimitExhaustion(ctx context.Context, session *models.Session, threadID *uuid.UUID, sandboxCfg SandboxConfig, log zerolog.Logger) error {
-	refreshedEnv := o.resolveContinueCredentialEnv(ctx, session, sandboxCfg)
+	refreshedEnv := o.resolveSessionCredentialEnv(ctx, session, sandboxCfg)
 	authErr := o.env.CheckAuth(session.AgentType, refreshedEnv)
 	if authErr == nil {
 		return nil
 	}
-	logCredentialRateLimitBlockedContinue(log, session, authErr)
+	logCredentialRateLimitBlocked(log, session, authErr)
 	o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
 	return authErr
 }
 
-func (o *Orchestrator) resolveContinueCredentialEnv(ctx context.Context, session *models.Session, sandboxCfg SandboxConfig) map[string]string {
+func (o *Orchestrator) resolveSessionCredentialEnv(ctx context.Context, session *models.Session, sandboxCfg SandboxConfig) map[string]string {
 	refreshedEnv := refreshAgentCredentialEnv(sandboxCfg.Env, o.env.Resolve(ctx, session.OrgID, session.AgentType, session.TriggeredByUserID), session.AgentType)
 	if refreshedEnv == nil {
 		refreshedEnv = make(map[string]string)
@@ -6085,6 +6098,13 @@ func refreshAgentCredentialEnv(current, resolved map[string]string, agentType mo
 		out[k] = v
 	}
 	return out
+}
+
+// RefreshAgentCredentialEnv replaces only the agent credential keys in current
+// with a fresh AgentEnv.Resolve result, preserving execution-scoped values such
+// as HOME, GitHub auth, internal API tokens, branch metadata, and socket paths.
+func RefreshAgentCredentialEnv(current, resolved map[string]string, agentType models.AgentType) map[string]string {
+	return refreshAgentCredentialEnv(current, resolved, agentType)
 }
 
 func clearAgentCredentialEnv(env map[string]string, agentType models.AgentType) {
@@ -6129,7 +6149,7 @@ func (o *Orchestrator) prepareAgentAuthForRetry(ctx context.Context, session *mo
 	}
 }
 
-func logCredentialRateLimitBlockedContinue(log zerolog.Logger, session *models.Session, authErr error) {
+func logCredentialRateLimitBlocked(log zerolog.Logger, session *models.Session, authErr error) {
 	authLog := log.Error().Err(authErr).
 		Str("session_id", session.ID.String()).
 		Str("agent_type", string(session.AgentType))
@@ -6142,7 +6162,7 @@ func logCredentialRateLimitBlockedContinue(log zerolog.Logger, session *models.S
 			authLog = authLog.Time("rate_limited_until", *structuredAuthErr.RateLimitedUntil)
 		}
 	}
-	authLog.Msg("continue_session fallback credentials unavailable after rate-limit signal")
+	authLog.Msg("fallback credentials unavailable after rate-limit signal")
 }
 
 func (o *Orchestrator) createContinueAuthFailureMessage(ctx context.Context, session *models.Session, threadID *uuid.UUID, authErr error, log zerolog.Logger) {
@@ -6170,11 +6190,11 @@ func (o *Orchestrator) createContinueAuthFailureMessage(ctx context.Context, ses
 // failures; this is the fast-path hint that prevents repeat picks before the
 // resolver cache refreshes.
 //
-// Provider mapping is intentionally limited to agent types whose API-key auth
-// flows go through AgentEnv.pickFromCodingProvider. Codex subscription auth
-// uses codexauth.Service's own selector; because that path records no
-// ProviderOpenAI pick, the shed call below remains a no-op for subscription
-// runs.
+// Provider mapping is intentionally limited to agent types whose runtime auth
+// flows go through AgentEnv credential selection. Unified Codex subscription
+// rows are recorded under the OpenAI request provider too, so subscription
+// usage-limit output sheds the picked subscription row and lets the retry pick
+// the next Codex/OpenAI credential.
 func (o *Orchestrator) shedOnRunResult(ctx context.Context, agentType models.AgentType, orgID uuid.UUID, userID *uuid.UUID, result *AgentResult, runErr error, log zerolog.Logger) {
 	if o.env == nil || result == nil {
 		return
@@ -6224,9 +6244,15 @@ func parseCredentialFailureSignal(result *AgentResult, now time.Time) Credential
 	}
 }
 
-// codingProviderForAgent maps an agent type to the unified provider name its
-// API-key auth uses. Subscription picks are intentionally not represented
-// here; they do not write the recentPicks tracker under these providers.
+// CredentialFailureSignalFromResult exposes the runtime credential-failure
+// parser to service packages that execute adapters outside the orchestrator
+// but still need to shed and retry the same unified coding credentials.
+func CredentialFailureSignalFromResult(result *AgentResult, now time.Time) CredentialFailureSignal {
+	return parseCredentialFailureSignal(result, now)
+}
+
+// codingProviderForAgent maps an agent type to the unified request provider
+// used for credential picking and shedding.
 func codingProviderForAgent(agentType models.AgentType) models.ProviderName {
 	switch agentType {
 	case models.AgentTypeClaudeCode:
@@ -6242,6 +6268,12 @@ func codingProviderForAgent(agentType models.AgentType) models.ProviderName {
 	default:
 		return ""
 	}
+}
+
+// CodingProviderForAgent exposes the provider mapping for PM/autopilot
+// execution paths that invoke adapters directly.
+func CodingProviderForAgent(agentType models.AgentType) models.ProviderName {
+	return codingProviderForAgent(agentType)
 }
 
 // isRateLimitedError matches the same surface as the failure classifier so

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -6058,17 +6058,6 @@ func (o *Orchestrator) retrySessionOnCredentialRateLimit(
 	return retryResult, retryErr, true
 }
 
-func (o *Orchestrator) blockedContinueAfterRateLimitExhaustion(ctx context.Context, session *models.Session, threadID *uuid.UUID, sandboxCfg SandboxConfig, log zerolog.Logger) error {
-	refreshedEnv := o.resolveSessionCredentialEnv(ctx, session, sandboxCfg)
-	authErr := o.env.CheckAuth(session.AgentType, refreshedEnv)
-	if authErr == nil {
-		return nil
-	}
-	logCredentialRateLimitBlocked(log, session, authErr)
-	o.createContinueAuthFailureMessage(ctx, session, threadID, authErr, log)
-	return authErr
-}
-
 func (o *Orchestrator) resolveSessionCredentialEnv(ctx context.Context, session *models.Session, sandboxCfg SandboxConfig) map[string]string {
 	refreshedEnv := refreshAgentCredentialEnv(sandboxCfg.Env, o.env.Resolve(ctx, session.OrgID, session.AgentType, session.TriggeredByUserID), session.AgentType)
 	if refreshedEnv == nil {

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -158,6 +159,7 @@ func (m *mockCodingCredentialProvider) ListResolvable(ctx context.Context, orgID
 func (m *mockCodingCredentialProvider) PickRunnableMulti(ctx context.Context, orgIDScope models.Scope, providers []models.ProviderName) (*models.DecryptedCodingCredential, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	var candidates []models.DecryptedCodingCredential
 	for _, provider := range providers {
 		for _, cred := range m.resolvable[provider] {
 			if cred.Status != models.CodingCredentialStatusActive {
@@ -169,9 +171,26 @@ func (m *mockCodingCredentialProvider) PickRunnableMulti(ctx context.Context, or
 			if limit, ok := m.rateLimitedIDs[cred.ID]; ok && limit.Until.After(time.Now()) {
 				continue
 			}
-			picked := cred
-			return &picked, nil
+			candidates = append(candidates, cred)
 		}
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		leftPersonal := candidates[i].UserID != nil
+		rightPersonal := candidates[j].UserID != nil
+		if leftPersonal != rightPersonal {
+			return leftPersonal
+		}
+		if candidates[i].Priority != candidates[j].Priority {
+			return candidates[i].Priority < candidates[j].Priority
+		}
+		if !candidates[i].CreatedAt.Equal(candidates[j].CreatedAt) {
+			return candidates[i].CreatedAt.Before(candidates[j].CreatedAt)
+		}
+		return false
+	})
+	if len(candidates) > 0 {
+		picked := candidates[0]
+		return &picked, nil
 	}
 	return nil, errors.New("all eligible coding credentials are currently shed")
 }
@@ -1480,6 +1499,117 @@ func TestRunAgent_SuccessfulRun(t *testing.T) {
 
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
+}
+
+func TestRunAgent_RateLimitRetriesWithFallbackCredential(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.AgentType = models.AgentTypeAmp
+
+	firstCredID := uuid.New()
+	secondCredID := uuid.New()
+	d := defaultDeps()
+	d.adapter = &mockAgentAdapter{name: models.AgentTypeAmp}
+	d.codingCreds = &mockCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderAmp: {
+				{
+					ID:        firstCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-first"},
+					Priority:  1,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        secondCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-fallback"},
+					Priority:  2,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+			},
+		},
+	}
+	d.issues.issue = issue
+
+	var seenKeys []string
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		seenKeys = append(seenKeys, sandbox.Env["AMP_API_KEY"])
+		if len(seenKeys) == 1 {
+			return &agent.AgentResult{ExitCode: 1, Error: "rate limit exceeded retry-after=60"}, errors.New("rate limit exceeded")
+		}
+		return &agent.AgentResult{
+			Diff:            "--- a/main.go\n+++ b/main.go",
+			Summary:         "completed with fallback",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+		}, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should retry with a fallback credential after a rate-limit result")
+	require.Equal(t, []string{"amp-first", "amp-fallback"}, seenKeys, "RunAgent should refresh agent credentials before retrying")
+	require.Len(t, d.sessions.getResultUpdates(), 1, "RunAgent should persist one successful result after fallback retry")
+}
+
+func TestRunAgent_RateLimitFallbackExhaustionFailsWithBlockedAuth(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.AgentType = models.AgentTypeAmp
+
+	firstCredID := uuid.New()
+	secondCredID := uuid.New()
+	codingCreds := &mockCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderAmp: {
+				{
+					ID:        firstCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-first"},
+					Priority:  1,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        secondCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-fallback"},
+					Priority:  2,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+			},
+		},
+	}
+	d := defaultDeps()
+	d.adapter = &mockAgentAdapter{name: models.AgentTypeAmp}
+	d.codingCreds = codingCreds
+	d.issues.issue = issue
+
+	var seenKeys []string
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		seenKeys = append(seenKeys, sandbox.Env["AMP_API_KEY"])
+		return &agent.AgentResult{ExitCode: 1, Error: "rate limit exceeded retry-after=60"}, errors.New("rate limit exceeded")
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.Error(t, err, "RunAgent should fail when every fallback credential is rate limited")
+	require.Contains(t, err.Error(), "all Amp auths are rate limited", "RunAgent should return the clear blocked-auth message")
+	require.Equal(t, []string{"amp-first", "amp-fallback"}, seenKeys, "RunAgent should try the next credential before blocking")
+	require.Contains(t, codingCreds.rateLimitedIDs, firstCredID, "RunAgent should mark the first credential rate-limited")
+	require.Contains(t, codingCreds.rateLimitedIDs, secondCredID, "RunAgent should mark the fallback credential rate-limited")
 }
 
 func TestRunAgent_MaterializesUploadedAttachments(t *testing.T) {
@@ -7311,6 +7441,75 @@ func TestRunAgent_CodexTokenExpiredRetryKeepsTriggeredUserScope(t *testing.T) {
 	tokens, ok := authJSON["tokens"].(map[string]interface{})
 	require.True(t, ok, "auth.json should contain tokens after retry injection")
 	require.Equal(t, "personal-access", tokens["access_token"], "retry injection should use the triggering user's personal subscription")
+}
+
+func TestRunAgent_CodexSubscriptionUsageLimitRetriesWithFallbackCredential(t *testing.T) {
+	t.Parallel()
+
+	orgID := testOrg()
+	issue := testIssue(orgID)
+	run := testRun(orgID, issue.ID)
+	run.AgentType = models.AgentTypeCodex
+
+	subCredID := uuid.New()
+	apiCredID := uuid.New()
+	codingCreds := &mockCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderOpenAISubscription: {
+				{
+					ID:        subCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderOpenAISubscription,
+					Priority:  1,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+					Config: models.OpenAISubscriptionConfig{
+						AccessToken:  "sub-access",
+						RefreshToken: "sub-refresh",
+						ExpiresAt:    time.Now().Add(time.Hour),
+					},
+				},
+			},
+			models.ProviderOpenAI: {
+				{
+					ID:        apiCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderOpenAI,
+					Priority:  2,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+					Config:    models.OpenAIConfig{APIKey: "sk-fallback"},
+				},
+			},
+		},
+	}
+	d := defaultDeps()
+	d.adapter.name = models.AgentTypeCodex
+	d.codexAuth = nil
+	d.codingCreds = codingCreds
+
+	var seenKeys []string
+	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
+		seenKeys = append(seenKeys, sandbox.Env["OPENAI_API_KEY"])
+		if len(seenKeys) == 1 {
+			return &agent.AgentResult{
+				ExitCode: 1,
+				Error:    "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at 8:50 AM.",
+			}, errors.New("usage limit")
+		}
+		return &agent.AgentResult{
+			Diff:            "--- a/main.go\n+++ b/main.go",
+			Summary:         "codex fallback succeeded",
+			ConfidenceScore: 0.9,
+			ExitCode:        0,
+		}, nil
+	}
+
+	err := buildOrchestrator(d).RunAgent(context.Background(), run)
+	require.NoError(t, err, "RunAgent should retry Codex with the fallback credential after a subscription usage-limit result")
+	require.Equal(t, []string{"", "sk-fallback"}, seenKeys, "RunAgent should move from subscription auth.json to the OpenAI API-key fallback in the same attempt")
+	require.Contains(t, codingCreds.rateLimitedIDs, subCredID, "RunAgent should mark the subscription credential rate-limited after usage-limit output")
+	require.NotContains(t, codingCreds.rateLimitedIDs, apiCredID, "RunAgent should not mark the successful API-key fallback rate-limited")
 }
 
 func TestRunAgent_CancelReturnsToIdle(t *testing.T) {

--- a/internal/services/pm/bootstrap.go
+++ b/internal/services/pm/bootstrap.go
@@ -146,7 +146,7 @@ func (s *Service) runAgentInSandbox(ctx context.Context, params sandboxRunParams
 	}()
 
 	execCtx := adapters.WithSandboxProvider(ctx, s.sandbox)
-	if _, err := adapter.Execute(execCtx, sb, params.prompt, logCh); err != nil {
+	if _, err := s.executeAgentWithCredentialFallback(ctx, params.orgID, agentType, settings, sbCfg, sb, adapter, execCtx, params.prompt, logCh); err != nil {
 		exitReason = containerExitReason(ctx, err)
 		close(logCh)
 		logWg.Wait()

--- a/internal/services/pm/project_analyze.go
+++ b/internal/services/pm/project_analyze.go
@@ -146,7 +146,7 @@ func (s *Service) AnalyzeProject(ctx context.Context, orgID, projectID uuid.UUID
 	defer close(logCh)
 
 	execCtx := adapters.WithSandboxProvider(ctx, s.sandbox)
-	result, err := adapter.Execute(execCtx, sb, prompt, logCh)
+	result, err := s.executeAgentWithCredentialFallback(ctx, orgID, agentType, settings, sbCfg, sb, adapter, execCtx, prompt, logCh)
 	if err != nil {
 		exitReason = containerExitReason(ctx, err)
 		return fmt.Errorf("project pm agent execution: %w", err)

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -1,6 +1,7 @@
 package pm
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -253,13 +254,7 @@ func (s *Service) executeAgentWithCredentialFallback(
 	}
 
 	s.shedCredentialFailure(ctx, orgID, agentType, result)
-	refreshedEnv := agent.RefreshAgentCredentialEnv(sbCfg.Env, s.env.Resolve(ctx, orgID, agentType, nil), agentType)
-	if refreshedEnv == nil {
-		refreshedEnv = make(map[string]string)
-	}
-	if _, ok := refreshedEnv["HOME"]; !ok {
-		refreshedEnv["HOME"] = sbCfg.HomeDir
-	}
+	refreshedEnv := s.refreshPMCredentialEnv(ctx, orgID, agentType, sbCfg)
 	if authErr := s.finalizeSandboxEnv(agentType, refreshedEnv); authErr != nil {
 		return result, authErr
 	}
@@ -278,18 +273,23 @@ func (s *Service) executeAgentWithCredentialFallback(
 	retryResult, retryErr := adapter.Execute(execCtx, sb, prompt, logCh)
 	if agent.CredentialFailureSignalFromResult(retryResult, time.Now()).RateLimited {
 		s.shedCredentialFailure(ctx, orgID, agentType, retryResult)
-		refreshedEnv = agent.RefreshAgentCredentialEnv(sbCfg.Env, s.env.Resolve(ctx, orgID, agentType, nil), agentType)
-		if refreshedEnv == nil {
-			refreshedEnv = make(map[string]string)
-		}
-		if _, ok := refreshedEnv["HOME"]; !ok {
-			refreshedEnv["HOME"] = sbCfg.HomeDir
-		}
+		refreshedEnv = s.refreshPMCredentialEnv(ctx, orgID, agentType, sbCfg)
 		if authErr := s.finalizeSandboxEnv(agentType, refreshedEnv); authErr != nil {
 			return retryResult, authErr
 		}
 	}
 	return retryResult, retryErr
+}
+
+func (s *Service) refreshPMCredentialEnv(ctx context.Context, orgID uuid.UUID, agentType models.AgentType, sbCfg agent.SandboxConfig) map[string]string {
+	refreshedEnv := agent.RefreshAgentCredentialEnv(sbCfg.Env, s.env.Resolve(ctx, orgID, agentType, nil), agentType)
+	if refreshedEnv == nil {
+		refreshedEnv = make(map[string]string)
+	}
+	if _, ok := refreshedEnv["HOME"]; !ok {
+		refreshedEnv["HOME"] = sbCfg.HomeDir
+	}
+	return refreshedEnv
 }
 
 func (s *Service) shedCredentialFailure(ctx context.Context, orgID uuid.UUID, agentType models.AgentType, result *agent.AgentResult) {
@@ -321,7 +321,7 @@ func (s *Service) prepareAgentAuthForRetry(ctx context.Context, orgID uuid.UUID,
 func (s *Service) removeCodexAuthFile(ctx context.Context, sb *agent.Sandbox) error {
 	authPath := path.Join(sb.HomeDir, ".codex", "auth.json")
 	cmd := fmt.Sprintf("rm -f '%s'", pmShellEscapeSingleQuote(authPath))
-	var stdout, stderr syncBuffer
+	var stdout, stderr bytes.Buffer
 	exitCode, err := s.sandbox.Exec(ctx, sb, cmd, &stdout, &stderr)
 	if err != nil {
 		return fmt.Errorf("remove stale codex auth: %w", err)
@@ -330,24 +330,6 @@ func (s *Service) removeCodexAuthFile(ctx context.Context, sb *agent.Sandbox) er
 		return fmt.Errorf("remove stale codex auth: exited with code %d: %s", exitCode, stderr.String())
 	}
 	return nil
-}
-
-type syncBuffer struct {
-	mu sync.Mutex
-	b  []byte
-}
-
-func (b *syncBuffer) Write(p []byte) (int, error) {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	b.b = append(b.b, p...)
-	return len(p), nil
-}
-
-func (b *syncBuffer) String() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	return string(b.b)
 }
 
 func pmShellEscapeSingleQuote(s string) string {

--- a/internal/services/pm/service.go
+++ b/internal/services/pm/service.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path"
+	"strings"
 	"sync"
 	"time"
 
@@ -197,15 +199,159 @@ func (s *Service) injectRequiredAgentAuth(ctx context.Context, orgID uuid.UUID, 
 		}
 		return agent.TokenBillingModeSubscription, nil
 	case models.AgentTypeClaudeCode:
-		if env["ANTHROPIC_API_KEY"] != "" {
-			return agent.TokenBillingModeAPIKey, nil
+		injected, err := s.env.InjectClaudeCodeAuth(ctx, orgID, sb)
+		if err != nil {
+			if fallbackErr := s.env.PrepareClaudeCodeAPIKeyFallback(ctx, sb, env); fallbackErr == nil {
+				s.logger.Warn().
+					Err(err).
+					Str("org_id", orgID.String()).
+					Msg("PM Claude subscription injection failed; continuing with Anthropic API-key fallback")
+				return agent.TokenBillingModeAPIKey, nil
+			}
+			return agent.TokenBillingModeUnknown, &agent.AuthError{
+				AgentType: agentType,
+				Detail:    fmt.Sprintf("failed to prepare Claude subscription authentication: %v", err),
+			}
 		}
-		return agent.TokenBillingModeUnknown, nil
+		if injected {
+			return agent.TokenBillingModeSubscription, nil
+		}
+		if err := s.env.PrepareClaudeCodeAPIKeyFallback(ctx, sb, env); err == nil {
+			return agent.TokenBillingModeAPIKey, nil
+		} else if agent.IsClaudeCodeFallbackUnavailable(err) {
+			return agent.TokenBillingModeUnknown, nil
+		} else {
+			return agent.TokenBillingModeUnknown, &agent.AuthError{
+				AgentType: agentType,
+				Detail:    fmt.Sprintf("failed to prepare Anthropic API-key fallback: %v", err),
+			}
+		}
 	case models.AgentTypeGeminiCLI, models.AgentTypeAmp, models.AgentTypePi:
 		return agent.TokenBillingModeAPIKey, nil
 	default:
 		return agent.TokenBillingModeUnknown, nil
 	}
+}
+
+func (s *Service) executeAgentWithCredentialFallback(
+	ctx context.Context,
+	orgID uuid.UUID,
+	agentType models.AgentType,
+	settings models.OrgSettings,
+	sbCfg agent.SandboxConfig,
+	sb *agent.Sandbox,
+	adapter agent.AgentAdapter,
+	execCtx context.Context,
+	prompt *agent.AgentPrompt,
+	logCh chan<- agent.LogEntry,
+) (*agent.AgentResult, error) {
+	result, err := adapter.Execute(execCtx, sb, prompt, logCh)
+	signal := agent.CredentialFailureSignalFromResult(result, time.Now())
+	if !signal.RateLimited {
+		s.shedCredentialFailure(ctx, orgID, agentType, result)
+		return result, err
+	}
+
+	s.shedCredentialFailure(ctx, orgID, agentType, result)
+	refreshedEnv := agent.RefreshAgentCredentialEnv(sbCfg.Env, s.env.Resolve(ctx, orgID, agentType, nil), agentType)
+	if refreshedEnv == nil {
+		refreshedEnv = make(map[string]string)
+	}
+	if _, ok := refreshedEnv["HOME"]; !ok {
+		refreshedEnv["HOME"] = sbCfg.HomeDir
+	}
+	if authErr := s.finalizeSandboxEnv(agentType, refreshedEnv); authErr != nil {
+		return result, authErr
+	}
+	sb.Env = refreshedEnv
+	authBillingMode, authErr := s.prepareAgentAuthForRetry(ctx, orgID, agentType, sb, refreshedEnv)
+	if authErr != nil {
+		return result, authErr
+	}
+	prompt.UsageHint = buildPMTokenUsageHint(settings, agentType, refreshedEnv, authBillingMode)
+
+	s.logger.Info().
+		Str("org_id", orgID.String()).
+		Str("agent_type", string(agentType)).
+		Msg("retrying PM agent with fallback credential after rate-limit signal")
+
+	retryResult, retryErr := adapter.Execute(execCtx, sb, prompt, logCh)
+	if agent.CredentialFailureSignalFromResult(retryResult, time.Now()).RateLimited {
+		s.shedCredentialFailure(ctx, orgID, agentType, retryResult)
+		refreshedEnv = agent.RefreshAgentCredentialEnv(sbCfg.Env, s.env.Resolve(ctx, orgID, agentType, nil), agentType)
+		if refreshedEnv == nil {
+			refreshedEnv = make(map[string]string)
+		}
+		if _, ok := refreshedEnv["HOME"]; !ok {
+			refreshedEnv["HOME"] = sbCfg.HomeDir
+		}
+		if authErr := s.finalizeSandboxEnv(agentType, refreshedEnv); authErr != nil {
+			return retryResult, authErr
+		}
+	}
+	return retryResult, retryErr
+}
+
+func (s *Service) shedCredentialFailure(ctx context.Context, orgID uuid.UUID, agentType models.AgentType, result *agent.AgentResult) {
+	if s.env == nil || result == nil {
+		return
+	}
+	provider := agent.CodingProviderForAgent(agentType)
+	if provider == "" {
+		return
+	}
+	signal := agent.CredentialFailureSignalFromResult(result, time.Now())
+	switch {
+	case signal.AuthRejected:
+		s.env.ShedAuthRejectedWithContext(ctx, orgID, nil, provider)
+	case signal.RateLimited:
+		s.env.ShedRateLimitedWithSignal(ctx, orgID, nil, provider, signal)
+	}
+}
+
+func (s *Service) prepareAgentAuthForRetry(ctx context.Context, orgID uuid.UUID, agentType models.AgentType, sb *agent.Sandbox, env map[string]string) (agent.TokenBillingMode, error) {
+	if agentType == models.AgentTypeCodex && env["OPENAI_API_KEY"] != "" {
+		if err := s.removeCodexAuthFile(ctx, sb); err != nil {
+			return agent.TokenBillingModeUnknown, err
+		}
+	}
+	return s.injectRequiredAgentAuth(ctx, orgID, agentType, sb, env)
+}
+
+func (s *Service) removeCodexAuthFile(ctx context.Context, sb *agent.Sandbox) error {
+	authPath := path.Join(sb.HomeDir, ".codex", "auth.json")
+	cmd := fmt.Sprintf("rm -f '%s'", pmShellEscapeSingleQuote(authPath))
+	var stdout, stderr syncBuffer
+	exitCode, err := s.sandbox.Exec(ctx, sb, cmd, &stdout, &stderr)
+	if err != nil {
+		return fmt.Errorf("remove stale codex auth: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("remove stale codex auth: exited with code %d: %s", exitCode, stderr.String())
+	}
+	return nil
+}
+
+type syncBuffer struct {
+	mu sync.Mutex
+	b  []byte
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.b = append(b.b, p...)
+	return len(p), nil
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.b)
+}
+
+func pmShellEscapeSingleQuote(s string) string {
+	return strings.ReplaceAll(s, "'", "'\\''")
 }
 
 func buildPMTokenUsageHint(settings models.OrgSettings, agentType models.AgentType, env map[string]string, billingMode agent.TokenBillingMode) agent.TokenUsageHint {
@@ -568,7 +714,7 @@ func (s *Service) Analyze(ctx context.Context, orgID uuid.UUID, trigger models.P
 	}()
 
 	execCtx := adapters.WithSandboxProvider(ctx, s.sandbox)
-	result, err := adapter.Execute(execCtx, sb, prompt, logCh)
+	result, err := s.executeAgentWithCredentialFallback(ctx, orgID, agentType, ctxBundle.settings, sbCfg, sb, adapter, execCtx, prompt, logCh)
 	close(logCh)
 	logWg.Wait()
 	if err != nil {

--- a/internal/services/pm/service_helpers_test.go
+++ b/internal/services/pm/service_helpers_test.go
@@ -3,6 +3,7 @@ package pm
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -50,6 +51,135 @@ func (helperUsageTracker) ContainerStarted(context.Context, uuid.UUID, uuid.UUID
 }
 
 func (helperUsageTracker) ContainerStopped(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, string, time.Time, string) {
+}
+
+type helperCodingCredentialProvider struct {
+	mu             sync.Mutex
+	resolvable     map[models.ProviderName][]models.DecryptedCodingCredential
+	rateLimitedIDs map[uuid.UUID]models.CodingCredentialRateLimit
+}
+
+func (m *helperCodingCredentialProvider) ListResolvable(_ context.Context, _ uuid.UUID, _ *uuid.UUID, provider models.ProviderName) ([]models.DecryptedCodingCredential, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.DecryptedCodingCredential(nil), m.resolvable[provider]...), nil
+}
+
+func (m *helperCodingCredentialProvider) PickRunnableMulti(_ context.Context, _ models.Scope, providers []models.ProviderName) (*models.DecryptedCodingCredential, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, provider := range providers {
+		for _, cred := range m.resolvable[provider] {
+			if cred.Status != models.CodingCredentialStatusActive {
+				continue
+			}
+			if limit, ok := m.rateLimitedIDs[cred.ID]; ok && limit.Until.After(time.Now()) {
+				continue
+			}
+			picked := cred
+			return &picked, nil
+		}
+	}
+	return nil, errors.New("all eligible coding credentials are currently shed")
+}
+
+func (m *helperCodingCredentialProvider) MarkRateLimitedForScope(_ context.Context, _ models.Scope, id uuid.UUID, limit models.CodingCredentialRateLimit) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rateLimitedIDs == nil {
+		m.rateLimitedIDs = make(map[uuid.UUID]models.CodingCredentialRateLimit)
+	}
+	m.rateLimitedIDs[id] = limit
+	for provider, creds := range m.resolvable {
+		for i := range creds {
+			if creds[i].ID == id {
+				until := limit.Until
+				observedAt := time.Now()
+				message := limit.Message
+				creds[i].RateLimitedUntil = &until
+				creds[i].RateLimitedObservedAt = &observedAt
+				creds[i].RateLimitMessage = &message
+			}
+		}
+		m.resolvable[provider] = creds
+	}
+	return nil
+}
+
+func (m *helperCodingCredentialProvider) MarkAuthRejectedForScope(_ context.Context, _ models.Scope, _ uuid.UUID) error {
+	return nil
+}
+
+func (m *helperCodingCredentialProvider) MarkRateLimited(id uuid.UUID) {
+	_ = m.MarkRateLimitedForScope(context.Background(), models.Scope{}, id, models.CodingCredentialRateLimit{Until: time.Now().Add(time.Minute)})
+}
+
+func (m *helperCodingCredentialProvider) MarkAuthRejected(uuid.UUID) {}
+
+type helperRetryAdapter struct {
+	mu       sync.Mutex
+	seenKeys []string
+}
+
+func (a *helperRetryAdapter) Name() models.AgentType { return models.AgentTypeAmp }
+
+func (a *helperRetryAdapter) PreparePrompt(context.Context, *agent.AgentInput) (*agent.AgentPrompt, error) {
+	return &agent.AgentPrompt{}, nil
+}
+
+func (a *helperRetryAdapter) Execute(_ context.Context, sb *agent.Sandbox, _ *agent.AgentPrompt, _ chan<- agent.LogEntry) (*agent.AgentResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.seenKeys = append(a.seenKeys, sb.Env["AMP_API_KEY"])
+	if len(a.seenKeys) == 1 {
+		return &agent.AgentResult{ExitCode: 1, Error: "rate limit exceeded retry-after=60"}, errors.New("rate limit exceeded")
+	}
+	return &agent.AgentResult{Summary: "ok", ExitCode: 0}, nil
+}
+
+func (a *helperRetryAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeUnsupported
+}
+
+func (a *helperRetryAdapter) keys() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.seenKeys...)
+}
+
+type helperClaudeRetryAdapter struct {
+	mu      sync.Mutex
+	seen    []string
+	sandbox *pmSandboxMock
+}
+
+func (a *helperClaudeRetryAdapter) Name() models.AgentType { return models.AgentTypeClaudeCode }
+
+func (a *helperClaudeRetryAdapter) PreparePrompt(context.Context, *agent.AgentInput) (*agent.AgentPrompt, error) {
+	return &agent.AgentPrompt{}, nil
+}
+
+func (a *helperClaudeRetryAdapter) Execute(_ context.Context, sb *agent.Sandbox, _ *agent.AgentPrompt, _ chan<- agent.LogEntry) (*agent.AgentResult, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.seen = append(a.seen, sb.Env["ANTHROPIC_API_KEY"])
+	if len(a.seen) == 1 {
+		return &agent.AgentResult{ExitCode: 1, Error: "rate limit exceeded retry-after=60"}, errors.New("rate limit exceeded")
+	}
+	if a.sandbox.writePath == "" {
+		return &agent.AgentResult{ExitCode: 1, Error: "missing claude subscription file"}, errors.New("missing claude subscription file")
+	}
+	return &agent.AgentResult{Summary: "ok", ExitCode: 0}, nil
+}
+
+func (a *helperClaudeRetryAdapter) ResumeMode() agent.SessionResumeMode {
+	return agent.ResumeUnsupported
+}
+
+func (a *helperClaudeRetryAdapter) keys() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.seen...)
 }
 
 func TestResolveAgentType(t *testing.T) {
@@ -228,6 +358,136 @@ func TestServiceInjectRequiredAgentAuth(t *testing.T) {
 			require.NoError(t, err, "injectRequiredAgentAuth should succeed for %s", tt.name)
 		})
 	}
+}
+
+func TestExecuteAgentWithCredentialFallbackRetriesRateLimitedCredential(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	firstCredID := uuid.New()
+	secondCredID := uuid.New()
+	codingCreds := &helperCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderAmp: {
+				{
+					ID:        firstCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-first"},
+					Priority:  1,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+				{
+					ID:        secondCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAmp,
+					Config:    models.AmpConfig{APIKey: "amp-fallback"},
+					Priority:  2,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+			},
+		},
+	}
+	sandboxProvider := &pmSandboxMock{}
+	env := agent.NewAgentEnv(agent.AgentEnvDeps{
+		CodingCredentials: codingCreds,
+		Provider:          sandboxProvider,
+		Logger:            zerolog.Nop(),
+	})
+	svc := &Service{
+		env:     env,
+		sandbox: sandboxProvider,
+		logger:  zerolog.Nop(),
+	}
+	sbCfg := agent.SandboxConfig{
+		HomeDir: "/home/sandbox",
+		Env:     env.Resolve(ctx, orgID, models.AgentTypeAmp, nil),
+	}
+	sb := &agent.Sandbox{ID: "pm-sandbox", HomeDir: sbCfg.HomeDir, Env: sbCfg.Env}
+	adapter := &helperRetryAdapter{}
+	prompt := &agent.AgentPrompt{}
+	logCh := make(chan agent.LogEntry, 10)
+
+	result, err := svc.executeAgentWithCredentialFallback(ctx, orgID, models.AgentTypeAmp, models.OrgSettings{}, sbCfg, sb, adapter, ctx, prompt, logCh)
+
+	require.NoError(t, err, "PM execution should retry with a fallback credential after a rate-limit result")
+	require.Equal(t, &agent.AgentResult{Summary: "ok", ExitCode: 0}, result, "PM execution should return the successful fallback result")
+	require.Equal(t, []string{"amp-first", "amp-fallback"}, adapter.keys(), "PM execution should refresh credentials before retrying")
+	require.Contains(t, codingCreds.rateLimitedIDs, firstCredID, "PM execution should mark the first credential rate-limited")
+}
+
+func TestExecuteAgentWithCredentialFallbackRetriesClaudeAPIKeyWithSubscription(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	orgID := uuid.New()
+	apiCredID := uuid.New()
+	subCredID := uuid.New()
+	codingCreds := &helperCodingCredentialProvider{
+		resolvable: map[models.ProviderName][]models.DecryptedCodingCredential{
+			models.ProviderAnthropic: {
+				{
+					ID:        apiCredID,
+					OrgID:     orgID,
+					Provider:  models.ProviderAnthropic,
+					Config:    models.AnthropicConfig{APIKey: "anthropic-first"},
+					Priority:  1,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+			},
+			models.ProviderAnthropicSubscription: {
+				{
+					ID:       subCredID,
+					OrgID:    orgID,
+					Provider: models.ProviderAnthropicSubscription,
+					Config: models.AnthropicSubscriptionConfig{
+						AccessToken:   "claude-access",
+						RefreshToken:  "claude-refresh",
+						ExpiresAt:     time.Now().Add(time.Hour),
+						AccountType:   "pro",
+						RateLimitTier: "default",
+						Scopes:        []string{"org:create_api_key"},
+					},
+					Priority:  2,
+					Status:    models.CodingCredentialStatusActive,
+					CreatedAt: time.Now(),
+				},
+			},
+		},
+	}
+	sandboxProvider := &pmSandboxMock{}
+	env := agent.NewAgentEnv(agent.AgentEnvDeps{
+		CodingCredentials: codingCreds,
+		Provider:          sandboxProvider,
+		Logger:            zerolog.Nop(),
+	})
+	svc := &Service{
+		env:     env,
+		sandbox: sandboxProvider,
+		logger:  zerolog.Nop(),
+	}
+	sbCfg := agent.SandboxConfig{
+		HomeDir: "/home/sandbox",
+		Env:     env.Resolve(ctx, orgID, models.AgentTypeClaudeCode, nil),
+	}
+	sb := &agent.Sandbox{ID: "pm-sandbox", HomeDir: sbCfg.HomeDir, Env: sbCfg.Env}
+	adapter := &helperClaudeRetryAdapter{sandbox: sandboxProvider}
+	prompt := &agent.AgentPrompt{}
+	logCh := make(chan agent.LogEntry, 10)
+
+	result, err := svc.executeAgentWithCredentialFallback(ctx, orgID, models.AgentTypeClaudeCode, models.OrgSettings{}, sbCfg, sb, adapter, ctx, prompt, logCh)
+
+	require.NoError(t, err, "PM Claude execution should retry with subscription credentials after API-key rate limiting")
+	require.Equal(t, &agent.AgentResult{Summary: "ok", ExitCode: 0}, result, "PM Claude execution should return the successful subscription fallback result")
+	require.Equal(t, []string{"anthropic-first", ""}, adapter.keys(), "PM Claude execution should clear ANTHROPIC_API_KEY when retrying with subscription auth")
+	require.Equal(t, "/home/sandbox/.claude/.credentials.json", sandboxProvider.writePath, "PM Claude retry should write the subscription credentials file")
+	require.Contains(t, string(sandboxProvider.writeData), "claude-access", "PM Claude retry should write the selected subscription token")
+	require.Contains(t, codingCreds.rateLimitedIDs, apiCredID, "PM Claude execution should mark the API key rate-limited")
+	require.NotContains(t, codingCreds.rateLimitedIDs, subCredID, "PM Claude execution should not mark the successful subscription fallback rate-limited")
 }
 
 func TestServiceSetUsageTrackerPersistFailedPlanAndContainerExitReason(t *testing.T) {


### PR DESCRIPTION
## Summary
Adds a Claude Code subscription authentication fallback for PM “Claude Code” runs when executions are rate-limited. This ensures PM can still write the expected Claude credentials file even if a selected coding credential requires a different auth flow.

## Changes
- **internal/services/agent/env.go**
  - Added `claudeCodeAuth ClaudeCodeAuthProvider` to `AgentEnv` deps.
  - Implemented `InjectClaudeCodeAuth` / `InjectClaudeCodeAuthForUser` to:
    - Prefer recently picked Anthropic *subscription* coding credentials when available.
    - Otherwise obtain a valid Claude Code subscription token via `ClaudeCodeAuthProvider`.
    - Write the appropriate credentials under `~/.claude/` (via existing helper `writeClaudeCodeAuth`).
- **internal/services/agent/orchestrator.go**
  - Updated orchestrator auth/credential injection to trigger the Claude Code subscription fallback in the rate-limited execution path.
- **internal/services/agent/orchestrator_test.go**
  - Extended tests to cover the new fallback behavior.
- **internal/services/pm/bootstrap.go**
  - Wired the Claude Code subscription auth provider into the PM/agent environment setup.
- **internal/services/pm/project_analyze.go**, **internal/services/pm/service.go**
  - Ensured PM Claude Code execution uses the new fallback injection behavior when needed.
- **internal/services/pm/service_helpers_test.go**
  - Updated/added helper tests for the rate-limited + fallback auth scenario.

## Test plan
- Ran `go test ./internal/services/agent ./internal/services/pm` with workspace-local `GOTMPDIR` and `GOCACHE` to avoid `/tmp` space limits.
- Verified `git diff --check` passes (no formatting/lint issues).

[143.dev](https://143.dev) | [session 9cec3245](https://143.dev/sessions/9cec3245-c92a-4ad6-9155-4c8d44ba70c5)