### PR TITLE
Fix active tab underline by preventing Tooltip state from overriding TabsTrigger state

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx
@@ -164,6 +164,7 @@ describe("AgentTabStrip", () => {
     expect(scrollWrapper).toHaveClass("overflow-y-hidden");
     expect(scrollWrapper).toHaveClass("pb-1");
     expect(activeTab).toHaveTextContent(/Main tab/i);
+    expect(activeTab).toHaveAttribute("data-state", "active");
     expect(activeTab).not.toHaveTextContent(/Idle/i);
     expect(activeTab).toHaveClass("data-[state=active]:text-primary");
     expect(activeTab).toHaveClass("data-[state=active]:bg-transparent");

--- a/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx
@@ -285,46 +285,48 @@ export function AgentTabStrip({
                     <div key={thread.id} className="group relative flex shrink-0 items-center">
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <TabsTrigger
-                            value={thread.id}
-                            disabled={isNonInteractive}
-                            className={cn(
-                              "h-7 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
-                              showArchiveButton && "pr-8",
-                              tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
-                              isNonInteractive && "cursor-default opacity-60",
-                            )}
-                          >
-                            {showUnreadDot ? (
-                              <span
-                                className={cn(
-                                  "h-2 w-2 shrink-0 rounded-full bg-primary",
-                                  thread.status === "running" && !isCancelling && "animate-pulse",
-                                )}
-                                aria-hidden
-                              />
-                            ) : (
-                              <span className="h-2 w-2 shrink-0" aria-hidden />
-                            )}
-                            <span className="truncate">{thread.label}</span>
-                            {isCancelling && (
-                              <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-label="Cancelling" />
-                            )}
-                            {queued > 0 && (
-                              <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
-                                {queued}
-                              </Badge>
-                            )}
-                            {needsAttention && (
-                              <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-label="Needs attention" />
-                            )}
-                            {overlap.length > 0 && (
-                              <AlertTriangle
-                                className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
-                                aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
-                              />
-                            )}
-                          </TabsTrigger>
+                          <span className="inline-flex">
+                            <TabsTrigger
+                              value={thread.id}
+                              disabled={isNonInteractive}
+                              className={cn(
+                                "h-7 max-w-[15rem] gap-1.5 rounded-md px-2 text-xs data-[state=active]:bg-transparent data-[state=active]:text-primary data-[state=active]:shadow-none",
+                                showArchiveButton && "pr-8",
+                                tabs.length === 1 && "data-[state=active]:bg-transparent data-[state=active]:shadow-none",
+                                isNonInteractive && "cursor-default opacity-60",
+                              )}
+                            >
+                              {showUnreadDot ? (
+                                <span
+                                  className={cn(
+                                    "h-2 w-2 shrink-0 rounded-full bg-primary",
+                                    thread.status === "running" && !isCancelling && "animate-pulse",
+                                  )}
+                                  aria-hidden
+                                />
+                              ) : (
+                                <span className="h-2 w-2 shrink-0" aria-hidden />
+                              )}
+                              <span className="truncate">{thread.label}</span>
+                              {isCancelling && (
+                                <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" aria-label="Cancelling" />
+                              )}
+                              {queued > 0 && (
+                                <Badge variant="secondary" className="h-4 px-1 text-xs leading-none">
+                                  {queued}
+                                </Badge>
+                              )}
+                              {needsAttention && (
+                                <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-label="Needs attention" />
+                              )}
+                              {overlap.length > 0 && (
+                                <AlertTriangle
+                                  className="h-3 w-3 shrink-0 text-amber-600 dark:text-amber-400"
+                                  aria-label={`Overlaps with another tab on ${overlap.length} file${overlap.length === 1 ? "" : "s"}`}
+                                />
+                              )}
+                            </TabsTrigger>
+                          </span>
                         </TooltipTrigger>
                         <TooltipContent side="bottom" className="max-w-sm text-xs">
                           <div className="space-y-1">


### PR DESCRIPTION
## Summary
Fixes an issue where the active tab indicator/underline was not appearing. The root cause was tooltip-owned `data-state="closed"` overwriting the `TabsTrigger` element’s `data-state="active"`, so the underline selector no longer matched.

## Changes
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.tsx`**
  - Adjusted tooltip/tab markup so the tooltip’s DOM/state does not sit on top of the `TabsTrigger` element that needs `data-state="active"` for styling.
- **`frontend/src/app/(dashboard)/sessions/[id]/agent-tab-strip.test.tsx`**
  - Strengthened the test to assert the active tab has `data-state="active"`, ensuring the regression is caught when underline styles depend on that attribute.

## Test plan
- `npm test -- agent-tab-strip.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session fe017f60](https://143.dev/sessions/fe017f60-3cd8-41a4-b48a-4ebc783c3a32)