### PR TITLE
Fix preview HTML injection to avoid corrupting Next Flight payloads

### DIFF
--- a/internal/api/gateway/preview_gateway.go
+++ b/internal/api/gateway/preview_gateway.go
@@ -658,8 +658,14 @@ func (g *Gateway) injectScriptsIntoHTML(resp *http.Response, previewID uuid.UUID
 func injectBeforeEndTag(body []byte, scriptBlock string) []byte {
 	z := html.NewTokenizer(bytes.NewReader(body))
 	offset := -1
+	consumed := 0
 	for {
-		switch z.Next() {
+		tokenType := z.Next()
+		raw := z.Raw()
+		tokenStart := consumed
+		consumed += len(raw)
+
+		switch tokenType {
 		case html.ErrorToken:
 			// End of input or parse error — no matching end tag found.
 			if offset == -1 {
@@ -669,16 +675,11 @@ func injectBeforeEndTag(body []byte, scriptBlock string) []byte {
 		case html.EndTagToken:
 			name, _ := z.TagName()
 			if string(name) == "head" {
-				// Offset is the position immediately before the `<` that
-				// started this token. Compute from remaining bytes.
-				raw := z.Raw()
-				tokenStart := len(body) - len(z.Buffered()) - len(raw)
 				return spliceAt(body, tokenStart, scriptBlock)
 			}
 			if string(name) == "body" && offset == -1 {
 				// Remember body offset as a fallback if no </head> appears.
-				raw := z.Raw()
-				offset = len(body) - len(z.Buffered()) - len(raw)
+				offset = tokenStart
 			}
 		}
 	}

--- a/internal/api/gateway/preview_gateway_test.go
+++ b/internal/api/gateway/preview_gateway_test.go
@@ -483,6 +483,28 @@ func TestInjectScriptsIntoHTML_UnsupportedEncodingSkipsInjectionWithoutMutatingR
 	require.Equal(t, original, body, "unsupported encoded bodies should not be mutated")
 }
 
+func TestInjectBeforeEndTag_InsertsBeforeRealHeadNotFlightPayload(t *testing.T) {
+	t.Parallel()
+
+	marker := "<script>preview marker</script>"
+	body := []byte(`<!DOCTYPE html><html><head><title>Login</title></head><body>` +
+		`<script>self.__next_f.push([1,"0:{\"children\":[\"$\",\"html\",null,{\"children\":[\"$\",\"body\",null,{\"children\":\"payload\"}]}]}"])</script>` +
+		strings.Repeat("x", 8192) +
+		`</body></html>`)
+
+	out := string(injectBeforeEndTag(body, marker))
+	markerIndex := strings.Index(out, marker)
+	headCloseIndex := strings.Index(out, "</head>")
+	flightIndex := strings.Index(out, "self.__next_f.push")
+
+	require.NotEqual(t, -1, markerIndex, "injection should add the marker script")
+	require.NotEqual(t, -1, headCloseIndex, "test document should contain a real head close tag")
+	require.NotEqual(t, -1, flightIndex, "test document should contain a Next Flight script payload")
+	require.Less(t, markerIndex, headCloseIndex, "injection should happen before the real closing head tag")
+	require.Less(t, headCloseIndex, flightIndex, "the real head should close before the Flight script payload begins")
+	require.NotContains(t, out, `[\"$\",<script>preview marker</script>`, "injection should not splice the marker into the escaped Flight payload")
+}
+
 func TestGateway_ServeHTTP_InvalidHost(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fix the preview gateway HTML injector so it tracks tokenizer byte offsets directly instead of relying on buffered-byte math.
- Add a regression test covering large App Router HTML with an embedded Next Flight payload.
- This prevents the injected preview script from landing inside the streamed Flight script and exposing raw script text in the browser.

## Testing
- Added a regression test for `injectBeforeEndTag` against a document containing a Next Flight payload.
- Ran `go vet ./...`, `go build ./...`, and `go test ./...` successfully.