### PR TITLE
Left-align Remove action by removing extra padding

### DIFF
--- a/frontend/src/app/(dashboard)/settings/team/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.test.tsx
@@ -332,7 +332,9 @@ describe('TeamSettingsPage', () => {
     });
 
     // Remove button should exist for the other member
-    expect(screen.getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+    const removeButton = screen.getByRole('button', { name: 'Remove' });
+    expect(removeButton).toBeInTheDocument();
+    expect(removeButton).toHaveClass('px-0');
   });
 
   it('shows confirmation dialog when Remove is clicked and calls removeMember on confirm', async () => {

--- a/frontend/src/app/(dashboard)/settings/team/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/team/page.tsx
@@ -429,7 +429,7 @@ export default function TeamSettingsPage() {
                           <Button
                             variant="ghost"
                             size="sm"
-                            className="text-destructive hover:text-destructive"
+                            className="px-0 text-destructive hover:text-destructive"
                             disabled={removeMemberMutation.isPending}
                             onClick={() => setRemovingMember(member)}
                           >


### PR DESCRIPTION
## Summary
Adjusted the “Remove” ghost button styling in the team members table so it aligns with the “Current user” label in the same Actions column. Added a regression assertion to ensure the spacing doesn’t drift back.

## Changes
- **`frontend/src/app/(dashboard)/settings/team/page.tsx`**
  - Updated the Remove button (`variant="ghost"`) to include `className="px-0 ..."` so it removes the extra leading padding from the ghost button.
- **`frontend/src/app/(dashboard)/settings/team/page.test.tsx`**
  - Enhanced the non-self members test to assert the Remove button has `px-0`.

## Test plan
- Ran: `npm test -- --run 'src/app/(dashboard)/settings/team/page.test.tsx' -t 'shows Remove button for non-self members'`
- Also ran: `npm run typecheck`, `npm run lint`, and `npm run build`

[143.dev](https://143.dev) | [session c3732fac](https://143.dev/sessions/c3732fac-9a93-4312-a651-7716aeca65d0)