### PR TITLE
Handle coding agent thread failures to terminally fail review loops

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -12,6 +12,11 @@ structured `/review` messages for Codex and Claude Code, one review thread per
 loop, pass-limit enforcement, and automatic continuation from review to
 decision to fix to confirmation review.
 
+If the coding-agent turn that owns a review-loop thread fails before a normal
+completion callback, the worker marks the running loop terminal `failed` while
+also releasing the thread. The session overview must therefore render the
+review as failed instead of continuing to show a stale loading/running state.
+
 Manual session detail now exposes a `Review` action that starts a two-pass loop
 in the current sandbox. Automations persist `pre_pr_review_loops`; new
 automations default to one pass, existing rows backfill to zero, and the

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -272,6 +272,17 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 	}
 }
 
+func (s *Service) OnThreadTurnFailed(ctx context.Context, orgID, threadID uuid.UUID, summary string) error {
+	loop, err := s.store.GetRunningLoopByThread(ctx, orgID, threadID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNoRunningReviewLoop
+		}
+		return err
+	}
+	return s.failLoop(ctx, orgID, loop, strings.TrimSpace(summary))
+}
+
 func (s *Service) failLoop(ctx context.Context, orgID uuid.UUID, loop models.SessionReviewLoop, summary string) error {
 	if loop.AutomationRunID != nil {
 		return s.store.MarkLoopFailedAndEnqueueOpenPR(ctx, orgID, loop.ID, summary, automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -342,6 +342,63 @@ func TestService_OnThreadTurnCompleteAutomationDecisionFailureEnqueuesOpenPRGate
 	require.Equal(t, []string{"failed_open_pr"}, store.events, "invalid automation review decision should durably queue the PR gate")
 }
 
+func TestService_OnThreadTurnFailedMarksRunningLoopFailed(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	loopID := uuid.New()
+	store := &fakeReviewLoopStore{
+		runningLoop: models.SessionReviewLoop{
+			ID:        loopID,
+			OrgID:     orgID,
+			SessionID: sessionID,
+			ThreadID:  &threadID,
+			Status:    models.ReviewLoopStatusRunning,
+			AgentType: models.AgentTypeCodex,
+			MaxPasses: 2,
+		},
+	}
+	svc := NewService(store, &fakeThreadService{})
+
+	err := svc.OnThreadTurnFailed(context.Background(), orgID, threadID, " sandbox hydrate failed ")
+
+	require.NoError(t, err, "thread failure should terminalize the running review loop")
+	require.Equal(t, loopID, store.failedLoopID, "thread failure should mark the active review loop failed")
+	require.Equal(t, "sandbox hydrate failed", store.failedSummary, "thread failure should store a trimmed failure summary")
+	require.Equal(t, []string{"failed"}, store.events, "manual review-loop failure should not enqueue PR creation")
+}
+
+func TestService_OnThreadTurnFailedAutomationEnqueuesOpenPRGate(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	loopID := uuid.New()
+	automationRunID := uuid.New()
+	store := &fakeReviewLoopStore{
+		runningLoop: models.SessionReviewLoop{
+			ID:              loopID,
+			OrgID:           orgID,
+			SessionID:       sessionID,
+			AutomationRunID: &automationRunID,
+			ThreadID:        &threadID,
+			Status:          models.ReviewLoopStatusRunning,
+			AgentType:       models.AgentTypeCodex,
+			MaxPasses:       1,
+		},
+	}
+	svc := NewService(store, &fakeThreadService{})
+
+	err := svc.OnThreadTurnFailed(context.Background(), orgID, threadID, "agent exited")
+
+	require.NoError(t, err, "automation thread failure should terminalize the running review loop")
+	require.Equal(t, loopID, store.failedLoopID, "automation thread failure should mark the review loop failed")
+	require.Equal(t, []string{"failed_open_pr"}, store.events, "automation review-loop failure should requeue the PR gate")
+}
+
 func TestParseDecisionRequiresExactSentinel(t *testing.T) {
 	t.Parallel()
 
@@ -387,6 +444,7 @@ type fakeReviewLoopStore struct {
 	needsHumanDecision           models.ReviewLoopDecision
 	needsHumanLoopID             uuid.UUID
 	failedLoopID                 uuid.UUID
+	failedSummary                string
 	fixSummary                   string
 	terminalErr                  error
 	events                       []string
@@ -504,7 +562,10 @@ func (f *fakeReviewLoopStore) MarkLoopNeedsHumanDecisionAndEnqueueOpenPR(_ conte
 	return nil
 }
 
-func (f *fakeReviewLoopStore) MarkLoopFailed(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string) error {
+func (f *fakeReviewLoopStore) MarkLoopFailed(_ context.Context, _ uuid.UUID, loopID uuid.UUID, summary string) error {
+	f.failedLoopID = loopID
+	f.failedSummary = summary
+	f.events = append(f.events, "failed")
 	return nil
 }
 

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -330,6 +330,7 @@ type Services struct {
 	Linear          *linear.Service               // nil-safe: Linear session-linking disabled if nil
 	ReviewLoops     interface {
 		OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid.UUID, assistantSummary string) error
+		OnThreadTurnFailed(ctx context.Context, orgID, threadID uuid.UUID, summary string) error
 		Start(ctx context.Context, orgID, sessionID uuid.UUID, req reviewloopsvc.StartReviewLoopRequest) (*models.SessionReviewLoop, error)
 	}
 	// EvalBatchStreams publishes lightweight pub/sub signals on every batch
@@ -1529,6 +1530,16 @@ func newContinueSessionHandler(stores *Stores, services *Services, logger zerolo
 						Msg("failed to release session thread after continue_session failure")
 				}
 				cleanupCancel()
+				if services.ReviewLoops != nil {
+					reviewCleanupCtx, reviewCleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+					if reviewErr := services.ReviewLoops.OnThreadTurnFailed(reviewCleanupCtx, orgID, threadID, err.Error()); reviewErr != nil && !errors.Is(reviewErr, reviewloopsvc.ErrNoRunningReviewLoop) {
+						logger.Warn().Err(reviewErr).
+							Str("session_id", sessionID.String()).
+							Str("thread_id", threadID.String()).
+							Msg("failed to mark review loop failed after thread turn failure")
+					}
+					reviewCleanupCancel()
+				}
 			}
 			return err
 		}

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2785,7 +2785,8 @@ func workerReviewLoopColumns() []string {
 }
 
 type stubWorkerReviewLoops struct {
-	starts []stubWorkerReviewLoopStart
+	starts   []stubWorkerReviewLoopStart
+	failures []stubWorkerReviewLoopFailure
 }
 
 type stubWorkerReviewLoopStart struct {
@@ -2794,7 +2795,18 @@ type stubWorkerReviewLoopStart struct {
 	req       reviewloopsvc.StartReviewLoopRequest
 }
 
+type stubWorkerReviewLoopFailure struct {
+	orgID    uuid.UUID
+	threadID uuid.UUID
+	summary  string
+}
+
 func (s *stubWorkerReviewLoops) OnThreadTurnComplete(context.Context, uuid.UUID, uuid.UUID, string) error {
+	return nil
+}
+
+func (s *stubWorkerReviewLoops) OnThreadTurnFailed(_ context.Context, orgID, threadID uuid.UUID, summary string) error {
+	s.failures = append(s.failures, stubWorkerReviewLoopFailure{orgID: orgID, threadID: threadID, summary: summary})
 	return nil
 }
 
@@ -5089,6 +5101,55 @@ func TestContinueSessionHandler_ReleasesThreadOnContinuationFailure(t *testing.T
 	err := handler(context.Background(), "continue_session", payload)
 	require.ErrorIs(t, err, continuationErr, "continue_session should preserve the orchestrator failure")
 	require.Equal(t, 1, orch.continueSessionCalls, "continue_session should invoke the orchestrator once")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestContinueSessionHandler_MarksReviewLoopFailedOnContinuationFailure(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+	stores.SessionThreads = db.NewSessionThreadStore(mock)
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	issueID := uuid.New()
+	continuationErr := errors.New("coding agent exited with an error")
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(workerSessionColumns).AddRow(
+				workerSessionRow(sessionID, issueID, orgID, string(models.SessionStatusIdle), 2, nil, nil)...,
+			),
+		)
+	mock.ExpectQuery("SELECT .* FROM session_threads").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionThreadColumns).AddRow(
+			workerSessionThreadRow(threadID, sessionID, orgID, models.AgentTypeCodex, nil, models.ThreadStatusRunning)...,
+		))
+	mock.ExpectExec("UPDATE session_threads SET status = @status").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	reviews := &stubWorkerReviewLoops{}
+	orch := &orchestratorServiceStub{
+		continueSessionFn: func(ctx context.Context, session *models.Session, opts *agent.ContinueSessionOptions) error {
+			require.NotNil(t, opts, "continue_session should pass thread execution options to the orchestrator")
+			return continuationErr
+		},
+	}
+	handler := newContinueSessionHandler(stores, &Services{Orchestrator: orch, ReviewLoops: reviews}, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `","thread_id":"` + threadID.String() + `"}`)
+
+	err := handler(context.Background(), "continue_session", payload)
+
+	require.ErrorIs(t, err, continuationErr, "continue_session should preserve the orchestrator failure")
+	require.Len(t, reviews.failures, 1, "review loop service should be notified about the failed review-thread turn")
+	require.Equal(t, orgID, reviews.failures[0].orgID, "review-loop failure should be org scoped")
+	require.Equal(t, threadID, reviews.failures[0].threadID, "review-loop failure should target the failed thread")
+	require.Equal(t, continuationErr.Error(), reviews.failures[0].summary, "review-loop failure should preserve the agent error")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 


### PR DESCRIPTION
## Summary
When a coding-agent turn that owns a review-loop thread fails, the worker could previously leave the review loop in a stale “running/loading” state. This change adds an explicit thread-failure callback that marks the active review loop terminal `failed` (and trims/stores the failure summary) so session overviews render correctly.

## Changes
- **internal/services/reviewloop/service.go**
  - Added `OnThreadTurnFailed(ctx, orgID, threadID, summary)` to look up the running loop by thread and call existing `failLoop(...)`.
  - Ensures missing running loops map to `ErrNoRunningReviewLoop`.
- **internal/services/reviewloop/service_test.go**
  - Added tests covering:
    - Non-automation thread failure marks the running loop `failed` and does **not** enqueue PR creation.
    - Automation-associated failures enqueue the appropriate PR gate (per existing `failLoop` behavior).
- **internal/worker/handlers.go**
  - Updated worker handling so coding-agent errors route to the new review-loop failure path (preventing stuck loading/running states).
- **internal/worker/handlers_test.go**
  - Extended worker tests to validate the failure-to-loop-terminal behavior.
- **docs/design/implemented/78-review-agent-loops.md**
  - Documented the failure-mode behavior: terminal `failed` + thread release, and session overview should show failed instead of continuing a stale state.

## Test plan
- Ran the updated unit tests for `reviewloop` and `worker` services (`go test ./...`), including new coverage for thread failure terminalization and automation vs non-automation behavior.

[143.dev](https://143.dev) | [session cd55002f](https://143.dev/sessions/cd55002f-2506-4729-af7c-f90d7227b424)