### PR TITLE
[codex] Add runtime stall watchdog and interactive lifecycle logs

### DIFF
--- a/internal/db/session_runtime_store_test.go
+++ b/internal/db/session_runtime_store_test.go
@@ -45,6 +45,88 @@ func TestSessionStore_RecordRuntimeProgress(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionStore_MarkRuntimeStopRequested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		execErr      error
+		expectErr    bool
+		queryPattern string
+	}{
+		{
+			name:         "records stop reason on running session",
+			queryPattern: `UPDATE sessions\s+SET runtime_stop_reason = CASE`,
+		},
+		{
+			name:         "wraps exec errors",
+			execErr:      errors.New("write failed"),
+			expectErr:    true,
+			queryPattern: `runtime_stop_reason = CASE`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err, "should create mock pool")
+			defer mock.Close()
+
+			store := NewSessionStore(mock)
+			expect := mock.ExpectExec(tt.queryPattern).
+				WithArgs(
+					pgxmock.AnyArg(),
+					pgxmock.AnyArg(),
+					pgxmock.AnyArg(),
+					pgxmock.AnyArg(),
+				)
+			if tt.execErr != nil {
+				expect.WillReturnError(tt.execErr)
+			} else {
+				expect.WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+			}
+
+			err = store.MarkRuntimeStopRequested(
+				context.Background(),
+				uuid.New(),
+				uuid.New(),
+				models.RuntimeStopReasonNoProgress,
+				time.Now().UTC().Add(5*time.Minute),
+			)
+			if tt.expectErr {
+				require.Error(t, err, "MarkRuntimeStopRequested should wrap database errors")
+			} else {
+				require.NoError(t, err, "MarkRuntimeStopRequested should persist the requested stop reason")
+			}
+			require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+		})
+	}
+}
+
+func TestSessionStore_ListRuntimeControlStalledSessions(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewSessionStore(mock)
+	mock.ExpectQuery(`runtime_graceful_stop_at < @stop_after_before`).
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(sessionTestColumns))
+
+	sessions, err := store.ListRuntimeControlStalledSessions(
+		context.Background(),
+		time.Now().UTC().Add(-2*time.Minute),
+		time.Now().UTC().Add(-2*time.Minute),
+	)
+	require.NoError(t, err, "ListRuntimeControlStalledSessions should query stalled runtime rows")
+	require.Empty(t, sessions, "empty result set should return no sessions")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
 func TestSessionStore_GrantRuntimeExtension(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_store.go
+++ b/internal/db/session_store.go
@@ -866,6 +866,75 @@ func (s *SessionStore) RecordRuntimeProgress(ctx context.Context, orgID, session
 	return err
 }
 
+func (s *SessionStore) MarkRuntimeStopRequested(ctx context.Context, orgID, sessionID uuid.UUID, reason models.RuntimeStopReason, stopAfter time.Time) error {
+	query := `
+		UPDATE sessions
+		SET runtime_stop_reason = CASE
+		        WHEN runtime_stop_reason = '' OR @runtime_stop_reason = 'user_cancel' THEN @runtime_stop_reason
+		        ELSE runtime_stop_reason
+		    END,
+		    runtime_graceful_stop_at = CASE
+		        WHEN runtime_graceful_stop_at IS NULL OR @runtime_stop_reason = 'user_cancel' THEN @runtime_stop_after
+		        ELSE runtime_graceful_stop_at
+		    END
+		WHERE id = @id
+		  AND org_id = @org_id
+		  AND deleted_at IS NULL
+		  AND status = 'running'`
+
+	_, err := s.db.Exec(ctx, query, pgx.NamedArgs{
+		"id":                  sessionID,
+		"org_id":              orgID,
+		"runtime_stop_reason": string(reason),
+		"runtime_stop_after":  stopAfter.UTC(),
+	})
+	if err != nil {
+		return fmt.Errorf("mark runtime stop requested: %w", err)
+	}
+	return nil
+}
+
+// ListRuntimeControlStalledSessions returns running sessions whose runtime
+// controller should already have stopped or requested stop handling. This is a
+// narrower watchdog than ListStaleRunningSessions: it only targets rows whose
+// own runtime budget has already expired or whose persisted stop-after deadline
+// has passed.
+// lint:allow-no-orgid reason="cross-org reaper scan for stalled runtime control"
+func (s *SessionStore) ListRuntimeControlStalledSessions(ctx context.Context, deadlineBefore, stopAfterBefore time.Time) ([]models.Session, error) {
+	query := `
+		SELECT ` + sessionListColumns + `
+		FROM sessions
+		WHERE status = 'running'
+		  AND deleted_at IS NULL
+		  AND (
+		    (
+		      runtime_stop_reason <> ''
+		      AND runtime_graceful_stop_at IS NOT NULL
+		      AND runtime_graceful_stop_at < @stop_after_before
+		    )
+		    OR (
+		      runtime_stop_reason = ''
+		      AND runtime_soft_deadline_at IS NOT NULL
+		      AND runtime_soft_deadline_at < @deadline_before
+		    )
+		  )
+		ORDER BY COALESCE(runtime_graceful_stop_at, runtime_soft_deadline_at) ASC
+		LIMIT 100`
+
+	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
+		"deadline_before":   deadlineBefore,
+		"stop_after_before": stopAfterBefore,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query runtime-control stalled sessions: %w", err)
+	}
+	sessions, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.Session])
+	if err != nil {
+		return nil, fmt.Errorf("collect runtime-control stalled sessions: %w", err)
+	}
+	return sessions, nil
+}
+
 func (s *SessionStore) GrantRuntimeExtension(ctx context.Context, orgID, sessionID uuid.UUID, lockToken uuid.UUID, expectedSoftDeadline, newSoftDeadline, hardDeadline time.Time, extensionSeconds int) (bool, error) {
 	args := pgx.NamedArgs{
 		"id":                     sessionID,

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -492,9 +492,10 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 				}
 			case "command_execution":
 				metadata := map[string]interface{}{
-					"tool":   "command_execution",
-					"input":  map[string]interface{}{"command": event.Item.Command},
-					"status": event.Item.Status,
+					"tool":    "command_execution",
+					"item_id": event.Item.ID,
+					"input":   map[string]interface{}{"command": event.Item.Command},
+					"status":  event.Item.Status,
 				}
 				if event.Item.ExitCode != nil {
 					metadata["exit_code"] = *event.Item.ExitCode
@@ -510,7 +511,7 @@ func parseCodexStreamLine(line []byte, result *agent.AgentResult, logCh chan<- a
 						Timestamp: time.Now(),
 						Level:     "output",
 						Message:   event.Item.AggregatedOutput,
-						Metadata:  map[string]interface{}{"type": "tool_result"},
+						Metadata:  map[string]interface{}{"type": "tool_result", "item_id": event.Item.ID},
 					}
 				}
 			default:

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -437,11 +437,13 @@ func TestParseCodexStreamOutput(t *testing.T) {
 				require.Len(t, logs, 2, "should have tool_use + tool_result")
 				require.Equal(t, "tool_use", logs[0].Level)
 				require.Equal(t, "command_execution", logs[0].Metadata["tool"])
+				require.Equal(t, "item_1", logs[0].Metadata["item_id"])
 				inputMap, ok := logs[0].Metadata["input"].(map[string]interface{})
 				require.True(t, ok)
 				require.Contains(t, inputMap["command"], "ls -la /workspace")
 				require.Equal(t, "output", logs[1].Level)
 				require.Equal(t, "tool_result", logs[1].Metadata["type"])
+				require.Equal(t, "item_1", logs[1].Metadata["item_id"])
 			},
 		},
 		{

--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -288,6 +288,7 @@ type SessionStore interface {
 	RequestCancel(ctx context.Context, orgID, sessionID uuid.UUID) error
 	ConsumeCancelRequest(ctx context.Context, orgID, sessionID uuid.UUID) (bool, error)
 	RecordRuntimeProgress(ctx context.Context, orgID, sessionID uuid.UUID, progressType models.RuntimeProgressType, strength models.RuntimeProgressStrength, observedAt time.Time) error
+	MarkRuntimeStopRequested(ctx context.Context, orgID, sessionID uuid.UUID, reason models.RuntimeStopReason, stopAfter time.Time) error
 	GrantRuntimeExtension(ctx context.Context, orgID, sessionID uuid.UUID, lockToken uuid.UUID, expectedSoftDeadline, newSoftDeadline, hardDeadline time.Time, extensionSeconds int) (bool, error)
 	PublishCheckpoint(ctx context.Context, orgID, sessionID uuid.UUID, lockToken uuid.UUID, agentSessionID, snapshotKey string, kind models.CheckpointKind, capability models.CheckpointCapability, sizeBytes int64, checkpointedAt time.Time, checkpointErr *string, stopReason models.RuntimeStopReason) (bool, error)
 	UpdateRecoveryState(ctx context.Context, orgID, sessionID uuid.UUID, state models.RecoveryState, queuedAt, startedAt *time.Time, incrementAttempt bool) error
@@ -2452,7 +2453,7 @@ func (o *Orchestrator) RunAgent(ctx context.Context, run *models.Session) error 
 	if snapshotErr != nil {
 		log.Warn().Err(snapshotErr).Msg("failed to snapshot session, session will not support follow-up turns")
 	} else if snapshotKey != "" {
-		runtimeTracker.Record(models.RuntimeProgressTypeCheckpoint, models.RuntimeProgressStrengthStrong, time.Now().UTC())
+		runtimeTracker.Record(models.RuntimeProgressTypeCheckpoint, models.RuntimeProgressStrengthStrong, time.Now().UTC(), "")
 		lockToken, _ := jobctx.LockTokenFromContext(ctx)
 		if _, err := o.sessions.PublishCheckpoint(ctx, run.OrgID, run.ID, lockToken, result.AgentSessionID, snapshotKey, models.CheckpointKindTurnComplete, checkpointCapabilityForAgent(run.AgentType), snapshotSize, time.Now().UTC(), nil, models.RuntimeStopReasonNone); err != nil {
 			log.Warn().Err(err).Msg("failed to publish checkpoint metadata")
@@ -3729,7 +3730,7 @@ func (o *Orchestrator) ContinueSession(ctx context.Context, session *models.Sess
 	if snapshotErr != nil {
 		log.Warn().Err(snapshotErr).Msg("failed to snapshot session after continue")
 	} else if newSnapshotKey != "" {
-		runtimeTracker.Record(models.RuntimeProgressTypeCheckpoint, models.RuntimeProgressStrengthStrong, time.Now().UTC())
+		runtimeTracker.Record(models.RuntimeProgressTypeCheckpoint, models.RuntimeProgressStrengthStrong, time.Now().UTC(), "")
 		lockToken, _ := jobctx.LockTokenFromContext(ctx)
 		if _, err := o.sessions.PublishCheckpoint(ctx, session.OrgID, session.ID, lockToken, result.AgentSessionID, newSnapshotKey, models.CheckpointKindTurnComplete, checkpointCapabilityForAgent(session.AgentType), snapshotSize, time.Now().UTC(), nil, models.RuntimeStopReasonNone); err != nil {
 			log.Warn().Err(err).Msg("failed to publish checkpoint metadata after continue")
@@ -4326,8 +4327,8 @@ func (o *Orchestrator) checkConcurrency(ctx context.Context, orgID uuid.UUID, ex
 func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, agentType models.AgentType, threadID *uuid.UUID, turnNumber int, logCh <-chan LogEntry, tracker *runtimeProgressTracker) {
 	for entry := range logCh {
 		if tracker != nil {
-			if progressType, strength, ok := runtimeProgressFromLog(entry); ok {
-				tracker.Record(progressType, strength, entry.Timestamp)
+			if progressType, strength, toolID, ok := runtimeProgressFromLog(entry); ok {
+				tracker.Record(progressType, strength, entry.Timestamp, toolID)
 			}
 		}
 		effectiveThreadID := threadID

--- a/internal/services/agent/orchestrator_drain_internal_test.go
+++ b/internal/services/agent/orchestrator_drain_internal_test.go
@@ -74,6 +74,9 @@ func (s *drainStubSessions) ConsumeCancelRequest(context.Context, uuid.UUID, uui
 func (s *drainStubSessions) RecordRuntimeProgress(context.Context, uuid.UUID, uuid.UUID, models.RuntimeProgressType, models.RuntimeProgressStrength, time.Time) error {
 	return nil
 }
+func (s *drainStubSessions) MarkRuntimeStopRequested(context.Context, uuid.UUID, uuid.UUID, models.RuntimeStopReason, time.Time) error {
+	return nil
+}
 func (s *drainStubSessions) GrantRuntimeExtension(context.Context, uuid.UUID, uuid.UUID, uuid.UUID, time.Time, time.Time, time.Time, int) (bool, error) {
 	return false, nil
 }

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -302,6 +302,7 @@ type mockSessionStore struct {
 	turnUpdates            []turnUpdate
 	runtimeBegins          []runtimeBegin
 	progressUpdates        []runtimeProgressUpdate
+	stopRequests           []models.RuntimeStopReason
 	extensionGrants        []runtimeExtensionGrant
 	checkpoints            []checkpointUpdate
 	recoveryStates         []recoveryStateUpdate
@@ -496,6 +497,13 @@ func (m *mockSessionStore) RecordRuntimeProgress(ctx context.Context, orgID, ses
 		strength:     strength,
 		observedAt:   observedAt,
 	})
+	return nil
+}
+
+func (m *mockSessionStore) MarkRuntimeStopRequested(ctx context.Context, orgID, sessionID uuid.UUID, reason models.RuntimeStopReason, stopAfter time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopRequests = append(m.stopRequests, reason)
 	return nil
 }
 

--- a/internal/services/agent/providers/docker_handle.go
+++ b/internal/services/agent/providers/docker_handle.go
@@ -186,6 +186,15 @@ func (d *DockerProvider) StartInteractiveCommand(ctx context.Context, sb *agent.
 		h.stdinW = attachResp.Conn
 	}
 
+	log := d.scopedLogger(sb)
+	log.Info().
+		Str("exec_id", execResp.ID).
+		Bool("tty", wantTTY).
+		Bool("stdin", wantStdin).
+		Bool("signal_shim", hasShim).
+		Str("pid_file", pidFile).
+		Msg("started interactive command in sandbox")
+
 	return h, nil
 }
 
@@ -332,6 +341,15 @@ func (h *dockerInteractiveHandle) Interrupt(ctx context.Context, spec agent.Canc
 		method = agent.CancellationMethodCtrlC
 	}
 
+	log := h.provider.scopedLogger(h.sandbox)
+	log.Info().
+		Str("exec_id", h.execID).
+		Str("method", string(method)).
+		Bool("tty", h.spec.TTY).
+		Bool("stdin_open", h.stdinW != nil).
+		Bool("signal_shim", h.hasShim).
+		Msg("interrupting interactive command")
+
 	switch method {
 	case agent.CancellationMethodEscape:
 		if h.stdinW == nil {
@@ -360,6 +378,12 @@ func (h *dockerInteractiveHandle) signalTrackedChild(ctx context.Context, signal
 	if h.pidFile == "" {
 		return agent.ErrUnsupportedInterruptMethod
 	}
+	log := h.provider.scopedLogger(h.sandbox)
+	log.Info().
+		Str("exec_id", h.execID).
+		Str("signal", signal).
+		Str("pid_file", h.pidFile).
+		Msg("signaling tracked interactive command child")
 	deadline, cancel := context.WithTimeout(ctx, pidFileWriteTimeout)
 	defer cancel()
 	if err := h.waitForPIDFile(deadline); err != nil {
@@ -424,6 +448,15 @@ func (h *dockerInteractiveHandle) execSignal(ctx context.Context, signal string)
 // Wait return. The container itself stays alive — only the exec process
 // is torn down.
 func (h *dockerInteractiveHandle) Kill(ctx context.Context) error {
+	log := h.provider.scopedLogger(h.sandbox)
+	log.Warn().
+		Str("exec_id", h.execID).
+		Bool("tty", h.spec.TTY).
+		Bool("stdin_open", h.stdinW != nil).
+		Bool("signal_shim", h.hasShim).
+		Str("pid_file", h.pidFile).
+		Msg("force-stopping interactive command")
+
 	var killErr error
 	switch {
 	case h.hasShim:

--- a/internal/services/agent/providers/docker_test.go
+++ b/internal/services/agent/providers/docker_test.go
@@ -2059,6 +2059,40 @@ func TestDockerHandle_Kill_ShimSendsSIGKILL(t *testing.T) {
 		"Kill on a shim handle must exec-send SIGKILL to the pidfile-tracked child, not just close the connection")
 }
 
+func TestDockerHandle_LogsInteractiveLifecycle(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	mock := &mockDockerClient{}
+	mock.containerExecCreateFn = func(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+		return container.ExecCreateResponse{ID: "exec-logged"}, nil
+	}
+	mock.containerExecAttachFn = func(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error) {
+		return newMockHijackedResponse(""), nil
+	}
+	mock.containerExecInspectFn = func(ctx context.Context, execID string) (container.ExecInspect, error) {
+		return container.ExecInspect{ExitCode: 0}, nil
+	}
+
+	p := NewDockerProvider(mock, logger)
+	sb := &agent.Sandbox{ID: "container-logged", Provider: "docker", WorkDir: "/workspace", HomeDir: "/home/sandbox", SessionID: "session-logged", OrgID: "org-logged"}
+
+	h, err := p.StartInteractiveCommand(context.Background(), sb, agent.InteractiveCommandSpec{
+		Cmd:              "agent",
+		CancellationSpec: agent.DefaultCancellationSpec,
+	})
+	require.NoError(t, err, "interactive command should start")
+	require.NoError(t, h.Kill(context.Background()), "kill should force-stop the handle")
+
+	got := logs.String()
+	require.Contains(t, got, "started interactive command in sandbox", "start log should identify the interactive exec")
+	require.Contains(t, got, "force-stopping interactive command", "kill log should identify force-stop escalation")
+	require.Contains(t, got, "exec-logged", "logs should include the Docker exec id")
+	require.Contains(t, got, "container-logged", "logs should include the container id")
+	require.Contains(t, got, "session-logged", "logs should include the session id")
+}
+
 func TestDockerProvider_ConnectionInfo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/reaper.go
+++ b/internal/services/agent/reaper.go
@@ -38,6 +38,9 @@ type PreviewStopper interface {
 // SessionReaper periodically cleans up stale sessions and expired snapshots
 // in seven phases:
 //   - Phase 0: Fail sessions stuck in pending for longer than maxPendingAge
+//   - Phase 0.4: Fail sessions whose runtime controller missed an already
+//     expired soft deadline or left a stop request in-flight past its grace
+//     window
 //   - Phase 0.5: Fail sessions stuck in running for longer than maxRunningAge
 //     (safety net for orphaned sessions when the worker handler timeout path
 //     didn't run, e.g. worker crash or DB write failure during failure handling)
@@ -57,6 +60,7 @@ type SessionReaper struct {
 	previewStopper   PreviewStopper // nil-safe — if unset, reaper skips preview teardown before snapshot expiry
 	maxIdleAge       time.Duration
 	maxPendingAge    time.Duration
+	runtimeStallAge  time.Duration
 	maxRunningAge    time.Duration
 	maxSnapshotAge   time.Duration
 	interval         time.Duration
@@ -70,6 +74,7 @@ type StaleSessionLister interface {
 	ListStaleIdleSessions(ctx context.Context, olderThan time.Time) ([]models.Session, error)
 	ListStalePendingSessions(ctx context.Context, createdBefore time.Time) ([]models.Session, error)
 	ListStaleRunningSessions(ctx context.Context, startedBefore time.Time) ([]models.Session, error)
+	ListRuntimeControlStalledSessions(ctx context.Context, deadlineBefore, stopRequestedBefore time.Time) ([]models.Session, error)
 	ListExpiredSnapshots(ctx context.Context, olderThan time.Time) ([]models.Session, error)
 	UpdateStatus(ctx context.Context, orgID, sessionID uuid.UUID, status string) error
 	UpdateFailure(ctx context.Context, orgID, runID uuid.UUID, explanation, category string, nextSteps []string, retryAdvised bool) error
@@ -120,6 +125,8 @@ func WithStuckThreadLister(t StuckThreadLister) SessionReaperOption {
 // before the reaper considers it stuck and marks it as failed.
 const defaultMaxPendingAge = 10 * time.Minute
 
+const defaultRuntimeStallAge = 2 * time.Minute
+
 // reaperPreviewStopTimeout is the deadline the reaper gives
 // StopActivePreviewForSession before moving on to delete the snapshot blob.
 // Must be generous enough for the preview's hold-aware destroy path
@@ -150,14 +157,15 @@ var minRunningAgeFloor = time.Duration(models.MaxMaxSessionDurationSeconds)*time
 
 func NewSessionReaper(sessions StaleSessionLister, snapshotStore storage.SnapshotStore, maxIdleAge, maxSnapshotAge, interval time.Duration, logger zerolog.Logger, opts ...SessionReaperOption) *SessionReaper {
 	r := &SessionReaper{
-		sessions:       sessions,
-		snapshotStore:  snapshotStore,
-		maxIdleAge:     maxIdleAge,
-		maxPendingAge:  defaultMaxPendingAge,
-		maxRunningAge:  defaultMaxRunningAge,
-		maxSnapshotAge: maxSnapshotAge,
-		interval:       interval,
-		logger:         logger,
+		sessions:        sessions,
+		snapshotStore:   snapshotStore,
+		maxIdleAge:      maxIdleAge,
+		maxPendingAge:   defaultMaxPendingAge,
+		runtimeStallAge: defaultRuntimeStallAge,
+		maxRunningAge:   defaultMaxRunningAge,
+		maxSnapshotAge:  maxSnapshotAge,
+		interval:        interval,
+		logger:          logger,
 	}
 	for _, opt := range opts {
 		opt(r)
@@ -190,6 +198,7 @@ func (r *SessionReaper) Run(ctx context.Context) {
 	r.logger.Info().
 		Dur("interval", r.interval).
 		Dur("max_pending", r.maxPendingAge).
+		Dur("runtime_stall", r.runtimeStallAge).
 		Dur("max_running", r.maxRunningAge).
 		Dur("max_idle", r.maxIdleAge).
 		Dur("max_snapshot_age", r.maxSnapshotAge).
@@ -216,6 +225,12 @@ const FailureCategoryStuckPending = "stuck_pending"
 // handler context timeout path didn't execute (crashed worker, DB write
 // failure during failure bookkeeping, or a new silent-failure code path).
 const FailureCategoryStuckRunning = "stuck_running"
+
+// FailureCategoryRuntimeControlStalled is for sessions whose per-run runtime
+// controller missed or could not complete its own stop policy. This is narrower
+// than stuck_running and should page earlier because it means an active worker
+// may still be renewing the job lease while no useful agent work is happening.
+const FailureCategoryRuntimeControlStalled = "runtime_control_stalled"
 
 // FailureCategoryStuckThread is the failure category for threads stuck in
 // status='running' past maxRunningAge. Distinguished from StuckRunning so
@@ -250,6 +265,47 @@ func (r *SessionReaper) reap(ctx context.Context) {
 				Str("org_id", s.OrgID.String()).
 				Time("created_at", s.CreatedAt).
 				Msg("reaper: failed stale pending session")
+		}
+	}
+
+	// Phase 0.4: Fail sessions whose runtime controller has already missed
+	// an expired deadline or left a stop request past its persisted stop-after
+	// deadline. Unlike the broad maxRunningAge safety net, this is keyed off
+	// the row's own runtime budget fields, so it can act quickly without
+	// cutting off healthy long-running sessions.
+	now := time.Now()
+	runtimeDeadlineCutoff := now.Add(-r.runtimeStallAge)
+	runtimeStalled, err := r.sessions.ListRuntimeControlStalledSessions(ctx, runtimeDeadlineCutoff, now)
+	if err != nil {
+		r.logger.Error().Err(err).Msg("reaper: failed to list runtime-control stalled sessions")
+	} else {
+		for _, s := range runtimeStalled {
+			if err := r.sessions.UpdateStatus(ctx, s.OrgID, s.ID, string(models.SessionStatusFailed)); err != nil {
+				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to mark runtime-control stalled session as failed")
+				continue
+			}
+			explanation := "This session crossed its runtime stop deadline, but the worker kept the job alive without completing shutdown. The platform stopped it so it does not consume capacity indefinitely."
+			nextSteps := []string{
+				"Retry the session; a fresh worker should start from the latest durable state when available",
+				"If this repeats, inspect worker logs for interactive command cancellation and Docker exec shutdown failures",
+			}
+			if err := r.sessions.UpdateFailure(ctx, s.OrgID, s.ID, explanation, FailureCategoryRuntimeControlStalled, nextSteps, true); err != nil {
+				r.logger.Error().Err(err).Str("session_id", s.ID.String()).Msg("reaper: failed to update failure details for runtime-control stalled session")
+			}
+			event := r.logger.Error().
+				Str("session_id", s.ID.String()).
+				Str("org_id", s.OrgID.String()).
+				Str("runtime_stop_reason", string(s.RuntimeStopReason))
+			if s.RuntimeLastProgressAt != nil {
+				event = event.Time("runtime_last_progress_at", *s.RuntimeLastProgressAt)
+			}
+			if s.RuntimeSoftDeadlineAt != nil {
+				event = event.Time("runtime_soft_deadline_at", *s.RuntimeSoftDeadlineAt)
+			}
+			if s.RuntimeGracefulStopAt != nil {
+				event = event.Time("runtime_graceful_stop_at", *s.RuntimeGracefulStopAt)
+			}
+			event.Msg("reaper: failed runtime-control stalled session")
 		}
 	}
 

--- a/internal/services/agent/reaper_test.go
+++ b/internal/services/agent/reaper_test.go
@@ -21,6 +21,7 @@ type reaperMockSessionLister struct {
 	staleIdleSessions    []models.Session
 	stalePendingSessions []models.Session
 	staleRunningSessions []models.Session
+	runtimeStalled       []models.Session
 	expiredSnapshots     []models.Session
 	listIdleErr          error
 	listPendingErr       error
@@ -33,6 +34,8 @@ type reaperMockSessionLister struct {
 	updatedStatuses  []statusUpdate
 	updatedFailures  []failureUpdate
 	updatedSandboxes []sandboxUpdate
+	deadlineBefore   time.Time
+	stopAfterBefore  time.Time
 }
 
 type statusUpdate struct {
@@ -65,6 +68,12 @@ func (m *reaperMockSessionLister) ListStalePendingSessions(_ context.Context, _ 
 
 func (m *reaperMockSessionLister) ListStaleRunningSessions(_ context.Context, _ time.Time) ([]models.Session, error) {
 	return m.staleRunningSessions, m.listRunningErr
+}
+
+func (m *reaperMockSessionLister) ListRuntimeControlStalledSessions(_ context.Context, deadlineBefore, stopAfterBefore time.Time) ([]models.Session, error) {
+	m.deadlineBefore = deadlineBefore
+	m.stopAfterBefore = stopAfterBefore
+	return m.runtimeStalled, nil
 }
 
 func (m *reaperMockSessionLister) ListExpiredSnapshots(_ context.Context, _ time.Time) ([]models.Session, error) {
@@ -186,6 +195,32 @@ func TestReapPhase0_5_FailsStaleRunningSessions(t *testing.T) {
 	require.Len(t, mock.updatedFailures, 2)
 	assert.Equal(t, FailureCategoryStuckRunning, mock.updatedFailures[0].category)
 	assert.Equal(t, FailureCategoryStuckRunning, mock.updatedFailures[1].category)
+}
+
+func TestReapPhase0_4_FailsRuntimeControlStalledSessions(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	mock := &reaperMockSessionLister{
+		runtimeStalled: []models.Session{
+			{ID: sessionID, OrgID: orgID, Status: string(models.SessionStatusRunning)},
+		},
+	}
+	snapStore := &reaperMockSnapshotStore{}
+
+	reaper := NewSessionReaper(mock, snapStore, 30*time.Minute, 24*time.Hour, time.Minute, zerolog.Nop())
+	before := time.Now()
+	reaper.reap(context.Background())
+	after := time.Now()
+
+	require.Len(t, mock.updatedStatuses, 1, "runtime-control stalled session should be marked failed")
+	require.Equal(t, string(models.SessionStatusFailed), mock.updatedStatuses[0].status, "runtime-control stalled session should fail")
+	require.Equal(t, sessionID, mock.updatedStatuses[0].sessionID, "runtime-control stalled session should be updated")
+	require.Len(t, mock.updatedFailures, 1, "runtime-control stalled session should get failure details")
+	require.Equal(t, FailureCategoryRuntimeControlStalled, mock.updatedFailures[0].category, "failure should be attributable to runtime control")
+	require.True(t, !mock.stopAfterBefore.Before(before) && !mock.stopAfterBefore.After(after), "stop-after cutoff should use now so per-run persisted grace deadlines are honored")
+	require.True(t, mock.deadlineBefore.Before(mock.stopAfterBefore), "soft-deadline cutoff should retain watchdog slack for sessions with no persisted stop request")
 }
 
 func TestReapPhase0_5_ContinuesOnUpdateStatusError(t *testing.T) {

--- a/internal/services/agent/runtime.go
+++ b/internal/services/agent/runtime.go
@@ -216,11 +216,6 @@ func isTerminalCommandExecution(metadata map[string]any) bool {
 	}
 }
 
-func isCommandExecutionStart(message string) bool {
-	_, ok := commandExecutionStartItemID(message)
-	return ok
-}
-
 func commandExecutionStartItemID(message string) (string, bool) {
 	if message == "" {
 		return "", false

--- a/internal/services/agent/runtime.go
+++ b/internal/services/agent/runtime.go
@@ -14,6 +14,7 @@ import (
 )
 
 const defaultExtensionQueueAgeThreshold = 2 * time.Minute
+const runtimeStopPersistenceTimeout = 2 * time.Second
 
 type runtimeConfig struct {
 	SoftBudget               time.Duration
@@ -95,6 +96,7 @@ type runtimeProgressTracker struct {
 	lastStrongAt     time.Time
 	lastPersistedAt  time.Time
 	activeToolAt     time.Time
+	activeTools      map[string]time.Time
 }
 
 func newRuntimeProgressTracker(now time.Time) *runtimeProgressTracker {
@@ -106,7 +108,7 @@ func newRuntimeProgressTracker(now time.Time) *runtimeProgressTracker {
 	}
 }
 
-func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType, strength models.RuntimeProgressStrength, observedAt time.Time) {
+func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType, strength models.RuntimeProgressStrength, observedAt time.Time, toolID string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if observedAt.IsZero() {
@@ -120,11 +122,21 @@ func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType,
 	}
 	switch progressType {
 	case models.RuntimeProgressTypeToolUse:
-		if t.activeToolAt.IsZero() {
+		if toolID != "" {
+			if t.activeTools == nil {
+				t.activeTools = make(map[string]time.Time)
+			}
+			t.activeTools[toolID] = observedAt
+		} else if t.activeToolAt.IsZero() {
 			t.activeToolAt = observedAt
 		}
 	case models.RuntimeProgressTypeToolResult, models.RuntimeProgressTypeQuestionBlocked, models.RuntimeProgressTypeCheckpoint:
-		t.activeToolAt = time.Time{}
+		if toolID != "" && t.activeTools != nil {
+			delete(t.activeTools, toolID)
+		} else {
+			t.activeToolAt = time.Time{}
+			clear(t.activeTools)
+		}
 	}
 }
 
@@ -137,7 +149,7 @@ func (t *runtimeProgressTracker) Snapshot() (time.Time, time.Time, models.Runtim
 func (t *runtimeProgressTracker) ToolActive() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return !t.activeToolAt.IsZero()
+	return !t.activeToolAt.IsZero() || len(t.activeTools) > 0
 }
 
 func (t *runtimeProgressTracker) ShouldPersist() bool {
@@ -153,30 +165,38 @@ func (t *runtimeProgressTracker) ShouldPersist() bool {
 	return false
 }
 
-func runtimeProgressFromLog(entry LogEntry) (models.RuntimeProgressType, models.RuntimeProgressStrength, bool) {
+func runtimeProgressFromLog(entry LogEntry) (models.RuntimeProgressType, models.RuntimeProgressStrength, string, bool) {
 	switch entry.Level {
 	case "tool_use":
 		if isTerminalCommandExecution(entry.Metadata) {
-			return models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, true
+			return models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, commandExecutionItemIDFromMetadata(entry.Metadata), true
 		}
-		return models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, true
+		return models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, commandExecutionItemIDFromMetadata(entry.Metadata), true
 	case "question":
-		return models.RuntimeProgressTypeQuestionBlocked, models.RuntimeProgressStrengthStrong, true
+		return models.RuntimeProgressTypeQuestionBlocked, models.RuntimeProgressStrengthStrong, "", true
 	case "output":
 		if entry.Metadata != nil {
 			if typ, ok := entry.Metadata["type"].(string); ok && typ == "tool_result" {
-				return models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, true
+				return models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, commandExecutionItemIDFromMetadata(entry.Metadata), true
 			}
 		}
-		return models.RuntimeProgressTypeAssistantOutput, models.RuntimeProgressStrengthWeak, true
+		return models.RuntimeProgressTypeAssistantOutput, models.RuntimeProgressStrengthWeak, "", true
 	case "debug":
-		if isCommandExecutionStart(entry.Message) {
-			return models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, true
+		if itemID, ok := commandExecutionStartItemID(entry.Message); ok {
+			return models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, itemID, true
 		}
-		return models.RuntimeProgressTypeAssistantReason, models.RuntimeProgressStrengthWeak, true
+		return models.RuntimeProgressTypeAssistantReason, models.RuntimeProgressStrengthWeak, "", true
 	default:
-		return models.RuntimeProgressTypeNone, models.RuntimeProgressStrengthNone, false
+		return models.RuntimeProgressTypeNone, models.RuntimeProgressStrengthNone, "", false
 	}
+}
+
+func commandExecutionItemIDFromMetadata(metadata map[string]any) string {
+	if metadata == nil {
+		return ""
+	}
+	itemID, _ := metadata["item_id"].(string)
+	return itemID
 }
 
 func isTerminalCommandExecution(metadata map[string]any) bool {
@@ -197,19 +217,28 @@ func isTerminalCommandExecution(metadata map[string]any) bool {
 }
 
 func isCommandExecutionStart(message string) bool {
+	_, ok := commandExecutionStartItemID(message)
+	return ok
+}
+
+func commandExecutionStartItemID(message string) (string, bool) {
 	if message == "" {
-		return false
+		return "", false
 	}
 	var event struct {
 		Type string `json:"type"`
 		Item struct {
+			ID   string `json:"id"`
 			Type string `json:"type"`
 		} `json:"item"`
 	}
 	if err := json.Unmarshal([]byte(message), &event); err != nil {
-		return false
+		return "", false
 	}
-	return event.Type == "item.started" && event.Item.Type == "command_execution"
+	if event.Type != "item.started" || event.Item.Type != "command_execution" {
+		return "", false
+	}
+	return event.Item.ID, true
 }
 
 type runtimeController struct {
@@ -295,6 +324,23 @@ func (c *runtimeController) RequestStop(reason StopReason) {
 	if c.cancels != nil {
 		c.cancels.RequestStop(c.sessionID, reason, c.cfg.GracefulShutdownWindow)
 	}
+	runtimeReason := stopReasonToRuntime(reason)
+	if runtimeReason != models.RuntimeStopReasonNone {
+		stopAfter := time.Now().UTC().Add(c.cfg.GracefulShutdownWindow + c.cfg.CheckpointFinalizeWindow + defaultRuntimeStallAge)
+		persistCtx, cancel := context.WithTimeout(context.Background(), runtimeStopPersistenceTimeout)
+		defer cancel()
+		if err := c.sessions.MarkRuntimeStopRequested(persistCtx, c.orgID, c.sessionID, runtimeReason, stopAfter); err != nil {
+			c.logger.Warn().
+				Err(err).
+				Str("session_id", c.sessionID.String()).
+				Str("stop_reason", string(runtimeReason)).
+				Msg("failed to persist runtime stop request")
+		}
+	}
+	c.logger.Info().
+		Str("session_id", c.sessionID.String()).
+		Str("stop_reason", string(runtimeReason)).
+		Msg("runtime stop requested")
 }
 
 func (c *runtimeController) tick(ctx context.Context, now time.Time) {
@@ -337,6 +383,12 @@ func (c *runtimeController) tick(ctx context.Context, now time.Time) {
 }
 
 func (c *runtimeController) shouldExtend(ctx context.Context, now, lastStrongAt time.Time) bool {
+	if lastStrongAt.IsZero() {
+		return false
+	}
+	if now.Sub(lastStrongAt) > c.cfg.ExtensionIncrement {
+		return false
+	}
 	if c.isDraining != nil && c.isDraining() {
 		return false
 	}
@@ -352,10 +404,7 @@ func (c *runtimeController) shouldExtend(ctx context.Context, now, lastStrongAt 
 			return false
 		}
 	}
-	if lastStrongAt.IsZero() {
-		return false
-	}
-	return now.Sub(lastStrongAt) <= c.cfg.ExtensionIncrement
+	return true
 }
 
 func (c *runtimeController) tryExtend(ctx context.Context, expectedSoftDeadline time.Time) bool {

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -17,12 +17,18 @@ import (
 
 type runtimeTestSessionStore struct {
 	countRunning               int
+	countRunningCalls          int
 	extensionGrants            int
 	countRunningErr            error
 	beginErr                   error
 	beginCalls                 int
 	recordRuntimeProgressCalls int
 	recordRuntimeProgressErr   error
+	stopRequests               []models.RuntimeStopReason
+	stopAfter                  []time.Time
+	markRuntimeStopErr         error
+	markRuntimeStopStarted     chan struct{}
+	markRuntimeStopRelease     chan struct{}
 	lastProgressType           models.RuntimeProgressType
 	lastProgressStrength       models.RuntimeProgressStrength
 	lastProgressObservedAt     time.Time
@@ -45,6 +51,7 @@ func (s *runtimeTestSessionStore) UpdateResult(context.Context, uuid.UUID, uuid.
 }
 
 func (s *runtimeTestSessionStore) CountRunningByOrg(context.Context, uuid.UUID) (int, error) {
+	s.countRunningCalls++
 	return s.countRunning, s.countRunningErr
 }
 
@@ -75,6 +82,22 @@ func (s *runtimeTestSessionStore) RecordRuntimeProgress(_ context.Context, _ uui
 	s.lastProgressStrength = strength
 	s.lastProgressObservedAt = observedAt
 	return s.recordRuntimeProgressErr
+}
+
+func (s *runtimeTestSessionStore) MarkRuntimeStopRequested(ctx context.Context, _ uuid.UUID, _ uuid.UUID, reason models.RuntimeStopReason, stopAfter time.Time) error {
+	if s.markRuntimeStopStarted != nil {
+		close(s.markRuntimeStopStarted)
+	}
+	if s.markRuntimeStopRelease != nil {
+		select {
+		case <-s.markRuntimeStopRelease:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	s.stopRequests = append(s.stopRequests, reason)
+	s.stopAfter = append(s.stopAfter, stopAfter)
+	return s.markRuntimeStopErr
 }
 
 func (s *runtimeTestSessionStore) GrantRuntimeExtension(_ context.Context, _ uuid.UUID, _ uuid.UUID, lockToken uuid.UUID, expectedSoftDeadline, newSoftDeadline, hardDeadline time.Time, extensionSeconds int) (bool, error) {
@@ -172,9 +195,10 @@ func (s *runtimeTestJobStore) OldestPendingSessionJobAge(context.Context) (time.
 }
 
 type runtimeTestJobBacklogStore struct {
-	age time.Duration
-	ok  bool
-	err error
+	age   time.Duration
+	ok    bool
+	err   error
+	calls int
 }
 
 func (s *runtimeTestJobBacklogStore) Enqueue(context.Context, uuid.UUID, string, string, any, int, *string) (uuid.UUID, error) {
@@ -186,6 +210,7 @@ func (s *runtimeTestJobBacklogStore) EnqueueWithTarget(context.Context, uuid.UUI
 }
 
 func (s *runtimeTestJobBacklogStore) OldestPendingSessionJobAge(context.Context) (time.Duration, bool, error) {
+	s.calls++
 	return s.age, s.ok, s.err
 }
 
@@ -229,7 +254,7 @@ func TestRuntimeController_ExtendsHealthyRunAfterStrongProgress(t *testing.T) {
 	startedAt := time.Now().UTC()
 	require.NoError(t, controller.Begin(context.Background(), startedAt, models.CheckpointCapabilityFullResume), "Begin should seed the runtime deadlines")
 
-	controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, startedAt.Add(900*time.Millisecond))
+	controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, startedAt.Add(900*time.Millisecond), "")
 	controller.tick(context.Background(), startedAt.Add(1100*time.Millisecond))
 
 	require.Equal(t, 1, sessionStore.extensionGrants, "strong recent progress should grant a runtime extension after the soft budget expires")
@@ -263,7 +288,7 @@ func TestRuntimeController_ExtendsAtConfiguredConcurrencyLimit(t *testing.T) {
 	startedAt := time.Now().UTC()
 	require.NoError(t, controller.Begin(context.Background(), startedAt, models.CheckpointCapabilityFullResume), "Begin should seed the runtime deadlines")
 
-	controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, startedAt.Add(900*time.Millisecond))
+	controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, startedAt.Add(900*time.Millisecond), "")
 	controller.tick(context.Background(), startedAt.Add(1100*time.Millisecond))
 
 	require.Equal(t, 1, sessionStore.extensionGrants, "hitting the org concurrency cap should not block an in-flight session from receiving a bounded extension")
@@ -351,7 +376,7 @@ func TestRuntimeProgressTracker_RecordAndPersist(t *testing.T) {
 	tracker := &runtimeProgressTracker{}
 	require.False(t, tracker.ShouldPersist(), "ShouldPersist should ignore an empty tracker with no observed progress")
 
-	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, time.Time{})
+	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, time.Time{}, "")
 	lastProgressAt, lastStrongAt, progressType, strength := tracker.Snapshot()
 	require.False(t, lastProgressAt.IsZero(), "Record should synthesize the observation timestamp when none is supplied")
 	require.Equal(t, models.RuntimeProgressTypeToolResult, progressType, "Record should store the latest progress type")
@@ -359,6 +384,92 @@ func TestRuntimeProgressTracker_RecordAndPersist(t *testing.T) {
 	require.Equal(t, lastProgressAt, lastStrongAt, "strong progress should update the strong-progress watermark")
 	require.True(t, tracker.ShouldPersist(), "ShouldPersist should persist newly observed progress once")
 	require.False(t, tracker.ShouldPersist(), "ShouldPersist should not re-persist the same progress snapshot twice")
+}
+
+func TestRuntimeController_RequestStopCancelsBeforePersistingStopMarker(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	graceWindow := 5 * time.Minute
+	checkpointWindow := 3 * time.Minute
+	stopStarted := make(chan struct{})
+	stopRelease := make(chan struct{})
+	sessionStore := &runtimeTestSessionStore{
+		markRuntimeStopStarted: stopStarted,
+		markRuntimeStopRelease: stopRelease,
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancelObserved := make(chan struct{})
+	go func() {
+		<-cancelCtx.Done()
+		close(cancelObserved)
+	}()
+	cancels := NewCancelRegistry(zerolog.Nop())
+	cancels.Register(sessionID, cancel, DefaultCancellationSpec)
+
+	controller := newRuntimeController(
+		runtimeConfig{
+			GracefulShutdownWindow:   graceWindow,
+			CheckpointFinalizeWindow: checkpointWindow,
+		},
+		sessionStore,
+		&runtimeTestJobStore{},
+		cancels,
+		zerolog.Nop(),
+		orgID,
+		sessionID,
+		0,
+		nil,
+		newRuntimeProgressTracker(time.Now()),
+	)
+
+	requestedAt := time.Now().UTC()
+	done := make(chan struct{})
+	go func() {
+		controller.RequestStop(StopReasonNoProgress)
+		close(done)
+	}()
+
+	select {
+	case <-cancelObserved:
+	case <-time.After(time.Second):
+		t.Fatal("RequestStop should deliver cancellation before waiting on stop-marker persistence")
+	}
+
+	select {
+	case <-stopStarted:
+	case <-time.After(time.Second):
+		t.Fatal("RequestStop should still attempt to persist the stop marker")
+	}
+	close(stopRelease)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("RequestStop should finish once stop-marker persistence unblocks")
+	}
+
+	require.Equal(t, []models.RuntimeStopReason{models.RuntimeStopReasonNoProgress}, sessionStore.stopRequests, "RequestStop should persist the stop reason")
+	require.Len(t, sessionStore.stopAfter, 1, "RequestStop should persist one stop-after deadline")
+	minStopAfter := requestedAt.Add(graceWindow + checkpointWindow + defaultRuntimeStallAge - time.Second)
+	require.True(t, sessionStore.stopAfter[0].After(minStopAfter), "stop-after deadline should include graceful shutdown, checkpoint finalization, and watchdog slack")
+}
+
+func TestRuntimeProgressTracker_TracksConcurrentCommandExecutions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	tracker := newRuntimeProgressTracker(now)
+
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(time.Second), "item_1")
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(2*time.Second), "item_2")
+	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(3*time.Second), "item_2")
+	require.True(t, tracker.ToolActive(), "completing one command should not clear another active command")
+
+	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(4*time.Second), "item_1")
+	require.False(t, tracker.ToolActive(), "all completed command IDs should clear active tool state")
 }
 
 func TestRuntimeProgressFromLog(t *testing.T) {
@@ -369,16 +480,17 @@ func TestRuntimeProgressFromLog(t *testing.T) {
 		entry        LogEntry
 		expectedType models.RuntimeProgressType
 		expected     models.RuntimeProgressStrength
+		expectedID   string
 		wantOK       bool
 	}{
 		{name: "tool use", entry: LogEntry{Level: "tool_use"}, expectedType: models.RuntimeProgressTypeToolUse, expected: models.RuntimeProgressStrengthWeak, wantOK: true},
-		{name: "completed command execution", entry: LogEntry{Level: "tool_use", Metadata: map[string]any{"tool": "command_execution", "status": "completed"}}, expectedType: models.RuntimeProgressTypeToolResult, expected: models.RuntimeProgressStrengthStrong, wantOK: true},
+		{name: "completed command execution", entry: LogEntry{Level: "tool_use", Metadata: map[string]any{"tool": "command_execution", "status": "completed", "item_id": "item_1"}}, expectedType: models.RuntimeProgressTypeToolResult, expected: models.RuntimeProgressStrengthStrong, expectedID: "item_1", wantOK: true},
 		{name: "failed command execution", entry: LogEntry{Level: "tool_use", Metadata: map[string]any{"tool": "command_execution", "status": "failed"}}, expectedType: models.RuntimeProgressTypeToolResult, expected: models.RuntimeProgressStrengthStrong, wantOK: true},
 		{name: "question", entry: LogEntry{Level: "question"}, expectedType: models.RuntimeProgressTypeQuestionBlocked, expected: models.RuntimeProgressStrengthStrong, wantOK: true},
 		{name: "tool result output", entry: LogEntry{Level: "output", Metadata: map[string]any{"type": "tool_result"}}, expectedType: models.RuntimeProgressTypeToolResult, expected: models.RuntimeProgressStrengthStrong, wantOK: true},
 		{name: "assistant output", entry: LogEntry{Level: "output"}, expectedType: models.RuntimeProgressTypeAssistantOutput, expected: models.RuntimeProgressStrengthWeak, wantOK: true},
 		{name: "debug", entry: LogEntry{Level: "debug"}, expectedType: models.RuntimeProgressTypeAssistantReason, expected: models.RuntimeProgressStrengthWeak, wantOK: true},
-		{name: "debug item started command execution", entry: LogEntry{Level: "debug", Message: `{"type":"item.started","item":{"type":"command_execution"}}`}, expectedType: models.RuntimeProgressTypeToolUse, expected: models.RuntimeProgressStrengthWeak, wantOK: true},
+		{name: "debug item started command execution", entry: LogEntry{Level: "debug", Message: `{"type":"item.started","item":{"id":"item_1","type":"command_execution"}}`}, expectedType: models.RuntimeProgressTypeToolUse, expected: models.RuntimeProgressStrengthWeak, expectedID: "item_1", wantOK: true},
 		{name: "unknown", entry: LogEntry{Level: "trace"}, expectedType: models.RuntimeProgressTypeNone, expected: models.RuntimeProgressStrengthNone, wantOK: false},
 	}
 
@@ -386,9 +498,10 @@ func TestRuntimeProgressFromLog(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			progressType, strength, ok := runtimeProgressFromLog(tt.entry)
+			progressType, strength, toolID, ok := runtimeProgressFromLog(tt.entry)
 			require.Equal(t, tt.expectedType, progressType, "runtimeProgressFromLog should map the progress type correctly")
 			require.Equal(t, tt.expected, strength, "runtimeProgressFromLog should map the progress strength correctly")
+			require.Equal(t, tt.expectedID, toolID, "runtimeProgressFromLog should preserve the command execution item id")
 			require.Equal(t, tt.wantOK, ok, "runtimeProgressFromLog should report whether the log entry counts as progress")
 		})
 	}
@@ -441,15 +554,16 @@ func TestRuntimeController_ShouldExtend_GatesOnQueuePressureAndProgress(t *testi
 		queueErr    error
 		lastStrong  time.Time
 		expectAllow bool
+		expectReads bool
 	}{
 		{name: "rejects while draining", isDraining: true, lastStrong: now, expectAllow: false},
-		{name: "rejects above concurrency limit", running: 4, lastStrong: now, expectAllow: false},
-		{name: "ignores concurrency count errors", runningErr: errors.New("count failed"), lastStrong: now, expectAllow: true},
-		{name: "rejects old queue backlog", queueAge: 3 * time.Minute, queueOK: true, lastStrong: now, expectAllow: false},
-		{name: "ignores queue age errors", queueErr: errors.New("queue failed"), lastStrong: now, expectAllow: true},
+		{name: "rejects above concurrency limit", running: 4, lastStrong: now, expectAllow: false, expectReads: true},
+		{name: "ignores concurrency count errors", runningErr: errors.New("count failed"), lastStrong: now, expectAllow: true, expectReads: true},
+		{name: "rejects old queue backlog", queueAge: 3 * time.Minute, queueOK: true, lastStrong: now, expectAllow: false, expectReads: true},
+		{name: "ignores queue age errors", queueErr: errors.New("queue failed"), lastStrong: now, expectAllow: true, expectReads: true},
 		{name: "rejects without strong progress", lastStrong: time.Time{}, expectAllow: false},
 		{name: "rejects stale strong progress", lastStrong: now.Add(-3 * time.Second), expectAllow: false},
-		{name: "allows recent strong progress", lastStrong: now.Add(-time.Second), expectAllow: true},
+		{name: "allows recent strong progress", lastStrong: now.Add(-time.Second), expectAllow: true, expectReads: true},
 	}
 
 	for _, tt := range tests {
@@ -476,6 +590,10 @@ func TestRuntimeController_ShouldExtend_GatesOnQueuePressureAndProgress(t *testi
 			)
 
 			require.Equal(t, tt.expectAllow, controller.shouldExtend(context.Background(), now, tt.lastStrong), "shouldExtend should enforce queue-pressure and progress gates")
+			if !tt.expectReads {
+				require.Equal(t, 0, sessionStore.countRunningCalls, "shouldExtend should not read concurrency when progress already rejects extension")
+				require.Equal(t, 0, backlogStore.calls, "shouldExtend should not read queue pressure when progress already rejects extension")
+			}
 		})
 	}
 }
@@ -641,7 +759,7 @@ func TestRuntimeController_TickPersistsProgressAndRequestsStops(t *testing.T) {
 		)
 		controller.softDeadline = now.Add(5 * time.Second)
 		controller.hardDeadline = now.Add(time.Minute)
-		controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(time.Second))
+		controller.tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(time.Second), "")
 
 		controller.tick(context.Background(), now)
 		require.Equal(t, 1, store.recordRuntimeProgressCalls, "tick should attempt to persist fresh runtime progress once")
@@ -651,6 +769,7 @@ func TestRuntimeController_TickPersistsProgressAndRequestsStops(t *testing.T) {
 	t.Run("requests no-progress stop", func(t *testing.T) {
 		t.Parallel()
 
+		sessionStore := &runtimeTestSessionStore{}
 		controller := newRuntimeController(
 			runtimeConfig{
 				SoftBudget:             10 * time.Second,
@@ -658,7 +777,7 @@ func TestRuntimeController_TickPersistsProgressAndRequestsStops(t *testing.T) {
 				ExtensionIncrement:     time.Second,
 				AbsoluteRuntimeCeiling: time.Hour,
 			},
-			&runtimeTestSessionStore{},
+			sessionStore,
 			&runtimeTestJobStore{},
 			nil,
 			zerolog.Nop(),
@@ -673,6 +792,7 @@ func TestRuntimeController_TickPersistsProgressAndRequestsStops(t *testing.T) {
 
 		controller.tick(context.Background(), now)
 		require.Equal(t, StopReasonNoProgress, controller.stopRequested, "tick should request a no-progress stop after the configured idle timeout")
+		require.Equal(t, []models.RuntimeStopReason{models.RuntimeStopReasonNoProgress}, sessionStore.stopRequests, "tick should persist the requested no-progress stop immediately")
 	})
 
 	t.Run("does not request no-progress stop while tool is active", func(t *testing.T) {
@@ -697,7 +817,7 @@ func TestRuntimeController_TickPersistsProgressAndRequestsStops(t *testing.T) {
 		)
 		controller.softDeadline = now.Add(5 * time.Second)
 		controller.hardDeadline = now.Add(time.Minute)
-		controller.tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(-5*time.Second))
+		controller.tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(-5*time.Second), "")
 
 		controller.tick(context.Background(), now)
 		require.Equal(t, StopReasonNone, controller.stopRequested, "tick should not request a no-progress stop while a tool command is still active")


### PR DESCRIPTION
## Summary

This PR hardens session runtime control for the failure mode where a Codex session remains leased and running but stops producing user-visible progress.

Changes include:
- Track concurrent Codex `command_execution` items by `item_id`, so one completed command no longer clears another active command from runtime progress tracking.
- Persist runtime stop requests immediately with `runtime_stop_reason` and a stop-request timestamp.
- Short-circuit soft-deadline extension when there is no recent strong progress before querying queue or concurrency state.
- Add a runtime-control reaper watchdog that marks sessions failed with `runtime_control_stalled` when the runtime deadline or stop-request grace window has already been missed.
- Add Docker interactive exec lifecycle logs for start, interrupt, signal delivery, and force-stop with session/container/exec identifiers.

## Root Cause / Impact

The investigated stuck sessions appeared to be active worker leases sitting inside long-running Codex shell command executions after visible progress stopped. The previous runtime tracker could lose active-command state when command executions overlapped, and stop requests were not immediately durable enough for an earlier watchdog to catch the condition. This PR makes those states explicit and observable, and gives the reaper a narrower early failure path before the broad stuck-running timeout.

## Validation

- `go vet ./...`
- `go build ./...`
- `go test ./...`