### PR TITLE
Move stopped preview status pill into preview panel and remove header badge

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -218,10 +218,9 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("No preview running")).toBeInTheDocument();
     });
 
-    // Should also render the status badge
-    expect(screen.getByText("Stopped")).toBeInTheDocument();
+    expect(screen.queryByText("Stopped")).not.toBeInTheDocument();
     expect(screen.getByText(/Started 5m ago/)).toBeInTheDocument();
-    expect(screen.getByText(/Stopped 1m ago/)).toBeInTheDocument();
+    expect(screen.getByText(/Stopped 1m ago/)).toHaveClass("rounded-full");
   });
 
   it("treats async start success as startup in progress and resumes polling", async () => {

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -727,7 +727,7 @@ export function PreviewPanel({
         </div>
 
         {/* Status badge */}
-        {status && status !== "failed" && (
+        {status && status !== "failed" && status !== "stopped" && status !== "expired" && (
           <Badge variant="secondary" className={cn(statusColor(status))}>
             {status === "ready" && <CheckCircle2 className="size-3" />}
             {status === "unhealthy" && <AlertTriangle className="size-3" />}
@@ -1155,11 +1155,14 @@ export function PreviewPanel({
               Start a preview to see live changes from the agent. Note that it can take a few minutes for the environment to finish booting.
             </p>
             {instance?.created_at && lastPreviewStoppedAt && (
-              <p className="text-xs text-muted-foreground">
-                Started {formatTimeAgo(instance.created_at)}
-                <span aria-hidden="true" className="mx-1 text-muted-foreground/50">·</span>
-                Stopped {formatTimeAgo(lastPreviewStoppedAt)}
-              </p>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <span className="text-xs text-muted-foreground">
+                  Started {formatTimeAgo(instance.created_at)}
+                </span>
+                <Badge variant="secondary" className={cn(statusColor(status ?? "stopped"))}>
+                  Stopped {formatTimeAgo(lastPreviewStoppedAt)}
+                </Badge>
+              </div>
             )}
           </div>
           <Button


### PR DESCRIPTION
## Summary
Updated the preview status UI so terminal `Stopped`/`Expired` states no longer render as pills in the header toolbar. Instead, `Stopped 20m ago` is now shown as a rounded `Badge` inside the idle preview panel, and tests were updated to match.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Removed header/toolbar status pill rendering for `stopped` and `expired` (in addition to existing `failed`).
  - Updated the idle preview panel to render `Started {…}` plus a rounded `Badge` for `Stopped {…}` when `instance.created_at` and `lastPreviewStoppedAt` are present.
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Assert that the header no longer contains the text `Stopped`.
  - Assert `Stopped 1m ago` exists in the idle panel and has the `rounded-full` class (badge styling).

## Test plan
- `npm test -- preview-panel.test.tsx`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session b4f04cad](https://143.dev/sessions/b4f04cad-f1c6-40ab-968a-a7093adc3e94)