### PR TITLE
Fix failed preview retry to start a fresh preview

### DIFF
--- a/frontend/src/components/preview/preview-panel.test.tsx
+++ b/frontend/src/components/preview/preview-panel.test.tsx
@@ -1317,7 +1317,7 @@ describe("PreviewPanel component", () => {
 
   /* ---------- Try Again button in failed state ---------- */
 
-  it("calls restart mutation when Try Again is clicked in failed state", async () => {
+  it("calls start mutation when Try Again is clicked in failed state", async () => {
     const user = userEvent.setup();
     mockGet.mockResolvedValue(
       makePreviewStatus({
@@ -1335,8 +1335,9 @@ describe("PreviewPanel component", () => {
     await user.click(screen.getByText("Try Again"));
 
     await waitFor(() => {
-      expect(mockRestart).toHaveBeenCalledWith("sess-1");
+      expect(mockStart).toHaveBeenCalledWith("sess-1");
     });
+    expect(mockRestart).not.toHaveBeenCalled();
   });
 
   /* ---------- Bootstrap origin enforcement ---------- */

--- a/frontend/src/components/preview/preview-panel.tsx
+++ b/frontend/src/components/preview/preview-panel.tsx
@@ -1064,7 +1064,7 @@ export function PreviewPanel({
               variant="outline"
               onClick={() => {
                 setShowFullStartupLogs(false);
-                restartMutation.mutate();
+                startMutation.mutate();
               }}
               disabled={isMutating}
             >


### PR DESCRIPTION
## Summary
- Change the failed-preview “Try Again” action to start a new preview instead of calling restart on a terminal preview state.
- Add a regression test to verify failed-state retry triggers `start` and does not call `restart`.

## Testing
- Focused Vitest coverage for the failed-state retry path.
- Frontend validation passed: typecheck, lint, and production build.