### PR TITLE
Run fixes during review loop instead of NEEDS_FIX_PASS, and tighten REVIEW_CLEAN sentinel handling

### DIFF
--- a/docs/design/implemented/78-review-agent-loops.md
+++ b/docs/design/implemented/78-review-agent-loops.md
@@ -331,21 +331,25 @@ continue. That decision should come from the coding agent, not from a generic
 finding parser.
 
 After each review pass, the loop asks the same agent for a bounded continuation
-decision:
+turn:
 
 ```text
-Based on your latest review, are there remaining issues you should fix in this
-sandbox before this work is considered clean? Apply the nit policy above and use
-your coding judgment when deciding whether remaining nits require another fix
-pass. Answer with one of:
+Based on your latest review, decide whether this sandbox is clean. Apply the nit
+policy above and use your coding judgment when deciding whether remaining nits
+require action.
 
-- REVIEW_CLEAN
-- NEEDS_FIX_PASS
+If the review found no remaining issues that should be fixed, answer with
+exactly:
+
+REVIEW_CLEAN
+
+If the review found remaining issues that should be fixed, fix the issues now in
+this sandbox, run relevant verification, and summarize what changed.
 ```
 
-The UI can display the raw review output, the raw fix summary, and this compact
-decision. It should not reclassify findings into `blocking`, `major`, `minor`,
-or any other platform-wide severity scheme.
+The UI can display the raw review output, the raw fix summary, and the clean
+sentinel when present. It should not reclassify findings into `blocking`,
+`major`, `minor`, or any other platform-wide severity scheme.
 
 ## Execution Model
 
@@ -355,12 +359,11 @@ For `passIndex` from `1..max_review_passes`:
 2. Capture a loop checkpoint before the first review pass.
 3. Create or reuse the review-loop thread.
 4. Run the selected agent's native review command in that thread.
-5. Ask the same agent whether the latest review is clean or needs a fix pass.
+5. Ask the same agent whether the latest review is clean; if it is not clean,
+   the agent fixes the issues in that turn.
 6. If the agent reports `REVIEW_CLEAN`, mark the loop `clean` and stop.
-7. If the agent reports `NEEDS_FIX_PASS`, send the fix instruction in the same
-   thread.
-8. Wait for the fix pass to complete.
-9. Capture a checkpoint and continue to the next review pass.
+7. If the agent made fixes, capture the fix summary and continue to the next
+   review pass.
 
 After the final allowed pass:
 
@@ -689,7 +692,7 @@ for both review and fixes.
 - **Prefill then user sends:** rejected for the implemented loop because it
   leaves automation runs without a durable continuation point.
 
-Implemented behavior: auto-send the native review, decision, fix, and
+Implemented behavior: auto-send the native review, clean-or-fix, and
 confirmation prompts through the durable thread/message path.
 
 ## Rollout Status
@@ -705,8 +708,8 @@ confirmation prompts through the durable thread/message path.
 
 ### Phase 2: Sequential fix and confirmation
 
-- Add the agent decision step: `REVIEW_CLEAN` or `NEEDS_FIX_PASS`.
-- Send fix instructions in the same review-loop tab.
+- Add the agent clean-or-fix step: return `REVIEW_CLEAN` when clean, otherwise
+  fix the review findings in the same review-loop tab.
 - Run a second review pass after fixes.
 - Stop early when clean.
 - Support `max_passes` from `1..5`.

--- a/internal/prompts/review_loop_test.go
+++ b/internal/prompts/review_loop_test.go
@@ -42,8 +42,8 @@ func TestReviewLoopDecisionPrompt(t *testing.T) {
 
 	got := ReviewLoopDecisionPrompt()
 	require.Contains(t, got, "REVIEW_CLEAN", "decision prompt should expose the clean sentinel")
-	require.Contains(t, got, "NEEDS_FIX_PASS", "decision prompt should expose the fix sentinel")
-	require.Contains(t, got, "Answer with one of", "decision prompt should constrain the response")
+	require.NotContains(t, got, "NEEDS_FIX_PASS", "decision prompt should not expose the old fix sentinel")
+	require.Contains(t, got, "fix the issues now", "decision prompt should ask the agent to fix remaining issues directly")
 	require.Contains(t, got, "coding judgment", "decision prompt should ask the agent to apply coding judgment")
 }
 

