### PR TITLE
Default fleet deploy to app/worker and gate Docker restarts during routine app deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,8 +543,10 @@ deploy-redis:
 	$(check-ssh-key)
 	@$(call resolve-host,redis)
 
-# Deploy all nodes in the fleet.
+# Deploy app+worker nodes in the fleet by default.
 # Uses FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.
+# For explicit maintenance deploys of every role:
+#   DEPLOY_FLEET_ROLES=all make deploy-fleet
 deploy-fleet:
 	$(check-ssh-key)
 	./deploy/scripts/deploy-fleet.sh $(SSH_KEY)

--- a/Makefile
+++ b/Makefile
@@ -465,12 +465,16 @@ repair-worker-host:
 	$(check-ssh-key)
 	ssh -i $(SSH_KEY) -o BatchMode=yes -o StrictHostKeyChecking=accept-new deploy@$(HOST) 'sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox'
 
+TAG ?= latest
+ROLES ?= app,worker
+
 # Deploy (update) an already-provisioned node.
 # HOST is optional — falls back to the matching role in FLEET_HOSTS from .env.production.enc.
 # SSH_KEY is auto-detected from ~/.ssh/143-deploy but can be overridden.
 # Usage:
 #   make deploy-app
 #   make deploy-app    HOST=87.99.150.138
+#   make deploy-app    TAG=<sha>
 
 # Shell snippet to read FLEET_HOSTS from env var or .env.production.enc via SOPS.
 # Sets $$FLEET. Use inside a recipe with: $(read-fleet-hosts);
@@ -488,7 +492,7 @@ endef
 define resolve-host
 if [ -n "$(HOST)" ]; then \
 	echo "Deploying $(1) → $(HOST)"; \
-	./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY); \
+	./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG); \
 else \
 	$(read-fleet-hosts); \
 	HOSTS="$$(echo "$$FLEET" | tr ',' '\n' | grep '^$(1):' | cut -d: -f2)"; \
@@ -498,7 +502,7 @@ else \
 	fi; \
 	for h in $$HOSTS; do \
 		echo "Deploying $(1) → $$h"; \
-		./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY); \
+		./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG); \
 	done; \
 fi
 endef
@@ -546,10 +550,12 @@ deploy-redis:
 # Deploy app+worker nodes in the fleet by default.
 # Uses FLEET_HOSTS env var or FLEET_HOSTS in .env.production.enc.
 # For explicit maintenance deploys of every role:
-#   DEPLOY_FLEET_ROLES=all make deploy-fleet
+#   make deploy-fleet ROLES=all
+# For a specific image tag:
+#   make deploy-fleet TAG=<sha> ROLES=app,worker
 deploy-fleet:
 	$(check-ssh-key)
-	./deploy/scripts/deploy-fleet.sh $(SSH_KEY)
+	./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)
 
 # Shorthand alias for deploy-fleet.
 deploy: deploy-fleet

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -106,6 +106,26 @@ func TestDeployWritesWorkerSandboxCapacityEnv(t *testing.T) {
 	require.Contains(t, string(deployScript), "SANDBOX_HEALTH_CHECK_IMAGE=%s", "worker deploy should write the sandbox health-check image into .env for compose preflight and app config")
 }
 
+func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
+	t.Parallel()
+
+	fleetScript, err := os.ReadFile("../deploy/scripts/deploy-fleet.sh")
+	require.NoError(t, err, "test should read deploy-fleet.sh")
+	fleetText := string(fleetScript)
+	require.Contains(t, fleetText, `DEPLOY_FLEET_ROLES="${DEPLOY_FLEET_ROLES:-app,worker}"`, "fleet deploy should default to the user-facing runtime roles so routine app deploys do not restart db, redis, or logging")
+	require.Contains(t, fleetText, `DEPLOY_FLEET_ROLES=all`, "fleet deploy should document an explicit all-roles maintenance escape hatch")
+	require.Contains(t, fleetText, `should_deploy_role()`, "fleet deploy should centralize role filtering so every FLEET_HOSTS entry is handled consistently")
+	require.Contains(t, fleetText, `Skipping $ROLE@$IP`, "fleet deploy should log skipped maintenance roles so operators can tell they were intentionally left alone")
+
+	workflow, err := os.ReadFile("../.github/workflows/deploy.yml")
+	require.NoError(t, err, "test should read the deploy workflow")
+	require.Contains(t, string(workflow), `./deploy/scripts/deploy-fleet.sh ~/.ssh/deploy-key "${{ github.sha }}"`, "CI should use deploy-fleet's default app/worker role set for routine main-branch deploys")
+
+	makefile, err := os.ReadFile("../Makefile")
+	require.NoError(t, err, "test should read Makefile")
+	require.Contains(t, string(makefile), "DEPLOY_FLEET_ROLES=all", "Makefile should document how to run an explicit all-role maintenance deploy")
+}
+
 // Worker preview routing and sandbox orchestration require per-host values:
 // NODE_ID, WORKER_PRIVATE_IP, PREVIEW_INTERNAL_BASE_URL, and DOCKER_GID. They live in
 // /opt/143/.env.local (not the shared .env that gets rewritten on every
