### PR TITLE
Remove GitHub integration “Repository access” header and duplicate repo pills from settings page

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -135,4 +135,25 @@ describe("IntegrationsPage", () => {
     expect(within(githubCard as HTMLElement).getByText("acme/api")).toBeInTheDocument();
     expect(screen.queryByText("GitHub repositories")).not.toBeInTheDocument();
   });
+
+  it("renders GitHub repository cards without duplicate repo pills or section intro copy", async () => {
+    repositoriesListMock.mockResolvedValue({
+      data: [
+        {
+          id: "repo-1",
+          full_name: "acme/web",
+          status: "active",
+        },
+      ],
+      meta: {},
+    });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    await screen.findByText("acme/api");
+
+    expect(screen.queryByText("acme/web")).not.toBeInTheDocument();
+    expect(screen.queryByText("Repository access")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Choose which repositories this 143 organization owns/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -24,7 +24,6 @@ import {
 import { useAutosave } from "@/hooks/useAutosave";
 import { useDisconnectIntegration } from "@/hooks/use-disconnect-integration";
 import { queryKeys } from "@/lib/query-keys";
-import { useDisconnectRepository } from "@/hooks/use-repository-connection";
 import { useAuth } from "@/hooks/use-auth";
 import { Badge } from "@/components/ui/badge";
 import type { GitHubRepositoryClaimCandidate } from "@/lib/types";
@@ -88,13 +87,7 @@ function GitHubRepositoryClaims({
 
   return (
     <>
-      <div className="mt-3 border-t border-border pt-3">
-        <div className="mb-2">
-          <p className="text-xs font-medium text-foreground">Repository access</p>
-          <p className="mt-0.5 text-xs text-muted-foreground">
-            Choose which repositories this 143 organization owns from the connected GitHub installation.
-          </p>
-        </div>
+      <div className="mt-3">
         {isLoading ? (
           <p className="text-sm text-muted-foreground">Loading repositories...</p>
         ) : error ? (
@@ -344,12 +337,7 @@ export default function IntegrationsPage() {
     queryKey: ["integrations"],
     queryFn: () => api.integrations.list(),
   });
-  const { data: reposResp } = useQuery({
-    queryKey: ["repositories", { includeDisconnected: true }],
-    queryFn: () => api.repositories.list({ includeDisconnected: true }),
-  });
   const disconnectMutation = useDisconnectIntegration();
-  const disconnectRepoMutation = useDisconnectRepository();
 
   const [notionDialogOpen, setNotionDialogOpen] = useState(false);
   const [notionError, setNotionError] = useState<string | null>(null);
@@ -408,15 +396,6 @@ export default function IntegrationsPage() {
     (integration) => integration.provider === "circleci" && integration.status === "active"
   );
 
-  const githubRepos = (reposResp?.data ?? []).map((r) => ({
-    id: r.id,
-    full_name: r.full_name,
-    status: r.status,
-  }));
-  const pendingRepoID = disconnectRepoMutation.isPending
-    ? (disconnectRepoMutation.variables ?? null)
-    : null;
-
   return (
     <PageContainer size="default">
       <div className="space-y-6">
@@ -431,10 +410,6 @@ export default function IntegrationsPage() {
       )}
       <AllIntegrationCards
         githubConnected={githubConnected}
-        githubRepos={githubRepos}
-        onDisconnectRepo={(id) => disconnectRepoMutation.mutate(id)}
-        onReconnectRepo={undefined}
-        pendingRepoID={pendingRepoID}
         githubExtra={
           isAdmin && githubConnected ? (
             <GitHubRepositoryClaims


### PR DESCRIPTION
## Summary
Updated the GitHub integration UI on the settings integrations page to remove the “Repository access” header/helper copy and divider, and to prevent duplicate repository “pills” from rendering. The page now passes no repo chips into the GitHub card so only the repository cards display.

## Changes
- **frontend/src/app/(dashboard)/settings/integrations/page.tsx**
  - Removed the “Repository access” section header and helper text from `GitHubRepositoryClaims`.
  - Stopped loading repository data for repo chips by removing the `useQuery`/mapping for `api.repositories.list(...)`.
  - Removed repo-chip wiring to `AllIntegrationCards` by passing `githubRepos={[]}`, avoiding duplicate pills while keeping repository cards intact.
- **frontend/src/app/(dashboard)/settings/integrations/page.test.tsx**
  - Added coverage to assert:
    - GitHub repository cards still render (e.g., repo full name appears).
    - Duplicate repo pill text (“Repository access”) and the intro copy are absent.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/settings/integrations/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 7824ad5b](https://143.dev/sessions/7824ad5b-4f2d-434a-93cb-9a52e4563248)