### PR TITLE
Fix race conditions in agent log-capture tests

### DIFF
--- a/internal/services/agent/log_buffer_test.go
+++ b/internal/services/agent/log_buffer_test.go
@@ -1,0 +1,31 @@
+package agent_test
+
+import (
+	"bytes"
+	"sync"
+)
+
+// syncBuffer is a thread-safe bytes.Buffer wrapper for capturing zerolog output
+// from code paths that may log from background goroutines.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.buf.Bytes()...)
+}

--- a/internal/services/agent/orchestrator_test.go
+++ b/internal/services/agent/orchestrator_test.go
@@ -1449,7 +1449,11 @@ func buildOrchestrator(d testDeps) *agent.Orchestrator {
 	})
 }
 
-func findLogEvent(t *testing.T, logs *bytes.Buffer, message string) map[string]any {
+type logEventBuffer interface {
+	Bytes() []byte
+}
+
+func findLogEvent(t *testing.T, logs logEventBuffer, message string) map[string]any {
 	t.Helper()
 	for _, line := range bytes.Split(bytes.TrimSpace(logs.Bytes()), []byte("\n")) {
 		if len(bytes.TrimSpace(line)) == 0 {
@@ -1788,8 +1792,8 @@ func TestRunAgent_SuccessLogIncludesPlatformHealthFields(t *testing.T) {
 	issue := testIssue(orgID)
 	run := testRun(orgID, issue.ID)
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 
@@ -1797,7 +1801,7 @@ func TestRunAgent_SuccessLogIncludesPlatformHealthFields(t *testing.T) {
 	err := orch.RunAgent(context.Background(), run)
 	require.NoError(t, err, "RunAgent should complete successfully")
 
-	completion := findLogEvent(t, &logs, "agent run finished")
+	completion := findLogEvent(t, logs, "agent run finished")
 	require.NotNil(t, completion, "RunAgent should emit agent run finished log")
 	require.Equal(t, string(models.AgentTypeClaudeCode), completion["agent_type"], "completion log should include agent type")
 	require.Equal(t, "completed", completion["outcome"], "completion log should include platform outcome")
@@ -1817,8 +1821,8 @@ func TestRunAgent_InteractiveSuccessLogIncludesPlatformHealthFields(t *testing.T
 	run.InteractionMode = models.SessionInteractionModeInteractive
 	run.ValidationPolicy = models.SessionValidationPolicyOnSessionEnd
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 	d.issues.issue = issue
@@ -1837,7 +1841,7 @@ func TestRunAgent_InteractiveSuccessLogIncludesPlatformHealthFields(t *testing.T
 	err := orch.RunAgent(context.Background(), run)
 	require.NoError(t, err, "interactive RunAgent should complete successfully")
 
-	completion := findLogEvent(t, &logs, "agent run finished")
+	completion := findLogEvent(t, logs, "agent run finished")
 	require.NotNil(t, completion, "interactive RunAgent should emit agent run finished log")
 	require.Equal(t, string(models.AgentTypeClaudeCode), completion["agent_type"], "interactive completion log should include agent type")
 	require.Equal(t, "idle", completion["outcome"], "interactive completion log should include idle outcome")
@@ -1929,8 +1933,8 @@ func TestRunAgent_LogsDuplicateMarkerFailureAndSucceeds(t *testing.T) {
 		}, nil
 	}
 
-	var buf bytes.Buffer
-	logger := zerolog.New(&buf)
+	buf := &syncBuffer{}
+	logger := zerolog.New(buf)
 	orch := agent.NewOrchestrator(agent.OrchestratorConfig{
 		Provider:         d.provider,
 		Adapters:         map[models.AgentType]agent.AgentAdapter{d.adapter.Name(): d.adapter},
@@ -3444,8 +3448,8 @@ func TestRunAgent_FailureLogIncludesPlatformHealthFields(t *testing.T) {
 	issue := testIssue(orgID)
 	run := testRun(orgID, issue.ID)
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
@@ -3456,7 +3460,7 @@ func TestRunAgent_FailureLogIncludesPlatformHealthFields(t *testing.T) {
 	err := orch.RunAgent(context.Background(), run)
 	require.Error(t, err, "RunAgent should fail when the adapter fails")
 
-	failure := findLogEvent(t, &logs, "agent run failed")
+	failure := findLogEvent(t, logs, "agent run failed")
 	require.NotNil(t, failure, "RunAgent should emit agent run failed log")
 	require.Equal(t, string(models.AgentTypeClaudeCode), failure["agent_type"], "failure log should include agent type")
 	require.Equal(t, "failed", failure["outcome"], "failure log should include platform outcome")
@@ -7670,8 +7674,8 @@ func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
 
 	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 	d.cancels = cancelReg
@@ -7722,7 +7726,7 @@ func TestRunAgent_CancelReturnsToIdle(t *testing.T) {
 	// Sandbox should be destroyed.
 	require.Equal(t, 1, d.provider.GetDestroyCalls())
 
-	completion := findLogEvent(t, &logs, "agent run finished")
+	completion := findLogEvent(t, logs, "agent run finished")
 	require.NotNil(t, completion, "cancelled RunAgent should emit agent run finished log")
 	require.Equal(t, "cancelled", completion["outcome"], "cancelled completion log should include cancelled outcome")
 	require.Equal(t, string(models.RuntimeStopReasonUserCancel), completion["stop_reason"], "cancelled completion log should include user cancel stop reason")
@@ -7925,8 +7929,8 @@ func TestRunAgent_TimeoutLogIncludesPlatformHealthFields(t *testing.T) {
 	startedAt := time.Now().Add(-10 * time.Minute)
 	run.StartedAt = &startedAt
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 	d.adapter.executeFn = func(ctx context.Context, sandbox *agent.Sandbox, prompt *agent.AgentPrompt, logCh chan<- agent.LogEntry) (*agent.AgentResult, error) {
@@ -7942,7 +7946,7 @@ func TestRunAgent_TimeoutLogIncludesPlatformHealthFields(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, agent.ErrSessionTimedOut)
 
-	timeout := findLogEvent(t, &logs, "session exceeded configured timeout")
+	timeout := findLogEvent(t, logs, "session exceeded configured timeout")
 	require.NotNil(t, timeout, "timeout RunAgent should emit the canonical timeout log line")
 	require.Equal(t, string(models.AgentTypeClaudeCode), timeout["agent_type"], "timeout log should include agent type")
 	require.Equal(t, "timeout", timeout["outcome"], "timeout log should include platform outcome")
@@ -7953,7 +7957,7 @@ func TestRunAgent_TimeoutLogIncludesPlatformHealthFields(t *testing.T) {
 	// The canonical timeout log is the only failure event emitted on this
 	// path. Emitting a second "agent run failed" log would double-count
 	// timeouts in dashboards/alerts that key off either message.
-	require.Nil(t, findLogEvent(t, &logs, "agent run failed"), "timeout path should not also emit agent run failed log")
+	require.Nil(t, findLogEvent(t, logs, "agent run failed"), "timeout path should not also emit agent run failed log")
 }
 
 func TestRunAgent_DeadlineExceededClassifiesAsTimeout(t *testing.T) {
@@ -8085,8 +8089,8 @@ func TestRunAgent_GracefullyStopsAndPreservesCheckpointOnNoProgress(t *testing.T
 
 	cancelReg := agent.NewCancelRegistry(zerolog.Nop())
 
-	var logs bytes.Buffer
-	logger := zerolog.New(&logs)
+	logs := &syncBuffer{}
+	logger := zerolog.New(logs)
 	d := defaultDeps()
 	d.logger = &logger
 	d.orgs = &mockOrgStore{org: models.Organization{ID: orgID, Settings: settings}}
@@ -8124,7 +8128,7 @@ func TestRunAgent_GracefullyStopsAndPreservesCheckpointOnNoProgress(t *testing.T
 	require.Equal(t, agent.FailureCategoryTimeout, failures[0].category, "policy stop should use the timeout family category")
 	require.Contains(t, failures[0].explanation, "saved a resumable checkpoint", "policy stop should explain that the latest state was preserved")
 
-	completion := findLogEvent(t, &logs, "agent run finished")
+	completion := findLogEvent(t, logs, "agent run finished")
 	require.NotNil(t, completion, "policy-stopped RunAgent should emit agent run finished log")
 	require.Equal(t, "runtime_policy_stopped", completion["outcome"], "policy stop completion log should include policy outcome")
 	require.Equal(t, string(models.RuntimeStopReasonNoProgress), completion["stop_reason"], "policy stop completion log should include runtime stop reason")

--- a/internal/services/agent/runtime_sampler_test.go
+++ b/internal/services/agent/runtime_sampler_test.go
@@ -333,31 +333,6 @@ type wrappedErr struct {
 func (w *wrappedErr) Error() string { return w.prefix + ": " + w.err.Error() }
 func (w *wrappedErr) Unwrap() error { return w.err }
 
-// syncBuffer is a thread-safe bytes.Buffer wrapper for capturing zerolog output
-// when a writer goroutine and an Eventually reader goroutine touch the same buffer.
-type syncBuffer struct {
-	mu  sync.Mutex
-	buf bytes.Buffer
-}
-
-func (s *syncBuffer) Write(p []byte) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.buf.Write(p)
-}
-
-func (s *syncBuffer) String() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.buf.String()
-}
-
-func (s *syncBuffer) Bytes() []byte {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]byte(nil), s.buf.Bytes()...)
-}
-
 func TestUsageTrackerSnapshot_IsCopy(t *testing.T) {
 	t.Parallel()
 	tracker := agent.NewUsageTracker(nil, newMetrics(t), zerolog.Nop())


### PR DESCRIPTION
## Summary
- Replaced unsafe `bytes.Buffer` log sinks in race-sensitive agent tests with a thread-safe `syncBuffer`
- Broadened `findLogEvent` to accept any buffer exposing `Bytes()`, so the helper works with safe test sinks
- Moved the shared test buffer into its own file and removed the duplicate sampler-local copy

## Testing
- `go test ./internal/services/agent -race -count=1`
- `go test ./internal/... -coverprofile=coverage.out -covermode=atomic -race -timeout=180s`
- `go vet ./...`
- `go build ./...`
- `go test ./...`