### PR TITLE
Fix PreviewPanel test to scope “1 hr” assertion to lifetime menu items

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -512,7 +512,7 @@ describe("PreviewPanel component", () => {
     expect(screen.getByRole("menuitem", { name: "Keep for 15 min" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Keep for 30 min" })).toBeInTheDocument();
     expect(screen.getByRole("menuitem", { name: "Stop in 5 min" })).toBeInTheDocument();
-    expect(screen.queryByText(/1 hr/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: /1 hr/i })).not.toBeInTheDocument();
   });
 
   it("updates preview lifetime from the hidden menu", async () => {


### PR DESCRIPTION
## Summary
The `PreviewPanel` test was failing because a broad `/1 hr/i` text query matched the visible TTL/remaining-time label text (e.g., `5401 hr ... left`) even though the hidden lifetime menu doesn’t include a 1-hour option. This change scopes the assertion to actual menu items.

## Changes
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Updated the “bounded preview lifetime controls” test from `queryByText(/1 hr/i)` to:
    - `queryByRole("menuitem", { name: /1 hr/i })`
  - Ensures we only fail when a **menu option** for “1 hr” is present.

## Test plan
- `npm test -- src/components/preview/preview-panel.test.tsx -t "offers bounded preview lifetime controls"`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 45651826](https://143.dev/sessions/45651826-9bce-4bff-bef8-177ffc40d44c)