### PR TITLE
Apply selected review fix mode to initial /review prompt and document minimal vs exhaustive behavior

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -196,8 +196,7 @@ The first review message includes the native command:
 
 ```text
 /review the current workspace diff. If you find issues, report them in your
-normal review format. Then, when asked to fix, address the issues you found and
-run relevant verification.
+normal review format.
 ```
 
 The command token is persisted through the existing structured slash-command
@@ -298,13 +297,15 @@ and other supported agents have their own review language and may change their
 finding formats over time. The product should preserve and display the native
 review output.
 
-### Nits and polish policy
+### Review and fix modes
 
 Even though the product should not normalize findings into platform severities,
-the loop must still be explicit about how to handle nits. The product rule is:
-**fix low-risk local nits only**.
+the loop must still be explicit about how to handle nits and deferred findings.
+The selected fix mode applies to both the initial review prompt and the
+follow-up fix prompt.
 
-The review-loop prompt tells the agent:
+In minimal mode, the product rule is: **fix low-risk local nits only**. The
+review-loop prompt tells the agent:
 
 ```text
 Fix nits when they are local, low-risk, and relevant to the current change. Use
@@ -316,8 +317,18 @@ leave it for later and mention it in your summary.
 ```
 
 This keeps the default loop useful for polish and stale-code cleanup without
-turning every review into an unbounded cleanup pass. It is not exposed as a
-setup option in v1.
+turning every review into an unbounded cleanup pass.
+
+In exhaustive mode, the product rule is: **report every relevant review finding
+so the next fix pass can address it**. The review-loop prompt tells the agent:
+
+```text
+Report every issue you find that is relevant to whether this workspace diff
+should ship. Do not defer broad or risky findings as later work: include them in
+the review output so the follow-up fix pass can address them or explicitly
+explain why they are impossible or unsafe to fix in this sandbox. Keep findings
+grounded in this diff and nearby code it makes stale or inconsistent.
+```
 
 The only structured decision the platform needs is whether the loop should
 continue. That decision should come from the coding agent, not from a generic

--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -323,11 +323,7 @@ In exhaustive mode, the product rule is: **report every relevant review finding
 so the next fix pass can address it**. The review-loop prompt tells the agent:
 
 ```text
-Report every issue you find that is relevant to whether this workspace diff
-should ship. Do not defer broad or risky findings as later work: include them in
-the review output so the follow-up fix pass can address them or explicitly
-explain why they are impossible or unsafe to fix in this sandbox. Keep findings
-grounded in this diff and nearby code it makes stale or inconsistent.
+Report every issue you find. Do not defer findings as later work.
 ```
 
 The only structured decision the platform needs is whether the loop should