--- a/internal/prompts/templates/review_loop_decision.template
+++ b/internal/prompts/templates/review_loop_decision.template
@@ -1,6 +1,7 @@
-Based on your latest review, are there remaining issues you should fix in this sandbox before this work is considered clean? Apply the nit policy from the review instruction and use your coding judgment when deciding whether remaining nits require another fix pass.
+Based on your latest review, decide whether this sandbox is clean. Apply the nit policy from the review instruction and use your coding judgment when deciding whether remaining nits require action.
 
-Answer with one of:
+If the review found no remaining issues that should be fixed, answer with exactly:
 
-- REVIEW_CLEAN
-- NEEDS_FIX_PASS
+REVIEW_CLEAN
+
+If the review found remaining issues that should be fixed, fix the issues now in this sandbox. Keep the fixes grounded in your review findings, add or update tests when appropriate, run relevant verification, and summarize what you changed and anything you could not verify.

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -229,11 +229,8 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 		return s.store.MarkPassDeciding(ctx, orgID, pass.ID, summary, msg.ID)
 	case models.ReviewLoopPassStatusDeciding:
 		decision, err := parseDecision(summary)
-		if err != nil {
-			_ = s.failLoop(ctx, orgID, loop, err.Error())
-			return err
-		}
-		if decision == models.ReviewLoopDecisionClean {
+		switch {
+		case err == nil && decision == models.ReviewLoopDecisionClean:
 			if loop.AutomationRunID != nil {
 				return s.store.MarkPassCleanAndEnqueueOpenPR(ctx, orgID, loop.ID, pass.ID, decision, summary, automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))
 			}
@@ -241,45 +238,69 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 				return err
 			}
 			return nil
+		case err == nil && decision == models.ReviewLoopDecisionNeedsFix:
+			return s.startLegacyFixPass(ctx, orgID, loop, pass, decision)
+		case isMalformedDecision(summary):
+			_ = s.failLoop(ctx, orgID, loop, ErrUnrecognizedDecision.Error())
+			return ErrUnrecognizedDecision
+		default:
+			return s.completeFixAndStartNextReview(ctx, orgID, loop, pass, summary)
 		}
-		if pass.PassIndex >= loop.MaxPasses {
-			if loop.AutomationRunID != nil {
-				return s.store.MarkPassNeedsHumanDecisionAndEnqueueOpenPR(ctx, orgID, loop.ID, pass.ID, decision, "Review pass limit reached with remaining issues.", automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))
-			}
-			if err := s.store.MarkPassNeedsHumanDecision(ctx, orgID, loop.ID, pass.ID, decision, "Review pass limit reached with remaining issues."); err != nil {
-				return err
-			}
-			return nil
-		}
-		msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopFixPrompt(prompts.ReviewLoopFixPromptData{FixMode: loop.FixMode}), nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, pass.ID, "fix")))
-		if err != nil {
-			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start fix pass: %s", err))
-			return err
-		}
-		return s.store.MarkPassFixing(ctx, orgID, pass.ID, decision, msg.ID)
 	case models.ReviewLoopPassStatusFixing:
