### PR TITLE
Fix Linear agent PR pushes and terminal milestone reporting

### DIFF
--- a/internal/services/github/pr.go
+++ b/internal/services/github/pr.go
@@ -1367,6 +1367,7 @@ trap cleanup EXIT
 cd %[2]s
 git config user.name %[3]s
 git config user.email %[4]s
+git checkout -B %[7]s
 git add -A
 if ! git diff --cached --quiet; then
     git commit -F %[1]s

--- a/internal/services/github/pr_test.go
+++ b/internal/services/github/pr_test.go
@@ -3732,6 +3732,11 @@ func TestBuildPushScript_Structure(t *testing.T) {
 	// WorkDir is cd'd into.
 	require.Contains(t, script, "cd '/home/user/repo'")
 
+	// Hydrated snapshots may have been captured while the repo was on a stale
+	// branch. The PR push path must normalize the current branch before the
+	// pre-push guard runs.
+	require.Contains(t, script, "git checkout -B '143/abc123/fix-typo'")
+
 	// Commit message is read from file (not argv).
 	require.Contains(t, script, "git commit -F '/home/user/.143-pr-commit-msg'")
 
@@ -3766,9 +3771,10 @@ func TestBuildPushScript_QuotesHostileBranchName(t *testing.T) {
 		"https://github.com/o/r.git",
 	)
 	require.Contains(t, script, `HEAD:refs/heads/'143/abc/it'\''s-fine'`)
-	// The branch is interpolated three times now (ls-remote, lease ref, push
-	// ref); each must round-trip through shellQuote so the embedded quote
-	// can't break out and corrupt the script.
+	// The branch is interpolated four times now (checkout, ls-remote, lease
+	// ref, push ref); each must round-trip through shellQuote so the embedded
+	// quote can't break out and corrupt the script.
+	require.Contains(t, script, `git checkout -B '143/abc/it'\''s-fine'`)
 	require.Contains(t, script, `git ls-remote 'https://github.com/o/r.git' refs/heads/'143/abc/it'\''s-fine'`)
 	require.Contains(t, script, `--force-with-lease=refs/heads/'143/abc/it'\''s-fine':"${remote_sha}"`)
 }

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1912,6 +1912,7 @@ func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger)
 				}
 				return &FatalError{Err: createErr}
 			}
+			registerOpenPRDeadLetterMilestone(ctx, stores, logger, orgID, runID)
 			return createErr
 		}
 
@@ -1920,6 +1921,17 @@ func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger)
 		}
 		return nil
 	}
+}
+
+func registerOpenPRDeadLetterMilestone(ctx context.Context, stores *Stores, logger zerolog.Logger, orgID, sessionID uuid.UUID) {
+	if stores == nil || stores.Jobs == nil {
+		return
+	}
+	jobctx.RegisterDeadLetterHook(ctx, func(hookCtx context.Context, _ error) {
+		writeCtx, cancel := context.WithTimeout(context.WithoutCancel(hookCtx), 10*time.Second)
+		defer cancel()
+		linear.EnqueueMilestone(writeCtx, stores.Jobs, logger, orgID, sessionID, "failed", 0)
+	})
 }
 
 // create_branch pushes a completed session snapshot to GitHub without opening

--- a/internal/worker/handlers.go
+++ b/internal/worker/handlers.go
@@ -1899,17 +1899,17 @@ func newOpenPRHandler(stores *Stores, services *Services, logger zerolog.Logger)
 			if stateErr := stores.Sessions.UpdatePRCreationState(ctx, orgID, runID, models.PRCreationStateFailed, msg); stateErr != nil {
 				logger.Error().Err(stateErr).Msg("failed to mark PR creation as failed")
 			}
