### PR TITLE
Fix diff view header gap and restyle file headers to attach to diff surface

### DIFF
--- a/frontend/src/components/code-review/diff-pane.test.tsx
+++ b/frontend/src/components/code-review/diff-pane.test.tsx
@@ -61,6 +61,14 @@ describe("DiffPane", () => {
     expect(screen.getByText("src/b.ts")).toBeInTheDocument();
   });
 
+  it("keeps the first file header flush with the toolbar by removing top padding from the scroll pane", () => {
+    const { container } = render(<DiffPane files={[makeDiffFile("src/a.ts")]} viewMode="unified" />);
+    const scrollContainer = container.firstElementChild;
+
+    expect(scrollContainer).toHaveClass("pt-0");
+    expect(scrollContainer).not.toHaveClass("p-3");
+  });
+
   it("renders a single file", () => {
     render(<DiffPane files={[makeDiffFile("index.ts")]} viewMode="split" />);
     expect(screen.getByTestId("file-index.ts")).toBeInTheDocument();

--- a/frontend/src/components/code-review/diff-pane.tsx
+++ b/frontend/src/components/code-review/diff-pane.tsx
@@ -206,7 +206,7 @@ export const DiffPane = forwardRef<DiffPaneHandle, DiffPaneProps>(
         key={resetScrollKey ?? "all-files"}
         ref={containerRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-3 space-y-3 md:p-4 md:space-y-4"
+        className="flex-1 overflow-y-auto px-3 pb-3 pt-0 space-y-3 md:px-4 md:pb-4 md:pt-0 md:space-y-4"
       >
         {files.map((file, i) => (
           <FileDiffSection

--- a/frontend/src/components/code-review/file-diff-header.test.tsx
+++ b/frontend/src/components/code-review/file-diff-header.test.tsx
@@ -10,6 +10,15 @@ describe("FileDiffHeader", () => {
     expect(screen.getByText("src/app.ts")).toBeInTheDocument();
   });
 
+  it("uses attached diff-surface styling without an independent sticky shadow", () => {
+    const { container } = render(<FileDiffHeader filePath="src/app.ts" added={3} removed={1} />);
+    const header = container.firstElementChild;
+
+    expect(header).toHaveClass("bg-card/95");
+    expect(header).toHaveClass("border-b");
+    expect(header).toHaveClass("shadow-none");
+  });
+
   it("renders diff stats badge", () => {
     render(<FileDiffHeader filePath="src/app.ts" added={5} removed={2} />);
     expect(screen.getByText("+5")).toBeInTheDocument();

--- a/frontend/src/components/code-review/file-diff-header.tsx
+++ b/frontend/src/components/code-review/file-diff-header.tsx
@@ -1,5 +1,6 @@
 import { Copy, Check, ExternalLink } from "lucide-react";
 import { useState, useCallback, useEffect } from "react";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { DiffStatsBadge } from "./diff-stats-badge";
 
@@ -31,7 +32,7 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
   return (
     <div
       className={cn(
-        "sticky top-0 z-10 flex items-center justify-between px-3 py-2 bg-muted/60 backdrop-blur-sm border-b border-border",
+        "sticky top-0 z-10 flex items-center justify-between rounded-t-lg border-b border-border/70 bg-card/95 px-3 py-1.5 shadow-none backdrop-blur supports-[backdrop-filter]:bg-card/85",
         className
       )}
     >
@@ -43,17 +44,23 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
       </div>
       <div className="flex items-center gap-0.5 shrink-0">
         {onBrowseFile && (
-          <button
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
             onClick={() => onBrowseFile(filePath)}
-            className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+            className="h-7 w-7 text-muted-foreground hover:text-foreground"
             title="Browse in repository explorer"
           >
             <ExternalLink className="h-3.5 w-3.5" />
-          </button>
+          </Button>
         )}
-        <button
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
           onClick={copyPath}
-          className="p-1 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
+          className="h-7 w-7 text-muted-foreground hover:text-foreground"
           title="Copy file path"
         >
           {copied ? (
@@ -61,7 +68,7 @@ export function FileDiffHeader({ filePath, added, removed, className, onBrowseFi
           ) : (
             <Copy className="h-3.5 w-3.5" />
           )}
-        </button>
+        </Button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
Adjusted the diff pane layout to remove the top “gap” so the first file header aligns flush under the main review toolbar. Updated file header styling and controls to better visually attach the header to the diff surface, matching the intended UX polish.

## Changes
- **`frontend/src/components/code-review/diff-pane.tsx`**
  - Removed top padding from the scroll container (`pt-0` / `md:pt-0`) so the first file header sits flush under the toolbar.
- **`frontend/src/components/code-review/file-diff-header.tsx`**
  - Restyled the sticky file header to feel attached to the diff surface (more subtle border, `bg-card/95`, `shadow-none`, tighter vertical padding).
  - Replaced raw icon `<button>` elements with the shared `Button` component for consistent behavior/appearance.
- **Regression tests**
  - **`frontend/src/components/code-review/diff-pane.test.tsx`**: added coverage ensuring the scroll pane has no top padding classes.
  - **`frontend/src/components/code-review/file-diff-header.test.tsx`**: added coverage for attached-surface styling (e.g., `bg-card/95`, `border-b`, `shadow-none`).

## Test plan
- Ran `npm run test:ci -- src/components/code-review/diff-pane.test.tsx src/components/code-review/file-diff-header.test.tsx`
- Ran `npm run typecheck`, `npm run lint`, and `npm run build`
- Verified locally with the dev server (`http://localhost:3000`).

[143.dev](https://143.dev) | [session b17c2a71](https://143.dev/sessions/b17c2a71-d89d-4326-8901-6c370666d484)