-		if err := s.store.MarkPassFixComplete(ctx, orgID, pass.ID, summary); err != nil {
-			return err
-		}
-		next := &models.SessionReviewLoopPass{
-			OrgID:     orgID,
-			LoopID:    loop.ID,
-			SessionID: loop.SessionID,
-			PassIndex: pass.PassIndex + 1,
-			Status:    models.ReviewLoopPassStatusReviewing,
-		}
-		if err := s.store.CreatePass(ctx, next); err != nil {
-			return err
-		}
-		msg, err := s.sendReview(ctx, &loop, next, nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, next.ID, "review")))
-		if err != nil {
-			_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start confirmation review: %s", err))
-			return err
-		}
-		return s.store.SetPassReviewMessage(ctx, orgID, next.ID, msg.ID)
+		return s.completeFixAndStartNextReview(ctx, orgID, loop, pass, summary)
 	default:
 		return nil
 	}
+}
+
+func (s *Service) startLegacyFixPass(ctx context.Context, orgID uuid.UUID, loop models.SessionReviewLoop, pass models.SessionReviewLoopPass, decision models.ReviewLoopDecision) error {
+	if pass.PassIndex >= loop.MaxPasses {
+		if loop.AutomationRunID != nil {
+			return s.store.MarkPassNeedsHumanDecisionAndEnqueueOpenPR(ctx, orgID, loop.ID, pass.ID, decision, "Review pass limit reached with remaining issues.", automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))
+		}
+		if err := s.store.MarkPassNeedsHumanDecision(ctx, orgID, loop.ID, pass.ID, decision, "Review pass limit reached with remaining issues."); err != nil {
+			return err
+		}
+		return nil
+	}
+	msg, err := s.sendPlain(ctx, loop, prompts.ReviewLoopFixPrompt(prompts.ReviewLoopFixPromptData{FixMode: loop.FixMode}), nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, pass.ID, "fix")))
+	if err != nil {
+		_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start fix pass: %s", err))
+		return err
+	}
+	return s.store.MarkPassFixing(ctx, orgID, pass.ID, decision, msg.ID)
+}
+
+func (s *Service) completeFixAndStartNextReview(ctx context.Context, orgID uuid.UUID, loop models.SessionReviewLoop, pass models.SessionReviewLoopPass, summary string) error {
+	if err := s.store.MarkPassFixComplete(ctx, orgID, pass.ID, summary); err != nil {
+		return err
+	}
+	if pass.PassIndex >= loop.MaxPasses {
+		terminalSummary := "Review pass limit reached after fixes; confirmation review is still needed."
+		if loop.AutomationRunID != nil {
+			return s.store.MarkPassNeedsHumanDecisionAndEnqueueOpenPR(ctx, orgID, loop.ID, pass.ID, models.ReviewLoopDecisionNeedsFix, terminalSummary, automationOpenPRPayload(loop), automationOpenPRDedupeKey(loop.SessionID))
+		}
+		if err := s.store.MarkPassNeedsHumanDecision(ctx, orgID, loop.ID, pass.ID, models.ReviewLoopDecisionNeedsFix, terminalSummary); err != nil {
+			return err
+		}
+		return nil
+	}
+	next := &models.SessionReviewLoopPass{
+		OrgID:     orgID,
+		LoopID:    loop.ID,
+		SessionID: loop.SessionID,
+		PassIndex: pass.PassIndex + 1,
+		Status:    models.ReviewLoopPassStatusReviewing,
+	}
+	if err := s.store.CreatePass(ctx, next); err != nil {
+		return err
+	}
+	msg, err := s.sendReview(ctx, &loop, next, nil, withContinuationDedupeKey(reviewLoopContinuationDedupeKey(loop.ID, next.ID, "review")))
+	if err != nil {
+		_ = s.failLoop(ctx, orgID, loop, fmt.Sprintf("failed to start confirmation review: %s", err))
+		return err
+	}
+	return s.store.SetPassReviewMessage(ctx, orgID, next.ID, msg.ID)
 }
 
 func (s *Service) OnThreadTurnFailed(ctx context.Context, orgID, threadID uuid.UUID, summary string) error {
@@ -381,6 +402,12 @@ func parseDecision(summary string) (models.ReviewLoopDecision, error) {
 	default:
 		return "", ErrUnrecognizedDecision
 	}
+}
+
+func isMalformedDecision(summary string) bool {
+	trimmed := strings.TrimSpace(summary)
+	return strings.HasPrefix(trimmed, string(models.ReviewLoopDecisionClean)) ||
+		strings.HasPrefix(trimmed, string(models.ReviewLoopDecisionNeedsFix))
 }
 
 func reviewThreadLabel(agentType models.AgentType) string {

--- a/internal/services/reviewloop/service.go
+++ b/internal/services/reviewloop/service.go
@@ -240,6 +240,9 @@ func (s *Service) OnThreadTurnComplete(ctx context.Context, orgID, threadID uuid
 			return nil
 		case err == nil && decision == models.ReviewLoopDecisionNeedsFix:
 			return s.startLegacyFixPass(ctx, orgID, loop, pass, decision)
+		case summary == "":
+			_ = s.failLoop(ctx, orgID, loop, ErrUnrecognizedDecision.Error())
+			return ErrUnrecognizedDecision
 		case isMalformedDecision(summary):
 			_ = s.failLoop(ctx, orgID, loop, ErrUnrecognizedDecision.Error())
 			return ErrUnrecognizedDecision

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -362,6 +362,43 @@ func TestService_OnThreadTurnCompleteAutomationDecisionFailureEnqueuesOpenPRGate
 	require.Equal(t, []string{"failed_open_pr"}, store.events, "invalid automation review decision should durably queue the PR gate")
 }
 
+func TestService_OnThreadTurnCompleteEmptyDecisionFailsLoop(t *testing.T) {
+	t.Parallel()
+
+	orgID := uuid.New()
+	sessionID := uuid.New()
+	threadID := uuid.New()
+	loopID := uuid.New()
+	passID := uuid.New()
+	store := &fakeReviewLoopStore{
+		runningLoop: models.SessionReviewLoop{
+			ID:        loopID,
+			OrgID:     orgID,
+			SessionID: sessionID,
+			ThreadID:  &threadID,
+			Status:    models.ReviewLoopStatusRunning,
+			AgentType: models.AgentTypeCodex,
+			MaxPasses: 2,
+		},
+		latestPass: models.SessionReviewLoopPass{
+			ID:        passID,
+			OrgID:     orgID,
+			LoopID:    loopID,
+			SessionID: sessionID,
+			PassIndex: 1,
+			Status:    models.ReviewLoopPassStatusDeciding,
+		},
+	}
+	svc := NewService(store, &fakeThreadService{})
+
+	err := svc.OnThreadTurnComplete(context.Background(), orgID, threadID, " \n\t ")
+
+	require.ErrorIs(t, err, ErrUnrecognizedDecision, "empty review decision should fail instead of consuming another review pass")
+	require.Equal(t, loopID, store.failedLoopID, "empty review decision should mark the loop failed")
+	require.Empty(t, store.fixSummary, "empty review decision should not be recorded as a fix summary")
+	require.Empty(t, store.createdPasses, "empty review decision should not create a confirmation review pass")
+}
+
 func TestService_OnThreadTurnFailedMarksRunningLoopFailed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/services/reviewloop/service_test.go
+++ b/internal/services/reviewloop/service_test.go
@@ -192,22 +192,14 @@ func TestService_OnThreadTurnCompleteDirtyThenClean(t *testing.T) {
 	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, passID, "decision"), *threads.sent[0].ContinuationDedupeKeyOverride, "review decision prompt should not collide with the currently running review job")
 
 	store.latestPass.Status = models.ReviewLoopPassStatusDeciding
