### PR TITLE
Remove Duplicate “Add agent tab” Button from Session Header Bar

### DIFF
--- a/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx
@@ -969,7 +969,7 @@ describe('SessionDetailPage', () => {
     expect(screen.getByPlaceholderText('Send a message to Codex 2...')).toBeInTheDocument();
   });
 
-  it('shows a desktop header add-tab action that creates a tab directly', async () => {
+  it('only shows the desktop add-tab action in the agent tab strip', async () => {
     const sessionId = 'session-header-new-tab';
     const threads: SessionThread[] = [
       {
@@ -1035,8 +1035,10 @@ describe('SessionDetailPage', () => {
     await screen.findByPlaceholderText('Send a message to Codex...');
 
     const headerActions = screen.getByTestId('session-header-actions');
-    const newTabButton = within(headerActions).getByRole('button', { name: 'Add agent tab' });
-    await user.click(newTabButton);
+    expect(within(headerActions).queryByRole('button', { name: 'Add agent tab' })).not.toBeInTheDocument();
+
+    const stripAddButton = screen.getByRole('button', { name: 'Add agent tab' });
+    await user.click(stripAddButton);
 
     await waitFor(() => {
       expect(createdThread).toBe(true);
@@ -7753,72 +7755,6 @@ describe('SessionDetailPage', () => {
 
     await waitFor(() => {
       expect(stripAddButton).toHaveFocus();
-    });
-  });
-
-  it('returns focus to the desktop header add-tab trigger when a new tab has no composer', async () => {
-    const sessionId = 'session-header-create-tab-no-composer';
-    const threads: SessionThread[] = [
-      {
-        id: 'thread-main',
-        session_id: sessionId,
-        org_id: 'org-1',
-        agent_type: 'pm_agent',
-        label: 'Planner',
-        status: 'idle',
-        current_turn: 1,
-        created_at: '2026-02-17T07:00:00Z',
-        cost_cents: 0,
-        pending_message_count: 0,
-      },
-    ];
-
-    server.use(
-      http.get('/api/v1/sessions/:id', () => {
-        return HttpResponse.json({
-          data: {
-            ...mockSessions[0],
-            id: sessionId,
-            agent_type: 'pm_agent',
-            status: 'idle',
-            sandbox_state: 'snapshotted',
-            threads,
-          },
-        } satisfies SingleResponse<Session & { threads: SessionThread[] }>);
-      }),
-      http.get('/api/v1/sessions/:id/threads/:threadId/messages', () => {
-        return HttpResponse.json({ data: [], meta: {} } satisfies ListResponse<SessionMessage>);
-      }),
-      http.get('/api/v1/sessions/:id/threads/:threadId/logs', () => {
-        return HttpResponse.json({ data: [], meta: {} });
-      }),
-      http.post('/api/v1/sessions/:id/threads', async () => {
-        const thread: SessionThread = {
-          id: 'thread-new',
-          session_id: sessionId,
-          org_id: 'org-1',
-          agent_type: 'codex',
-          label: 'Codex 2',
-          status: 'idle',
-          current_turn: 0,
-          created_at: '2026-02-17T07:04:00Z',
-          cost_cents: 0,
-          pending_message_count: 0,
-        };
-        threads.push(thread);
-        return HttpResponse.json({ data: thread } satisfies SingleResponse<SessionThread>, { status: 201 });
-      }),
-    );
-
-    const user = userEvent.setup();
-    renderWithProviders(<SessionDetailContent id={sessionId} />);
-
-    const headerActions = await screen.findByTestId('session-header-actions');
-    const headerAddButton = within(headerActions).getByRole('button', { name: 'Add agent tab' });
-    await user.click(headerAddButton);
-
-    await waitFor(() => {
-      expect(headerAddButton).toHaveFocus();
     });
   });
 

--- a/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
+++ b/frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx
@@ -426,7 +426,6 @@ type PRActionErrorState = {
   message: string;
 };
 
-type AddTabTriggerSource = "strip" | "header";
 type PendingThreadPreview = Pick<
   SessionThread,
   "id" | "session_id" | "org_id" | "agent_type" | "label" | "status" | "current_turn" | "created_at" | "cost_cents" | "pending_message_count" | "cancel_requested_at" | "model_override"
@@ -3901,8 +3900,6 @@ export function SessionDetailContent({ id }: { id: string }) {
   const [newThreadLabel, setNewThreadLabel] = useState("");
   const focusComposerAfterThreadCreateRef = useRef(false);
   const addTabButtonRef = useRef<HTMLButtonElement>(null);
-  const headerAddTabButtonRef = useRef<HTMLButtonElement>(null);
-  const lastAddTabTriggerSourceRef = useRef<AddTabTriggerSource>("strip");
   const composerTextareaRef = useRef<HTMLTextAreaElement>(null);
   const composerUploadInputRef = useRef<HTMLInputElement>(null);
   // Tracks an in-flight agent-switch PATCH so the send-time PATCH can wait
@@ -4441,19 +4438,13 @@ export function SessionDetailContent({ id }: { id: string }) {
         return;
       }
 
-      if (lastAddTabTriggerSourceRef.current === "header") {
-        headerAddTabButtonRef.current?.focus();
-        return;
-      }
-
       addTabButtonRef.current?.focus();
     });
 
     return () => window.cancelAnimationFrame(rafID);
   }, [activeThread?.id, composerCanSendMessage, session?.agent_type]);
 
-  const handleCreateThreadFrom = useCallback((source: AddTabTriggerSource) => {
-    lastAddTabTriggerSourceRef.current = source;
+  const handleCreateThread = useCallback(() => {
     createThreadMutation.mutate(buildDefaultThreadRequest());
   }, [buildDefaultThreadRequest, createThreadMutation]);
 
@@ -5257,23 +5248,6 @@ export function SessionDetailContent({ id }: { id: string }) {
                 <LinkedIssueChips session={session} />
               </div>
               <div className="flex items-center gap-2" data-testid="session-header-actions">
-                <Button
-                  ref={headerAddTabButtonRef}
-                  type="button"
-                  variant="ghost"
-                  size="icon"
-                  className="h-7 w-7 shrink-0 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:text-foreground hover:opacity-100 focus-visible:opacity-100"
-                  aria-label="Add agent tab"
-                  title="Add agent tab"
-                  onClick={() => handleCreateThreadFrom("header")}
-                  disabled={createThreadMutation.isPending}
-                >
-                  {createThreadMutation.isPending ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Plus className="h-3.5 w-3.5" />
-                  )}
-                </Button>
                 <DisabledTooltip disabled={centerMode === "review" && showDetailPanel} content={detailToggleTitle}>
                   <Button
                     variant="ghost"
@@ -5302,7 +5276,7 @@ export function SessionDetailContent({ id }: { id: string }) {
             overlapsByThreadId={overlapsByThreadId}
             statusConfig={statusConfig}
             onActiveThreadChange={setActiveThreadId}
-            onAddTab={() => handleCreateThreadFrom("strip")}
+            onAddTab={handleCreateThread}
             addTabPending={createThreadMutation.isPending}
             onRevertThread={(tid) => revertThreadMutation.mutate(tid)}
             onArchiveThread={(tid) => archiveThreadMutation.mutate(tid)}


### PR DESCRIPTION
## Summary
Removed the duplicate desktop “Add agent tab” button from the session header so there is only one desktop add-tab action available via the agent tab strip. This avoids conflicting UX and keeps the test expectation aligned with the intended layout.

## Changes
- **frontend/src/app/(dashboard)/sessions/[id]/session-detail-content.tsx**
  - Removed the duplicate top-header “Add agent tab” button and left the agent tab strip button as the only desktop add-tab trigger.
- **frontend/src/app/(dashboard)/sessions/[id]/page.test.tsx**
  - Updated the test to assert the header “Add agent tab” button is **not** rendered.
  - Adjusted the interaction to click the agent tab strip “Add agent tab” button instead of the header button.
  - Removed the now-obsolete focus-management test tied to the deleted header trigger.

## Test plan
- `npm test -- --run 'src/app/(dashboard)/sessions/[id]/page.test.tsx' -t 'only shows the desktop add-tab action in the agent tab strip'`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

[143.dev](https://143.dev) | [session 50b21491](https://143.dev/sessions/50b21491-4d3c-4b5a-bc70-503d95ec1441)