### PR TITLE
Stabilize automation emoji picker tests

### DIFF
--- a/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/automations/[id]/page.test.tsx
@@ -34,6 +34,13 @@ vi.mock("./automation-stats-card", () => ({
   AutomationStatsCard: () => <div data-testid="automation-stats-card" />,
 }));
 
+const selectEmojiOption = async (name: string) => {
+  const listbox = await screen.findByRole("listbox");
+  const option = listbox.querySelector<HTMLElement>(`[role="option"][aria-label="${name}"]`);
+  expect(option).not.toBeNull();
+  fireEvent.click(option as HTMLElement);
+};
+
 describe("AutomationDetailPage", () => {
   beforeEach(() => {
     currentUserRole.value = "member";
@@ -488,7 +495,7 @@ describe("AutomationDetailPage", () => {
 
     await user.click(screen.getByRole("tab", { name: "Settings" }));
     await user.click(screen.getByRole("button", { name: "Automation emoji" }));
-    await user.click(await screen.findByRole("option", { name: /Rocket/ }));
+    await selectEmojiOption("Rocket");
     await user.click(screen.getByRole("button", { name: "Save changes" }));
 
     await waitFor(() => {
@@ -611,7 +618,7 @@ describe("AutomationDetailPage", () => {
     });
 
     await user.click(screen.getByRole("button", { name: "Change automation emoji" }));
-    await user.click(await screen.findByRole("option", { name: /Rocket/ }));
+    await selectEmojiOption("Rocket");
 
     expect(screen.getByRole("tab", { name: "Runs" })).toHaveAttribute("data-state", "active");
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Replace the slow `userEvent` click path in the automation detail tests with a targeted option click helper
- Keep the existing picker interaction coverage while avoiding timeout-prone traversal of the large emoji menu

## Testing
- `npm run test:ci` passed
- `npm run typecheck` passed
- `npm run lint` passed
- `npm run build` passed