### PR TITLE
Retry preview capacity failures and surface a clearer message

### DIFF
--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -408,7 +408,7 @@ func (h *PreviewHandler) acquireSandbox(ctx context.Context, orgID uuid.UUID, se
 		})
 		if capErr != nil {
 			return acquireSandboxResult{
-				ErrCode: "PREVIEW_CAPACITY_REACHED",
+				ErrCode: preview.PreviewCapacityCode,
 				Err:     fmt.Errorf("%w: %w", preview.ErrPreviewCapacity, capErr),
 			}
 		}
@@ -574,7 +574,7 @@ func (h *PreviewHandler) enqueueStartPreviewJob(ctx context.Context, orgID, user
 	if err != nil {
 		h.logger.Warn().Err(err).Str("session_id", session.ID.String()).Msg("preview reserve failed")
 		if errors.Is(err, preview.ErrPreviewCapacity) {
-			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, "PREVIEW_CAPACITY_REACHED", err.Error(), err)
+			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, preview.PreviewCapacityCode, preview.PreviewCapacityMessage, err)
 		}
 		return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_START_FAILED", "failed to start preview", err)
 	}
@@ -640,7 +640,7 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 	if err != nil {
 		h.logger.Warn().Err(err).Str("session_id", sessionID.String()).Msg("preview reserve failed")
 		if errors.Is(err, preview.ErrPreviewCapacity) {
-			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, "PREVIEW_CAPACITY_REACHED", err.Error(), err)
+			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, preview.PreviewCapacityCode, preview.PreviewCapacityMessage, err)
 		}
 		return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_START_FAILED", "failed to start preview", err)
 	}
@@ -661,7 +661,11 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 		// hydratedContainerID is "" — either we never hydrated, or
 		// acquireSandbox's race-loss branch already destroyed the local
 		// container before returning.
