### PR TITLE
Stabilize Linear agent dead-letter handling and canonical issue fingerprints

### DIFF
--- a/docs/design/implemented/69-linear-agent.md
+++ b/docs/design/implemented/69-linear-agent.md
@@ -168,6 +168,10 @@ update both sides in the same PR.
 - **Repo unmapped**: `response` activity + AgentSession state pinned
   to `complete`. Treated as a benign user-actionable state, not a
   system error.
+- **Created worker dead-letter before session start**: emit an `error`
+  activity and pin the AgentSession/bridge state to `error` so Linear
+  does not keep showing only the bootstrap "Reading…" thought after the
+  retry budget is exhausted.
 - **Activity emit failure post-Reserve**: row stays present without
   `linear_activity_id`; replays short-circuit on UNIQUE collision.
   Trade-off: prefer "missing activity" to "duplicate notifications".

--- a/internal/db/issue_store_test.go
+++ b/internal/db/issue_store_test.go
@@ -278,7 +278,7 @@ func TestIssueStore_Upsert(t *testing.T) {
 		Fingerprint:           "fp-upsert",
 	}
 
-	mock.ExpectQuery("INSERT INTO issues").
+	mock.ExpectQuery("ON CONFLICT \\(org_id, source, external_id\\) DO UPDATE").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
 			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
@@ -293,6 +293,49 @@ func TestIssueStore_Upsert(t *testing.T) {
 	require.Equal(t, generatedID, issue.ID, "should set the generated ID on the issue")
 	require.Equal(t, now, issue.CreatedAt, "should set the created_at timestamp on the issue")
 	require.Equal(t, now, issue.UpdatedAt, "should set the updated_at timestamp on the issue")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
+}
+
+func TestIssueStore_UpsertPMAgentUsesFingerprintConflictTarget(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "should create mock pool")
+	defer mock.Close()
+
+	store := NewIssueStore(mock)
+	now := time.Now()
+	generatedID := uuid.New()
+
+	issue := &models.Issue{
+		OrgID:                 uuid.New(),
+		ExternalID:            "pm-agent-generated-id",
+		Source:                models.IssueSourcePMAgent,
+		Title:                 "PM Agent Issue",
+		Status:                "open",
+		RawData:               json.RawMessage(`{"key":"value"}`),
+		FirstSeenAt:           now,
+		LastSeenAt:            now,
+		OccurrenceCount:       1,
+		AffectedCustomerCount: 1,
+		Severity:              "medium",
+		Tags:                  []string{"pm"},
+		Fingerprint:           "content-derived-fingerprint",
+	}
+
+	mock.ExpectQuery("ON CONFLICT \\(org_id, fingerprint\\) DO UPDATE").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).
+				AddRow(generatedID, now, now),
+		)
+
+	err = store.Upsert(context.Background(), issue)
+	require.NoError(t, err, "Upsert should not return an error for PM agent issues")
+	require.Equal(t, generatedID, issue.ID, "should set the generated ID on the PM agent issue")
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 

