### PR TITLE
Fix Usage Settings cost display for estimated LLM token costs

### DIFF
--- a/docs/design/implemented/46-billing-usage-dashboard.md
+++ b/docs/design/implemented/46-billing-usage-dashboard.md
@@ -127,7 +127,9 @@ No schema change to `container_usage_events` needed — the session → user lin
 
 The `total_cost_usd` from agent output reflects the **raw API provider cost** (what Anthropic/OpenAI charges per token). This is useful as a relative measure ("Alice uses 3x more than Bob") but doesn't represent what a subscription-plan user is actually billed.
 
-**Approach:** Display cost as "Estimated API cost" with a tooltip: *"Estimated cost at standard provider rates. Your actual billing may differ based on your plan."* This is accurate for pay-as-you-go users and still useful for subscription users as a consumption signal. The column header in the breakdown table reads "Est. cost" to keep it compact.
+**Approach:** Display cost as "Estimated API cost" with a tooltip: *"Estimated cost at standard provider rates. Your actual billing may differ based on your plan."* This is accurate for pay-as-you-go users and still useful for subscription users as a consumption signal. The column header in the breakdown table reads "Est. API cost" so it is explicit that the value is not an invoice amount.
+
+If a row has LLM tokens but no computed USD cost, the UI must show the cost as unavailable rather than `$0.00`. A zero in the rollup can mean "no normalized USD was reported or safely derived" for subscription/native-credit runs, not that the run was free. Very small positive USD costs should render as `<$0.01` instead of being rounded down to zero.
 
 When actual billing integration exists (Stripe, etc.), we can add a "Billed cost" column that reflects the real charge. Until then, estimated API cost is the best signal we have and is strictly more useful than showing nothing.
 

--- a/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/page.test.tsx
@@ -10,6 +10,7 @@ import {
   formatMinutes,
   formatTokenCount,
   formatCost,
+  formatEstimatedCost,
   formatNumber,
   getDateRangePreset,
   groupByLocalDay,
@@ -139,6 +140,16 @@ describe('formatCost', () => {
   it('formats negative costs', () => {
     expect(formatCost(-1.5)).toBe('-$1.50');
     expect(formatCost(-0.005)).toBe('$0.00');
+  });
+});
+
+describe('formatEstimatedCost', () => {
+  it('shows unavailable when tokens exist but no USD cost was computed', () => {
+    expect(formatEstimatedCost(0, 1908300000)).toBe('Unavailable');
+  });
+
+  it('shows sub-cent costs without rounding them down to zero', () => {
+    expect(formatEstimatedCost(0.001, 7000)).toBe('<$0.01');
   });
 });
 
@@ -587,6 +598,34 @@ describe('UsageSummaryCards', () => {
     });
     expect(screen.getByText('10')).toBeInTheDocument();
     expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Est. API cost: $5.25')).toBeInTheDocument();
+  });
+
+  it('renders cost unavailable when tokens have no computed USD cost', async () => {
+    server.use(
+      http.get('*/api/v1/usage', () => {
+        return HttpResponse.json({
+          data: {
+            org_id: 'org-1',
+            period_start: '2026-04-01T00:00:00Z',
+            period_end: '2026-04-30T00:00:00Z',
+            total_container_minutes: 90,
+            total_sessions: 10,
+            peak_concurrent: 3,
+            by_capacity: [],
+            total_input_tokens: 2500000,
+            total_output_tokens: 800000,
+            total_llm_cost_usd: 0,
+          },
+        });
+      })
+    );
+    renderWithProviders(
+      <UsageSummaryCards start="2026-04-01T00:00:00Z" end="2026-04-30T00:00:00Z" />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Cost unavailable')).toBeInTheDocument();
+    });
   });
 });
 
