### PR TITLE
Add active command context to runtime stall logs

### DIFF
--- a/internal/services/agent/orchestrator.go
+++ b/internal/services/agent/orchestrator.go
@@ -4345,7 +4345,7 @@ func (o *Orchestrator) streamLogs(ctx context.Context, runID, orgID uuid.UUID, a
 	for entry := range logCh {
 		if tracker != nil {
 			if progressType, strength, toolID, ok := runtimeProgressFromLog(entry); ok {
-				tracker.Record(progressType, strength, entry.Timestamp, toolID)
+				tracker.Record(progressType, strength, entry.Timestamp, toolID, runtimeToolSummaryFromLog(entry))
 			}
 		}
 		effectiveThreadID := threadID

--- a/internal/services/agent/runtime.go
+++ b/internal/services/agent/runtime.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"sync"
 	"time"
 
@@ -95,7 +96,12 @@ type runtimeProgressTracker struct {
 	lastStrength     models.RuntimeProgressStrength
 	lastStrongAt     time.Time
 	lastPersistedAt  time.Time
-	activeTools      map[string]time.Time
+	activeTools      map[string]activeToolProgress
+}
+
+type activeToolProgress struct {
+	startedAt time.Time
+	summary   string
 }
 
 func newRuntimeProgressTracker(now time.Time) *runtimeProgressTracker {
@@ -107,7 +113,7 @@ func newRuntimeProgressTracker(now time.Time) *runtimeProgressTracker {
 	}
 }
 
-func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType, strength models.RuntimeProgressStrength, observedAt time.Time, toolID string) {
+func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType, strength models.RuntimeProgressStrength, observedAt time.Time, toolID string, toolSummary ...string) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	if observedAt.IsZero() {
@@ -123,9 +129,13 @@ func (t *runtimeProgressTracker) Record(progressType models.RuntimeProgressType,
 	case models.RuntimeProgressTypeToolUse:
 		if toolID != "" {
 			if t.activeTools == nil {
-				t.activeTools = make(map[string]time.Time)
+				t.activeTools = make(map[string]activeToolProgress)
 			}
-			t.activeTools[toolID] = observedAt
+			progress := activeToolProgress{startedAt: observedAt}
+			if len(toolSummary) > 0 {
+				progress.summary = toolSummary[0]
+			}
+			t.activeTools[toolID] = progress
 		}
 	case models.RuntimeProgressTypeToolResult, models.RuntimeProgressTypeQuestionBlocked, models.RuntimeProgressTypeCheckpoint:
 		if toolID != "" && t.activeTools != nil {
@@ -146,6 +156,50 @@ func (t *runtimeProgressTracker) ToolActive() bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	return len(t.activeTools) > 0
+}
+
+func (t *runtimeProgressTracker) ActiveToolSummaries(limit int) []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.activeTools) == 0 || limit <= 0 {
+		return nil
+	}
+	tools := make([]struct {
+		id       string
+		progress activeToolProgress
+	}, 0, len(t.activeTools))
+	for id, progress := range t.activeTools {
+		tools = append(tools, struct {
+			id       string
+			progress activeToolProgress
+		}{id: id, progress: progress})
+	}
+	sort.Slice(tools, func(i, j int) bool {
+		if tools[i].progress.startedAt.Equal(tools[j].progress.startedAt) {
+			return tools[i].id < tools[j].id
+		}
+		return tools[i].progress.startedAt.Before(tools[j].progress.startedAt)
+	})
+	if len(tools) > limit {
+		tools = tools[:limit]
+	}
+	summaries := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		summary := tool.id
+		if tool.progress.summary != "" {
+			summary += ": " + truncateRuntimeToolSummary(tool.progress.summary)
+		}
+		summaries = append(summaries, summary)
+	}
+	return summaries
+}
+
+func truncateRuntimeToolSummary(summary string) string {
+	const maxRuntimeToolSummaryBytes = 170
+	if len(summary) <= maxRuntimeToolSummaryBytes {
+		return summary
+	}
+	return summary[:maxRuntimeToolSummaryBytes-3] + "..."
 }
 
 func (t *runtimeProgressTracker) ShouldPersist() bool {
@@ -185,6 +239,29 @@ func runtimeProgressFromLog(entry LogEntry) (models.RuntimeProgressType, models.
 	default:
 		return models.RuntimeProgressTypeNone, models.RuntimeProgressStrengthNone, "", false
 	}
+}
+
+func runtimeToolSummaryFromLog(entry LogEntry) string {
+	if entry.Level == "debug" {
+		if itemID, ok := commandExecutionStartItemID(entry.Message); ok && itemID != "" {
+			if command, ok := commandExecutionStartCommand(entry.Message); ok {
+				return command
+			}
+		}
+	}
+	if entry.Metadata == nil {
+		return ""
+	}
+	tool, _ := entry.Metadata["tool"].(string)
+	if tool != "command_execution" {
+		return ""
+	}
+	input, _ := entry.Metadata["input"].(map[string]any)
+	if input == nil {
+		return ""
+	}
+	command, _ := input["command"].(string)
+	return command
 }
 
 func commandExecutionItemIDFromMetadata(metadata map[string]any) string {
@@ -230,6 +307,37 @@ func commandExecutionStartItemID(message string) (string, bool) {
 		return "", false
 	}
 	return event.Item.ID, true
+}
+
+func commandExecutionStartCommand(message string) (string, bool) {
+	if message == "" {
+		return "", false
+	}
+	var event struct {
+		Type string `json:"type"`
+		Item struct {
+			Type    string `json:"type"`
+			Command string `json:"command"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal([]byte(message), &event); err != nil {
+		return "", false
+	}
+	if event.Type != "item.started" || event.Item.Type != "command_execution" || event.Item.Command == "" {
+		return "", false
+	}
+	return event.Item.Command, true
+}
+
+func (c *runtimeController) activeToolLogFields(event *zerolog.Event) *zerolog.Event {
+	if c.tracker == nil {
+		return event
+	}
+	summaries := c.tracker.ActiveToolSummaries(5)
+	if len(summaries) == 0 {
+		return event
+	}
+	return event.Int("active_tool_count", len(summaries)).Strs("active_tools", summaries)
 }
 
 type runtimeController struct {
@@ -328,10 +436,10 @@ func (c *runtimeController) RequestStop(reason StopReason) {
 				Msg("failed to persist runtime stop request")
 		}
 	}
-	c.logger.Info().
+	event := c.logger.Info().
 		Str("session_id", c.sessionID.String()).
-		Str("stop_reason", string(runtimeReason)).
-		Msg("runtime stop requested")
+		Str("stop_reason", string(runtimeReason))
+	c.activeToolLogFields(event).Msg("runtime stop requested")
 }
 
 func (c *runtimeController) tick(ctx context.Context, now time.Time) {

--- a/internal/services/agent/runtime_test.go
+++ b/internal/services/agent/runtime_test.go
@@ -1,9 +1,11 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -457,19 +459,64 @@ func TestRuntimeController_RequestStopCancelsBeforePersistingStopMarker(t *testi
 	require.True(t, sessionStore.stopAfter[0].After(minStopAfter), "stop-after deadline should include graceful shutdown, checkpoint finalization, and watchdog slack")
 }
 
+func TestRuntimeController_RequestStopLogsActiveToolSummaries(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	now := time.Now().UTC()
+	tracker := newRuntimeProgressTracker(now)
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(time.Second), "item_3", "/bin/bash -lc 'rg session internal'")
+
+	controller := newRuntimeController(
+		runtimeConfig{
+			GracefulShutdownWindow:   time.Second,
+			CheckpointFinalizeWindow: time.Second,
+		},
+		&runtimeTestSessionStore{},
+		&runtimeTestJobStore{},
+		nil,
+		logger,
+		uuid.New(),
+		uuid.New(),
+		0,
+		nil,
+		tracker,
+	)
+
+	controller.RequestStop(StopReasonSoftBudget)
+
+	require.Contains(t, logs.String(), `"active_tools":["item_3: /bin/bash -lc 'rg session internal'"]`, "runtime stop log should include active command summaries")
+}
+
 func TestRuntimeProgressTracker_TracksConcurrentCommandExecutions(t *testing.T) {
 	t.Parallel()
 
 	now := time.Now().UTC()
 	tracker := newRuntimeProgressTracker(now)
 
-	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(time.Second), "item_1")
-	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(2*time.Second), "item_2")
-	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(3*time.Second), "item_2")
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(time.Second), "item_1", "npm test")
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(2*time.Second), "item_2", "go test ./...")
+	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(3*time.Second), "item_2", "")
 	require.True(t, tracker.ToolActive(), "completing one command should not clear another active command")
+	require.Equal(t, []string{"item_1: npm test"}, tracker.ActiveToolSummaries(10), "tracker should retain the active command summary for stop logs")
 
-	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(4*time.Second), "item_1")
+	tracker.Record(models.RuntimeProgressTypeToolResult, models.RuntimeProgressStrengthStrong, now.Add(4*time.Second), "item_1", "")
 	require.False(t, tracker.ToolActive(), "all completed command IDs should clear active tool state")
+}
+
+func TestRuntimeProgressTracker_ActiveToolSummariesAreBounded(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	tracker := newRuntimeProgressTracker(now)
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(time.Second), "item_1", strings.Repeat("x", 240))
+	tracker.Record(models.RuntimeProgressTypeToolUse, models.RuntimeProgressStrengthWeak, now.Add(2*time.Second), "item_2", "go test ./...")
+
+	summaries := tracker.ActiveToolSummaries(1)
+	require.Len(t, summaries, 1, "ActiveToolSummaries should honor the requested limit")
+	require.LessOrEqual(t, len(summaries[0]), 180, "ActiveToolSummaries should truncate oversized commands for structured logs")
+	require.Contains(t, summaries[0], "item_1:", "ActiveToolSummaries should include the tool id with the command summary")
 }
 
 func TestRuntimeProgressFromLog(t *testing.T) {
@@ -503,6 +550,40 @@ func TestRuntimeProgressFromLog(t *testing.T) {
 			require.Equal(t, tt.expected, strength, "runtimeProgressFromLog should map the progress strength correctly")
 			require.Equal(t, tt.expectedID, toolID, "runtimeProgressFromLog should preserve the command execution item id")
 			require.Equal(t, tt.wantOK, ok, "runtimeProgressFromLog should report whether the log entry counts as progress")
+		})
+	}
+}
+
+func TestRuntimeToolSummaryFromLog(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entry    LogEntry
+		expected string
+	}{
+		{
+			name:     "debug item started command execution",
+			entry:    LogEntry{Level: "debug", Message: `{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/bash -lc 'rg session internal'"}}`},
+			expected: `/bin/bash -lc 'rg session internal'`,
+		},
+		{
+			name:     "tool metadata command input",
+			entry:    LogEntry{Level: "tool_use", Metadata: map[string]any{"tool": "command_execution", "input": map[string]any{"command": "go test ./..."}}},
+			expected: "go test ./...",
+		},
+		{
+			name:     "non-command log",
+			entry:    LogEntry{Level: "output", Message: "done"},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, runtimeToolSummaryFromLog(tt.entry), "runtimeToolSummaryFromLog should extract command text only for command execution progress")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Added active command summaries to runtime stop logging so `runtime_control_stalled` events now show which command was still in flight when shutdown was requested.
- Tracked active command metadata in the runtime progress tracker and taught log streaming to preserve command text for `command_execution` events.
- Kept the new context bounded and covered it with tests for tracker behavior, log extraction, and stop-log emission.

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`
- Added/updated unit tests in `internal/services/agent/runtime_test.go` for active-tool tracking and stop logging.