### PR TITLE
Fix automation interval edit state and disable save until Run every value is valid

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -113,6 +113,77 @@ describe("AutomationDetailPage", () => {
     expect(screen.queryByText(/Run time is in/i)).not.toBeInTheDocument();
   });
 
+  it("allows the interval value to be cleared while editing", async () => {
+    const user = userEvent.setup();
+    let updateBody: Record<string, unknown> | null = null;
+
+    server.use(
+      http.get("*/api/v1/automations/auto-1", () => HttpResponse.json({
+        data: {
+          id: "auto-1",
+          org_id: "org-1",
+          repository_id: "repo-1",
+          name: "Weekly audit",
+          goal: "Check release health",
+          scope: "",
+          interval_value: 1,
+          interval_unit: "hours",
+          base_branch: "main",
+          enabled: true,
+          timezone: "UTC",
+          last_run_at: null,
+          next_run_at: null,
+          priority: 50,
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      })),
+      http.get("*/api/v1/automations/auto-1/runs*", () => HttpResponse.json({ data: [], meta: {} })),
+      http.get("*/api/v1/automations/auto-1/stats*", () => HttpResponse.json({
+        data: {
+          since: "2026-01-01T00:00:00Z",
+          until: "2026-01-31T00:00:00Z",
+          buckets: [],
+          totals: {
+            total: 0,
+            completed: 0,
+            completed_noop: 0,
+            failed: 0,
+            skipped: 0,
+            running: 0,
+            pending: 0,
+            success_rate: 0,
+            avg_duration_seconds: 0,
+          },
+        },
+      })),
+      http.patch("*/api/v1/automations/auto-1", async ({ request }) => {
+        updateBody = await request.json() as Record<string, unknown>;
+        return HttpResponse.json({ data: { id: "auto-1" } });
+      }),
+    );
+
+    renderWithProviders(<AutomationDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Weekly audit")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("tab", { name: "Settings" }));
+    const intervalInput = screen.getByLabelText("Interval value");
+    await user.clear(intervalInput);
+
+    expect(intervalInput).toHaveValue(null);
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+
+    await user.type(intervalInput, "2");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(updateBody).toMatchObject({ interval_value: 2 });
+    });
+  });
+
   it("hides member-only automation actions from builders", async () => {
     currentUserRole.value = "builder";
     server.use(

--- a/frontend/src/app/(dashboard)/automations/[id]/page.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.tsx
@@ -74,7 +74,7 @@ function SettingsTab({
   const [goal, setGoal] = useState(automation.goal);
   const [iconValue, setIconValue] = useState(automation.icon_value || "⚙️");
   const [scope, setScope] = useState(automation.scope ?? "");
-  const [intervalValue, setIntervalValue] = useState(automation.interval_value ?? 1);
+  const [intervalValue, setIntervalValue] = useState(String(automation.interval_value ?? 1));
   const [intervalUnit, setIntervalUnit] = useState<IntervalUnit>(
     toIntervalUnit(automation.interval_unit ?? "days", "days"),
   );
@@ -116,6 +116,11 @@ function SettingsTab({
   const showReasoningSelector = supportsReasoningEffort(effectiveAgentType);
   const reasoningOptions = getCodingAgentReasoningOptions(effectiveAgentType);
   const goalLength = automationGoalLengthState(goal);
+  const parsedIntervalValue = Number(intervalValue.trim());
+  const intervalValueIsValid = intervalValue.trim() !== ""
+    && Number.isInteger(parsedIntervalValue)
+    && parsedIntervalValue >= 1
+    && parsedIntervalValue <= 365;
 
   const updateMutation = useMutation({
     mutationFn: () =>
@@ -125,7 +130,7 @@ function SettingsTab({
         icon_type: "emoji",
         icon_value: iconValue,
         scope: scope.trim() || undefined,
-        interval_value: intervalValue,
+        interval_value: parsedIntervalValue,
         interval_unit: intervalUnit,
         interval_run_at: `${intervalRunHour}:${intervalRunMinute}`,
         timezone,
@@ -223,10 +228,8 @@ function SettingsTab({
               min={1}
               max={365}
               value={intervalValue}
-              onChange={(e) => {
-                const parsed = parseInt(e.target.value, 10);
-                setIntervalValue(Number.isNaN(parsed) ? 1 : Math.max(1, parsed));
-              }}
+              onChange={(e) => setIntervalValue(e.target.value)}
+              aria-invalid={!intervalValueIsValid}
               className="w-20"
             />
             <Select
@@ -367,7 +370,7 @@ function SettingsTab({
         <div className="flex items-center gap-3 pt-2">
           <Button
             onClick={() => updateMutation.mutate()}
-            disabled={updateMutation.isPending || goalLength.isTooLong}
+            disabled={updateMutation.isPending || goalLength.isTooLong || !intervalValueIsValid}
           >
             {updateMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
             Save changes


### PR DESCRIPTION
## Summary
Fix the automation settings form so clearing the **Run every** (“interval value”) field while editing no longer snaps back to `1` due to `NaN` parsing. Save is now prevented until the interval draft is a valid integer within the allowed range, and a regression test was added.

## Changes
- **frontend/src/app/(dashboard)/automations/[id]/page.tsx**
  - Store `intervalValue` as a draft **string** (instead of a number) so the input can be temporarily blank while the user edits.
  - Validate the draft on change:
    - Disable **Save changes** when blank, non-integer, or outside `1..365`.
    - Ensure the API PATCH is only triggered with a parsed, valid number when the user saves.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Add regression test: allows clearing the interval input, keeps it blank temporarily, disables Save, and verifies saving sends `interval_value: 2`.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/automations/[id]/page.test.tsx'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 6e5fdc39](https://143.dev/sessions/6e5fdc39-87f6-4df1-b5b6-96c8ee08d5e5)