### PR TITLE
Match session dropdown font size for “Create branch” action

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -3622,6 +3622,11 @@ describe('SessionDetailPage', () => {
     await screen.findAllByText('Fixed TypeError by adding null check');
     expect(await screen.findByRole('button', { name: /Create PR/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Create PR/ })).not.toBeDisabled();
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: 'More publish actions' }));
+
+    expect(await screen.findByRole('menuitem', { name: /Create branch/ })).toHaveClass('text-xs');
   });
 
   it('shows a durable View branch link after branch-only publish succeeds', async () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -4931,6 +4931,7 @@ export function SessionDetailContent({ id }: { id: string }) {
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="end">
                         <DropdownMenuItem
+                          className="text-xs"
                           onClick={createBranch}
                           disabled={branchActionDisabled}
                           title={branchActionTitle}


### PR DESCRIPTION
## Summary
This updates the Session details “Create branch” dropdown item to use the same compact typography as the “Create PR” action. Adds a regression test to prevent future styling drift.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Added `className="text-xs"` to the **Create branch** `DropdownMenuItem` so it matches the compact **Create PR** text.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Added an assertion that the **Create branch** dropdown menu item has the `text-xs` class after opening the actions menu.

## Test plan
- Ran targeted **Vitest** test (session detail page).
- Ran **npm run typecheck**
- Ran **npm run lint**
- Ran **npm run build**
- Note: used `npm ci` because `frontend/node_modules` was missing.

[143.dev](https://143.dev) | [session 6ae7ba87](https://143.dev/sessions/6ae7ba87-c08e-4b8e-8b92-bd538cde934a)