### PR TITLE
Fix legacy thread log visibility and refresh resumed thread start time

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.test.ts
@@ -199,6 +199,13 @@ describe("thread message windows", () => {
       [message(1, 1), message(2, 3)],
     ).map((item) => item.id)).toEqual([10, 30]);
   });
+
+  it("keeps logs when a legacy thread has no persisted messages", () => {
+    expect(filterThreadLogsForLoadedMessages(
+      [log(10, 1), log(20, 1)],
+      [],
+    ).map((item) => item.id)).toEqual([10, 20]);
+  });
 });
 
 describe("trackInFlightAgentUpdate", () => {

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -1848,7 +1848,7 @@ export function filterThreadLogsForLoadedMessages(
   logs: SessionLog[],
   messages: SessionMessage[],
 ): SessionLog[] {
-  if (messages.length === 0) return [];
+  if (messages.length === 0) return logs;
   const loadedTurns = new Set(messages.map((message) => message.turn_number));
   return logs.filter((log) => loadedTurns.has(log.turn_number));
 }

--- a/internal/db/session_thread_store.go
+++ b/internal/db/session_thread_store.go
@@ -412,12 +412,13 @@ func (s *SessionThreadStore) ClaimIdleForSession(ctx context.Context, orgID, ses
 // surfaces ErrThreadRunningLimitReached the same way, so callers can keep one
 // "limit hit, queue instead" branch regardless of which claim path failed.
 //
-// Does not reset started_at — the original thread start time remains the
-// authoritative "first activity" stamp. completed_at is cleared so the row
-// reflects the new in-flight turn rather than the previous terminal state.
-// failure_explanation and failure_category are intentionally preserved as
-// audit history of the prior run; mirrors SessionStore.ClaimForResume, which
-// also leaves session-level failure fields untouched on resume.
+// Resets started_at for the new turn so runtime watchdogs and the stuck-thread
+// reaper measure the resumed execution instead of the original thread age.
+// completed_at is cleared so the row reflects the new in-flight turn rather
+// than the previous terminal state. failure_explanation and failure_category
+// are intentionally preserved as audit history of the prior run; mirrors
+// SessionStore.ClaimForResume, which also leaves session-level failure fields
+// untouched on resume.
 func (s *SessionThreadStore) ClaimForResumeInSession(ctx context.Context, orgID, sessionID, threadID uuid.UUID, maxRunning int) (models.SessionThread, error) {
 	return s.claimForSession(ctx, claimForSessionArgs{
 		orgID:             orgID,
@@ -454,9 +455,9 @@ func claimModeSetClause(mode claimMode) string {
 		// time-on-task surfaces have a precise begin stamp.
 		return "started_at = now(),"
 	case claimModeResume:
-		// Resume of a terminal/paused row — clear the stale completed_at
-		// from the previous turn so the row reflects the new in-flight one.
-		return "completed_at = NULL,"
+		// Resume of a terminal/paused row — refresh started_at for this turn
+		// and clear stale completed_at from the previous turn.
+		return "started_at = now(),\n\t\t    completed_at = NULL,"
 	default:
 		// Unreachable in normal code paths; panic is preferable to silently
 		// emitting an UPDATE that does the wrong thing.

--- a/internal/db/session_thread_store_test.go
+++ b/internal/db/session_thread_store_test.go
@@ -677,13 +677,12 @@ func TestSessionThreadStore_ClaimForResumeInSession(t *testing.T) {
 	row[11] = &now
 	row[17] = &now
 
-	// Pin the resume claim's distinguishing properties: it should clear
-	// completed_at (so the row reflects the new in-flight turn rather than
-	// the previous terminal state), preserve started_at (the original
-	// thread start time stays meaningful), and only fire when status is in
-	// the resumable set. The 5 named args mirror ClaimIdleForSession;
-	// claimable_statuses carries models.ResumableThreadStatuses.
-	mock.ExpectQuery(`(?s)WITH locked_threads AS.*WHERE org_id = @org_id AND session_id = @session_id AND archived_at IS NULL.*FOR UPDATE.*target_claimable.*status\s*=\s*ANY\(@claimable_statuses\).*UPDATE session_threads\s+SET status = 'running',\s+completed_at = NULL,\s+last_activity_at = now\(\),\s+cancel_requested_at = NULL.*archived_at IS NULL.*EXISTS\s*\(\s*SELECT 1 FROM eligible\s*\).*RETURNING`).
+	// Pin the resume claim's distinguishing properties: it should refresh
+	// started_at for the new turn so the stuck-running reaper measures this
+	// execution, clear completed_at so the row reflects the new in-flight turn,
+	// and only fire when status is in the resumable set. The 5 named args mirror
+	// ClaimIdleForSession; claimable_statuses carries models.ResumableThreadStatuses.
+	mock.ExpectQuery(`(?s)WITH locked_threads AS.*WHERE org_id = @org_id AND session_id = @session_id AND archived_at IS NULL.*FOR UPDATE.*target_claimable.*status\s*=\s*ANY\(@claimable_statuses\).*UPDATE session_threads\s+SET status = 'running',\s+started_at = now\(\),\s+completed_at = NULL,\s+last_activity_at = now\(\),\s+cancel_requested_at = NULL.*archived_at IS NULL.*EXISTS\s*\(\s*SELECT 1 FROM eligible\s*\).*RETURNING`).
 		WithArgs(anyArgs(5)...).
 		WillReturnRows(pgxmock.NewRows(sessionThreadTestColumns).AddRow(row...))
 


### PR DESCRIPTION
## Summary
- Show thread logs even when a legacy thread has no persisted `session_messages` rows, so old sessions no longer render as blank until a `/review` message is added.
- Refresh `started_at` when a thread is resumed so runtime watchdogs and the stuck-thread reaper measure the current turn instead of the original run.
- Add regression coverage for both the log-only thread case and the resumed-thread claim SQL.

## Testing
- Added frontend unit coverage for log-only thread histories.
- Added backend store coverage for resumed thread claims.
- Verified with `go vet ./...`, `go build ./...`, `go test ./...`, `npm run typecheck`, `npm run lint`, and `npm run build`.