--- a/internal/prompts/prompts.go
+++ b/internal/prompts/prompts.go
@@ -221,6 +221,7 @@ func LinkedIssuesContext(data LinkedIssueContextData) string {
 
 type ReviewLoopReviewPromptData struct {
 	AgentType any
+	FixMode   any
 }
 
 func ReviewLoopReviewPrompt(data ReviewLoopReviewPromptData) string {

--- a/internal/prompts/review_loop_test.go
+++ b/internal/prompts/review_loop_test.go
@@ -7,17 +7,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestReviewLoopReviewPrompt(t *testing.T) {
+func TestReviewLoopReviewPromptMinimal(t *testing.T) {
 	t.Parallel()
 
 	got := ReviewLoopReviewPrompt(ReviewLoopReviewPromptData{
 		AgentType: models.AgentTypeClaudeCode,
+		FixMode:   models.ReviewLoopFixModeMinimal,
 	})
 	require.Contains(t, got, "/review", "review prompt should include the native slash command")
 	require.Contains(t, got, "Fix nits when they are local, low-risk", "review prompt should include the nit policy")
 	require.Contains(t, got, "current workspace diff", "review prompt should target the current sandbox diff")
 	require.NotContains(t, got, "files already touched", "review prompt should not block relevant fixes only because the file was untouched")
 	require.Contains(t, got, "stale or outdated adjacent code", "review prompt should allow relevant low-risk stale-code cleanup")
+}
+
+func TestReviewLoopReviewPromptExhaustive(t *testing.T) {
+	t.Parallel()
+
+	got := ReviewLoopReviewPrompt(ReviewLoopReviewPromptData{
+		AgentType: models.AgentTypeClaudeCode,
+		FixMode:   models.ReviewLoopFixModeExhaustive,
+	})
+	require.Contains(t, got, "/review", "review prompt should include the native slash command")
+	require.Contains(t, got, "Report every issue", "exhaustive review prompt should ask for every review finding")
+	require.Contains(t, got, "Do not defer broad or risky findings", "exhaustive review prompt should not tell the reviewer to leave findings for later")
+	require.Contains(t, got, "current workspace diff", "review prompt should target the current sandbox diff")
+	require.NotContains(t, got, "Fix nits when they are local, low-risk", "exhaustive review prompt should not use the minimal nit policy")
+	require.NotContains(t, got, "leave it for later", "exhaustive review prompt should not ask the reviewer to defer findings")
 }
 
 func TestReviewLoopDecisionPrompt(t *testing.T) {

--- a/internal/prompts/review_loop_test.go
+++ b/internal/prompts/review_loop_test.go
@@ -30,10 +30,11 @@ func TestReviewLoopReviewPromptExhaustive(t *testing.T) {
 	})
 	require.Contains(t, got, "/review", "review prompt should include the native slash command")
 	require.Contains(t, got, "Report every issue", "exhaustive review prompt should ask for every review finding")
-	require.Contains(t, got, "Do not defer broad or risky findings", "exhaustive review prompt should not tell the reviewer to leave findings for later")
+	require.Contains(t, got, "Do not defer findings", "exhaustive review prompt should not tell the reviewer to leave findings for later")
 	require.Contains(t, got, "current workspace diff", "review prompt should target the current sandbox diff")
 	require.NotContains(t, got, "Fix nits when they are local, low-risk", "exhaustive review prompt should not use the minimal nit policy")
 	require.NotContains(t, got, "leave it for later", "exhaustive review prompt should not ask the reviewer to defer findings")
+	require.NotContains(t, got, "impossible or unsafe", "exhaustive review prompt should stay concise because the native review is already thorough")
 }
 
 func TestReviewLoopDecisionPrompt(t *testing.T) {

--- a/internal/prompts/templates/review_loop_review.template
+++ b/internal/prompts/templates/review_loop_review.template
@@ -1,5 +1,5 @@
 /review the current workspace diff. If you find issues, report them in your normal review format.
 
-{{if eq .FixMode "exhaustive"}}Report every issue you find that is relevant to whether this workspace diff should ship. Do not defer broad or risky findings as later work: include them in the review output so the follow-up fix pass can address them or explicitly explain why they are impossible or unsafe to fix in this sandbox. Keep findings grounded in this diff and nearby code it makes stale or inconsistent.{{else}}
+{{if eq .FixMode "exhaustive"}}Report every issue you find. Do not defer findings as later work.{{else}}
 Fix nits when they are local, low-risk, and relevant to the current change. Use your judgment: if the change makes stale or outdated adjacent code obsolete, remove or adjust it even when that code was not directly modified by the original diff. Do not expand the scope of the diff just to satisfy subjective style preferences. If a nit is broad, risky, or unrelated to the current change, leave it for later and mention it in your summary.
 {{end}}

--- a/internal/prompts/templates/review_loop_review.template
+++ b/internal/prompts/templates/review_loop_review.template
@@ -1,3 +1,5 @@
 /review the current workspace diff. If you find issues, report them in your normal review format.
 
+{{if eq .FixMode "exhaustive"}}Report every issue you find that is relevant to whether this workspace diff should ship. Do not defer broad or risky findings as later work: include them in the review output so the follow-up fix pass can address them or explicitly explain why they are impossible or unsafe to fix in this sandbox. Keep findings grounded in this diff and nearby code it makes stale or inconsistent.{{else}}
 Fix nits when they are local, low-risk, and relevant to the current change. Use your judgment: if the change makes stale or outdated adjacent code obsolete, remove or adjust it even when that code was not directly modified by the original diff. Do not expand the scope of the diff just to satisfy subjective style preferences. If a nit is broad, risky, or unrelated to the current change, leave it for later and mention it in your summary.
+{{end}}

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -324,7 +324,11 @@ func reviewLoopContinuationDedupeKey(loopID, passID uuid.UUID, phase string) str
 }
 
 func (s *Service) sendReview(ctx context.Context, loop *models.SessionReviewLoop, pass *models.SessionReviewLoopPass, userID *uuid.UUID, opts ...sendOption) (*models.SessionMessage, error) {
-	arguments := strings.TrimPrefix(prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{AgentType: loop.AgentType}), "/review")
+	reviewPrompt := prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{
+		AgentType: loop.AgentType,
+		FixMode:   loop.FixMode,
+	})
+	arguments := strings.TrimPrefix(reviewPrompt, "/review")
 	arguments = strings.TrimSpace(arguments)
 	command := models.SessionInputCommand{
 		Kind:      "command",
@@ -335,7 +339,7 @@ func (s *Service) sendReview(ctx context.Context, loop *models.SessionReviewLoop
 		Arguments: arguments,
 		Source:    models.SessionInputCommandSourceBuiltin,
 	}
-	return s.sendPlain(ctx, *loop, prompts.ReviewLoopReviewPrompt(prompts.ReviewLoopReviewPromptData{AgentType: loop.AgentType}), userID, append(opts, withCommands(command))...)
+	return s.sendPlain(ctx, *loop, reviewPrompt, userID, append(opts, withCommands(command))...)
 }
 
 func withCommands(commands ...models.SessionInputCommand) sendOption {


### PR DESCRIPTION
## Summary

Yes, it needed updating. The “Fix every finding” mode was only applied to the later fix pass; the initial `/review` prompt still used the minimal/nit policy and could tell the reviewer to leave broad or risky findings for later.

I changed it so the selected fix mode applies to the initial review prompt too:
- Minimal mode keeps the existing low-risk nit policy.
- Exhaustive mode now asks the agent to report every relevant issue and not defer broad/risky findings as later work.
- The review-loop service now passes the loop’s persisted `fix_mode` into the review prompt.
- Updated the review-loop design doc to describe the two prompt modes.

Verification passed:
- `go test ./internal/prompts`
- `go test ./internal/services/reviewloop`
- `TMPDIR=/home/sandbox/143/.tmp go vet ./...`
- `TMPDIR=/home/sandbox/143/.tmp go build ./...`
- `TMPDIR=/home/sandbox/143/.tmp go test ./...`

The first full verification attempt hit `/var/tmp` space limits, so I reran sequentially with a workspace temp dir and it passed.

## Test plan

Validated by automated agent run.


[143.dev](https://143.dev) | [session 251941d0](https://143.dev/sessions/251941d0-e61c-4784-ab2a-06eb7d8cd6b8)