### PR TITLE
Add tooltip explaining disabled Review action in PR health banner

### DIFF
--- a/frontend/src/components/pr-health-banner.test.tsx
+++ b/frontend/src/components/pr-health-banner.test.tsx
@@ -94,6 +94,33 @@ describe("PRHealthBanner", () => {
     expect(onReview).toHaveBeenCalledTimes(1);
   });
 
+  it("shows the disabled Review action reason in a hover tooltip", async () => {
+    renderWithProviders(
+      <PRHealthBanner
+        health={baseHealth}
+        pendingAction={null}
+        repairError={null}
+        mergeAuthRequired={false}
+        onFixTests={vi.fn()}
+        onResolveConflicts={vi.fn()}
+        onMerge={vi.fn()}
+        reviewAction={{
+          disabled: true,
+          spinning: false,
+          title: "Review can start after the current turn finishes",
+          onClick: vi.fn(),
+        }}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /^Review$/ });
+    expect(button).toBeDisabled();
+
+    await userEvent.setup().hover(button.parentElement as HTMLElement);
+
+    expect(await screen.findByRole("tooltip", { name: "Review can start after the current turn finishes" })).toBeInTheDocument();
+  });
+
 	it("renders the Merge button when can_merge is true and invokes onMerge", async () => {
 		const onMerge = vi.fn();
 		renderWithProviders(

--- a/frontend/src/components/pr-health-banner.tsx
+++ b/frontend/src/components/pr-health-banner.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { DisabledTooltip } from "@/components/ui/disabled-tooltip";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { SyncTimeText } from "@/components/sync-time-text";
 
@@ -240,20 +241,22 @@ export function PRHealthBanner({
                     </Button>
                   )}
                   {reviewAction && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      disabled={reviewAction.disabled || pendingAction !== null}
-                      title={reviewAction.title}
-                      onClick={reviewAction.onClick}
-                    >
-                      {reviewAction.spinning ? (
-                        <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-                      ) : (
-                        <ClipboardList className="mr-1.5 h-3.5 w-3.5" />
-                      )}
-                      Review
-                    </Button>
+                    <DisabledTooltip disabled={reviewAction.disabled || pendingAction !== null} content={reviewAction.title}>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={reviewAction.disabled || pendingAction !== null}
+                        title={reviewAction.title}
+                        onClick={reviewAction.onClick}
+                      >
+                        {reviewAction.spinning ? (
+                          <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                          <ClipboardList className="mr-1.5 h-3.5 w-3.5" />
+                        )}
+                        Review
+                      </Button>
+                    </DisabledTooltip>
                   )}
                   {pushChanges && (
                     <Button


### PR DESCRIPTION
## Summary
Wrap the PR health banner’s disabled **Review** button with the shared `DisabledTooltip` so users can see why the action is unavailable. Add a test to verify the tooltip content appears on hover.

## Changes
- **frontend/src/components/pr-health-banner.tsx**
  - Import `DisabledTooltip`
  - Wrap the `Review` `<Button>` in `DisabledTooltip`, using:
    - `disabled={reviewAction.disabled || pendingAction !== null}`
    - `content={reviewAction.title}`
- **frontend/src/components/pr-health-banner.test.tsx**
  - Add test: hover over the disabled Review action shows the tooltip with the provided disabled reason.

## Test plan
- `npm test -- pr-health-banner.test.tsx --run`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session a5f59f47](https://143.dev/sessions/a5f59f47-d467-49a6-9277-272b48a4c2c2)