@@ -657,6 +696,43 @@ describe('UsageBreakdownTable', () => {
     expect(screen.getByText('Minutes / Session')).toBeInTheDocument();
     expect(screen.getByText('Tokens / Session')).toBeInTheDocument();
     expect(screen.getByText('87.5%')).toBeInTheDocument();
+  });
+
+  it('does not render unavailable row costs as zero dollars', async () => {
+    server.use(
+      http.get('*/api/v1/usage/breakdown', () => {
+        return HttpResponse.json({
+          data: [
+            {
+              key: 'user-1',
+              label: 'alice@example.com',
+              total_container_minutes: 60,
+              total_sessions: 3,
+              total_container_starts: 3,
+              peak_concurrent: 1,
+              total_input_tokens: 5000,
+              total_output_tokens: 2000,
+              total_tokens: 7000,
+              total_llm_cost_usd: 0,
+              percentage: 60.0,
+              share_of_tokens: 87.5,
+            },
+          ],
+          meta: {},
+        });
+      })
+    );
+    renderWithProviders(
+      <UsageBreakdownTable
+        start="2026-04-01T00:00:00Z"
+        end="2026-04-30T00:00:00Z"
+        dimension="agent"
+      />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Unavailable')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx
@@ -5,7 +5,7 @@ import { api } from "@/lib/api";
 import { queryKeys } from "@/lib/query-keys";
 import { Card, CardContent } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { formatCost, formatMinutes, formatNumber, formatTokenCount } from "./usage-helpers";
+import { formatEstimatedCost, formatMinutes, formatNumber, formatTokenCount } from "./usage-helpers";
 import { cn } from "@/lib/utils";
 
 export type UsageBreakdownDimension = "user" | "capacity" | "agent" | "model" | "reasoning";
@@ -96,7 +96,7 @@ export function UsageBreakdownTable({ start, end, dimension, filters, onRowClick
                   <TableHead className="text-right text-xs">Minutes / Session</TableHead>
                   <TableHead className="text-right text-xs">Total Tokens</TableHead>
                   <TableHead className="text-right text-xs">Tokens / Session</TableHead>
-                  <TableHead className="text-right text-xs">Est. Cost</TableHead>
+                  <TableHead className="text-right text-xs">Est. API Cost</TableHead>
                   <TableHead className="pr-4 text-right text-xs">Share of Tokens</TableHead>
                 </TableRow>
               </TableHeader>
@@ -118,7 +118,7 @@ export function UsageBreakdownTable({ start, end, dimension, filters, onRowClick
                       <TableCell className="text-right text-[13px] tabular-nums">{formatMinutes(minutesPerSession)}</TableCell>
                       <TableCell className="text-right text-[13px] tabular-nums">{formatTokenCount(row.total_tokens)}</TableCell>
                       <TableCell className="text-right text-[13px] tabular-nums">{formatTokenCount(tokensPerSession)}</TableCell>
-                      <TableCell className="text-right text-[13px] tabular-nums">{formatCost(row.total_llm_cost_usd)}</TableCell>
+                      <TableCell className="text-right text-[13px] tabular-nums">{formatEstimatedCost(row.total_llm_cost_usd, row.total_tokens)}</TableCell>
                       <TableCell className="pr-4 text-right text-[13px] tabular-nums">
                         {shareOfTokens.toFixed(1)}%
                       </TableCell>

--- a/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts
@@ -103,6 +103,12 @@ export function formatCost(usd: number): string {
   return `$${usd.toFixed(2)}`;
 }
 
+export function formatEstimatedCost(usd: number, totalTokens: number): string {
+  if (usd === 0 && totalTokens > 0) return "Unavailable";
+  if (usd > 0 && usd < 0.01) return "<$0.01";
+  return formatCost(usd);
+}
+
 export function formatMinutes(minutes: number): string {
   if (minutes >= 60) {
     const hours = minutes / 60;

--- a/frontend/src/app/(dashboard)/settings/usage/usage-summary-cards.tsx
+++ b/frontend/src/app/(dashboard)/settings/usage/usage-summary-cards.tsx
@@ -7,7 +7,7 @@ import { queryKeys } from "@/lib/query-keys";
 import { Card, CardContent } from "@/components/ui/card";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Activity, Layers, Gauge, Cpu, Info } from "lucide-react";
-import { formatNumber, formatTokenCount, formatCost } from "./usage-helpers";
+import { formatNumber, formatTokenCount, formatEstimatedCost } from "./usage-helpers";
 import type { LucideIcon } from "lucide-react";
 
 interface UsageSummaryCardsProps {
@@ -73,6 +73,13 @@ export function UsageSummaryCards({ start, end }: UsageSummaryCardsProps) {
     output: summary?.total_output_tokens ?? 0,
     cost: summary?.total_llm_cost_usd ?? 0,
   };
+  const totalTokens = tokenTotals.input + tokenTotals.output;
+  const tokenCostSubtitle =
+    tokenTotals.cost > 0
+      ? `Est. API cost: ${formatEstimatedCost(tokenTotals.cost, totalTokens)}`
+      : totalTokens > 0
+        ? "Cost unavailable"
+        : undefined;
 
   if (isError) {
     return (
@@ -109,8 +116,8 @@ export function UsageSummaryCards({ start, end }: UsageSummaryCardsProps) {
       <KPICard
         icon={Cpu}
         label="LLM Tokens"
-        value={isLoading ? "" : formatTokenCount(tokenTotals.input + tokenTotals.output)}
-        subtitle={`~${formatCost(tokenTotals.cost)} est. cost`}
+        value={isLoading ? "" : formatTokenCount(totalTokens)}
+        subtitle={isLoading ? undefined : tokenCostSubtitle}
         loading={isLoading}
         labelTooltip={
           isLoading ? null : (


### PR DESCRIPTION
## Summary
Update the Usage Settings UI to render LLM cost estimates consistently and avoid misleading `$0.00` values when USD cost can’t be computed. Also clarify the breakdown column/header and improve formatting for sub-cent costs.

## Changes
- **Docs:** `docs/design/implemented/46-billing-usage-dashboard.md`
  - Rename breakdown header to **“Est. API cost”** (explicitly not an invoice).
  - Specify display rules:
    - If tokens exist but computed USD cost is missing/unsafe, show **“Unavailable”** (not `$0.00`).
    - Render tiny positive estimates as **`<$0.01`** instead of rounding down to zero.
- **UI tests:** `frontend/src/app/(dashboard)/settings/usage/page.test.tsx`
  - Add unit tests for `formatEstimatedCost`:
    - Tokens with no computed USD cost → `Unavailable`
    - Sub-cent positive cost → `<$0.01`
  - Add integration coverage for summary cards when `total_llm_cost_usd` is not safely derived.
- **Formatting/helpers:** `frontend/src/app/(dashboard)/settings/usage/usage-helpers.ts`
  - Implement/adjust `formatEstimatedCost` to follow the “Unavailable” and sub-cent rendering rules.
- **Components:**
  - `frontend/src/app/(dashboard)/settings/usage/usage-summary-cards.tsx`:
    - Update summary label to **“Est. API cost: $X.XX”**.
  - `frontend/src/app/(dashboard)/settings/usage/usage-breakdown-table.tsx`:
    - Update breakdown column header to **“Est. API Cost”**.
    - Ensure missing USD estimates display **“Unavailable”**.

## Test plan
- `npm test -- --run src/app/'(dashboard)'/settings/usage/page.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 4abe2023](https://143.dev/sessions/4abe2023-6e28-4942-aacf-6d93d903f002)