### PR TITLE
Make GitHub repo list responsive grid and add coverage for layout

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.test.tsx
@@ -136,6 +136,43 @@ describe("IntegrationsPage", () => {
     expect(screen.queryByText("GitHub repositories")).not.toBeInTheDocument();
   });
 
+  it("lays out GitHub repositories in a compact responsive grid", async () => {
+    listGitHubRepositoriesMock.mockResolvedValue({
+      data: [
+        {
+          github_id: 67890,
+          full_name: "acme/api",
+          default_branch: "main",
+          private: true,
+          clone_url: "https://github.com/acme/api.git",
+          installation_id: 12345,
+          status: "unclaimed",
+          can_transfer: false,
+        },
+        {
+          github_id: 67891,
+          full_name: "acme/web",
+          default_branch: "main",
+          private: true,
+          clone_url: "https://github.com/acme/web.git",
+          installation_id: 12345,
+          status: "owned_by_current_org",
+          can_transfer: false,
+        },
+      ],
+      meta: {},
+    });
+
+    renderWithProviders(<IntegrationsPage />);
+
+    await screen.findByText("acme/api");
+
+    const repoGrid = screen.getByTestId("github-repository-grid");
+    expect(repoGrid).toHaveClass("grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]");
+    expect(within(repoGrid).getByText("acme/api")).toBeInTheDocument();
+    expect(within(repoGrid).getByText("acme/web")).toBeInTheDocument();
+  });
+
   it("renders GitHub repository cards without duplicate repo pills or section intro copy", async () => {
     repositoriesListMock.mockResolvedValue({
       data: [

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -82,6 +82,7 @@ function GitHubRepositoryClaims({
   const actionable = repos.filter((repo) =>
     repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (repo.status === "owned_by_other_org" && repo.can_transfer)
   );
+  const connectedCount = repos.filter((repo) => repo.status === "owned_by_current_org").length;
   const claimError = claimMutation.error;
   const needsGitHubUserAuth = claimError instanceof ApiError && claimError.code === "GITHUB_USER_AUTH_REQUIRED";
 
@@ -98,38 +99,46 @@ function GitHubRepositoryClaims({
           <p className="text-sm text-muted-foreground">No repositories are available to this GitHub App installation.</p>
         ) : (
           <div className="space-y-2">
-            {repos.map((repo) => {
-              const transfer = repo.status === "owned_by_other_org";
-              const canClaim = repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (transfer && repo.can_transfer);
-              const pending = claimMutation.isPending && claimMutation.variables?.githubId === repo.github_id;
-              return (
-                <div key={repo.github_id} className="flex items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium">{repo.full_name}</div>
-                    <div className="mt-1 flex items-center gap-2">
-                      <Badge variant={repo.status === "owned_by_current_org" ? "secondary" : "outline"} className="text-xs">
-                        {claimStatusLabel(repo)}
-                      </Badge>
-                      {repo.private && <span className="text-xs text-muted-foreground">Private</span>}
+            <p className="text-xs text-muted-foreground">
+              {repos.length} repositor{repos.length === 1 ? "y" : "ies"} · {connectedCount} connected · {actionable.length} available
+            </p>
+            <div
+              data-testid="github-repository-grid"
+              className="grid grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-2"
+            >
+              {repos.map((repo) => {
+                const transfer = repo.status === "owned_by_other_org";
+                const canClaim = repo.status === "unclaimed" || repo.status === "disconnected_in_current_org" || (transfer && repo.can_transfer);
+                const pending = claimMutation.isPending && claimMutation.variables?.githubId === repo.github_id;
+                return (
+                  <div key={repo.github_id} className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-2 rounded-md border border-border px-3 py-2">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">{repo.full_name}</div>
+                      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-1.5">
+                        <Badge variant={repo.status === "owned_by_current_org" ? "secondary" : "outline"} className="text-xs">
+                          {claimStatusLabel(repo)}
+                        </Badge>
+                        {repo.private && <span className="text-xs text-muted-foreground">Private</span>}
+                      </div>
                     </div>
+                    {canClaim ? (
+                      <Button
+                        size="sm"
+                        variant={transfer ? "outline" : "default"}
+                        loading={pending}
+                        disabled={pending}
+                        onClick={() => {
+                          if (transfer) setTransferRepo(repo);
+                          else claimMutation.mutate({ githubId: repo.github_id, allowTransfer: false });
+                        }}
+                      >
+                        {transfer ? "Transfer" : "Claim"}
+                      </Button>
+                    ) : null}
                   </div>
-                  {canClaim ? (
-                    <Button
-                      size="sm"
-                      variant={transfer ? "outline" : "default"}
-                      loading={pending}
-                      disabled={pending}
-                      onClick={() => {
-                        if (transfer) setTransferRepo(repo);
-                        else claimMutation.mutate({ githubId: repo.github_id, allowTransfer: false });
-                      }}
-                    >
-                      {transfer ? "Transfer" : "Claim"}
-                    </Button>
-                  ) : null}
-                </div>
-              );
-            })}
+                );
+              })}
+            </div>
             {claimMutation.isError && (
               <div className="flex flex-col items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3">
                 <p className="text-sm text-destructive">


### PR DESCRIPTION
## Summary
Updated the GitHub repository list on the Integrations settings page to use a compact, responsive CSS grid so it spreads across available horizontal space and wraps cleanly on smaller screens. Added a small repository count line above the grid and introduced test coverage to lock in the new grid behavior and multi-repo rendering.

## Changes
- **`frontend/src/app/(dashboard)/settings/integrations/page.tsx`**
  - Changed the GitHub repositories layout to a responsive grid using `repeat(auto-fit, minmax(12rem, 1fr))` (via Tailwind class), reducing tall stacks on wide screens.
  - Added a repo count line above the GitHub repository grid to improve at-a-glance context.
  - Computed `connectedCount` from repos with `status === "owned_by_current_org"` for use in the UI copy.
- **`frontend/src/app/(dashboard)/settings/integrations/page.test.tsx`**
  - Added a test asserting the grid uses `grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]` and that multiple repos render within the grid.

## Test plan
- Ran: `npm test -- --run 'src/app/(dashboard)/settings/integrations/page.test.tsx'`
- Ran: `npm run typecheck`
- Ran: `npm run lint`
- Ran: `npm run build`

[143.dev](https://143.dev) | [session adce2703](https://143.dev/sessions/adce2703-e13b-411b-b589-39ec5f8e97b6)