### PR TITLE
Fix session executor Docker socket access and recovery cleanup

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -980,12 +980,24 @@ func configureSessionExecutorDispatch(
 				"/var/run/docker.sock:/var/run/docker.sock",
 				"/var/run/143/sandbox-auth:/var/run/143/sandbox-auth",
 			},
-			Env: os.Environ(),
+			GroupAdd: sessionExecutorGroupAddFromEnv(),
+			Env:      os.Environ(),
 		}),
 		NodeID:   cfg.NodeID,
 		Image:    cfg.SessionExecutorImage,
 		BuildSHA: version.BuildSHA,
 	}
+}
+
+func sessionExecutorGroupAddFromEnv() []string {
+	return sessionExecutorGroupAdd(os.Getenv("DOCKER_GID"))
+}
+
+func sessionExecutorGroupAdd(dockerGID string) []string {
+	if dockerGID == "" {
+		return nil
+	}
+	return []string{dockerGID}
 }
 
 // buildServices constructs the full set of Phase 3+ worker services.

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -234,6 +234,29 @@ func TestValidateSessionExecutorStartupConfig(t *testing.T) {
 	}
 }
 
+func TestSessionExecutorGroupAdd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		dockerGID string
+		expected  []string
+	}{
+		{name: "empty docker gid omits supplemental groups", dockerGID: "", expected: nil},
+		{name: "configured docker gid is passed through", dockerGID: "123", expected: []string{"123"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := sessionExecutorGroupAdd(tt.dockerGID)
+
+			require.Equal(t, tt.expected, got, "session executor group add should reflect the configured Docker socket group")
+		})
+	}
+}
+
 func TestBuildWorkerMetadataProvider_IncludesSandboxCapacity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/session_executor_store.go
+++ b/internal/db/session_executor_store.go
@@ -208,11 +208,12 @@ func (s *SessionExecutorStore) ReclaimLost(ctx context.Context, staleBefore time
 			 AND j.id = se.job_id
 			WHERE se.status IN ('starting', 'running', 'draining')
 			  AND se.heartbeat_at < $1
-			  AND j.lock_token = se.lock_token
 			  AND (
-				(j.status = 'running' AND j.owner_kind = 'session_executor' AND j.lease_expires_at < now())
+				(j.status = 'running' AND j.owner_kind = 'session_executor' AND j.lock_token = se.lock_token AND j.lease_expires_at < now())
 				OR
-				(se.status = 'starting' AND j.owner_kind = 'worker')
+				(se.status = 'starting' AND j.owner_kind = 'worker' AND (j.lock_token IS NULL OR j.lock_token = se.lock_token))
+				OR
+				(j.status IN ('succeeded', 'failed', 'cancelled', 'skipped', 'dead_letter') AND (j.lock_token IS NULL OR j.lock_token = se.lock_token))
 			  )
 			ORDER BY se.heartbeat_at ASC
 			FOR UPDATE SKIP LOCKED
@@ -227,7 +228,10 @@ func (s *SessionExecutorStore) ReclaimLost(ctx context.Context, staleBefore time
 				updated_at = now()
 			FROM stale_active stale
 			WHERE se.id = stale.id
-			  AND stale.owner_kind = 'worker'
+			  AND (
+				stale.owner_kind = 'worker'
+				OR stale.job_status IN ('succeeded', 'failed', 'cancelled', 'skipped', 'dead_letter')
+			  )
 			RETURNING se.id
 		),
 		lost_executors AS (
@@ -239,6 +243,7 @@ func (s *SessionExecutorStore) ReclaimLost(ctx context.Context, staleBefore time
 			FROM stale_active stale
 			WHERE se.id = stale.id
 			  AND stale.owner_kind = 'session_executor'
+			  AND stale.job_status = 'running'
 			RETURNING stale.org_id, stale.job_id, stale.lock_token
 		),
 		updated_jobs AS (

--- a/internal/db/session_executor_store_test.go
+++ b/internal/db/session_executor_store_test.go
@@ -318,6 +318,17 @@ func TestSessionExecutorStore_ReclaimLostClearsPreHandoffOrphans(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestSessionExecutorStore_ReclaimLostClearsTerminalJobOrphans(t *testing.T) {
+	t.Parallel()
+
+	src, err := os.ReadFile("session_executor_store.go")
+	require.NoError(t, err, "test should read session executor store source")
+
+	body := string(src)
+	require.Contains(t, body, "j.lock_token IS NULL", "ReclaimLost should consider stale executors whose job lock was already cleared")
+	require.Contains(t, body, "stale.job_status IN ('succeeded', 'failed', 'cancelled', 'skipped', 'dead_letter')", "ReclaimLost should clear active executor rows for terminal jobs")
+}
+
 func TestJobStore_GetRunningForSessionExecutor(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/docker_executor_launcher.go
+++ b/internal/worker/docker_executor_launcher.go
@@ -22,6 +22,7 @@ type DockerExecutorLauncherConfig struct {
 	Image       string
 	NetworkMode string
 	Binds       []string
+	GroupAdd    []string
 	Env         []string
 }
 
@@ -65,7 +66,8 @@ func (l *DockerExecutorLauncher) Launch(ctx context.Context, spec ExecutorLaunch
 
 	name := "143-session-executor-" + spec.ExecutorID.String()
 	hostConfig := &container.HostConfig{
-		Binds: l.cfg.Binds,
+		Binds:    l.cfg.Binds,
+		GroupAdd: l.cfg.GroupAdd,
 	}
 	if l.cfg.NetworkMode != "" {
 		hostConfig.NetworkMode = container.NetworkMode(l.cfg.NetworkMode)

--- a/internal/worker/docker_executor_launcher_test.go
+++ b/internal/worker/docker_executor_launcher_test.go
@@ -48,6 +48,7 @@ func TestDockerExecutorLauncher_LaunchCreatesLabeledExecutorContainer(t *testing
 			Image:       "ghcr.io/assembledhq/143-server:test",
 			NetworkMode: "143_default",
 			Binds:       []string{"/var/run/docker.sock:/var/run/docker.sock"},
+			GroupAdd:    []string{"123"},
 			Env:         []string{"DATABASE_URL=postgres://example"},
 		},
 	}
@@ -76,6 +77,7 @@ func TestDockerExecutorLauncher_LaunchCreatesLabeledExecutorContainer(t *testing
 	require.Equal(t, jobID.String(), client.createConfig.Labels["com.143.job_id"], "Launch should label the job id")
 	require.Equal(t, container.NetworkMode("143_default"), client.createHostConfig.NetworkMode, "Launch should attach to the configured Docker network")
 	require.Equal(t, []string{"/var/run/docker.sock:/var/run/docker.sock"}, client.createHostConfig.Binds, "Launch should mount required host resources")
+	require.Equal(t, []string{"123"}, client.createHostConfig.GroupAdd, "Launch should add the configured supplemental groups")
 	require.Equal(t, "container-1", client.startID, "Launch should start the created container")
 }
 


### PR DESCRIPTION
## Summary
- pass the worker’s Docker group into durable session executor containers so they can reach `/var/run/docker.sock`
- harden stale executor reclamation so terminaled jobs can clear orphaned active rows instead of wedging retries on the one-active-executor constraint
- add tests covering the new Docker group wiring and recovery behavior

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`