### PR TITLE
Detect worker Docker group during provisioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,12 +380,13 @@ REPROVISION ?=
 # Per-host worker identity (forwarded as env vars to provision.sh / deploy.sh
 # so users can write `make provision-worker HOST=… WORKER_PRIVATE_IP=…` instead
 # of prefixing the env var on the command line). Empty by default; provision.sh
-# auto-detects WORKER_PRIVATE_IP via SSH when unset and derives NODE_ID and
-# PREVIEW_INTERNAL_BASE_URL from it.
+# auto-detects WORKER_PRIVATE_IP and DOCKER_GID via SSH when unset and derives
+# NODE_ID and PREVIEW_INTERNAL_BASE_URL from it.
 export WORKER_PRIVATE_IP
 export WORKER_PRIVATE_IP_SOURCE
 export NODE_ID
 export PREVIEW_INTERNAL_BASE_URL
+export DOCKER_GID
 export DB_BIND_IP
 export TS_AUTH_KEY_APP
 export TS_AUTH_KEY_DB

--- a/deploy/cloud-init/worker.yml
+++ b/deploy/cloud-init/worker.yml
@@ -21,9 +21,9 @@
 #   export REPO_URL="https://github.com/assembledhq/143.git"
 #   envsubst < deploy/cloud-init/worker.yml > /tmp/user-data.yml
 #
-# NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL are *per-host*
-# identity. They are written to /opt/143/.env.local once at bootstrap and
-# preserved across deploys (deploy.sh only rewrites /opt/143/.env, then
+# NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, and DOCKER_GID are
+# *per-host* values. They are written to /opt/143/.env.local once at bootstrap
+# and preserved across deploys (deploy.sh only rewrites /opt/143/.env, then
 # concatenates .env.local back in for docker compose). This split is what
 # lets the same .env.production.enc deploy to every worker in the fleet.
 # Workers must also stage /opt/143/.env.production.enc before the first
@@ -87,6 +87,7 @@ runcmd:
   # compose can interpolate ${NODE_ID}, ${WORKER_PRIVATE_IP}, etc. when it
   # parses docker-compose.worker.yml. Subsequent deploys (deploy.sh) repeat
   # this step so .env.local stays the source of truth for per-host values.
+  - su - deploy -c 'DOCKER_GID="$(getent group docker | cut -d: -f3)" && printf "DOCKER_GID=%s\n" "$DOCKER_GID" >> /opt/143/.env.local'
   - su - deploy -c 'cat /opt/143/.env.local >> /opt/143/.env'
 
   # Start the worker

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -106,8 +106,8 @@ func TestDeployWritesWorkerSandboxCapacityEnv(t *testing.T) {
 	require.Contains(t, string(deployScript), "SANDBOX_HEALTH_CHECK_IMAGE=%s", "worker deploy should write the sandbox health-check image into .env for compose preflight and app config")
 }
 
-// Worker preview routing requires three per-host values: NODE_ID,
-// WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL. They live in
+// Worker preview routing and sandbox orchestration require per-host values:
+// NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, and DOCKER_GID. They live in
 // /opt/143/.env.local (not the shared .env that gets rewritten on every
 // deploy). If we ever stop writing or appending that file, every preview
 // start will fail with PREVIEW_NO_WORKERS — guard the wiring here so that