--- a/internal/db/issues.go
+++ b/internal/db/issues.go
@@ -173,25 +173,32 @@ func (s *IssueStore) UpdateRepositoryID(ctx context.Context, orgID, issueID uuid
 }
 
 func (s *IssueStore) Upsert(ctx context.Context, issue *models.Issue) error {
-	query := `
+	conflictTarget := "(org_id, source, external_id)"
+	if issue.Source == models.IssueSourcePMAgent {
+		conflictTarget = "(org_id, fingerprint)"
+	}
+	query := fmt.Sprintf(`
 		INSERT INTO issues (org_id, external_id, source, source_integration_id, repository_id,
 		                    title, description, raw_data, status, first_seen_at, last_seen_at,
 		                    occurrence_count, affected_customer_count, severity, tags, fingerprint)
 		VALUES (@org_id, @external_id, @source, @source_integration_id, @repository_id,
 		        @title, @description, @raw_data, @status, @first_seen_at, @last_seen_at,
 		        @occurrence_count, @affected_customer_count, @severity, @tags, @fingerprint)
-		ON CONFLICT (org_id, fingerprint) DO UPDATE
+		ON CONFLICT %s DO UPDATE
 		SET title = EXCLUDED.title,
 		    description = EXCLUDED.description,
 		    raw_data = EXCLUDED.raw_data,
+		    source_integration_id = COALESCE(EXCLUDED.source_integration_id, issues.source_integration_id),
+		    repository_id = COALESCE(EXCLUDED.repository_id, issues.repository_id),
 		    last_seen_at = GREATEST(issues.last_seen_at, EXCLUDED.last_seen_at),
 		    occurrence_count = issues.occurrence_count + EXCLUDED.occurrence_count,
 		    affected_customer_count = GREATEST(issues.affected_customer_count, EXCLUDED.affected_customer_count),
 		    severity = EXCLUDED.severity,
 		    tags = EXCLUDED.tags,
+		    fingerprint = EXCLUDED.fingerprint,
 		    updated_at = now()
 		WHERE issues.deleted_at IS NULL
-		RETURNING id, created_at, updated_at`
+		RETURNING id, created_at, updated_at`, conflictTarget)
 
 	args := pgx.NamedArgs{
 		"org_id":                  issue.OrgID,

--- a/internal/models/issue_fingerprint.go
+++ b/internal/models/issue_fingerprint.go
@@ -11,5 +11,5 @@ import (
 func IssueFingerprint(source IssueSource, externalID string) string {
 	h := sha256.New()
 	h.Write([]byte(fmt.Sprintf("%s:%s", source, externalID)))
-	return fmt.Sprintf("%x", h.Sum(nil))[:32]
+	return fmt.Sprintf("%s:%s", source, fmt.Sprintf("%x", h.Sum(nil))[:32])
 }

--- a/internal/models/issue_fingerprint.go
+++ b/internal/models/issue_fingerprint.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// IssueFingerprint returns the canonical dedupe fingerprint for an external
+// issue. Keep every ingestion and provider-specific upsert path on this helper
+// so both unique indexes on issues agree about what "same issue" means.
+func IssueFingerprint(source IssueSource, externalID string) string {
+	h := sha256.New()
+	h.Write([]byte(fmt.Sprintf("%s:%s", source, externalID)))
+	return fmt.Sprintf("%x", h.Sum(nil))[:32]
+}

--- a/internal/models/issue_fingerprint_test.go
+++ b/internal/models/issue_fingerprint_test.go
@@ -1,0 +1,40 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssueFingerprint(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		source     IssueSource
+		externalID string
+		expected   string
+	}{
+		{
+			name:       "linear issue id uses ingestion-compatible hash",
+			source:     IssueSourceLinear,
+			externalID: "2563b72a-e241-44db-85a3-4267084bb274",
+			expected:   "2072004d71b40dd3c2eac1cdfa1c7290",
+		},
+		{
+			name:       "sentry issue id remains source scoped",
+			source:     IssueSourceSentry,
+			externalID: "12345",
+			expected:   "97d01c7db052953ab2eed34a407e8545",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := IssueFingerprint(tt.source, tt.externalID)
+			require.Equal(t, tt.expected, got, "IssueFingerprint should match the canonical ingestion fingerprint")
+		})
+	}
+}

--- a/internal/models/issue_fingerprint_test.go
+++ b/internal/models/issue_fingerprint_test.go
@@ -16,16 +16,16 @@ func TestIssueFingerprint(t *testing.T) {
 		expected   string
 	}{
 		{
-			name:       "linear issue id uses ingestion-compatible hash",
+			name:       "linear issue id uses source-prefixed hash",
 			source:     IssueSourceLinear,
 			externalID: "2563b72a-e241-44db-85a3-4267084bb274",
-			expected:   "2072004d71b40dd3c2eac1cdfa1c7290",
+			expected:   "linear:2072004d71b40dd3c2eac1cdfa1c7290",
 		},
 		{
 			name:       "sentry issue id remains source scoped",
 			source:     IssueSourceSentry,
 			externalID: "12345",
-			expected:   "97d01c7db052953ab2eed34a407e8545",
+			expected:   "sentry:97d01c7db052953ab2eed34a407e8545",
 		},
 	}
 

