### PR TITLE
Adjust nit policy to allow removing outdated adjacent review items in loop

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -285,14 +285,17 @@ the loop must still be explicit about how to handle nits. The product rule is:
 The review-loop prompt tells the agent:
 
 ```text
-Fix nits when they are local, low-risk, and in files already touched by this
-change. Do not expand the scope of the diff just to satisfy subjective style
-preferences. If a nit is broad, risky, or unrelated to the current change,
+Fix nits when they are local, low-risk, and relevant to the current change. Use
+your judgment: if the change makes stale or outdated adjacent code obsolete,
+remove or adjust it even when that code was not directly modified by the
+original diff. Do not expand the scope of the diff just to satisfy subjective
+style preferences. If a nit is broad, risky, or unrelated to the current change,
 leave it for later and mention it in your summary.
 ```
 
-This keeps the default loop useful for polish without turning every review into
-an unbounded cleanup pass. It is not exposed as a setup option in v1.
+This keeps the default loop useful for polish and stale-code cleanup without
+turning every review into an unbounded cleanup pass. It is not exposed as a
+setup option in v1.
 
 The only structured decision the platform needs is whether the loop should
 continue. That decision should come from the coding agent, not from a generic
@@ -303,8 +306,9 @@ decision:
 
 ```text
 Based on your latest review, are there remaining issues you should fix in this
-sandbox before this work is considered clean? Apply the nit policy above when
-deciding whether remaining nits require another fix pass. Answer with one of:
+sandbox before this work is considered clean? Apply the nit policy above and use
+your coding judgment when deciding whether remaining nits require another fix
+pass. Answer with one of:
 
 - REVIEW_CLEAN
 - NEEDS_FIX_PASS

--- a/internal/prompts/review_loop_test.go
+++ b/internal/prompts/review_loop_test.go
@@ -16,6 +16,8 @@ func TestReviewLoopReviewPrompt(t *testing.T) {
 	require.Contains(t, got, "/review", "review prompt should include the native slash command")
 	require.Contains(t, got, "Fix nits when they are local, low-risk", "review prompt should include the nit policy")
 	require.Contains(t, got, "current workspace diff", "review prompt should target the current sandbox diff")
+	require.NotContains(t, got, "files already touched", "review prompt should not block relevant fixes only because the file was untouched")
+	require.Contains(t, got, "stale or outdated adjacent code", "review prompt should allow relevant low-risk stale-code cleanup")
 }
 
 func TestReviewLoopDecisionPrompt(t *testing.T) {
@@ -25,6 +27,7 @@ func TestReviewLoopDecisionPrompt(t *testing.T) {
 	require.Contains(t, got, "REVIEW_CLEAN", "decision prompt should expose the clean sentinel")
 	require.Contains(t, got, "NEEDS_FIX_PASS", "decision prompt should expose the fix sentinel")
 	require.Contains(t, got, "Answer with one of", "decision prompt should constrain the response")
+	require.Contains(t, got, "coding judgment", "decision prompt should ask the agent to apply coding judgment")
 }
 
 func TestReviewLoopFixPrompt(t *testing.T) {

--- a/internal/prompts/templates/review_loop_decision.template
+++ b/internal/prompts/templates/review_loop_decision.template
@@ -1,4 +1,4 @@
-Based on your latest review, are there remaining issues you should fix in this sandbox before this work is considered clean? Apply the nit policy from the review instruction when deciding whether remaining nits require another fix pass.
+Based on your latest review, are there remaining issues you should fix in this sandbox before this work is considered clean? Apply the nit policy from the review instruction and use your coding judgment when deciding whether remaining nits require another fix pass.
 
 Answer with one of:
 

--- a/internal/prompts/templates/review_loop_review.template
+++ b/internal/prompts/templates/review_loop_review.template
@@ -1,3 +1,3 @@
 /review the current workspace diff. If you find issues, report them in your normal review format.
 
-Fix nits when they are local, low-risk, and in files already touched by this change. Do not expand the scope of the diff just to satisfy subjective style preferences. If a nit is broad, risky, or unrelated to the current change, leave it for later and mention it in your summary.
+Fix nits when they are local, low-risk, and relevant to the current change. Use your judgment: if the change makes stale or outdated adjacent code obsolete, remove or adjust it even when that code was not directly modified by the original diff. Do not expand the scope of the diff just to satisfy subjective style preferences. If a nit is broad, risky, or unrelated to the current change, leave it for later and mention it in your summary.


### PR DESCRIPTION
## Summary
Updated the review-loop nit policy to allow fixing/removing stale or outdated adjacent code when it’s low-risk and relevant, even if that file wasn’t part of the original diff. This prevents the loop from repeatedly leaving behind obsolete items and keeps the cleanup bounded by “local, low-risk, relevant” plus explicit judgment.

## Changes
- `internal/prompts/templates/review_loop_review.template`
  - Removed the “files already touched” boundary.
  - Added guidance to use judgment to remove/adjust stale or outdated adjacent code when it becomes obsolete due to the current change.
- `internal/prompts/templates/review_loop_decision.template`
  - Added “coding judgment” language when choosing whether another fix pass is needed (`REVIEW_CLEAN` vs `NEEDS_FIX_PASS`).
- `docs/design/implemented/78-review-agent-loops.md`
  - Synced the living design doc with the updated nit policy and decision wording.
- `internal/prompts/review_loop_test.go`
  - Added regression assertions to ensure the old “files already touched” restriction does not return and that stale/outdated adjacent cleanup guidance remains present.

## Test plan
- `go test ./internal/prompts -run TestReviewLoop -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

[143.dev](https://143.dev) | [session 9afb5d2c](https://143.dev/sessions/9afb5d2c-63e8-4836-8f8c-8a60ca57653b)