-	err = svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "NEEDS_FIX_PASS")
-	require.NoError(t, err, "dirty decision should enqueue a fix pass")
-	require.Equal(t, models.ReviewLoopDecisionNeedsFix, store.fixDecision, "dirty decision should be persisted")
-	require.Contains(t, threads.sent[1].Message, "Fix every issue", "exhaustive fix prompt should ask the agent to fix all review findings")
-	require.NotNil(t, threads.sent[1].ContinuationDedupeKeyOverride, "review fix prompt should use a dedicated continuation dedupe key")
-	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, passID, "fix"), *threads.sent[1].ContinuationDedupeKeyOverride, "review fix prompt should not collide with the decision job")
-
-	store.latestPass.Status = models.ReviewLoopPassStatusFixing
 	err = svc.OnThreadTurnComplete(context.Background(), orgID, threadID, "Added the regression test")
-	require.NoError(t, err, "fix completion should enqueue the next review pass")
+	require.NoError(t, err, "dirty decision turn should record fixes and enqueue the next review pass")
 	require.Equal(t, "Added the regression test", store.fixSummary, "fix summary should be stored")
 	require.Len(t, store.createdPasses, 1, "fix completion should create the confirmation pass")
 	require.Equal(t, 2, store.createdPasses[0].PassIndex, "confirmation pass should increment pass_index")
