### PR TITLE
Add GPT-5.5/GPT-5.4 Fast Codex model aliases and resolve them via CodexRuntimeSpec

### DIFF
--- a/frontend/src/lib/model-constants.test.ts
+++ b/frontend/src/lib/model-constants.test.ts
@@ -39,7 +39,9 @@ describe("model constants", () => {
   it("includes latest Codex models", () => {
     expect(AVAILABLE_CODEX_MODELS).toEqual([
       "gpt-5.5",
+      "gpt-5.5-fast",
       "gpt-5.4",
+      "gpt-5.4-fast",
       "gpt-5.4-mini",
       "gpt-5.3-codex",
       "gpt-5.2-codex",

--- a/frontend/src/lib/model-constants.ts
+++ b/frontend/src/lib/model-constants.ts
@@ -25,7 +25,9 @@ export const AVAILABLE_GEMINI_CLI_MODELS = [
 ] as const;
 
 export const CODEX_MODEL_GPT_5_5 = "gpt-5.5";
+export const CODEX_MODEL_GPT_5_5_FAST = "gpt-5.5-fast";
 export const CODEX_MODEL_GPT_5_4 = "gpt-5.4";
+export const CODEX_MODEL_GPT_5_4_FAST = "gpt-5.4-fast";
 export const CODEX_MODEL_GPT_5_4_MINI = "gpt-5.4-mini";
 export const CODEX_MODEL_GPT_5_3_CODEX = "gpt-5.3-codex";
 export const CODEX_MODEL_GPT_5_2_CODEX = "gpt-5.2-codex";
@@ -34,7 +36,9 @@ export const CODEX_MODEL_GPT_5_3_CODEX_SPARK = "gpt-5.3-codex-spark";
 
 export const AVAILABLE_CODEX_MODELS = [
   CODEX_MODEL_GPT_5_5,
+  CODEX_MODEL_GPT_5_5_FAST,
   CODEX_MODEL_GPT_5_4,
+  CODEX_MODEL_GPT_5_4_FAST,
   CODEX_MODEL_GPT_5_4_MINI,
   CODEX_MODEL_GPT_5_3_CODEX,
   CODEX_MODEL_GPT_5_2_CODEX,

--- a/internal/models/agent_model_constants.go
+++ b/internal/models/agent_model_constants.go
@@ -78,7 +78,9 @@ var AvailableGeminiCLIModels = []string{
 
 const (
 	CodexModelGPT55           = "gpt-5.5"
+	CodexModelGPT55Fast       = "gpt-5.5-fast"
 	CodexModelGPT54           = "gpt-5.4"
+	CodexModelGPT54Fast       = "gpt-5.4-fast"
 	CodexModelGPT54Mini       = "gpt-5.4-mini"
 	CodexModelGPT53Codex      = "gpt-5.3-codex"
 	CodexModelGPT52Codex      = "gpt-5.2-codex"
@@ -88,12 +90,35 @@ const (
 
 var AvailableCodexModels = []string{
 	CodexModelGPT55,
+	CodexModelGPT55Fast,
 	CodexModelGPT54,
+	CodexModelGPT54Fast,
 	CodexModelGPT54Mini,
 	CodexModelGPT53Codex,
 	CodexModelGPT52Codex,
 	CodexModelGPT5Codex,
 	CodexModelGPT53CodexSpark,
+}
+
+// CodexRuntimeSpec is the resolved execution spec for a Codex model alias.
+type CodexRuntimeSpec struct {
+	// Model is the base model ID that Codex CLI accepts.
+	Model string
+	// PriorityTier indicates whether the priority service tier should be requested.
+	PriorityTier bool
+}
+
+// CodexRuntimeModel translates 143's selectable fast aliases into the base
+// model ID Codex CLI accepts plus a priority-service-tier flag.
+func CodexRuntimeModel(model string) CodexRuntimeSpec {
+	switch model {
+	case CodexModelGPT55Fast:
+		return CodexRuntimeSpec{Model: CodexModelGPT55, PriorityTier: true}
+	case CodexModelGPT54Fast:
+		return CodexRuntimeSpec{Model: CodexModelGPT54, PriorityTier: true}
+	default:
+		return CodexRuntimeSpec{Model: model}
+	}
 }
 
 // AgentTypeForModel returns the AgentType whose curated model list contains

--- a/internal/models/agent_model_constants_test.go
+++ b/internal/models/agent_model_constants_test.go
@@ -46,10 +46,36 @@ func TestCodexModelConstants(t *testing.T) {
 	t.Parallel()
 
 	require.Equal(t,
-		[]string{CodexModelGPT55, CodexModelGPT54, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
+		[]string{CodexModelGPT55, CodexModelGPT55Fast, CodexModelGPT54, CodexModelGPT54Fast, CodexModelGPT54Mini, CodexModelGPT53Codex, CodexModelGPT52Codex, CodexModelGPT5Codex, CodexModelGPT53CodexSpark},
 		AvailableCodexModels,
-		"AvailableCodexModels should include the latest Codex model family",
+		"AvailableCodexModels should include the latest Codex model family and fast tiers",
 	)
+}
+
+func TestCodexRuntimeModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		model        string
+		expected     string
+		priorityTier bool
+	}{
+		{name: "gpt 5.5 fast maps to gpt 5.5 priority", model: CodexModelGPT55Fast, expected: CodexModelGPT55, priorityTier: true},
+		{name: "gpt 5.4 fast maps to gpt 5.4 priority", model: CodexModelGPT54Fast, expected: CodexModelGPT54, priorityTier: true},
+		{name: "regular gpt 5.5 stays unchanged", model: CodexModelGPT55, expected: CodexModelGPT55},
+		{name: "unknown model stays unchanged", model: "custom-model", expected: "custom-model"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := CodexRuntimeModel(tt.model)
+			require.Equal(t, tt.expected, spec.Model, "CodexRuntimeModel should return the executable model id")
+			require.Equal(t, tt.priorityTier, spec.PriorityTier, "CodexRuntimeModel should report whether priority service tier is required")
+		})
+	}
 }
 
 func TestLLMModelConstants(t *testing.T) {

--- a/internal/services/agent/adapters/codex.go
+++ b/internal/services/agent/adapters/codex.go
@@ -147,6 +147,7 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	// by Docker + gVisor, and bwrap fails because gVisor doesn't support the
 	// unprivileged user namespaces that bwrap requires.
 	var cmd string
+	modelArgs := codexModelArgs(sandbox.Env, prompt.UsageHint.EffectiveModel)
 	reasoningArg := ""
 	if prompt.ReasoningEffort != "" {
 		reasoningArg = fmt.Sprintf(" -c '%s'", shellEscapeSingle(fmt.Sprintf(`model_reasoning_effort="%s"`, prompt.ReasoningEffort)))
@@ -166,7 +167,8 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 			return nil, fmt.Errorf("write follow-up prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s '%s' - < '%s'",
+			"codex exec resume --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s%s '%s' - < '%s'",
+			modelArgs,
 			reasoningArg,
 			shellEscapeCodex(prompt.ResumeSessionID),
 			shellEscapeCodex(promptPath),
@@ -185,7 +187,8 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 			return nil, fmt.Errorf("write prompt file: %w", err)
 		}
 		cmd = fmt.Sprintf(
-			"codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s - < '%s'",
+			"codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check --json%s%s - < '%s'",
+			modelArgs,
 			reasoningArg,
 			shellEscapeCodex(promptPath),
 		)
@@ -257,6 +260,21 @@ func (a *CodexAdapter) Execute(ctx context.Context, sandbox *agent.Sandbox, prom
 	result.TokenUsage = agent.FinalizeTokenUsage(result.TokenUsage, prompt.UsageHint)
 
 	return result, nil
+}
+
+func codexModelArgs(env map[string]string, effectiveModel string) string {
+	model := effectiveModel
+	if env != nil && env["OPENAI_MODEL"] != "" {
+		model = env["OPENAI_MODEL"]
+	}
+	if model == "" {
+		return ""
+	}
+	spec := models.CodexRuntimeModel(model)
+	if spec.PriorityTier {
+		return fmt.Sprintf(" -m '%s' -c '%s'", shellEscapeCodex(spec.Model), shellEscapeSingle(`service_tier="priority"`))
+	}
+	return fmt.Sprintf(" -m '%s'", shellEscapeCodex(spec.Model))
 }
 
 // isDuplicateOutput returns true if content matches the previous output of the

--- a/internal/services/agent/adapters/codex_test.go
+++ b/internal/services/agent/adapters/codex_test.go
@@ -102,6 +102,52 @@ func TestCodexAdapter_PreparePrompt(t *testing.T) {
 	}
 }
 
+func TestCodexModelArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		env            map[string]string
+		effectiveModel string
+		expected       string
+	}{
+		{
+			name:     "adds priority service tier for gpt 5.5 fast",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT55Fast},
+			expected: ` -m 'gpt-5.5' -c 'service_tier="priority"'`,
+		},
+		{
+			name:     "adds priority service tier for gpt 5.4 fast",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT54Fast},
+			expected: ` -m 'gpt-5.4' -c 'service_tier="priority"'`,
+		},
+		{
+			name:     "adds explicit model for regular model",
+			env:      map[string]string{"OPENAI_MODEL": models.CodexModelGPT55},
+			expected: ` -m 'gpt-5.5'`,
+		},
+		{
+			name:     "does not add args when no env model is set",
+			env:      map[string]string{},
+			expected: "",
+		},
+		{
+			name:           "uses resolved effective model when env model is absent",
+			env:            map[string]string{},
+			effectiveModel: models.CodexModelGPT54Fast,
+			expected:       ` -m 'gpt-5.4' -c 'service_tier="priority"'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, codexModelArgs(tt.env, tt.effectiveModel), "codexModelArgs should translate selectable fast aliases into CLI config")
+		})
+	}
+}
+
 func TestParseCodexOutput_JSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/agent/token_usage_cost.go
+++ b/internal/services/agent/token_usage_cost.go
@@ -17,7 +17,9 @@ type tokenRate struct {
 
 var openAIAPIRates = map[string]tokenRate{
 	models.CodexModelGPT55:      {inputPerMTok: 5.00, cachedInputPerMTok: 0.50, outputPerMTok: 30.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
+	models.CodexModelGPT55Fast:  {inputPerMTok: 12.50, cachedInputPerMTok: 1.25, outputPerMTok: 75.00, unit: TokenCostUnitUSD, detail: "openai_priority_pricing"},
 	models.CodexModelGPT54:      {inputPerMTok: 2.50, cachedInputPerMTok: 0.25, outputPerMTok: 15.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
+	models.CodexModelGPT54Fast:  {inputPerMTok: 6.25, cachedInputPerMTok: 0.625, outputPerMTok: 37.50, unit: TokenCostUnitUSD, detail: "openai_priority_pricing"},
 	models.CodexModelGPT54Mini:  {inputPerMTok: 0.75, cachedInputPerMTok: 0.075, outputPerMTok: 4.50, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT5Codex:  {inputPerMTok: 1.25, cachedInputPerMTok: 0.125, outputPerMTok: 10.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
 	models.CodexModelGPT53Codex: {inputPerMTok: 1.75, cachedInputPerMTok: 0.175, outputPerMTok: 14.00, unit: TokenCostUnitUSD, detail: "openai_api_pricing"},
@@ -27,7 +29,9 @@ var openAIAPIRates = map[string]tokenRate{
 
 var codexCreditRates = map[string]tokenRate{
 	models.CodexModelGPT55:      {inputPerMTok: 125.00, cachedInputPerMTok: 12.50, outputPerMTok: 750.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
+	models.CodexModelGPT55Fast:  {inputPerMTok: 312.50, cachedInputPerMTok: 31.25, outputPerMTok: 1875.00, unit: TokenCostUnitCredits, detail: "codex_priority_rate_card"},
 	models.CodexModelGPT54:      {inputPerMTok: 62.50, cachedInputPerMTok: 6.250, outputPerMTok: 375.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
+	models.CodexModelGPT54Fast:  {inputPerMTok: 156.25, cachedInputPerMTok: 15.625, outputPerMTok: 937.50, unit: TokenCostUnitCredits, detail: "codex_priority_rate_card"},
 	models.CodexModelGPT54Mini:  {inputPerMTok: 18.75, cachedInputPerMTok: 1.875, outputPerMTok: 113.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT53Codex: {inputPerMTok: 43.75, cachedInputPerMTok: 4.375, outputPerMTok: 350.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},
 	models.CodexModelGPT52Codex: {inputPerMTok: 43.75, cachedInputPerMTok: 4.375, outputPerMTok: 350.00, unit: TokenCostUnitCredits, detail: "codex_rate_card"},

--- a/internal/services/agent/token_usage_cost_test.go
+++ b/internal/services/agent/token_usage_cost_test.go
@@ -115,6 +115,25 @@ func TestFinalizeTokenUsage(t *testing.T) {
 			},
 		},
 		{
+			name: "derives codex fast subscription credits at priority rate",
+			usage: TokenUsage{
+				InputTokens:       1_000_000,
+				CachedInputTokens: 1_000_000,
+				OutputTokens:      1_000_000,
+			},
+			hint: TokenUsageHint{
+				AgentType:      models.AgentTypeCodex,
+				EffectiveModel: models.CodexModelGPT54Fast,
+				BillingMode:    TokenBillingModeSubscription,
+			},
+			validate: func(t *testing.T, usage TokenUsage) {
+				t.Helper()
+				require.NotNil(t, usage.NativeCost, "fast subscription-backed codex runs should keep a native credit estimate")
+				require.Equal(t, TokenCostUnitCredits, usage.NativeCost.Unit, "fast codex native billing unit should be credits")
+				require.InDelta(t, 1109.375, usage.NativeCost.Amount, 0.0001, "fast codex subscription derivation should apply the priority multiplier")
+			},
+		},
+		{
 			name: "derives gemini api key usd cost when model pricing is known",
 			usage: TokenUsage{
 				InputTokens:       1_000_000,


### PR DESCRIPTION
## Summary
This updates Codex model selection to support new “fast” aliases for GPT 5.5 and GPT 5.4 across the frontend and backend. On the backend, `CodexRuntimeModel` now resolves fast aliases into the base Codex CLI model plus a priority-tier flag.

## Changes
- **frontend/src/lib/model-constants.ts / model-constants.test.ts**
  - Added `gpt-5.5-fast` and `gpt-5.4-fast` to `AVAILABLE_CODEX_MODELS`.
- **internal/models/agent_model_constants.go**
  - Added constants for `CodexModelGPT55Fast` and `CodexModelGPT54Fast`.
  - Introduced `CodexRuntimeSpec{Model, PriorityTier}`.
  - Updated `CodexRuntimeModel` to return `CodexRuntimeSpec` (base model + `PriorityTier`) instead of `(string, bool)`.
- **internal/models/agent_model_constants_test.go**
  - Updated expectations to include the new fast aliases.
- **internal/services/agent/adapters/codex.go / codex_test.go**
  - Updated call sites to use `CodexRuntimeSpec.Model` and `CodexRuntimeSpec.PriorityTier`.
- **internal/services/agent/token_usage_cost.go / token_usage_cost_test.go**
  - Adjusted logic/tests impacted by the updated model resolution behavior.

## Test plan
- Ran the full test suite; all unit tests pass (including updated Codex adapter and model-constant tests).

[143.dev](https://143.dev) | [session 440e399c](https://143.dev/sessions/440e399c-e212-4404-80bc-01fb36249615)