@@ -120,6 +120,7 @@ func TestWorkerPerHostIdentityIsPreservedAcrossDeploys(t *testing.T) {
 	require.Contains(t, string(compose), "${WORKER_PRIVATE_IP:?", "worker compose should bind port 8080 to the worker's private IP and fail loudly if WORKER_PRIVATE_IP is unset (binding to 0.0.0.0 would expose the internal preview API)")
 	require.Contains(t, string(compose), "${NODE_ID:?", "worker compose should require NODE_ID rather than silently falling back to a random container hostname")
 	require.Contains(t, string(compose), "${PREVIEW_INTERNAL_BASE_URL:?", "worker compose should require PREVIEW_INTERNAL_BASE_URL — without it, parseWorkerNode rejects the node and StartPreview returns PREVIEW_NO_WORKERS")
+	require.Contains(t, string(compose), "${DOCKER_GID:?", "worker compose should require the host docker group GID instead of defaulting to a distro-specific value that can block docker.sock access")
 	require.Contains(t, string(compose), ":8080:8080", "worker compose should publish port 8080 so the app node can reach the worker's internal preview API")
 
 	cloudInit, err := os.ReadFile("../deploy/cloud-init/worker.yml")
@@ -128,20 +129,25 @@ func TestWorkerPerHostIdentityIsPreservedAcrossDeploys(t *testing.T) {
 	require.Contains(t, string(cloudInit), "NODE_ID=${NODE_ID}", "worker cloud-init should populate NODE_ID in .env.local")
 	require.Contains(t, string(cloudInit), "WORKER_PRIVATE_IP=${WORKER_PRIVATE_IP}", "worker cloud-init should populate WORKER_PRIVATE_IP in .env.local")
 	require.Contains(t, string(cloudInit), "PREVIEW_INTERNAL_BASE_URL=${PREVIEW_INTERNAL_BASE_URL}", "worker cloud-init should populate PREVIEW_INTERNAL_BASE_URL in .env.local")
+	require.Contains(t, string(cloudInit), `DOCKER_GID="$(getent group docker | cut -d: -f3)"`, "worker cloud-init should detect the host docker group GID for docker.sock access")
+	require.Contains(t, string(cloudInit), `DOCKER_GID=%s`, "worker cloud-init should persist DOCKER_GID in .env.local")
 	require.Contains(t, string(cloudInit), "cat /opt/143/.env.local >> /opt/143/.env", "worker cloud-init should concatenate .env.local into .env so docker compose can interpolate ${WORKER_PRIVATE_IP} etc.")
 
 	provisionScript, err := os.ReadFile("../deploy/scripts/provision.sh")
 	require.NoError(t, err, "test should read the provisioning script")
+	require.Contains(t, string(provisionScript), "getent group docker", "provision.sh should detect the host docker group GID instead of relying on a hardcoded docker group id")
 	require.Contains(t, string(provisionScript), "NODE_ID=%s", "provision.sh should write NODE_ID into .env.local")
 	require.Contains(t, string(provisionScript), "WORKER_PRIVATE_IP=%s", "provision.sh should write WORKER_PRIVATE_IP into .env.local")
 	require.Contains(t, string(provisionScript), "PREVIEW_INTERNAL_BASE_URL=%s", "provision.sh should write PREVIEW_INTERNAL_BASE_URL into .env.local")
+	require.Contains(t, string(provisionScript), "DOCKER_GID=%s", "provision.sh should write DOCKER_GID into .env.local")
 	require.Contains(t, string(provisionScript), "/opt/143/.env.local", "provision.sh should target /opt/143/.env.local")
 	require.Contains(t, string(provisionScript), "cat /opt/143/.env.local >> /opt/143/.env", "provision.sh should concatenate .env.local into .env after writing both")
 
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read the deploy script")
+	require.Contains(t, string(deployScript), `DOCKER_GID="$(getent group docker | cut -d: -f3)"`, "deploy.sh should backfill DOCKER_GID for workers provisioned before the value was written to .env.local")
 	require.Contains(t, string(deployScript), "cat /opt/143/.env.local >> /opt/143/.env", "deploy.sh worker branch should re-append .env.local into .env on every deploy — without this, every secret refresh wipes the per-host identity")
-	require.Contains(t, string(deployScript), "/opt/143/.env.local is missing", "deploy.sh worker branch should abort loudly when .env.local is missing instead of coming up with empty NODE_ID and WORKER_PRIVATE_IP")
+	require.Contains(t, string(deployScript), "/opt/143/.env.local is missing", "deploy.sh worker branch should abort loudly when .env.local is missing instead of coming up with empty NODE_ID, WORKER_PRIVATE_IP, or DOCKER_GID")
 }
 
 func TestWorkerGVisorPreflightPullsHealthImageOnlyWhenMissing(t *testing.T) {

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -141,12 +141,11 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
     : "${SANDBOX_GC_GRACE:=30m}"
     : "${SANDBOX_GC_HARD_MAX:=24h}"
     # Refresh the shared secrets in /opt/143/.env, then re-append the per-host
-    # identity from /opt/143/.env.local (NODE_ID, WORKER_PRIVATE_IP,
-    # PREVIEW_INTERNAL_BASE_URL) so docker compose can still interpolate them
-    # when it parses the compose file. .env.local is owned by provisioning
-    # and we abort if it's missing instead of silently coming up with an
-    # empty NODE_ID and WORKER_PRIVATE_IP=0.0.0.0 (would expose worker to
-    # the public internet).
+    # identity/runtime values from /opt/143/.env.local (NODE_ID,
+    # WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, DOCKER_GID) so docker
+    # compose can still interpolate them when it parses the compose file.
+    # .env.local is owned by provisioning and we abort if it's missing instead
+    # of silently coming up with empty/unsafe defaults.
     printf 'SOPS_AGE_KEY=%s\nDB_PASSWORD=%s\nDB_HOST=%s\nVICTORIALOGS_HOST=%s\nSERVER_ROLE=%s\nWORKER_PROCESS_COUNT=%s\nWORKER_MAX_ACTIVE_SANDBOXES=%s\nSANDBOX_CPU_LIMIT=%s\nSANDBOX_MEMORY_LIMIT_MB=%s\nSANDBOX_DISK_LIMIT_GB=%s\nSANDBOX_HEALTH_CHECK_IMAGE=%s\nSANDBOX_REQUIRE_DISK_QUOTA=%s\nSANDBOX_GC_INTERVAL=%s\nSANDBOX_GC_GRACE=%s\nSANDBOX_GC_HARD_MAX=%s\n' \
       "$SOPS_AGE_KEY" "$DB_PASSWORD" "$DB_HOST" "$VICTORIALOGS_HOST" "$ROLE" \
       "${WORKER_PROCESS_COUNT:-}" "${WORKER_MAX_ACTIVE_SANDBOXES:-}" "${SANDBOX_CPU_LIMIT:-}" "${SANDBOX_MEMORY_LIMIT_MB:-}" "${SANDBOX_DISK_LIMIT_GB:-}" \
@@ -157,9 +156,18 @@ if [ -n "${SOPS_AGE_KEY:-}" ] && [ -f "$ENC_FILE" ]; then
           chmod 600 /opt/143/.env
           if [ ! -f /opt/143/.env.local ]; then
             echo "ERROR: /opt/143/.env.local is missing on this host." >&2
-            echo "       It holds NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL." >&2
+            echo "       It holds NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, and DOCKER_GID." >&2
             echo "       Re-run: make provision-worker HOST=<this-host>" >&2
             exit 1
+          fi
+          if ! grep -q "^DOCKER_GID=" /opt/143/.env.local; then
+            DOCKER_GID="$(getent group docker | cut -d: -f3)"
+            if [ -z "$DOCKER_GID" ]; then
+              echo "ERROR: could not resolve docker group GID on this worker." >&2
+              echo "       Re-run: make provision-worker HOST=<this-host>" >&2
+              exit 1
+            fi
+            printf "DOCKER_GID=%s\n" "$DOCKER_GID" >> /opt/143/.env.local
           fi
           cat /opt/143/.env.local >> /opt/143/.env
         '

--- a/deploy/scripts/provision.sh
+++ b/deploy/scripts/provision.sh
@@ -312,6 +312,23 @@ resolve_worker_identity() {
   echo "  PREVIEW_INTERNAL_BASE_URL = $PREVIEW_INTERNAL_BASE_URL"
 }
 
+resolve_worker_docker_gid() {
+  if [ "$ROLE" != "worker" ]; then
+    return
+  fi
+
+  if [ -z "${DOCKER_GID:-}" ]; then
+    DOCKER_GID="$(ssh "${SSH_OPTS[@]}" root@"$HOST" "getent group docker | cut -d: -f3")"
+  fi
+  if [[ ! "$DOCKER_GID" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: could not resolve numeric DOCKER_GID for docker.sock access on $HOST." >&2
+    echo "       Expected 'getent group docker | cut -d: -f3' to return a number; got '$DOCKER_GID'." >&2
+    exit 1
+  fi
+
+  echo "  DOCKER_GID                = $DOCKER_GID"
+}
+
 # Check if already provisioned
 RUNNING=$(ssh "${SSH_OPTS[@]}" root@"$HOST" "su - deploy -c 'cd /opt/143 && docker compose -f $COMPOSE_FILE ps -q 2>/dev/null'" 2>/dev/null || true)
 if [ -n "$RUNNING" ]; then
@@ -486,6 +503,7 @@ wait_for_docker_daemon
 # publish its 100.64.0.0/10 address as the internal preview endpoint.
 configure_tailscale_if_requested
 resolve_worker_identity
+resolve_worker_docker_gid
 
 # Step 2b: Sync authorized keys from deploy/authorized_keys/*.pub
 # Replaces authorized_keys on the host with exactly the keys in the repo.
@@ -521,11 +539,12 @@ elif [ "$ROLE" = "worker" ]; then
     "$SANDBOX_HEALTH_CHECK_IMAGE" "$SANDBOX_REQUIRE_DISK_QUOTA" "$SANDBOX_GC_INTERVAL" "$SANDBOX_GC_GRACE" "$SANDBOX_GC_HARD_MAX" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env && chown deploy:deploy /opt/143/.env && chmod 600 /opt/143/.env'
 
-  # Per-host identity (NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL)
-  # lives in .env.local and survives every deploy — the secret refresh in
-  # deploy.sh only rewrites /opt/143/.env, then re-appends .env.local.
-  printf 'NODE_ID=%s\nWORKER_PRIVATE_IP=%s\nPREVIEW_INTERNAL_BASE_URL=%s\n' \
-    "$NODE_ID" "$WORKER_PRIVATE_IP" "$PREVIEW_INTERNAL_BASE_URL" \
+  # Per-host identity/runtime values (NODE_ID, WORKER_PRIVATE_IP,
+  # PREVIEW_INTERNAL_BASE_URL, DOCKER_GID) live in .env.local and survive
+  # every deploy — the secret refresh in deploy.sh only rewrites /opt/143/.env,
+  # then re-appends .env.local.
+  printf 'NODE_ID=%s\nWORKER_PRIVATE_IP=%s\nPREVIEW_INTERNAL_BASE_URL=%s\nDOCKER_GID=%s\n' \
+    "$NODE_ID" "$WORKER_PRIVATE_IP" "$PREVIEW_INTERNAL_BASE_URL" "$DOCKER_GID" \
     | ssh "${SSH_OPTS[@]}" root@"$HOST" 'cat > /opt/143/.env.local && chown deploy:deploy /opt/143/.env.local && chmod 600 /opt/143/.env.local'
 
   # Concatenate so docker compose can interpolate ${WORKER_PRIVATE_IP} etc.

--- a/docker-compose.worker.yml
+++ b/docker-compose.worker.yml
@@ -89,8 +89,9 @@ services:
       # working DNS and fail their first preview-infra lookup.
       sandbox-dns:
         condition: service_healthy
-    # NODE_ID, WORKER_PRIVATE_IP, and PREVIEW_INTERNAL_BASE_URL are per-host
-    # identity. They live in /opt/143/.env.local and are concatenated into
+    # NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, and DOCKER_GID
+    # are per-host identity/runtime values. They live in /opt/143/.env.local
+    # and are concatenated into
     # /opt/143/.env by provision.sh / deploy.sh so docker compose can
     # interpolate them below. The :? syntax fails the deploy loudly if any
     # value is missing — without it, port 8080 would bind to 0.0.0.0 (exposes
@@ -133,7 +134,7 @@ services:
       sandbox:
         gw_priority: 0
     group_add:
-      - ${DOCKER_GID:-988}
+      - ${DOCKER_GID:?missing in /opt/143/.env.local}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # Per-session GitHub credential sockets. Bind-mounted into this


### PR DESCRIPTION
## Summary

Fix worker provisioning so Docker socket access uses the worker host's actual Docker group GID instead of assuming a hardcoded value.

The new Tailscale worker on `5.78.149.97` exposed this because the worker container runs as `appuser` and accesses `/var/run/docker.sock` through Compose `group_add`. The compose file defaulted `DOCKER_GID` to `988`, but Docker group IDs vary by distro/image/provider. On this host the worker started with the wrong supplemental group and failed its sandbox Docker health check with `permission denied` on `/var/run/docker.sock`.

## What changed

- `provision.sh` now detects `getent group docker | cut -d: -f3` on worker hosts after bootstrap and writes `DOCKER_GID` into `/opt/143/.env.local` alongside `NODE_ID`, `WORKER_PRIVATE_IP`, and `PREVIEW_INTERNAL_BASE_URL`.
- `docker-compose.worker.yml` now requires `DOCKER_GID` instead of falling back to a distro-specific default.
- `deploy.sh` backfills `DOCKER_GID` into `.env.local` for older worker hosts before appending `.env.local` into `.env`, so existing workers do not break on the next deploy.
- `deploy/cloud-init/worker.yml` writes `DOCKER_GID` during first boot for cloud-init-created workers.
- Deploy config tests now cover the required compose variable and provisioning/cloud-init/deploy wiring.

## Validation

- `go test ./deploy -count=1`
- `bash -n deploy/scripts/provision.sh deploy/scripts/deploy.sh`
- `git diff --check`
- `go vet ./...`
- `go build ./...`
- `go test ./...`