--- a/internal/services/ingestion/service.go
+++ b/internal/services/ingestion/service.go
@@ -2,7 +2,6 @@ package ingestion
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -102,9 +101,7 @@ func (s *Service) IngestNormalized(ctx context.Context, orgID uuid.UUID, ni Norm
 }
 
 func computeFingerprint(source, externalID string) string {
-	h := sha256.New()
-	h.Write([]byte(fmt.Sprintf("%s:%s", source, externalID)))
-	return fmt.Sprintf("%x", h.Sum(nil))[:32]
+	return models.IssueFingerprint(models.IssueSource(source), externalID)
 }
 
 func normalizeSeverity(raw string) string {

--- a/internal/services/ingestion/service_test.go
+++ b/internal/services/ingestion/service_test.go
@@ -23,7 +23,7 @@ func TestComputeFingerprint(t *testing.T) {
 				t.Helper()
 				fp2 := computeFingerprint("sentry", "12345")
 				require.Equal(t, fp, fp2, "same inputs should produce identical fingerprints")
-				require.Len(t, fp, 32, "fingerprint should be 32 characters (hex-encoded MD5)")
+				require.Equal(t, "sentry:97d01c7db052953ab2eed34a407e8545", fp, "fingerprint should include a readable source prefix and bounded hash")
 			},
 		},
 		{

--- a/internal/services/linear/service.go
+++ b/internal/services/linear/service.go
@@ -938,7 +938,7 @@ func (s *Service) upsertLinearIssue(ctx context.Context, orgID, integrationID uu
 		OccurrenceCount:     1,
 		Severity:            "medium",
 		Tags:                tags,
-		Fingerprint:         "linear:" + fetched.ID,
+		Fingerprint:         models.IssueFingerprint(models.IssueSourceLinear, fetched.ID),
 	}
 	if err := s.issues.Upsert(ctx, issue); err != nil {
 		return uuid.Nil, err

--- a/internal/worker/handlers_linear_agent_created.go
+++ b/internal/worker/handlers_linear_agent_created.go
@@ -227,6 +227,9 @@ func registerLinearAgentCreatedDeadLetter(
 		if row.State.IsTerminal() {
 			return
 		}
+		if row.SessionID != nil {
+			return
+		}
 		client, err := deps.ClientForOrg(hookCtx, orgID)
 		if err != nil {
 			logger.Warn().Err(err).

--- a/internal/worker/handlers_linear_agent_created.go
+++ b/internal/worker/handlers_linear_agent_created.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
 	"github.com/assembledhq/143/internal/services/linear"
 	"github.com/google/uuid"
@@ -43,9 +44,11 @@ func handleLinearAgentCreated(
 	if err != nil {
 		return fmt.Errorf("invalid org_id: %w", err)
 	}
-	if _, err := uuid.Parse(payload.AgentSessionRowID); err != nil {
+	agentSessionRowID, err := uuid.Parse(payload.AgentSessionRowID)
+	if err != nil {
 		return fmt.Errorf("invalid agent_session_row_id: %w", err)
 	}
+	registerLinearAgentCreatedDeadLetter(ctx, deps, agentSessions, activities, orgID, agentSessionRowID, payload.LinearAgentSessionID, logger)
 
 	// 1. Idempotency guard. The dispatcher's UNIQUE on
 	// linear_agent_sessions guarantees we have at most one row per
@@ -196,6 +199,69 @@ func handleLinearAgentCreated(
 		Str("repo_resolution", repoResult.Source).
 		Msg("linear_agent_event: session created")
 	return nil
+}
+
+func registerLinearAgentCreatedDeadLetter(
+	ctx context.Context,
+	deps LinearAgentEventHandlerDeps,
+	agentSessions *db.LinearAgentSessionStore,
+	activities *db.LinearAgentActivityLogStore,
+	orgID, agentSessionRowID uuid.UUID,
+	linearAgentSessionID string,
+	logger zerolog.Logger,
+) {
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, deadLetterErr error) {
+		if agentSessions == nil || activities == nil || deps.ClientForOrg == nil {
+			logger.Warn().
+				Str("agent_session_id", linearAgentSessionID).
+				Msg("linear_agent_event: cannot close dead-lettered AgentSession; dependencies unavailable")
+			return
+		}
+		row, err := agentSessions.GetByID(hookCtx, orgID, agentSessionRowID)
+		if err != nil {
+			logger.Warn().Err(err).
+				Str("agent_session_id", linearAgentSessionID).
+				Msg("linear_agent_event: failed to load bridge row for dead-letter close")
+			return
+		}
+		if row.State.IsTerminal() {
+			return
+		}
+		client, err := deps.ClientForOrg(hookCtx, orgID)
+		if err != nil {
+			logger.Warn().Err(err).
+				Str("agent_session_id", row.LinearAgentSessionID).
+				Msg("linear_agent_event: failed to resolve Linear client for dead-letter close")
+			if stateErr := agentSessions.SetState(hookCtx, orgID, row.ID, models.LinearAgentSessionStateError); stateErr != nil {
+				logger.Warn().Err(stateErr).
+					Str("agent_session_id", row.LinearAgentSessionID).
+					Msg("linear_agent_event: failed to record dead-letter error state")
+			}
+			return
+		}
+
+		activity := linear.AgentMilestoneActivity{
+			Type:            models.LinearAgentActivityError,
+			Body:            "I hit an internal error before I could start the coding session. Please retry or check the 143 session logs.",
+			IdemKey:         "bootstrap:failed",
+			PinSessionState: "error",
+		}
+		if err := emitOnce(hookCtx, client, activities, orgID, row.ID, row.LinearAgentSessionID, activity, logger); err != nil {
+			logger.Warn().Err(err).
+				Str("agent_session_id", row.LinearAgentSessionID).
+				Msg("linear_agent_event: failed to emit dead-letter error activity")
+		}
+		if err := agentSessions.SetState(hookCtx, orgID, row.ID, models.LinearAgentSessionStateError); err != nil {
+			logger.Warn().Err(err).
+				Str("agent_session_id", row.LinearAgentSessionID).
+				Msg("linear_agent_event: failed to record dead-letter error state")
+		}
+		if deadLetterErr != nil {
+			logger.Error().Err(deadLetterErr).
+				Str("agent_session_id", row.LinearAgentSessionID).
+				Msg("linear_agent_event: created job dead-lettered before session creation")
+		}
+	})
 }
 
 func createAndAttachLinearAgentSession(ctx context.Context, stores *Stores, orgID, agentSessionRowID uuid.UUID, session *models.Session) error {

--- a/internal/worker/handlers_linear_agent_created_test.go
+++ b/internal/worker/handlers_linear_agent_created_test.go
@@ -270,6 +270,48 @@ func TestLinearAgentCreatedDeadLetterHookEmitsErrorAndMarksBridge(t *testing.T) 
 	require.Equal(t, "error", client.lastUpdate.State, "Linear AgentSession should be explicitly pinned to error")
 }
 
+func TestLinearAgentCreatedDeadLetterHookSkipsAttachedSession(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	rowID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now().UTC()
+	clientCalls := 0
+
+	mock.ExpectQuery("SELECT id, org_id, integration_id, linear_agent_session_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "integration_id", "linear_agent_session_id",
+			"linear_issue_id", "linear_issue_identifier",
+			"linear_app_user_id", "linear_creator_user_id",
+			"session_id", "state", "last_event_received_at",
+			"created_at", "updated_at",
+		}).AddRow(
+			rowID, orgID, uuid.New(), "as_1",
+			"iss_1", "VIR-102",
+			"", "",
+			&sessionID, "in_progress", &now,
+			now, now,
+		))
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	registerLinearAgentCreatedDeadLetter(ctx, LinearAgentEventHandlerDeps{
+		ClientForOrg: func(context.Context, uuid.UUID) (linear.Client, error) {
+			clientCalls++
+			return &linearAgentCreatedDeadLetterClient{}, nil
+		},
+	}, db.NewLinearAgentSessionStore(mock), db.NewLinearAgentActivityLogStore(mock), orgID, rowID, "as_1", zerolog.Nop())
+
+	jobctx.RunDeadLetterHooks(ctx, errors.New("reconcile failed"))
+	require.Zero(t, clientCalls, "dead-letter hook should not close Linear when a 143 session is already attached")
+	require.NoError(t, mock.ExpectationsWereMet(), "attached bridge rows should only be inspected, not mutated")
+}
+
 // TestReconcileLinearAgentCreatedRejectsZeroValueSession pins the guardrail
 // that protects against a future SessionStore schema change silently
 // returning a zero-value row. The session_id is the worker's only handle

--- a/internal/worker/handlers_linear_agent_created_test.go
+++ b/internal/worker/handlers_linear_agent_created_test.go
@@ -9,12 +9,35 @@ import (
 	"time"
 
 	"github.com/assembledhq/143/internal/db"
+	"github.com/assembledhq/143/internal/jobctx"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/services/linear"
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v4"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 )
+
+type linearAgentCreatedDeadLetterClient struct {
+	linear.Client
+
+	activityCalls int
+	updateCalls   int
+	lastActivity  linear.AgentActivityInput
+	lastUpdate    linear.AgentSessionUpdateInput
+}
+
+func (c *linearAgentCreatedDeadLetterClient) AgentActivityCreate(_ context.Context, in linear.AgentActivityInput) (linear.AgentActivityResult, error) {
+	c.activityCalls++
+	c.lastActivity = in
+	return linear.AgentActivityResult{ActivityID: "act_error"}, nil
+}
+
+func (c *linearAgentCreatedDeadLetterClient) AgentSessionUpdate(_ context.Context, in linear.AgentSessionUpdateInput) error {
+	c.updateCalls++
+	c.lastUpdate = in
+	return nil
+}
 
 func TestCreateAndAttachLinearAgentSessionUsesSingleTransaction(t *testing.T) {
 	t.Parallel()
@@ -187,6 +210,64 @@ func TestReconcileLinearAgentCreatedNoPrimaryIssueOnlyReenqueuesRunAgent(t *test
 	require.NoError(t, err, "reconcile with no primary issue should succeed by only re-enqueueing run_agent")
 	require.NoError(t, mock.ExpectationsWereMet(),
 		"reconcile must not touch FetchIssue, the SessionIssueLinks store, or the LinearProviderStateStore on the no-primary-issue branch")
+}
+
+func TestLinearAgentCreatedDeadLetterHookEmitsErrorAndMarksBridge(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	rowID := uuid.New()
+	integrationID := uuid.New()
+	now := time.Now().UTC()
+	client := &linearAgentCreatedDeadLetterClient{}
+	clientCalls := 0
+
+	mock.ExpectQuery("SELECT id, org_id, integration_id, linear_agent_session_id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"id", "org_id", "integration_id", "linear_agent_session_id",
+			"linear_issue_id", "linear_issue_identifier",
+			"linear_app_user_id", "linear_creator_user_id",
+			"session_id", "state", "last_event_received_at",
+			"created_at", "updated_at",
+		}).AddRow(
+			rowID, orgID, integrationID, "as_1",
+			"iss_1", "VIR-102",
+			"", "",
+			nil, "pending", &now,
+			now, now,
+		))
+	mock.ExpectQuery("INSERT INTO linear_agent_activity_log").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "inserted"}).AddRow(uuid.New(), true))
+	mock.ExpectExec("UPDATE linear_agent_activity_log").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+	mock.ExpectExec("UPDATE linear_agent_sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	registerLinearAgentCreatedDeadLetter(ctx, LinearAgentEventHandlerDeps{
+		ClientForOrg: func(context.Context, uuid.UUID) (linear.Client, error) {
+			clientCalls++
+			return client, nil
+		},
+	}, db.NewLinearAgentSessionStore(mock), db.NewLinearAgentActivityLogStore(mock), orgID, rowID, "as_1", zerolog.Nop())
+
+	jobctx.RunDeadLetterHooks(ctx, errors.New("upsert linear issue failed"))
+	require.Equal(t, 1, clientCalls, "dead-letter hook should resolve a Linear client before emitting")
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should persist the local bridge state")
+	require.Equal(t, 1, client.activityCalls, "dead-letter hook should emit exactly one Linear error activity")
+	require.Equal(t, "as_1", client.lastActivity.AgentSessionID, "error activity should target the stuck Linear AgentSession")
+	require.Equal(t, string(models.LinearAgentActivityError), client.lastActivity.Type, "dead-letter activity should render as an error")
+	require.Contains(t, client.lastActivity.Body, "internal error", "dead-letter activity should explain that the agent failed before starting")
+	require.Equal(t, 1, client.updateCalls, "dead-letter hook should pin the Linear AgentSession into an error state")
+	require.Equal(t, "error", client.lastUpdate.State, "Linear AgentSession should be explicitly pinned to error")
 }
 
 // TestReconcileLinearAgentCreatedRejectsZeroValueSession pins the guardrail

