### PR TITLE
Make automation emoji picker compact and searchable in new/settings layouts

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -425,6 +425,62 @@ describe("AutomationDetailPage", () => {
     });
   });
 
+  it("keeps the settings emoji selector small on the same row as the name field", async () => {
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          icon_type: "emoji",
+          icon_value: "🧪",
+          interval_value: 1,
+          interval_unit: "weeks",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await screen.findByText("Weekly audit");
+    await userEvent.click(screen.getByRole("tab", { name: "Settings" }));
+
+    const identityRow = screen.getByTestId("automation-settings-identity-row");
+    expect(identityRow).toHaveClass("grid-cols-[4.75rem_minmax(0,1fr)]");
+    expect(screen.getByRole("button", { name: "Automation emoji" })).toHaveClass("w-16");
+    expect(screen.getByLabelText("Name")).toHaveValue("Weekly audit");
+  });
+
   it("updates the automation emoji from the header picker without changing tabs", async () => {
     const user = userEvent.setup();
     let updateBody: Record<string, unknown> | null = null;

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -142,17 +142,22 @@ function SettingsTab({
 
   return (
     <div className="space-y-4 rounded-lg border border-border bg-card p-5">
-      <div className="space-y-1.5">
-        <Label>Emoji</Label>
-        <AutomationEmojiPicker
-          value={iconValue}
-          onChange={setIconValue}
-          className="w-full sm:w-64"
-        />
-      </div>
-      <div className="space-y-1.5">
-        <Label htmlFor="name">Name</Label>
-        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+      <div
+        data-testid="automation-settings-identity-row"
+        className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-end gap-3"
+      >
+        <div className="space-y-1.5">
+          <Label>Emoji</Label>
+          <AutomationEmojiPicker
+            value={iconValue}
+            onChange={setIconValue}
+            className="w-16"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="name">Name</Label>
+          <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+        </div>
       </div>
       <div className="space-y-1.5">
         <div className="flex items-center justify-between gap-3">

--- a/frontend/src/app/(dashboard)/automations/automation-emoji-picker.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/automation-emoji-picker.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, renderWithProviders, screen, within } from "@/test/test-utils";
+import { describe, expect, it } from "vitest";
+import { AutomationEmojiPicker } from "./automation-emoji-picker";
+
+describe("AutomationEmojiPicker", () => {
+  it("shows a broad searchable emoji dropdown and selects an emoji", async () => {
+    const selected: string[] = [];
+
+    renderWithProviders(
+      <AutomationEmojiPicker
+        value="⚙️"
+        onChange={(value) => selected.push(value)}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Automation emoji" }));
+
+    const listbox = await screen.findByRole("listbox");
+    expect(within(listbox).getAllByRole("option").length).toBeGreaterThan(100);
+
+    fireEvent.change(screen.getByPlaceholderText("Search emoji..."), {
+      target: { value: "rocket" },
+    });
+    fireEvent.click(await screen.findByRole("option", { name: /Rocket/ }));
+
+    expect(selected).toEqual(["🚀"]);
+  });
+});

--- a/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
+++ b/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
@@ -1,20 +1,26 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronsUpDown } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Command,
-  CommandCheckItem,
   CommandEmpty,
   CommandGroup,
   CommandInput,
+  CommandItem,
   CommandList,
 } from "@/components/ui/command";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 
-const AUTOMATION_EMOJIS = [
+type EmojiOption = {
+  emoji: string;
+  label: string;
+  keywords: string;
+};
+
+const FEATURED_EMOJIS = [
   { emoji: "⚙️", label: "Gear" },
   { emoji: "🧹", label: "Broom" },
   { emoji: "🧪", label: "Test tube" },
@@ -25,7 +31,59 @@ const AUTOMATION_EMOJIS = [
   { emoji: "🛠️", label: "Tools" },
   { emoji: "📈", label: "Chart" },
   { emoji: "🤖", label: "Robot" },
+  { emoji: "✨", label: "Sparkles" },
+  { emoji: "🔥", label: "Fire" },
+  { emoji: "✅", label: "Check mark" },
+  { emoji: "🚨", label: "Siren" },
+  { emoji: "🧠", label: "Brain" },
+  { emoji: "💡", label: "Light bulb" },
+  { emoji: "🧰", label: "Toolbox" },
+  { emoji: "🧯", label: "Fire extinguisher" },
+  { emoji: "🩺", label: "Stethoscope" },
+  { emoji: "🧭", label: "Compass" },
 ] as const;
+
+const EMOJI_RANGES = [
+  { start: 0x1F300, end: 0x1F5FF, label: "Symbols and pictographs" },
+  { start: 0x1F600, end: 0x1F64F, label: "Smileys and people" },
+  { start: 0x1F680, end: 0x1F6FF, label: "Transport and map" },
+  { start: 0x1F700, end: 0x1F77F, label: "Alchemical symbols" },
+  { start: 0x1F780, end: 0x1F7FF, label: "Geometric symbols" },
+  { start: 0x1F800, end: 0x1F8FF, label: "Supplemental arrows" },
+  { start: 0x1F900, end: 0x1F9FF, label: "Supplemental symbols and pictographs" },
+  { start: 0x1FA70, end: 0x1FAFF, label: "Symbols and pictographs extended" },
+  { start: 0x2600, end: 0x27BF, label: "Miscellaneous symbols" },
+] as const;
+
+const emojiPresentation = (codePoint: number) =>
+  codePoint >= 0x2600 && codePoint <= 0x27BF
+    ? `${String.fromCodePoint(codePoint)}\uFE0F`
+    : String.fromCodePoint(codePoint);
+
+const unicodeLabel = (codePoint: number, category: string) =>
+  `${category} U+${codePoint.toString(16).toUpperCase()}`;
+
+const AUTOMATION_EMOJIS: EmojiOption[] = (() => {
+  const seen = new Set<string>();
+  const options: EmojiOption[] = [];
+
+  const add = (emoji: string, label: string, keywords = "") => {
+    if (seen.has(emoji)) return;
+    seen.add(emoji);
+    options.push({ emoji, label, keywords: `${label} ${emoji} ${keywords}` });
+  };
+
+  FEATURED_EMOJIS.forEach((item) => add(item.emoji, item.label, "automation"));
+  EMOJI_RANGES.forEach((range) => {
+    for (let codePoint = range.start; codePoint <= range.end; codePoint += 1) {
+      add(emojiPresentation(codePoint), unicodeLabel(codePoint, range.label), range.label);
+    }
+  });
+
+  return options;
+})();
+
+const INITIAL_EMOJI_COUNT = 128;
 
 export function AutomationEmojiPicker({
   value,
@@ -47,12 +105,20 @@ export function AutomationEmojiPicker({
   disabled?: boolean;
 }) {
   const [internalOpen, setInternalOpen] = useState(false);
+  const [query, setQuery] = useState("");
   const pickerOpen = open ?? internalOpen;
   const setPickerOpen = onOpenChange ?? setInternalOpen;
   const selected = useMemo(
-    () => AUTOMATION_EMOJIS.find((item) => item.emoji === value) ?? AUTOMATION_EMOJIS[0],
+    () => AUTOMATION_EMOJIS.find((item) => item.emoji === value) ?? { emoji: value || "⚙️", label: "Selected emoji", keywords: value || "gear" },
     [value],
   );
+  const visibleOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return AUTOMATION_EMOJIS.slice(0, INITIAL_EMOJI_COUNT);
+    }
+    return AUTOMATION_EMOJIS.filter((item) => item.keywords.toLowerCase().includes(normalizedQuery));
+  }, [query]);
 
   return (
     <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
@@ -74,35 +140,40 @@ export function AutomationEmojiPicker({
             variant="outline"
             aria-label={triggerLabel}
             disabled={disabled}
-            className={cn("h-10 justify-between", className)}
+            className={cn("h-10 w-16 justify-center gap-1 px-2", className)}
           >
-            <span className="flex min-w-0 items-center gap-2">
-              <span className="text-lg leading-none" aria-hidden="true">{selected.emoji}</span>
-              <span className="truncate">{selected.label}</span>
-            </span>
-            <ChevronsUpDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="text-lg leading-none" aria-hidden="true">{selected.emoji}</span>
+            <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           </Button>
         )}
       </PopoverTrigger>
-      <PopoverContent className="w-72 p-0" align="start">
-        <Command>
-          <CommandInput placeholder="Search emoji..." />
-          <CommandList>
+      <PopoverContent className="w-80 p-0" align="start">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search emoji..."
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList className="max-h-80">
             <CommandEmpty>No emoji found.</CommandEmpty>
-            <CommandGroup>
-              {AUTOMATION_EMOJIS.map((item) => (
-                <CommandCheckItem
+            <CommandGroup className="grid grid-cols-8 gap-1 p-2">
+              {visibleOptions.map((item) => (
+                <CommandItem
                   key={item.emoji}
-                  value={`${item.label} ${item.emoji}`}
-                  checked={item.emoji === selected.emoji}
+                  value={item.keywords}
+                  aria-label={item.label}
+                  className={cn(
+                    "flex h-8 w-8 cursor-pointer items-center justify-center rounded-md p-0 text-lg leading-none",
+                    item.emoji === selected.emoji && "bg-primary text-primary-foreground data-[selected=true]:bg-primary data-[selected=true]:text-primary-foreground",
+                  )}
                   onSelect={() => {
                     onChange(item.emoji);
                     setPickerOpen(false);
                   }}
                 >
-                  <span className="text-lg leading-none" aria-hidden="true">{item.emoji}</span>
-                  <span>{item.label}</span>
-                </CommandCheckItem>
+                  <span aria-hidden="true">{item.emoji}</span>
+                  <span className="sr-only">{item.label}</span>
+                </CommandItem>
               ))}
             </CommandGroup>
           </CommandList>

--- a/frontend/src/app/(dashboard)/automations/new/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.test.tsx
@@ -117,6 +117,42 @@ describe("NewAutomationPage", () => {
     );
   });
 
+  it("keeps the emoji selector small on the same row as the name field", async () => {
+    server.use(
+      http.get("/api/v1/repositories", () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "repo-1",
+              org_id: "org-1",
+              integration_id: "int-1",
+              github_id: 1,
+              full_name: "acme/repo",
+              default_branch: "main",
+              private: false,
+              clone_url: "https://github.com/acme/repo.git",
+              installation_id: 10,
+              status: "active",
+              settings: {},
+              created_at: "2026-03-05T12:00:00Z",
+              updated_at: "2026-03-05T12:00:00Z",
+            },
+          ],
+          meta: {},
+        }),
+      ),
+    );
+
+    renderWithProviders(<NewAutomationPage />);
+
+    await screen.findByDisplayValue("Security sweep");
+
+    const identityRow = screen.getByTestId("automation-identity-row");
+    expect(identityRow).toHaveClass("grid-cols-[4.75rem_minmax(0,1fr)]");
+    expect(screen.getByRole("button", { name: "Automation emoji" })).toHaveClass("w-16");
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+  });
+
   it("inserts selected @ mentions into the automation goal", async () => {
     const user = userEvent.setup();
 

--- a/frontend/src/app/(dashboard)/automations/new/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/new/page.tsx
@@ -257,19 +257,27 @@ export default function NewAutomationPage() {
 
         {/* Main form */}
         <div className="space-y-4 rounded-lg border border-border bg-card p-5">
-          <div className="space-y-1.5">
-            <Label>Emoji</Label>
-            <AutomationEmojiPicker value={iconValue} onChange={setIconValue} className="w-full sm:w-64" />
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="name">Name</Label>
-            <Input
-              id="name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. Find flaky tests"
-            />
+          <div
+            data-testid="automation-identity-row"
+            className="grid grid-cols-[4.75rem_minmax(0,1fr)] items-end gap-3"
+          >
+            <div className="space-y-1.5">
+              <Label>Emoji</Label>
+              <AutomationEmojiPicker
+                value={iconValue}
+                onChange={setIconValue}
+                className="w-16"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Find flaky tests"
+              />
+            </div>
           </div>
 
           <div className="space-y-1.5">


### PR DESCRIPTION
## Summary
This updates the automation emoji picker to use a compact, built-in Unicode emoji dropdown that stays small beside the Name field in both “New” and “Settings” screens. It also adds search and improves coverage with tests to prevent layout regressions and verify picker interactions.

## Changes
- `frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx`
  - Reworked the trigger to be compact.
  - Added a searchable emoji grid using the system Unicode emoji set (no new dependencies).
- `frontend/src/app/(dashboard)/automations/new/page.tsx`
  - Adjusted layout so the emoji selector sits on the same row as the Name input and remains small.
- `frontend/src/app/(dashboard)/automations/[id]/page.tsx`
  - Matched the same compact “emoji + name” row layout in the settings tab (added `data-testid="automation-settings-identity-row"` for testing).
- Tests
  - `frontend/src/app/(dashboard)/automations/automation-emoji-picker.test.tsx`: added/updated search + select behavior assertions.
  - `frontend/src/app/(dashboard)/automations/new/page.test.tsx`: updated layout/interaction expectations for the new layout.
  - `frontend/src/app/(dashboard)/automations/[id]/page.test.tsx`: added a regression test ensuring the settings emoji selector stays small and aligned with the Name field.

## Test plan
- `npm run test -- automation-emoji-picker.test.tsx 'src/app/(dashboard)/automations/new/page.test.tsx' 'src/app/(dashboard)/automations/[id]/page.test.tsx' --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 5e836ccb](https://143.dev/sessions/5e836ccb-fe1a-479f-a4cd-dd6318625a72)