### PR TITLE
Fix session details tab rail overflow scrollbar to keep actions aligned

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -2898,7 +2898,7 @@ describe('SessionDetailPage', () => {
     expect(within(actions).getByRole('link', { name: 'View PR' })).toBeInTheDocument();
   });
 
-  it('shows the horizontal tab scrollbar only when tabs run into the action buttons', async () => {
+  it('keeps the overflowing tab rail scrollbar hidden so actions stay vertically aligned', async () => {
     renderWithProviders(<SessionDetailContent id="session-abcdef12-3456-7890" />);
 
     const tabRail = await screen.findByLabelText('Session detail tabs');
@@ -2917,7 +2917,7 @@ describe('SessionDetailPage', () => {
     });
 
     await waitFor(() => {
-      expect(tabRail).not.toHaveClass('scrollbar-hide');
+      expect(tabRail).toHaveClass('scrollbar-hide');
     });
     expect(tabRail).toHaveClass('mask-fade-r');
   });

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4918,8 +4918,8 @@ export function SessionDetailContent({ id }: { id: string }) {
             ref={detailTabsRef}
             aria-label="Session detail tabs"
             className={cn(
-              "flex h-full min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden",
-              detailTabsOverflow ? "mask-fade-r" : "scrollbar-hide",
+              "flex h-full min-w-0 flex-1 items-center overflow-x-auto overflow-y-hidden scrollbar-hide",
+              detailTabsOverflow && "mask-fade-r",
             )}
           >
             <TabsList variant="line" size="sm" className="border-b-0 min-w-max">


### PR DESCRIPTION
## Summary
Fixes a regression in the Session Details “tabs” area where the horizontal tab rail would briefly show a scrollbar when tabs overflow, misaligning the adjacent action buttons. The tab rail now always keeps the scrollbar hidden and uses a fade mask to indicate overflow.

## Changes
- `frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx`
  - Update the session detail tab rail classes to **always** include `scrollbar-hide`.
  - Apply `mask-fade-r` only when `detailTabsOverflow` is true to preserve the overflow cue without showing the scrollbar.
- `frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx`
  - Update the regression test to assert the tab rail **keeps** the `scrollbar-hide` class when tabs overflow (so action buttons remain aligned).
  - Keep asserting `mask-fade-r` is present as the visual overflow indicator.

## Test plan
- Ran: `npm test -- --run 'src/app/(dashboard)/sessions/[id]/page.test.tsx' -t 'keeps the overflowing tab rail scrollbar hidden'`
- Also verified: `npm run typecheck`, `npm run lint`, `npm run build`

[143.dev](https://143.dev) | [session a0597a00](https://143.dev/sessions/a0597a00-a0a8-44ef-bacb-7753907bcba9)