-	require.Contains(t, threads.sent[2].Message, "/review", "confirmation pass should run /review again")
-	require.NotNil(t, threads.sent[2].ContinuationDedupeKeyOverride, "confirmation review prompt should use a dedicated continuation dedupe key")
-	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, store.createdPasses[0].ID, "review"), *threads.sent[2].ContinuationDedupeKeyOverride, "confirmation review prompt should not collide with the fix job")
+	require.Contains(t, threads.sent[1].Message, "/review", "confirmation pass should run /review again")
+	require.NotNil(t, threads.sent[1].ContinuationDedupeKeyOverride, "confirmation review prompt should use a dedicated continuation dedupe key")
+	require.Equal(t, reviewLoopContinuationDedupeKey(loopID, store.createdPasses[0].ID, "review"), *threads.sent[1].ContinuationDedupeKeyOverride, "confirmation review prompt should not collide with the decision job")
 
 	store.latestPass = store.createdPasses[0]
 	store.latestPass.Status = models.ReviewLoopPassStatusDeciding


### PR DESCRIPTION
## Summary
Updated the review-loop flow to either return the exact `REVIEW_CLEAN` sentinel or immediately fix remaining issues in the sandbox within the same turn. This simplifies the control flow (removing the separate `NEEDS_FIX_PASS` fix-pass step) while keeping strict validation to prevent malformed clean responses.

## Changes
- **`internal/prompts/templates/review_loop_decision.template`**
  - Replaced the decision contract (`REVIEW_CLEAN`/`NEEDS_FIX_PASS`) with a **clean-or-fix** instruction:
    - If clean: respond with **exactly** `REVIEW_CLEAN`
    - If not clean: **fix now in the sandbox**, run verification, and provide a fix summary
  - Preserved strict rejection of malformed clean sentinels (e.g., `REVIEW_CLEAN with commentary`).
- **`internal/services/reviewloop/service.go`**
  - Updated handling so a **non-clean** turn is treated as a fix summary and automatically triggers the **next confirmation review pass**.
  - Kept legacy `NEEDS_FIX_PASS` handling for older/in-flight review turns to avoid breaking existing threads.
- **`internal/prompts/review_loop_test.go`**
  - Adjusted prompt assertions to reflect the new clean-or-fix contract and sentinel expectations.
- **`internal/services/reviewloop/service_test.go`**
  - Updated tests to match the new sequencing: clean ends the loop; otherwise fixes summary leads directly to the next review pass.
- **`docs/design/implemented/78-review-agent-loops.md`**
  - Updated the design/spec to describe the clean-or-fix behavior and new execution model.

## Test plan
- `go vet ./...`
- `go build ./...`
- `go test ./...`

[143.dev](https://143.dev) | [session 91696a6e](https://143.dev/sessions/91696a6e-3798-40cc-86bf-04b2af5df4b5)