### PR TITLE
Disable the dogfood preview gateway in the committed preview config

### DIFF
--- a/.143/config.json
+++ b/.143/config.json
@@ -25,7 +25,8 @@
         "env": {
           "MODE": "api",
           "LOG_LEVEL": "info",
-          "DEMO_MODE": "true"
+          "DEMO_MODE": "true",
+          "PREVIEW_GATEWAY_PORT": "0"
         },
         "ready": {
           "http_path": "/readyz",

--- a/internal/services/preview/config_test.go
+++ b/internal/services/preview/config_test.go
@@ -876,6 +876,10 @@ func TestParseConfig_CommittedDogfoodConfig(t *testing.T) {
 			require.True(t, ok, "dogfood preview config should define the frontend service")
 			require.Contains(t, frontend.Env, "NEXT_PUBLIC_API_URL", "dogfood preview should explicitly neutralize public API origin inherited from the surrounding environment")
 			require.Equal(t, "", frontend.Env["NEXT_PUBLIC_API_URL"], "dogfood preview must force same-origin API calls so preview CSRF cookies match the request origin")
+			server, ok := cfg.Services["server"]
+			require.True(t, ok, "dogfood preview config should define the server service")
+			require.Equal(t, "api", server.Env["MODE"], "dogfood preview server should avoid worker mode because the sandbox has no Docker socket")
+			require.Equal(t, "0", server.Env["PREVIEW_GATEWAY_PORT"], "dogfood preview server should disable the nested preview gateway to avoid binding the platform preview port")
 			return
 		}
 		parent := filepath.Dir(dir)


### PR DESCRIPTION
**Summary**
- Set the dogfood server preview config to `MODE=api` with `PREVIEW_GATEWAY_PORT=0` so the inner 143 instance does not try to bind the platform preview port.
- Added a regression test that locks the committed `.143/config.json` to the expected dogfood preview env.

**Testing**
- Added coverage in `internal/services/preview/config_test.go` for the committed dogfood preview config.
- Ran repository checks successfully: `go vet ./...`, `go build ./...`, and `go test ./...`.