-		h.manager.AbortReservation(ctx, reservation, "", fmt.Sprintf("acquire sandbox: %v", acq.Err))
+		abortReason := fmt.Sprintf("acquire sandbox: %v", acq.Err)
+		if errors.Is(acq.Err, preview.ErrPreviewCapacity) {
+			abortReason = preview.PreviewCapacityMessage
+		}
+		h.manager.AbortReservation(ctx, reservation, "", abortReason)
 		switch acq.ErrCode {
 		case "SNAPSHOT_EXPIRED":
 			return nil, newPreviewHTTPError(http.StatusGone, acq.ErrCode, acq.Err.Error(), acq.Err)
@@ -671,8 +675,8 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 			return nil, newPreviewHTTPError(http.StatusConflict, acq.ErrCode, acq.Err.Error(), acq.Err)
 		case "SANDBOX_BUSY":
 			return nil, newPreviewHTTPError(http.StatusConflict, acq.ErrCode, acq.Err.Error(), acq.Err)
-		case "PREVIEW_CAPACITY_REACHED":
-			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, acq.ErrCode, acq.Err.Error(), acq.Err)
+		case preview.PreviewCapacityCode:
+			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, acq.ErrCode, preview.PreviewCapacityMessage, acq.Err)
 		default:
 			return nil, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_HYDRATE_FAILED", "failed to hydrate sandbox for preview", acq.Err)
 		}

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -1371,9 +1371,10 @@ func TestPreviewHandler_StartPreview_CapacityReached(t *testing.T) {
 
 	require.Equal(t, http.StatusServiceUnavailable, w.Code, "capacity errors must map to 503")
 	var resp models.ErrorResponse
-	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
-	require.Equal(t, "PREVIEW_CAPACITY_REACHED", resp.Error.Code)
-	require.NoError(t, mock.ExpectationsWereMet())
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "response body should decode as an error response")
+	require.Equal(t, preview.PreviewCapacityCode, resp.Error.Code, "capacity errors should keep their stable API code")
+	require.Equal(t, preview.PreviewCapacityMessage, resp.Error.Message, "capacity errors should show a user-facing recovery message")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewHandler_StartPreview_WorkerRoutedEnqueuesStartPreviewJob(t *testing.T) {
@@ -1631,7 +1632,8 @@ func TestPreviewHandler_StartPreview_HydrateCapacityReached(t *testing.T) {
 	h.StartPreview(w, req)
 
 	require.Equal(t, http.StatusServiceUnavailable, w.Code, "preview hydrate capacity should surface as 503")
-	require.Contains(t, w.Body.String(), "PREVIEW_CAPACITY_REACHED", "preview hydrate capacity should use the capacity error code")
+	require.Contains(t, w.Body.String(), preview.PreviewCapacityCode, "preview hydrate capacity should use the capacity error code")
+	require.Contains(t, w.Body.String(), preview.PreviewCapacityMessage, "preview hydrate capacity should use user-facing copy")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/services/preview/errors.go
+++ b/internal/services/preview/errors.go
@@ -7,6 +7,11 @@ import "errors"
 // instead of a generic "failed to start preview". Wrap with %w when adding
 // context (e.g. fmt.Errorf("%w: pull postgres:17-alpine: %v", ErrInfraImageUnavailable, err)).
 var (
+	// ErrPreviewCapacity is returned when a preview cannot start because a
+	// preview or sandbox concurrency cap is full. Wrap with %w so callers can
+	// detect transient capacity pressure with errors.Is.
+	ErrPreviewCapacity = errors.New("preview capacity reached")
+
 	// ErrInfraImageUnavailable means a preview infrastructure container could
 	// not be created because the requested image is not present locally and
 	// the on-demand pull failed (registry unreachable, image renamed/removed,

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -38,11 +38,17 @@ const (
 	ProviderDocker = "docker"
 )
 
-// ErrPreviewCapacity is returned by StartPreview when a concurrency cap
-// (per-user, per-org, or per-worker) would be exceeded. Handlers should
-// translate this to HTTP 503 with a friendly "try again later" message
-// rather than a 422.
-var ErrPreviewCapacity = errors.New("preview capacity reached")
+const (
+	// PreviewCapacityCode is the stable API error code for preview capacity
+	// failures.
+	PreviewCapacityCode = "PREVIEW_CAPACITY_REACHED"
+	// PreviewCapacityMessage is the user-facing message for transient preview
+	// capacity failures. Keep lower-level live/reserved counts in logs.
+	PreviewCapacityMessage = "Preview capacity is full. Try again shortly; if this keeps happening, stop another active preview or session and retry."
+	// PreviewCapacityRetryExhaustedMessage is persisted when the durable
+	// start_preview job gives up after retrying capacity admission.
+	PreviewCapacityRetryExhaustedMessage = "Preview capacity stayed full while retrying. Stop another active preview or session, then retry the preview."
+)
 
 // =============================================================================
 // Manager

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -95,6 +95,10 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 			Str("session_id", payload.SessionID.String()).
 			Str("error_code", acq.ErrCode).
 			Msg("preview start job: failed to acquire sandbox")
+		if errors.Is(acq.Err, ErrPreviewCapacity) {
+			r.registerCapacityDeadLetter(ctx, reservation)
+			return fmt.Errorf("%s: %w", acq.ErrCode, acq.Err)
+		}
 		r.abort(ctx, reservation, "", fmt.Sprintf("acquire sandbox: %v", acq.Err))
 		return fmt.Errorf("%s: %w", acq.ErrCodeOr("PREVIEW_HYDRATE_FAILED"), acq.Err)
 	}
@@ -149,6 +153,21 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 
 func shouldReassignPreviewWorker(deadTargetNode, reservationWorkerNode, claimingWorkerNode string) bool {
 	return deadTargetNode != "" && claimingWorkerNode != "" && claimingWorkerNode != reservationWorkerNode
+}
+
+func (r *StartRunner) registerCapacityDeadLetter(ctx context.Context, reservation *models.PreviewInstance) {
+	if r == nil || r.manager == nil || reservation == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		if deadLetterErr != nil {
+			r.logger.Warn().Err(deadLetterErr).
+				Str("preview_id", reservation.ID.String()).
+				Str("session_id", reservation.SessionID.String()).
+				Msg("preview start dead-lettered after capacity retries")
+		}
+		r.manager.AbortReservation(hookCtx, reservation, "", PreviewCapacityRetryExhaustedMessage)
+	})
 }
 
 func (r *StartRunner) abort(ctx context.Context, reservation *models.PreviewInstance, hydratedID, reason string) {
@@ -274,7 +293,7 @@ func (r *StartRunner) acquireSandbox(ctx context.Context, orgID uuid.UUID, sessi
 			Purpose: sandboxCfg.Purpose, SessionID: sandboxCfg.SessionID, OrgID: sandboxCfg.OrgID,
 		})
 		if capErr != nil {
-			return acquireSandboxResult{ErrCode: "PREVIEW_CAPACITY_REACHED", Err: fmt.Errorf("%w: %w", ErrPreviewCapacity, capErr)}
+			return acquireSandboxResult{ErrCode: PreviewCapacityCode, Err: fmt.Errorf("%w: %w", ErrPreviewCapacity, capErr)}
 		}
 		defer capacityReservation.Release()
 	}

