### PR TITLE
Warm CSRF on public auth routes

### DIFF
--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -724,14 +724,18 @@ func NewRouter(cfg *config.Config, pool *pgxpool.Pool, logger zerolog.Logger, se
 		// bucket only — exactly the guarantee this public route needs.
 		r.With(middleware.ClaimRateLimit(10)).Post("/api/v1/team/invitations/accept", teamHandler.AcceptInvitation)
 
-		// Auth routes (no auth)
-		r.Get("/api/v1/auth/providers", authHandler.Providers)
-		r.Get("/api/v1/auth/github/login", authHandler.Login)
-		r.Get("/api/v1/auth/github/callback", authHandler.Callback)
-		r.Get("/api/v1/auth/google/login", authHandler.GoogleLogin)
-		r.Get("/api/v1/auth/google/callback", authHandler.GoogleCallback)
-		r.Post("/api/v1/auth/register", authHandler.Register)
-		r.Post("/api/v1/auth/login", authHandler.EmailLogin)
+		// Auth routes (no auth). CSRF still wraps this group so safe public
+		// auth reads warm the double-submit cookie before email login/register.
+		r.Group(func(r chi.Router) {
+			r.Use(middleware.CSRF(cfg.CSRFSigningKey, logger))
+			r.Get("/api/v1/auth/providers", authHandler.Providers)
+			r.Get("/api/v1/auth/github/login", authHandler.Login)
+			r.Get("/api/v1/auth/github/callback", authHandler.Callback)
+			r.Get("/api/v1/auth/google/login", authHandler.GoogleLogin)
+			r.Get("/api/v1/auth/google/callback", authHandler.GoogleCallback)
+			r.Post("/api/v1/auth/register", authHandler.Register)
+			r.Post("/api/v1/auth/login", authHandler.EmailLogin)
+		})
 
 		// Protected routes (authenticated)
 		r.Group(func(r chi.Router) {

--- a/internal/api/router_test.go
+++ b/internal/api/router_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/assembledhq/143/internal/api/middleware"
 	"github.com/assembledhq/143/internal/cache"
 	"github.com/assembledhq/143/internal/config"
 	"github.com/assembledhq/143/internal/db"
@@ -173,6 +174,43 @@ func TestNewRouter_BuildsWithoutOptionalReviewWiring(t *testing.T) {
 	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	require.NoError(t, err, "NewRouter should still construct the router without session-review wiring")
 	require.NotNil(t, router, "NewRouter should still construct the router without session-review wiring")
+}
+
+func TestNewRouter_PublicAuthRoutesWarmAndRequireCSRF(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		CSRFSigningKey: "test-signing-key-that-is-long-enough",
+	}
+	codexSvc := codexauth.NewService(nil, zerolog.Nop())
+	claudeSvc := claudecodeauth.NewService(nil, zerolog.Nop())
+
+	router, _, _, _, _, err := NewRouter(cfg, nil, zerolog.Nop(), nil, codexSvc, claudeSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err, "NewRouter should build successfully for public auth CSRF wiring")
+	require.NotNil(t, router, "NewRouter should construct a router for public auth CSRF wiring")
+
+	providersReq := httptest.NewRequest(http.MethodGet, "/api/v1/auth/providers", nil)
+	providersRR := httptest.NewRecorder()
+	router.ServeHTTP(providersRR, providersReq)
+
+	require.Equal(t, http.StatusOK, providersRR.Code, "public auth provider lookup should still succeed")
+	var csrfCookie *http.Cookie
+	for _, cookie := range providersRR.Result().Cookies() {
+		if cookie.Name == middleware.CSRFCookieName {
+			csrfCookie = cookie
+			break
+		}
+	}
+	require.NotNil(t, csrfCookie, "public auth provider lookup should warm a CSRF cookie for the login form")
+	require.False(t, csrfCookie.HttpOnly, "CSRF cookie must be readable by the frontend login form")
+
+	loginReq := httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(`{"email":"preview-admin@143.dev","password":"preview"}`))
+	loginReq.Header.Set("Content-Type", "application/json")
+	loginRR := httptest.NewRecorder()
+	router.ServeHTTP(loginRR, loginReq)
+
+	require.Equal(t, http.StatusForbidden, loginRR.Code, "public email login should require a CSRF token before reaching the handler")
+	require.Contains(t, loginRR.Body.String(), "missing CSRF cookie", "missing public auth CSRF should return the middleware error")
 }
 
 func TestNewRouter_InternalPreviewRoutesSkipGlobalBodyLimit(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wrap public auth routes in CSRF middleware so safe GETs set the `csrf_token` cookie before the login form renders.
- Keep email login and registration protected by CSRF instead of leaving the preview login page stuck in the disabled state.
- Add a router regression test that verifies the cookie is warmed and POST login is rejected without it.

## Testing
- `go test ./internal/api -run TestNewRouter_PublicAuthRoutesWarmAndRequireCSRF -count=1`
- `go vet ./...`
- `go build ./...`
- `go test ./...`