-			// "no changes to push" is a terminal-but-non-failure outcome:
-			// the session ran to completion but produced nothing worth
-			// shipping. Tell the Linear linker so the attachment subtitle
-			// stops saying "Running" forever and the audit log records the
-			// terminal state. Other PR creation errors are not fired as
-			// `failed` here because failRun in the orchestrator is the
-			// canonical entry point for those.
+			// PR creation failures happen after the agent run has already
+			// completed, so failRun will not fire for them. Tell the Linear
+			// linker about terminal outcomes here so agent-triggered sessions
+			// do not stay in-progress forever after a dead-lettered open_pr.
 			if errors.Is(createErr, ghservice.ErrNoChanges) {
 				linear.EnqueueMilestone(ctx, stores.Jobs, logger, orgID, runID, "ended_no_pr", 0)
 			}
 			if shouldDeadLetterPRError(createErr) {
+				if !errors.Is(createErr, ghservice.ErrNoChanges) {
+					linear.EnqueueMilestone(ctx, stores.Jobs, logger, orgID, runID, "failed", 0)
+				}
 				return &FatalError{Err: createErr}
 			}
 			return createErr

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1974,6 +1974,49 @@ func TestOpenPRHandler_TerminalPRErrorsBecomeFatal(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
+func TestOpenPRHandler_RetryablePRErrorEnqueuesFailedMilestoneOnDeadLetter(t *testing.T) {
+	t.Parallel()
+
+	stores, mock := newTestStores(t)
+	defer mock.Close()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	now := time.Now()
+	snapshotKey := "snap-open-pr-retryable"
+
+	mock.ExpectQuery("SELECT .* FROM sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns).AddRow(newWorkerSessionRow(sessionID, orgID, now, &snapshotKey)...))
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("UPDATE sessions").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
+
+	retryableErr := errors.New("transient github push failure")
+	services := &Services{
+		PR: &stubPRService{
+			createPRFn: func(ctx context.Context, run *models.Session, params ...ghservice.CreatePRParams) (*models.PullRequest, error) {
+				return nil, retryableErr
+			},
+		},
+	}
+
+	ctx := jobctx.WithDeadLetterHooks(context.Background())
+	handler := newOpenPRHandler(stores, services, zerolog.Nop())
+	payload := json.RawMessage(`{"session_id":"` + sessionID.String() + `","org_id":"` + orgID.String() + `"}`)
+	err := handler(ctx, "open_pr", payload)
+
+	require.ErrorIs(t, err, retryableErr, "open_pr should return retryable PR errors to the worker")
+	jobctx.RunDeadLetterHooks(ctx, err)
+	require.NoError(t, mock.ExpectationsWereMet(), "dead-letter hook should enqueue a failed Linear milestone after retry exhaustion")
+}
+
 func TestPullRequestHealthJobHandlers(t *testing.T) {
 	t.Parallel()
 

--- a/internal/worker/handlers_test.go
+++ b/internal/worker/handlers_test.go
@@ -1952,6 +1952,9 @@ func TestOpenPRHandler_TerminalPRErrorsBecomeFatal(t *testing.T) {
 	mock.ExpectQuery("UPDATE sessions").
 		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
 		WillReturnRows(pgxmock.NewRows(workerSessionColumns))
+	mock.ExpectQuery("INSERT INTO jobs").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(pgxmock.NewRows([]string{"id"}).AddRow(uuid.New()))
 
 	services := &Services{
 		PR: &stubPRService{


### PR DESCRIPTION
## Summary
- Normalize hydrated PR-push sandboxes onto the session’s canonical working branch before commit/push so stale snapshot branches do not trip the pre-push guard.
- Emit a Linear `failed` milestone for terminal `open_pr` errors so agent-triggered sessions do not remain stuck in-progress after PR creation dead-letters.
- Add regression coverage for the push script branch normalization and the terminal Linear milestone enqueue path.

## Testing
- Added focused unit coverage for the GitHub push script and the worker open-PR failure path.
- Ran `go vet ./...`, `go build ./...`, and `go test ./...` successfully.