--- a/internal/services/preview/worker_client_test.go
+++ b/internal/services/preview/worker_client_test.go
@@ -178,7 +178,7 @@ func TestWorkerPreviewClient_PropagatesStructuredWorkerErrors(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		require.NoError(t, json.NewEncoder(w).Encode(models.ErrorResponse{
-			Error: models.ErrorDetail{Code: "PREVIEW_CAPACITY_REACHED", Message: "all preview slots are in use"},
+			Error: models.ErrorDetail{Code: PreviewCapacityCode, Message: "all preview slots are in use"},
 		}), "worker error responses should encode structured errors")
 	}))
 	defer server.Close()
@@ -193,8 +193,8 @@ func TestWorkerPreviewClient_PropagatesStructuredWorkerErrors(t *testing.T) {
 	reqErr, ok := AsWorkerRequestError(err)
 	require.True(t, ok, "StartPreview should expose structured worker errors")
 	require.Equal(t, http.StatusServiceUnavailable, reqErr.StatusCode, "worker error status should be preserved")
-	require.Equal(t, "PREVIEW_CAPACITY_REACHED", reqErr.Code, "worker error code should be preserved")
-	require.Contains(t, reqErr.Error(), "PREVIEW_CAPACITY_REACHED", "worker error string should include the code")
+	require.Equal(t, PreviewCapacityCode, reqErr.Code, "worker error code should be preserved")
+	require.Contains(t, reqErr.Error(), PreviewCapacityCode, "worker error string should include the code")
 }
 
 func TestWorkerPreviewClient_DecodeFailures(t *testing.T) {
@@ -277,7 +277,7 @@ func TestDecodeWorkerResponses_ErrorVariants(t *testing.T) {
 
 		resp := &http.Response{
 			StatusCode: http.StatusServiceUnavailable,
-			Body:       ioNopCloserString(`{"error":{"code":"PREVIEW_CAPACITY_REACHED","message":"full"}}`),
+			Body:       ioNopCloserString(fmt.Sprintf(`{"error":{"code":%q,"message":"full"}}`, PreviewCapacityCode)),
 		}
 
 		_, err := decodeWorkerResponse[models.PreviewInstance](resp)
@@ -285,7 +285,7 @@ func TestDecodeWorkerResponses_ErrorVariants(t *testing.T) {
 
 		reqErr, ok := AsWorkerRequestError(err)
 		require.True(t, ok, "decodeWorkerResponse should return a worker request error")
-		require.Equal(t, "PREVIEW_CAPACITY_REACHED", reqErr.Code, "decodeWorkerResponse should preserve the worker error code")
+		require.Equal(t, PreviewCapacityCode, reqErr.Code, "decodeWorkerResponse should preserve the worker error code")
 	})
 
 	t.Run("single response plain worker error", func(t *testing.T) {

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -36,6 +36,7 @@ import (
 )
 
 const sandboxCapacityRetryDelay = 10 * time.Second
+const previewCapacityRetryDelay = 5 * time.Second
 const prePRReviewRetryDelay = 5 * time.Second
 const failureCategoryStaleSandbox = "stale_sandbox"
 
@@ -434,6 +435,16 @@ func newStartPreviewHandler(services *Services, logger zerolog.Logger) JobHandle
 			Str("session_id", input.SessionID.String()).
 			Msg("processing start_preview job")
 		if err := services.PreviewStarter.StartReservedPreview(ctx, input); err != nil {
+			if errors.Is(err, previewsvc.ErrPreviewCapacity) {
+				retryAfter := previewCapacityRetryDelay
+				logger.Info().
+					Err(err).
+					Str("preview_id", input.PreviewID.String()).
+					Str("session_id", input.SessionID.String()).
+					Dur("retry_after", retryAfter).
+					Msg("preview capacity reached; retrying start_preview")
+				return &RetryableError{Err: err, RetryAfter: &retryAfter}
+			}
 			return &FatalError{Err: err}
 		}
 		return nil

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -2709,12 +2709,13 @@ func TestRegisterHandlers_AutomationRunRegisteredWithoutPMService(t *testing.T) 
 type mockPreviewStarter struct {
 	called  bool
 	payload previewsvc.StartPreviewJobPayload
+	err     error
 }
 
 func (m *mockPreviewStarter) StartReservedPreview(ctx context.Context, payload previewsvc.StartPreviewJobPayload) error {
 	m.called = true
 	m.payload = payload
-	return nil
+	return m.err
 }
 
 func TestRegisterHandlers_StartPreviewRegisteredWithPreviewStarter(t *testing.T) {
@@ -2748,6 +2749,33 @@ func TestRegisterHandlers_StartPreviewRegisteredWithPreviewStarter(t *testing.T)
 	err = handler(context.Background(), models.JobTypeStartPreview, raw)
 	require.NoError(t, err, "start_preview handler should delegate successfully")
 	require.True(t, starter.called, "start_preview handler should call the preview starter")
+	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
+}
+
+func TestStartPreviewHandler_PreviewCapacityRetries(t *testing.T) {
+	t.Parallel()
+
+	logger := zerolog.Nop()
+	starter := &mockPreviewStarter{err: fmt.Errorf("%s: %w", previewsvc.PreviewCapacityCode, previewsvc.ErrPreviewCapacity)}
+	handler := newStartPreviewHandler(&Services{PreviewStarter: starter}, logger)
+
+	payload := previewsvc.StartPreviewJobPayload{
+		OrgID:     uuid.New(),
+		UserID:    uuid.New(),
+		SessionID: uuid.New(),
+		PreviewID: uuid.New(),
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err, "start_preview payload should marshal")
+
+	err = handler(context.Background(), models.JobTypeStartPreview, raw)
+
+	var retryable *RetryableError
+	require.ErrorAs(t, err, &retryable, "preview capacity should requeue start_preview instead of dead-lettering the preview")
+	require.ErrorIs(t, retryable.Err, previewsvc.ErrPreviewCapacity, "retryable error should preserve the preview capacity sentinel")
+	require.NotNil(t, retryable.RetryAfter, "preview capacity retry should use an explicit short delay")
+	require.Equal(t, 5*time.Second, *retryable.RetryAfter, "preview capacity retry should run again quickly")
+	require.True(t, starter.called, "start_preview handler should call the preview starter before deciding retry behavior")
 	require.Equal(t, payload, starter.payload, "start_preview handler should pass the decoded payload")
 }
 


### PR DESCRIPTION
## Summary
- Retry `start_preview` jobs after preview capacity failures with a 5s backoff instead of dead-lettering immediately
- Reuse a shared `PreviewCapacityCode` constant and `ErrPreviewCapacity` sentinel with `errors.Is` for capacity decisions
- Show a clearer user-facing preview capacity message while preserving the stable API error code
- Cover the new retry path and response copy with unit tests

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`