### PR TITLE
Fix Linear agent integration lookup to ignore inactive rows

### DIFF
--- a/internal/db/integration_store_test.go
+++ b/internal/db/integration_store_test.go
@@ -79,7 +79,18 @@ func TestIntegrationStore_GetByOrgAndProvider(t *testing.T) {
 		{
 			name: "returns integration when found",
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, integrationID uuid.UUID, now time.Time) {
-				mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+				mock.ExpectQuery("SELECT .+ FROM integrations[\\s\\S]*status IN \\('active', 'error'\\)[\\s\\S]*ORDER BY \\(status = 'active'\\) DESC, created_at DESC[\\s\\S]*LIMIT 1").
+					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+					WillReturnRows(
+						pgxmock.NewRows(integrationColumns).
+							AddRow(integrationID, orgID, "github", json.RawMessage(`{}`), "active", nil, now),
+					)
+			},
+		},
+		{
+			name: "filters out inactive integrations",
+			setupMock: func(mock pgxmock.PgxPoolIface, orgID, integrationID uuid.UUID, now time.Time) {
+				mock.ExpectQuery("SELECT .+ FROM integrations[\\s\\S]*status IN \\('active', 'error'\\)[\\s\\S]*ORDER BY \\(status = 'active'\\) DESC, created_at DESC[\\s\\S]*LIMIT 1").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(
 						pgxmock.NewRows(integrationColumns).
@@ -90,7 +101,7 @@ func TestIntegrationStore_GetByOrgAndProvider(t *testing.T) {
 		{
 			name: "returns error when integration not found",
 			setupMock: func(mock pgxmock.PgxPoolIface, orgID, integrationID uuid.UUID, now time.Time) {
-				mock.ExpectQuery("SELECT .+ FROM integrations WHERE org_id").
+				mock.ExpectQuery("SELECT .+ FROM integrations[\\s\\S]*status IN \\('active', 'error'\\)[\\s\\S]*ORDER BY \\(status = 'active'\\) DESC, created_at DESC[\\s\\S]*LIMIT 1").
 					WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
 					WillReturnRows(pgxmock.NewRows(integrationColumns))
 			},

--- a/internal/db/integrations.go
+++ b/internal/db/integrations.go
@@ -49,7 +49,11 @@ func (s *IntegrationStore) GetByOrgAndProvider(ctx context.Context, orgID uuid.U
 	query := `
 		SELECT id, org_id, provider, config, status, last_synced_at, created_at
 		FROM integrations
-		WHERE org_id = @org_id AND provider = @provider`
+		WHERE org_id = @org_id
+		  AND provider = @provider
+		  AND status IN ('active', 'error')
+		ORDER BY (status = 'active') DESC, created_at DESC
+		LIMIT 1`
 
 	rows, err := s.db.Query(ctx, query, pgx.NamedArgs{
 		"org_id":   orgID,


### PR DESCRIPTION
## Summary
- Restrict `GetByOrgAndProvider` to active/error integrations and prefer active rows when resolving Linear clients.
- Add a regression test to cover the inactive-integration case so the worker does not pick a stale Linear connection.
- This unblocks Linear agent jobs that were failing with `linear integration not found` even though a valid active integration existed.

## Testing
- Added unit coverage for the integration lookup behavior.
- `go vet ./...` passed.
- `go build ./...` passed.
- `go test ./...` passed.