### PR TITLE
Fix mobile wrapping for audit log rows and make shared TableCell wrap by default

### DIFF
--- a/frontend/src/components/audit/audit-log-entry.test.tsx
+++ b/frontend/src/components/audit/audit-log-entry.test.tsx
@@ -38,6 +38,21 @@ describe('AuditLogEntry', () => {
     expect(screen.getByText('created session')).toBeInTheDocument();
   });
 
+  it('allows long audit row labels to wrap on narrow screens', () => {
+    render(
+      <AuditLogEntry
+        entry={makeEntry({ action: 'session.pr_push_requested' })}
+        members={mockMembers}
+      />
+    );
+
+    expect(screen.getByRole('button')).toHaveClass('whitespace-normal');
+    expect(screen.getByText('session pr_push_requested').parentElement).toHaveClass(
+      'whitespace-normal',
+      'break-words'
+    );
+  });
+
   it('labels team role changes without saying member role', () => {
     render(
       <AuditLogEntry

--- a/frontend/src/components/audit/audit-log-entry.tsx
+++ b/frontend/src/components/audit/audit-log-entry.tsx
@@ -100,13 +100,13 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
             setExpanded(!expanded);
           }
         }}
-        className="flex w-full items-start gap-2 px-6 py-3.5 text-left text-sm hover:bg-muted/30 transition-all duration-150 h-auto rounded-none"
+        className="flex w-full items-start gap-2 whitespace-normal px-6 py-3.5 text-left text-sm hover:bg-muted/30 transition-all duration-150 h-auto rounded-none"
         disabled={!onSelect && !hasDetails}
       >
         <span className="shrink-0 w-14 text-xs text-muted-foreground/70 pt-0.5 tabular-nums">
           {formatTimeAgo(entry.created_at)}
         </span>
-        <span className="flex-1 min-w-0">
+        <span className="flex-1 min-w-0 whitespace-normal break-words">
           <span className="font-medium text-foreground">{actorName}</span>
           {" "}
           <span className="text-muted-foreground">{actionLabel}</span>
@@ -128,7 +128,7 @@ export function AuditLogEntry({ entry, members, onSelect }: AuditLogEntryProps) 
               {Object.entries(entry.details!).map(([key, value]) => (
                 <div key={key} className="flex gap-2">
                   <span className="font-medium text-muted-foreground min-w-[80px]">{key}:</span>
-                  <span className="text-foreground break-all">
+                  <span className="min-w-0 text-foreground break-words">
                     {formatAuditDetailValue(key, value)}
                   </span>
                 </div>

--- a/frontend/src/components/ui/table.test.tsx
+++ b/frontend/src/components/ui/table.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Table, TableBody, TableCell, TableRow } from './table';
+
+describe('Table', () => {
+  it('allows body cells to wrap long content by default', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>long_session_pr_push_requested_value</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(screen.getByText('long_session_pr_push_requested_value')).toHaveClass(
+      'whitespace-normal',
+      'break-words'
+    );
+  });
+
+  it('allows callers to keep specific cells on one line', () => {
+    render(
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell className="whitespace-nowrap">5m ago</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    );
+
+    expect(screen.getByText('5m ago')).toHaveClass('whitespace-nowrap');
+  });
+});

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -78,7 +78,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-3 py-2.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-3 py-2.5 align-middle whitespace-normal break-words [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Audit log row labels were not wrapping on narrow screens because `AuditLogEntry` renders them as a full-width shared `Button`, whose base styles enforce `whitespace-nowrap`. This change restores wrapping in `AuditLogEntry` and updates the shared `TableCell` default to wrap long content so other tables don’t “bleed” no-wrap behavior.

## Changes
- **`frontend/src/components/audit/audit-log-entry.tsx`**
  - Added `whitespace-normal` to the row container button so long labels can wrap on mobile.
  - Updated the action/body span to use `whitespace-normal break-words` to prevent long text overflow.
  - Adjusted audit detail value rendering to use `break-words` (and avoid overly restrictive wrapping behavior).
- **`frontend/src/components/ui/table.tsx`**
  - Changed `TableCell` from `whitespace-nowrap` to `whitespace-normal break-words` so shared table body cells wrap by default.
- **`frontend/src/components/audit/audit-log-entry.test.tsx`**
  - Added a test asserting long audit row labels can wrap on narrow screens (checks for `whitespace-normal` and `break-words`).
- **`frontend/src/components/ui/table.test.tsx`**
  - Added a test verifying `TableCell` allows long content to wrap by default.

## Test plan
- Ran the updated unit tests for both `AuditLogEntry` and `Table` (`vitest`), verifying:
  - audit row content wraps and has the expected wrapping classes
  - `TableCell` no longer enforces no-wrap behavior for long text

[143.dev](https://143.dev) | [session 34fa3ae0](https://143.dev/sessions/34fa3ae0-9b29-4bc4-a4aa-aaaa470e2ef4)