### PR TITLE
Surface actionable preview config errors

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1157,6 +1157,31 @@ describe("PreviewPanel component", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("shows invalid config details verbatim when .143/config.json cannot be parsed", async () => {
+    const user = userEvent.setup();
+    mockGet.mockResolvedValue(makePreviewStatus({ status: "stopped" }));
+    const backendMessage =
+      "Invalid .143/config.json preview config: parse preview config: invalid character 'n' looking for beginning of object key string. Fix the committed config and start preview again.";
+    const err = new Error(backendMessage);
+    (err as Error & { code?: string }).code = "PREVIEW_CONFIG_INVALID";
+    mockStart.mockRejectedValueOnce(err);
+
+    renderWithProviders(<PreviewPanel {...DEFAULT_PROPS} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No preview running")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Start Preview" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(backendMessage)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(`Failed to start preview: ${backendMessage}`)
+    ).not.toBeInTheDocument();
+  });
+
   // Provider-side launch failures (image pull, infra health, init script,
   // readiness) carry a backend-built message that names the failing image
   // or service and the underlying cause. We pass it through verbatim — if

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -526,6 +526,12 @@ export function PreviewPanel({
         setMutationError(err.message);
         return;
       }
+      if (code === PREVIEW_ERROR_CODES.CONFIG_INVALID) {
+        // Backend message includes the exact parse/validation failure and the
+        // committed file that needs to be fixed.
+        setMutationError(err.message);
+        return;
+      }
       // Provider-side launch failures (image pull, infra health, init
       // script, readiness probe). The backend builds a message that
       // names the failing image / service and includes the underlying

--- a/frontend/src/lib/preview-types.ts
+++ b/frontend/src/lib/preview-types.ts
@@ -46,6 +46,10 @@ export const PREVIEW_ERROR_CODES = {
   // didn't supply an explicit config, so the backend has nothing to launch.
   // User fix is to commit the config file (see docs/guides/previews.md).
   NO_CONFIG: "PREVIEW_NO_CONFIG",
+  // 422 — .143/config.json exists, but the preview section cannot be parsed or
+  // fails structural validation. Backend message includes the specific config
+  // error and the recovery action.
+  CONFIG_INVALID: "PREVIEW_CONFIG_INVALID",
   // 422 — a preview infrastructure container's image is not on the worker
   // and the on-demand pull failed (registry unreachable, image renamed,
   // rate-limit, no egress). The user-visible message names the image so an

--- a/internal/api/handlers/preview.go
+++ b/internal/api/handlers/preview.go
@@ -187,14 +187,10 @@ func (h *PreviewHandler) requireManager(w http.ResponseWriter, r *http.Request) 
 // Returns:
 //   - (cfg, nil)   when a valid committed config is found and parsed.
 //   - (nil, nil)   for "no config to use" cases where the caller should fall
-//     back to built-in defaults: no fileReader wired, the file is absent, or
-//     its contents fail to parse (a malformed committed config is a user
-//     authoring problem, not an infrastructure failure; surfacing it as a 500
-//     would make the preview worse, not better, than the default).
+//     back to the no-config path: no fileReader wired or the file is absent.
 //   - (nil, err)   for genuine infrastructure failures (docker exec failed,
-//     context cancelled, sandbox gone) — the caller should surface these
-//     instead of silently swapping in Node.js defaults for what may well be
-//     a Go/Python/etc. project.
+//     context cancelled, sandbox gone) or invalid committed config. The caller
+//     should surface these instead of reporting that the file is absent.
 func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *agent.Sandbox, sessionID uuid.UUID) (*models.PreviewConfig, error) {
 	if h.fileReader == nil {
 		return nil, nil
@@ -221,8 +217,8 @@ func (h *PreviewHandler) readWorkspacePreviewConfig(ctx context.Context, sb *age
 			Err(err).
 			Str("session_id", sessionID.String()).
 			Str("path", repoconfig.ConfigPath).
-			Msg("committed preview config failed to parse; falling back to defaults")
-		return nil, nil
+			Msg("committed preview config failed to parse")
+		return nil, fmt.Errorf("%w: parse %s: %w", preview.ErrInvalidConfig, repoconfig.ConfigPath, err)
 	}
 	h.logger.Info().
 		Str("session_id", sessionID.String()).
@@ -576,6 +572,9 @@ func (h *PreviewHandler) enqueueStartPreviewJob(ctx context.Context, orgID, user
 		if errors.Is(err, preview.ErrPreviewCapacity) {
 			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, preview.PreviewCapacityCode, preview.PreviewCapacityMessage, err)
 		}
+		if errors.Is(err, preview.ErrInvalidConfig) {
+			return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_CONFIG_INVALID", preview.InvalidConfigMessage(err), err)
+		}
 		return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_START_FAILED", "failed to start preview", err)
 	}
 
@@ -642,6 +641,9 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 		if errors.Is(err, preview.ErrPreviewCapacity) {
 			return nil, newPreviewHTTPError(http.StatusServiceUnavailable, preview.PreviewCapacityCode, preview.PreviewCapacityMessage, err)
 		}
+		if errors.Is(err, preview.ErrInvalidConfig) {
+			return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_CONFIG_INVALID", preview.InvalidConfigMessage(err), err)
+		}
 		return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_START_FAILED", "failed to start preview", err)
 	}
 
@@ -698,6 +700,11 @@ func (h *PreviewHandler) startPreviewLocal(ctx context.Context, orgID, userID, s
 		// Returning a clear PREVIEW_NO_CONFIG error is strictly more useful.
 		cfg, err := h.readWorkspacePreviewConfig(ctx, sb, sessionID)
 		if err != nil {
+			if errors.Is(err, preview.ErrInvalidConfig) {
+				msg := preview.InvalidConfigMessage(err)
+				h.manager.AbortReservation(ctx, reservation, hydratedID, msg)
+				return nil, newPreviewHTTPError(http.StatusUnprocessableEntity, "PREVIEW_CONFIG_INVALID", msg, err)
+			}
 			h.manager.AbortReservation(ctx, reservation, hydratedID, fmt.Sprintf("read workspace config: %v", err))
 			return nil, newPreviewHTTPError(http.StatusInternalServerError, "PREVIEW_CONFIG_READ_FAILED", "failed to read preview config from workspace", err)
 		}

--- a/internal/api/handlers/preview_test.go
+++ b/internal/api/handlers/preview_test.go
@@ -799,7 +799,7 @@ func TestReadWorkspacePreviewConfig_FileNotFound(t *testing.T) {
 
 	// The common "no .143/config.json committed" case: the underlying FileReader
 	// returns sandbox.ErrFileNotFound (wrapped). Must NOT bubble up — caller
-	// falls back to built-in defaults.
+	// surfaces PREVIEW_NO_CONFIG instead of an infrastructure failure.
 	h := &PreviewHandler{
 		fileReader: &fakeFileReader{errorsByPath: map[string]error{
 			repoconfig.ConfigPath: fmt.Errorf("read file %s: %w", repoconfig.ConfigPath, sandbox.ErrFileNotFound),
@@ -835,18 +835,17 @@ func TestReadWorkspacePreviewConfig_UnexpectedReadError(t *testing.T) {
 func TestReadWorkspacePreviewConfig_ParseError(t *testing.T) {
 	t.Parallel()
 
-	// Parse errors are a user authoring problem, not infrastructure. Returning
-	// (nil, nil) keeps the response shape identical to "file not present", so
-	// the caller surfaces PREVIEW_NO_CONFIG (the user fix is the same: commit
-	// a valid .143/config.json) instead of a misleading 500. The Warn log
-	// emitted by readWorkspacePreviewConfig is the operator-side breadcrumb.
+	// Parse errors are a user authoring problem, not missing config. Returning
+	// an explicit invalid-config error lets the caller avoid the misleading
+	// PREVIEW_NO_CONFIG path when the repo did commit .143/config.json.
 	h := &PreviewHandler{
 		fileReader: &fakeFileReader{content: "{not valid json"},
 		logger:     zerolog.Nop(),
 	}
 	cfg, err := h.readWorkspacePreviewConfig(context.Background(), &agent.Sandbox{ID: "c1", WorkDir: "/workspace"}, uuid.New())
-	require.NoError(t, err, "invalid JSON must not surface as a 500")
-	require.Nil(t, cfg)
+	require.Error(t, err, "invalid JSON must surface as invalid preview config")
+	require.ErrorIs(t, err, preview.ErrInvalidConfig, "invalid workspace config should use the stable invalid-config sentinel")
+	require.Nil(t, cfg, "invalid preview config should not return a fallback config")
 }
 
 func TestReadWorkspacePreviewConfig_ValidConfig(t *testing.T) {
@@ -1208,6 +1207,47 @@ func TestPreviewHandler_StartPreview_AutoDetectInfraError(t *testing.T) {
 	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
 	require.Equal(t, "PREVIEW_CONFIG_READ_FAILED", resp.Error.Code)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestPreviewHandler_StartPreview_AutoDetectInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err, "pgx mock should initialize")
+	defer mock.Close()
+
+	orgID := uuid.New()
+	userID := uuid.New()
+	sessionID := uuid.New()
+
+	mock.ExpectQuery("SELECT .+ FROM sessions WHERE id").
+		WithArgs(pgxmock.AnyArg(), pgxmock.AnyArg()).
+		WillReturnRows(
+			pgxmock.NewRows(sessionRowColumns).
+				AddRow(sessionRowWithContainer(sessionID, orgID, "container-1")...),
+		)
+	expectReserveSuccess(mock, sessionID, orgID, userID)
+	expectAbortReservationNoDestroy(mock)
+
+	h := newPreviewHandlerWithMock(mock)
+	h.sessionStore = db.NewSessionStore(mock)
+	h.fileReader = &fakeFileReader{content: "{not valid json"}
+
+	req := httptest.NewRequest(http.MethodPost, "/preview", strings.NewReader(""))
+	req = previewTestContextWithIDs(req, orgID, userID, sessionID.String())
+	w := httptest.NewRecorder()
+
+	h.StartPreview(w, req)
+
+	require.Equal(t, http.StatusUnprocessableEntity, w.Code, "invalid committed config should be a user-actionable 422")
+
+	var resp models.ErrorResponse
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp), "response body should decode as an error response")
+	require.Equal(t, "PREVIEW_CONFIG_INVALID", resp.Error.Code, "invalid committed config should use the stable invalid-config code")
+	require.Contains(t, resp.Error.Message, "Invalid .143/config.json preview config", "message should name the committed config file")
+	require.Contains(t, resp.Error.Message, "invalid character", "message should include the parser's specific failure")
+	require.Contains(t, resp.Error.Message, "Fix the committed config", "message should include a recovery action")
+	require.NoError(t, mock.ExpectationsWereMet(), "all database expectations should be met")
 }
 
 func TestPreviewHandler_StartPreview_SnapshotUnavailable_NoSnapshot(t *testing.T) {

--- a/internal/services/preview/config.go
+++ b/internal/services/preview/config.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -50,17 +51,50 @@ const (
 	MaxPort              = 65535
 )
 
+var ErrInvalidConfig = errors.New("invalid preview config")
+
+func InvalidConfigMessage(err error) string {
+	detail := "unknown error"
+	if err != nil {
+		detail = err.Error()
+		detail = strings.TrimPrefix(detail, ErrInvalidConfig.Error()+": ")
+		detail = strings.TrimPrefix(detail, "parse "+repoconfig.ConfigPath+": ")
+		detail = strings.TrimPrefix(detail, "validate "+repoconfig.ConfigPath+": ")
+	}
+	return fmt.Sprintf("Invalid %s preview config: %s. Fix the committed config and start preview again.", repoconfig.ConfigPath, detail)
+}
+
 // =============================================================================
 // Raw preview config (direct JSON unmarshal of the nested "preview" section in
 // .143/config.json).
 // =============================================================================
+
+type previewVersion string
+
+func (v *previewVersion) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*v = ""
+		return nil
+	}
+	var asString string
+	if err := json.Unmarshal(data, &asString); err == nil {
+		*v = previewVersion(asString)
+		return nil
+	}
+	var asNumber json.Number
+	if err := json.Unmarshal(data, &asNumber); err == nil {
+		*v = previewVersion(asNumber.String())
+		return nil
+	}
+	return fmt.Errorf("version must be a string or number")
+}
 
 // rawPreviewConfig is the direct JSON representation of the nested preview
 // section inside .143/config.json.
 // It supports both single-service (top-level command/port) and multi-service
 // (services map) formats.
 type rawPreviewConfig struct {
-	Version        string                                 `json:"version"`
+	Version        previewVersion                         `json:"version"`
 	Name           string                                 `json:"name"`
 	Primary        string                                 `json:"primary,omitempty"`
 	Services       map[string]models.ServiceConfig        `json:"services,omitempty"`
@@ -110,7 +144,7 @@ func ParseConfig(data []byte) (*models.PreviewConfig, error) {
 	}
 
 	cfg := &models.PreviewConfig{
-		Version:        raw.Version,
+		Version:        string(raw.Version),
 		Name:           raw.Name,
 		Infrastructure: raw.Infrastructure,
 		Credentials:    raw.Credentials,

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -2,6 +2,7 @@ package preview
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -89,6 +90,47 @@ func TestParseConfig_MultiService(t *testing.T) {
 	if len(cfg.Services) != 2 {
 		t.Errorf("len(Services) = %d, want 2", len(cfg.Services))
 	}
+}
+
+func TestParseConfig_AcceptsNumericVersionMarker(t *testing.T) {
+	t.Parallel()
+
+	raw := `{
+		"preview": {
+			"version": 1,
+			"name": "Full Stack",
+			"primary": "frontend",
+			"services": {
+				"frontend": {
+					"command": ["npm", "run", "dev"],
+					"port": 3000,
+					"ready": {"http_path": "/", "timeout_seconds": 90}
+				}
+			},
+			"credentials": {"mode": "none"},
+			"network": {"mode": "managed"}
+		}
+	}`
+
+	cfg, err := ParseConfig([]byte(raw))
+	require.NoError(t, err, "ParseConfig should accept numeric preview.version markers from committed repo configs")
+	require.Equal(t, "1", cfg.Version, "ParseConfig should preserve a numeric version marker as its JSON text")
+	require.Equal(t, "frontend", cfg.Primary, "ParseConfig should still parse the rest of the preview section")
+}
+
+func TestInvalidConfigMessage(t *testing.T) {
+	t.Parallel()
+
+	err := fmt.Errorf("%w: parse .143/config.json: parse preview config: invalid character 'n' looking for beginning of object key string", ErrInvalidConfig)
+
+	msg := InvalidConfigMessage(err)
+
+	require.Equal(
+		t,
+		"Invalid .143/config.json preview config: parse preview config: invalid character 'n' looking for beginning of object key string. Fix the committed config and start preview again.",
+		msg,
+		"InvalidConfigMessage should include the specific config failure and a recovery action without duplicating path prefixes",
+	)
 }
 
 func TestParseConfig_WithInfrastructure(t *testing.T) {

--- a/internal/services/preview/manager.go
+++ b/internal/services/preview/manager.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/assembledhq/143/internal/db"
 	"github.com/assembledhq/143/internal/models"
+	"github.com/assembledhq/143/internal/repoconfig"
 	"github.com/assembledhq/143/internal/services/agent"
 )
 
@@ -244,7 +245,7 @@ func (m *Manager) reservePreview(ctx context.Context, store *db.PreviewStore, in
 		return nil, fmt.Errorf("preview store is not configured")
 	}
 	if errs := ValidateConfig(input.Config); len(errs) > 0 {
-		return nil, fmt.Errorf("invalid preview config: %s", strings.Join(errs, "; "))
+		return nil, fmt.Errorf("%w: validate %s: %s", ErrInvalidConfig, repoconfig.ConfigPath, strings.Join(errs, "; "))
 	}
 
 	existing, err := store.GetActivePreviewForSession(ctx, input.OrgID, input.SessionID)
@@ -342,7 +343,7 @@ func (m *Manager) LaunchPreview(ctx context.Context, instance *models.PreviewIns
 		return nil, fmt.Errorf("sandbox must not be nil")
 	}
 	if errs := ValidateConfig(input.Config); len(errs) > 0 {
-		return nil, fmt.Errorf("invalid preview config: %s", strings.Join(errs, "; "))
+		return nil, fmt.Errorf("%w: validate %s: %s", ErrInvalidConfig, repoconfig.ConfigPath, strings.Join(errs, "; "))
 	}
 
 	// If the caller resolved a different config after reservation (autodetect

--- a/internal/services/preview/start_runner.go
+++ b/internal/services/preview/start_runner.go
@@ -120,6 +120,11 @@ func (r *StartRunner) StartReservedPreview(ctx context.Context, payload StartPre
 	if input.Config == nil {
 		cfg, err := r.readWorkspacePreviewConfig(ctx, acq.Sandbox, payload.SessionID)
 		if err != nil {
+			if errors.Is(err, ErrInvalidConfig) {
+				msg := InvalidConfigMessage(err)
+				r.abort(ctx, reservation, hydratedID, msg)
+				return fmt.Errorf("PREVIEW_CONFIG_INVALID: %s: %w", msg, err)
+			}
 			r.abort(ctx, reservation, hydratedID, fmt.Sprintf("read workspace config: %v", err))
 			return fmt.Errorf("PREVIEW_CONFIG_READ_FAILED: %w", err)
 		}
@@ -198,6 +203,8 @@ func ClassifyLaunchFailure(err error) StartFailure {
 		return StartFailure{Code: "PREVIEW_INIT_SCRIPT_FAILED", Message: "preview init script failed. Check the script referenced in .143/config.json. Details: " + cause}
 	case errors.Is(err, ErrServiceNotReady):
 		return StartFailure{Code: "PREVIEW_SERVICE_NOT_READY", Message: "preview service did not pass its readiness probe. The service may have crashed at boot, taken too long to start, or be listening on a different port than declared in .143/config.json. Details: " + cause}
+	case errors.Is(err, ErrInvalidConfig):
+		return StartFailure{Code: "PREVIEW_CONFIG_INVALID", Message: InvalidConfigMessage(err)}
 	default:
 		return StartFailure{Code: "PREVIEW_START_FAILED", Message: "failed to start preview: " + cause}
 	}
@@ -333,8 +340,8 @@ func (r *StartRunner) readWorkspacePreviewConfig(ctx context.Context, sb *agent.
 	}
 	cfg, err := ParseConfig([]byte(content))
 	if err != nil {
-		r.logger.Warn().Err(err).Str("session_id", sessionID.String()).Str("path", repoconfig.ConfigPath).Msg("committed preview config failed to parse; falling back to defaults")
-		return nil, nil
+		r.logger.Warn().Err(err).Str("session_id", sessionID.String()).Str("path", repoconfig.ConfigPath).Msg("committed preview config failed to parse")
+		return nil, fmt.Errorf("%w: parse %s: %w", ErrInvalidConfig, repoconfig.ConfigPath, err)
 	}
 	return cfg, nil
 }

--- a/internal/services/preview/start_runner_test.go
+++ b/internal/services/preview/start_runner_test.go
@@ -1,9 +1,16 @@
 package preview
 
 import (
+	"context"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+
+	"github.com/assembledhq/143/internal/repoconfig"
+	"github.com/assembledhq/143/internal/services/agent"
+	"github.com/assembledhq/143/internal/services/sandbox"
 )
 
 func TestShouldReassignPreviewWorker(t *testing.T) {
@@ -61,4 +68,41 @@ func TestShouldReassignPreviewWorker(t *testing.T) {
 			require.Equal(t, tt.expected, actual, "shouldReassignPreviewWorker should match the expected fallback ownership behavior")
 		})
 	}
+}
+
+type startRunnerFileReader struct {
+	content string
+	err     error
+}
+
+func (r startRunnerFileReader) ListDir(context.Context, string, string, string) ([]sandbox.FileEntry, error) {
+	panic("not used")
+}
+
+func (r startRunnerFileReader) ReadFile(context.Context, string, string, string) (string, bool, error) {
+	return r.content, false, r.err
+}
+
+func (r startRunnerFileReader) ReadFileContext(context.Context, string, string, string, int, int, int) (sandbox.FileContextResult, error) {
+	panic("not used")
+}
+
+func TestStartRunnerReadWorkspacePreviewConfig_ParseError(t *testing.T) {
+	t.Parallel()
+
+	runner := &StartRunner{
+		fileReader: startRunnerFileReader{content: `{"preview":{"version":{}}}`},
+		logger:     zerolog.Nop(),
+	}
+
+	cfg, err := runner.readWorkspacePreviewConfig(
+		context.Background(),
+		&agent.Sandbox{ID: "container-1", WorkDir: "/home/sandbox/repo"},
+		uuid.New(),
+	)
+
+	require.Error(t, err, "invalid committed preview config should surface instead of being treated as missing config")
+	require.ErrorIs(t, err, ErrInvalidConfig, "invalid committed preview config should use the shared invalid-config sentinel")
+	require.Contains(t, err.Error(), repoconfig.ConfigPath, "invalid config error should name the repo config path")
+	require.Nil(t, cfg, "invalid committed preview config should not return a fallback config")
 }


### PR DESCRIPTION
## Summary
- Accept numeric `preview.version` markers in committed `.143/config.json` files.
- Distinguish malformed or structurally invalid preview configs from genuinely missing configs.
- Return `PREVIEW_CONFIG_INVALID` with the specific parse or validation failure so the user can fix the repo config directly.
- Pass the new invalid-config error through the preview UI without wrapping it in a generic prefix.

## Testing
- Added unit coverage for numeric version parsing, invalid-config message formatting, and auto-detect error handling.
- Added frontend coverage to verify invalid preview config errors render verbatim.
- Verified Go vet, Go build, full Go test suite, and frontend typecheck/lint/build all pass.