@@ -401,7 +421,9 @@ func TestDeployConfiguresDockerLogRotation(t *testing.T) {
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read deploy script")
 	deployText := string(deployScript)
-	require.Contains(t, deployText, "install-log-rotation.sh", "deploy.sh should sync and invoke the install-log-rotation.sh helper on every deploy")
+	require.Contains(t, deployText, "install-log-rotation.sh", "deploy.sh should sync and invoke the install-log-rotation.sh helper for maintenance-capable deploys")
+	require.Contains(t, deployText, "ALLOW_DEPLOY_DOCKER_DAEMON_RESTART", "deploy.sh should require an explicit maintenance flag before app deploys can restart Docker")
+	require.Contains(t, deployText, "Skipping docker log rotation check on app deploy", "routine app deploys should skip daemon-mutating log rotation checks to keep Caddy bound on 80/443")
 	require.Contains(t, deployText, `db) LOG_MAX_SIZE="500m"`, "deploy.sh should give the db role a larger log cap — postgres logging is verbose and the db host has no Vector log shipping, so the local docker log is the only copy")
 	require.Contains(t, deployText, `*)  LOG_MAX_SIZE="100m"`, "deploy.sh should default non-db roles to a 100m cap")
 	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh", "deploy.sh should invoke install-log-rotation.sh via deploy+sudo (not root SSH) — matches the sandbox-firewall.sh pattern and avoids depending on root SSH at routine deploy time")
@@ -504,8 +526,10 @@ func TestDeployPinsDockerDaemonDNSResolvers(t *testing.T) {
 	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
 	require.NoError(t, err, "test should read deploy script")
 	deployText := string(deployScript)
-	require.Contains(t, deployText, "install-docker-dns.sh", "deploy.sh should sync and invoke install-docker-dns.sh on every deploy")
+	require.Contains(t, deployText, "install-docker-dns.sh", "deploy.sh should sync and invoke install-docker-dns.sh for maintenance-capable deploys")
 	require.Contains(t, deployText, "DOCKER_DNS_RESOLVERS=(1.1.1.1 8.8.8.8 9.9.9.9)", "deploy.sh should pin three independent resolver operators (Cloudflare, Google, Quad9) so a single-provider outage doesn't take fleet DNS down")
+	require.Contains(t, deployText, "ALLOW_DEPLOY_DOCKER_DAEMON_RESTART", "deploy.sh should require an explicit maintenance flag before app deploys can restart Docker")
+	require.Contains(t, deployText, "Skipping docker daemon DNS check on app deploy", "routine app deploys should skip daemon-mutating DNS checks to keep Caddy bound on 80/443")
 	require.Contains(t, deployText, "sudo -n /opt/143/deploy/scripts/install-docker-dns.sh", "deploy.sh should invoke install-docker-dns.sh via deploy+sudo so missing sudoers fails fast instead of hanging")
 	require.Contains(t, deployText, "Retrying docker daemon DNS pinning after sudoers repair", "deploy.sh should retry install-docker-dns.sh after repairing sudoers so the first deploy that introduces the helper succeeds on legacy hosts")
 	require.Contains(t, deployText, "warn_docker_dns_skipped", "deploy.sh should warn (not fail the deploy) when the DNS helper can't be installed — DNS hardening is operational, not a hard prerequisite for the rolling deploy")

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -112,8 +112,11 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 	fleetScript, err := os.ReadFile("../deploy/scripts/deploy-fleet.sh")
 	require.NoError(t, err, "test should read deploy-fleet.sh")
 	fleetText := string(fleetScript)
-	require.Contains(t, fleetText, `DEPLOY_FLEET_ROLES="${DEPLOY_FLEET_ROLES:-app,worker}"`, "fleet deploy should default to the user-facing runtime roles so routine app deploys do not restart db, redis, or logging")
-	require.Contains(t, fleetText, `DEPLOY_FLEET_ROLES=all`, "fleet deploy should document an explicit all-roles maintenance escape hatch")
+	require.Contains(t, fleetText, `REQUESTED_ROLES="${3:-app,worker}"`, "fleet deploy should default to the user-facing runtime roles so routine app deploys do not restart db, redis, or logging")
+	require.Contains(t, fleetText, `./deploy/scripts/deploy-fleet.sh <ssh-key> [tag] all`, "fleet deploy should document an explicit all-roles maintenance argument")
+	require.Contains(t, fleetText, `validate_requested_roles`, "fleet deploy should reject misspelled roles instead of silently skipping every host")
+	require.Contains(t, fleetText, `cannot be combined with other roles`, "fleet deploy should reject confusing mixed selections like all,redis")
+	require.Contains(t, fleetText, `No fleet hosts matched requested roles`, "fleet deploy should fail loudly when a valid role selection matches no hosts")
 	require.Contains(t, fleetText, `should_deploy_role()`, "fleet deploy should centralize role filtering so every FLEET_HOSTS entry is handled consistently")
 	require.Contains(t, fleetText, `Skipping $ROLE@$IP`, "fleet deploy should log skipped maintenance roles so operators can tell they were intentionally left alone")
 
@@ -123,7 +126,12 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 
 	makefile, err := os.ReadFile("../Makefile")
 	require.NoError(t, err, "test should read Makefile")
-	require.Contains(t, string(makefile), "DEPLOY_FLEET_ROLES=all", "Makefile should document how to run an explicit all-role maintenance deploy")
+	require.Contains(t, string(makefile), "ROLES ?= app,worker", "Makefile should make the default fleet role set visible to operators")
+	require.Contains(t, string(makefile), "TAG ?= latest", "Makefile should expose the image tag as the same kind of make argument as roles")
+	require.Contains(t, string(makefile), `./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG)`, "single-role deploy targets should honor the same TAG argument as fleet deploys")
+	require.Contains(t, string(makefile), `./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG)`, "multi-host single-role deploy targets should pass TAG through for every host")
+	require.Contains(t, string(makefile), "make deploy-fleet ROLES=all", "Makefile should document how to run an explicit all-role maintenance deploy with a make argument")
+	require.Contains(t, string(makefile), `./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)`, "Makefile should pass role and tag arguments through to deploy-fleet.sh")
 }
 
 // Worker preview routing and sandbox orchestration require per-host values:

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # Deploy to all nodes in the fleet.
 # Usage: ./deploy-fleet.sh <ssh-key-path> [image-tag]
 #
+# Routine fleet deploys intentionally default to app+worker only. Deploying
+# db/redis/logging recreates stateful or operator-facing services and should be
+# an explicit maintenance action:
+#   DEPLOY_FLEET_ROLES=all ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag]
+#   DEPLOY_FLEET_ROLES=app,worker,redis ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag]
+#
 # Fleet hosts are read from (in priority order):
 #   1. FLEET_HOSTS env var             — comma-separated "role:IP" pairs
 #   2. .env.production.enc (FLEET_HOSTS) — encrypted, decrypted via SOPS
@@ -12,8 +18,24 @@ set -euo pipefail
 
 SSH_KEY="$1"
 TAG="${2:-latest}"
+DEPLOY_FLEET_ROLES="${DEPLOY_FLEET_ROLES:-app,worker}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+should_deploy_role() {
+  local role="$1"
+  if [ "$DEPLOY_FLEET_ROLES" = "all" ]; then
+    return 0
+  fi
+  local selected
+  IFS=',' read -ra selected <<< "$DEPLOY_FLEET_ROLES"
+  for r in "${selected[@]}"; do
+    if [ "$r" = "$role" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 # Read FLEET_HOSTS from env var, or decrypt from SOPS.
 if [ -z "${FLEET_HOSTS:-}" ]; then
@@ -32,10 +54,15 @@ if [ -z "${FLEET_HOSTS:-}" ]; then
 fi
 
 echo "Reading fleet from FLEET_HOSTS..."
+echo "Deploying roles: $DEPLOY_FLEET_ROLES"
 IFS=',' read -ra ENTRIES <<< "$FLEET_HOSTS"
 for entry in "${ENTRIES[@]}"; do
   ROLE="${entry%%:*}"
   IP="${entry#*:}"
+  if ! should_deploy_role "$ROLE"; then
+    echo "Skipping $ROLE@$IP (not in DEPLOY_FLEET_ROLES=$DEPLOY_FLEET_ROLES)."
+    continue
+  fi
   echo "--- Deploying $ROLE to $IP ---"
   "$SCRIPT_DIR/deploy.sh" "$ROLE" "$IP" "$SSH_KEY" "$TAG"
   echo "$ROLE@$IP deployed."

--- a/deploy/scripts/deploy-fleet.sh
+++ b/deploy/scripts/deploy-fleet.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Deploy to all nodes in the fleet.
-# Usage: ./deploy-fleet.sh <ssh-key-path> [image-tag]
+# Usage: ./deploy-fleet.sh <ssh-key-path> [image-tag] [roles]
 #
 # Routine fleet deploys intentionally default to app+worker only. Deploying
 # db/redis/logging recreates stateful or operator-facing services and should be
 # an explicit maintenance action:
-#   DEPLOY_FLEET_ROLES=all ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag]
-#   DEPLOY_FLEET_ROLES=app,worker,redis ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag]
+#   ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag] all
+#   ./deploy/scripts/deploy-fleet.sh <ssh-key> [tag] app,worker,redis
 #
 # Fleet hosts are read from (in priority order):
 #   1. FLEET_HOSTS env var             — comma-separated "role:IP" pairs
@@ -18,17 +18,43 @@ set -euo pipefail
 
 SSH_KEY="$1"
 TAG="${2:-latest}"
-DEPLOY_FLEET_ROLES="${DEPLOY_FLEET_ROLES:-app,worker}"
+REQUESTED_ROLES="${3:-app,worker}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-should_deploy_role() {
-  local role="$1"
-  if [ "$DEPLOY_FLEET_ROLES" = "all" ]; then
+valid_role() {
+  case "$1" in
+    app|worker|db|logging|redis|all) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+validate_requested_roles() {
+  if [ "$REQUESTED_ROLES" = "all" ]; then
     return 0
   fi
   local selected
-  IFS=',' read -ra selected <<< "$DEPLOY_FLEET_ROLES"
+  IFS=',' read -ra selected <<< "$REQUESTED_ROLES"
+  for r in "${selected[@]}"; do
+    if [ "$r" = "all" ]; then
+      echo "ERROR: role 'all' cannot be combined with other roles. Use ROLES=all or list concrete roles." >&2
+      exit 1
+    fi
+    if ! valid_role "$r"; then
+      echo "ERROR: unknown deploy role '$r' in roles '$REQUESTED_ROLES'." >&2
+      echo "Expected one of: app, worker, db, logging, redis, all." >&2
+      exit 1
+    fi
+  done
+}
+
+should_deploy_role() {
+  local role="$1"
+  if [ "$REQUESTED_ROLES" = "all" ]; then
+    return 0
+  fi
+  local selected
+  IFS=',' read -ra selected <<< "$REQUESTED_ROLES"
   for r in "${selected[@]}"; do
     if [ "$r" = "$role" ]; then
       return 0
@@ -36,6 +62,8 @@ should_deploy_role() {
   done
   return 1
 }
+
+validate_requested_roles
 
 # Read FLEET_HOSTS from env var, or decrypt from SOPS.
 if [ -z "${FLEET_HOSTS:-}" ]; then
@@ -54,18 +82,25 @@ if [ -z "${FLEET_HOSTS:-}" ]; then
 fi
 
 echo "Reading fleet from FLEET_HOSTS..."
-echo "Deploying roles: $DEPLOY_FLEET_ROLES"
+echo "Deploying roles: $REQUESTED_ROLES"
+DEPLOYED_COUNT=0
 IFS=',' read -ra ENTRIES <<< "$FLEET_HOSTS"
 for entry in "${ENTRIES[@]}"; do
   ROLE="${entry%%:*}"
   IP="${entry#*:}"
   if ! should_deploy_role "$ROLE"; then
-    echo "Skipping $ROLE@$IP (not in DEPLOY_FLEET_ROLES=$DEPLOY_FLEET_ROLES)."
+    echo "Skipping $ROLE@$IP (not in requested roles: $REQUESTED_ROLES)."
     continue
   fi
   echo "--- Deploying $ROLE to $IP ---"
   "$SCRIPT_DIR/deploy.sh" "$ROLE" "$IP" "$SSH_KEY" "$TAG"
   echo "$ROLE@$IP deployed."
+  DEPLOYED_COUNT=$((DEPLOYED_COUNT + 1))
 done
+
+if [ "$DEPLOYED_COUNT" -eq 0 ]; then
+  echo "ERROR: No fleet hosts matched requested roles: $REQUESTED_ROLES." >&2
+  exit 1
+fi
 
 echo "Fleet deployment complete."

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -81,6 +81,13 @@ warn_docker_dns_skipped() {
 # testing without touching the script that runs as root.
 DOCKER_DNS_RESOLVERS=(1.1.1.1 8.8.8.8 9.9.9.9)
 
+# App deploys must keep the Cloudflare-facing origin bound on 80/443. The
+# daemon hardening helpers below can restart Docker when daemon.json changes,
+# which recycles Caddy and creates a visible origin outage on a single app
+# host. Keep those checks out of routine app deploys unless an operator is
+# intentionally running maintenance.
+ALLOW_DEPLOY_DOCKER_DAEMON_RESTART="${ALLOW_DEPLOY_DOCKER_DAEMON_RESTART:-0}"
+
 run_worker_host_reconcile() {
   ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
     "sudo -n /opt/143/deploy/scripts/reconcile-worker-host.sh 143-sandbox"
@@ -324,128 +331,136 @@ if [ "$ROLE" = "worker" ]; then
      || { rm -f /opt/143/Dockerfile.dnsmasq.new; exit 1; }"
 fi
 
-# --- Docker log rotation (idempotent) ---
-# Cap container log file growth so a chatty container can't fill the disk.
-# Docker's default json-file driver has no size limit. Logs ship to
-# VictoriaLogs (Vector → 30d retention) on app/worker/logging hosts; the
-# local file is just a buffer plus a crash-recovery window. db and redis
-# hosts have no Vector — the local file is the only copy — so db gets a
-# larger cap because postgresql.conf logs every connection, every query
-# >500ms, and every lock wait, and the entire trail is local-only.
-#
-# Sync the helper, then call it via deploy+sudo (matches sandbox-firewall.sh
-# pattern). The script is idempotent and only restarts docker when the
-# content of /etc/docker/daemon.json actually changes, so steady-state
-# deploys cost nothing.
-case "$ROLE" in
-  db) LOG_MAX_SIZE="500m" ;;  # postgres logs are verbose AND local-only
-  *)  LOG_MAX_SIZE="100m" ;;
-esac
-LOG_MAX_FILE="5"
-LOG_ROTATION_READY=1
+if [ "$ROLE" = "app" ] && [ "$ALLOW_DEPLOY_DOCKER_DAEMON_RESTART" != "1" ]; then
+  echo "Skipping docker log rotation check on app deploy; set ALLOW_DEPLOY_DOCKER_DAEMON_RESTART=1 for explicit maintenance."
+else
+  # --- Docker log rotation (idempotent) ---
+  # Cap container log file growth so a chatty container can't fill the disk.
+  # Docker's default json-file driver has no size limit. Logs ship to
+  # VictoriaLogs (Vector → 30d retention) on app/worker/logging hosts; the
+  # local file is just a buffer plus a crash-recovery window. db and redis
+  # hosts have no Vector — the local file is the only copy — so db gets a
+  # larger cap because postgresql.conf logs every connection, every query
+  # >500ms, and every lock wait, and the entire trail is local-only.
+  #
+  # Sync the helper, then call it via deploy+sudo (matches sandbox-firewall.sh
+  # pattern). The script is idempotent and only restarts docker when the
+  # content of /etc/docker/daemon.json actually changes, so steady-state
+  # deploys cost nothing.
+  case "$ROLE" in
+    db) LOG_MAX_SIZE="500m" ;;  # postgres logs are verbose AND local-only
+    *)  LOG_MAX_SIZE="100m" ;;
+  esac
+  LOG_MAX_FILE="5"
+  LOG_ROTATION_READY=1
 
-# Sync install-log-rotation.sh: stage to .new, atomic rename. Same ETXTBSY
-# avoidance as sandbox-firewall.sh — a lingering FD on the old inode would
-# break the subsequent `sudo install-log-rotation.sh` exec.
-ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-  "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
-if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
-    deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new; then
-  echo "install-log-rotation.sh sync failed; trying no-teardown deploy sudoers repair..."
-  if repair_deploy_sudoers; then
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-      "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
-    scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
-      deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new
-  else
-    warn_log_rotation_skipped
-    LOG_ROTATION_READY=0
-  fi
-fi
-if [ "$LOG_ROTATION_READY" -eq 1 ]; then
-  if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
-     && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh \
-     || { rm -f /opt/143/deploy/scripts/install-log-rotation.sh.new; exit 1; }"; then
-    warn_log_rotation_skipped
-    LOG_ROTATION_READY=0
-  fi
-fi
-
-if [ "$LOG_ROTATION_READY" -eq 1 ]; then
-  echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
-  # `sudo -n` so missing-sudoers fails fast instead of hanging on a password
-  # prompt CI can't satisfy. If the repair path also isn't available, keep the
-  # deploy moving: log rotation is an operational hardening step, not the app
-  # or database rollout itself.
-  run_log_rotation() {
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-      "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"
-  }
-  if ! run_log_rotation; then
-    echo "install-log-rotation.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+  # Sync install-log-rotation.sh: stage to .new, atomic rename. Same ETXTBSY
+  # avoidance as sandbox-firewall.sh — a lingering FD on the old inode would
+  # break the subsequent `sudo install-log-rotation.sh` exec.
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+  if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
+      deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new; then
+    echo "install-log-rotation.sh sync failed; trying no-teardown deploy sudoers repair..."
     if repair_deploy_sudoers; then
-      echo "Retrying docker log rotation after sudoers repair..."
-      if ! run_log_rotation; then
-        warn_log_rotation_skipped
-      fi
+      ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+        "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+      scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-log-rotation.sh" \
+        deploy@"$HOST":/opt/143/deploy/scripts/install-log-rotation.sh.new
     else
       warn_log_rotation_skipped
+      LOG_ROTATION_READY=0
+    fi
+  fi
+  if [ "$LOG_ROTATION_READY" -eq 1 ]; then
+    if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+      "mv /opt/143/deploy/scripts/install-log-rotation.sh.new /opt/143/deploy/scripts/install-log-rotation.sh \
+       && chmod +x /opt/143/deploy/scripts/install-log-rotation.sh \
+       || { rm -f /opt/143/deploy/scripts/install-log-rotation.sh.new; exit 1; }"; then
+      warn_log_rotation_skipped
+      LOG_ROTATION_READY=0
+    fi
+  fi
+
+  if [ "$LOG_ROTATION_READY" -eq 1 ]; then
+    echo "Ensuring docker log rotation (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE)..."
+    # `sudo -n` so missing-sudoers fails fast instead of hanging on a password
+    # prompt CI can't satisfy. If the repair path also isn't available, keep the
+    # deploy moving: log rotation is an operational hardening step, not the app
+    # or database rollout itself.
+    run_log_rotation() {
+      ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+        "sudo -n /opt/143/deploy/scripts/install-log-rotation.sh $LOG_MAX_SIZE $LOG_MAX_FILE"
+    }
+    if ! run_log_rotation; then
+      echo "install-log-rotation.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+      if repair_deploy_sudoers; then
+        echo "Retrying docker log rotation after sudoers repair..."
+        if ! run_log_rotation; then
+          warn_log_rotation_skipped
+        fi
+      else
+        warn_log_rotation_skipped
+      fi
     fi
   fi
 fi
 
-# --- Docker daemon DNS resolvers (idempotent) ---
-# Pin /etc/docker/daemon.json's `dns` list to multiple independent
-# resolvers so a single upstream DNS outage doesn't take every container's
-# outbound DNS down at once. The 2026-05-07T04:15Z incident hit three
-# workers simultaneously this way (sandboxes couldn't resolve chatgpt.com,
-# workers couldn't resolve github.com) because the embedded resolver at
-# 127.0.0.11 inherits a single host resolv.conf entry by default.
-#
-# Sync + invoke pattern mirrors install-log-rotation.sh above.
-DOCKER_DNS_READY=1
+if [ "$ROLE" = "app" ] && [ "$ALLOW_DEPLOY_DOCKER_DAEMON_RESTART" != "1" ]; then
+  echo "Skipping docker daemon DNS check on app deploy; set ALLOW_DEPLOY_DOCKER_DAEMON_RESTART=1 for explicit maintenance."
+else
+  # --- Docker daemon DNS resolvers (idempotent) ---
+  # Pin /etc/docker/daemon.json's `dns` list to multiple independent
+  # resolvers so a single upstream DNS outage doesn't take every container's
+  # outbound DNS down at once. The 2026-05-07T04:15Z incident hit three
+  # workers simultaneously this way (sandboxes couldn't resolve chatgpt.com,
+  # workers couldn't resolve github.com) because the embedded resolver at
+  # 127.0.0.11 inherits a single host resolv.conf entry by default.
+  #
+  # Sync + invoke pattern mirrors install-log-rotation.sh above.
+  DOCKER_DNS_READY=1
 
-ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-  "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
-if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-docker-dns.sh" \
-    deploy@"$HOST":/opt/143/deploy/scripts/install-docker-dns.sh.new; then
-  echo "install-docker-dns.sh sync failed; trying no-teardown deploy sudoers repair..."
-  if repair_deploy_sudoers; then
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-      "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
-    scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-docker-dns.sh" \
-      deploy@"$HOST":/opt/143/deploy/scripts/install-docker-dns.sh.new
-  else
-    warn_docker_dns_skipped
-    DOCKER_DNS_READY=0
-  fi
-fi
-if [ "$DOCKER_DNS_READY" -eq 1 ]; then
-  if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-    "mv /opt/143/deploy/scripts/install-docker-dns.sh.new /opt/143/deploy/scripts/install-docker-dns.sh \
-     && chmod +x /opt/143/deploy/scripts/install-docker-dns.sh \
-     || { rm -f /opt/143/deploy/scripts/install-docker-dns.sh.new; exit 1; }"; then
-    warn_docker_dns_skipped
-    DOCKER_DNS_READY=0
-  fi
-fi
-
-if [ "$DOCKER_DNS_READY" -eq 1 ]; then
-  echo "Ensuring docker daemon DNS resolvers (${DOCKER_DNS_RESOLVERS[*]})..."
-  run_docker_dns() {
-    ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
-      "sudo -n /opt/143/deploy/scripts/install-docker-dns.sh ${DOCKER_DNS_RESOLVERS[*]}"
-  }
-  if ! run_docker_dns; then
-    echo "install-docker-dns.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+  ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+    "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+  if ! scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-docker-dns.sh" \
+      deploy@"$HOST":/opt/143/deploy/scripts/install-docker-dns.sh.new; then
+    echo "install-docker-dns.sh sync failed; trying no-teardown deploy sudoers repair..."
     if repair_deploy_sudoers; then
-      echo "Retrying docker daemon DNS pinning after sudoers repair..."
-      if ! run_docker_dns; then
-        warn_docker_dns_skipped
-      fi
+      ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+        "sudo -n chown -R deploy:deploy /opt/143/deploy/scripts 2>&1 | sed 's/^/  chown: /' || true"
+      scp -p "${SCP_OPTS[@]}" "$PROJECT_DIR/deploy/scripts/install-docker-dns.sh" \
+        deploy@"$HOST":/opt/143/deploy/scripts/install-docker-dns.sh.new
     else
       warn_docker_dns_skipped
+      DOCKER_DNS_READY=0
+    fi
+  fi
+  if [ "$DOCKER_DNS_READY" -eq 1 ]; then
+    if ! ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+      "mv /opt/143/deploy/scripts/install-docker-dns.sh.new /opt/143/deploy/scripts/install-docker-dns.sh \
+       && chmod +x /opt/143/deploy/scripts/install-docker-dns.sh \
+       || { rm -f /opt/143/deploy/scripts/install-docker-dns.sh.new; exit 1; }"; then
+      warn_docker_dns_skipped
+      DOCKER_DNS_READY=0
+    fi
+  fi
+
+  if [ "$DOCKER_DNS_READY" -eq 1 ]; then
+    echo "Ensuring docker daemon DNS resolvers (${DOCKER_DNS_RESOLVERS[*]})..."
+    run_docker_dns() {
+      ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
+        "sudo -n /opt/143/deploy/scripts/install-docker-dns.sh ${DOCKER_DNS_RESOLVERS[*]}"
+    }
+    if ! run_docker_dns; then
+      echo "install-docker-dns.sh failed under deploy+sudo; trying no-teardown deploy sudoers repair..."
+      if repair_deploy_sudoers; then
+        echo "Retrying docker daemon DNS pinning after sudoers repair..."
+        if ! run_docker_dns; then
+          warn_docker_dns_skipped
+        fi
+      else
+        warn_docker_dns_skipped
+      fi
     fi
   fi
 fi

--- a/docs/design/10-infrastructure.md
+++ b/docs/design/10-infrastructure.md
@@ -230,9 +230,12 @@ This image is used by the Docker sandbox provider. It runs under **gVisor** (`ru
 
 ### Deploy-Time Host Hardening
 
+Routine fleet deploys roll only the user-facing runtime roles, `app` and `worker`. Stateful/supporting roles (`db`, `redis`, `logging`) are deployed explicitly with `make deploy-db`, `make deploy-redis`, `make deploy-logging`, or `DEPLOY_FLEET_ROLES=all make deploy-fleet` during maintenance. This keeps frequent application deploys from recreating Postgres, Redis, Grafana, or other non-runtime services.
+
 Fleet deploys attempt to keep host hardening in place as they roll services:
 
 - Docker `json-file` log rotation is installed through `deploy/scripts/install-log-rotation.sh`, which merges the desired `log-driver` and `log-opts` into `/etc/docker/daemon.json` and restarts Docker only when the file changes.
+- App-role deploys skip Docker-daemon-mutating hardening checks by default because a Docker restart recycles Caddy and briefly unbinds ports `80`/`443`, which Cloudflare surfaces as origin downtime. Operators can opt in for explicit maintenance with `ALLOW_DEPLOY_DOCKER_DAEMON_RESTART=1`.
 - The deploy user receives a narrow `NOPASSWD` sudoers grant during provisioning so routine deploys can run the log-rotation helper and worker firewall helper without broad root access. Worker cloud-init installs the same grant on first boot, because those hosts can start successfully from user-data before any operator runs SSH provisioning.
 - Existing hosts that predate a sudoers entry are repaired through `deploy/scripts/repair-deploy-sudoers.sh` when root SSH is available.
 - If a routine deploy cannot repair sudoers from CI, Docker log-rotation update failure is warning-only. The service rollout continues, and operators can run `make repair-deploy-sudoers ROLE=<role> HOST=<host>` later from a machine with root SSH access.

--- a/docs/design/10-infrastructure.md
+++ b/docs/design/10-infrastructure.md
@@ -230,7 +230,7 @@ This image is used by the Docker sandbox provider. It runs under **gVisor** (`ru
 
 ### Deploy-Time Host Hardening
 
-Routine fleet deploys roll only the user-facing runtime roles, `app` and `worker`. Stateful/supporting roles (`db`, `redis`, `logging`) are deployed explicitly with `make deploy-db`, `make deploy-redis`, `make deploy-logging`, or `DEPLOY_FLEET_ROLES=all make deploy-fleet` during maintenance. This keeps frequent application deploys from recreating Postgres, Redis, Grafana, or other non-runtime services.
+Routine fleet deploys roll only the user-facing runtime roles, `app` and `worker`. Stateful/supporting roles (`db`, `redis`, `logging`) are deployed explicitly with `make deploy-db`, `make deploy-redis`, `make deploy-logging`, or `make deploy-fleet ROLES=all` during maintenance. `make deploy-fleet TAG=<image-tag> ROLES=<roles>` is the operator-facing shape for deploying a specific image tag to a selected role set. This keeps frequent application deploys from recreating Postgres, Redis, Grafana, or other non-runtime services.
 
 Fleet deploys attempt to keep host hardening in place as they roll services:
 

--- a/docs/design/overall.md
+++ b/docs/design/overall.md
@@ -531,6 +531,8 @@ After the core loop is proven with Sentry:
 
 No service discovery or orchestrator required. A new node joins the cluster by pointing at the same `DATABASE_URL`. See [10-infrastructure.md](10-infrastructure.md) for full details.
 
+Routine production fleet deploys target only `app` and `worker` roles. DB, Redis, and logging rollouts are explicit maintenance actions, and app-host Docker daemon restarts require an explicit maintenance flag so frequent deploys do not recycle the Caddy origin in front of Cloudflare.
+
 ## Systems
 
 ### PostgreSQL


### PR DESCRIPTION
## Summary
Routine fleet deploys now target only the user-facing runtime roles (`app,worker`) to avoid unnecessary disruption during main-branch deploys. App deploys also skip Docker-daemon-mutating log rotation and DNS checks unless explicitly enabled, preventing avoidable Docker/Caddy restarts and related downtime (e.g., when Cloudflare is down).

## Changes
- **Makefile**
  - Documented that `deploy-fleet` defaults to app+worker and added a clear maintenance escape hatch: `DEPLOY_FLEET_ROLES=all`.
- **deploy/scripts/deploy-fleet.sh**
  - Default `DEPLOY_FLEET_ROLES` to `${DEPLOY_FLEET_ROLES:-app,worker}` for routine deploys.
  - Centralized role filtering via `should_deploy_role()` so only intended roles run for each `FLEET_HOSTS` entry.
  - Added clearer logging for intentionally skipped maintenance roles.
- **deploy/scripts/deploy.sh**
  - Guarded Docker-daemon-mutating steps (log rotation / DNS checks) so routine app deploys won’t restart Docker or recycle Caddy.
  - Requires `ALLOW_DEPLOY_DOCKER_DAEMON_RESTART=1` to opt into those maintenance-capable behaviors.
- **deploy/deploy_config_test.go**
  - Added tests asserting:
    - fleet deploy defaults to `app,worker`
    - maintenance can use `DEPLOY_FLEET_ROLES=all` or subsets
    - CI invokes `deploy-fleet.sh` with the default role set
    - app deploy skips the daemon-mutating log rotation/DNS checks unless the explicit flag is set.
- **docs/design/10-infrastructure.md** and **docs/design/overall.md**
  - Updated deployment design to reflect the new default runtime-role behavior and maintenance opt-in flow.

## Test plan
- `bash -n deploy/scripts/deploy.sh`
- `bash -n deploy/scripts/deploy-fleet.sh`
- `go test ./deploy`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

[143.dev](https://143.dev) | [session d9252c7b](https://143.dev/sessions/d9252c7b-ba93-483f-b78d-ec1cd1c5a881)