### PR TITLE
Fix session detail tab header alignment by using fixed-height scroller

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2650,12 +2650,16 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     const tabRail = await screen.findByLabelText('Session detail tabs');
+    const headerBar = screen.getByTestId('session-detail-header-bar');
     const actions = screen.getByLabelText('Session detail actions');
 
-	expect(tabRail).toHaveClass('overflow-x-auto');
-	expect(tabRail).toHaveClass('scrollbar-hide');
-	expect(tabRail).toHaveClass('min-w-0');
-	expect(actions).toHaveClass('shrink-0');
+    expect(headerBar).toHaveClass('items-center');
+    expect(tabRail).toHaveClass('h-full');
+    expect(tabRail).toHaveClass('items-center');
+    expect(tabRail).toHaveClass('overflow-x-auto');
+    expect(tabRail).toHaveClass('scrollbar-hide');
+    expect(tabRail).toHaveClass('min-w-0');
+    expect(actions).toHaveClass('shrink-0');
     expect(within(actions).getByRole('link', { name: 'View PR' })).toBeInTheDocument();
   });
 
@@ -4590,7 +4594,7 @@ describe('SessionDetailPage', () => {
     });
   });
 
-  it('reserves bottom space for the active Changes underline when the file count badge is shown', async () => {
+  it('keeps the active Changes underline inside the fixed header height when the file count badge is shown', async () => {
     const sessionWithDiff: Session = {
       ...mockSessions[0],
       diff: 'diff --git a/src/app.ts b/src/app.ts\n--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,4 @@\n import express from "express";\n+import cors from "cors";\n const app = express();\n app.listen(3000);\ndiff --git a/src/new.ts b/src/new.ts\n--- /dev/null\n+++ b/src/new.ts\n@@ -0,0 +1 @@\n+export const x = 1;',
@@ -4601,7 +4605,7 @@ describe('SessionDetailPage', () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
     await screen.findAllByText('Fixed TypeError by adding null check');
 
-    expect(screen.getByLabelText('Session detail tabs')).toHaveClass('pb-1');
+    expect(screen.getByLabelText('Session detail tabs')).toHaveClass('h-full');
   });
 
   it('does not show file count badge on Changes tab when session has no diff', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4771,7 +4771,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             ref={detailTabsRef}
             aria-label="Session detail tabs"
             className={cn(
-              "min-w-0 flex-1 overflow-x-auto overflow-y-hidden pb-1",
+              "flex h-full min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden",
               detailTabsOverflow ? "mask-fade-r" : "scrollbar-hide",
             )}
           >


### PR DESCRIPTION
## Summary
Adjusted the session detail tabs container to align correctly within the fixed header area. This removes the previous bottom padding approach that could cause scrollbar-driven vertical shifts relative to the action button.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Updated the session detail tabs container styling:
    - Replaced bottom padding (`pb-1`) with a fixed-height layout (`h-full`) and centered alignment (`items-center`).
    - Ensures the scroller fills the fixed header height and keeps the active underline/content visually consistent.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Updated/expanded regression assertions to verify the new fixed-height + centered behavior:
    - Added checks for the header bar test id and for `h-full` / `items-center` on the tabs container.
  - Renamed the relevant test to reflect the fixed-header alignment requirement.

## Test plan
- Focused Vitest regression tests
- `npm run typecheck`
- `npm run lint`
- `npm run build` (completed successfully; only existing Next.js warnings)

[143.dev](https://143.dev) | [session fb072a30](https://143.dev/sessions/fb072a30-2948-4051-ab97-b277f6f3eae6)