### PR TITLE
Fix logging deploy script sync and Vector healthcheck

### DIFF
--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -545,6 +545,7 @@ func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
 	require.Contains(t, deployText, "deploy/vector.yaml", "logging deploy should sync Vector config for the logging node")
 	require.Contains(t, deployText, "deploy/grafana/provisioning", "logging deploy should sync Grafana provisioning files")
 	require.Contains(t, deployText, "deploy/vmalert/rules", "logging deploy should sync vmalert rules")
+	require.Contains(t, deployText, "deploy/scripts/alertmanager_slack_relay.py", "logging deploy should sync the Alertmanager Slack relay script mounted by docker-compose.logging.yml")
 	require.Contains(t, deployText, "rm -rf /opt/143/deploy/grafana/provisioning /opt/143/deploy/vmalert/rules", "logging deploy should remove stale provisioned dashboards and rules before syncing repo-owned config")
 
 	compose, err := os.ReadFile("../docker-compose.logging.yml")
@@ -554,6 +555,10 @@ func TestLoggingDeploySyncsProvisionedObservabilityConfig(t *testing.T) {
 	require.Contains(t, deployText, "SERVER_ROLE=%s", "logging deploy should write SERVER_ROLE=logging for Vector")
 	vectorCheck := deployText[strings.Index(deployText, "# Verify Vector is running"):]
 	require.Contains(t, vectorCheck, `"$ROLE" = "logging"`, "logging deploy should verify the logging-node Vector collector after stack recreation")
+
+	vectorCompose, err := os.ReadFile("../docker-compose.vector.yml")
+	require.NoError(t, err, "test should read shared Vector compose file")
+	require.Contains(t, string(vectorCompose), "--api.enabled=true", "Vector compose should enable the API endpoint used by its /health healthcheck")
 
 	dashboardProvider, err := os.ReadFile("../deploy/grafana/provisioning/dashboards/dashboards.yml")
 	require.NoError(t, err, "test should read Grafana dashboard provider config")

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -204,10 +204,17 @@ if [ "$ROLE" = "logging" ]; then
   # so the rm still runs on hosts where files are already deploy-owned.
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "sudo -n chown -R deploy:deploy /opt/143/deploy/vmalert 2>&1 | sed 's/^/  chown: /' || true; \
-     sudo -n chown -R deploy:deploy /opt/143/deploy/grafana 2>&1 | sed 's/^/  chown: /' || true"
+     sudo -n chown -R deploy:deploy /opt/143/deploy/grafana 2>&1 | sed 's/^/  chown: /' || true; \
+     sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" "rm -rf /opt/143/deploy/grafana/provisioning /opt/143/deploy/vmalert/rules && mkdir -p /opt/143/deploy/grafana /opt/143/deploy/vmalert"
   scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/grafana/provisioning" deploy@"$HOST":/opt/143/deploy/grafana/
   scp -r "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/vmalert/rules" deploy@"$HOST":/opt/143/deploy/vmalert/
+  scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/alertmanager_slack_relay.py" \
+    deploy@"$HOST":/opt/143/deploy/scripts/alertmanager_slack_relay.py.new
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "mv /opt/143/deploy/scripts/alertmanager_slack_relay.py.new /opt/143/deploy/scripts/alertmanager_slack_relay.py \
+     && chmod 644 /opt/143/deploy/scripts/alertmanager_slack_relay.py \
+     || { rm -f /opt/143/deploy/scripts/alertmanager_slack_relay.py.new; exit 1; }"
 fi
 if [ "$ROLE" = "app" ]; then
   # Sync Caddyfile so the remote always has the latest reverse-proxy config.

--- a/docker-compose.vector.yml
+++ b/docker-compose.vector.yml
@@ -11,7 +11,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./deploy/vector.yaml:/etc/vector/vector.yaml:ro
       - vector-buffer:/var/lib/vector
-    command: ["--config", "/etc/vector/vector.yaml"]
+    command: ["--config", "/etc/vector/vector.yaml", "--api.enabled=true"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8686/health"]
       interval: 30s


### PR DESCRIPTION
## Summary
- Sync `alertmanager_slack_relay.py` during logging deploys so the Alertmanager relay container can start correctly on the logging node.
- Enable the Vector API in the shared compose file so the existing `/health` check can pass.
- Extend deploy config coverage to lock both behaviors in place.

## Testing
- Added/updated deploy configuration tests for the logging-node sync path and Vector API flag.
- Verified the focused deploy test and the full Go test suite passed locally.
- Verified shell syntax for `deploy/scripts/deploy.sh`.