### PR TITLE
Add golangci-lint to repo sandbox dependencies

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "golangci-lint": "2.10.1"
+  },
   "preview": {
     "name": "manado",
     "primary": "frontend",


### PR DESCRIPTION
## Summary
- Add `golangci-lint` as a pinned repo dependency in `.143/config.json`
- Keep the 143 sandbox aligned with this repo’s `make lint` workflow

## Testing
- Not run (not requested)