### PR TITLE
Preserve app CSRF cookies through the preview proxy

### DIFF
--- a/internal/api/handlers/internal_preview.go
+++ b/internal/api/handlers/internal_preview.go
@@ -446,7 +446,7 @@ func (h *InternalPreviewHandler) handleHTTPProxy(w http.ResponseWriter, r *http.
 			req.RequestURI = ""
 			req.Host = "preview-target"
 			req.Header.Del("Authorization")
-			req.Header.Del("Cookie")
+			stripPreviewAccessCookies(req)
 		},
 		Transport: &internalPreviewTransport{
 			manager:   h.manager,
@@ -554,8 +554,18 @@ func cloneWebSocketRequestForInternalProxy(req *http.Request, previewID uuid.UUI
 	}
 	cloned.RequestURI = ""
 	cloned.Header.Del("Authorization")
-	cloned.Header.Del("Cookie")
+	stripPreviewAccessCookies(cloned)
 	return cloned
+}
+
+func stripPreviewAccessCookies(req *http.Request) {
+	cookies := req.Cookies()
+	req.Header.Del("Cookie")
+	for _, c := range cookies {
+		if c.Name != "__Host-preview_session" && c.Name != "preview_session" {
+			req.AddCookie(c)
+		}
+	}
 }
 
 func trimInternalPreviewProxyPath(path string, previewID uuid.UUID) string {

--- a/internal/api/handlers/internal_preview_test.go
+++ b/internal/api/handlers/internal_preview_test.go
@@ -636,7 +636,7 @@ func TestInternalPreviewHandler_ProxyHTTP_Success(t *testing.T) {
 		}
 		require.Equal(t, "/assets/app.js", req.URL.Path, "internal proxy should trim the worker proxy prefix before dialing the preview backend")
 		require.Empty(t, req.Header.Get("Authorization"), "internal proxy should strip authorization headers before dialing the preview backend")
-		require.Empty(t, req.Header.Get("Cookie"), "internal proxy should strip cookies before dialing the preview backend")
+		require.Equal(t, "csrf_token=csrf-token; session_token=session-token", req.Header.Get("Cookie"), "internal proxy should preserve preview-app cookies for in-sandbox auth and CSRF")
 		_, _ = io.WriteString(serverConn, "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\n\r\nok")
 	}()
 
@@ -661,7 +661,7 @@ func TestInternalPreviewHandler_ProxyHTTP_Success(t *testing.T) {
 	req.Header.Set("Authorization", internalPreviewAuthHeader(t, auth.PreviewTokenClaims{
 		OrgID: orgID, PreviewID: &previewID, TargetNodeID: "worker-1", Action: "proxy", ExpiresAt: time.Now().Add(time.Minute),
 	}))
-	req.Header.Set("Cookie", "session=secret")
+	req.Header.Set("Cookie", "__Host-preview_session=preview-secret; csrf_token=csrf-token; session_token=session-token")
 	rr := httptest.NewRecorder()
 
 	handler.Proxy(rr, req)


### PR DESCRIPTION
## Summary
- Fixed the worker-side preview proxy so it strips only gateway-owned preview session cookies and preserves sandbox app cookies like `csrf_token` and `session_token`.
- This removes the login failure caused by the backend seeing `missing CSRF cookie` during preview email sign-in.
- Updated the proxy test to verify the forwarded cookie header keeps app auth/CSRF cookies while still dropping the preview access cookie.

## Testing
- Added and ran a focused handler test covering the proxy cookie-forwarding behavior.
- Verified the backend with `go vet ./...`, `go build ./...`, and `go test ./...`.