### PR TITLE
Enable image drop uploads on Continue Session composer input

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -6075,6 +6075,59 @@ describe('SessionDetailPage', () => {
     expect(await screen.findByRole('button', { name: 'Preview pasted-follow-up.png' })).toBeInTheDocument();
   });
 
+  it('uploads an image dropped onto the follow-up input surface and shows it in the attachment strip', async () => {
+    const idleSession: Session = {
+      ...mockSessions[0],
+      status: 'idle',
+      completed_at: undefined,
+      current_turn: 1,
+      sandbox_state: 'snapshotted',
+    };
+
+    server.use(
+      http.get('/api/v1/sessions/:id', () => {
+        return HttpResponse.json({ data: idleSession } satisfies SingleResponse<Session>);
+      }),
+    );
+
+    const uploadSpy = vi.spyOn(api.uploads, 'upload').mockResolvedValue({
+      url: 'https://example.com/dropped-follow-up.png',
+      file_name: 'dropped-follow-up.png',
+      content_type: 'image/png',
+    });
+
+    renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
+    const textarea = await screen.findByPlaceholderText('Send a follow-up message...');
+    const inputSurface = screen.getByTestId('session-composer-input-surface');
+    const file = new File(['image-bytes'], 'dropped-follow-up.png', { type: 'image/png' });
+
+    fireEvent.dragEnter(inputSurface, {
+      dataTransfer: {
+        files: [file],
+        items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+        types: ['Files'],
+      },
+    });
+
+    expect(inputSurface).toHaveAttribute('data-drag-active', 'true');
+
+    fireEvent.drop(inputSurface, {
+      dataTransfer: {
+        files: [file],
+        items: [{ kind: 'file', type: 'image/png', getAsFile: () => file }],
+        types: ['Files'],
+      },
+    });
+
+    await waitFor(() => {
+      expect(uploadSpy).toHaveBeenCalledWith(file);
+    });
+    expect(await screen.findByRole('button', { name: 'Preview dropped-follow-up.png' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(textarea).toHaveFocus();
+    });
+  });
+
   it('adds an image URL from the continue-session dropdown and shows it in the attachment strip', async () => {
     const idleSession: Session = {
       ...mockSessions[0],

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1018,6 +1018,7 @@ function SessionComposer({
   const [showLinearInput, setShowLinearInput] = useState(false);
   const [linearInput, setLinearInput] = useState("");
   const [linearInputError, setLinearInputError] = useState<string | null>(null);
+  const [isDragActive, setIsDragActive] = useState(false);
 
   // Focus the Linear input the render after it mounts. Using a layout
   // effect (rather than the previous requestAnimationFrame inside the menu
@@ -1328,6 +1329,65 @@ function SessionComposer({
     });
   }
 
+  function isFileDrag(event: React.DragEvent<HTMLElement>) {
+    const types = Array.from(event.dataTransfer.types ?? []);
+    return types.includes("Files");
+  }
+
+  function resetDragState() {
+    setIsDragActive(false);
+  }
+
+  function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
+    if (!canSendMessage || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    setIsDragActive(true);
+  }
+
+  function handleDragOver(event: React.DragEvent<HTMLDivElement>) {
+    if (!canSendMessage || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setIsDragActive(true);
+  }
+
+  function handleDragLeave(event: React.DragEvent<HTMLDivElement>) {
+    if (!canSendMessage || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    const nextTarget = event.relatedTarget ?? (event.nativeEvent as DragEvent).relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
+      return;
+    }
+    resetDragState();
+  }
+
+  async function handleDrop(event: React.DragEvent<HTMLDivElement>) {
+    if (!canSendMessage || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    const files = Array.from(event.dataTransfer.files ?? []);
+    resetDragState();
+    if (files.length === 0) {
+      return;
+    }
+    await onPasteFiles(files);
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+    });
+  }
+
   const firstError = uploadError || sendError;
   const errorMessage = typeof firstError === "string"
     ? firstError
@@ -1461,7 +1521,16 @@ function SessionComposer({
         <div
           ref={composerInputSurfaceRef}
           data-testid="session-composer-input-surface"
-          className={cn("rounded-xl border bg-muted/30 focus-within:border-ring focus-within:ring-1 focus-within:ring-ring", planMode ? "border-amber-200 dark:border-amber-800/50" : "border-border")}
+          data-drag-active={isDragActive ? "true" : "false"}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          className={cn(
+            "rounded-xl border bg-muted/30 transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
+            planMode ? "border-amber-200 dark:border-amber-800/50" : "border-border",
+            isDragActive && "border-primary/40 bg-primary/5 ring-1 ring-primary/30",
+          )}
         >
           {openComments.length > 0 && (
             <div className="flex flex-wrap gap-1.5 px-3 pt-2.5 pb-1">

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -87,6 +87,7 @@ import { ChatTimeline } from "@/components/chat-timeline";
 import { SessionComposerAttachmentMenu } from "@/components/session-composer-attachment-menu";
 import { SessionComposerTriggerPicker, flattenGroups, type TriggerPickerGroup, type TriggerPickerPosition } from "@/components/session-composer-trigger-picker";
 import { useSessionComposerSlashCommands } from "@/hooks/use-session-composer-slash-commands";
+import { useFileDropzone } from "@/hooks/use-file-dropzone";
 import {
   COMPOSER_TRIGGER_SPECS,
   findActiveTrigger,
@@ -1018,7 +1019,6 @@ function SessionComposer({
   const [showLinearInput, setShowLinearInput] = useState(false);
   const [linearInput, setLinearInput] = useState("");
   const [linearInputError, setLinearInputError] = useState<string | null>(null);
-  const [isDragActive, setIsDragActive] = useState(false);
 
   // Focus the Linear input the render after it mounts. Using a layout
   // effect (rather than the previous requestAnimationFrame inside the menu
@@ -1329,64 +1329,17 @@ function SessionComposer({
     });
   }
 
-  function isFileDrag(event: React.DragEvent<HTMLElement>) {
-    const types = Array.from(event.dataTransfer.types ?? []);
-    return types.includes("Files");
-  }
-
-  function resetDragState() {
-    setIsDragActive(false);
-  }
-
-  function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
-    if (!canSendMessage || !isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    setIsDragActive(true);
-  }
-
-  function handleDragOver(event: React.DragEvent<HTMLDivElement>) {
-    if (!canSendMessage || !isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
-    setIsDragActive(true);
-  }
-
-  function handleDragLeave(event: React.DragEvent<HTMLDivElement>) {
-    if (!canSendMessage || !isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-    const nextTarget = event.relatedTarget ?? (event.nativeEvent as DragEvent).relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
-      return;
-    }
-    resetDragState();
-  }
-
-  async function handleDrop(event: React.DragEvent<HTMLDivElement>) {
-    if (!canSendMessage || !isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    const files = Array.from(event.dataTransfer.files ?? []);
-    resetDragState();
-    if (files.length === 0) {
-      return;
-    }
-    await onPasteFiles(files);
-    requestAnimationFrame(() => {
-      const el = textareaRef.current;
-      if (!el) return;
-      el.focus();
-    });
-  }
+  const fileDropzone = useFileDropzone({
+    enabled: canSendMessage,
+    onFilesDropped: onPasteFiles,
+    onAfterDrop: () => {
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+      });
+    },
+  });
 
   const firstError = uploadError || sendError;
   const errorMessage = typeof firstError === "string"
@@ -1521,15 +1474,11 @@ function SessionComposer({
         <div
           ref={composerInputSurfaceRef}
           data-testid="session-composer-input-surface"
-          data-drag-active={isDragActive ? "true" : "false"}
-          onDragEnter={handleDragEnter}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
+          {...fileDropzone.dropzoneProps}
           className={cn(
             "rounded-xl border bg-muted/30 transition-colors focus-within:border-ring focus-within:ring-1 focus-within:ring-ring",
             planMode ? "border-amber-200 dark:border-amber-800/50" : "border-border",
-            isDragActive && "border-primary/40 bg-primary/5 ring-1 ring-primary/30",
+            fileDropzone.isDragActive && "border-primary/40 bg-primary/5 ring-1 ring-primary/30",
           )}
         >
           {openComments.length > 0 && (

--- a/frontend/src/components/manual-session-composer.tsx
+++ b/frontend/src/components/manual-session-composer.tsx
@@ -66,6 +66,7 @@ import {
   syncReferencesWithMessage,
 } from "@/lib/session-composer-mentions";
 import { useSessionComposerSlashCommands } from "@/hooks/use-session-composer-slash-commands";
+import { useFileDropzone } from "@/hooks/use-file-dropzone";
 import { clearDraft, loadDraft, saveDraft } from "@/lib/session-draft";
 import { queryKeys } from "@/lib/query-keys";
 import { cn } from "@/lib/utils";
@@ -337,8 +338,6 @@ export function ManualSessionComposer({
   const [selectedTriggerIndex, setSelectedTriggerIndex] = useState(0);
   const [triggerDismissed, setTriggerDismissed] = useState(false);
   const [pickerPosition, setPickerPosition] = useState<ComposerPickerPosition | null>(null);
-  const [isDragActive, setIsDragActive] = useState(false);
-  const [dragMessage, setDragMessage] = useState<string | null>(null);
   const [mobileSettingsOpen, setMobileSettingsOpen] = useState(false);
   // Gates the persist effect until after hydration so we never overwrite a
   // stored draft with the component's initial (empty) state on first mount.
@@ -346,7 +345,6 @@ export function ManualSessionComposer({
   // so dependent effects don't stall.
   const [draftHydrated, setDraftHydrated] = useState(!enableDrafts);
   const previousRepoIdRef = useRef<string>("");
-  const dragDepthRef = useRef(0);
 
   const { addOptimisticSession, removeOptimisticSession, markOptimisticResolved } = useOptimisticSessionsSafe();
   const isMobile = useMediaQuery("(max-width: 767px)");
@@ -974,11 +972,6 @@ export function ManualSessionComposer({
     event.target.value = "";
   }
 
-  function isFileDrag(event: React.DragEvent<HTMLElement>) {
-    const types = Array.from(event.dataTransfer.types ?? []);
-    return types.includes("Files");
-  }
-
   function summarizeDraggedFiles(files: File[]) {
     if (files.length === 0) {
       return "Drop images to attach";
@@ -990,64 +983,15 @@ export function ManualSessionComposer({
     return "Drop files to attach";
   }
 
-  function resetDragState() {
-    dragDepthRef.current = 0;
-    setIsDragActive(false);
-    setDragMessage(null);
-  }
-
-  function handleDragEnter(event: React.DragEvent<HTMLDivElement>) {
-    if (!isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    dragDepthRef.current += 1;
-    setIsDragActive(true);
-    const files = Array.from(event.dataTransfer.files ?? []);
-    setDragMessage(summarizeDraggedFiles(files));
-  }
-
-  function handleDragOver(event: React.DragEvent<HTMLDivElement>) {
-    if (!isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    event.dataTransfer.dropEffect = "copy";
-    const files = Array.from(event.dataTransfer.files ?? []);
-    setDragMessage(summarizeDraggedFiles(files));
-    setIsDragActive(true);
-  }
-
-  function handleDragLeave(event: React.DragEvent<HTMLDivElement>) {
-    if (!isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-    const nextTarget = event.relatedTarget ?? (event.nativeEvent as DragEvent).relatedTarget;
-    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
-      return;
-    }
-    resetDragState();
-  }
-
-  async function handleDrop(event: React.DragEvent<HTMLDivElement>) {
-    if (!isFileDrag(event)) {
-      return;
-    }
-    event.preventDefault();
-    const files = Array.from(event.dataTransfer.files ?? []);
-    resetDragState();
-    if (files.length === 0) {
-      return;
-    }
-    await uploadFiles(files);
-    requestAnimationFrame(() => {
-      messageInputRef.current?.focus();
-    });
-  }
+  const fileDropzone = useFileDropzone({
+    onFilesDropped: uploadFiles,
+    getDragMessage: summarizeDraggedFiles,
+    onAfterDrop: () => {
+      requestAnimationFrame(() => {
+        messageInputRef.current?.focus();
+      });
+    },
+  });
 
   async function handlePaste(event: React.ClipboardEvent<HTMLTextAreaElement>) {
     const files = getClipboardFiles(event.clipboardData);
@@ -1205,15 +1149,11 @@ export function ManualSessionComposer({
         "relative flex flex-col rounded-[2rem] border border-transparent transition-all duration-200 ease-out",
         "before:pointer-events-none before:absolute before:inset-0 before:rounded-[inherit] before:border before:border-dashed before:opacity-0 before:transition-opacity before:duration-200",
         "after:pointer-events-none after:absolute after:inset-0 after:rounded-[inherit] after:bg-[radial-gradient(circle_at_top,rgba(59,130,246,0.08),transparent_58%)] after:opacity-0 after:transition-opacity after:duration-200",
-        isDragActive && "border-primary/20 bg-primary/5 shadow-[0_20px_70px_-40px_rgba(59,130,246,0.45)] before:opacity-100 before:border-primary/40 after:opacity-100",
+        fileDropzone.isDragActive && "border-primary/20 bg-primary/5 shadow-[0_20px_70px_-40px_rgba(59,130,246,0.45)] before:opacity-100 before:border-primary/40 after:opacity-100",
         className,
       )}
       data-testid={dataTestId}
-      data-drag-active={isDragActive ? "true" : "false"}
-      onDragEnter={handleDragEnter}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
+      {...fileDropzone.dropzoneProps}
     >
       {showDropIndicator && (
         <div className="pointer-events-none absolute inset-x-6 top-6 flex justify-center">
@@ -1221,12 +1161,12 @@ export function ManualSessionComposer({
             aria-live="polite"
             className={cn(
               "inline-flex min-h-8 items-center rounded-full border px-3 py-1 text-xs font-medium tracking-[0.02em] text-muted-foreground transition-all duration-200",
-              isDragActive
+              fileDropzone.isDragActive
                 ? "translate-y-0 border-primary/30 bg-background/90 text-foreground opacity-100 shadow-sm"
                 : "translate-y-1 border-transparent bg-transparent opacity-0",
             )}
           >
-            {dragMessage ?? "Drop images to attach"}
+            {fileDropzone.dragMessage ?? "Drop images to attach"}
           </div>
         </div>
       )}
@@ -1277,7 +1217,7 @@ export function ManualSessionComposer({
             ref={composerCardRef}
             className={cn(
               "w-full rounded-2xl border-border/60 bg-card shadow-lg transition-all duration-200 ease-out dark:shadow-[0_0_20px_oklch(0.6_0.15_270_/_6%)]",
-              isDragActive && "-translate-y-0.5 border-primary/25 shadow-[0_24px_70px_-45px_rgba(59,130,246,0.55)]",
+              fileDropzone.isDragActive && "-translate-y-0.5 border-primary/25 shadow-[0_24px_70px_-45px_rgba(59,130,246,0.55)]",
               cardClassName,
             )}
             data-testid="manual-session-composer"

--- a/frontend/src/hooks/use-file-dropzone.test.tsx
+++ b/frontend/src/hooks/use-file-dropzone.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useFileDropzone } from "./use-file-dropzone";
+
+function fileDragPayload(file: File) {
+  return {
+    dataTransfer: {
+      files: [file],
+      items: [{ kind: "file", type: file.type, getAsFile: () => file }],
+      types: ["Files"],
+    },
+  };
+}
+
+function DropzoneHarness({
+  enabled = true,
+  onFilesDropped,
+  onAfterDrop,
+}: {
+  enabled?: boolean;
+  onFilesDropped: (files: File[]) => Promise<void> | void;
+  onAfterDrop?: () => void;
+}) {
+  const dropzone = useFileDropzone({
+    enabled,
+    onFilesDropped,
+    onAfterDrop,
+    getDragMessage: (files) => files.length === 1 ? `Drop ${files[0].name}` : "Drop files",
+  });
+
+  return (
+    <div data-testid="dropzone" {...dropzone.dropzoneProps}>
+      <span>{dropzone.dragMessage ?? "No drag"}</span>
+      <span>{dropzone.isDragActive ? "Active" : "Inactive"}</span>
+    </div>
+  );
+}
+
+describe("useFileDropzone", () => {
+  it("sets active drag state and message for file drags", () => {
+    const onFilesDropped = vi.fn();
+    const file = new File(["image-bytes"], "shot.png", { type: "image/png" });
+
+    render(<DropzoneHarness onFilesDropped={onFilesDropped} />);
+
+    fireEvent.dragEnter(screen.getByTestId("dropzone"), fileDragPayload(file));
+
+    expect(screen.getByTestId("dropzone")).toHaveAttribute("data-drag-active", "true");
+    expect(screen.getByText("Drop shot.png")).toBeInTheDocument();
+  });
+
+  it("uploads dropped files, resets drag state, and runs the after-drop callback", async () => {
+    const onFilesDropped = vi.fn().mockResolvedValue(undefined);
+    const onAfterDrop = vi.fn();
+    const file = new File(["image-bytes"], "drop.png", { type: "image/png" });
+
+    render(<DropzoneHarness onFilesDropped={onFilesDropped} onAfterDrop={onAfterDrop} />);
+    const dropzone = screen.getByTestId("dropzone");
+
+    fireEvent.dragEnter(dropzone, fileDragPayload(file));
+    fireEvent.drop(dropzone, fileDragPayload(file));
+
+    await waitFor(() => {
+      expect(onFilesDropped).toHaveBeenCalledWith([file]);
+    });
+    expect(dropzone).toHaveAttribute("data-drag-active", "false");
+    expect(onAfterDrop).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores file drops when disabled", () => {
+    const onFilesDropped = vi.fn();
+    const file = new File(["image-bytes"], "disabled.png", { type: "image/png" });
+
+    render(<DropzoneHarness enabled={false} onFilesDropped={onFilesDropped} />);
+    const dropzone = screen.getByTestId("dropzone");
+
+    fireEvent.dragEnter(dropzone, fileDragPayload(file));
+    fireEvent.drop(dropzone, fileDragPayload(file));
+
+    expect(dropzone).toHaveAttribute("data-drag-active", "false");
+    expect(onFilesDropped).not.toHaveBeenCalled();
+  });
+
+  it("clears active drag state when the dropzone becomes disabled mid-drag", async () => {
+    const onFilesDropped = vi.fn();
+    const file = new File(["image-bytes"], "stale.png", { type: "image/png" });
+
+    const { rerender } = render(<DropzoneHarness enabled onFilesDropped={onFilesDropped} />);
+    const dropzone = screen.getByTestId("dropzone");
+
+    fireEvent.dragEnter(dropzone, fileDragPayload(file));
+    expect(dropzone).toHaveAttribute("data-drag-active", "true");
+
+    rerender(<DropzoneHarness enabled={false} onFilesDropped={onFilesDropped} />);
+
+    await waitFor(() => {
+      expect(dropzone).toHaveAttribute("data-drag-active", "false");
+    });
+  });
+});

--- a/frontend/src/hooks/use-file-dropzone.ts
+++ b/frontend/src/hooks/use-file-dropzone.ts
@@ -1,0 +1,107 @@
+import { useEffect, useState, type DragEvent } from "react";
+
+type UseFileDropzoneOptions = {
+  enabled?: boolean;
+  onFilesDropped: (files: File[]) => Promise<void> | void;
+  onAfterDrop?: () => void;
+  getDragMessage?: (files: File[]) => string;
+};
+
+function isFileDrag(event: DragEvent<HTMLElement>) {
+  const types = Array.from(event.dataTransfer.types ?? []);
+  return types.includes("Files");
+}
+
+export function useFileDropzone({
+  enabled = true,
+  onFilesDropped,
+  onAfterDrop,
+  getDragMessage,
+}: UseFileDropzoneOptions) {
+  const [isDragActive, setIsDragActive] = useState(false);
+  const [dragMessage, setDragMessage] = useState<string | null>(null);
+
+  function resetDragState() {
+    setIsDragActive(false);
+    setDragMessage(null);
+  }
+
+  useEffect(() => {
+    if (enabled) {
+      return;
+    }
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- disabled state invalidates any in-progress browser drag gesture.
+    resetDragState();
+  }, [enabled]);
+
+  function getFiles(event: DragEvent<HTMLElement>) {
+    return Array.from(event.dataTransfer.files ?? []);
+  }
+
+  function updateDragMessage(event: DragEvent<HTMLElement>) {
+    if (!getDragMessage) {
+      return;
+    }
+    setDragMessage(getDragMessage(getFiles(event)));
+  }
+
+  function handleDragEnter(event: DragEvent<HTMLElement>) {
+    if (!enabled || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    setIsDragActive(true);
+    updateDragMessage(event);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLElement>) {
+    if (!enabled || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+    setIsDragActive(true);
+    updateDragMessage(event);
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLElement>) {
+    if (!enabled || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+    const nextTarget = event.relatedTarget ?? event.nativeEvent.relatedTarget;
+    if (nextTarget instanceof Node && event.currentTarget.contains(nextTarget)) {
+      return;
+    }
+    resetDragState();
+  }
+
+  async function handleDrop(event: DragEvent<HTMLElement>) {
+    if (!enabled || !isFileDrag(event)) {
+      return;
+    }
+    event.preventDefault();
+    const files = getFiles(event);
+    resetDragState();
+    if (files.length === 0) {
+      return;
+    }
+    await onFilesDropped(files);
+    onAfterDrop?.();
+  }
+
+  return {
+    isDragActive,
+    dragMessage,
+    dropzoneProps: {
+      "data-drag-active": isDragActive ? "true" : "false",
+      onDragEnter: handleDragEnter,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
This change turns the “Continue Session” follow-up input surface into a drag-and-drop target for image files. It reuses the existing uploads flow, blocks drops when the composer can’t send, and restores focus after the upload so the user can keep typing.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`**
  - Added drag state handling via `isDragActive` (controls `data-drag-active`).
  - Implemented drop-area event handlers on `session-composer-input-surface`:
    - `handleDragEnter`, `handleDragOver`, `handleDragLeave`, `handleDrop`
  - Drops are **prevented** when `canSendMessage` is false and when the drag data isn’t a file drop.
  - Clears drag state on **drop** and **leave** (`resetDragState`).
  - On drop, routes the file through the **existing upload path** and restores focus to the follow-up textarea after upload completes.

- **`frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`**
  - Added test: dropping an image on the follow-up input surface:
    - sets active drag UI state
    - calls `api.uploads.upload` with the dropped file
    - shows the attachment preview in the strip
    - restores focus to the textarea

## Test plan
- Ran the updated unit/integration test suite for the session detail page, including the new drop/upload/focus restoration test.
- Verified the new test mocks the upload function and asserts the expected attachment preview and focus behavior.

[143.dev](https://143.dev) | [session 9805d413](https://143.dev/sessions/9805d413-a677-42f8-854e-34e16893157a)