### PR TITLE
Normalize Linear webhook shapes and retry transient install refreshes

### DIFF
--- a/internal/api/handlers/ingestion_webhooks.go
+++ b/internal/api/handlers/ingestion_webhooks.go
@@ -332,7 +332,6 @@ func sniffLinearEventEnvelope(body []byte) (LinearAgentEventType, *linearAgentEv
 	if err := json.Unmarshal(body, &env); err != nil {
 		return "", nil
 	}
-	env.normalize()
 	switch LinearAgentEventType(env.Type) {
 	case LinearAgentEventAgentSession, LinearAgentEventAppUserNotification:
 		return LinearAgentEventType(env.Type), &env

--- a/internal/api/handlers/ingestion_webhooks.go
+++ b/internal/api/handlers/ingestion_webhooks.go
@@ -332,6 +332,7 @@ func sniffLinearEventEnvelope(body []byte) (LinearAgentEventType, *linearAgentEv
 	if err := json.Unmarshal(body, &env); err != nil {
 		return "", nil
 	}
+	env.normalize()
 	switch LinearAgentEventType(env.Type) {
 	case LinearAgentEventAgentSession, LinearAgentEventAppUserNotification:
 		return LinearAgentEventType(env.Type), &env

--- a/internal/api/handlers/integrations.go
+++ b/internal/api/handlers/integrations.go
@@ -19,6 +19,7 @@ import (
 	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	linearservice "github.com/assembledhq/143/internal/services/linear"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -700,7 +701,7 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 		bgCtx, bgCancel := context.WithTimeout(context.WithoutCancel(r.Context()), 3*time.Second)
 		go func() {
 			defer bgCancel()
-			if err := h.linearTeamKeyRefresher(bgCtx, orgID); err != nil {
+			if err := h.refreshLinearTeamKeysAfterInstall(bgCtx, orgID); err != nil {
 				logger.Warn().Err(err).
 					Str("org_id", orgID.String()).
 					Msg("background refresh_linear_team_keys after install failed; worker fallback or 24h cron will retry")
@@ -717,6 +718,32 @@ func (h *IntegrationHandler) HandleLinearOAuthCallback(w http.ResponseWriter, r 
 	}
 
 	http.Redirect(w, r, h.frontendURL+"/integrations?linear=connected", http.StatusTemporaryRedirect)
+}
+
+const linearTeamKeyInstallRetryDelay = 100 * time.Millisecond
+
+func (h *IntegrationHandler) refreshLinearTeamKeysAfterInstall(ctx context.Context, orgID uuid.UUID) error {
+	if h.linearTeamKeyRefresher == nil {
+		return nil
+	}
+	err := h.linearTeamKeyRefresher(ctx, orgID)
+	if err == nil || !isTransientLinearIntegrationLookupMiss(err) {
+		return err
+	}
+
+	timer := time.NewTimer(linearTeamKeyInstallRetryDelay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+	}
+	return h.linearTeamKeyRefresher(ctx, orgID)
+}
+
+func isTransientLinearIntegrationLookupMiss(err error) bool {
+	return errors.Is(err, linearservice.ErrIntegrationNotFound) ||
+		(err != nil && strings.Contains(err.Error(), "linear integration not found"))
 }
 
 func (h *IntegrationHandler) preserveExistingWebhookSecret(ctx context.Context, orgID uuid.UUID, cfg models.ProviderConfig) (models.ProviderConfig, error) {

--- a/internal/api/handlers/integrations_test.go
+++ b/internal/api/handlers/integrations_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -909,6 +910,89 @@ func TestIntegrationHandler_HandleLinearOAuthCallback_AsyncRefreshAndEnqueue(t *
 		t.Fatal("inline RefreshTeamKeys goroutine never ran within 2s")
 	}
 	require.NoError(t, mock.ExpectationsWereMet(), "exactly one INSERT INTO jobs should fire as the durable fallback")
+}
+
+func TestIntegrationHandler_HandleLinearOAuthCallback_RetriesTransientTeamKeyIntegrationMiss(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	jobID := uuid.New()
+	now := time.Now().UTC()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := db.NewIntegrationStore(mock)
+	credentialStore := db.NewOrgCredentialStore(mock, nil)
+
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.URL.String() {
+		case "https://api.linear.app/oauth/token":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"access_token":"linear-access-token","token_type":"Bearer","scope":"read"}`)),
+			}, nil
+		case "https://api.linear.app/graphql":
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(bytes.NewBufferString(`{"data":{"viewer":{"organization":{"id":"lin-org-1","name":"Acme"}}}}`)),
+			}, nil
+		default:
+			return nil, errors.New("unexpected request URL")
+		}
+	})
+
+	handler := NewIntegrationHandler(store, credentialStore, "linear-client-id", "linear-client-secret", "http://localhost:8080", "http://localhost:3000")
+	handler.client = &http.Client{Transport: transport}
+	handler.SetLinearJobStore(db.NewJobStore(mock))
+
+	inlineCalls := make(chan uuid.UUID, 2)
+	var refreshAttempts atomic.Int32
+	handler.SetLinearTeamKeyRefresher(func(_ context.Context, gotOrg uuid.UUID) error {
+		inlineCalls <- gotOrg
+		if refreshAttempts.Add(1) == 1 {
+			return errors.New("lookup linear integration: linear integration not found")
+		}
+		return nil
+	})
+
+	expectNoExistingCredentialLookup(mock)
+	mock.ExpectQuery("INSERT INTO org_credentials").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+	mock.ExpectQuery("SELECT .+ FROM integrations .+ provider = @provider .+ status IN \\('active', 'error'\\)").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "org_id", "provider", "config", "status", "last_synced_at", "created_at"}))
+	mock.ExpectQuery("INSERT INTO integrations").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at"}).AddRow(integrationID, now))
+	expectLinearWorkspaceIDPersist(mock)
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(jobID))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations/linear/callback?code=test-code&state=test-state", nil)
+	req.AddCookie(&http.Cookie{Name: "linear_integration_oauth_state", Value: "test-state"})
+	req = req.WithContext(middleware.WithOrgID(req.Context(), orgID))
+	w := httptest.NewRecorder()
+
+	handler.HandleLinearOAuthCallback(w, req)
+
+	require.Equal(t, http.StatusTemporaryRedirect, w.Code, "callback should redirect even when the inline refresh has to retry")
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-inlineCalls:
+			require.Equal(t, orgID, got, "inline refresher retry should keep the callback org id")
+		case <-time.After(2 * time.Second):
+			t.Fatal("inline RefreshTeamKeys retry never ran within 2s")
+		}
+	}
+	require.NoError(t, mock.ExpectationsWereMet(), "worker fallback should still enqueue exactly once")
 }
 
 func TestIntegrationHandler_HandleLinearOAuthCallback_StateMismatch(t *testing.T) {

--- a/internal/api/handlers/linear_agent_webhook.go
+++ b/internal/api/handlers/linear_agent_webhook.go
@@ -37,35 +37,51 @@ const (
 // linearAgentEventEnvelope is the minimal subset of the AgentSessionEvent
 // payload the dispatcher needs to (a) decide whether to act, (b) idempotency-
 // upsert the linear_agent_sessions row, and (c) build the worker job
-// payload.
+// payload. It accepts both Linear's top-level `agentSession` shape and the
+// older/wrapped `payload.agentSession` shape.
 //
 // We deliberately don't try to consume the full Linear payload here — the
 // worker fetches the live issue from Linear when it runs (see Phase 2.7),
 // which gives it the freshest issue body and label set. Caching the inbound
 // payload would just risk going stale between dispatch and worker
 // execution.
+type linearAgentEventIssue struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier,omitempty"`
+	TeamID     string `json:"teamId,omitempty"`
+	ProjectID  string `json:"projectId,omitempty"`
+}
+
+type linearAgentEventCreator struct {
+	ID string `json:"id,omitempty"`
+}
+
+type linearAgentEventSession struct {
+	ID        string                  `json:"id"`
+	IssueID   string                  `json:"issueId"`
+	CommentID string                  `json:"commentId,omitempty"`
+	Issue     linearAgentEventIssue   `json:"issue,omitempty"`
+	Creator   linearAgentEventCreator `json:"creator,omitempty"`
+}
+
+type linearAgentEventActivity struct {
+	Body string `json:"body,omitempty"`
+}
+
+type linearAgentEventPayload struct {
+	AgentSession  linearAgentEventSession  `json:"agentSession"`
+	AgentActivity linearAgentEventActivity `json:"agentActivity,omitempty"`
+}
+
 type linearAgentEventEnvelope struct {
-	Type    string `json:"type"`
-	Action  string `json:"action"`
-	Payload struct {
-		AgentSession struct {
-			ID        string `json:"id"`
-			IssueID   string `json:"issueId"`
-			CommentID string `json:"commentId,omitempty"`
-			Issue     struct {
-				ID         string `json:"id"`
-				Identifier string `json:"identifier,omitempty"`
-				TeamID     string `json:"teamId,omitempty"`
-				ProjectID  string `json:"projectId,omitempty"`
-			} `json:"issue,omitempty"`
-			Creator struct {
-				ID string `json:"id,omitempty"`
-			} `json:"creator,omitempty"`
-		} `json:"agentSession"`
-		AgentActivity struct {
-			Body string `json:"body,omitempty"`
-		} `json:"agentActivity,omitempty"`
-	} `json:"payload"`
+	Type    string                  `json:"type"`
+	Action  string                  `json:"action"`
+	Payload linearAgentEventPayload `json:"payload"`
+	// Linear has emitted both payload.agentSession and top-level
+	// agentSession shapes. Normalize either shape into Payload before
+	// dispatch so the rest of the pipeline has one contract.
+	AgentSession  linearAgentEventSession  `json:"agentSession,omitempty"`
+	AgentActivity linearAgentEventActivity `json:"agentActivity,omitempty"`
 	// AppUserID is the id of the Linear app user this webhook is
 	// addressed to. Linear sets it on AppUserNotification deliveries and
 	// recent AgentSessionEvent payloads; older AgentSessionEvent
@@ -75,6 +91,18 @@ type linearAgentEventEnvelope struct {
 	// URL setups). Empty here means "Linear didn't tell us the target
 	// user" — we don't filter on it in that case.
 	AppUserID string `json:"appUserId,omitempty"`
+}
+
+func (e *linearAgentEventEnvelope) normalize() {
+	if e.Payload.AgentSession.ID == "" && e.AgentSession.ID != "" {
+		e.Payload.AgentSession = e.AgentSession
+	}
+	if e.Payload.AgentActivity.Body == "" && e.AgentActivity.Body != "" {
+		e.Payload.AgentActivity = e.AgentActivity
+	}
+	if e.Payload.AgentSession.IssueID == "" {
+		e.Payload.AgentSession.IssueID = e.Payload.AgentSession.Issue.ID
+	}
 }
 
 // linearAgentEventAction names a value of envelope.action. The worker
@@ -269,6 +297,7 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 			Msg("agent dispatcher: HMAC verified but body failed to parse; requesting Linear redelivery")
 		return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("parse agent event envelope: %w", err)}
 	}
+	env.normalize()
 
 	action = linearAgentEventAction(env.Action)
 	if action != linearAgentActionCreated && action != linearAgentActionPrompted {

--- a/internal/api/handlers/linear_agent_webhook.go
+++ b/internal/api/handlers/linear_agent_webhook.go
@@ -74,12 +74,11 @@ type linearAgentEventPayload struct {
 }
 
 type linearAgentEventEnvelope struct {
-	Type    string                  `json:"type"`
-	Action  string                  `json:"action"`
-	Payload linearAgentEventPayload `json:"payload"`
-	// Linear has emitted both payload.agentSession and top-level
-	// agentSession shapes. Normalize either shape into Payload before
-	// dispatch so the rest of the pipeline has one contract.
+	Type   string `json:"type"`
+	Action string `json:"action"`
+	// Linear currently emits agentSession/agentActivity at the top level.
+	// Payload remains as a read-only fallback for older wrapped deliveries.
+	Payload       linearAgentEventPayload  `json:"payload,omitempty"`
 	AgentSession  linearAgentEventSession  `json:"agentSession,omitempty"`
 	AgentActivity linearAgentEventActivity `json:"agentActivity,omitempty"`
 	// AppUserID is the id of the Linear app user this webhook is
@@ -93,16 +92,22 @@ type linearAgentEventEnvelope struct {
 	AppUserID string `json:"appUserId,omitempty"`
 }
 
-func (e *linearAgentEventEnvelope) normalize() {
-	if e.Payload.AgentSession.ID == "" && e.AgentSession.ID != "" {
-		e.Payload.AgentSession = e.AgentSession
+func (e linearAgentEventEnvelope) agentSession() linearAgentEventSession {
+	session := e.AgentSession
+	if session.ID == "" {
+		session = e.Payload.AgentSession
 	}
-	if e.Payload.AgentActivity.Body == "" && e.AgentActivity.Body != "" {
-		e.Payload.AgentActivity = e.AgentActivity
+	if session.IssueID == "" {
+		session.IssueID = session.Issue.ID
 	}
-	if e.Payload.AgentSession.IssueID == "" {
-		e.Payload.AgentSession.IssueID = e.Payload.AgentSession.Issue.ID
+	return session
+}
+
+func (e linearAgentEventEnvelope) agentActivity() linearAgentEventActivity {
+	if e.AgentActivity.Body != "" {
+		return e.AgentActivity
 	}
+	return e.Payload.AgentActivity
 }
 
 // linearAgentEventAction names a value of envelope.action. The worker
@@ -297,8 +302,6 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 			Msg("agent dispatcher: HMAC verified but body failed to parse; requesting Linear redelivery")
 		return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("parse agent event envelope: %w", err)}
 	}
-	env.normalize()
-
 	action = linearAgentEventAction(env.Action)
 	if action != linearAgentActionCreated && action != linearAgentActionPrompted {
 		// Linear may add new actions in the future. Surface as 500 so
@@ -311,7 +314,9 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 			Msg("agent dispatcher: unrecognized action; requesting Linear redelivery")
 		return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("unrecognized agent event action: %q", env.Action)}
 	}
-	if env.Payload.AgentSession.ID == "" || env.Payload.AgentSession.IssueID == "" {
+	agentSession := env.agentSession()
+	agentActivity := env.agentActivity()
+	if agentSession.ID == "" || agentSession.IssueID == "" {
 		// Missing required IDs is a contract violation, not transient.
 		// Don't retry — Linear sending the same malformed payload again
 		// won't help. Operator must investigate.
@@ -382,15 +387,15 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 		row, created, err = d.agentSessions.UpsertOnCreated(ctx, integration.OrgID, db.UpsertOnCreatedInput{
 			OrgID:                 integration.OrgID,
 			IntegrationID:         integration.ID,
-			LinearAgentSessionID:  env.Payload.AgentSession.ID,
-			LinearIssueID:         env.Payload.AgentSession.IssueID,
-			LinearIssueIdentifier: env.Payload.AgentSession.Issue.Identifier,
+			LinearAgentSessionID:  agentSession.ID,
+			LinearIssueID:         agentSession.IssueID,
+			LinearIssueIdentifier: agentSession.Issue.Identifier,
 			LinearAppUserID:       env.AppUserID,
-			LinearCreatorUserID:   env.Payload.AgentSession.Creator.ID,
+			LinearCreatorUserID:   agentSession.Creator.ID,
 		})
 		if err != nil {
 			d.logger.Error().Err(err).
-				Str("agent_session_id", env.Payload.AgentSession.ID).
+				Str("agent_session_id", agentSession.ID).
 				Msg("failed to upsert linear_agent_sessions; requesting Linear redelivery")
 			return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("upsert linear_agent_sessions: %w", err)}
 		}
@@ -403,30 +408,30 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 		// activity-log writes that key on agent_session_row_id — have a
 		// real UUID to bind to. The late-arriving `created` re-upserts
 		// idempotently on the (org_id, linear_agent_session_id) UNIQUE.
-		row, err = d.agentSessions.Lookup(ctx, integration.OrgID, env.Payload.AgentSession.ID)
+		row, err = d.agentSessions.Lookup(ctx, integration.OrgID, agentSession.ID)
 		if err != nil {
 			if errors.Is(err, db.ErrLinearAgentSessionNotFound) {
 				d.logger.Warn().
-					Str("agent_session_id", env.Payload.AgentSession.ID).
+					Str("agent_session_id", agentSession.ID).
 					Msg("prompted event arrived before created; persisting synthetic row")
 				row, _, err = d.agentSessions.UpsertOnCreated(ctx, integration.OrgID, db.UpsertOnCreatedInput{
 					OrgID:                 integration.OrgID,
 					IntegrationID:         integration.ID,
-					LinearAgentSessionID:  env.Payload.AgentSession.ID,
-					LinearIssueID:         env.Payload.AgentSession.IssueID,
-					LinearIssueIdentifier: env.Payload.AgentSession.Issue.Identifier,
+					LinearAgentSessionID:  agentSession.ID,
+					LinearIssueID:         agentSession.IssueID,
+					LinearIssueIdentifier: agentSession.Issue.Identifier,
 					LinearAppUserID:       env.AppUserID,
-					LinearCreatorUserID:   env.Payload.AgentSession.Creator.ID,
+					LinearCreatorUserID:   agentSession.Creator.ID,
 				})
 				if err != nil {
 					d.logger.Error().Err(err).
-						Str("agent_session_id", env.Payload.AgentSession.ID).
+						Str("agent_session_id", agentSession.ID).
 						Msg("failed to persist synthetic linear_agent_sessions row; requesting Linear redelivery")
 					return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("persist synthetic linear_agent_sessions: %w", err)}
 				}
 			} else {
 				d.logger.Error().Err(err).
-					Str("agent_session_id", env.Payload.AgentSession.ID).
+					Str("agent_session_id", agentSession.ID).
 					Msg("failed to lookup linear_agent_sessions; requesting Linear redelivery")
 				return DispatchResult{Status: "retryable_error", Err: fmt.Errorf("lookup linear_agent_sessions: %w", err)}
 			}
@@ -442,7 +447,7 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 	// because the AgentSession is already alive and Linear's UI doesn't
 	// need a "Reading…" thought for follow-ups.
 	if action == linearAgentActionCreated && d.emitter != nil {
-		bootstrap := linear.BootstrapActivity(env.Payload.AgentSession.Issue.Identifier)
+		bootstrap := linear.BootstrapActivity(agentSession.Issue.Identifier)
 		bootstrapStart := time.Now()
 		// Hard sub-second cap on the synchronous Linear roundtrip. The
 		// outer Linear webhook ack SLA is 5s and we still owe an enqueue
@@ -492,8 +497,8 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 		url.QueryEscape(row.LinearAgentSessionID),
 		url.QueryEscape(string(action)),
 	}
-	if action == linearAgentActionPrompted && env.Payload.AgentSession.CommentID != "" {
-		dedupeParts = append(dedupeParts, url.QueryEscape(env.Payload.AgentSession.CommentID))
+	if action == linearAgentActionPrompted && agentSession.CommentID != "" {
+		dedupeParts = append(dedupeParts, url.QueryEscape(agentSession.CommentID))
 	}
 	dedupe := strings.Join(dedupeParts, ":")
 	// Surface payload context that's missing from the webhook envelope so
@@ -501,11 +506,11 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 	// production logs. The worker tolerates empty values (FetchIssue
 	// re-derives them), but a chronically-empty team_id usually means the
 	// workspace is sending a slimmer payload than we expect.
-	if env.Payload.AgentSession.Issue.TeamID == "" || env.Payload.AgentSession.Issue.ProjectID == "" {
+	if agentSession.Issue.TeamID == "" || agentSession.Issue.ProjectID == "" {
 		d.logger.Debug().
 			Str("agent_session_id", row.LinearAgentSessionID).
-			Bool("missing_team_id", env.Payload.AgentSession.Issue.TeamID == "").
-			Bool("missing_project_id", env.Payload.AgentSession.Issue.ProjectID == "").
+			Bool("missing_team_id", agentSession.Issue.TeamID == "").
+			Bool("missing_project_id", agentSession.Issue.ProjectID == "").
 			Msg("agent event payload missing optional issue context; worker will derive from FetchIssue")
 	}
 	jobPayload := map[string]any{
@@ -514,12 +519,12 @@ func (d *LinearAgentDispatcher) Dispatch(ctx context.Context, integration *model
 		"integration_id":          integration.ID.String(),
 		"agent_session_row_id":    row.ID.String(),
 		"linear_agent_session_id": row.LinearAgentSessionID,
-		"linear_issue_id":         env.Payload.AgentSession.IssueID,
-		"linear_issue_team_id":    env.Payload.AgentSession.Issue.TeamID,
-		"linear_issue_project_id": env.Payload.AgentSession.Issue.ProjectID,
-		"linear_creator_user_id":  env.Payload.AgentSession.Creator.ID,
-		"linear_comment_id":       env.Payload.AgentSession.CommentID,
-		"linear_prompt_body":      env.Payload.AgentActivity.Body,
+		"linear_issue_id":         agentSession.IssueID,
+		"linear_issue_team_id":    agentSession.Issue.TeamID,
+		"linear_issue_project_id": agentSession.Issue.ProjectID,
+		"linear_creator_user_id":  agentSession.Creator.ID,
+		"linear_comment_id":       agentSession.CommentID,
+		"linear_prompt_body":      agentActivity.Body,
 	}
 	jobID, err := d.jobs.Enqueue(ctx, integration.OrgID, "linear", "linear_agent_event", jobPayload, 5, &dedupe)
 	if err != nil {

--- a/internal/api/handlers/linear_agent_webhook_test.go
+++ b/internal/api/handlers/linear_agent_webhook_test.go
@@ -141,6 +141,58 @@ func TestLinearAgentDispatcher_PromptedWithoutCreatedEnqueuesRetryableJob(t *tes
 	require.NoError(t, mock.ExpectationsWereMet(), "dispatcher should look up, then upsert a synthetic row before enqueueing the retry job")
 }
 
+func TestLinearAgentDispatcher_CreatedAcceptsTopLevelAgentSession(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	integrationID := uuid.New()
+	rowID := uuid.New()
+	now := time.Now().UTC()
+	jobs := &fakeJobs{}
+	enabled := true
+	d := &LinearAgentDispatcher{
+		logger:        zerolog.Nop(),
+		agentSessions: db.NewLinearAgentSessionStore(mock),
+		jobs:          jobs,
+		settingsLoader: func(_ context.Context, _ uuid.UUID) (models.LinearAgentSettings, error) {
+			return models.LinearAgentSettings{Enabled: &enabled}, nil
+		},
+		featureEnabled: true,
+	}
+
+	mock.ExpectQuery("INSERT INTO linear_agent_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "integration_id", "linear_agent_session_id",
+			"linear_issue_id", "linear_issue_identifier",
+			"linear_app_user_id", "linear_creator_user_id",
+			"session_id", "state", "last_event_received_at",
+			"created_at", "updated_at", "inserted",
+		}).AddRow(
+			rowID, orgID, integrationID, "as_top_level",
+			"iss_1", "ACS-1",
+			"app_user_1", "user_1",
+			nil, "pending", &now,
+			now, now, true,
+		))
+
+	body := []byte(`{"type":"AgentSessionEvent","action":"created","appUserId":"app_user_1","agentSession":{"id":"as_top_level","issueId":"iss_1","issue":{"id":"iss_1","identifier":"ACS-1","teamId":"team_1"},"creator":{"id":"user_1"}}}`)
+	res := d.Dispatch(context.Background(), &models.Integration{ID: integrationID, OrgID: orgID}, LinearAgentEventAgentSession, body, nil)
+
+	require.Equal(t, "agent_dispatched", res.Status, "dispatcher should accept Linear's top-level agentSession webhook shape")
+	require.Len(t, jobs.calls, 1, "dispatcher should enqueue one created worker job")
+	payload, ok := jobs.calls[0].Payload.(map[string]any)
+	require.True(t, ok, "dispatcher should enqueue a map payload")
+	require.Equal(t, "as_top_level", payload["linear_agent_session_id"], "worker payload should carry the top-level Linear AgentSession id")
+	require.Equal(t, "created", payload["action"], "worker payload should identify created action")
+	require.NoError(t, mock.ExpectationsWereMet(), "dispatcher should upsert the AgentSession row from the top-level payload")
+}
+
 func TestLinearAgentDispatcher_EnqueueFailureReturnsRetryableStatus(t *testing.T) {
 	t.Parallel()
 
@@ -473,6 +525,18 @@ func TestSniffLinearEventType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSniffLinearEventEnvelope_NormalizesTopLevelAgentSession(t *testing.T) {
+	t.Parallel()
+
+	eventType, env := sniffLinearEventEnvelope([]byte(`{"type":"AgentSessionEvent","action":"created","agentSession":{"id":"as_top_level","issueId":"iss_1","issue":{"identifier":"ACS-1"}}}`))
+
+	require.Equal(t, LinearAgentEventAgentSession, eventType, "sniffing should identify top-level AgentSessionEvent payloads")
+	require.NotNil(t, env, "sniffing should return a parsed envelope")
+	require.Equal(t, "as_top_level", env.Payload.AgentSession.ID, "sniffing should normalize top-level agentSession into payload.agentSession")
+	require.Equal(t, "iss_1", env.Payload.AgentSession.IssueID, "sniffing should preserve the top-level issue id")
+	require.Equal(t, "ACS-1", env.Payload.AgentSession.Issue.Identifier, "sniffing should preserve the issue identifier")
 }
 
 // newDispatcherForTest constructs a dispatcher with non-nil feature-required

--- a/internal/api/handlers/linear_agent_webhook_test.go
+++ b/internal/api/handlers/linear_agent_webhook_test.go
@@ -417,11 +417,11 @@ func TestLinearAgentDispatcher_UsesParsedEnvelopeWhenProvided(t *testing.T) {
 	var env linearAgentEventEnvelope
 	env.Type = string(LinearAgentEventAgentSession)
 	env.Action = string(linearAgentActionCreated)
-	env.Payload.AgentSession.ID = "as_parsed"
-	env.Payload.AgentSession.IssueID = "iss_1"
-	env.Payload.AgentSession.Issue.ID = "iss_1"
-	env.Payload.AgentSession.Issue.Identifier = "ACS-1"
-	env.Payload.AgentSession.Creator.ID = "user_1"
+	env.AgentSession.ID = "as_parsed"
+	env.AgentSession.IssueID = "iss_1"
+	env.AgentSession.Issue.ID = "iss_1"
+	env.AgentSession.Issue.Identifier = "ACS-1"
+	env.AgentSession.Creator.ID = "user_1"
 
 	res := d.Dispatch(context.Background(), &models.Integration{ID: integrationID, OrgID: orgID}, LinearAgentEventAgentSession, []byte(`not json`), &env)
 	require.Equal(t, "agent_dispatched", res.Status, "dispatcher should reuse the parsed envelope instead of reparsing the body")
@@ -527,16 +527,17 @@ func TestSniffLinearEventType(t *testing.T) {
 	}
 }
 
-func TestSniffLinearEventEnvelope_NormalizesTopLevelAgentSession(t *testing.T) {
+func TestSniffLinearEventEnvelope_ParsesTopLevelAgentSession(t *testing.T) {
 	t.Parallel()
 
 	eventType, env := sniffLinearEventEnvelope([]byte(`{"type":"AgentSessionEvent","action":"created","agentSession":{"id":"as_top_level","issueId":"iss_1","issue":{"identifier":"ACS-1"}}}`))
 
 	require.Equal(t, LinearAgentEventAgentSession, eventType, "sniffing should identify top-level AgentSessionEvent payloads")
 	require.NotNil(t, env, "sniffing should return a parsed envelope")
-	require.Equal(t, "as_top_level", env.Payload.AgentSession.ID, "sniffing should normalize top-level agentSession into payload.agentSession")
-	require.Equal(t, "iss_1", env.Payload.AgentSession.IssueID, "sniffing should preserve the top-level issue id")
-	require.Equal(t, "ACS-1", env.Payload.AgentSession.Issue.Identifier, "sniffing should preserve the issue identifier")
+	session := env.agentSession()
+	require.Equal(t, "as_top_level", session.ID, "sniffing should parse the top-level agentSession")
+	require.Equal(t, "iss_1", session.IssueID, "sniffing should preserve the top-level issue id")
+	require.Equal(t, "ACS-1", session.Issue.Identifier, "sniffing should preserve the issue identifier")
 }
 
 // newDispatcherForTest constructs a dispatcher with non-nil feature-required


### PR DESCRIPTION
## Summary
- Normalize Linear agent webhook envelopes so both top-level `agentSession` and wrapped `payload.agentSession` shapes dispatch correctly
- Add a short retry for post-install Linear team key refresh when the integration lookup is not yet visible
- Cover the new webhook normalization and OAuth callback retry behavior with tests

## Testing
- Added handler and dispatcher tests for top-level Linear AgentSession payloads and transient refresh retries
- Not run (not requested)