### PR TITLE
Stabilize host resource sampler test on computed CPU sample

### DIFF
--- a/internal/worker/platform_health_test.go
+++ b/internal/worker/platform_health_test.go
@@ -162,7 +162,17 @@ func TestRunHostResourceSamplerEmitsStructuredSamples(t *testing.T) {
 
 	events := parseJSONLogEvents(t, logs.Bytes())
 	require.NotEmpty(t, events, "host resource sampler should write at least one event")
-	event := events[len(events)-1]
+	var event map[string]any
+	for _, candidate := range events {
+		if candidate["message"] != "platform health: host resource sample" {
+			continue
+		}
+		if candidate["host_cpu_util"] == float64(0.9) {
+			event = candidate
+			break
+		}
+	}
+	require.NotNil(t, event, "host resource sampler should emit the computed second sample")
 	require.Equal(t, "platform health: host resource sample", event["message"], "host resource sampler should use the canonical log message")
 	require.Equal(t, "worker-1", event["worker_node_id"], "host resource sampler should include worker node id")
 	require.Equal(t, float64(0.9), event["host_cpu_util"], "host resource sampler should compute CPU utilization from consecutive samples")


### PR DESCRIPTION
## Summary
- Make `TestRunHostResourceSamplerEmitsStructuredSamples` select the sample with the computed `host_cpu_util` instead of assuming the last emitted log line is the second tick.
- This removes a timing-sensitive assertion while still verifying the sampler derives CPU utilization from consecutive counters.

## Testing
- Not run (not requested)