### PR TITLE
Add make force flag for guarded deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,6 +467,9 @@ repair-worker-host:
 
 TAG ?= latest
 ROLES ?= app,worker
+force ?=
+
+deploy-force-env = FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=$(if $(filter true 1 yes,$(force)),1,$(FORCE_DEPLOY_WITH_ACTIVE_SESSIONS))
 
 # Deploy (update) an already-provisioned node.
 # HOST is optional — falls back to the matching role in FLEET_HOSTS from .env.production.enc.
@@ -475,6 +478,7 @@ ROLES ?= app,worker
 #   make deploy-app
 #   make deploy-app    HOST=87.99.150.138
 #   make deploy-app    TAG=<sha>
+#   make deploy-worker force=true
 
 # Shell snippet to read FLEET_HOSTS from env var or .env.production.enc via SOPS.
 # Sets $$FLEET. Use inside a recipe with: $(read-fleet-hosts);
@@ -492,7 +496,7 @@ endef
 define resolve-host
 if [ -n "$(HOST)" ]; then \
 	echo "Deploying $(1) → $(HOST)"; \
-	./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG); \
+	$(deploy-force-env) ./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG); \
 else \
 	$(read-fleet-hosts); \
 	HOSTS="$$(echo "$$FLEET" | tr ',' '\n' | grep '^$(1):' | cut -d: -f2)"; \
@@ -502,7 +506,7 @@ else \
 	fi; \
 	for h in $$HOSTS; do \
 		echo "Deploying $(1) → $$h"; \
-		./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG); \
+		$(deploy-force-env) ./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG); \
 	done; \
 fi
 endef
@@ -553,9 +557,11 @@ deploy-redis:
 #   make deploy-fleet ROLES=all
 # For a specific image tag:
 #   make deploy-fleet TAG=<sha> ROLES=app,worker
+# To override the active-session guardrail:
+#   make deploy-fleet force=true
 deploy-fleet:
 	$(check-ssh-key)
-	./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)
+	$(deploy-force-env) ./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)
 
 # Shorthand alias for deploy-fleet.
 deploy: deploy-fleet

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -134,6 +134,10 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 	require.Contains(t, string(makefile), "make deploy-fleet ROLES=all", "Makefile should document how to run an explicit all-role maintenance deploy with a make argument")
 	require.Contains(t, string(makefile), "make deploy-fleet force=true", "Makefile should document how to override the active-session guardrail with a make argument")
 	require.Contains(t, string(makefile), `$(deploy-force-env) ./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)`, "Makefile should pass role, tag, and force arguments through to deploy-fleet.sh")
+
+	deployScript, err := os.ReadFile("../deploy/scripts/deploy.sh")
+	require.NoError(t, err, "test should read deploy.sh")
+	require.Contains(t, string(deployScript), `-e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}"`, "worker deploy guardrail container should receive the force override from the deploy environment")
 }
 
 // Worker preview routing and sandbox orchestration require per-host values:

--- a/deploy/deploy_config_test.go
+++ b/deploy/deploy_config_test.go
@@ -127,11 +127,13 @@ func TestFleetDeployDefaultsToUserFacingRuntimeRoles(t *testing.T) {
 	makefile, err := os.ReadFile("../Makefile")
 	require.NoError(t, err, "test should read Makefile")
 	require.Contains(t, string(makefile), "ROLES ?= app,worker", "Makefile should make the default fleet role set visible to operators")
+	require.Contains(t, string(makefile), "force ?=", "Makefile should expose active-session force deploys as a make argument")
 	require.Contains(t, string(makefile), "TAG ?= latest", "Makefile should expose the image tag as the same kind of make argument as roles")
-	require.Contains(t, string(makefile), `./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG)`, "single-role deploy targets should honor the same TAG argument as fleet deploys")
-	require.Contains(t, string(makefile), `./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG)`, "multi-host single-role deploy targets should pass TAG through for every host")
+	require.Contains(t, string(makefile), `$(deploy-force-env) ./deploy/scripts/deploy.sh $(1) $(HOST) $(SSH_KEY) $(TAG)`, "single-role deploy targets should honor the same force argument as fleet deploys")
+	require.Contains(t, string(makefile), `$(deploy-force-env) ./deploy/scripts/deploy.sh $(1) $$h $(SSH_KEY) $(TAG)`, "multi-host single-role deploy targets should pass force through for every host")
 	require.Contains(t, string(makefile), "make deploy-fleet ROLES=all", "Makefile should document how to run an explicit all-role maintenance deploy with a make argument")
-	require.Contains(t, string(makefile), `./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)`, "Makefile should pass role and tag arguments through to deploy-fleet.sh")
+	require.Contains(t, string(makefile), "make deploy-fleet force=true", "Makefile should document how to override the active-session guardrail with a make argument")
+	require.Contains(t, string(makefile), `$(deploy-force-env) ./deploy/scripts/deploy-fleet.sh $(SSH_KEY) $(TAG) $(ROLES)`, "Makefile should pass role, tag, and force arguments through to deploy-fleet.sh")
 }
 
 // Worker preview routing and sandbox orchestration require per-host values:

--- a/deploy/scripts/deploy.sh
+++ b/deploy/scripts/deploy.sh
@@ -835,7 +835,9 @@ ssh "${SSH_OPTS[@]}" deploy@"$HOST" \
       return 0
     fi
     echo "Checking active long-running sessions before worker deploy..."
-    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps "$HEALTH_SERVICE" /bin/deploy-guardrail worker-sessions < /dev/null
+    docker compose -f "$COMPOSE_FILE" run --rm -T --no-deps \
+      -e "FORCE_DEPLOY_WITH_ACTIVE_SESSIONS=${FORCE_DEPLOY_WITH_ACTIVE_SESSIONS:-}" \
+      "$HEALTH_SERVICE" /bin/deploy-guardrail worker-sessions < /dev/null
   }
 
   # wait_container_healthy CONTAINER_ID TIMEOUT — poll until a specific container


### PR DESCRIPTION
## Summary
- Add a `force=true` make argument for fleet and single-role deploys.
- Forward the deploy override through `deploy.sh` into the worker guardrail container so the active-session check honors it.
- Update deploy config coverage to lock in the new Makefile contract and env propagation.

## Testing
- Added and updated deploy config tests for the new Makefile argument and guardrail env forwarding.
- Ran `go vet ./...`, `go build ./...`, and `go test ./...` successfully.