### PR TITLE
Fix emoji trigger height to match Input height and update settings test

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -548,7 +548,7 @@ describe("AutomationDetailPage", () => {
 
     const identityRow = screen.getByTestId("automation-settings-identity-row");
     expect(identityRow).toHaveClass("grid-cols-[4.75rem_minmax(0,1fr)]");
-    expect(screen.getByRole("button", { name: "Automation emoji" })).toHaveClass("w-16");
+    expect(screen.getByRole("button", { name: "Automation emoji" })).toHaveClass("h-9", "w-16");
     expect(screen.getByLabelText("Name")).toHaveValue("Weekly audit");
   });
 

--- a/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
+++ b/frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx
@@ -140,7 +140,7 @@ export function AutomationEmojiPicker({
             variant="outline"
             aria-label={triggerLabel}
             disabled={disabled}
-            className={cn("h-10 w-16 justify-center gap-1 px-2", className)}
+            className={cn("h-9 w-16 justify-center gap-1 px-2", className)}
           >
             <span className="text-lg leading-none" aria-hidden="true">{selected.emoji}</span>
             <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## Summary
Adjusted the Automation emoji trigger to use the same height as the shared `Input` component (`h-9`), aligning labels and visual layout. Updated the existing settings-page test to assert the new `h-9 w-16` classes.

## Changes
- **frontend/src/app/(dashboard)/automations/automation-emoji-picker.tsx**
  - Updated the emoji trigger button styles from `h-10 w-16 ...` to `h-9 w-16 ...` to match the shared `Input` height.
- **frontend/src/app/(dashboard)/automations/[id]/page.test.tsx**
  - Updated the settings page assertion for the `"Automation emoji"` button to expect `h-9` in addition to `w-16`.

## Test plan
- Ran focused Vitest test for the updated page (`page.test.tsx`).
- Ran `npm run typecheck`
- Ran `npm run lint`
- Ran `npm run build`
- Note: ran `npm ci` first because `frontend/node_modules` was missing.

[143.dev](https://143.dev) | [session ad7d6e72](https://143.dev/sessions/ad7d6e72-b346-4300-823c-0cc53e541c10)