### PR TITLE
Simplify PreviewPanel ready-state actions and update related tests

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -427,7 +427,7 @@ describe("PreviewPanel component", () => {
     );
   });
 
-  it("renders width preset buttons in ready state", async () => {
+  it("renders a prominent preview link instead of viewport preset buttons in ready state", async () => {
     mockGet.mockResolvedValue(makePreviewStatus({ status: "ready" }));
 
     const { container } = renderWithProviders(
@@ -438,17 +438,15 @@ describe("PreviewPanel component", () => {
       expect(screen.getByText("Ready")).toBeInTheDocument();
     });
 
-    // Width presets container with 4 icon buttons (Mobile, Tablet, Desktop, Full)
+    const previewLink = screen.getByRole("link", { name: /Open Preview/i });
+    expect(previewLink).toHaveAttribute("href", "http://prev-1.preview.test");
+    expect(previewLink).toHaveAttribute("target", "_blank");
+
+    // The old viewport preset group (Mobile, Tablet, Desktop, Full) should not render.
     const presetContainer = container.querySelector(
       ".flex.items-center.gap-0\\.5.rounded-md.border",
     );
-    expect(presetContainer).toBeInTheDocument();
-
-    // Check for the 4 preset icon buttons via tooltip trigger data attribute
-    const presetButtons = presetContainer!.querySelectorAll(
-      "[data-slot='tooltip-trigger']",
-    );
-    expect(presetButtons).toHaveLength(4);
+    expect(presetContainer).not.toBeInTheDocument();
   });
 
   it("renders ConsoleBadge in ready state", async () => {
@@ -681,7 +679,7 @@ describe("PreviewPanel component", () => {
 
   /* ---------- Service status indicators ---------- */
 
-  it("renders service status indicators when multiple services exist", async () => {
+  it("does not render ready-state service status indicators when multiple services exist", async () => {
     mockGet.mockResolvedValue(
       makePreviewStatus({ status: "ready" }, [
         {
@@ -698,7 +696,7 @@ describe("PreviewPanel component", () => {
         {
           id: "svc-2",
           preview_instance_id: "prev-1",
-          service_name: "api",
+          service_name: "server",
           role: "support",
           status: "starting",
           command: ["go", "run", "."],
@@ -713,11 +711,12 @@ describe("PreviewPanel component", () => {
     renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
 
     await waitFor(() => {
-      expect(screen.getByText("frontend")).toBeInTheDocument();
+      expect(screen.getByText("Ready")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("api")).toBeInTheDocument();
-    expect(screen.getByText("(port binding)")).toBeInTheDocument();
+    expect(screen.queryByText("frontend")).not.toBeInTheDocument();
+    expect(screen.queryByText("server")).not.toBeInTheDocument();
+    expect(screen.queryByText("(port binding)")).not.toBeInTheDocument();
   });
 
   it("does not render service indicators when only one service exists", async () => {
@@ -1264,36 +1263,6 @@ describe("PreviewPanel component", () => {
     await waitFor(() => {
       expect(screen.getByText("Failed to restart preview: server error")).toBeInTheDocument();
     });
-  });
-
-  /* ---------- Width preset interactions ---------- */
-
-  it("changes iframe container max-width when a width preset is clicked", async () => {
-    const user = userEvent.setup();
-    mockGet.mockResolvedValue(makePreviewStatus({ status: "ready", id: "prev-1" }));
-
-    const { container } = renderWithProviders(
-      <PreviewPanel {...DEFAULT_PROPS} />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText("Ready")).toBeInTheDocument();
-    });
-
-    // Find the preset buttons container
-    const presetContainer = container.querySelector(
-      ".flex.items-center.gap-0\\.5.rounded-md.border",
-    )!;
-    const presetButtons = presetContainer.querySelectorAll("button");
-
-    // Click Mobile preset (first button, 375px)
-    await user.click(presetButtons[0]);
-
-    // The iframe wrapper div should have maxWidth 375px
-    const iframeWrapper = container.querySelector(
-      "[style*='max-width: 375px']",
-    );
-    expect(iframeWrapper).toBeInTheDocument();
   });
 
   /* ---------- Design mode toggle ---------- */

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -7,10 +7,7 @@ import {
   Square,
   RotateCw,
   ExternalLink,
-  Smartphone,
-  Tablet,
   Monitor,
-  Maximize2,
   Loader2,
   AlertTriangle,
   CheckCircle2,
@@ -67,13 +64,6 @@ export interface PreviewPanelProps {
   previewOriginTemplate: string; // e.g. "http://{id}.preview.localhost:9090"
 }
 
-const WIDTH_PRESETS = [
-  { name: "Mobile", width: 375, icon: Smartphone },
-  { name: "Tablet", width: 768, icon: Tablet },
-  { name: "Desktop", width: 1280, icon: Monitor },
-  { name: "Full", width: 0, icon: Maximize2 },
-] as const;
-
 const PREVIEW_LIFETIME_OPTIONS = [
   { label: "Keep for 15 min", durationSeconds: 15 * 60 },
   { label: "Keep for 30 min", durationSeconds: 30 * 60 },
@@ -126,20 +116,6 @@ function statusColor(status: PreviewStatus): string {
       return "bg-muted text-muted-foreground border-border";
     default:
       return "bg-primary/15 text-primary border-primary/20";
-  }
-}
-
-function serviceStatusIcon(status: string) {
-  switch (status) {
-    case "ready":
-      return <CheckCircle2 className="size-3 text-emerald-500" />;
-    case "failed":
-      return <AlertTriangle className="size-3 text-destructive" />;
-    case "starting":
-    case "pending":
-      return <Loader2 className="size-3 animate-spin text-muted-foreground" />;
-    default:
-      return <Circle className="size-3 text-muted-foreground" />;
   }
 }
 
@@ -408,7 +384,6 @@ export function PreviewPanel({
   const queryClient = useQueryClient();
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const startupPhaseRailRef = useRef<HTMLDivElement | null>(null);
-  const [selectedWidth, setSelectedWidth] = useState<number>(0); // 0 = full
   const [designMode, setDesignMode] = useState(false);
   const [bootstrapComplete, setBootstrapComplete] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -799,6 +774,23 @@ export function PreviewPanel({
       {/* Controls bar */}
       {showTopControls && (
       <div className="flex items-center gap-2 flex-wrap">
+        {/* Open preview */}
+        {isReady && previewOrigin && (
+          <Button
+            size="sm"
+            asChild
+          >
+            <a
+              href={previewOrigin}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <ExternalLink className="size-3.5" />
+              Open Preview
+            </a>
+          </Button>
+        )}
+
         {/* Start / Stop / Restart */}
         <div className="flex items-center gap-1">
           {isActive ? (
@@ -863,37 +855,6 @@ export function PreviewPanel({
 
         <div className="flex-1" />
 
-        {/* Width presets */}
-        {isReady && (
-          <TooltipProvider>
-            <div className="flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5">
-              {WIDTH_PRESETS.map((preset) => (
-                <Tooltip key={preset.name}>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={() => setSelectedWidth(preset.width)}
-                      className={cn(
-                        "rounded p-1 transition-colors",
-                        selectedWidth === preset.width
-                          ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground"
-                      )}
-                    >
-                      <preset.icon className="size-3.5" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    {preset.name}
-                    {preset.width > 0 ? ` (${preset.width}px)` : ""}
-                  </TooltipContent>
-                </Tooltip>
-              ))}
-            </div>
-          </TooltipProvider>
-        )}
-
         {/* Design mode toggle */}
         {isReady && (
           <TooltipProvider>
@@ -914,29 +875,6 @@ export function PreviewPanel({
           </TooltipProvider>
         )}
 
-        {/* Open in new tab */}
-        {isReady && previewOrigin && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  size="icon-sm"
-                  variant="ghost"
-                  asChild
-                >
-                  <a
-                    href={previewOrigin}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <ExternalLink className="size-3.5" />
-                  </a>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Open in new tab</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
       </div>
       )}
 
@@ -974,23 +912,6 @@ export function PreviewPanel({
             <RefreshCw className="size-3.5" />
             Retry
           </Button>
-        </div>
-      )}
-
-      {/* Service status indicators */}
-      {services.length > 1 && isReady && (
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
-          {services.map((svc) => (
-            <div key={svc.service_name} className="flex items-center gap-1">
-              {serviceStatusIcon(svc.status)}
-              <span>{svc.service_name}</span>
-              {svc.error && (
-                <span className="text-destructive truncate max-w-[200px]">
-                  ({svc.error})
-                </span>
-              )}
-            </div>
-          ))}
         </div>
       )}
 
@@ -1206,14 +1127,7 @@ export function PreviewPanel({
       {isReady && iframeSrc && (
         <div className="relative rounded-lg border bg-muted/30 overflow-hidden">
           <div
-            className={cn(
-              "mx-auto transition-all duration-300",
-              selectedWidth > 0 ? "border-x border-dashed border-border" : ""
-            )}
-            style={{
-              maxWidth: selectedWidth > 0 ? `${selectedWidth}px` : "100%",
-              width: "100%",
-            }}
+            className="mx-auto w-full"
           >
             <div className="relative" style={{ paddingBottom: "62.5%" }}>
               {/* Sandbox threat model: allow-same-origin is required so the


### PR DESCRIPTION
## Summary
Updated `PreviewPanel` so the ready state shows a single prominent “Open Preview” link instead of viewport preset (Mobile/Tablet/Desktop/Full) buttons. Adjusted service-status indicator behavior to avoid rendering ready-state indicators for multiple services, and updated the existing test suite accordingly.

## Changes
- **frontend/src/components/preview/preview-panel.tsx**
  - Replace viewport width preset buttons with a prominent external “Open Preview” link in the **ready** state.
  - Remove/avoid rendering the old viewport preset UI group in ready state.
  - Do not render ready-state service status indicators when multiple services exist (aligns UI expectations and removes unrelated indicators).
- **frontend/src/components/preview/preview-panel.test.tsx**
  - Update test to assert the presence of the “Open Preview” link (`href="http://prev-1.preview.test"`, `target="_blank"`) and assert the preset container no longer renders.
  - Update multi-service service indicator test to confirm ready-state indicators are not shown (e.g., no “frontend”/“server” and no “(port binding)” text).
  - Remove/trim obsolete “width preset interactions” tests that depended on the removed preset button behavior.

## Test plan
- Ran the existing unit tests for `PreviewPanel` (updated assertions cover the new link-based action and removed preset UI). No additional test reruns were required beyond the component/test changes in this diff.

[143.dev](https://143.dev) | [session 68883201](https://143.dev/sessions/68883201-c263-4200-8f1a-258246a12bd9)