### PR TITLE
Unify swipe archive tray background to single darker amber color

### DIFF
--- a/frontend/src/components/swipe-action-row.test.tsx
+++ b/frontend/src/components/swipe-action-row.test.tsx
@@ -255,6 +255,34 @@ describe('SwipeActionRow', () => {
     expect(container).toHaveAttribute('data-swipe-state', 'committed');
   });
 
+  it('uses a single darker archive tray color while swiping', () => {
+    renderWithProviders(
+      <SwipeActionRow
+        actionLabel="Archive item"
+        actionText="Archive"
+        onAction={() => {}}
+      >
+        <div>Row content</div>
+      </SwipeActionRow>,
+    );
+
+    const surface = screen.getByText('Row content').closest('[data-swipe-surface="true"]');
+    expect(surface).not.toBeNull();
+    const container = surface!.parentElement;
+    expect(container).not.toBeNull();
+
+    fireEvent.touchStart(surface!, {
+      touches: [{ clientX: 220, clientY: 20 }],
+    });
+    fireEvent.touchMove(surface!, {
+      touches: [{ clientX: 120, clientY: 24 }],
+    });
+
+    const colorLayers = container!.querySelectorAll('[data-swipe-action-color="true"]');
+    expect(colorLayers).toHaveLength(1);
+    expect(colorLayers[0]).toHaveClass('bg-amber-600/88');
+  });
+
   it('keeps the trailing archive affordance to two text lines while swiping', () => {
     renderWithProviders(
       <SwipeActionRow

--- a/frontend/src/components/swipe-action-row.tsx
+++ b/frontend/src/components/swipe-action-row.tsx
@@ -307,9 +307,6 @@ export function SwipeActionRow({
       : "closed";
   const trailingActionHidden = state === "closed";
   const actionAreaWidth = trailingActionHidden ? 0 : Math.max(ACTION_WIDTH, offset);
-  const commitThreshold = commitThresholdFor(gestureWidth);
-  const swipeProgress = Math.max(0, Math.min(1, offset / commitThreshold));
-  const progressFill = trailingActionHidden ? 0 : Math.max(0.18, swipeProgress);
   const actionHint = isCommitted
     ? `Release to ${actionText.toLowerCase()}`
     : "Keep swiping";
@@ -347,18 +344,11 @@ export function SwipeActionRow({
         >
           <div
             aria-hidden="true"
+            data-swipe-action-color="true"
             className={cn(
               "absolute inset-0 rounded-r-lg shadow-[inset_1px_0_0_rgba(255,255,255,0.18)] transition-colors duration-150 ease-out",
-              isCommitted ? "bg-amber-700" : "bg-amber-500",
+              isCommitted ? "bg-amber-700" : "bg-amber-600/88",
             )}
-          />
-          <div
-            aria-hidden="true"
-            className={cn(
-              "absolute inset-y-0 right-0 rounded-r-lg transition-all duration-150 ease-out",
-              isCommitted ? "bg-amber-800/90" : "bg-amber-600/88",
-            )}
-            style={{ width: `${progressFill * 100}%` }}
           />
           <Button
             variant="ghost"


### PR DESCRIPTION
## Summary
Updated `SwipeActionRow` so the mobile archive tray uses a single, consistent darker amber surface while swiping (instead of layered light/dark orange panels). This prevents confusing visual banding and keeps the swipe affordance readable during the gesture.

## Changes
- **`frontend/src/components/swipe-action-row.tsx`**
  - Render only one archive tray color layer via `data-swipe-action-color="true"`.
  - Switch the open/active archive surface styling from `bg-amber-500` to `bg-amber-600/88`, while committed still uses `bg-amber-700`.
  - Removed the second, width-based progress fill layer (and its associated progress calculations) so the background remains uniform during the swipe.
- **`frontend/src/components/swipe-action-row.test.tsx`**
  - Added a regression test: verifies that swiping results in **exactly one** swipe action color layer and that it uses `bg-amber-600/88`.

## Test plan
- Ran `npm test -- --run src/components/swipe-action-row.test.tsx`
- Ran `npm run typecheck`
- Ran `npm run lint`
- Ran `npm run build` (existing Next.js workspace/root and deprecated middleware warnings only)

[143.dev](https://143.dev) | [session ddc506db](https://143.dev/sessions/ddc506db-8c0d-42a8-97cf-d46730b9632e)