--- a/internal/worker/handlers_linear_agent_helpers.go
+++ b/internal/worker/handlers_linear_agent_helpers.go
@@ -37,7 +37,7 @@ func upsertLinearIssueForAgent(ctx context.Context, stores *Stores, orgID uuid.U
 		LastSeenAt:      now,
 		OccurrenceCount: 1,
 		Severity:        "medium",
-		Fingerprint:     "linear:" + fetched.ID,
+		Fingerprint:     models.IssueFingerprint(models.IssueSourceLinear, fetched.ID),
 		RepositoryID:    repoID,
 	}
 	if err := stores.Issues.Upsert(ctx, issue); err != nil {

--- a/internal/worker/handlers_linear_agent_helpers_test.go
+++ b/internal/worker/handlers_linear_agent_helpers_test.go
@@ -194,7 +194,7 @@ func TestUpsertLinearIssueForAgentUsesCanonicalFingerprint(t *testing.T) {
 		Title:       "Make a full screen mode for the file diff viewer",
 		Description: "Diff viewer should support full-screen review.",
 	}
-	expectedFingerprint := "2072004d71b40dd3c2eac1cdfa1c7290"
+	expectedFingerprint := "linear:2072004d71b40dd3c2eac1cdfa1c7290"
 
 	mock.ExpectQuery("INSERT INTO issues").
 		WithArgs(

--- a/internal/worker/handlers_linear_agent_helpers_test.go
+++ b/internal/worker/handlers_linear_agent_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
@@ -174,6 +175,43 @@ func TestEnqueueRunAgentForLinearAgentSkipsTerminalSessions(t *testing.T) {
 	err = enqueueRunAgentForLinearAgent(context.Background(), &Stores{Sessions: db.NewSessionStore(mock), Jobs: db.NewJobStore(mock)}, orgID, sessionID)
 	require.NoError(t, err, "terminal Linear agent reconciliation should be a no-op instead of enqueueing duplicate completed work")
 	require.NoError(t, mock.ExpectationsWereMet(), "completed sessions should only be loaded; no run_agent job should be inserted")
+}
+
+func TestUpsertLinearIssueForAgentUsesCanonicalFingerprint(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "test should create pgx mock")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	repoID := uuid.New()
+	issueID := uuid.New()
+	now := time.Now().UTC()
+	fetched := &linear.FetchedIssue{
+		ID:          "2563b72a-e241-44db-85a3-4267084bb274",
+		Identifier:  "VIR-102",
+		Title:       "Make a full screen mode for the file diff viewer",
+		Description: "Diff viewer should support full-screen review.",
+	}
+	expectedFingerprint := "2072004d71b40dd3c2eac1cdfa1c7290"
+
+	mock.ExpectQuery("INSERT INTO issues").
+		WithArgs(
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(),
+			pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), expectedFingerprint,
+		).
+		WillReturnRows(pgxmock.NewRows([]string{"id", "created_at", "updated_at"}).AddRow(issueID, now, now))
+
+	issue, err := upsertLinearIssueForAgent(context.Background(), &Stores{
+		Issues: db.NewIssueStore(mock),
+	}, orgID, fetched, &repoID)
+	require.NoError(t, err, "linear agent issue upsert should use the canonical fingerprint")
+	require.Equal(t, issueID, issue.ID, "linear agent issue upsert should return the existing or inserted issue id")
+	require.Equal(t, expectedFingerprint, issue.Fingerprint, "linear agent issue model should carry the canonical fingerprint")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestLinearAgentPinSessionStateUsesRequestedState(t *testing.T) {


### PR DESCRIPTION
**Summary**
- Add a shared `IssueFingerprint` helper and route Linear ingestion and worker upserts through it so both issue paths use the same canonical dedupe key.
- Handle Linear agent-created dead letters by emitting an error activity and pinning the bridge session to `error` instead of leaving the bootstrap state visible.
- Update the design notes to document the new dead-letter behavior.
- Add tests covering the fingerprint helper, Linear issue upserts, and the dead-letter hook behavior.

**Testing**
- Added/updated unit tests for fingerprint generation, Linear issue upsert fingerprinting, and dead-letter session handling.
- Not run (not requested).